### PR TITLE
Stats: Correct the number of arguments for SQL call

### DIFF
--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -158,7 +158,7 @@ func GetAdminStats(query *models.GetAdminStatsQuery) error {
 		) AS active_sessions`
 
 	var stats models.AdminStats
-	_, err := x.SQL(rawSql, activeEndDate, activeEndDate, activeEndDate, activeEndDate, activeEndDate.Unix()).Get(&stats)
+	_, err := x.SQL(rawSql, activeEndDate, activeEndDate.Unix()).Get(&stats)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/sqlstore/stats_integration_test.go
+++ b/pkg/services/sqlstore/stats_integration_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIntegration_GetAdminStats(t *testing.T) {
+	InitTestDB(t)
+
+	query := models.GetAdminStatsQuery{}
+	err := GetAdminStats(&query)
+	require.NoError(t, err)
+}
+
 func TestIntegration_GetUserStats(t *testing.T) {
 	InitTestDB(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a missing integration test + fixes the admin stats page.
