### PR TITLE
Drone: Upgrade build pipeline tool

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -133,8 +133,7 @@ steps:
   image: grafana/ci-e2e:12.18-1
   commands:
   - ./node_modules/.bin/cypress install
-  - ./e2e/wait-for-grafana
-  - ./e2e/run-suite
+  - ./bin/grabpl e2e-tests
   environment:
     HOST: end-to-end-tests-server
   depends_on:
@@ -360,8 +359,7 @@ steps:
   image: grafana/ci-e2e:12.18-1
   commands:
   - ./node_modules/.bin/cypress install
-  - ./e2e/wait-for-grafana
-  - ./e2e/run-suite
+  - ./bin/grabpl e2e-tests
   environment:
     HOST: end-to-end-tests-server
   depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.5.1
+    GRABPL_VERSION: 0.5.3
 
 - name: lint-backend
   image: grafana/build-container:1.2.24
@@ -253,7 +253,7 @@ steps:
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.5.1
+    GRABPL_VERSION: 0.5.3
 
 - name: lint-backend
   image: grafana/build-container:1.2.24
@@ -521,7 +521,7 @@ steps:
   - gcloud auth activate-service-account --key-file=gcpkey.json
   - rm gcpkey.json
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.1/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.3/windows/grabpl.exe -OutFile grabpl.exe
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/oss/master/grafana-7.2.0-9fffe273pre.windows-amd64.zip -OutFile grafana.zip
   - cp C:\App\nssm-2.24.zip .
   - ./grabpl.exe windows-installer --edition oss grafana.zip

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.5.3
+    GRABPL_VERSION: 0.5.4
 
 - name: lint-backend
   image: grafana/build-container:1.2.24
@@ -252,7 +252,7 @@ steps:
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
-    GRABPL_VERSION: 0.5.3
+    GRABPL_VERSION: 0.5.4
 
 - name: lint-backend
   image: grafana/build-container:1.2.24
@@ -519,7 +519,7 @@ steps:
   - gcloud auth activate-service-account --key-file=gcpkey.json
   - rm gcpkey.json
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.3/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.4/windows/grabpl.exe -OutFile grabpl.exe
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/oss/master/grafana-7.2.0-9fffe273pre.windows-amd64.zip -OutFile grafana.zip
   - cp C:\App\nssm-2.24.zip .
   - ./grabpl.exe windows-installer --edition oss grafana.zip

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -3,7 +3,7 @@ publish_image = 'grafana/grafana-ci-deploy:1.2.5'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.2.0'
 alpine_image = 'alpine:3.12'
 windows_image = 'mcr.microsoft.com/windows:1809'
-grabpl_version = '0.5.1'
+grabpl_version = '0.5.3'
 
 def pr_pipelines(edition):
     services = [

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -3,7 +3,7 @@ publish_image = 'grafana/grafana-ci-deploy:1.2.5'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.2.0'
 alpine_image = 'alpine:3.12'
 windows_image = 'mcr.microsoft.com/windows:1809'
-grabpl_version = '0.5.3'
+grabpl_version = '0.5.4'
 
 def pr_pipelines(edition):
     services = [

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -459,8 +459,7 @@ def e2e_tests_step():
             # Have to re-install Cypress since it insists on searching for its binary beneath /root/.cache,
             # even though the Yarn cache directory is beneath /usr/local/share somewhere
             './node_modules/.bin/cypress install',
-            './e2e/wait-for-grafana',
-            './e2e/run-suite',
+            './bin/grabpl e2e-tests',
         ],
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the build pipeline tool in Drone, for automatic e2e retries.