### PR TITLE
Stats: fix admin stats query parameters

### DIFF
--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -158,7 +158,7 @@ func GetAdminStats(query *models.GetAdminStatsQuery) error {
 		) AS active_sessions`
 
 	var stats models.AdminStats
-	_, err := x.SQL(rawSql, activeEndDate, activeEndDate, activeEndDate, activeEndDate, activeEndDate.Unix()).Get(&stats)
+	_, err := x.SQL(rawSql, activeEndDate, activeEndDate.Unix()).Get(&stats)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix number of parameters for AdminStats query

**Special notes for your reviewer**:
This is a quick fix to fix the failing tests but I think it would be good to refactor this function to use the `SqlBuilder` and avoid this kind of errors in the future.

