### PR TITLE
Dashlist: Tweaked design of folder addition

### DIFF
--- a/public/app/plugins/panel/dashlist/module.html
+++ b/public/app/plugins/panel/dashlist/module.html
@@ -6,13 +6,10 @@
       </h6>
       <div class="dashlist-item" ng-repeat="dash in group.list">
         <a class="dashlist-link dashlist-link-{{dash.type}}" href="{{dash.url}}">
-          <span class="dashlist-title">
-            {{dash.title}}
-          </span>
-          <span ng-if="dash.folderTitle" class="dashlist-folder">
-            <icon name="'folder'" type="mono" size="'xs'"></icon>
-            {{dash.folderTitle}}
-          </span>
+          <div class="dashlist-link-body">
+            <div class="dashlist-title">{{dash.title}}</div>
+            <div ng-if="dash.folderTitle" class="dashlist-folder">{{dash.folderTitle}}</div>
+          </div>
           <span class="dashlist-star" ng-click="ctrl.starDashboard(dash, $event)">
             <icon name="dash.isStarred ? 'favorite':'star'" type="dash.isStarred ? 'mono':'default'"></icon>
           </span>

--- a/public/sass/components/_panel_dashlist.scss
+++ b/public/sass/components/_panel_dashlist.scss
@@ -8,26 +8,30 @@
   padding-top: 3px;
 }
 
-.dashlist {
-  &-link {
-    @include list-item();
+.dashlist-link {
+  @include list-item();
+  display: flex;
 
-    .fa {
-      padding-top: 3px;
-    }
-
-    .fa-star {
-      color: $orange;
-    }
+  .fa {
+    padding-top: 3px;
   }
 
-  &-star {
-    float: right;
+  .fa-star {
+    color: $orange;
   }
+}
 
-  &-folder {
-    color: $text-color-weak;
-    margin-left: $space-sm;
-    font-size: $font-size-xs;
-  }
+.dashlist-star {
+  display: flex;
+  align-items: center;
+  color: $text-color-weak;
+}
+
+.dashlist-folder {
+  color: $text-color-weak;
+  font-size: $font-size-xs;
+}
+
+.dashlist-link-body {
+  flex-grow: 1;
 }


### PR DESCRIPTION
Was not super happy with the design of https://github.com/grafana/grafana/pull/27214 that added folder name to dashboard list panel items. 

Main problem was that was a very different design from search results. 

Before: 
![Screenshot from 2020-08-27 09-17-17](https://user-images.githubusercontent.com/10999/91409738-24254b00-e846-11ea-837e-bd1872ed531f.png)

After (Trying to have similar design as search results):
![Screenshot from 2020-08-27 09-17-00](https://user-images.githubusercontent.com/10999/91409764-2be4ef80-e846-11ea-98c6-5053fabbcc28.png)

