### PR TITLE
Docs: Use relref links for data sources in whats new docs

### DIFF
--- a/docs/sources/guides/whats-new-in-v5-1.md
+++ b/docs/sources/guides/whats-new-in-v5-1.md
@@ -51,7 +51,7 @@ The Prometheus data source now support transforming Prometheus histograms to the
 really happy to finally allow our users to render those as heatmaps. Please read [Heatmap panel documentation](/features/panels/heatmap/#pre-bucketed-data)
 for more information on how to use it.
 
-Prometheus query editor also got support for autocomplete of template variables. More information in the [Prometheus data source documentation](/features/datasources/prometheus/).
+Prometheus query editor also got support for autocomplete of template variables. More information in the [Prometheus data source documentation]({{< relref "../features/datasources/prometheus/" >}}).
 
 <div class="clearfix"></div>
 
@@ -63,7 +63,7 @@ Grafana v5.1 now ships with a built-in Microsoft SQL Server (MSSQL) data source 
 Microsoft SQL Server 2005 or newer, including Microsoft Azure SQL Database. Do you have metric or log data in MSSQL? You can now visualize
 that data and define alert rules on it like with any of Grafana's other core data sources.
 
-Please read [Using Microsoft SQL Server in Grafana documentation](/features/datasources/mssql/) for more detailed information on how to get started and use it.
+Please read [Using Microsoft SQL Server in Grafana documentation]({{< relref "../features/datasources/mssql/" >}}) for more detailed information on how to get started and use it.
 
 <div class="clearfix"></div>
 

--- a/docs/sources/guides/whats-new-in-v5-3.md
+++ b/docs/sources/guides/whats-new-in-v5-3.md
@@ -39,7 +39,7 @@ The Grafana Stackdriver plugin comes with support for automatic unit detection. 
 The data source is still in the `beta` phase, meaning it's currently in active development and is still missing one important feature - templating queries.
 Please try it out, but be aware of that it might be subject to changes and possible bugs. We would love to hear your feedback.
 
-Please read [Using Google Stackdriver in Grafana](/features/datasources/stackdriver/) for more detailed information on how to get started and use it.
+Please read [Using Google Stackdriver in Grafana]({{< relref "../features/datasources/cloudmonitoring/" >}}) for more detailed information on how to get started and use it.
 
 ## TV and Kiosk Mode
 
@@ -65,7 +65,7 @@ Learn how to enable and configure reminders [here](/alerting/notifications/#send
 
 ## Postgres Query Builder
 
-Grafana 5.3 comes with a new graphical query builder for Postgres. This brings Postgres integration more in line with some of the other data sources and makes it easier for both advanced users and beginners to work with timeseries in Postgres. Learn more about it in the [documentation](/features/datasources/postgres/#query-editor).
+Grafana 5.3 comes with a new graphical query builder for Postgres. This brings Postgres integration more in line with some of the other data sources and makes it easier for both advanced users and beginners to work with timeseries in Postgres. Learn more about it in the [documentation]({{< relref "../features/datasources/postgres/#query-editor" >}}).
 
 {{< docs-imagebox img="/img/docs/v53/postgres_query_still.png" class="docs-image--no-shadow" animated-gif="/img/docs/v53/postgres_query.gif" >}}
 

--- a/docs/sources/guides/whats-new-in-v5-4.md
+++ b/docs/sources/guides/whats-new-in-v5-4.md
@@ -47,15 +47,15 @@ Stackdriver is the first data source which has support for a custom templating q
 create their very own templating query editor.
 
 Additionally, if Grafana is running on a Google Compute Engine (GCE) virtual machine, it is now possible for Grafana to automatically retrieve default credentials from the metadata server.
-This has the advantage of not needing to generate a private key file for the service account and also not having to upload the file to Grafana. [Learn more](/features/datasources/stackdriver/#using-gce-default-service-account).
+This has the advantage of not needing to generate a private key file for the service account and also not having to upload the file to Grafana. [Learn more]({{< relref "../features/datasources/cloudmonitoring/#using-gce-default-service-account" >}}).
 
-Please read [Using Google Stackdriver in Grafana](/features/datasources/stackdriver/) for more detailed information on how to get started and use it.
+Please read [Using Google Stackdriver in Grafana]({{< relref "../features/datasources/cloudmonitoring/" >}}) for more detailed information on how to get started and use it.
 
 <div class="clearfix"></div>
 
 ## MySQL Query Builder
 
-Grafana v5.4 comes with a new graphical query builder for MySQL. This brings MySQL integration more in line with some of the other data sources and makes it easier for both advanced users and beginners to work with timeseries in MySQL. Learn more about it in the [documentation](/features/datasources/mysql/#query-editor).
+Grafana v5.4 comes with a new graphical query builder for MySQL. This brings MySQL integration more in line with some of the other data sources and makes it easier for both advanced users and beginners to work with timeseries in MySQL. Learn more about it in the [documentation]({{< relref "../features/datasources/mysql/#query-editor" >}}).
 
 {{< docs-imagebox img="/img/docs/v54/mysql_query_still.png" animated-gif="/img/docs/v54/mysql_query.gif" >}}
 

--- a/docs/sources/guides/whats-new-in-v6-0.md
+++ b/docs/sources/guides/whats-new-in-v6-0.md
@@ -21,8 +21,8 @@ The main highlights are:
 - [Gauge Panel]({{< relref "#gauge-panel" >}}) - A new standalone panel for gauges.
 - [New Panel Editor UX]({{< relref "#new-panel-editor" >}}) improves panel editing
     and enables easy switching between different visualizations.
-- [Google Stackdriver data source]({{< relref "#google-stackdriver-datasource" >}}) is out of beta and is officially released.
-- [Azure Monitor]({{< relref "#azure-monitor-datasource" >}}) plugin is ported from being an external plugin to being a core data source
+- [Google Stackdriver data source]({{< relref "#google-stackdriver-data-source" >}}) is out of beta and is officially released.
+- [Azure Monitor]({{< relref "#azure-monitor-data-source" >}}) plugin is ported from being an external plugin to being a core data source
 - [React Plugin]({{< relref "#react-panels-query-editors" >}}) support enables an easier way to build plugins.
 - [Named Colors]({{< relref "#named-colors" >}}) in our new improved color picker.
 - [Removal of user session storage]({{< relref "#easier-to-deploy-improved-security" >}}) makes Grafana easier to deploy and improves security.
@@ -116,7 +116,7 @@ will be shared soon.
 
 Built-in support for [Google Stackdriver](https://cloud.google.com/stackdriver/) is officially released in Grafana 6.0. Beta support was added in Grafana 5.3 and we have added lots of improvements since then.
 
-To get started read the guide: [Using Google Stackdriver in Grafana](/features/datasources/stackdriver/).
+To get started read the guide: [Using Google Stackdriver in Grafana]({{< relref "../features/datasources/cloudmonitoring/" >}}).
 
 ## Azure Monitor data source
 
@@ -124,7 +124,7 @@ One of the goals of the Grafana v6.0 release is to add support for the three maj
 
 The Azure Monitor data source integrates four Azure services with Grafana - Azure Monitor, Azure Log Analytics, Azure Application Insights and Azure Application Insights Analytics.
 
-Please read [Using Azure Monitor in Grafana documentation](/features/datasources/azuremonitor/) for more detailed information on how to get started and use it.
+Please read [Using Azure Monitor in Grafana documentation]({{< relref "../features/datasources/azuremonitor/" >}}) for more detailed information on how to get started and use it.
 
 ## Provisioning support for alert notifiers
 

--- a/docs/sources/guides/whats-new-in-v6-2.md
+++ b/docs/sources/guides/whats-new-in-v6-2.md
@@ -37,7 +37,7 @@ To mitigate the risk of sensitive information being cached in browser after a us
 
 ## Official support for Elasticsearch 7
 
-Grafana v6.2 ships with official support for Elasticsearch v7, see [Using Elasticsearch in Grafana](/features/datasources/elasticsearch/#elasticsearch-version) for more information.
+Grafana v6.2 ships with official support for Elasticsearch v7, see [Using Elasticsearch in Grafana]({{< relref "../features/datasources/elasticsearch/#elasticsearch-version" >}}) for more information.
 
 ## Bar Gauge Panel
 

--- a/docs/sources/guides/whats-new-in-v6-3.md
+++ b/docs/sources/guides/whats-new-in-v6-3.md
@@ -50,7 +50,7 @@ simplified query interface specifically designed for logs search.
 
 {{< docs-imagebox img="/img/docs/v63/elasticsearch_explore_logs.png" max-width="600px" caption="New Time Picker" >}}
 
-Please read [Using Elasticsearch in Grafana](/features/datasources/elasticsearch/#querying-logs-beta) for more detailed information on how to get started and use it.
+Please read [Using Elasticsearch in Grafana]({{< relref "../features/datasources/elasticsearch/#elasticsearch-version" >}}) for more detailed information on how to get started and use it.
 
 ### InfluxDB logs support
 
@@ -59,7 +59,7 @@ simplified query interface specifically designed for logs search.
 
 {{< docs-imagebox img="/img/docs/v63/influxdb_explore_logs.png" max-width="600px" caption="New Time Picker" >}}
 
-Please read [Using InfluxDB in Grafana](/features/datasources/influxdb/#querying-logs-beta) for more detailed information on how to get started and use it.
+Please read [Using InfluxDB in Grafana]({{< relref "../features/datasources/influxdb/#querying-logs-beta" >}}) for more detailed information on how to get started and use it.
 
 ## Data Links
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some what's new docs in our docs site had wrong links for data sources. This pr fixes those.

