### PR TITLE
InfluxDB: Update Flux placeholder URL with respect to latest Go client

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -108,7 +108,7 @@ export class ConfigEditor extends PureComponent<Props> {
               <Input
                 className="width-20"
                 value={options.url || ''}
-                placeholder="http://localhost:9999/api/v2"
+                placeholder="http://localhost:9999"
                 onChange={this.onUpdateInflux2xURL}
               />
             </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove /api/v2 suffix from Flux placeholder URL, since after upgrading the Go client, it's no longer required. Actually, if you use the suffix now, you get a 404 from InfluxDB. I assume the Go client now applies the suffix automatically, or something along those lines.

