### PR TITLE
@grafana/e2e-selectors: fix to qualify as not aria-label

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -130,7 +130,7 @@ export const Pages = {
       table: 'Explore Table',
     },
     Toolbar: {
-      navBar: '.explore-toolbar',
+      navBar: () => '.explore-toolbar',
     },
   },
 };


### PR DESCRIPTION
I wrote it wrong in #27235. The magic syntax for avoiding the default `aria-label` was not obvious to me. The mapped value must be a function with no argument.

Related: https://github.com/grafana/grafana/issues/25166