### PR TITLE
API: Support paging in the admin orgs list API

### DIFF
--- a/docs/sources/http_api/org.md
+++ b/docs/sources/http_api/org.md
@@ -325,7 +325,7 @@ Content-Type: application/json
 
 ### Search all Organizations
 
-`GET /api/orgs`
+`GET /api/orgs?perpage=10&page=1`
 
 Only works with Basic Authentication (username and password), see [introduction](#admin-organizations-api).
 
@@ -338,6 +338,8 @@ Content-Type: application/json
 ```
 Note: The api will only work when you pass the admin name and password
 to the request HTTP URL, like http://admin:admin@localhost:3000/api/orgs
+
+Default value for the `perpage` parameter is `1000` and for the `page` parameter is `0`.
 
 **Example Response**:
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -203,7 +203,10 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Post("/orgs", quota("org"), bind(models.CreateOrgCommand{}), Wrap(CreateOrg))
 
 		// search all orgs
-		apiRoute.Get("/orgs", reqGrafanaAdmin, Wrap(SearchOrgs))
+		apiRoute.Group("/orgs", func(orgsRoute routing.RouteRegister) {
+			orgsRoute.Get("/", Wrap(SearchOrgs))
+			orgsRoute.Get("/search", Wrap(SearchOrgs))
+		}, reqGrafanaAdmin)
 
 		// orgs (admin routes)
 		apiRoute.Group("/orgs/:orgId", func(orgsRoute routing.RouteRegister) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -203,10 +203,7 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Post("/orgs", quota("org"), bind(models.CreateOrgCommand{}), Wrap(CreateOrg))
 
 		// search all orgs
-		apiRoute.Group("/orgs", func(orgsRoute routing.RouteRegister) {
-			orgsRoute.Get("/", Wrap(SearchOrgs))
-			orgsRoute.Get("/search", Wrap(SearchOrgs))
-		}, reqGrafanaAdmin)
+		apiRoute.Get("/orgs", reqGrafanaAdmin, Wrap(SearchOrgs))
 
 		// orgs (admin routes)
 		apiRoute.Group("/orgs/:orgId", func(orgsRoute routing.RouteRegister) {

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -166,9 +166,6 @@ func SearchOrgs(c *models.ReqContext) Response {
 	}
 
 	page := c.QueryInt("page")
-	if page < 1 {
-		page = 1
-	}
 
 	query := models.SearchOrgsQuery{
 		Query: c.Query("query"),

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -160,11 +160,21 @@ func DeleteOrgByID(c *models.ReqContext) Response {
 }
 
 func SearchOrgs(c *models.ReqContext) Response {
+	perPage := c.QueryInt("perpage")
+	if perPage <= 0 {
+		perPage = 1000
+	}
+
+	page := c.QueryInt("page")
+	if page < 1 {
+		page = 1
+	}
+
 	query := models.SearchOrgsQuery{
 		Query: c.Query("query"),
 		Name:  c.Query("name"),
-		Page:  0,
-		Limit: 1000,
+		Page:  page,
+		Limit: perPage,
 	}
 
 	if err := bus.Dispatch(&query); err != nil {

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -36,37 +36,31 @@ func TestAccountDataAccess(t *testing.T) {
 		})
 
 		Convey("Given we have organizations, we can limit and paginate search", func() {
-			var err error
-			var cmd *models.CreateOrgCommand
-			ids := []int64{}
-
 			for i := 1; i < 4; i++ {
-				cmd = &models.CreateOrgCommand{Name: fmt.Sprint("Org #", i)}
-				err = CreateOrg(cmd)
+				cmd := &models.CreateOrgCommand{Name: fmt.Sprint("Org #", i)}
+				err := CreateOrg(cmd)
 				So(err, ShouldBeNil)
-
-				ids = append(ids, cmd.Result.Id)
 			}
 
-			Convey("Should be able to limit search", func() {
-				query := &models.SearchOrgsQuery{Limit: 1}
-				err = SearchOrgs(query)
-
-				So(err, ShouldBeNil)
-				So(len(query.Result), ShouldEqual, 1)
-			})
-
-			Convey("Should be able to paginate search", func() {
-				query := &models.SearchOrgsQuery{Page: 0}
-				err = SearchOrgs(query)
+			Convey("Should be able to search with defaults", func() {
+				query := &models.SearchOrgsQuery{}
+				err := SearchOrgs(query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 3)
 			})
 
+			Convey("Should be able to limit search", func() {
+				query := &models.SearchOrgsQuery{Limit: 1}
+				err := SearchOrgs(query)
+
+				So(err, ShouldBeNil)
+				So(len(query.Result), ShouldEqual, 1)
+			})
+
 			Convey("Should be able to limit and paginate search", func() {
 				query := &models.SearchOrgsQuery{Limit: 2, Page: 1}
-				err = SearchOrgs(query)
+				err := SearchOrgs(query)
 
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 1)

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -35,6 +35,44 @@ func TestAccountDataAccess(t *testing.T) {
 			So(len(query.Result), ShouldEqual, 3)
 		})
 
+		Convey("Given we have organizations, we can limit and paginate search", func() {
+			var err error
+			var cmd *models.CreateOrgCommand
+			ids := []int64{}
+
+			for i := 1; i < 4; i++ {
+				cmd = &models.CreateOrgCommand{Name: fmt.Sprint("Org #", i)}
+				err = CreateOrg(cmd)
+				So(err, ShouldBeNil)
+
+				ids = append(ids, cmd.Result.Id)
+			}
+
+			Convey("Should be able to limit search", func() {
+				query := &models.SearchOrgsQuery{Limit: 1}
+				err = SearchOrgs(query)
+
+				So(err, ShouldBeNil)
+				So(len(query.Result), ShouldEqual, 1)
+			})
+
+			Convey("Should be able to paginate search", func() {
+				query := &models.SearchOrgsQuery{Page: 0}
+				err = SearchOrgs(query)
+
+				So(err, ShouldBeNil)
+				So(len(query.Result), ShouldEqual, 3)
+			})
+
+			Convey("Should be able to limit and paginate search", func() {
+				query := &models.SearchOrgsQuery{Limit: 2, Page: 1}
+				err = SearchOrgs(query)
+
+				So(err, ShouldBeNil)
+				So(len(query.Result), ShouldEqual, 1)
+			})
+		})
+
 		Convey("Given single org mode", func() {
 			setting.AutoAssignOrg = true
 			setting.AutoAssignOrgId = 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow users to set page limits and page for org list.

**Which issue(s) this PR fixes**:
Fixes #26171

**Special notes for your reviewer**:
I tried to follow the pattern set by the `/users` route (since it allows pagination and page limits), but found that setting the page to 1 as the default skipped entries that were present on page 0.
