### PR TITLE
Playlists: Remove API validation for empty playlists and remove redundant API call

### DIFF
--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"net/http"
-
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 )
@@ -24,18 +22,6 @@ func ValidateOrgPlaylist(c *models.ReqContext) {
 
 	if query.Result.OrgId != c.OrgId {
 		c.JsonApiErr(403, "You are not allowed to edit/view playlist", nil)
-		return
-	}
-
-	items, itemsErr := LoadPlaylistItemDTOs(id)
-
-	if itemsErr != nil {
-		c.JsonApiErr(404, "Playlist items not found", err)
-		return
-	}
-
-	if len(items) == 0 && c.Context.Req.Method != http.MethodDelete {
-		c.JsonApiErr(404, "Playlist is empty", itemsErr)
 		return
 	}
 }

--- a/public/app/features/playlist/playlist_edit_ctrl.ts
+++ b/public/app/features/playlist/playlist_edit_ctrl.ts
@@ -46,14 +46,7 @@ export class PlaylistEditCtrl {
           .get('/api/playlists/' + playlistId)
           .then((result: any) => {
             this.playlist = result;
-          })
-      );
-
-      promiseToDigest(this.$scope)(
-        getBackendSrv()
-          .get('/api/playlists/' + playlistId + '/items')
-          .then((result: any) => {
-            this.playlistItems = result;
+            this.playlistItems = result.items;
           })
       );
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Remove validation if a playlist is empty. This validation was introduced [here](https://github.com/grafana/grafana/commit/c737704eebbf0e56d8fcbaa70f3dbdfaf4f5d608). Unfortunately the commit message does not contain the reasoning for having this validation.

It removes also redundant API call for fetching the playlist items. I have noticed that the frontend calls `/api/playlists/:id/items` directly after `/api/playlists/:id` . However this information is already included in the `/api/playlists/:id` response:
<img width="1371" alt="Screenshot 2020-08-13 at 09 22 23" src="https://user-images.githubusercontent.com/1632407/90103476-4057c100-dd4b-11ea-81e0-cb12315306fa.png">
<img width="1371" alt="Screenshot 2020-08-13 at 09 22 25" src="https://user-images.githubusercontent.com/1632407/90103528-55345480-dd4b-11ea-873d-75cee358eb18.png">


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26951

**Special notes for your reviewer**:

