### PR TITLE
OAuth: Increase state cookie max age

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -301,8 +301,8 @@ signout_redirect_url =
 # This setting is ignored if multiple OAuth providers are configured.
 oauth_auto_login = false
 
-# OAuth state max age cookie duration. Defaults to 60 seconds.
-oauth_state_cookie_max_age = 60
+# OAuth state max age cookie duration. Defaults to 600 seconds.
+oauth_state_cookie_max_age = 600
 
 # limit of api_key seconds to live before expiration
 api_key_max_seconds_to_live = -1

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -301,7 +301,7 @@ signout_redirect_url =
 # This setting is ignored if multiple OAuth providers are configured.
 oauth_auto_login = false
 
-# OAuth state max age cookie duration. Defaults to 600 seconds.
+# OAuth state max age cookie duration in seconds. Defaults to 600 seconds.
 oauth_state_cookie_max_age = 600
 
 # limit of api_key seconds to live before expiration

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -300,7 +300,7 @@
 # This setting is ignored if multiple OAuth providers are configured.
 ;oauth_auto_login = false
 
-# OAuth state max age cookie duration. Defaults to 600 seconds.
+# OAuth state max age cookie duration in seconds. Defaults to 600 seconds.
 ;oauth_state_cookie_max_age = 600
 
 # limit of api_key seconds to live before expiration

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -300,8 +300,8 @@
 # This setting is ignored if multiple OAuth providers are configured.
 ;oauth_auto_login = false
 
-# OAuth state max age cookie duration. Defaults to 60 seconds.
-;oauth_state_cookie_max_age = 60
+# OAuth state max age cookie duration. Defaults to 600 seconds.
+;oauth_state_cookie_max_age = 600
 
 # limit of api_key seconds to live before expiration
 ;api_key_max_seconds_to_live = -1

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -646,7 +646,7 @@ This setting is ignored if multiple OAuth providers are configured. Default is `
 
 ### oauth_state_cookie_max_age
 
-How long the OAuth state cookie lives before being deleted. Default is `60` (seconds)
+How long the OAuth state cookie lives before being deleted. Default is `600` (seconds)
 Administrators can increase this if they experience OAuth login state mismatch errors.
 
 ### api_key_max_seconds_to_live

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -646,7 +646,7 @@ This setting is ignored if multiple OAuth providers are configured. Default is `
 
 ### oauth_state_cookie_max_age
 
-How long the OAuth state cookie lives before being deleted. Default is `600` (seconds)
+How many seconds the OAuth state cookie lives before being deleted. Default is `600` (seconds)
 Administrators can increase this if they experience OAuth login state mismatch errors.
 
 ### api_key_max_seconds_to_live

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1009,7 +1009,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) error {
 	DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
 	OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)
-	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(60)
+	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
 	SignoutRedirectUrl, err = valueAsString(auth, "signout_redirect_url", "")
 	if err != nil {
 		return err


### PR DESCRIPTION
60s can be too short if the oauth provider is slow
for some reason and its defintly too slow if the
OAuth provider requires 2FA.