### PR TITLE
Chore: Use `--no-cache-dir` flag to `pip` in Dockerfiles, to save space

### DIFF
--- a/devenv/docker/blocks/collectd/Dockerfile
+++ b/devenv/docker/blocks/collectd/Dockerfile
@@ -10,7 +10,7 @@ ADD     etc_mtab /etc/mtab
 
 ADD     collectd.conf.tpl /etc/collectd/collectd.conf.tpl
 
-RUN	pip install envtpl
+RUN	pip install --no-cache-dir envtpl
 ADD     start_container /usr/bin/start_container
 RUN     chmod +x /usr/bin/start_container
 CMD     start_container

--- a/devenv/docker/blocks/graphite1/Dockerfile
+++ b/devenv/docker/blocks/graphite1/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ ! -z "${CONTAINER_TIMEZONE}" ]; \
 
 # fix python dependencies (LTS Django and newer memcached/txAMQP)
 RUN pip install --upgrade pip && \
-  pip install django==1.8.18 \
+  pip install --no-cache-dir django==1.8.18 \
   python-memcached==1.53 \
   txAMQP==0.6.2
 
@@ -62,13 +62,13 @@ RUN python ./setup.py install
 # install carbon
 RUN git clone -b ${carbon_version} --depth 1 ${carbon_repo} /usr/local/src/carbon
 WORKDIR /usr/local/src/carbon
-RUN pip install -r requirements.txt \
+RUN pip install --no-cache-dir -r requirements.txt \
   && python ./setup.py install
 
 # install graphite
 RUN git clone -b ${graphite_version} --depth 1 ${graphite_repo} /usr/local/src/graphite-web
 WORKDIR /usr/local/src/graphite-web
-RUN pip install -r requirements.txt \
+RUN pip install --no-cache-dir -r requirements.txt \
   && python ./setup.py install
 
 # install statsd


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>
