### PR TITLE
Table: Support showing numbers in strings with full original value

### DIFF
--- a/docs/sources/panels/field-configuration-options.md
+++ b/docs/sources/panels/field-configuration-options.md
@@ -203,7 +203,7 @@ You can also paste a native emoji in the unit picker and pick it as a custom uni
 
 #### String unit
 
-Grafana can sometime be too agressive in parsing strings and displaying them as numbers. To make Grafana show the original
+Grafana can sometime be too aggressive in parsing strings and displaying them as numbers. To make Grafana show the original
 string create a field override and add a unit property with the `string` unit.
 
 ### Thresholds

--- a/docs/sources/panels/field-configuration-options.md
+++ b/docs/sources/panels/field-configuration-options.md
@@ -99,7 +99,6 @@ Allows you to type in a regular expression against which fields to be overridden
 
 Allows you to select fields by their type (string, numeric, etc).
 
-
 ## Field options
 
 This section explains all available field options. They are listed in alphabetical order.
@@ -157,13 +156,13 @@ When multiple stats, fields, or series are shown, this field controls the title 
 
 Given a field with a name of Temp, and labels of {"Loc"="PBI", "Sensor"="3"}
 
-| Expression syntax            | Example                | Renders to                        | Explanation |
-| ---------------------------- | ---------------------- | --------------------------------- | ----------- |
-| `${__field.displayName}`     | Same as syntax         | `Temp {Loc="PBI", Sensor="3"}`    | Displays the field name, and labels in `{}` if they are present. If there is only one label key in the response, then for the label portion, Grafana displays the value of the label without the enclosing braces. |
-| `${__field.name}`            | Same as syntax          | `Temp`                           | Displays the name of the field (without labels). |
-| `${__field.labels}`          | Same as syntax          | `Loc="PBI", Sensor="3"`          | Displays the labels without the name. |
-| `${__field.labels.X}`        | `${__field.labels.Loc}` | `PBI`                            | Displays the value of the specified label key. |
-| `${__field.labels.__values}` | Same as Syntax          | `PBI, 3`                         | Displays the values of the labels separated by a comma (without label keys). |
+| Expression syntax            | Example                 | Renders to                     | Explanation                                                                                                                                                                                                        |
+| ---------------------------- | ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `${__field.displayName}`     | Same as syntax          | `Temp {Loc="PBI", Sensor="3"}` | Displays the field name, and labels in `{}` if they are present. If there is only one label key in the response, then for the label portion, Grafana displays the value of the label without the enclosing braces. |
+| `${__field.name}`            | Same as syntax          | `Temp`                         | Displays the name of the field (without labels).                                                                                                                                                                   |
+| `${__field.labels}`          | Same as syntax          | `Loc="PBI", Sensor="3"`        | Displays the labels without the name.                                                                                                                                                                              |
+| `${__field.labels.X}`        | `${__field.labels.Loc}` | `PBI`                          | Displays the value of the specified label key.                                                                                                                                                                     |
+| `${__field.labels.__values}` | Same as Syntax          | `PBI, 3`                       | Displays the values of the labels separated by a comma (without label keys).                                                                                                                                       |
 
 If the value is an empty string after rendering the expression for a particular field, then the default display method is used.
 
@@ -201,6 +200,11 @@ To select a custom unit enter the unit and select the last `Custom: xxx` option 
 You can also paste a native emoji in the unit picker and pick it as a custom unit:
 
 {{< docs-imagebox img="/img/docs/v66/custom_unit_burger2.png" max-width="600px" caption="Custom unit emoji" >}}
+
+#### String unit
+
+Grafana can sometime be too agressive in parsing strings and displaying them as numbers. To make Grafana show the original
+string create a field override and add a unit property with the `string` unit.
 
 ### Thresholds
 

--- a/docs/sources/panels/visualizations/table-panel.md
+++ b/docs/sources/panels/visualizations/table-panel.md
@@ -26,3 +26,10 @@ Table visualizations allow you to apply:
 ## Display options
 
 - **Show header -** Show or hide column names imported from your data source..
+
+## Tips
+
+### Display original string value
+
+Grafana can sometime be too agressive in parsing strings and displaying them as numbers. To make Grafana show the original
+string create a field override and add a unit property with the `string` unit.

--- a/docs/sources/panels/visualizations/table-panel.md
+++ b/docs/sources/panels/visualizations/table-panel.md
@@ -31,5 +31,5 @@ Table visualizations allow you to apply:
 
 ### Display original string value
 
-Grafana can sometime be too agressive in parsing strings and displaying them as numbers. To make Grafana show the original
+Grafana can sometime be too aggressive in parsing strings and displaying them as numbers. To make Grafana show the original
 string create a field override and add a unit property with the `string` unit.

--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -305,34 +305,24 @@ describe('Date display options', () => {
   });
 
   describe('number formatting for string values', () => {
-    it('should preserve string unchanged if no unit', () => {
+    it('should preserve string unchanged if unit is strings', () => {
       const processor = getDisplayProcessor({
         field: {
           type: FieldType.string,
-          config: {},
+          config: { unit: 'string' },
         },
       });
       expect(processor('22.1122334455').text).toEqual('22.1122334455');
     });
 
-    it('should preserve string unchanged if unit set to none', () => {
+    it('should format string as number if no unit', () => {
       const processor = getDisplayProcessor({
         field: {
           type: FieldType.string,
-          config: { unit: 'none' },
+          config: { decimals: 2 },
         },
       });
-      expect(processor('22.1122334455').text).toEqual('22.1122334455');
-    });
-
-    it('should format string as number if number unit', () => {
-      const processor = getDisplayProcessor({
-        field: {
-          type: FieldType.string,
-          config: { unit: 'short' },
-        },
-      });
-      expect(processor('22.1122334455').text).toEqual('22');
+      expect(processor('22.1122334455').text).toEqual('22.11');
     });
   });
 });

--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -303,4 +303,36 @@ describe('Date display options', () => {
 
     expect(processor('2020-08-01T08:48:43.783337Z').text).toEqual('2020-08-01 08:48:43');
   });
+
+  describe('number formatting for string values', () => {
+    it('should preserve string unchanged if no unit', () => {
+      const processor = getDisplayProcessor({
+        field: {
+          type: FieldType.string,
+          config: {},
+        },
+      });
+      expect(processor('22.1122334455').text).toEqual('22.1122334455');
+    });
+
+    it('should preserve string unchanged if unit set to none', () => {
+      const processor = getDisplayProcessor({
+        field: {
+          type: FieldType.string,
+          config: { unit: 'none' },
+        },
+      });
+      expect(processor('22.1122334455').text).toEqual('22.1122334455');
+    });
+
+    it('should format string as number if number unit', () => {
+      const processor = getDisplayProcessor({
+        field: {
+          type: FieldType.string,
+          config: { unit: 'short' },
+        },
+      });
+      expect(processor('22.1122334455').text).toEqual('22');
+    });
+  });
 });

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -43,16 +43,18 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
   const formatFunc = getValueFormat(unit || 'none');
   const scaleFunc = getScaleCalculator(field as Field, options.theme);
+  const hasUnit = unit && unit !== 'none';
 
   return (value: any) => {
     const { mappings } = config;
+    const valueIsString = typeof value === 'string';
 
-    if (hasDateUnit && typeof value === 'string') {
+    if (hasDateUnit && valueIsString) {
       value = dateTime(value).valueOf();
     }
 
     let text = _.toString(value);
-    let numeric = toNumber(value);
+    let numeric = hasUnit || !valueIsString ? toNumber(value) : NaN;
     let prefix: string | undefined = undefined;
     let suffix: string | undefined = undefined;
     let shouldFormat = true;

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -47,14 +47,14 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
   return (value: any) => {
     const { mappings } = config;
-    const valueIsString = typeof value === 'string';
+    const isStringUnit = unit === 'string';
 
-    if (hasDateUnit && valueIsString) {
+    if (hasDateUnit && typeof value === 'string') {
       value = dateTime(value).valueOf();
     }
 
     let text = _.toString(value);
-    let numeric = hasUnit || !valueIsString ? toNumber(value) : NaN;
+    let numeric = isStringUnit ? NaN : toNumber(value);
     let prefix: string | undefined = undefined;
     let suffix: string | undefined = undefined;
     let shouldFormat = true;
@@ -64,7 +64,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
       if (mappedValue) {
         text = mappedValue.text;
-        const v = toNumber(text);
+        const v = isStringUnit ? NaN : toNumber(text);
 
         if (!isNaN(v)) {
           numeric = v;

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -43,7 +43,6 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
 
   const formatFunc = getValueFormat(unit || 'none');
   const scaleFunc = getScaleCalculator(field as Field, options.theme);
-  const hasUnit = unit && unit !== 'none';
 
   return (value: any) => {
     const { mappings } = config;

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -1,4 +1,4 @@
-import { locale, scaledUnits, simpleCountUnit, toFixedUnit, ValueFormatCategory } from './valueFormats';
+import { locale, scaledUnits, simpleCountUnit, toFixedUnit, ValueFormatCategory, textFormatter } from './valueFormats';
 import {
   dateTimeAsIso,
   dateTimeAsUS,
@@ -26,19 +26,20 @@ export const getCategories = (): ValueFormatCategory[] => [
     name: 'Misc',
     formats: [
       { name: 'none', id: 'none', fn: toFixedUnit('') },
+      { name: 'Text', id: 'text', fn: textFormatter },
       {
         name: 'short',
         id: 'short',
         fn: scaledUnits(1000, ['', ' K', ' Mil', ' Bil', ' Tri', ' Quadr', ' Quint', ' Sext', ' Sept']),
       },
-      { name: 'percent (0-100)', id: 'percent', fn: toPercent },
-      { name: 'percent (0.0-1.0)', id: 'percentunit', fn: toPercentUnit },
+      { name: 'Percent (0-100)', id: 'percent', fn: toPercent },
+      { name: 'Percent (0.0-1.0)', id: 'percentunit', fn: toPercentUnit },
       { name: 'Humidity (%H)', id: 'humidity', fn: toFixedUnit('%H') },
-      { name: 'decibel', id: 'dB', fn: toFixedUnit('dB') },
-      { name: 'hexadecimal (0x)', id: 'hex0x', fn: toHex0x },
-      { name: 'hexadecimal', id: 'hex', fn: toHex },
-      { name: 'scientific notation', id: 'sci', fn: sci },
-      { name: 'locale format', id: 'locale', fn: locale },
+      { name: 'Decibel', id: 'dB', fn: toFixedUnit('dB') },
+      { name: 'Hexadecimal (0x)', id: 'hex0x', fn: toHex0x },
+      { name: 'Hexadecimal', id: 'hex', fn: toHex },
+      { name: 'Scientific notation', id: 'sci', fn: sci },
+      { name: 'Locale format', id: 'locale', fn: locale },
       { name: 'Pixels', id: 'pixel', fn: toFixedUnit('px') },
     ],
   },

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -1,4 +1,4 @@
-import { locale, scaledUnits, simpleCountUnit, toFixedUnit, ValueFormatCategory, textFormatter } from './valueFormats';
+import { locale, scaledUnits, simpleCountUnit, toFixedUnit, ValueFormatCategory, stringFormater } from './valueFormats';
 import {
   dateTimeAsIso,
   dateTimeAsUS,
@@ -26,7 +26,7 @@ export const getCategories = (): ValueFormatCategory[] => [
     name: 'Misc',
     formats: [
       { name: 'none', id: 'none', fn: toFixedUnit('') },
-      { name: 'Text', id: 'text', fn: textFormatter },
+      { name: 'String', id: 'string', fn: stringFormater },
       {
         name: 'short',
         id: 'short',

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -156,6 +156,10 @@ export function simpleCountUnit(symbol: string): ValueFormatter {
   };
 }
 
+export function textFormatter(value: number): FormattedValue {
+  return { text: value as any };
+}
+
 function buildFormats() {
   categories = getCategories();
 

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -156,7 +156,7 @@ export function simpleCountUnit(symbol: string): ValueFormatter {
   };
 }
 
-export function textFormatter(value: number): FormattedValue {
+export function stringFormater(value: number): FormattedValue {
   return { text: value as any };
 }
 

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -157,7 +157,7 @@ export function simpleCountUnit(symbol: string): ValueFormatter {
 }
 
 export function stringFormater(value: number): FormattedValue {
-  return { text: value as any };
+  return { text: `${value}` };
 }
 
 function buildFormats() {


### PR DESCRIPTION
We have a few problems where we always try to parse values as numbers and if possible we do format them and show them as numbers without any way to show the raw string.

for example when we show a value as "10e2" and "1231232.12312312321" 
https://github.com/grafana/grafana/issues/26606

I tried to fix this by introducing a string unit that overrides the logic of always parsing things to numbers in the display processor. 

But units are not applied to string type fields so this did not work in the app:
https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/utils/standardEditors.tsx#L74