### PR TITLE
Improve validation for grafanaDependency

### DIFF
--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -50,7 +50,7 @@ Plugin dependencies.
 
 | Property            | Type     | Required | Description                                                                                                                   |
 |---------------------|----------|----------|-------------------------------------------------------------------------------------------------------------------------------|
-| `grafanaDependency` | string   | **Yes**  | Required Grafana version for this plugin, e.g. `>=7.0.0` to denote plugin requires Grafana 7.0.0 or later.                    |
+| `grafanaDependency` | string   | **Yes**  | Required Grafana version for this plugin. Validated using https://github.com/npm/node-semver.                                 |
 | `grafanaVersion`    | string   | No       | (Deprecated) Required Grafana version for this plugin, e.g. `6.x.x 7.x.x` to denote plugin requires Grafana v6.x.x or v7.x.x. |
 | `plugins`           | string[] | No       | An array of required plugins on which this plugin depends.                                                                    |
 

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -131,8 +131,8 @@
         },
         "grafanaDependency": {
           "type": "string",
-          "description": "Required Grafana version for this plugin, e.g. `>=7.0.0` to denote plugin requires Grafana 7.0.0 or later.",
-          "pattern": "^(>=|<|>|<=)?([0-9]+)(\\.[0-9]+)?(\\.[0-9])?$"
+          "description": "Required Grafana version for this plugin. Validated using https://github.com/npm/node-semver.",
+          "pattern": "^(<=|>=|<|>|=|~|\\^)?([0-9]+)(\\.[0-9x\\*]+)(\\.[0-9x\\*])?(\\s(<=|>=|<|=>)?([0-9]+)(\\.[0-9x]+)(\\.[0-9x]))?$"
         },
         "plugins": {
           "type": "array",


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the validation of `grafanaDependency` to more closely follow [node-semver](https://github.com/npm/node-semver).

Test corpus (all listed are accepted):

```
=1.0.0
1.0.0
~1.0.0
^1.0.0
1.x.0
0.0.x
1.*.0
>=1.0.0
>=1.0.0 <2.0.0
```

Test here: https://regex101.com/r/4G0OUp/2

Not that it's regexp, and not magic. It won't actually validate that ranges are correct. It will still accept impossible ranges like `<=6.0.0 >7.0.0`.