### PR TITLE
Field overrides: Filter by field name using regex

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -7,6 +7,10 @@
   "required": ["type", "name", "id", "info", "dependencies"],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Schema definition for the plugin.json file"
+    },
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin id has to follow the naming conventions.",
@@ -23,8 +27,8 @@
     },
     "category": {
       "type": "string",
-      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, and `sql`.",
-      "enum": ["tsdb", "logging", "cloud", "tracing", "sql"]
+      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, `sql`, `enterprise` and `other`.",
+      "enum": ["tsdb", "logging", "cloud", "tracing", "sql", "enterprise", "other"]
     },
     "annotations": {
       "type": "boolean",
@@ -146,7 +150,7 @@
     "info": {
       "type": "object",
       "description": "Metadata for the plugin. Some fields are used on the plugins page in Grafana and others on grafana.com if the plugin is published.",
-      "required": ["logos", "version", "updated"],
+      "required": ["logos", "version", "updated", "keywords"],
       "additionalProperties": false,
       "properties": {
         "author": {
@@ -177,6 +181,7 @@
         "keywords": {
           "type": "array",
           "description": "Array of plugin keywords. Used for search on grafana.com.",
+          "minItems": 1,
           "items": {
             "type": "string"
           }

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -8,8 +8,8 @@
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
-      "description": "Schema definition for the plugin.json file"
+        "type": "string",
+        "description": "Schema definition for the plugin.json file"
     },
     "id": {
       "type": "string",

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -7,10 +7,6 @@
   "required": ["type", "name", "id", "info", "dependencies"],
   "additionalProperties": false,
   "properties": {
-    "$schema": {
-      "type": "string",
-      "description": "Schema definition for the plugin.json file"
-    },
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin id has to follow the naming conventions.",
@@ -27,8 +23,8 @@
     },
     "category": {
       "type": "string",
-      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, `sql`, `enterprise` and `other`.",
-      "enum": ["tsdb", "logging", "cloud", "tracing", "sql", "enterprise", "other"]
+      "description": "Plugin category used on the Add data source page. Possible values are: `tsdb`, `logging`, `cloud`, `tracing`, and `sql`.",
+      "enum": ["tsdb", "logging", "cloud", "tracing", "sql"]
     },
     "annotations": {
       "type": "boolean",
@@ -150,7 +146,7 @@
     "info": {
       "type": "object",
       "description": "Metadata for the plugin. Some fields are used on the plugins page in Grafana and others on grafana.com if the plugin is published.",
-      "required": ["logos", "version", "updated", "keywords"],
+      "required": ["logos", "version", "updated"],
       "additionalProperties": false,
       "properties": {
         "author": {
@@ -181,7 +177,6 @@
         "keywords": {
           "type": "array",
           "description": "Array of plugin keywords. Used for search on grafana.com.",
-          "minItems": 1,
           "items": {
             "type": "string"
           }

--- a/docs/sources/panels/field-configuration-options.md
+++ b/docs/sources/panels/field-configuration-options.md
@@ -76,15 +76,24 @@ Field overrides allow you to change the settings for one field (column in tables
 1. Navigate to the panel you want to edit, click the panel title, and then click **Edit**.
 1. Click the **Overrides** tab.
 1. Click **Add override**.
-1. Select a filter option to choose which fields the override applies to.
-
-   **Note:** Currently you can only match by name, so after you choose the filter, select which field it applies to from the dropdown list.
-
+1. Select a [filter option](#filter-options) to choose which fields the override applies to.
 1. Click **Add override property**.
 1. Select the [field option](#field-options) you want to apply.
 1. Enter options by adding values in the fields. To return options to default values, delete the white text in the fields.
 1. Continue to add overrides to this field by clicking **Add override property**, or you can click **Add override** and select a different field to add overrides to.
 1. When finished, click **Save** to save all panel edits to the dashboard.
+
+## Filter options
+
+This section explains all available filter options for field overrides. They are listed in alphabetical order.
+
+### Filter field by name
+
+Allows you to select a field from the list of all available fields that the override will be applied to.
+
+### Filter field by name using regex
+
+Allows you to type in a regular expression against which fields to be overridden will be matched.
 
 ## Field options
 

--- a/docs/sources/panels/field-configuration-options.md
+++ b/docs/sources/panels/field-configuration-options.md
@@ -95,6 +95,11 @@ Allows you to select a field from the list of all available fields that the over
 
 Allows you to type in a regular expression against which fields to be overridden will be matched.
 
+### Filter field by type
+
+Allows you to select fields by their type (string, numeric, etc).
+
+
 ## Field options
 
 This section explains all available field options. They are listed in alphabetical order.

--- a/packages/grafana-ui/src/components/MatchersUI/FieldNameByRegexMatcherEditor.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldNameByRegexMatcherEditor.tsx
@@ -1,0 +1,25 @@
+import React, { memo, useCallback } from 'react';
+import { MatcherUIProps, FieldMatcherUIRegistryItem } from './types';
+import { FieldMatcherID, fieldMatchers } from '@grafana/data';
+import { Input } from '../Input/Input';
+
+export const FieldNameByRegexMatcherEditor = memo<MatcherUIProps<string>>(props => {
+  const { options } = props;
+
+  const onBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      return props.onChange(e.target.value);
+    },
+    [props.onChange]
+  );
+
+  return <Input placeholder="Enter regular expression" defaultValue={options} onBlur={onBlur} />;
+});
+
+export const fieldNameByRegexMatcherItem: FieldMatcherUIRegistryItem<string> = {
+  id: FieldMatcherID.byRegexp,
+  component: FieldNameByRegexMatcherEditor,
+  matcher: fieldMatchers.get(FieldMatcherID.byRegexp),
+  name: 'Filter by field using regex',
+  description: 'Set properties for fields with names matching provided regex',
+};

--- a/packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts
+++ b/packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts
@@ -1,6 +1,6 @@
 import { Registry } from '@grafana/data';
-import { FieldMatcherUIRegistryItem } from './types';
 import { fieldNameMatcherItem } from './FieldNameMatcherEditor';
+import { FieldMatcherUIRegistryItem } from './types';
 import { fieldNameByRegexMatcherItem } from './FieldNameByRegexMatcherEditor';
 
 export const fieldMatchersUI = new Registry<FieldMatcherUIRegistryItem<any>>(() => {

--- a/packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts
+++ b/packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts
@@ -1,7 +1,8 @@
 import { Registry } from '@grafana/data';
-import { fieldNameMatcherItem } from './FieldNameMatcherEditor';
 import { FieldMatcherUIRegistryItem } from './types';
+import { fieldNameMatcherItem } from './FieldNameMatcherEditor';
+import { fieldNameByRegexMatcherItem } from './FieldNameByRegexMatcherEditor';
 
 export const fieldMatchersUI = new Registry<FieldMatcherUIRegistryItem<any>>(() => {
-  return [fieldNameMatcherItem];
+  return [fieldNameMatcherItem, fieldNameByRegexMatcherItem];
 });

--- a/packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts
+++ b/packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts
@@ -2,6 +2,7 @@ import { Registry } from '@grafana/data';
 import { fieldNameMatcherItem } from './FieldNameMatcherEditor';
 import { FieldMatcherUIRegistryItem } from './types';
 import { fieldNameByRegexMatcherItem } from './FieldNameByRegexMatcherEditor';
+import { fieldTypeMatcherItem } from './FieldTypeMatcherEditor';
 
 export const fieldMatchersUI = new Registry<FieldMatcherUIRegistryItem<any>>(() => {
   return [fieldNameMatcherItem, fieldNameByRegexMatcherItem, fieldTypeMatcherItem];


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/26831

Introduces a new matcher UI that enables matching fields for overrides using a regular expression.

@kylebrandt @mckn do you think this ultra-simple UI is fine for the needs?

----
**tldr;**
As an alternative, we could introduce a sort of combo UI that would either allow selecting from the list or providing a regex, similar as we do with Filter by name transformation. My initial idea was to have that, but I found it too complex:

![Kapture 2020-08-19 at 13 34 36](https://user-images.githubusercontent.com/2376619/90630136-c3cc5300-e220-11ea-9168-bdb26747b588.gif)

