### PR TITLE
CloudWatch: Fix error message returned from tag:GetResources

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -694,7 +694,7 @@ func (e *cloudWatchExecutor) resourceGroupsGetResources(region string, filters [
 			resp.ResourceTagMappingList = append(resp.ResourceTagMappingList, page.ResourceTagMappingList...)
 			return !lastPage
 		}); err != nil {
-		return nil, fmt.Errorf("failed to call tags:GetResources, %w", err)
+		return nil, fmt.Errorf("failed to call tag:GetResources, %w", err)
 	}
 
 	return &resp, nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This fixes the log for AWS permission related error that can confuse the user.

**Which issue(s) this PR fixes**:

The action name is `tag:GetResources`, not `tags:GetResources`. This creates a confusing error message that can have the user add the wrong permission to the IAM role.

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

