### PR TITLE
Docs: Add documentation for Explore Query Inspector

### DIFF
--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -274,3 +274,10 @@ Simply clicking the button will return you to the origin dashboard, or, if you'd
 the arrow next to the button to reveal a "Return to panel with changes" menu item.
 
 {{< docs-imagebox img="/img/docs/v64/explore_return_dropdown.png" class="docs-image--no-shadow" caption="Screenshot of the expanded explore return dropdown" >}}
+
+## Query Inspector
+
+To help with debugging queries, Explore allows users to investigate query requests and responses, as well as query statistics,
+via the Query Inspector. You can drill down into specific portions of the query, expand or collapse all of it, or copy the data to the clipboard to use in other applications.
+
+{{< docs-imagebox img="/img/docs/v71/query_inspector_explore.png" class="docs-image--no-shadow" caption="Screenshot of the query inspector button in Explore" >}}

--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -278,7 +278,7 @@ the arrow next to the button to reveal a "Return to panel with changes" menu ite
 ## Query inspector
 
 To help with debugging queries, Explore allows you to investigate query requests and responses, as well as query statistics, via the Query inspector.
-This functionality is similar to the panel inspector [Stats tab]({{< relref "inspect-panel.md#inspect-query-performance" >}}) and
-[Query tab]({{< relref "inspect-panel.md##view-raw-request-and-response-to-data-source" >}}).
+This functionality is similar to the panel inspector [Stats tab]({{< relref "../../panels/inspect-panel.md#inspect-query-performance" >}}) and
+[Query tab]({{< relref "../../panels/inspect-panel.md##view-raw-request-and-response-to-data-source" >}}).
 
 {{< docs-imagebox img="/img/docs/v71/query_inspector_explore.png" class="docs-image--no-shadow" caption="Screenshot of the query inspector button in Explore" >}}

--- a/docs/sources/features/explore/index.md
+++ b/docs/sources/features/explore/index.md
@@ -275,9 +275,10 @@ the arrow next to the button to reveal a "Return to panel with changes" menu ite
 
 {{< docs-imagebox img="/img/docs/v64/explore_return_dropdown.png" class="docs-image--no-shadow" caption="Screenshot of the expanded explore return dropdown" >}}
 
-## Query Inspector
+## Query inspector
 
-To help with debugging queries, Explore allows users to investigate query requests and responses, as well as query statistics,
-via the Query Inspector. You can drill down into specific portions of the query, expand or collapse all of it, or copy the data to the clipboard to use in other applications.
+To help with debugging queries, Explore allows you to investigate query requests and responses, as well as query statistics, via the Query inspector.
+This functionality is similar to the panel inspector [Stats tab]({{< relref "inspect-panel.md#inspect-query-performance" >}}) and
+[Query tab]({{< relref "inspect-panel.md##view-raw-request-and-response-to-data-source" >}}).
 
 {{< docs-imagebox img="/img/docs/v71/query_inspector_explore.png" class="docs-image--no-shadow" caption="Screenshot of the query inspector button in Explore" >}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds documentation for the Query Inspector in Explore.

Doc images PR: https://github.com/grafana/website/pull/2122