### PR TITLE
Templating: Fixes so texts show in picker not the values

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -183,7 +183,7 @@ function mapToCurrent(picker: OptionsPickerState): VariableOption | undefined {
 
   return {
     value: values,
-    text: texts.join(' + '),
+    text: texts,
     tags: picker.tags.filter(t => t.selected),
     selected: true,
   };

--- a/public/app/features/variables/state/sharedReducer.test.ts
+++ b/public/app/features/variables/state/sharedReducer.test.ts
@@ -290,7 +290,7 @@ describe('sharedReducer', () => {
               { selected: true, text: 'A', value: 'A' },
               { selected: true, text: 'B', value: 'B' },
             ],
-            current: { selected: true, text: 'A + B', value: ['A', 'B'] },
+            current: { selected: true, text: ['A', 'B'], value: ['A', 'B'] },
           } as unknown) as QueryVariableModel,
         });
     });

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -4,7 +4,7 @@ import { default as lodashDefaults } from 'lodash/defaults';
 
 import { VariableType } from '@grafana/data';
 import { VariableModel, VariableOption, VariableWithOptions } from '../types';
-import { AddVariable, ALL_VARIABLE_VALUE, getInstanceState, NEW_VARIABLE_ID, VariablePayload } from './types';
+import { AddVariable, getInstanceState, NEW_VARIABLE_ID, VariablePayload } from './types';
 import { variableAdapters } from '../adapters';
 import { changeVariableNameSucceeded } from '../editor/reducer';
 import { Deferred } from '../../../core/utils/deferred';
@@ -123,12 +123,6 @@ const sharedReducerSlice = createSlice({
 
       const instanceState = getInstanceState<VariableWithOptions>(state, action.payload.id);
       const current = { ...action.payload.data.option };
-
-      if (Array.isArray(current.text) && current.text.length > 0) {
-        current.text = current.text.join(' + ');
-      } else if (Array.isArray(current.value) && current.value[0] !== ALL_VARIABLE_VALUE) {
-        current.text = current.value.join(' + ');
-      }
 
       instanceState.current = current;
       instanceState.options = instanceState.options.map(option => {


### PR DESCRIPTION
**What this PR does / why we need it**:
The templating system has gotten less complex when we migrated it to React but there is still at least one big complexity left that still causes us some issues. The complexity I'm talking about is how we for some VariableTypes have support for both `single value` and `multi value`. This causes a lot of if statement in our code that tries to handle this and `props` that can be both `string` and `string[]`.

This PR does not attempt to solve this complexity, but I think it pushes our code onto a better path. With this PR the `current` prop will always keep the same type as defined in `alignCurrentWithMulti` below: 
https://github.com/grafana/grafana/blob/1915d10980a1ac91fef6b3577432b47f7c744892/public/app/features/variables/shared/multiOptions.ts#L3 

This means that `OptionsPicker` is the only component/class/object/function that transforms the `current.text` to the correct value which seems a lot clearer to me.
https://github.com/grafana/grafana/blob/1915d10980a1ac91fef6b3577432b47f7c744892/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx#L107

I also did some refactoring of the tests because they weren't using "valid" data.

**Which issue(s) this PR fixes**:
Fixes #25711
Fixes #25959

**Special notes for your reviewer**:
There are probably other cases that are messed up with this, but I couldn't find any :)
