### PR TITLE
Panel/BarGauge: Prevent overflow in panel with many series

### DIFF
--- a/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
+++ b/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
@@ -24,6 +24,8 @@ interface Props<V, D> {
   itemSpacing?: number;
   /** When orientation is set to auto layout items in a grid */
   autoGrid?: boolean;
+  repeaterStyle?: React.CSSProperties;
+  minVizHeight?: number;
 }
 
 export interface VizRepeaterRenderValueProps<V, D = {}> {
@@ -137,7 +139,7 @@ export class VizRepeater<V, D = {}> extends PureComponent<Props<V, D>, State<V>>
   }
 
   render() {
-    const { renderValue, height, width, itemSpacing, getAlignmentFactors, autoGrid, orientation } = this
+    const { renderValue, height, width, itemSpacing, getAlignmentFactors, autoGrid, orientation, minVizHeight } = this
       .props as PropsWithDefaults<V, D>;
     const { values } = this.state;
 
@@ -151,6 +153,7 @@ export class VizRepeater<V, D = {}> extends PureComponent<Props<V, D>, State<V>>
 
     const repeaterStyle: React.CSSProperties = {
       display: 'flex',
+      ...this.props.repeaterStyle,
     };
 
     let vizHeight = height;
@@ -161,9 +164,10 @@ export class VizRepeater<V, D = {}> extends PureComponent<Props<V, D>, State<V>>
     switch (resolvedOrientation) {
       case VizOrientation.Horizontal:
         repeaterStyle.flexDirection = 'column';
+        repeaterStyle.height = `${height}px`;
         itemStyles.marginBottom = `${itemSpacing}px`;
         vizWidth = width;
-        vizHeight = height / values.length - itemSpacing + itemSpacing / values.length;
+        vizHeight = Math.max(height / values.length - itemSpacing + itemSpacing / values.length, minVizHeight ?? 0);
         break;
       case VizOrientation.Vertical:
         repeaterStyle.flexDirection = 'row';

--- a/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
+++ b/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
@@ -24,7 +24,6 @@ interface Props<V, D> {
   itemSpacing?: number;
   /** When orientation is set to auto layout items in a grid */
   autoGrid?: boolean;
-  repeaterStyle?: React.CSSProperties;
   minVizHeight?: number;
 }
 
@@ -153,7 +152,7 @@ export class VizRepeater<V, D = {}> extends PureComponent<Props<V, D>, State<V>>
 
     const repeaterStyle: React.CSSProperties = {
       display: 'flex',
-      ...this.props.repeaterStyle,
+      overflow: minVizHeight ? 'hidden scroll' : 'visible',
     };
 
     let vizHeight = height;

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -100,8 +100,10 @@ export class BarGaugePanel extends PureComponent<PanelProps<BarGaugeOptions>> {
         renderCounter={renderCounter}
         width={width}
         height={height}
+        minVizHeight={10}
         itemSpacing={this.getItemSpacing()}
         orientation={options.orientation}
+        repeaterStyle={{ overflow: 'hidden scroll' }}
       />
     );
   }

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -103,7 +103,6 @@ export class BarGaugePanel extends PureComponent<PanelProps<BarGaugeOptions>> {
         minVizHeight={10}
         itemSpacing={this.getItemSpacing()}
         orientation={options.orientation}
-        repeaterStyle={{ overflow: 'hidden scroll' }}
       />
     );
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents bar gauges from overflowing panel when there are many series.

Before: ![overflow](https://user-images.githubusercontent.com/45561153/89905108-a4f70c80-dbe1-11ea-945a-5c28eb4dad47.gif)

After: ![scrollable](https://user-images.githubusercontent.com/45561153/89905122-a88a9380-dbe1-11ea-82b4-833aa5edf22a.gif)


**Which issue(s) this PR fixes**:
Closes #24889
