### PR TITLE
Alerting: Store sensitive settings encrypted for LINE notifier

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -453,9 +453,9 @@ The following sections detail the supported settings and secure settings for eac
 
 #### Alert notification `LINE`
 
-| Name  |
-| ----- |
-| token |
+| Name  | Secure setting |
+| ----- | - |
+| token | yes |
 
 #### Alert notification `pagerduty`
 

--- a/pkg/services/alerting/notifiers/line.go
+++ b/pkg/services/alerting/notifiers/line.go
@@ -18,13 +18,23 @@ func init() {
 		Heading:     "LINE notify settings",
 		Factory:     NewLINENotifier,
 		OptionsTemplate: `
-    <div class="gf-form-group">
-      <h3 class="page-heading">LINE notify settings</h3>
-      <div class="gf-form">
-        <span class="gf-form-label width-14">Token</span>
-        <input type="text" required class="gf-form-input max-width-22" ng-model="ctrl.model.settings.token" placeholder="LINE notify token key"></input>
-      </div>
-    </div>
+		<h3 class="page-heading">LINE notify settings</h3>
+		<div class="gf-form">
+			<label class="gf-form-label max-width-14">Token</label>
+			<div class="gf-form gf-form--grow" ng-if="!ctrl.model.secureFields.token">
+				<input type="text"
+					required
+					class="gf-form-input max-width-22"
+					ng-init="ctrl.model.secureSettings.token = ctrl.model.settings.token || null; ctrl.model.settings.token = null;"
+					ng-model="ctrl.model.secureSettings.token"
+					data-placement="right">
+				</input>
+			</div>
+			<div class="gf-form" ng-if="ctrl.model.secureFields.token">
+			  <input type="text" class="gf-form-input max-width-18" disabled="disabled" value="configured" />
+			  <a class="btn btn-secondary gf-form-btn" href="#" ng-click="ctrl.model.secureFields.token = false">reset</a>
+			</div>
+		</div>
 `,
 		Options: []alerting.NotifierOption{
 			{
@@ -44,7 +54,7 @@ const (
 
 // NewLINENotifier is the constructor for the LINE notifier
 func NewLINENotifier(model *models.AlertNotification) (alerting.Notifier, error) {
-	token := model.Settings.Get("token").MustString()
+	token := model.DecryptedValue("token", model.Settings.Get("token").MustString())
 	if token == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find token in settings"}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to update all alert notifiers so that they support storing sensitive information encrypted. This PR covers LINE 

**Which issue(s) this PR fixes**:
(part of) https://github.com/grafana/grafana/issues/25967