### PR TITLE
UI/ClickOutsideWrapper: Adds eventType prop for situations where event should be on document

### DIFF
--- a/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
+++ b/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
@@ -10,6 +10,7 @@ export interface Props {
    *  Runs the 'onClick' function when pressing a key outside of the current element. Defaults to true.
    */
   includeButtonPress: boolean;
+  parent: Window | Document;
 }
 
 interface State {
@@ -19,22 +20,24 @@ interface State {
 export class ClickOutsideWrapper extends PureComponent<Props, State> {
   static defaultProps = {
     includeButtonPress: true,
+    parent: window,
   };
   state = {
     hasEventListener: false,
   };
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.onOutsideClick, false);
+    this.props.parent.addEventListener('click', this.onOutsideClick, false);
     if (this.props.includeButtonPress) {
-      document.addEventListener('keydown', this.onOutsideClick, false);
+      // Use keyup since keydown already has an eventlistener on window
+      this.props.parent.addEventListener('keyup', this.onOutsideClick, false);
     }
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.onOutsideClick, false);
+    this.props.parent.removeEventListener('click', this.onOutsideClick, false);
     if (this.props.includeButtonPress) {
-      document.removeEventListener('keydown', this.onOutsideClick, false);
+      this.props.parent.removeEventListener('keyup', this.onOutsideClick, false);
     }
   }
 

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -180,7 +180,7 @@ export class PanelHeader extends Component<Props, State> {
               <span className="panel-title-text">{title}</span>
               <Icon name="angle-down" className="panel-menu-toggle" />
               {this.state.panelMenuOpen && (
-                <ClickOutsideWrapper onClick={this.closeMenu}>
+                <ClickOutsideWrapper onClick={this.closeMenu} parent={document}>
                   <PanelHeaderMenu items={menuItems} />
                 </ClickOutsideWrapper>
               )}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `parent` prop to `ClickOutsideWrapper`, with a default of `window`, that can be overridden if the event should be on `document`, as in the case with `PanelHeader`.
This PR should also resolve issues with the dashboard variable dropdown not behaving properly.
