### PR TITLE
Dashboard: Adds folder name and link to the dashboard overview on the homepage

### DIFF
--- a/public/app/plugins/panel/dashlist/module.html
+++ b/public/app/plugins/panel/dashlist/module.html
@@ -9,7 +9,7 @@
           <span class="dashlist-title">
             {{dash.title}}
           </span>
-          <span class="dashlist-folder">
+          <span ng-if="dash.folderTitle" class="dashlist-folder">
             ({{dash.folderTitle}})
           </span>
           <span class="dashlist-star" ng-click="ctrl.starDashboard(dash, $event)">

--- a/public/app/plugins/panel/dashlist/module.html
+++ b/public/app/plugins/panel/dashlist/module.html
@@ -9,6 +9,9 @@
           <span class="dashlist-title">
             {{dash.title}}
           </span>
+          <span class="dashlist-folder">
+            ({{dash.folderTitle}})
+          </span>
           <span class="dashlist-star" ng-click="ctrl.starDashboard(dash, $event)">
             <icon name="dash.isStarred ? 'favorite':'star'" type="dash.isStarred ? 'mono':'default'"></icon>
           </span>

--- a/public/app/plugins/panel/dashlist/module.html
+++ b/public/app/plugins/panel/dashlist/module.html
@@ -10,7 +10,8 @@
             {{dash.title}}
           </span>
           <span ng-if="dash.folderTitle" class="dashlist-folder">
-            ({{dash.folderTitle}})
+            <icon name="'folder'" type="mono" size="'xs'"></icon>
+            {{dash.folderTitle}}
           </span>
           <span class="dashlist-star" ng-click="ctrl.starDashboard(dash, $event)">
             <icon name="dash.isStarred ? 'favorite':'star'" type="dash.isStarred ? 'mono':'default'"></icon>

--- a/public/sass/components/_panel_dashlist.scss
+++ b/public/sass/components/_panel_dashlist.scss
@@ -27,5 +27,7 @@
 
   &-folder {
     color: $text-color-weak;
+    margin-left: $space-sm;
+    font-size: $font-size-xs;
   }
 }

--- a/public/sass/components/_panel_dashlist.scss
+++ b/public/sass/components/_panel_dashlist.scss
@@ -8,18 +8,24 @@
   padding-top: 3px;
 }
 
-.dashlist-link {
-  @include list-item();
+.dashlist {
+  &-link {
+    @include list-item();
 
-  .fa {
-    padding-top: 3px;
+    .fa {
+      padding-top: 3px;
+    }
+
+    .fa-star {
+      color: $orange;
+    }
   }
 
-  .dashlist-star {
+  &-star {
     float: right;
   }
 
-  .fa-star {
-    color: $orange;
+  &-folder {
+    color: $text-color-weak;
   }
 }


### PR DESCRIPTION
Adds the `folderTitle` of the Dashboard to the Dashboard overview on the Grafana home.

fixes #26869