### PR TITLE
Dashboard: Panel menu no longer lingers

### DIFF
--- a/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
+++ b/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
@@ -25,17 +25,17 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    window.addEventListener('click', this.onOutsideClick, false);
+    document.addEventListener('click', this.onOutsideClick, false);
     if (this.props.includeButtonPress) {
       // Use keyup since keydown already has an eventlistener on window
-      window.addEventListener('keyup', this.onOutsideClick, false);
+      document.addEventListener('keyup', this.onOutsideClick, false);
     }
   }
 
   componentWillUnmount() {
-    window.removeEventListener('click', this.onOutsideClick, false);
+    document.removeEventListener('click', this.onOutsideClick, false);
     if (this.props.includeButtonPress) {
-      window.removeEventListener('keyup', this.onOutsideClick, false);
+      document.removeEventListener('keyup', this.onOutsideClick, false);
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes `ClickOutsideWrapper` so we listen on `document` rather than `window`, fixing an issue where menu panels would linger as detailed in #26306

**Which issue(s) this PR fixes**:
Closes #26306
