### PR TITLE
Graphite: Show and hide query editor function popup on click 

### DIFF
--- a/public/app/plugins/datasource/graphite/FunctionEditor.tsx
+++ b/public/app/plugins/datasource/graphite/FunctionEditor.tsx
@@ -73,7 +73,7 @@ class FunctionEditor extends React.PureComponent<FunctionEditorProps, FunctionEd
 
   render() {
     return (
-      <PopoverController content={this.renderContent} placement="top" hideAfter={300}>
+      <PopoverController content={this.renderContent} placement="top">
         {(showPopper, hidePopper, popperProps) => {
           return (
             <>
@@ -85,9 +85,7 @@ class FunctionEditor extends React.PureComponent<FunctionEditorProps, FunctionEd
                   className="popper__background"
                   onMouseLeave={() => {
                     this.setState({ showingDescription: false });
-                    hidePopper();
                   }}
-                  onMouseEnter={showPopper}
                   renderArrow={({ arrowProps, placement }) => (
                     <div className="popper__arrow" data-placement={placement} {...arrowProps} />
                   )}
@@ -98,7 +96,6 @@ class FunctionEditor extends React.PureComponent<FunctionEditorProps, FunctionEd
                 ref={this.triggerRef}
                 onClick={popperProps.show ? hidePopper : showPopper}
                 onMouseLeave={() => {
-                  hidePopper();
                   this.setState({ showingDescription: false });
                 }}
                 style={{ cursor: 'pointer' }}

--- a/public/app/plugins/datasource/graphite/FunctionEditor.tsx
+++ b/public/app/plugins/datasource/graphite/FunctionEditor.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { PopoverController, Popover } from '@grafana/ui';
+import { PopoverController, Popover, ClickOutsideWrapper } from '@grafana/ui';
 import { FunctionDescriptor, FunctionEditorControls, FunctionEditorControlsProps } from './FunctionEditorControls';
 
 interface FunctionEditorProps extends FunctionEditorControlsProps {
@@ -73,7 +73,7 @@ class FunctionEditor extends React.PureComponent<FunctionEditorProps, FunctionEd
 
   render() {
     return (
-      <PopoverController content={this.renderContent} placement="top">
+      <PopoverController content={this.renderContent} placement="top" hideAfter={100}>
         {(showPopper, hidePopper, popperProps) => {
           return (
             <>
@@ -91,17 +91,24 @@ class FunctionEditor extends React.PureComponent<FunctionEditorProps, FunctionEd
                   )}
                 />
               )}
-
-              <span
-                ref={this.triggerRef}
-                onClick={popperProps.show ? hidePopper : showPopper}
-                onMouseLeave={() => {
-                  this.setState({ showingDescription: false });
+              <ClickOutsideWrapper
+                onClick={() => {
+                  if (popperProps.show) {
+                    hidePopper();
+                  }
                 }}
-                style={{ cursor: 'pointer' }}
               >
-                {this.props.func.def.name}
-              </span>
+                <span
+                  ref={this.triggerRef}
+                  onClick={popperProps.show ? hidePopper : showPopper}
+                  onMouseLeave={() => {
+                    this.setState({ showingDescription: false });
+                  }}
+                  style={{ cursor: 'pointer' }}
+                >
+                  {this.props.func.def.name}
+                </span>
+              </ClickOutsideWrapper>
             </>
           );
         }}


### PR DESCRIPTION
**What this PR does / why we need it**:
More info on issue in #21177.

The problem is that  **popover's** `onMouseLeave` function sometimes run as the **popover** is on/super close to the **query editor function field**. Also the text of **query editor function field** has only `onMouseLeave` function and therefore when user moves the cursor away from text, but is still in the field, **popover** disappears. 

 I have created PRs with 2 possible fixing/improving solutions. This is the first one. The second one can be found in https://github.com/grafana/grafana/pull/26922.

This fix includes the UX change. Leaving the query editor function field and/or leaving the popover doesn't have impact on if the popover is shown. The popover can be only opened and closed by clicking on query editor function field. As click opens the popover, we think that closing it by clicking on field/or anywhere else again makes sense. 

![Kapture 2020-08-11 at 14 36 09](https://user-images.githubusercontent.com/30407135/89927926-5a888680-dc07-11ea-87d9-fa21cfd14bb8.gif)

**Which issue(s) this PR fixes**:

Fixes #21177 
