### PR TITLE
Add instructions on how to format multiple variables

### DIFF
--- a/docs/sources/developers/plugins/add-support-for-variables.md
+++ b/docs/sources/developers/plugins/add-support-for-variables.md
@@ -51,13 +51,33 @@ For data sources, you need to use the [getTemplateSrv]({{< relref "../../package
 
    ```ts
    async query(options: DataQueryRequest<MyQuery>): Promise<DataQueryResponse> {
-     const query = getTemplateSrv().replace('SELECT * FROM services WHERE id = "$service"'), options.scopedVars);
+     const query = getTemplateSrv().replace('SELECT * FROM services WHERE id = "$service"', options.scopedVars);
 
      const data = makeDbQuery(query);
 
      return { data };
    }
    ```
+
+## Format multiple variables
+
+If the user has selected multiple values, the value of the interpolated variable depends on the [variable format](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/).
+
+A data source can define the default format option when no format is specified, by adding a third argument to the interpolation function.
+
+Let's change the SQL query to use CSV format by default:
+
+```ts
+getTemplateSrv().replace('SELECT * FROM services WHERE id IN ($service)', options.scopedVars, "csv");
+```
+
+Now, when users write `$service`, the query looks like this:
+
+```sql
+SELECT * FROM services WHERE id IN (admin,auth,billing)
+```
+
+For more information on the available variable formats, refer to [Advanced variable format options](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/).
 
 ## Add support for query variables to your data source
 

--- a/docs/sources/developers/plugins/add-support-for-variables.md
+++ b/docs/sources/developers/plugins/add-support-for-variables.md
@@ -59,9 +59,9 @@ For data sources, you need to use the [getTemplateSrv]({{< relref "../../package
    }
    ```
 
-## Format multiple variables
+## Format multi-value variables
 
-If the user has selected multiple values, the value of the interpolated variable depends on the [variable format](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/).
+When a user selects multiple values for variable, the value of the interpolated variable depends on the [variable format](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/).
 
 A data source can define the default format option when no format is specified by adding a third argument to the interpolation function.
 

--- a/docs/sources/developers/plugins/add-support-for-variables.md
+++ b/docs/sources/developers/plugins/add-support-for-variables.md
@@ -63,7 +63,7 @@ For data sources, you need to use the [getTemplateSrv]({{< relref "../../package
 
 If the user has selected multiple values, the value of the interpolated variable depends on the [variable format](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/).
 
-A data source can define the default format option when no format is specified, by adding a third argument to the interpolation function.
+A data source can define the default format option when no format is specified by adding a third argument to the interpolation function.
 
 Let's change the SQL query to use CSV format by default:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds instructions on how to set default variable format for multiple variables.

Thanks @yesoreyeram for noticing this gap in our docs!