### PR TITLE
Chore: Use theme-specific color gradient for active tab header

### DIFF
--- a/packages/grafana-data/src/types/theme.ts
+++ b/packages/grafana-data/src/types/theme.ts
@@ -240,6 +240,10 @@ export interface GrafanaTheme extends GrafanaThemeCommons {
     formCheckboxBgChecked: string;
     formCheckboxBgCheckedHover: string;
     formCheckboxCheckmark: string;
+
+    // Active Tab Header Color
+    tabHeaderGradientStart: string;
+    tabHeaderGradientEnd: string;
   };
   shadows: {
     listItem: string;

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -97,7 +97,7 @@ const getTabStyles = stylesFactory((theme: GrafanaTheme) => {
         right: 0;
         height: 2px;
         top: 0;
-        background-image: linear-gradient(to right, #f05a28 30%, #fbca0a 99%);
+        background-image: linear-gradient(to right, ${colors.tabHeaderGradientStart}, ${colors.tabHeaderGradientEnd});
       }
     `,
   };

--- a/packages/grafana-ui/src/themes/dark.ts
+++ b/packages/grafana-ui/src/themes/dark.ts
@@ -126,6 +126,9 @@ const darkTheme: GrafanaTheme = {
     linkDisabled: basicColors.gray2,
     linkHover: basicColors.white,
     linkExternal: basicColors.blue85,
+
+    tabHeaderGradientStart: '#f05a28 30%',
+    tabHeaderGradientEnd: '#fbca0a 99%',
   },
   shadows: {
     listItem: 'none',

--- a/packages/grafana-ui/src/themes/light.ts
+++ b/packages/grafana-ui/src/themes/light.ts
@@ -127,6 +127,9 @@ const lightTheme: GrafanaTheme = {
     linkHover: textColors.textStrong,
     linkExternal: basicColors.blue85,
     textHeading: basicColors.gray25,
+
+    tabHeaderGradientStart: basicColors.blue80,
+    tabHeaderGradientEnd: basicColors.blue77,
   },
   shadows: {
     listItem: 'none',


### PR DESCRIPTION
This is a change for the Grafana UI.

## Change

The active tab header color is hardcoded in the Tab component. This PR makes the tab header color theme-specific by adding two additional variables to the theme and using their values in the Tab component.