### PR TITLE
plugin.json schema updates

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -7,6 +7,11 @@
   "required": ["type", "name", "id", "info", "dependencies"],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+        "type": "string",
+        "description": "Schema definition for the plugin.json file",
+        "enum": ["https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json"]
+    },
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin id has to follow the naming conventions.",

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -28,8 +28,8 @@
     },
     "category": {
       "type": "string",
-      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, and `sql`.",
-      "enum": ["tsdb", "logging", "cloud", "tracing", "sql"]
+      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, `sql` and `others`.",
+      "enum": ["tsdb", "logging", "cloud", "tracing", "sql", "others"]
     },
     "annotations": {
       "type": "boolean",
@@ -151,7 +151,7 @@
     "info": {
       "type": "object",
       "description": "Metadata for the plugin. Some fields are used on the plugins page in Grafana and others on grafana.com if the plugin is published.",
-      "required": ["logos", "version", "updated"],
+      "required": ["logos", "version", "updated", "keywords"],
       "additionalProperties": false,
       "properties": {
         "author": {
@@ -182,6 +182,7 @@
         "keywords": {
           "type": "array",
           "description": "Array of plugin keywords. Used for search on grafana.com.",
+          "minItems": 1,
           "items": {
             "type": "string"
           }

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -9,8 +9,7 @@
   "properties": {
     "$schema": {
         "type": "string",
-        "description": "Schema definition for the plugin.json file",
-        "enum": ["https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json"]
+        "description": "Schema definition for the plugin.json file"
     },
     "id": {
       "type": "string",
@@ -28,8 +27,8 @@
     },
     "category": {
       "type": "string",
-      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, `sql` and `others`.",
-      "enum": ["tsdb", "logging", "cloud", "tracing", "sql", "others"]
+      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, `sql`, `enterprise` and `other`.",
+      "enum": ["tsdb", "logging", "cloud", "tracing", "sql", "enterprise", "other"]
     },
     "annotations": {
       "type": "boolean",


### PR DESCRIPTION
This PR covers three changes to the plugin.json schema.

* Allow **$schema** in plugin.json to improve the plugin.json authoring experience
* Allow **others"" as a fallback category for plugin category.
* Mandate minimum one keyword in the info section to improve the plugin discovery in plugin repository.

##  Allow **$schema** in plugin.json

Current `plugin.schema.json` doesn't have option to enter `$schema`. Allowing `$schema` will enhance IDEs to autocomplete and lint the `plugin.json` file. 

#### **With schema**: ( Autocomplete and Linting ) 

![image](https://user-images.githubusercontent.com/153843/90332485-39cc8200-dfb5-11ea-9e2e-3607a339b1b2.png)
![image](https://user-images.githubusercontent.com/153843/90332193-f709aa80-dfb2-11ea-9831-b6a9dfff5e5c.png)
![image](https://user-images.githubusercontent.com/153843/90332328-cece7b80-dfb3-11ea-9b0f-e471f06e22c6.png)
![image](https://user-images.githubusercontent.com/153843/90332225-16a0d300-dfb3-11ea-8cc7-7b62dc67f372.png)


#### **Without schema**: ( No autocomplete, No Lint )

![image](https://user-images.githubusercontent.com/153843/90332235-24565880-dfb3-11ea-9cc4-715f21f56345.png)
![image](https://user-images.githubusercontent.com/153843/90332449-db9f9f00-dfb4-11ea-8a58-c08ea1af80c8.png)

This was previously raised against [plugin-validator repo](https://github.com/grafana/plugin-validator/issues/1). Thanks @marcusolsson for guiding me here.

## Allow "others" as a fallback category for plugin category.

Currently the plugin schema allows only following 5 categories. Most of the plugins doesn't fall into one of the allowed categories. Examples : Clock panel, Theme panel, Newrelic datasource, Servicenow datasource, etc,. 

![image](https://user-images.githubusercontent.com/153843/90332701-068af280-dfb7-11ea-87fc-bcb71063ee81.png)

So, Allowing `others` as a category will help the plugin authors to properly categorize their plugin. Otherwise plugin schema validation will force them to provide any the irrelevant category. Even though the field `category` is not mandatory, it is good to guide the developers properly categorize their plugin.

On the other side, I haven't seen the use of `category` field in [plugins repository](https://grafana.com/grafana/plugins). 

## Mandate minimum one keyword

Mandate minimum one keyword in the info section to improve the plugin discovery in plugin repository.