### PR TITLE
Chore: Fix tests for Go 1.15

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -828,7 +828,7 @@ func TestDashboardApiEndpoint(t *testing.T) {
 		bus.AddHandler("test", func(query *models.GetDashboardVersionQuery) error {
 			query.Result = &models.DashboardVersion{
 				Data: simplejson.NewFromAny(map[string]interface{}{
-					"title": "Dash" + string(query.DashboardId),
+					"title": fmt.Sprintf("Dash%d", query.DashboardId),
 				}),
 			}
 			return nil

--- a/pkg/components/gtime/gtime_test.go
+++ b/pkg/components/gtime/gtime_test.go
@@ -23,7 +23,7 @@ func TestParseInterval(t *testing.T) {
 		{interval: "1M", duration: now.Sub(now.AddDate(0, -1, 0))},
 		{interval: "1y", duration: now.Sub(now.AddDate(-1, 0, 0))},
 		{interval: "5y", duration: now.Sub(now.AddDate(-5, 0, 0))},
-		{interval: "invalid-duration", err: regexp.MustCompile(`^time: invalid duration \"invalid-duration\"$`)},
+		{interval: "invalid-duration", err: regexp.MustCompile(`^time: invalid duration "?invalid-duration"?$`)},
 	}
 
 	for i, tc := range tcs {

--- a/pkg/components/gtime/gtime_test.go
+++ b/pkg/components/gtime/gtime_test.go
@@ -2,6 +2,7 @@ package gtime
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ func TestParseInterval(t *testing.T) {
 	tcs := []struct {
 		interval string
 		duration time.Duration
-		err      string
+		err      *regexp.Regexp
 	}{
 		{interval: "1d", duration: now.Sub(now.AddDate(0, 0, -1))},
 		{interval: "1w", duration: now.Sub(now.AddDate(0, 0, -7))},
@@ -22,17 +23,18 @@ func TestParseInterval(t *testing.T) {
 		{interval: "1M", duration: now.Sub(now.AddDate(0, -1, 0))},
 		{interval: "1y", duration: now.Sub(now.AddDate(-1, 0, 0))},
 		{interval: "5y", duration: now.Sub(now.AddDate(-5, 0, 0))},
-		{interval: "invalid-duration", err: "time: invalid duration \"invalid-duration\""},
+		{interval: "invalid-duration", err: regexp.MustCompile(`^time: invalid duration \"invalid-duration\"$`)},
 	}
 
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
 			res, err := ParseInterval(tc.interval)
-			if tc.err == "" {
+			if tc.err == nil {
 				require.NoError(t, err, "interval %q", tc.interval)
 				require.Equal(t, tc.duration, res, "interval %q", tc.interval)
 			} else {
-				require.EqualError(t, err, tc.err, "interval %q", tc.interval)
+				require.Error(t, err, "interval %q", tc.interval)
+				require.Regexp(t, tc.err, err.Error())
 			}
 		})
 	}

--- a/pkg/components/gtime/gtime_test.go
+++ b/pkg/components/gtime/gtime_test.go
@@ -22,7 +22,7 @@ func TestParseInterval(t *testing.T) {
 		{interval: "1M", duration: now.Sub(now.AddDate(0, -1, 0))},
 		{interval: "1y", duration: now.Sub(now.AddDate(-1, 0, 0))},
 		{interval: "5y", duration: now.Sub(now.AddDate(-5, 0, 0))},
-		{interval: "invalid-duration", err: "time: invalid duration invalid-duration"},
+		{interval: "invalid-duration", err: "time: invalid duration \"invalid-duration\""},
 	}
 
 	for i, tc := range tcs {

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -168,7 +168,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 				cmd.Frequency = "invalid duration"
 
 				err := CreateAlertNotificationCommand(cmd)
-				So(err.Error(), ShouldEqual, "time: invalid duration invalid duration")
+				So(err.Error(), ShouldEqual, "time: invalid duration \"invalid duration\"")
 			})
 		})
 
@@ -199,7 +199,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 
 				err := UpdateAlertNotification(updateCmd)
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "time: invalid duration invalid duration")
+				So(err.Error(), ShouldEqual, "time: invalid duration \"invalid duration\"")
 			})
 		})
 

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -2,6 +2,7 @@ package sqlstore
 
 import (
 	"context"
+	"regexp"
 	"testing"
 	"time"
 
@@ -168,7 +169,8 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 				cmd.Frequency = "invalid duration"
 
 				err := CreateAlertNotificationCommand(cmd)
-				So(err.Error(), ShouldEqual, "time: invalid duration \"invalid duration\"")
+				So(regexp.MustCompile(`^time: invalid duration "?invalid duration"?$`).MatchString(
+					err.Error()), ShouldBeTrue)
 			})
 		})
 
@@ -199,7 +201,8 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 
 				err := UpdateAlertNotification(updateCmd)
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "time: invalid duration \"invalid duration\"")
+				So(regexp.MustCompile(`^time: invalid duration "?invalid duration"?$`).MatchString(
+					err.Error()), ShouldBeTrue)
 			})
 		})
 

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"context"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -191,14 +192,14 @@ func test(t *testing.T, dashboardProps DashboardProps, dashboardPermission *Dash
 }
 
 func createDummyUser() (*models.User, error) {
-	uid := rand.Intn(9999999)
+	uid := strconv.Itoa(rand.Intn(9999999))
 	createUserCmd := &models.CreateUserCommand{
-		Email:          string(uid) + "@example.com",
-		Login:          string(uid),
-		Name:           string(uid),
+		Email:          uid + "@example.com",
+		Login:          uid,
+		Name:           uid,
 		Company:        "",
 		OrgName:        "",
-		Password:       string(uid),
+		Password:       uid,
 		EmailVerified:  true,
 		IsAdmin:        false,
 		SkipOrgSetup:   false,


### PR DESCRIPTION
**What this PR does / why we need it**:
Some tests won't compile with Go 1.15, due to programming mistakes (naive conversion of ints to strings). Here are the fixes.
