### PR TITLE
Users: Improve conflict error handling

### DIFF
--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -33,7 +33,7 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) Respon
 
 	if err := bus.Dispatch(&cmd); err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
-			return Error(400, models.ErrOrgNotFound.Error(), nil)
+			return Error(400, err.Error(), nil)
 		}
 
 		if errors.Is(err, models.ErrUserAlreadyExists) {

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -31,11 +32,11 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) Respon
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		if err == models.ErrOrgNotFound {
+		if errors.Is(err, models.ErrOrgNotFound) {
 			return Error(400, models.ErrOrgNotFound.Error(), nil)
 		}
 
-		if err == models.ErrUserAlreadyExists {
+		if errors.Is(err, models.ErrUserAlreadyExists) {
 			return Error(412, fmt.Sprintf("User with email '%s' or username '%s' already exists", form.Email, form.Login), err)
 		}
 

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -36,7 +36,7 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) Respon
 		}
 
 		if err == models.ErrUserAlreadyExists {
-			return Error(412, fmt.Sprintf("User with email %s and/or login %s already exists", form.Email, form.Login), err)
+			return Error(412, fmt.Sprintf("User with email '%s' or username '%s' already exists", form.Email, form.Login), err)
 		}
 
 		return Error(500, "failed to create user", err)

--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -31,6 +33,10 @@ func AdminCreateUser(c *models.ReqContext, form dtos.AdminCreateUserForm) Respon
 	if err := bus.Dispatch(&cmd); err != nil {
 		if err == models.ErrOrgNotFound {
 			return Error(400, models.ErrOrgNotFound.Error(), nil)
+		}
+
+		if err == models.ErrUserAlreadyExists {
+			return Error(412, fmt.Sprintf("User with email %s and/or login %s already exists", form.Email, form.Login), err)
 		}
 
 		return Error(500, "failed to create user", err)

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -260,7 +260,7 @@ func TestAdminApiEndpoint(t *testing.T) {
 		})
 	})
 
-	Convey("When a server admin attempts to create a user with an already existing email / login", t, func() {
+	Convey("When a server admin attempts to create a user with an already existing email/login", t, func() {
 		bus.AddHandler("test", func(cmd *models.CreateUserCommand) error {
 			return models.ErrUserAlreadyExists
 		})

--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -259,6 +259,26 @@ func TestAdminApiEndpoint(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("When a server admin attempts to create a user with an already existing email / login", t, func() {
+		bus.AddHandler("test", func(cmd *models.CreateUserCommand) error {
+			return models.ErrUserAlreadyExists
+		})
+
+		createCmd := dtos.AdminCreateUserForm{
+			Login:    TestLogin,
+			Password: TestPassword,
+		}
+
+		adminCreateUserScenario("Should return an error", "/api/admin/users", "/api/admin/users", createCmd, func(sc *scenarioContext) {
+			sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
+			So(sc.resp.Code, ShouldEqual, 412)
+
+			respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
+			So(err, ShouldBeNil)
+			So(respJSON.Get("error").MustString(), ShouldEqual, "User already exists")
+		})
+	})
 }
 
 func putAdminScenario(desc string, url string, routePattern string, role models.RoleType, cmd dtos.AdminUpdateUserPermissionsForm, fn scenarioFunc) {

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -81,6 +82,7 @@ func AddOrgInvite(c *models.ReqContext, inviteDto dtos.AddInviteForm) Response {
 			if err == models.ErrSmtpNotEnabled {
 				return Error(412, err.Error(), err)
 			}
+
 			return Error(500, "Failed to send email invite", err)
 		}
 
@@ -181,6 +183,10 @@ func (hs *HTTPServer) CompleteInvite(c *models.ReqContext, completeInvite dtos.C
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
+		if errors.Is(err, models.ErrUserAlreadyExists) {
+			return Error(412, fmt.Sprintf("User with email '%s' or username '%s' already exists", completeInvite.Email, completeInvite.Username), err)
+		}
+
 		return Error(500, "failed to create user", err)
 	}
 

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -7,8 +7,9 @@ import (
 
 // Typed errors
 var (
-	ErrUserNotFound     = errors.New("User not found")
-	ErrLastGrafanaAdmin = errors.New("Cannot remove last grafana admin")
+	ErrUserNotFound      = errors.New("User not found")
+	ErrUserAlreadyExists = errors.New("User already exists")
+	ErrLastGrafanaAdmin  = errors.New("Cannot remove last grafana admin")
 )
 
 type Password string

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -68,6 +68,11 @@ func CreateUser(ctx context.Context, cmd *models.CreateUserCommand) error {
 			cmd.Email = cmd.Login
 		}
 
+		exists, _ := sess.Where("email=? OR login=?", cmd.Email, cmd.Login).Get(&models.User{})
+		if exists {
+			return models.ErrUserAlreadyExists
+		}
+
 		// create user
 		user := models.User{
 			Email:         cmd.Email,

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -541,28 +541,6 @@ func TestUserDataAccess(t *testing.T) {
 					}
 				})
 			})
-
-			Convey("When trying to create a new user with an existing email, an error is returned", func() {
-				createUserCmd := &models.CreateUserCommand{
-					Email:        "user2@test.com",
-					Name:         "user2",
-					Login:        "user2",
-					SkipOrgSetup: true,
-				}
-				err := CreateUser(context.Background(), createUserCmd)
-				So(err, ShouldEqual, models.ErrUserAlreadyExists)
-			})
-
-			Convey("When creating a new user with an already existing login returns error", func() {
-				createUserCmd := &models.CreateUserCommand{
-					Email:        "user-2@test.com",
-					Name:         "user2",
-					Login:        "loginuser2",
-					SkipOrgSetup: true,
-				}
-				err := CreateUser(context.Background(), createUserCmd)
-				So(err, ShouldEqual, models.ErrUserAlreadyExists)
-			})
 		})
 
 		Convey("Given one grafana admin user", func() {
@@ -588,6 +566,39 @@ func TestUserDataAccess(t *testing.T) {
 				So(getUserError, ShouldBeNil)
 
 				So(query.Result.IsAdmin, ShouldEqual, true)
+			})
+		})
+
+		Convey("Given one user", func() {
+			var err error
+			createUserCmd := &models.CreateUserCommand{
+				Email: fmt.Sprint("user", "@test.com"),
+				Name:  "user",
+				Login: "user",
+			}
+			err = CreateUser(context.Background(), createUserCmd)
+			So(err, ShouldBeNil)
+
+			Convey("When trying to create a new user with the same email, an error is returned", func() {
+				createUserCmd := &models.CreateUserCommand{
+					Email:        fmt.Sprint("user", "@test.com"),
+					Name:         "user2",
+					Login:        "user2",
+					SkipOrgSetup: true,
+				}
+				err := CreateUser(context.Background(), createUserCmd)
+				So(err, ShouldEqual, models.ErrUserAlreadyExists)
+			})
+
+			Convey("When trying to create a new user with the same login, an error is returned", func() {
+				createUserCmd := &models.CreateUserCommand{
+					Email:        fmt.Sprint("user2", "@test.com"),
+					Name:         "user2",
+					Login:        "user",
+					SkipOrgSetup: true,
+				}
+				err := CreateUser(context.Background(), createUserCmd)
+				So(err, ShouldEqual, models.ErrUserAlreadyExists)
 			})
 		})
 	})

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -570,18 +570,17 @@ func TestUserDataAccess(t *testing.T) {
 		})
 
 		Convey("Given one user", func() {
-			var err error
 			createUserCmd := &models.CreateUserCommand{
-				Email: fmt.Sprint("user", "@test.com"),
+				Email: "user@test.com",
 				Name:  "user",
 				Login: "user",
 			}
-			err = CreateUser(context.Background(), createUserCmd)
+			err := CreateUser(context.Background(), createUserCmd)
 			So(err, ShouldBeNil)
 
 			Convey("When trying to create a new user with the same email, an error is returned", func() {
 				createUserCmd := &models.CreateUserCommand{
-					Email:        fmt.Sprint("user", "@test.com"),
+					Email:        "user@test.com",
 					Name:         "user2",
 					Login:        "user2",
 					SkipOrgSetup: true,
@@ -592,7 +591,7 @@ func TestUserDataAccess(t *testing.T) {
 
 			Convey("When trying to create a new user with the same login, an error is returned", func() {
 				createUserCmd := &models.CreateUserCommand{
-					Email:        fmt.Sprint("user2", "@test.com"),
+					Email:        "user2@test.com",
 					Name:         "user2",
 					Login:        "user",
 					SkipOrgSetup: true,

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -570,17 +570,19 @@ func TestUserDataAccess(t *testing.T) {
 		})
 
 		Convey("Given one user", func() {
+			const email = "user@test.com"
+			const username = "user"
 			createUserCmd := &models.CreateUserCommand{
-				Email: "user@test.com",
+				Email: email,
 				Name:  "user",
-				Login: "user",
+				Login: username,
 			}
 			err := CreateUser(context.Background(), createUserCmd)
 			So(err, ShouldBeNil)
 
 			Convey("When trying to create a new user with the same email, an error is returned", func() {
 				createUserCmd := &models.CreateUserCommand{
-					Email:        "user@test.com",
+					Email:        email,
 					Name:         "user2",
 					Login:        "user2",
 					SkipOrgSetup: true,
@@ -593,7 +595,7 @@ func TestUserDataAccess(t *testing.T) {
 				createUserCmd := &models.CreateUserCommand{
 					Email:        "user2@test.com",
 					Name:         "user2",
-					Login:        "user",
+					Login:        username,
 					SkipOrgSetup: true,
 				}
 				err := CreateUser(context.Background(), createUserCmd)

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -541,6 +541,28 @@ func TestUserDataAccess(t *testing.T) {
 					}
 				})
 			})
+
+			Convey("When creating a new user with an already existing email returns error", func() {
+				createUserCmd := &models.CreateUserCommand{
+					Email:        "user2@test.com",
+					Name:         "user2",
+					Login:        "user2",
+					SkipOrgSetup: true,
+				}
+				err := CreateUser(context.Background(), createUserCmd)
+				So(err, ShouldEqual, models.ErrUserAlreadyExists)
+			})
+
+			Convey("When creating a new user with an already existing login returns error", func() {
+				createUserCmd := &models.CreateUserCommand{
+					Email:        "user-2@test.com",
+					Name:         "user2",
+					Login:        "loginuser2",
+					SkipOrgSetup: true,
+				}
+				err := CreateUser(context.Background(), createUserCmd)
+				So(err, ShouldEqual, models.ErrUserAlreadyExists)
+			})
 		})
 
 		Convey("Given one grafana admin user", func() {

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -542,7 +542,7 @@ func TestUserDataAccess(t *testing.T) {
 				})
 			})
 
-			Convey("When creating a new user with an already existing email returns error", func() {
+			Convey("When trying to create a new user with an existing email, an error is returned", func() {
 				createUserCmd := &models.CreateUserCommand{
 					Email:        "user2@test.com",
 					Name:         "user2",


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when an admin tries to create a new user with an already existing email / login, it returns a `500 Internal Server Error` with the ORM error text. So, the idea of this PR is to handle these situations properly and return a meaningful error.

**Which issue(s) this PR fixes**:

Fixes #26934

**Special notes for your reviewer**:
- Even though the issue's author requested to return a `409 Conflict`, I preferred to return the `412 Precondition Failed` because we're already returning that HTTP status code for very similar cases (i.e. trying to invite a user with an already existing email / login), so IMHO I'd try to keep the coherency among all of these cases.
- Both cases (already existing email / login) are handled as the same error because IMHO it does not worth it to have them divided (I prefer to keep it as simple as possible).
