### PR TITLE
Graphite: Improve disappearing query editor function popup

### DIFF
--- a/public/app/plugins/datasource/graphite/FunctionEditor.tsx
+++ b/public/app/plugins/datasource/graphite/FunctionEditor.tsx
@@ -101,7 +101,7 @@ class FunctionEditor extends React.PureComponent<FunctionEditorProps, FunctionEd
                   hidePopper();
                   this.setState({ showingDescription: false });
                 }}
-                style={{ cursor: 'pointer' }}
+                style={{ cursor: 'pointer', display: 'inline-block' }}
               >
                 {this.props.func.def.name}
               </span>


### PR DESCRIPTION
**What this PR does / why we need it**:
More info on issue in #21177.

The problem is that  **popover's** `onMouseLeave` function sometimes run as the **popover** is on/super close to the **query editor function field**. Also the text of **query editor function field** has only `onMouseLeave` function and therefore when user moves the cursor away from text, but is still in the field, **popover** disappears. 

 I have created PRs with 2 possible fixing/improving solutions. This is the second one. The first one can be found in https://github.com/grafana/grafana/pull/26923.

We move the popover a little bit higher by setting display of span with text of **query editor function field** to inline-block. So when clicking on standard places, it doesn't disappear. Also, it makes the area of  text of **query editor function field** that has only `onMouseLeave` function bigger. This way,  when user moves the cursor away from text, but is still in the field, **popover** doesn't disappear. 

Fixed:
![Kapture 2020-08-11 at 13 21 31](https://user-images.githubusercontent.com/30407135/89891616-ad494a80-dbd5-11ea-9670-0142e0dcca43.gif)

Edge case where it doesn't work:
![Kapture 2020-08-11 at 13 22 00](https://user-images.githubusercontent.com/30407135/89891636-b9350c80-dbd5-11ea-8e85-f37ea78d14b7.gif)

**Which issue(s) this PR fixes**:

Fixes #21177 
