### PR TITLE
Do not calculate min and max globally

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -44,7 +44,7 @@ describe('Process simple display values', () => {
     getDisplayProcessor(),
 
     // Add a simple option that is not used (uses a different base class)
-    getDisplayProcessorFromConfig({ min: 0, max: 100 }),
+    getDisplayProcessorFromConfig({ globalMin: 0, globalMax: 100 }),
 
     // Add a simple option that is not used (uses a different base class)
     getDisplayProcessorFromConfig({ unit: 'locale' }),

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -146,8 +146,8 @@ describe('FieldDisplay', () => {
     });
 
     const display = getFieldDisplayValues(options);
-    expect(display[0].field.min).toEqual(0);
-    expect(display[0].field.max).toEqual(0);
+    expect(display[0].field.globalMin).toEqual(0);
+    expect(display[0].field.globalMax).toEqual(0);
   });
 
   describe('Value mapping', () => {

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -286,8 +286,8 @@ function createNoValuesFieldDisplay(options: GetFieldDisplayValuesOptions): Fiel
     name: displayName,
     field: {
       ...defaults,
-      max: defaults.max ?? 0,
-      min: defaults.min ?? 0,
+      globalMax: defaults.globalMax ?? 0,
+      globalMin: defaults.globalMin ?? 0,
     },
     display: {
       text,

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -81,7 +81,7 @@ describe('applyFieldOverrides', () => {
   expect(f0.length).toEqual(3);
 
   // Hardcode the max value
-  f0.fields[1].config.max = 0;
+  f0.fields[1].config.globalMax = 0;
   f0.fields[1].config.decimals = 6;
 
   const src: FieldConfigSource = {
@@ -157,8 +157,8 @@ describe('applyFieldOverrides', () => {
 
   it('will merge FieldConfig with default values', () => {
     const field: FieldConfig = {
-      min: 0,
-      max: 100,
+      globalMin: 0,
+      globalMax: 100,
     };
 
     const f1 = {
@@ -187,8 +187,8 @@ describe('applyFieldOverrides', () => {
 
     const outField = processed.fields[0];
 
-    expect(outField.config.min).toEqual(0);
-    expect(outField.config.max).toEqual(100);
+    expect(outField.config.globalMin).toEqual(0);
+    expect(outField.config.globalMax).toEqual(100);
     expect(outField.config.unit).toEqual('ms');
     expect(getFieldDisplayName(outField, f)).toEqual('newTitle');
   });
@@ -206,10 +206,10 @@ describe('applyFieldOverrides', () => {
     const config = valueColumn.config;
 
     // Keep max from the original setting
-    expect(config.max).toEqual(0);
+    expect(config.globalMax).toEqual(0);
 
     // Don't Automatically pick the min value
-    expect(config.min).toEqual(undefined);
+    expect(config.globalMin).toEqual(undefined);
 
     // The default value applied
     expect(config.unit).toEqual('xyz');
@@ -234,10 +234,10 @@ describe('applyFieldOverrides', () => {
     const config = valueColumn.config;
 
     // Keep max from the original setting
-    expect(config.max).toEqual(0);
+    expect(config.globalMax).toEqual(0);
 
     // Don't Automatically pick the min value
-    expect(config.min).toEqual(-20);
+    expect(config.globalMin).toEqual(-20);
   });
 });
 
@@ -245,14 +245,14 @@ describe('setFieldConfigDefaults', () => {
   it('applies field config defaults', () => {
     const dsFieldConfig: FieldConfig = {
       decimals: 2,
-      min: 0,
-      max: 100,
+      globalMin: 0,
+      globalMax: 100,
     };
 
     const panelFieldConfig: FieldConfig = {
       decimals: 1,
-      min: 10,
-      max: 50,
+      globalMin: 10,
+      globalMax: 50,
       unit: 'km',
     };
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -156,32 +156,32 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
 
       // Some units have an implied range
       if (config.unit === 'percent') {
-        if (!isNumber(config.min)) {
-          config.min = 0;
+        if (!isNumber(config.globalMin)) {
+          config.globalMin = 0;
         }
-        if (!isNumber(config.max)) {
-          config.max = 100;
+        if (!isNumber(config.globalMax)) {
+          config.globalMax = 100;
         }
       } else if (config.unit === 'percentunit') {
-        if (!isNumber(config.min)) {
-          config.min = 0;
+        if (!isNumber(config.globalMin)) {
+          config.globalMin = 0;
         }
-        if (!isNumber(config.max)) {
-          config.max = 1;
+        if (!isNumber(config.globalMax)) {
+          config.globalMax = 1;
         }
       }
 
       // Set the Min/Max value automatically
       if (options.autoMinMax && field.type === FieldType.number) {
-        if (!isNumber(config.min) || !isNumber(config.max)) {
+        if (!isNumber(config.globalMin) || !isNumber(config.globalMax)) {
           if (!range) {
             range = findNumericFieldMinMax(options.data!); // Global value
           }
-          if (!isNumber(config.min)) {
-            config.min = range.min;
+          if (!isNumber(config.globalMin)) {
+            config.globalMin = range.min;
           }
-          if (!isNumber(config.max)) {
-            config.max = range.max;
+          if (!isNumber(config.globalMax)) {
+            config.globalMax = range.max;
           }
         }
       }
@@ -330,10 +330,10 @@ export function validateFieldConfig(config: FieldConfig) {
   }
 
   // Verify that max > min (swap if necessary)
-  if (config.hasOwnProperty('min') && config.hasOwnProperty('max') && config.min! > config.max!) {
-    const tmp = config.max;
-    config.max = config.min;
-    config.min = tmp;
+  if (config.hasOwnProperty('min') && config.hasOwnProperty('max') && config.globalMin! > config.globalMax!) {
+    const tmp = config.globalMax;
+    config.globalMax = config.globalMin;
+    config.globalMin = tmp;
   }
 }
 

--- a/packages/grafana-data/src/field/scale.test.ts
+++ b/packages/grafana-data/src/field/scale.test.ts
@@ -61,8 +61,8 @@ describe('scale', () => {
       name: 'test',
       type: FieldType.number,
       config: {
-        min: -100, // explicit range
-        max: 100, // note less then range of actual data
+        globalMin: -100, // explicit range
+        globalMax: 100, // note less then range of actual data
         thresholds,
         color: {
           mode: FieldColorMode.Scheme,

--- a/packages/grafana-data/src/field/scale.ts
+++ b/packages/grafana-data/src/field/scale.ts
@@ -33,8 +33,8 @@ export function getScaleCalculator(field: Field, theme?: GrafanaTheme): ScaleCal
 
   if (percentThresholds || useColorScheme) {
     // Calculate min/max if required
-    let min = config.min;
-    let max = config.max;
+    let min = config.globalMin;
+    let max = config.globalMax;
 
     if (!isNumber(min) || !isNumber(max)) {
       if (field.values && field.values.length) {

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -42,8 +42,8 @@ export interface FieldConfig<TOptions extends object = any> {
   // Numeric Options
   unit?: string;
   decimals?: number | null; // Significant digits (for display)
-  min?: number | null;
-  max?: number | null;
+  globalMin?: number | null;
+  globalMax?: number | null;
 
   // Convert input values into a display string
   mappings?: ValueMapping[];

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.story.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.story.tsx
@@ -45,8 +45,8 @@ function addBarGaugeStory(overrides: Partial<Props>) {
   const field: Partial<Field> = {
     type: FieldType.number,
     config: {
-      min: minValue,
-      max: maxValue,
+      globalMin: minValue,
+      globalMax: maxValue,
       thresholds: {
         mode: ThresholdsMode.Absolute,
         steps: [

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -20,8 +20,8 @@ function getProps(propOverrides?: Partial<Props>): Props {
   const field: Partial<Field> = {
     type: FieldType.number,
     config: {
-      min: 0,
-      max: 100,
+      globalMin: 0,
+      globalMax: 100,
       thresholds: {
         mode: ThresholdsMode.Absolute,
         steps: [

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -66,8 +66,8 @@ export class BarGauge extends PureComponent<Props> {
     displayMode: BarGaugeDisplayMode.Gradient,
     orientation: VizOrientation.Horizontal,
     field: {
-      min: 0,
-      max: 100,
+      globalMin: 0,
+      globalMax: 100,
       thresholds: {
         mode: ThresholdsMode.Absolute,
         steps: [],
@@ -180,8 +180,8 @@ export class BarGauge extends PureComponent<Props> {
       wrapperWidth,
       wrapperHeight,
     } = calculateBarAndValueDimensions(this.props);
-    const minValue = field.min!;
-    const maxValue = field.max!;
+    const minValue = field.globalMin!;
+    const maxValue = field.globalMax!;
 
     const isVert = isVertical(orientation);
     const valueRange = maxValue - minValue;
@@ -422,7 +422,7 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
   const { displayMode, field, value, alignmentFactors, orientation, theme } = props;
   const { valueWidth, valueHeight, maxBarHeight, maxBarWidth } = calculateBarAndValueDimensions(props);
 
-  const valuePercent = getValuePercent(value.numeric, field.min!, field.max!);
+  const valuePercent = getValuePercent(value.numeric, field.globalMin!, field.globalMax!);
   const valueColor = getValueColor(props);
 
   const valueToBaseSizeOn = alignmentFactors ? alignmentFactors : value;
@@ -514,8 +514,8 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
 export function getBarGradient(props: Props, maxSize: number): string {
   const { field, value, orientation } = props;
   const cssDirection = isVertical(orientation) ? '0deg' : '90deg';
-  const minValue = field.min!;
-  const maxValue = field.max!;
+  const minValue = field.globalMin!;
+  const maxValue = field.globalMax!;
 
   let gradient = '';
   let lastpos = 0;

--- a/packages/grafana-ui/src/components/Gauge/Gauge.test.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.test.tsx
@@ -11,8 +11,8 @@ jest.mock('jquery', () => ({
 
 const setup = (propOverrides?: FieldConfig) => {
   const field: FieldConfig = {
-    min: 0,
-    max: 100,
+    globalMin: 0,
+    globalMax: 100,
     thresholds: {
       mode: ThresholdsMode.Absolute,
       steps: [{ value: -Infinity, color: '#7EB26D' }],

--- a/packages/grafana-ui/src/components/Gauge/Gauge.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.tsx
@@ -32,8 +32,8 @@ export class Gauge extends PureComponent<Props> {
     showThresholdMarkers: true,
     showThresholdLabels: false,
     field: {
-      min: 0,
-      max: 100,
+      globalMin: 0,
+      globalMax: 100,
       thresholds: {
         mode: ThresholdsMode.Absolute,
         steps: [
@@ -57,8 +57,8 @@ export class Gauge extends PureComponent<Props> {
     const thresholds = field.thresholds ?? Gauge.defaultProps.field?.thresholds!;
     const isPercent = thresholds.mode === ThresholdsMode.Percentage;
     const steps = thresholds.steps;
-    let min = field.min!;
-    let max = field.max!;
+    let min = field.globalMin!;
+    let max = field.globalMax!;
     if (isPercent) {
       min = 0;
       max = 100;
@@ -116,8 +116,8 @@ export class Gauge extends PureComponent<Props> {
 
     const thresholdLabelFontSize = fontSize / 2.5;
 
-    let min = field.min!;
-    let max = field.max!;
+    let min = field.globalMin!;
+    let max = field.globalMax!;
     let numeric = value.numeric;
     if (field.thresholds?.mode === ThresholdsMode.Percentage) {
       min = 0;

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
@@ -194,8 +194,8 @@ describe('sharedSingleStatMigrationHandler', () => {
     const panel = {} as PanelModel;
     sharedSingleStatPanelChangedHandler(panel, 'singlestat', old);
     expect(panel.fieldConfig.defaults.unit).toBe('ms');
-    expect(panel.fieldConfig.defaults.min).toBe(undefined);
-    expect(panel.fieldConfig.defaults.max).toBe(undefined);
+    expect(panel.fieldConfig.defaults.globalMin).toBe(undefined);
+    expect(panel.fieldConfig.defaults.globalMax).toBe(undefined);
   });
 
   it('change from angular singlestat with tableColumn set', () => {
@@ -226,7 +226,7 @@ describe('sharedSingleStatMigrationHandler', () => {
     const panel = {} as PanelModel;
     sharedSingleStatPanelChangedHandler(panel, 'singlestat', old);
     expect(panel.fieldConfig.defaults.unit).toBe('ms');
-    expect(panel.fieldConfig.defaults.min).toBe(undefined);
-    expect(panel.fieldConfig.defaults.max).toBe(undefined);
+    expect(panel.fieldConfig.defaults.globalMin).toBe(undefined);
+    expect(panel.fieldConfig.defaults.globalMax).toBe(undefined);
   });
 });

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -113,8 +113,8 @@ function migrateFromAngularSinglestat(panel: PanelModel<Partial<SingleStatBaseOp
   }
 
   if (prevPanel.gauge && prevPanel.gauge.show) {
-    defaults.min = prevPanel.gauge.minValue;
-    defaults.max = prevPanel.gauge.maxValue;
+    defaults.globalMin = prevPanel.gauge.minValue;
+    defaults.globalMax = prevPanel.gauge.maxValue;
   }
 
   panel.fieldConfig.defaults = defaults;

--- a/packages/grafana-ui/src/components/Table/Table.story.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.story.tsx
@@ -58,8 +58,8 @@ function buildData(theme: GrafanaTheme, config: Record<string, FieldConfig>): Da
         values: [],
         config: {
           unit: 'percent',
-          min: 0,
-          max: 100,
+          globalMin: 0,
+          globalMax: 100,
           custom: {
             width: 150,
           },

--- a/public/app/features/dashboard/components/PanelEditor/utils.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.test.ts
@@ -4,8 +4,8 @@ import { supportsDataQuery } from './utils';
 describe('standardFieldConfigEditorRegistry', () => {
   const dummyConfig: FieldConfig = {
     displayName: 'Hello',
-    min: 10,
-    max: 10,
+    globalMin: 10,
+    globalMax: 10,
     decimals: 10,
     thresholds: {} as any,
     noValue: 'no value',

--- a/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
@@ -157,8 +157,8 @@ describe('Gauge Panel Migrations', () => {
     const panel = {} as PanelModel;
     const newOptions = gaugePanelChangedHandler(panel, 'singlestat', old);
     expect(panel.fieldConfig.defaults.unit).toBe('ms');
-    expect(panel.fieldConfig.defaults.min).toBe(-10);
-    expect(panel.fieldConfig.defaults.max).toBe(150);
+    expect(panel.fieldConfig.defaults.globalMin).toBe(-10);
+    expect(panel.fieldConfig.defaults.globalMax).toBe(150);
     expect(panel.fieldConfig.defaults.decimals).toBe(7);
     expect(newOptions.showThresholdMarkers).toBe(true);
     expect(newOptions.showThresholdLabels).toBe(true);

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -36,8 +36,8 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
         data: value.sparkline,
         xMin: timeRange.from.valueOf(),
         xMax: timeRange.to.valueOf(),
-        yMin: value.field.min,
-        yMax: value.field.max,
+        yMin: value.field.globalMin,
+        yMax: value.field.globalMax,
       };
 
       const calc = options.reduceOptions.calcs[0];


### PR DESCRIPTION
_According to the code the behaviour seemed intentional but I decided to open this up anyway._

Gauges are currently computed based on all values in the table. I thought that Gauge should rather be computed from values in a column where it is placed.

That said having

```
+---+---+
| A | B |
+---+---+
| 1 | 4 |
+---+---+
| 2 | 5 |
+---+---+
| 3 | 6 |
+---+---+
```
Gauge in column `A` should have min 1 and max 3.  
Gauge in column `B` should have min 4 and max 6.

Currently, all Gauges have min 1 and max 6. 