### PR TITLE
Alerting: copy queryType prop to tsdb.Query

### DIFF
--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -214,13 +214,15 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange *
 }
 
 func (c *QueryCondition) getRequestForAlertRule(datasource *models.DataSource, timeRange *tsdb.TimeRange, debug bool) *tsdb.TsdbQuery {
+	queryModel := c.Query.Model
 	req := &tsdb.TsdbQuery{
 		TimeRange: timeRange,
 		Queries: []*tsdb.Query{
 			{
 				RefId:      "A",
-				Model:      c.Query.Model,
+				Model:      queryModel,
 				DataSource: datasource,
+				QueryType:  queryModel.Get("queryType").MustString(""),
 			},
 		},
 		Headers: map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
Copies queryType property in model for the case of alerting. This field was added to our metrics endpoint, but not in the code that fetches the query model from the dashboard and create the alerting query from it.

**Which issue(s) this PR fixes**:

Fixes  #27048

**Special notes for your reviewer**:

@aocenas Can you try this and make sure it fixes what you are seeing? I'm not seeing a good place to put a test for this at the moment.
