### PR TITLE
Prometheus: Remove brackets from interpolated single variable with multi-select/all

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -502,6 +502,10 @@ describe('PrometheusDatasource', () => {
       it('should return pipe separated values if the value is an array of strings', () => {
         expect(ds.interpolateQueryExpr(['a|bc', 'de|f'], customVariable)).toEqual('(a\\\\|bc|de\\\\|f)');
       });
+
+      it('should return 1 regex escaped value if there is just 1 value in an array of strings', () => {
+        expect(ds.interpolateQueryExpr(['looking*glass'], customVariable)).toEqual('looking\\\\*glass');
+      });
     });
 
     describe('and variable allows all', () => {
@@ -515,6 +519,10 @@ describe('PrometheusDatasource', () => {
 
       it('should return pipe separated values if the value is an array of strings', () => {
         expect(ds.interpolateQueryExpr(['a|bc', 'de|f'], customVariable)).toEqual('(a\\\\|bc|de\\\\|f)');
+      });
+
+      it('should return 1 regex escaped value if there is just 1 value in an array of strings', () => {
+        expect(ds.interpolateQueryExpr(['looking*glass'], customVariable)).toEqual('looking\\\\*glass');
       });
     });
   });

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -159,6 +159,11 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     }
 
     const escapedValues = value.map(val => prometheusSpecialRegexEscape(val));
+
+    if (escapedValues.length === 1) {
+      return escapedValues[0];
+    }
+
     return '(' + escapedValues.join('|') + ')';
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to breaking change that was introduced in https://github.com/grafana/grafana/pull/26896/files. If dashboard had multi value/select all options for template variables, interpolated values were wrapped with `()`.This is also breaking change which is not wanted. This PR fixes it by doesn't adding brackets around interpolated value, if just 1 value. 

![Kapture 2020-08-13 at 19 07 42](https://user-images.githubusercontent.com/30407135/90165037-635c9200-dd98-11ea-8e62-55180a8522b7.gif)

![image](https://user-images.githubusercontent.com/30407135/90165104-796a5280-dd98-11ea-994a-eb76c9499bd4.png)

