### PR TITLE
Alerting: Increase PagerDuty dedup_key complexity

### DIFF
--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -99,6 +99,10 @@ func (c *EvalContext) GetNotificationTitle() string {
 
 // GetDashboardUID returns the dashboard uid for the alert rule.
 func (c *EvalContext) GetDashboardUID() (*models.DashboardRef, error) {
+	if c.IsTestRun {
+		return &models.DashboardRef{Uid: "testUID"}, nil
+	}
+
 	if c.dashboardRef != nil {
 		return c.dashboardRef, nil
 	}

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -1,8 +1,8 @@
 package notifiers
 
 import (
+	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -225,7 +225,7 @@ func (pn *PagerdutyNotifier) buildEventPayload(evalContext *alerting.EvalContext
 		pn.log.Error("Failed get dashboard reference", "error", err)
 		return []byte{}, err
 	}
-	
+
 	dedupKey := fmt.Sprintf("alertId-%d-%d-%d", evalContext.Rule.ID, evalContext.Rule.PanelID, dashboardRef.Uid)
 	if len(dedupKey) > 255 {
 		dedupKey = dedupKey[0:254]

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -220,14 +220,13 @@ func (pn *PagerdutyNotifier) buildEventPayload(evalContext *alerting.EvalContext
 	bodyJSON := simplejson.New()
 	bodyJSON.Set("routing_key", pn.Key)
 	bodyJSON.Set("event_action", eventType)
-	dedupKey := "alertId-" + strconv.FormatInt(evalContext.Rule.ID, 10) +
-		"-" + strconv.FormatInt(evalContext.Rule.PanelID, 10)
 	dashboardRef, err := evalContext.GetDashboardUID()
 	if err != nil {
 		pn.log.Error("Failed get dashboard reference", "error", err)
 		return []byte{}, err
 	}
-	dedupKey += "-" + dashboardRef.Uid
+	
+	dedupKey := fmt.Sprintf("alertId-%d-%d-%d", evalContext.Rule.ID, evalContext.Rule.PanelID, dashboardRef.Uid)
 	if len(dedupKey) > 255 {
 		dedupKey = dedupKey[0:254]
 	}

--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -226,7 +226,7 @@ func (pn *PagerdutyNotifier) buildEventPayload(evalContext *alerting.EvalContext
 		return []byte{}, err
 	}
 
-	dedupKey := fmt.Sprintf("alertId-%d-%d-%d", evalContext.Rule.ID, evalContext.Rule.PanelID, dashboardRef.Uid)
+	dedupKey := fmt.Sprintf("alertId-%d-%d-%s", evalContext.Rule.ID, evalContext.Rule.PanelID, dashboardRef.Uid)
 	if len(dedupKey) > 255 {
 		dedupKey = dedupKey[0:254]
 	}

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -134,6 +134,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				pagerdutyNotifier := not.(*PagerdutyNotifier)
 				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
 					ID:      0,
+					PanelID: 1,
 					Name:    "someRule",
 					Message: "someMessage",
 					State:   models.AlertStateAlerting,
@@ -148,7 +149,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				diff := cmp.Diff(map[string]interface{}{
 					"client":       "Grafana",
 					"client_url":   "",
-					"dedup_key":    "alertId-0",
+					"dedup_key":    "alertId-0-1-testUID",
 					"event_action": "trigger",
 					"links": []interface{}{
 						map[string]interface{}{
@@ -190,6 +191,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				pagerdutyNotifier := not.(*PagerdutyNotifier)
 				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
 					ID:      0,
+					PanelID: 1,
 					Name:    "someRule",
 					Message: "someMessage",
 					State:   models.AlertStateAlerting,
@@ -213,7 +215,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				diff := cmp.Diff(map[string]interface{}{
 					"client":       "Grafana",
 					"client_url":   "",
-					"dedup_key":    "alertId-0",
+					"dedup_key":    "alertId-0-1-testUID",
 					"event_action": "trigger",
 					"links": []interface{}{
 						map[string]interface{}{
@@ -260,6 +262,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 
 				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
 					ID:      0,
+					PanelID: 1,
 					Name:    "someRule",
 					Message: "someMessage",
 					State:   models.AlertStateAlerting,
@@ -282,7 +285,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				diff := cmp.Diff(map[string]interface{}{
 					"client":       "Grafana",
 					"client_url":   "",
-					"dedup_key":    "alertId-0",
+					"dedup_key":    "alertId-0-1-testUID",
 					"event_action": "trigger",
 					"links": []interface{}{
 						map[string]interface{}{
@@ -337,6 +340,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 
 				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
 					ID:      0,
+					PanelID: 1,
 					Name:    "someRule",
 					Message: "someMessage",
 					State:   models.AlertStateAlerting,
@@ -359,7 +363,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				diff := cmp.Diff(map[string]interface{}{
 					"client":       "Grafana",
 					"client_url":   "",
-					"dedup_key":    "alertId-0",
+					"dedup_key":    "alertId-0-1-testUID",
 					"event_action": "trigger",
 					"links": []interface{}{
 						map[string]interface{}{
@@ -415,6 +419,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 
 				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
 					ID:      0,
+					PanelID: 1,
 					Name:    "someRule",
 					Message: "someMessage",
 					State:   models.AlertStateAlerting,
@@ -437,7 +442,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				diff := cmp.Diff(map[string]interface{}{
 					"client":       "Grafana",
 					"client_url":   "",
-					"dedup_key":    "alertId-0",
+					"dedup_key":    "alertId-0-1-testUID",
 					"event_action": "trigger",
 					"links": []interface{}{
 						map[string]interface{}{


### PR DESCRIPTION
 - Updated dedup_key generation scheme

 - Updated UT's

**What this PR does / why we need it**:

Changes from this PR  should avoid incorrect PagerDuty incidents de-duplication. 

**Which issue(s) this PR fixes**:
This has been raised to fix Grafana issue [#26863 ](https://github.com/grafana/grafana/issues/26863)
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26863 

**Special notes for your reviewer**:
Currently, alerts haven't got generated UID, for this reason, I've used the corresponding dashboard UID. Since dashboard UID could be overridden by custom UID, the mentioned issue could be faced.  
