### PR TITLE
CI: Upgrade build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ executors:
       - image: cimg/go:1.14
   grafana-build:
     docker:
-      - image: grafana/build-container:1.2.23
+      - image: grafana/build-container:1.2.24
   grafana-publish:
     docker:
       - image: grafana/grafana-ci-deploy:1.2.5

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v$${GRABPL_VERSION}/grabpl
   - chmod +x grabpl
@@ -30,7 +30,7 @@ steps:
     GRABPL_VERSION: 0.4.25
 
 - name: lint-backend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -41,7 +41,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -49,7 +49,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -64,7 +64,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(go env GOCACHE) && cp -r go-cache $(go env GOCACHE)
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
@@ -74,7 +74,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
@@ -83,7 +83,7 @@ steps:
   - test-frontend
 
 - name: test-backend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
@@ -93,7 +93,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn run prettier:check
@@ -106,7 +106,7 @@ steps:
   - initialize
 
 - name: build-plugins
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
@@ -115,7 +115,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
   depends_on:
@@ -128,7 +128,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   detach: true
   commands:
   - ./e2e/start-server
@@ -148,7 +148,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn storybook:build
@@ -165,7 +165,7 @@ steps:
   - initialize
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - cp dist/*.tar.gz packaging/docker/
   depends_on:
@@ -181,7 +181,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -199,7 +199,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -251,7 +251,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v$${GRABPL_VERSION}/grabpl
   - chmod +x grabpl
@@ -267,7 +267,7 @@ steps:
     GRABPL_VERSION: 0.4.25
 
 - name: lint-backend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -278,7 +278,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -286,7 +286,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -301,7 +301,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(go env GOCACHE) && cp -r go-cache $(go env GOCACHE)
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER
@@ -311,7 +311,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
@@ -320,7 +320,7 @@ steps:
   - test-frontend
 
 - name: test-backend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
@@ -330,7 +330,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn run prettier:check
@@ -343,7 +343,7 @@ steps:
   - initialize
 
 - name: build-plugins
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
@@ -352,7 +352,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
@@ -365,7 +365,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   detach: true
   commands:
   - ./e2e/start-server
@@ -385,7 +385,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - rm -rf $(yarn cache dir) && cp -r yarn-cache $(yarn cache dir)
   - yarn storybook:build
@@ -414,7 +414,7 @@ steps:
   - initialize
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - cp dist/*.tar.gz packaging/docker/
   depends_on:
@@ -438,7 +438,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -456,7 +456,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -480,7 +480,7 @@ steps:
   - package
 
 - name: release-next-npm-packages
-  image: grafana/build-container:1.2.23
+  image: grafana/build-container:1.2.24
   commands:
   - npx lerna bootstrap
   - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.23"
+_version="1.2.24"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,4 +1,4 @@
-build_image = 'grafana/build-container:1.2.23'
+build_image = 'grafana/build-container:1.2.24'
 publish_image = 'grafana/grafana-ci-deploy:1.2.5'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.2.0'
 alpine_image = 'alpine:3.12'


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade build image revision in CI, since I pushed a new revision of 1.2.23 and there are now issues in Drone, since some machines have cached the old version of that tag. Lesson learnt I guess...