### PR TITLE
OAuth: Handle DEFLATE compressed payloads in JWT for Generic OAuth

### DIFF
--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -218,7 +218,11 @@ func (s *SocialGenericOAuth) extractFromToken(token *oauth2.Token) *UserInfoJson
 	}
 
 	var header map[string]string
-	err = json.Unmarshal(headerBytes, &header)
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		s.log.Error("Error deserializing header", "error", err)
+		return nil
+	}
+
 	if compression, ok := header["zip"]; ok {
 		if compression == "DEF" {
 			fr, err := zlib.NewReader(bytes.NewReader(rawJSON))
@@ -233,7 +237,7 @@ func (s *SocialGenericOAuth) extractFromToken(token *oauth2.Token) *UserInfoJson
 				return nil
 			}
 		} else {
-			s.log.Error("Unknown compression algorithm", "algorithm", compression)
+			s.log.Warn("Unknown compression algorithm", "algorithm", compression)
 			return nil
 		}
 	}

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -224,20 +224,20 @@ func (s *SocialGenericOAuth) extractFromToken(token *oauth2.Token) *UserInfoJson
 	}
 
 	if compression, ok := header["zip"]; ok {
-		if compression == "DEF" {
-			fr, err := zlib.NewReader(bytes.NewReader(rawJSON))
-			if err != nil {
-				s.log.Error("Error creating zlib reader", "error", err)
-				return nil
-			}
-			defer fr.Close()
-			rawJSON, err = ioutil.ReadAll(fr)
-			if err != nil {
-				s.log.Error("Error decompressing payload", "error", err)
-				return nil
-			}
-		} else {
+		if compression != "DEF" {
 			s.log.Warn("Unknown compression algorithm", "algorithm", compression)
+			return nil
+		}
+
+		fr, err := zlib.NewReader(bytes.NewReader(rawJSON))
+		if err != nil {
+			s.log.Error("Error creating zlib reader", "error", err)
+			return nil
+		}
+		defer fr.Close()
+		rawJSON, err = ioutil.ReadAll(fr)
+		if err != nil {
+			s.log.Error("Error decompressing payload", "error", err)
 			return nil
 		}
 	}

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"io/ioutil"
 	"net/http"
 	"net/mail"
@@ -16,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/util/errutil"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -194,6 +194,26 @@ func TestUserInfoSearchesForEmailAndRole(t *testing.T) {
 				ExpectedRole:      "Admin",
 			},
 			{
+				Name: "Given a valid GZIP compressed id_token, a valid role path, no API response, use id_token",
+				OAuth2Extra: map[string]interface{}{
+					// { "role": "Admin", "email": "john.doe@example.com" }
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkdaSVAifQ.H4sIAAAAAAAAAKtWSs1NzMxRslLKys_I00vJT3VIrUjMLchJ1UvOz1XSUSrKz0kFyjqm5GbmKdUCANotxTkvAAAA.85AXm3JOF5qflEA0goDFvlbZl2q3eFvqVcehz860W-o",
+				},
+				RoleAttributePath: "role",
+				ExpectedEmail:     "john.doe@example.com",
+				ExpectedRole:      "Admin",
+			},
+			{
+				Name: "Given a valid DEFLATE compressed id_token, a valid role path, no API response, use id_token",
+				OAuth2Extra: map[string]interface{}{
+					// { "role": "Admin", "email": "john.doe@example.com" }
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkdaSVAifQ.H4sIAAAAAAAAAKtWSs1NzMxRslLKys_I00vJT3VIrUjMLchJ1UvOz1XSUSrKz0kFyjqm5GbmKdUCANotxTkvAAAA.85AXm3JOF5qflEA0goDFvlbZl2q3eFvqVcehz860W-o",
+				},
+				RoleAttributePath: "role",
+				ExpectedEmail:     "john.doe@example.com",
+				ExpectedRole:      "Admin",
+			},
+			{
 				Name: "Given a valid id_token, no role path, no API response, use id_token",
 				OAuth2Extra: map[string]interface{}{
 					// { "email": "john.doe@example.com" }

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -429,66 +429,65 @@ func TestUserInfoSearchesForLogin(t *testing.T) {
 }
 
 func TestPayloadCompression(t *testing.T) {
-	t.Run("Given a generic OAuth provider", func(t *testing.T) {
-		provider := SocialGenericOAuth{
-			SocialBase: &SocialBase{
-				log: log.NewWithLevel("generic_oauth_test", log15.LvlDebug),
-			},
-			emailAttributePath: "email",
-		}
+	provider := SocialGenericOAuth{
+		SocialBase: &SocialBase{
+			log: log.NewWithLevel("generic_oauth_test", log15.LvlDebug),
+		},
+		emailAttributePath: "email",
+	}
 
-		tests := []struct {
-			Name          string
-			OAuth2Extra   interface{}
-			ExpectResult  bool
-			ExpectedEmail string
-		}{
-			{
-				Name: "Given a valid DEFLATE compressed id_token, return userInfo",
-				OAuth2Extra: map[string]interface{}{
-					// { "role": "Admin", "email": "john.doe@example.com" }
-					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkRFRiJ9.eJyrVkrNTczMUbJSysrPyNNLyU91SK1IzC3ISdVLzs9V0lEqys9JBco6puRm5inVAgCFRw_6.XrV4ZKhw19dTcnviXanBD8lwjeALCYtDiESMmGzC-ho",
-				},
-				ExpectResult:  true,
-				ExpectedEmail: "john.doe@example.com",
+	tests := []struct {
+		Name          string
+		OAuth2Extra   interface{}
+		ExpectResult  bool
+		ExpectedEmail string
+	}{
+		{
+			Name: "Given a valid DEFLATE compressed id_token, return userInfo",
+			OAuth2Extra: map[string]interface{}{
+				// { "role": "Admin", "email": "john.doe@example.com" }
+				"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkRFRiJ9.eJyrVkrNTczMUbJSysrPyNNLyU91SK1IzC3ISdVLzs9V0lEqys9JBco6puRm5inVAgCFRw_6.XrV4ZKhw19dTcnviXanBD8lwjeALCYtDiESMmGzC-ho",
 			},
-			{
-				Name: "Given an invalid DEFLATE compressed id_token, return nil",
-				OAuth2Extra: map[string]interface{}{
-					// { "role": "Admin", "email": "john.doe@example.com" }
-					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkRFRiJ9.00eJyrVkrNTczMUbJSysrPyNNLyU91SK1IzC3ISdVLzs9V0lEqys9JBco6puRm5inVAgCFRw_6.XrV4ZKhw19dTcnviXanBD8lwjeALCYtDiESMmGzC-ho",
-				},
-				ExpectResult: false,
+			ExpectResult:  true,
+			ExpectedEmail: "john.doe@example.com",
+		},
+		{
+			Name: "Given an invalid DEFLATE compressed id_token, return nil",
+			OAuth2Extra: map[string]interface{}{
+				// { "role": "Admin", "email": "john.doe@example.com" }
+				"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkRFRiJ9.00eJyrVkrNTczMUbJSysrPyNNLyU91SK1IzC3ISdVLzs9V0lEqys9JBco6puRm5inVAgCFRw_6.XrV4ZKhw19dTcnviXanBD8lwjeALCYtDiESMmGzC-ho",
 			},
-			{
-				Name: "Given an unsupported GZIP compressed id_token, return nil",
-				OAuth2Extra: map[string]interface{}{
-					// { "role": "Admin", "email": "john.doe@example.com" }
-					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkdaSVAifQ.H4sIAAAAAAAAAKtWSs1NzMxRslLKys_I00vJT3VIrUjMLchJ1UvOz1XSUSrKz0kFyjqm5GbmKdUCANotxTkvAAAA.85AXm3JOF5qflEA0goDFvlbZl2q3eFvqVcehz860W-o",
-				},
-				ExpectResult: false,
+			ExpectResult: false,
+		},
+		{
+			Name: "Given an unsupported GZIP compressed id_token, return nil",
+			OAuth2Extra: map[string]interface{}{
+				// { "role": "Admin", "email": "john.doe@example.com" }
+				"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkdaSVAifQ.H4sIAAAAAAAAAKtWSs1NzMxRslLKys_I00vJT3VIrUjMLchJ1UvOz1XSUSrKz0kFyjqm5GbmKdUCANotxTkvAAAA.85AXm3JOF5qflEA0goDFvlbZl2q3eFvqVcehz860W-o",
 			},
-		}
+			ExpectResult: false,
+		},
+	}
 
-		for _, test := range tests {
-			t.Run(test.Name, func(t *testing.T) {
-				staticToken := oauth2.Token{
-					AccessToken:  "",
-					TokenType:    "",
-					RefreshToken: "",
-					Expiry:       time.Now(),
-				}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			staticToken := oauth2.Token{
+				AccessToken:  "",
+				TokenType:    "",
+				RefreshToken: "",
+				Expiry:       time.Now(),
+			}
 
-				token := staticToken.WithExtra(test.OAuth2Extra)
-				userInfo := provider.extractFromToken(token)
+			token := staticToken.WithExtra(test.OAuth2Extra)
+			userInfo := provider.extractFromToken(token)
 
-				if test.ExpectResult == true {
-					require.NotNil(t, userInfo, "Testing case %q", test.Name)
-					require.Equal(t, test.ExpectedEmail, userInfo.Email)
-				} else {
-					require.Nil(t, userInfo, "Testing case %q", test.Name)
-				}
-			})
-		}
-	})
+			if test.ExpectResult == true {
+				require.NotNil(t, userInfo, "Testing case %q", test.Name)
+				require.Equal(t, test.ExpectedEmail, userInfo.Email)
+			} else {
+				require.Nil(t, userInfo, "Testing case %q", test.Name)
+			}
+		})
+	}
+
 }

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -489,5 +489,4 @@ func TestPayloadCompression(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -439,7 +439,6 @@ func TestPayloadCompression(t *testing.T) {
 	tests := []struct {
 		Name          string
 		OAuth2Extra   interface{}
-		ExpectResult  bool
 		ExpectedEmail string
 	}{
 		{
@@ -448,7 +447,6 @@ func TestPayloadCompression(t *testing.T) {
 				// { "role": "Admin", "email": "john.doe@example.com" }
 				"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkRFRiJ9.eJyrVkrNTczMUbJSysrPyNNLyU91SK1IzC3ISdVLzs9V0lEqys9JBco6puRm5inVAgCFRw_6.XrV4ZKhw19dTcnviXanBD8lwjeALCYtDiESMmGzC-ho",
 			},
-			ExpectResult:  true,
 			ExpectedEmail: "john.doe@example.com",
 		},
 		{
@@ -457,7 +455,7 @@ func TestPayloadCompression(t *testing.T) {
 				// { "role": "Admin", "email": "john.doe@example.com" }
 				"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkRFRiJ9.00eJyrVkrNTczMUbJSysrPyNNLyU91SK1IzC3ISdVLzs9V0lEqys9JBco6puRm5inVAgCFRw_6.XrV4ZKhw19dTcnviXanBD8lwjeALCYtDiESMmGzC-ho",
 			},
-			ExpectResult: false,
+			ExpectedEmail: "",
 		},
 		{
 			Name: "Given an unsupported GZIP compressed id_token, return nil",
@@ -465,7 +463,7 @@ func TestPayloadCompression(t *testing.T) {
 				// { "role": "Admin", "email": "john.doe@example.com" }
 				"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsInppcCI6IkdaSVAifQ.H4sIAAAAAAAAAKtWSs1NzMxRslLKys_I00vJT3VIrUjMLchJ1UvOz1XSUSrKz0kFyjqm5GbmKdUCANotxTkvAAAA.85AXm3JOF5qflEA0goDFvlbZl2q3eFvqVcehz860W-o",
 			},
-			ExpectResult: false,
+			ExpectedEmail: "",
 		},
 	}
 
@@ -481,11 +479,11 @@ func TestPayloadCompression(t *testing.T) {
 			token := staticToken.WithExtra(test.OAuth2Extra)
 			userInfo := provider.extractFromToken(token)
 
-			if test.ExpectResult == true {
+			if test.ExpectedEmail == "" {
+				require.Nil(t, userInfo, "Testing case %q", test.Name)
+			} else {
 				require.NotNil(t, userInfo, "Testing case %q", test.Name)
 				require.Equal(t, test.ExpectedEmail, userInfo.Email)
-			} else {
-				require.Nil(t, userInfo, "Testing case %q", test.Name)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #26967

If the JWT header indicates zip=DEF, then the JWT payload needs to be uncompressed after base64 decode and before unmarshalling to the UserInfoJson struct.

OAuth2 token providers can choose to compress the payload portion of the JWT and this change would improve the generic OAuth2 implementation's compliance with the standard.

Added cases to an existing unit test to verify that DEF code path works.

