### PR TITLE
Server: Add health check route

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -435,5 +435,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/api/snapshots-delete/:deleteKey", reqSnapshotPublicModeOrSignedIn, Wrap(DeleteDashboardSnapshotByDeleteKey))
 	r.Delete("/api/snapshots/:key", reqEditorRole, Wrap(DeleteDashboardSnapshot))
 
+	// Health check
+	r.Get("/api/health", hs.healthHandler)
+
 	r.Get("/*", reqSignedIn, hs.Index)
 }

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -386,7 +386,12 @@ func (hs *HTTPServer) healthHandler(ctx *macaron.Context) {
 		ctx.Resp.WriteHeader(200)
 	}
 
-	dataBytes, _ := data.EncodePretty()
+	dataBytes, err := data.EncodePretty()
+	if err != nil {
+		hs.log.Error("Failed to encode data", "err", err)
+		return
+	}
+
 	if _, err := ctx.Resp.Write(dataBytes); err != nil {
 		hs.log.Error("Failed to write to response", "err", err)
 	}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -324,7 +324,6 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 		Delims:     macaron.Delims{Left: "[[", Right: "]]"},
 	}))
 
-	m.Use(hs.healthHandler)
 	m.Use(hs.metricsEndpoint)
 	m.Use(middleware.GetContextHandler(
 		hs.AuthTokenService,

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -32,7 +32,6 @@ func GetDataSourceById(query *models.GetDataSourceByIdQuery) error {
 
 	datasource := models.DataSource{OrgId: query.OrgId, Id: query.Id}
 	has, err := x.Get(&datasource)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/services/sqlstore/session.go
+++ b/pkg/services/sqlstore/session.go
@@ -52,6 +52,7 @@ func (ss *SqlStore) WithDbSession(ctx context.Context, callback dbTransactionFun
 	if err != nil {
 		return err
 	}
+	defer sess.Close()
 
 	return callback(sess)
 }

--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -11,7 +11,7 @@ import (
 	"xorm.io/xorm"
 )
 
-// WithTransactionalDbSession calls the callback with an session within a transaction
+// WithTransactionalDbSession calls the callback with a session within a transaction.
 func (ss *SqlStore) WithTransactionalDbSession(ctx context.Context, callback dbTransactionFunc) error {
 	return inTransactionWithRetryCtx(ctx, ss.engine, callback, 0)
 }

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -53,7 +53,10 @@ func (e *cloudWatchExecutor) executeLogActions(ctx context.Context, queryContext
 				}
 			}
 
-			resultChan <- &tsdb.QueryResult{RefId: query.RefId, Dataframes: tsdb.NewDecodedDataFrames(data.Frames{dataframe})}
+			resultChan <- &tsdb.QueryResult{
+				RefId:      query.RefId,
+				Dataframes: tsdb.NewDecodedDataFrames(data.Frames{dataframe}),
+			}
 			return nil
 		})
 	}
@@ -165,7 +168,7 @@ func (e *cloudWatchExecutor) handleDescribeLogGroups(ctx context.Context,
 
 	var response *cloudwatchlogs.DescribeLogGroupsOutput = nil
 	var err error
-	if len(logGroupNamePrefix) < 1 {
+	if len(logGroupNamePrefix) == 0 {
 		response, err = logsClient.DescribeLogGroupsWithContext(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
 			Limit: aws.Int64(parameters.Get("limit").MustInt64(50)),
 		})

--- a/pkg/tsdb/models.go
+++ b/pkg/tsdb/models.go
@@ -109,11 +109,11 @@ type dataFrames struct {
 	encoded [][]byte
 }
 
-// NewDecodedDataFrames create new DataFrames from decoded frames.
+// NewDecodedDataFrames instantiates DataFrames from decoded frames.
 //
-// This should be the primary function for creating DataFrames if your implementing a plugin.
-// In Grafana alerting scenario it needs to operate on decoded frames why this function is
-// preferrable. When encoded data frames is needed, e.g. returned from Grafana HTTP API, it will
+// This should be the primary function for creating DataFrames if you're implementing a plugin.
+// In a Grafana alerting scenario it needs to operate on decoded frames, which is why this function is
+// preferrable. When encoded data frames are needed, e.g. returned from Grafana HTTP API, it will
 // happen automatically when MarshalJSON() is called.
 func NewDecodedDataFrames(decodedFrames data.Frames) DataFrames {
 	return &dataFrames{
@@ -121,7 +121,7 @@ func NewDecodedDataFrames(decodedFrames data.Frames) DataFrames {
 	}
 }
 
-// NewEncodedDataFrames create new DataFrames from encoded frames.
+// NewEncodedDataFrames instantiates DataFrames from encoded frames.
 //
 // This one is primarily used for creating DataFrames when receiving encoded data frames from an external
 // plugin or similar. This may allow the encoded data frames to be returned to Grafana UI without any additional


### PR DESCRIPTION
**What this PR does / why we need it**:
Add health check route to Grafana server, since we need it when writing API tests (this was derived from a [bigger PR](https://github.com/grafana/grafana/pull/26517)). @bergquist suggested we use HTTPServer.healthHandler.

I'm also including a bug fix (closing SqlStore sessions) and some minor cleanup from the bigger PR.