### PR TITLE
Alerting: Store sensitive settings encrypted for Sensu notifier 

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -466,13 +466,13 @@ The following sections detail the supported settings and secure settings for eac
 
 #### Alert notification `sensu`
 
-| Name     |
-| -------- |
-| url      |
-| source   |
-| handler  |
-| username |
-| password |
+| Name     | Secure setting |
+| -------- | - | 
+| url      | |
+| source   | |
+| handler  | |
+| username | |
+| password | yes |
 
 #### Alert notification `prometheus-alertmanager`
 

--- a/pkg/services/alerting/notifiers/sensu.go
+++ b/pkg/services/alerting/notifiers/sensu.go
@@ -19,27 +19,39 @@ func init() {
 		Heading:     "Sensu settings",
 		Factory:     NewSensuNotifier,
 		OptionsTemplate: `
-      <h3 class="page-heading">Sensu settings</h3>
-      <div class="gf-form">
-        <span class="gf-form-label width-10">Url</span>
-				<input type="text" required class="gf-form-input max-width-26" ng-model="ctrl.model.settings.url" placeholder="http://sensu-api.local:4567/results"></input>
-      </div>
-      <div class="gf-form">
-        <span class="gf-form-label width-10">Source</span>
-        <input type="text" class="gf-form-input max-width-14" ng-model="ctrl.model.settings.source" bs-tooltip="'If empty rule id will be used'" data-placement="right"></input>
-      </div>
-      <div class="gf-form">
-        <span class="gf-form-label width-10">Handler</span>
-        <input type="text" class="gf-form-input max-width-14" ng-model="ctrl.model.settings.handler" placeholder="default"></input>
-      </div>
-      <div class="gf-form">
-        <span class="gf-form-label width-10">Username</span>
-        <input type="text" class="gf-form-input max-width-14" ng-model="ctrl.model.settings.username"></input>
-      </div>
-      <div class="gf-form">
-        <span class="gf-form-label width-10">Password</span>
-        <input type="text" class="gf-form-input max-width-14" ng-model="ctrl.model.settings.password"></input>
-      </div>
+		<h3 class="page-heading">Sensu settings</h3>
+		<div class="gf-form">
+			<span class="gf-form-label width-10">Url</span>
+			<input type="text" required class="gf-form-input max-width-26" ng-model="ctrl.model.settings.url" placeholder="http://sensu-api.local:4567/results"></input>
+		</div>
+		<div class="gf-form">
+			<span class="gf-form-label width-10">Source</span>
+			<input type="text" class="gf-form-input max-width-14" ng-model="ctrl.model.settings.source" bs-tooltip="'If empty rule id will be used'" data-placement="right"></input>
+		</div>
+		<div class="gf-form">
+			<span class="gf-form-label width-10">Handler</span>
+			<input type="text" class="gf-form-input max-width-14" ng-model="ctrl.model.settings.handler" placeholder="default"></input>
+		</div>
+		<div class="gf-form">
+			<span class="gf-form-label width-10">Username</span>
+			<input type="text" class="gf-form-input max-width-14" ng-model="ctrl.model.settings.username"></input>
+		</div>
+		<div class="gf-form">
+			<label class="gf-form-label width-10">Password</label>
+			<div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.password">
+				<input type="text"
+					required
+					class="gf-form-input max-width-14"
+					ng-init="ctrl.model.secureSettings.password = ctrl.model.settings.password || null; ctrl.model.settings.password = null;"
+					ng-model="ctrl.model.secureSettings.password"
+					data-placement="right">
+				</input>
+			</div>
+			<div class="gf-form" ng-if="ctrl.model.secureFields.password">
+			  <input type="text" class="gf-form-input max-width-14" disabled="disabled" value="configured" />
+			  <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.password = false">reset</a>
+			</div>
+		</div>
     `,
 		Options: []alerting.NotifierOption{
 			{
@@ -92,7 +104,7 @@ func NewSensuNotifier(model *models.AlertNotification) (alerting.Notifier, error
 		URL:          url,
 		User:         model.Settings.Get("username").MustString(),
 		Source:       model.Settings.Get("source").MustString(),
-		Password:     model.Settings.Get("password").MustString(),
+		Password:     model.DecryptedValue("password", model.Settings.Get("password").MustString()),
 		Handler:      model.Settings.Get("handler").MustString(),
 		log:          log.New("alerting.notifier.sensu"),
 	}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to update all alert notifiers so that they support storing sensitive information encrypted. This PR covers Sensu 

**Which issue(s) this PR fixes**:
(part of) https://github.com/grafana/grafana/issues/25967




