### PR TITLE
Explore: Keep typeahead suggestions for exact label matches in Loki q…

### DIFF
--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -91,7 +91,15 @@ describe('Language completion provider', () => {
       const input = createTypeaheadInput('{}', '', '', 1);
       const result = await provider.provideCompletionItems(input, { absoluteRange: rangeMock });
       expect(result.context).toBe('context-labels');
-      expect(result.suggestions).toEqual([{ items: [{ label: 'label1' }, { label: 'label2' }], label: 'Labels' }]);
+      expect(result.suggestions).toEqual([
+        {
+          items: [
+            { label: 'label1', filterText: '"label1"' },
+            { label: 'label2', filterText: '"label2"' },
+          ],
+          label: 'Labels',
+        },
+      ]);
     });
 
     it('returns all label suggestions on selector when starting to type', async () => {
@@ -100,7 +108,15 @@ describe('Language completion provider', () => {
       const input = createTypeaheadInput('{l}', '', '', 2);
       const result = await provider.provideCompletionItems(input, { absoluteRange: rangeMock });
       expect(result.context).toBe('context-labels');
-      expect(result.suggestions).toEqual([{ items: [{ label: 'label1' }, { label: 'label2' }], label: 'Labels' }]);
+      expect(result.suggestions).toEqual([
+        {
+          items: [
+            { label: 'label1', filterText: '"label1"' },
+            { label: 'label2', filterText: '"label2"' },
+          ],
+          label: 'Labels',
+        },
+      ]);
     });
   });
 
@@ -140,7 +156,13 @@ describe('Language completion provider', () => {
       result = await provider.provideCompletionItems(input, { absoluteRange: rangeMock });
       expect(result.context).toBe('context-label-values');
       expect(result.suggestions).toEqual([
-        { items: [{ label: 'label1_val1' }, { label: 'label1_val2' }], label: 'Label values for "label1"' },
+        {
+          items: [
+            { label: 'label1_val1', filterText: '"label1_val1"' },
+            { label: 'label1_val2', filterText: '"label1_val2"' },
+          ],
+          label: 'Label values for "label1"',
+        },
       ]);
     });
   });

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -28,7 +28,7 @@ const HISTORY_COUNT_CUTOFF = 1000 * 60 * 60 * 24; // 24h
 const NS_IN_MS = 1000000;
 export const LABEL_REFRESH_INTERVAL = 1000 * 30; // 30sec
 
-const wrapLabel = (label: string) => ({ label });
+const wrapLabel = (label: string) => ({ label, filterText: `\"${label}\"` });
 export const rangeToParams = (range: AbsoluteTimeRange) => ({ start: range.from * NS_IN_MS, end: range.to * NS_IN_MS });
 
 export type LokiHistoryItem = HistoryItem<LokiQuery>;
@@ -196,13 +196,13 @@ export default class LokiLanguageProvider extends LanguageProvider {
         .take(HISTORY_ITEM_COUNT)
         .map(wrapLabel)
         .map((item: CompletionItem) => addHistoryMetadata(item, history))
-        .value();
+        .value() as unknown;
 
       suggestions.push({
         prefixMatch: true,
         skipSort: true,
         label: 'History',
-        items: historyItems,
+        items: historyItems as CompletionItem[],
       });
     }
 

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -29,6 +29,7 @@ const NS_IN_MS = 1000000;
 export const LABEL_REFRESH_INTERVAL = 1000 * 30; // 30sec
 
 const wrapLabel = (label: string) => ({ label, filterText: `\"${label}\"` });
+
 export const rangeToParams = (range: AbsoluteTimeRange) => ({ start: range.from * NS_IN_MS, end: range.to * NS_IN_MS });
 
 export type LokiHistoryItem = HistoryItem<LokiQuery>;
@@ -287,13 +288,13 @@ export default class LokiLanguageProvider extends LanguageProvider {
         context = 'context-label-values';
         suggestions.push({
           label: `Label values for "${labelKey}"`,
-          items: labelValues[labelKey].map(wrapLabel),
+          // Filter to prevent previously selected values from being repeatedly suggested
+          items: labelValues[labelKey].map(wrapLabel).filter(({ filterText }) => filterText !== text),
         });
       }
     } else {
       // Label keys
       const labelKeys = labelValues ? Object.keys(labelValues) : DEFAULT_KEYS;
-
       if (labelKeys) {
         const possibleKeys = _.difference(labelKeys, existingKeys);
         if (possibleKeys.length) {

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -188,21 +188,21 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const history = context?.history;
     const suggestions = [];
 
-    if (history && history.length) {
+    if (history?.length) {
       const historyItems = _.chain(history)
         .map(h => h.query.expr)
         .filter()
         .uniq()
         .take(HISTORY_ITEM_COUNT)
         .map(wrapLabel)
-        .map((item: CompletionItem) => addHistoryMetadata(item, history))
-        .value() as unknown;
+        .map(item => addHistoryMetadata(item, history))
+        .value();
 
       suggestions.push({
         prefixMatch: true,
         skipSort: true,
         label: 'History',
-        items: historyItems as CompletionItem[],
+        items: historyItems,
       });
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Exact matches in the Loki query editor typeahead weren't autosuggesting. The root cause is that they were getting filtered out by the slate suggestions plugin [here](https://github.com/grafana/grafana/blob/d1ee1d93c8817d6f09d519131c87511abaadbd9e/packages/grafana-ui/src/slate-plugins/suggestions.tsx#L310)

I didn't want to change the plugin behavior, so I added an extra property to the suggestion items in the loki query editor to get around that filter case. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/26661
