### PR TITLE
Docs: Fix SAML config field

### DIFF
--- a/docs/sources/enterprise/saml.md
+++ b/docs/sources/enterprise/saml.md
@@ -187,7 +187,7 @@ With the [`allowed_organizations`]({{< relref "./enterprise-configuration.md#all
 enabled = true
 certificate_path = "/path/to/certificate.cert"
 private_key_path = "/path/to/private_key.pem"
-metadata_path = "/my/metadata.xml"
+idp_metadata_path = "/my/metadata.xml"
 max_issue_delay = 90s
 metadata_valid_duration = 48h
 assertion_attribute_name = displayName


### PR DESCRIPTION
Fix SAML `idp_metadata_path` config field in the doc example.
