### PR TITLE
AzureAnalytics: Use fillmode Null with format as time series

### DIFF
--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -184,7 +184,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	if query.ResultFormat == "time_series" {
 		tsSchema := frame.TimeSeriesSchema()
 		if tsSchema.Type == data.TimeSeriesTypeLong {
-			wideFrame, err := data.LongToWide(frame, &data.FillMissing{Mode: data.FillModeNull})
+			wideFrame, err := data.LongToWide(frame, nil)
 			if err == nil {
 				frame = wideFrame
 			} else {

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -184,7 +184,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	if query.ResultFormat == "time_series" {
 		tsSchema := frame.TimeSeriesSchema()
 		if tsSchema.Type == data.TimeSeriesTypeLong {
-			wideFrame, err := data.LongToWide(frame, &data.FillMissing{})
+			wideFrame, err := data.LongToWide(frame, &data.FillMissing{Mode: data.FillModeNull})
 			if err == nil {
 				frame = wideFrame
 			} else {

--- a/pkg/tsdb/azuremonitor/insights-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/insights-analytics-datasource.go
@@ -162,7 +162,7 @@ func (e *InsightsAnalyticsDatasource) executeQuery(ctx context.Context, query *I
 	if query.ResultFormat == "time_series" {
 		tsSchema := frame.TimeSeriesSchema()
 		if tsSchema.Type == data.TimeSeriesTypeLong {
-			wideFrame, err := data.LongToWide(frame, &data.FillMissing{})
+			wideFrame, err := data.LongToWide(frame, nil)
 			if err == nil {
 				frame = wideFrame
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
When formatting as time series, and having string columns that trigger the long to wide conversion, we were using fill mode previous. This is not what we want here, instead we make them nil.

**Which issue(s) this PR fixes**:

Fixes #27013

**Special notes for your reviewer**:
previously was using fill mode previous, which is not what we want here (this was a mistake on my part).
Also we do not have fill missing with this data source anyways, so null makes more sense.
