### PR TITLE
Alerting: Store sensitive settings encrypted for OpsGenie notifier

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -511,12 +511,12 @@ The following sections detail the supported settings and secure settings for eac
 
 #### Alert notification `opsgenie`
 
-| Name             |
-| ---------------- |
-| apiKey           |
-| apiUrl           |
-| autoClose        |
-| overridePriority |
+| Name             | Secure setting |
+| ---------------- | - |
+| apiKey           | yes |
+| apiUrl           | |
+| autoClose        | |
+| overridePriority | |
 
 #### Alert notification `telegram`
 

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -21,9 +21,22 @@ func init() {
 		OptionsTemplate: `
       <h3 class="page-heading">OpsGenie settings</h3>
       <div class="gf-form">
-        <span class="gf-form-label width-14">API Key</span>
-        <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.apiKey" placeholder="OpsGenie API Key"></input>
-      </div>
+        <label class="gf-form-label max-width-14">API Key</label>
+		<div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.apiKey">
+		  <input type="text"
+              required
+              class="gf-form-input max-width-22"
+			  ng-init="ctrl.model.secureSettings.apiKey = ctrl.model.settings.apiKey || null; ctrl.model.settings.apiKey = null;"
+			  ng-model="ctrl.model.secureSettings.apiKey"
+			  placeholder="OpsGenie API Key"
+			  data-placement="right">
+		  </input>
+		</div>
+		<div class="gf-form" ng-if="ctrl.model.secureFields.apiKey">
+		  <input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
+		  <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.apiKey = false">reset</a>
+		</div>
+	  </div>
       <div class="gf-form">
         <span class="gf-form-label width-14">Alert API Url</span>
         <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.apiUrl" placeholder="https://api.opsgenie.com/v2/alerts"></input>
@@ -87,7 +100,7 @@ var (
 func NewOpsGenieNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
 	autoClose := model.Settings.Get("autoClose").MustBool(true)
 	overridePriority := model.Settings.Get("overridePriority").MustBool(true)
-	apiKey := model.Settings.Get("apiKey").MustString()
+	apiKey := model.DecryptedValue("apiKey", model.Settings.Get("apiKey").MustString())
 	apiURL := model.Settings.Get("apiUrl").MustString()
 	if apiKey == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find api key property in settings"}

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -19,46 +19,46 @@ func init() {
 		Heading:     "OpsGenie settings",
 		Factory:     NewOpsGenieNotifier,
 		OptionsTemplate: `
-      <h3 class="page-heading">OpsGenie settings</h3>
-      <div class="gf-form">
-        <label class="gf-form-label max-width-14">API Key</label>
-		<div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.apiKey">
-		  <input type="text"
-              required
-              class="gf-form-input max-width-22"
-			  ng-init="ctrl.model.secureSettings.apiKey = ctrl.model.settings.apiKey || null; ctrl.model.settings.apiKey = null;"
-			  ng-model="ctrl.model.secureSettings.apiKey"
-			  placeholder="OpsGenie API Key"
-			  data-placement="right">
-		  </input>
+		<h3 class="page-heading">OpsGenie settings</h3>
+		<div class="gf-form">
+			<label class="gf-form-label max-width-14">API Key</label>
+			<div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.apiKey">
+				<input type="text"
+					required
+					class="gf-form-input max-width-22"
+					ng-init="ctrl.model.secureSettings.apiKey = ctrl.model.settings.apiKey || null; ctrl.model.settings.apiKey = null;"
+					ng-model="ctrl.model.secureSettings.apiKey"
+					placeholder="OpsGenie API Key"
+					data-placement="right">
+				</input>
+			</div>
+			<div class="gf-form" ng-if="ctrl.model.secureFields.apiKey">
+			  <input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
+			  <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.apiKey = false">reset</a>
+			</div>
 		</div>
-		<div class="gf-form" ng-if="ctrl.model.secureFields.apiKey">
-		  <input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
-		  <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.apiKey = false">reset</a>
+		<div class="gf-form">
+			<span class="gf-form-label width-14">Alert API Url</span>
+			<input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.apiUrl" placeholder="https://api.opsgenie.com/v2/alerts"></input>
 		</div>
-	  </div>
-      <div class="gf-form">
-        <span class="gf-form-label width-14">Alert API Url</span>
-        <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.apiUrl" placeholder="https://api.opsgenie.com/v2/alerts"></input>
-      </div>
-      <div class="gf-form">
-        <gf-form-switch
-           class="gf-form"
-           label="Auto close incidents"
-           label-class="width-14"
-           checked="ctrl.model.settings.autoClose"
-           tooltip="Automatically close alerts in OpsGenie once the alert goes back to ok.">
-        </gf-form-switch>
-      </div>
-      <div class="gf-form">
-        <gf-form-switch
-           class="gf-form"
-           label="Override priority"
-           label-class="width-14"
-           checked="ctrl.model.settings.overridePriority"
-           tooltip="Allow the alert priority to be set using the og_priority tag">
-        </gf-form-switch>
-  </div>
+		<div class="gf-form">
+			<gf-form-switch
+				class="gf-form"
+				label="Auto close incidents"
+				label-class="width-14"
+				checked="ctrl.model.settings.autoClose"
+				tooltip="Automatically close alerts in OpsGenie once the alert goes back to ok.">
+			</gf-form-switch>
+		</div>
+		<div class="gf-form">
+			<gf-form-switch
+				class="gf-form"
+				label="Override priority"
+				label-class="width-14"
+				checked="ctrl.model.settings.overridePriority"
+				tooltip="Allow the alert priority to be set using the og_priority tag">
+			</gf-form-switch>
+  		</div>
 `,
 		Options: []alerting.NotifierOption{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to update all alert notifiers so that they support storing sensitive information encrypted. This PR covers OpsGenie 

**Which issue(s) this PR fixes**:
(part of) https://github.com/grafana/grafana/issues/25967




