### PR TITLE
Server: Add protocol setting to Cfg struct

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -227,6 +227,7 @@ type Cfg struct {
 	AppSubUrl        string
 	ServeFromSubPath bool
 	StaticRootPath   string
+	Protocol         Scheme
 
 	// build
 	BuildVersion string
@@ -672,6 +673,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	cfg.ServeFromSubPath = ServeFromSubPath
 
 	Protocol = HTTP
+	cfg.Protocol = Protocol
 	protocolStr, err := valueAsString(server, "protocol", "http")
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the _protocol_ configuration setting to the Cfg type, so it can be used without the global `setting.Protocol` variable. We want to stop using global variables in `setting`, so this is worthwhile.