### PR TITLE
Alerting: remove LongToWide call in alerting

### DIFF
--- a/pkg/tsdb/frame_util.go
+++ b/pkg/tsdb/frame_util.go
@@ -54,15 +54,6 @@ func FrameToSeriesSlice(frame *data.Frame) (TimeSeriesSlice, error) {
 		}
 		return nil, fmt.Errorf("input frame is not recognized as a time series")
 	}
-	// If Long, make wide
-	if tsSchema.Type == data.TimeSeriesTypeLong {
-		var err error
-		frame, err = data.LongToWide(frame, nil)
-		if err != nil {
-			return nil, errutil.Wrap("failed to convert long to wide series when converting from dataframe", err)
-		}
-		tsSchema = frame.TimeSeriesSchema()
-	}
 
 	seriesCount := len(tsSchema.ValueIndices)
 	seriesSlice := make(TimeSeriesSlice, 0, seriesCount)

--- a/pkg/tsdb/frame_util_test.go
+++ b/pkg/tsdb/frame_util_test.go
@@ -57,71 +57,22 @@ func TestFrameToSeriesSlice(t *testing.T) {
 			Err: require.NoError,
 		},
 		{
-			name: "a long series",
+			name: "empty wide series",
 			frame: data.NewFrame("",
-				data.NewField("Time", nil, []time.Time{
-					time.Date(2020, 1, 2, 3, 4, 0, 0, time.UTC),
-					time.Date(2020, 1, 2, 3, 4, 0, 0, time.UTC),
-					time.Date(2020, 1, 2, 3, 4, 30, 0, time.UTC),
-					time.Date(2020, 1, 2, 3, 4, 30, 0, time.UTC),
-				}),
-				data.NewField("Values Floats", nil, []float64{
-					1.0,
-					2.0,
-					3.0,
-					4.0,
-				}),
-				data.NewField("Values Int64", nil, []int64{
-					1,
-					2,
-					3,
-					4,
-				}),
-				data.NewField("Animal Factor", nil, []string{
-					"cat",
-					"sloth",
-					"cat",
-					"sloth",
-				}),
-				data.NewField("Location", nil, []string{
-					"Florida",
-					"Central & South America",
-					"Florida",
-					"Central & South America",
-				})),
+				data.NewField("Time", nil, []time.Time{}),
+				data.NewField(`Values Int64s`, data.Labels{"Animal Factor": "cat"}, []*int64{}),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth"}, []float64{})),
 
 			seriesSlice: TimeSeriesSlice{
 				&TimeSeries{
-					Name: "Values Floats",
-					Tags: map[string]string{"Animal Factor": "cat", "Location": "Florida"},
-					Points: TimeSeriesPoints{
-						TimePoint{null.FloatFrom(1), null.FloatFrom(1577934240000)},
-						TimePoint{null.FloatFrom(3), null.FloatFrom(1577934270000)},
-					},
+					Name:   "Values Int64s",
+					Tags:   map[string]string{"Animal Factor": "cat"},
+					Points: TimeSeriesPoints{},
 				},
 				&TimeSeries{
-					Name: "Values Floats",
-					Tags: map[string]string{"Animal Factor": "sloth", "Location": "Central & South America"},
-					Points: TimeSeriesPoints{
-						TimePoint{null.FloatFrom(2), null.FloatFrom(1577934240000)},
-						TimePoint{null.FloatFrom(4), null.FloatFrom(1577934270000)},
-					},
-				},
-				&TimeSeries{
-					Name: "Values Int64",
-					Tags: map[string]string{"Animal Factor": "cat", "Location": "Florida"},
-					Points: TimeSeriesPoints{
-						TimePoint{null.FloatFrom(1), null.FloatFrom(1577934240000)},
-						TimePoint{null.FloatFrom(3), null.FloatFrom(1577934270000)},
-					},
-				},
-				&TimeSeries{
-					Name: "Values Int64",
-					Tags: map[string]string{"Animal Factor": "sloth", "Location": "Central & South America"},
-					Points: TimeSeriesPoints{
-						TimePoint{null.FloatFrom(2), null.FloatFrom(1577934240000)},
-						TimePoint{null.FloatFrom(4), null.FloatFrom(1577934270000)},
-					},
+					Name:   "Values Floats",
+					Tags:   map[string]string{"Animal Factor": "sloth"},
+					Points: TimeSeriesPoints{},
 				},
 			},
 			Err: require.NoError,


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it so when alerting receives a "Long" formatted time series with no rows, there is "no_data" instead of an error.

**Which issue(s) this PR fixes**:

Fixes #27132

**Special notes for your reviewer**:
This removes the LongToWide call from the tsdb.FrameToSeriesSlice(). Alerting is the only place that calls this function, and this issue is a side effect of this call. The call does not make much sense here, as that call should be done when using formatAs timeseries on a table-model backed data source. (Like Azure's Kusto services, and in the future SQL - when switched to data frames).

This is a variation of the problem fixed in https://github.com/grafana/grafana/pull/26903 that was missed.
