### PR TITLE
AzureMonitor: fix panic introduced in 7.1.4 when unit was unspecified and alias was used 

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -299,8 +299,16 @@ func (e *AzureMonitorDatasource) parseResponse(queryRes *tsdb.QueryResult, amr A
 			})
 		}
 		if query.Alias != "" {
-			dataField.Config.DisplayName = formatAzureMonitorLegendKey(query.Alias, query.UrlComponents["resourceName"],
+			displayName := formatAzureMonitorLegendKey(query.Alias, query.UrlComponents["resourceName"],
 				amr.Value[0].Name.LocalizedValue, "", "", amr.Namespace, amr.Value[0].ID, labels)
+
+			if dataField.Config != nil {
+				dataField.Config.DisplayName = displayName
+			} else {
+				dataField.SetConfig(&data.FieldConfig{
+					DisplayName: displayName,
+				})
+			}
 		}
 
 		requestedAgg := query.Params.Get("aggregation")

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -405,6 +405,27 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 						&data.FieldConfig{Unit: "decbytes", DisplayName: "danieltest {Blob Type=Azure Data Lake Storage, Tier=Cool}"})),
 			},
 		},
+		{
+			name:         "unspecified unit with alias should not panic",
+			responseFile: "8-azure-monitor-response-unspecified-unit.json",
+			mockQuery: &AzureMonitorQuery{
+				Alias: "custom",
+				UrlComponents: map[string]string{
+					"resourceName": "grafana",
+				},
+				Params: url.Values{
+					"aggregation": {"Average"},
+				},
+			},
+			expectedFrames: data.Frames{
+				data.NewFrame("",
+					data.NewField("", nil,
+						[]time.Time{time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC)}),
+					data.NewField("Percentage CPU", nil, []float64{
+						2.0875,
+					}).SetConfig(&data.FieldConfig{DisplayName: "custom"})),
+			},
+		},
 	}
 
 	datasource := &AzureMonitorDatasource{}

--- a/pkg/tsdb/azuremonitor/testdata/azuremonitor/8-azure-monitor-response-unspecified-unit.json
+++ b/pkg/tsdb/azuremonitor/testdata/azuremonitor/8-azure-monitor-response-unspecified-unit.json
@@ -1,0 +1,31 @@
+{
+  "cost": 0,
+  "timespan": "2019-02-08T10:13:50Z\/2019-02-08T16:13:50Z",
+  "interval": "PT1M",
+  "value": [
+    {
+      "id": "\/subscriptions\/xxx\/resourceGroups\/grafanastaging\/providers\/Microsoft.Compute\/virtualMachines\/grafana\/providers\/Microsoft.Insights\/metrics\/Percentage CPU",
+      "type": "Microsoft.Insights\/metrics",
+      "name": {
+        "value": "Percentage CPU",
+        "localizedValue": "Percentage CPU"
+      },
+      "unit": "Unspecified",
+      "timeseries": [
+        {
+          "metadatavalues": [
+
+          ],
+          "data": [
+            {
+              "timeStamp": "2019-02-08T10:13:00Z",
+              "average": 2.0875
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "namespace": "Microsoft.Compute\/virtualMachines",
+  "resourceregion": "westeurope"
+}


### PR DESCRIPTION
happens when unit was "Unspecified" and alias is being used

