### PR TITLE
Cloud Monitoring: Fix missing title and text from cloud monitoring annotations

### DIFF
--- a/pkg/tsdb/cloudmonitoring/annotation_query.go
+++ b/pkg/tsdb/cloudmonitoring/annotation_query.go
@@ -25,9 +25,9 @@ func (e *CloudMonitoringExecutor) executeAnnotationQuery(ctx context.Context, ts
 	if err != nil {
 		return nil, err
 	}
-	title := firstQuery.Model.Get("title").MustString()
-	text := firstQuery.Model.Get("text").MustString()
-	tags := firstQuery.Model.Get("tags").MustString()
+	title := firstQuery.Model.Get("metricQuery").Get("title").MustString()
+	text := firstQuery.Model.Get("metricQuery").Get("text").MustString()
+	tags := firstQuery.Model.Get("metricQuery").Get("tags").MustString()
 	err = e.parseToAnnotations(queryRes, resp, queries[0], title, text, tags)
 	result.Results[firstQuery.RefId] = queryRes
 

--- a/pkg/tsdb/cloudmonitoring/annotation_query.go
+++ b/pkg/tsdb/cloudmonitoring/annotation_query.go
@@ -25,9 +25,11 @@ func (e *CloudMonitoringExecutor) executeAnnotationQuery(ctx context.Context, ts
 	if err != nil {
 		return nil, err
 	}
-	title := firstQuery.Model.Get("metricQuery").Get("title").MustString()
-	text := firstQuery.Model.Get("metricQuery").Get("text").MustString()
-	tags := firstQuery.Model.Get("metricQuery").Get("tags").MustString()
+
+	metricQuery := firstQuery.Model.Get("metricQuery")
+	title := metricQuery.Get("title").MustString()
+	text := metricQuery.Get("text").MustString()
+	tags := metricQuery.Get("tags").MustString()
 	err = e.parseToAnnotations(queryRes, resp, queries[0], title, text, tags)
 	result.Results[firstQuery.RefId] = queryRes
 

--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -302,7 +302,7 @@ func migrateLegacyQueryModel(query *tsdb.Query) {
 	if mq == nil {
 		migratedModel := simplejson.NewFromAny(map[string]interface{}{
 			"queryType":   metricQueryType,
-			"metricQuery": query.Model,
+			"metricQuery": query.Model.MustMap(),
 		})
 		query.Model = migratedModel
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

I found that the cloudmonitoring datasource annotation text is empty when upgrade to 7.x.

![image](https://user-images.githubusercontent.com/644501/91154255-490da700-e6fc-11ea-9842-9bf339f28d51.png)


![image](https://user-images.githubusercontent.com/644501/91153799-a9501900-e6fb-11ea-8cb7-852cacddf8ad.png)


- missing the metricQuery in migrate to new model.
- change simplejson object to map object. (simplejson.NewFromAny does not expect simplejson.Json object)

![image](https://user-images.githubusercontent.com/644501/91154197-3004f600-e6fc-11ea-85b3-e181af0b9aba.png)


refs #22917

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"


Fixes #
-->

**Special notes for your reviewer**:

