### PR TITLE
@grafana-ui/Table: Add ability to use a custom renderer for table cells

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.story.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.story.tsx
@@ -14,7 +14,9 @@ import {
   ThresholdsConfig,
   ThresholdsMode,
   FieldConfig,
+  formattedValueToString,
 } from '@grafana/data';
+import { TableCellProps } from './types';
 
 export default {
   title: 'Visualizations/Table',
@@ -148,6 +150,33 @@ export const ColoredCells = () => {
       custom: {
         width: 80,
         displayMode: 'color-background',
+      },
+      thresholds: defaultThresholds,
+    },
+  });
+
+  return (
+    <div className="panel-container" style={{ width: 'auto' }}>
+      <Table data={data} height={500} width={width} />
+    </div>
+  );
+};
+
+const CustomCellRenderer = ({ field, cell }: TableCellProps) => {
+  const value = field.display ? formattedValueToString(field.display(cell.value)) : cell.value;
+
+  return <div style={{ backgroundColor: 'red', color: 'white', fontWeight: 'bold' }}>{value}</div>;
+};
+
+export const CustomCells = () => {
+  const theme = useTheme();
+  const width = number('width', 750, {}, 'Props');
+  const data = buildData(theme, {
+    Progress: {
+      custom: {
+        width: 80,
+        // Use a custom component to render the value in the cell
+        render: CustomCellRenderer,
       },
       thresholds: defaultThresholds,
     },

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { CellProps } from 'react-table';
 import { Field } from '@grafana/data';
 import { TableStyles } from './styles';
@@ -8,6 +9,7 @@ export interface TableFieldOptions {
   align: FieldTextAlignment;
   displayMode: TableCellDisplayMode;
   hidden?: boolean;
+  render?: (props: TableCellProps) => React.ReactNode | null | number | string;
 }
 
 export enum TableCellDisplayMode {

--- a/packages/grafana-ui/src/components/Table/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/utils.test.ts
@@ -45,6 +45,39 @@ describe('Table utils', () => {
       expect(columns[0].width).toBe(450);
       expect(columns[1].width).toBe(100);
     });
+
+    it('Should be possible to use a custom renderer for a cell', () => {
+      const CustomRender = jest.fn();
+      const data = new MutableDataFrame({
+        fields: [
+          {
+            name: 'Value',
+            type: FieldType.number,
+            values: [],
+            config: {
+              custom: {
+                width: 100,
+                render: CustomRender,
+              },
+            },
+          },
+          {
+            name: 'Message',
+            type: FieldType.string,
+            values: [],
+            config: {
+              custom: {
+                align: 'center',
+              },
+            },
+          },
+        ],
+      });
+      const columns = getColumns(data, 1000, 120);
+
+      expect(columns[0].Cell).toEqual(CustomRender);
+      expect(columns[1].Cell).not.toEqual(CustomRender);
+    });
   });
 
   describe('getTextAlign', () => {

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -8,6 +8,7 @@ import { css, cx } from 'emotion';
 import { withTableStyles } from './withTableStyles';
 import tinycolor from 'tinycolor2';
 import { JSONViewCell } from './JSONViewCell';
+import { TableCell } from './TableCell';
 
 export function getTextAlign(field?: Field): TextAlignProperty {
   if (!field) {
@@ -85,6 +86,12 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
 }
 
 function getCellComponent(displayMode: TableCellDisplayMode, field: Field) {
+  // Use a custom renderer if it is explicitly defined
+  if (field.config.custom?.render) {
+    return field.config.custom.render;
+  }
+
+  // Use Field.config.custom.displayMode to determine how to display a Cell
   switch (displayMode) {
     case TableCellDisplayMode.ColorText:
       return withTableStyles(DefaultCell, getTextColorStyle);
@@ -98,10 +105,11 @@ function getCellComponent(displayMode: TableCellDisplayMode, field: Field) {
       return JSONViewCell;
   }
 
-  // Default or Auto
+  // Display other data as JSON
   if (field.type === FieldType.other) {
     return JSONViewCell;
   }
+
   return DefaultCell;
 }
 

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -8,7 +8,6 @@ import { css, cx } from 'emotion';
 import { withTableStyles } from './withTableStyles';
 import tinycolor from 'tinycolor2';
 import { JSONViewCell } from './JSONViewCell';
-import { TableCell } from './TableCell';
 
 export function getTextAlign(field?: Field): TextAlignProperty {
   if (!field) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to specify custom Cell renderers for Table fields.

**Example.:**
```javascript
const CustomCell = ({ field, cell }: TableCellProps) => {
  const value = field.display ? formattedValueToString(field.display(cell.value)) : cell.value;

  return <div className="my-fancy-cell">{value}</div>;
};

// Defining the table data
const data = new MutableDataFrame({
    fields: [
     // ...
      {
        name: 'Progress',
        type: FieldType.number,
        values: [],
        config: {
          unit: 'percent',
          min: 0,
          max: 100,
          custom: {
            width: 150,
            render: CustomCell,
          },
        },
      },
    ],
  });
```

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/26920

**Why?**
I am actually not sure what plans we had with this component and if this kind of direction is aligned with those plans, however I thought that if it is going to be the "generic" Table component that people could use in plugins as well, then we probably want to give the ability to use custom cell renderers. 
[More info in the issue &rarr;](https://github.com/grafana/grafana/issues/26920)