### PR TITLE
Loki: Add scopedVars support in legend formatting for repeated variables

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -210,6 +210,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
           responseListLength,
           linesLimit,
           this.instanceSettings.jsonData,
+          (options as DataQueryRequest<LokiQuery>).scopedVars,
           (options as DataQueryRequest<LokiQuery>).reverse
         )
       )

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -115,7 +115,7 @@ describe('loki result transformer', () => {
     });
   });
   describe('createMetricLabel', () => {
-    it('should create correct labels', () => {
+    it('should create correct label based on passed variables', () => {
       const label = ResultTransformer.createMetricLabel(
         {},
         { testLabel: { selected: true, text: 'label1', value: 'label1' } },

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -116,11 +116,10 @@ describe('loki result transformer', () => {
   });
   describe('createMetricLabel', () => {
     it('should create correct label based on passed variables', () => {
-      const label = ResultTransformer.createMetricLabel(
-        {},
-        { testLabel: { selected: true, text: 'label1', value: 'label1' } },
-        { legendFormat: '{{$testLabel}}' } as TransformerOptions
-      );
+      const label = ResultTransformer.createMetricLabel({}, ({
+        scopedVars: { testLabel: { selected: true, text: 'label1', value: 'label1' } },
+        legendFormat: '{{$testLabel}}',
+      } as unknown) as TransformerOptions);
       expect(label).toBe('label1');
     });
   });

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -1,5 +1,5 @@
 import { CircularDataFrame, FieldCache, FieldType, MutableDataFrame } from '@grafana/data';
-import { LokiStreamResult, LokiTailResponse, LokiStreamResponse, LokiResultType } from './types';
+import { LokiStreamResult, LokiTailResponse, LokiStreamResponse, LokiResultType, TransformerOptions } from './types';
 import * as ResultTransformer from './result_transformer';
 import { enhanceDataFrame } from './result_transformer';
 
@@ -112,6 +112,16 @@ describe('loki result transformer', () => {
         labels: { filename: '/var/log/grafana/grafana.log' },
         id: '19e8e093d70122b3b53cb6e24efd6e2d',
       });
+    });
+  });
+  describe('createMetricLabel', () => {
+    it('should create correct labels', () => {
+      const label = ResultTransformer.createMetricLabel(
+        {},
+        { testLabel: { selected: true, text: 'label1', value: 'label1' } },
+        { legendFormat: '{{$testLabel}}' } as TransformerOptions
+      );
+      expect(label).toBe('label1');
     });
   });
 });

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -245,7 +245,11 @@ export function lokiResultsToTableModel(
   return table;
 }
 
-function createMetricLabel(labelData: { [key: string]: string }, scopedVars: ScopedVars, options?: TransformerOptions) {
+export function createMetricLabel(
+  labelData: { [key: string]: string },
+  scopedVars: ScopedVars,
+  options?: TransformerOptions
+) {
   let label =
     options === undefined || _.isEmpty(options.legendFormat)
       ? getOriginalMetricName(labelData)

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData, QueryResultMeta } from '@grafana/data';
+import { DataQuery, DataSourceJsonData, QueryResultMeta, ScopedVars } from '@grafana/data';
 
 export interface LokiInstantQueryRequest {
   query: string;
@@ -122,6 +122,7 @@ export interface TransformerOptions {
   query: string;
   responseListLength: number;
   refId: string;
+  scopedVars: ScopedVars;
   meta?: QueryResultMeta;
   valueWithRefId?: boolean;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #25919 by passing scoped vars to `createMetricLabel` and using it in `templateSrv.replace` function. 

**Current master:**
![image](https://user-images.githubusercontent.com/30407135/90515864-85249300-e163-11ea-89e6-511746688391.png)

**This branch:**
![image](https://user-images.githubusercontent.com/30407135/90515147-7f7a7d80-e162-11ea-88ad-bb248de61ee6.png)

![image](https://user-images.githubusercontent.com/30407135/90503925-8ac4ad80-e150-11ea-8418-76eae2912106.png)


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/25919
