### PR TITLE
Loki: Re-introduce running of instant queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -49,16 +49,6 @@ describe('LokiDatasource', () => {
     },
   };
 
-  const testInstantResp: { data: LokiResponse } = {
-    data: {
-      data: {
-        resultType: LokiResultType.Stream,
-        result: [],
-      },
-      status: 'success',
-    },
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
     datasourceRequestMock.mockImplementation(() => Promise.resolve());
@@ -195,18 +185,15 @@ describe('LokiDatasource', () => {
       const ds = new LokiDatasource(customSettings, templateSrvMock);
 
       datasourceRequestMock.mockImplementation(
-        jest
-          .fn()
-          .mockReturnValueOnce(Promise.resolve(testInstantResp))
-          .mockReturnValueOnce(
-            Promise.reject({
-              data: {
-                message: 'parse error at line 1, col 6: invalid char escape',
-              },
-              status: 400,
-              statusText: 'Bad Request',
-            })
-          )
+        jest.fn().mockReturnValue(
+          Promise.reject({
+            data: {
+              message: 'parse error at line 1, col 6: invalid char escape',
+            },
+            status: 400,
+            statusText: 'Bad Request',
+          })
+        )
       );
       const options = getQueryOptions<LokiQuery>({
         targets: [{ expr: '{job="gra\\fana"}', refId: 'B' }],

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -138,7 +138,8 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
           data: [lokiResultsToTableModel(response.data.data.result, responseListLength, target.refId, meta, true)],
           key: `${target.refId}_instant`,
         };
-      })
+      }),
+      catchError((err: any) => this.throwUnless(err, err.status === 404, target))
     );
   };
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -91,7 +91,12 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
         expr: this.templateSrv.replace(target.expr, options.scopedVars, this.interpolateQueryExpr),
       }));
 
-    filteredTargets.forEach(target => subQueries.push(this.runRangeQuery(target, options, filteredTargets.length)));
+    filteredTargets.forEach(target =>
+      subQueries.push(
+        this.runInstantQuery(target, options, filteredTargets.length),
+        this.runRangeQuery(target, options, filteredTargets.length)
+      )
+    );
 
     // No valid targets, return the empty result to save a round trip.
     if (isEmpty(subQueries)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-introduces running of instant queries for Loki:

- In case of metrics queries, we visualise the result in table
- In case of log queries, then we know that we are dealing with a logs query, and drop the result from the instant query and only pass on the result from the range query

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/27162
