### PR TITLE
alerting: Change alerting source panel to view instead of edit.

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -148,9 +148,10 @@ describe('DashboardPage', () => {
       });
     });
 
-    it('Should update component state to fullscreen and edit', () => {
+    it('Should update component state to fullscreen and view', () => {
       const state = ctx.wrapper?.state();
-      expect(state?.editPanel).toBe(null);
+      expect(state).not.toBe(null);
+      expect(state?.viewPanel).toBeDefined();
     });
   });
   dashboardPageScenario('When user goes back to dashboard from view panel', ctx => {

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -114,24 +114,6 @@ export class DashboardPage extends PureComponent<Props, State> {
       return;
     }
 
-    // entering edit mode
-    if (!editPanel && urlEditPanelId) {
-      this.getPanelByIdFromUrlParam(urlEditPanelId, panel => {
-        // if no edit permission show error
-        if (!dashboard.canEditPanel(panel)) {
-          this.props.notifyApp(createErrorNotification('Permission to edit panel denied'));
-          return;
-        }
-
-        this.setState({ editPanel: panel });
-      });
-    }
-
-    // leaving edit mode
-    if (editPanel && !urlEditPanelId) {
-      this.setState({ editPanel: null });
-    }
-
     // entering view mode
     if (!viewPanel && urlViewPanelId) {
       this.getPanelByIdFromUrlParam(urlViewPanelId, panel => {
@@ -152,6 +134,28 @@ export class DashboardPage extends PureComponent<Props, State> {
         { viewPanel: null, updateScrollTop: this.state.rememberScrollTop },
         this.triggerPanelsRendering.bind(this)
       );
+    }
+
+    // entering edit mode
+    if (!editPanel && urlEditPanelId) {
+      this.getPanelByIdFromUrlParam(urlEditPanelId, panel => {
+        // if no edit permission show error
+        if (!dashboard.canEditPanel(panel)) {
+          this.props.notifyApp(createErrorNotification('Permission to edit panel denied'));
+          dashboard.initViewPanel(panel);
+          this.setState({
+            viewPanel: panel,
+            rememberScrollTop: this.state.scrollTop,
+          });
+        } else {
+          this.setState({ editPanel: panel });
+        }
+      });
+    }
+
+    // leaving edit mode
+    if (editPanel && !urlEditPanelId) {
+      this.setState({ editPanel: null });
     }
   }
 


### PR DESCRIPTION
This is because when a dashboard is locked from edits this will result in
an error denoting improper permissions. The same is likely in the case that
a person is only allowed view permissions.

Fixes #26931 