### PR TITLE
grafana-cli: Fix installing of plugins missing directory entries in zip

### DIFF
--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -233,6 +233,12 @@ func extractFiles(archiveFile string, pluginName string, filePath string, allowS
 				return fmt.Errorf(permissionsDeniedMessage, newFile)
 			}
 		} else {
+			// Create needed directories to extract file
+			err := os.MkdirAll(filepath.Dir(newFile), 0755)
+			if err != nil {
+				return errutil.Wrap("failed to create directory to extract plugin files", err)
+			}
+
 			if isSymlink(zf) {
 				if !allowSymlinks {
 					logger.Errorf("%v: plugin archive contains symlink which is not allowed. Skipping \n", zf.Name)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
If a plugin zip file does not have the base directory placed in the first position, this command will fail trying to create a file in
a directory that does not exists. Same problem if the zip file does not contain the parent directory of files/directories.

To create an unordered zip file (directory not the first one):

```
zip -r file.zip foo/bar foo/foobar foo/
```

Zip file without the base dir:

```
zip -r file.zip foo/bar foo/foobar
```



**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

