### PR TITLE
Backend plugins: Support Forward OAuth Identity for backend data source plugins

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -2,7 +2,6 @@ package pluginproxy
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -14,18 +13,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
-	"golang.org/x/oauth2"
+	"github.com/grafana/grafana/pkg/services/oauthtoken"
 
 	"github.com/grafana/grafana/pkg/api/datasource"
-	"github.com/grafana/grafana/pkg/bus"
 	glog "github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/proxyutil"
+	"github.com/opentracing/opentracing-go"
 )
 
 var (
@@ -211,8 +208,14 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.route, proxy.ds)
 		}
 
-		if proxy.ds.JsonData != nil && proxy.ds.JsonData.Get("oauthPassThru").MustBool() {
-			addOAuthPassThruAuth(proxy.ctx, req)
+		if oauthtoken.IsOAuthPassThruEnabled(proxy.ds) {
+			token, err := oauthtoken.GetCurrentOAuthToken(proxy.ctx.Req.Context(), *proxy.ctx.SignedInUser)
+			if err != nil {
+				logger.Error("Error fetching OAuth token for user", "error", err)
+				return
+			}
+			req.Header.Del("Authorization")
+			req.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
 		}
 	}
 }
@@ -303,65 +306,4 @@ func checkWhiteList(c *models.ReqContext, host string) bool {
 	}
 
 	return true
-}
-
-func addOAuthPassThruAuth(c *models.ReqContext, req *http.Request) {
-	authInfoQuery := &models.GetAuthInfoQuery{UserId: c.UserId}
-	if err := bus.Dispatch(authInfoQuery); err != nil {
-		logger.Error("Error fetching oauth information for user", "userid", c.UserId, "username", c.Login, "error", err)
-		return
-	}
-
-	authProvider := authInfoQuery.Result.AuthModule
-	connect, err := social.GetConnector(authProvider)
-	if err != nil {
-		logger.Error("Failed to get OAuth connector", "error", err)
-		return
-	}
-
-	persistedToken := &oauth2.Token{
-		AccessToken:  authInfoQuery.Result.OAuthAccessToken,
-		Expiry:       authInfoQuery.Result.OAuthExpiry,
-		RefreshToken: authInfoQuery.Result.OAuthRefreshToken,
-		TokenType:    authInfoQuery.Result.OAuthTokenType,
-	}
-
-	client, err := social.GetOAuthHttpClient(authProvider)
-	if err != nil {
-		logger.Error("Failed to create OAuth http client", "error", err)
-		return
-	}
-	oauthctx := context.WithValue(c.Req.Context(), oauth2.HTTPClient, client)
-
-	// TokenSource handles refreshing the token if it has expired
-	token, err := connect.TokenSource(oauthctx, persistedToken).Token()
-	if err != nil {
-		logger.Error("Failed to retrieve access token from OAuth provider", "provider", authInfoQuery.Result.AuthModule, "userid", c.UserId, "username", c.Login, "error", err)
-		return
-	}
-
-	// If the tokens are not the same, update the entry in the DB
-	if !tokensEq(persistedToken, token) {
-		updateAuthCommand := &models.UpdateAuthInfoCommand{
-			UserId:     authInfoQuery.Result.UserId,
-			AuthModule: authInfoQuery.Result.AuthModule,
-			AuthId:     authInfoQuery.Result.AuthId,
-			OAuthToken: token,
-		}
-		if err := bus.Dispatch(updateAuthCommand); err != nil {
-			logger.Error("Failed to update auth info during token refresh", "userid", c.UserId, "username", c.Login, "error", err)
-			return
-		}
-		logger.Debug("Updated OAuth info while proxying an OAuth pass-thru request", "userid", c.UserId, "username", c.Login)
-	}
-	req.Header.Del("Authorization")
-	req.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
-}
-
-// tokensEq checks for OAuth2 token equivalence given the fields of the struct Grafana is interested in
-func tokensEq(t1, t2 *oauth2.Token) bool {
-	return t1.AccessToken == t2.AccessToken &&
-		t1.RefreshToken == t2.RefreshToken &&
-		t1.Expiry == t2.Expiry &&
-		t1.TokenType == t2.TokenType
 }

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -209,7 +209,7 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 		}
 
 		if oauthtoken.IsOAuthPassThruEnabled(proxy.ds) {
-			token, err := oauthtoken.GetCurrentOAuthToken(proxy.ctx.Req.Context(), *proxy.ctx.SignedInUser)
+			token, err := oauthtoken.GetCurrentOAuthToken(proxy.ctx.Req.Context(), proxy.ctx.SignedInUser)
 			if err != nil {
 				logger.Error("Error fetching OAuth token for user", "error", err)
 				return

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -208,14 +208,7 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 		}
 
 		if oauthtoken.IsOAuthPassThruEnabled(proxy.ds) {
-			token, err := oauthtoken.GetCurrentOAuthToken(proxy.ctx.Req.Context(), proxy.ctx.SignedInUser)
-			if err != nil {
-				logger.Error("Error fetching OAuth token for user", "error", err)
-				return
-			}
-			// Token can still be nil if OAuthPassThruEnabled on the datasource, but the
-			// user is logged in another way.  The datasource can decide what to do.
-			if token != nil {
+			if token := oauthtoken.GetCurrentOAuthToken(proxy.ctx.Req.Context(), proxy.ctx.SignedInUser); token != nil {
 				req.Header.Del("Authorization")
 				req.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
 			}

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -13,12 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/oauthtoken"
-
 	"github.com/grafana/grafana/pkg/api/datasource"
 	glog "github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/proxyutil"

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -214,8 +214,12 @@ func (proxy *DataSourceProxy) getDirector() func(req *http.Request) {
 				logger.Error("Error fetching OAuth token for user", "error", err)
 				return
 			}
-			req.Header.Del("Authorization")
-			req.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
+			// Token can still be nil if OAuthPassThruEnabled on the datasource, but the
+			// user is logged in another way.  The datasource can decide what to do.
+			if token != nil {
+				req.Header.Del("Authorization")
+				req.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
+			}
 		}
 	}
 }

--- a/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
+++ b/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/services/oauthtoken"
-
-	"github.com/grafana/grafana-plugin-sdk-go/backend/grpcplugin"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/grpcplugin"
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 

--- a/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
+++ b/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
@@ -56,15 +56,7 @@ func (tw *DatasourcePluginWrapperV2) Query(ctx context.Context, ds *models.DataS
 	}
 
 	if oauthtoken.IsOAuthPassThruEnabled(ds) {
-		token, err := oauthtoken.GetCurrentOAuthToken(ctx, query.User)
-		if err != nil {
-			tw.logger.Error("Error fetching OAuth token for user", "error", err)
-			return nil, err
-		}
-		// Token can still be nil if OAuthPassThruEnabled on the datasource.
-		// The user might be logged in another way or this might be an alert call.
-		// The datasource can decide what to do.
-		if token != nil {
+		if token := oauthtoken.GetCurrentOAuthToken(ctx, query.User); token != nil {
 			delete(query.Headers, "Authorization")
 			query.Headers["Authorization"] = fmt.Sprintf("%s %s", token.Type(), token.AccessToken)
 		}

--- a/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
+++ b/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
@@ -63,9 +63,14 @@ func (tw *DatasourcePluginWrapperV2) Query(ctx context.Context, ds *models.DataS
 			token, err := oauthtoken.GetCurrentOAuthToken(ctx, *query.User)
 			if err != nil {
 				tw.logger.Error("Error fetching OAuth token for user", "error", err)
+				return nil, err
 			}
-			delete(query.Headers, "Authorization")
-			query.Headers["Authorization"] = fmt.Sprintf("%s %s", token.Type(), token.AccessToken)
+			// Token can still be nil if OAuthPassThruEnabled on the datasource, but the
+			// user is logged in another way.  The datasource can decide what to do.
+			if token != nil {
+				delete(query.Headers, "Authorization")
+				query.Headers["Authorization"] = fmt.Sprintf("%s %s", token.Type(), token.AccessToken)
+			}
 		}
 	}
 

--- a/pkg/services/oauthtoken/oauth_token_util.go
+++ b/pkg/services/oauthtoken/oauth_token_util.go
@@ -1,0 +1,70 @@
+package oauthtoken
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/login/social"
+	"github.com/grafana/grafana/pkg/models"
+	"golang.org/x/oauth2"
+)
+
+func GetCurrentOAuthToken(ctx context.Context, user models.SignedInUser) (*oauth2.Token, error) {
+	authInfoQuery := &models.GetAuthInfoQuery{UserId: user.UserId}
+	if err := bus.Dispatch(authInfoQuery); err != nil {
+		return nil, fmt.Errorf("Error fetching OAuth information for userid=%d username=%s error=%s", user.UserId, user.Login, err)
+	}
+
+	authProvider := authInfoQuery.Result.AuthModule
+	connect, err := social.GetConnector(authProvider)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get OAuth connector error=%s", err)
+	}
+
+	client, err := social.GetOAuthHttpClient(authProvider)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create OAuth http client error=%s", err)
+	}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
+
+	persistedToken := &oauth2.Token{
+		AccessToken:  authInfoQuery.Result.OAuthAccessToken,
+		Expiry:       authInfoQuery.Result.OAuthExpiry,
+		RefreshToken: authInfoQuery.Result.OAuthRefreshToken,
+		TokenType:    authInfoQuery.Result.OAuthTokenType,
+	}
+	// TokenSource handles refreshing the token if it has expired
+	token, err := connect.TokenSource(ctx, persistedToken).Token()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve access token from OAuth provider=%s userid=%d username=%s error=%s", authInfoQuery.Result.AuthModule, user.UserId, user.Login, err)
+	}
+
+	// If the tokens are not the same, update the entry in the DB
+	if !tokensEq(persistedToken, token) {
+		updateAuthCommand := &models.UpdateAuthInfoCommand{
+			UserId:     authInfoQuery.Result.UserId,
+			AuthModule: authInfoQuery.Result.AuthModule,
+			AuthId:     authInfoQuery.Result.AuthId,
+			OAuthToken: token,
+		}
+		if err := bus.Dispatch(updateAuthCommand); err != nil {
+			return nil, fmt.Errorf("Failed to update auth info during token refresh userId=%d username=%s error=%s", user.UserId, user.Login, err)
+		}
+		logger.Debug("Updated OAuth info while proxying an OAuth pass-thru request", "userid", user.UserId, "username", user.Login)
+	}
+	return token, nil
+}
+
+func IsOAuthPassThruEnabled(ds *models.DataSource) bool {
+	return ds.JsonData != nil && ds.JsonData.Get("oauthPassThru").MustBool()
+}
+
+// tokensEq checks for OAuth2 token equivalence given the fields of the struct Grafana is interested in
+func tokensEq(t1, t2 *oauth2.Token) bool {
+	return t1.AccessToken == t2.AccessToken &&
+		t1.RefreshToken == t2.RefreshToken &&
+		t1.Expiry == t2.Expiry &&
+		t1.TokenType == t2.TokenType
+}

--- a/pkg/services/oauthtoken/oauth_token_util.go
+++ b/pkg/services/oauthtoken/oauth_token_util.go
@@ -27,12 +27,12 @@ func GetCurrentOAuthToken(ctx context.Context, user models.SignedInUser) (*oauth
 	authProvider := authInfoQuery.Result.AuthModule
 	connect, err := social.GetConnector(authProvider)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get OAuth connector error=%s", err)
+		return nil, fmt.Errorf("failed to get OAuth connector error=%s", err)
 	}
 
 	client, err := social.GetOAuthHttpClient(authProvider)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create OAuth http client error=%s", err)
+		return nil, fmt.Errorf("failed to create OAuth http client error=%s", err)
 	}
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, client)
 
@@ -57,7 +57,7 @@ func GetCurrentOAuthToken(ctx context.Context, user models.SignedInUser) (*oauth
 			OAuthToken: token,
 		}
 		if err := bus.Dispatch(updateAuthCommand); err != nil {
-			return nil, fmt.Errorf("Failed to update auth info during token refresh userId=%d username=%s error=%s", user.UserId, user.Login, err)
+			return nil, fmt.Errorf("failed to update auth info during token refresh, userId=%d username=%s error=%s", user.UserId, user.Login, err)
 		}
 		logger.Debug("Updated OAuth info while proxying an OAuth pass-thru request", "userid", user.UserId, "username", user.Login)
 	}

--- a/pkg/services/oauthtoken/oauth_token_util.go
+++ b/pkg/services/oauthtoken/oauth_token_util.go
@@ -24,8 +24,12 @@ func GetCurrentOAuthToken(ctx context.Context, user *models.SignedInUser) (*oaut
 
 	authInfoQuery := &models.GetAuthInfoQuery{UserId: user.UserId}
 	if err := bus.Dispatch(authInfoQuery); err != nil {
-		logger.Debug("No oauth token for user", "userid", user.UserId, "username", user.Login)
-		// Not necessarily an error.  User may be logged in another way.
+		if err == models.ErrUserNotFound {
+			// Not necessarily an error.  User may be logged in another way.
+			logger.Debug("No oauth token for user", "userid", user.UserId, "username", user.Login)
+		} else {
+			logger.Error("Error getting oauth token for user", "userid", user.UserId, "username", user.Login, "error", err)
+		}
 		return nil, nil
 	}
 

--- a/pkg/services/oauthtoken/oauth_token_util.go
+++ b/pkg/services/oauthtoken/oauth_token_util.go
@@ -45,7 +45,7 @@ func GetCurrentOAuthToken(ctx context.Context, user models.SignedInUser) (*oauth
 	// TokenSource handles refreshing the token if it has expired
 	token, err := connect.TokenSource(ctx, persistedToken).Token()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve access token from OAuth provider=%s userid=%d username=%s error=%s", authInfoQuery.Result.AuthModule, user.UserId, user.Login, err)
+		return nil, fmt.Errorf("failed to retrieve access token from OAuth, provider=%s userid=%d username=%s error=%s", authInfoQuery.Result.AuthModule, user.UserId, user.Login, err)
 	}
 
 	// If the tokens are not the same, update the entry in the DB

--- a/pkg/services/oauthtoken/oauth_token_util.go
+++ b/pkg/services/oauthtoken/oauth_token_util.go
@@ -4,17 +4,24 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/grafana/grafana/pkg/infra/log"
+
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models"
 	"golang.org/x/oauth2"
 )
 
+var (
+	logger = log.New("oauthtoken")
+)
+
 func GetCurrentOAuthToken(ctx context.Context, user models.SignedInUser) (*oauth2.Token, error) {
 	authInfoQuery := &models.GetAuthInfoQuery{UserId: user.UserId}
 	if err := bus.Dispatch(authInfoQuery); err != nil {
-		return nil, fmt.Errorf("Error fetching OAuth information for userid=%d username=%s error=%s", user.UserId, user.Login, err)
+		logger.Debug("No oauth token for user", "userid", user.UserId, "username", user.Login)
+		// Not necessarily an error.  User may be logged in another way.
+		return nil, nil
 	}
 
 	authProvider := authInfoQuery.Result.AuthModule

--- a/pkg/services/oauthtoken/oauth_token_util.go
+++ b/pkg/services/oauthtoken/oauth_token_util.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models"
 	"golang.org/x/oauth2"


### PR DESCRIPTION
fixes #26023 

If configured to do so, pass the oauth token to the backend datasource code.
This is already being done in ds_proxy.go for backend proxied datasources.
This change moves the code from the addOAuthPassThruAuth method to a new package oauthtoken with slight refactoring.
This allows both datasource_plugin_wrapper_v2.go and ds_proxy.go to use the same code to get an up-to-date token.

