### PR TITLE
Graphite: Fix test data source query options

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -593,6 +593,9 @@ export class GraphiteDatasource extends DataSourceApi<GraphiteQuery, GraphiteOpt
     const query = ({
       panelId: 3,
       rangeRaw: { from: 'now-1h', to: 'now' },
+      range: {
+        raw: { from: 'now-1h', to: 'now' },
+      },
       targets: [{ target: 'constantLine(100)' }],
       maxDataPoints: 300,
     } as unknown) as DataQueryRequest<GraphiteQuery>;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the test query for Graphite data source.
It throw this error (Cannot read property 'raw' of undefined) without this.

![gdev-graphite_ Settings - Grafana - Google Chrome 2020-08-10 22_04_39](https://user-images.githubusercontent.com/13729989/89826768-09b95500-db57-11ea-9078-e4d289fd3331.png)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

