### PR TITLE
Loki: Fix refresh on time range change for template variable queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -16,6 +16,17 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => backendSrv,
 }));
 
+jest.mock('app/features/dashboard/services/TimeSrv', () => {
+  return {
+    getTimeSrv: () => ({
+      timeRange: () => ({
+        from: new Date(0),
+        to: new Date(1),
+      }),
+    }),
+  };
+});
+
 const datasourceRequestMock = jest.spyOn(backendSrv, 'datasourceRequest');
 
 describe('LokiDatasource', () => {
@@ -440,6 +451,19 @@ describe('LokiDatasource', () => {
         const query = 'incorrect_query';
         const res = await ds.metricFindQuery(query);
         expect(res.length).toBe(0);
+      });
+    });
+
+    mocks.forEach((mock, index) => {
+      it(`should return label names according to provided rangefor Loki v${index} `, async () => {
+        ds.getVersion = mock.getVersion;
+        ds.metadataRequest = mock.metadataRequest;
+        const query = 'label_names()';
+        const res = await ds.metricFindQuery(query, {
+          range: { from: new Date(2), to: new Date(3) },
+        });
+        expect(res[0].text).toEqual('label1');
+        expect(res.length).toBe(1);
       });
     });
   });

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -25,6 +25,10 @@ export function makeMockLokiDatasource(labelsAndValues: Labels, series?: SeriesF
   return {
     metadataRequest: (url: string, params?: { [key: string]: string }) => {
       if (url === lokiLabelsEndpoint) {
+        //To test custom time ranges
+        if (Number(params?.start) > 1000001) {
+          return [labels[0]];
+        }
         return labels;
       } else {
         const labelsMatch = url.match(lokiLabelsAndValuesEndpointRegex);

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -26,7 +26,7 @@ export function makeMockLokiDatasource(labelsAndValues: Labels, series?: SeriesF
     metadataRequest: (url: string, params?: { [key: string]: string }) => {
       if (url === lokiLabelsEndpoint) {
         //To test custom time ranges
-        if (Number(params?.start) > 1000001) {
+        if (Number(params?.start) === 2000000) {
           return [labels[0]];
         }
         return labels;


### PR DESCRIPTION
**What this PR does / why we need it**:

We weren't passing time range to `metricFindQuery` and therefore it was always running the same query for each time range refresh/change - which according to [docs](https://grafana.com/docs/loki/latest/api/#get-lokiapiv1labels) is between now and 6 hours ago. This PR fixes it and passes timerange to each request. 

https://github.com/grafana/grafana/issues/26213#issuecomment-672531167

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/26943

