### PR TITLE
Prometheus: Add scopedVars support in legend formatting for repeated variables

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -156,7 +156,7 @@ export class ResultTransformer {
 
   createLabelInfo(labels: { [key: string]: string }, options: any): { name?: string; labels: Labels; title?: string } {
     if (options?.legendFormat) {
-      const title = this.renderTemplate(this.templateSrv.replace(options.legendFormat), labels);
+      const title = this.renderTemplate(this.templateSrv.replace(options.legendFormat, options?.scopedVars), labels);
       return { name: title, title, labels };
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to Loki issue https://github.com/grafana/grafana/issues/25919 (PR fix for Loki https://github.com/grafana/grafana/pull/27046), but as mentioned on [community forum](https://community.grafana.com/t/extract-labels-values-from-prometheus-metrics/2087/13), it is issue in Prometheus as well.

**Current master:** 
![image](https://user-images.githubusercontent.com/30407135/90527294-ab512f80-e171-11ea-86fb-989a0f80d967.png)

**This branch:** 
![image](https://user-images.githubusercontent.com/30407135/90527088-72b15600-e171-11ea-9ebf-ceb8ce5493e1.png)
![image](https://user-images.githubusercontent.com/30407135/90526423-acce2800-e170-11ea-94dc-648a4db1243e.png)

