### PR TITLE
DataFrame: Data source field naming control that does not use field.config.displayName

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -95,7 +95,7 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
   ];
 
   if (timeSeries.title) {
-    (fields[1].config as FieldConfig).displayNameDS = timeSeries.title;
+    (fields[1].config as FieldConfig).displayNameFromDS = timeSeries.title;
   }
 
   return {

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -95,7 +95,7 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
   ];
 
   if (timeSeries.title) {
-    (fields[1].config as FieldConfig).displayName = timeSeries.title;
+    (fields[1].config as FieldConfig).useFrameName = true;
   }
 
   return {

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -95,7 +95,7 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
   ];
 
   if (timeSeries.title) {
-    (fields[1].config as FieldConfig).useFrameName = true;
+    (fields[1].config as FieldConfig).displayNameDS = timeSeries.title;
   }
 
   return {

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -58,8 +58,8 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     return displayName;
   }
 
-  if (frame && field.config?.useFrameName) {
-    return frame.name ?? 'missing name';
+  if (frame && field.config?.displayNameDS) {
+    return field.config.displayNameDS;
   }
 
   // This is an ugly exception for time field

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -58,8 +58,8 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     return displayName;
   }
 
-  if (frame && field.config?.displayNameDS) {
-    return field.config.displayNameDS;
+  if (frame && field.config?.displayNameFromDS) {
+    return field.config.displayNameFromDS;
   }
 
   // This is an ugly exception for time field

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -58,6 +58,10 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     return displayName;
   }
 
+  if (frame && field.config?.useFrameName) {
+    return frame.name ?? 'missing name';
+  }
+
   // This is an ugly exception for time field
   // For time series we should normally treat time field with same name
   // But in case it has a join source we should handle it as normal field

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -29,11 +29,10 @@ export interface FieldConfig<TOptions extends object = any> {
   displayName?: string;
 
   /**
-   * This can be used by data sources that return time series with labels to indicate that frame name contains the
-   * full series name.  Useful for data sources that have custom legend formats and naming schemes and want to
-   * control naming, but still return labels and allow for user override of name via default displayName option.
+   * This can be used by data sources that return time series with labels that want to control
+   * series naming and disable the default naming scheme.
    */
-  useFrameName?: boolean;
+  displayNameDS?: string;
 
   /**
    * True if data source field supports ad-hoc filters

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -29,8 +29,8 @@ export interface FieldConfig<TOptions extends object = any> {
   displayName?: string;
 
   /**
-   * This can be used by data sources that return time series with labels that want to control
-   * series naming and disable the default naming scheme.
+   * This can be used by data sources that return and explicit naming structure for values and labels 
+   * When this property is configured, this value is used rather than the default naming strategy.  
    */
   displayNameDS?: string;
 

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -29,10 +29,10 @@ export interface FieldConfig<TOptions extends object = any> {
   displayName?: string;
 
   /**
-   * This can be used by data sources that return and explicit naming structure for values and labels 
-   * When this property is configured, this value is used rather than the default naming strategy.  
+   * This can be used by data sources that return and explicit naming structure for values and labels
+   * When this property is configured, this value is used rather than the default naming strategy.
    */
-  displayNameDS?: string;
+  displayNameFromDS?: string;
 
   /**
    * True if data source field supports ad-hoc filters

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -23,7 +23,21 @@ export enum FieldType {
  * Plugins may extend this with additional properties. Something like series overrides
  */
 export interface FieldConfig<TOptions extends object = any> {
-  displayName?: string; // The display value for this field.  This supports template variables blank is auto
+  /**
+   * The display value for this field.  This supports template variables blank is auto
+   */
+  displayName?: string;
+
+  /**
+   * This can be used by data sources that return time series with labels to indicate that frame name contains the
+   * full series name.  Useful for data sources that have custom legend formats and naming schemes and want to
+   * control naming, but still return labels and allow for user override of name via default displayName option.
+   */
+  useFrameName?: boolean;
+
+  /**
+   * True if data source field supports ad-hoc filters
+   */
   filterable?: boolean;
 
   // Numeric Options

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -625,7 +625,7 @@ describe('PrometheusDatasource', () => {
       it('should return series list', async () => {
         const frame = toDataFrame(results.data[0]);
         expect(results.data.length).toBe(1);
-        expect(getFieldDisplayName(frame.fields[1])).toBe('test{job="testjob"}');
+        expect(getFieldDisplayName(frame.fields[1], frame)).toBe('test{job="testjob"}');
       });
     });
 
@@ -771,7 +771,7 @@ describe('PrometheusDatasource', () => {
       const frame = toDataFrame(results.data[0]);
       expect(results.data.length).toBe(1);
       expect(frame.name).toBe('test{job="testjob"}');
-      expect(getFieldDisplayName(frame.fields[1])).toBe('test{job="testjob"}');
+      expect(getFieldDisplayName(frame.fields[1], frame)).toBe('test{job="testjob"}');
     });
   });
 
@@ -1695,7 +1695,7 @@ describe('PrometheusDatasource for POST', () => {
     it('should return series list', () => {
       const frame = toDataFrame(results.data[0]);
       expect(results.data.length).toBe(1);
-      expect(getFieldDisplayName(frame.fields[1])).toBe('test{job="testjob"}');
+      expect(getFieldDisplayName(frame.fields[1], frame)).toBe('test{job="testjob"}');
     });
   });
 


### PR DESCRIPTION
In v7.0 we added label display name logic where Grafana uses the labels to render the field name as well as some initial smart behavior of removing duplicate info (duplicate metric names or field labels). This smart logic would be a big breaking change for Prometheus and graphite and with no time to do a UI option to control or disable this smart naming we opted to disable the smart behavior by setting field.config.displayName from Prometheus and graphite data sources as setting displayName from data source overrides the smart naming.

However, setting field.config.displayName from data source makes the panel Field tab (field config defaults) to have no effect.

Creating bugs like #25212 for both Graphite and Prometheus

First idea was to have a FieldNaming scheme on the frame, but that was tricky. Think it makes more sense to have on field config but also need some property to override field naming for data sources that have a custom legend naming schemes (like prometheus and graphite). So in order for data sources to be able to return a pre-backed series name I added a new field config option useFrameName bool that is currently always true for graphite and prometheus. With this new bool users can still override the naming using display name (and Gauge visualization won't show name for single series any). 

Need to pursue the short and complete naming schemes in future PR. 

There is a strange old time series title -> useFrameName bool translation that feels off. Might have to change TimeSeries.title to bool but do not know what to name it, as useFrameName is strange in that context. 

Updated to use new displayNameDS property

Fixes #25212