### PR TITLE
Cloudwatch: Add support for resolution of resource tags in alias

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/facebookgo/structtag v0.0.0-20150214074306-217e25fb9691 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
 	github.com/fatih/color v1.9.0
+	github.com/gigawattio/awsarn v0.0.0-20180317190237-a28d04d20421
 	github.com/go-macaron/binding v0.0.0-20190806013118-0b4f37bab25b
 	github.com/go-macaron/gzip v0.0.0-20160222043647-cad1c6580a07
 	github.com/go-macaron/session v0.0.0-20190805070824-1a3cdc6f5659

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ github.com/getkin/kin-openapi v0.2.0/go.mod h1:V1z9xl9oF5Wt7v32ne4FmiF1alpS4dM6m
 github.com/getkin/kin-openapi v0.13.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gigawattio/awsarn v0.0.0-20180317190237-a28d04d20421 h1:4Px7cZZbMByWjIE3VMa4yWYbrv9m5pe3/QXLed5flyg=
+github.com/gigawattio/awsarn v0.0.0-20180317190237-a28d04d20421/go.mod h1:V8dUKSLrMIV2Sq8tQw0PF1Oi/XK6Z4c3NJzLTY0T4Xg=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -37,7 +37,7 @@ var resourceComponentMap = map[string]int{
 }
 
 func (e *cloudWatchExecutor) getMetricResourceTags(queries map[string]*cloudWatchQuery) (map[string]map[string]string, error) {
-	/* We can query multiple resources types simultaneously, but only one region at a time, so we collect all query resource types into
+	/* We can query multiple resource types simultaneously, but only one region at a time, so we collect all query resource types into
 	 * regional buckets.
 	 */
 	resourceTypesByRegion := map[string][]string{}

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/gigawattio/awsarn"
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/tsdb"
@@ -37,7 +36,7 @@ var resourceComponentMap = map[string]int{
 	"ecs:service": 1,
 }
 
-func (e *cloudWatchExecutor) parseGetMetricResourceTags(queries map[string]*cloudWatchQuery) (map[string]map[string]string, error) {
+func (e *cloudWatchExecutor) getMetricResourceTags(queries map[string]*cloudWatchQuery) (map[string]map[string]string, error) {
 	/* We can query multiple resources types simultaneously, but only one region at a time, so we collect all query resource types into
 	 * regional buckets.
 	 */
@@ -121,7 +120,7 @@ func (e *cloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMe
 		}
 	}
 
-	resourceTags, err := e.parseGetMetricResourceTags(queries)
+	resourceTags, err := e.getMetricResourceTags(queries)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -29,7 +29,7 @@ var resourceTypesMap = map[string][]string{
 
 var resourcePrefixesMap = map[string]string{
 	// ELBv2 target groups have 'targetgroup/' prepended in the label but not the resource.
-	"elasticloadbalancing:targetgroup": "targetgroup/", 
+	"elasticloadbalancing:targetgroup": "targetgroup/",
 }
 
 var resourceComponentMap = map[string]int{
@@ -43,7 +43,7 @@ func (e *cloudWatchExecutor) parseGetMetricResourceTags(queries map[string]*clou
 	 */
 	resourceTypesByRegion := map[string][]string{}
 	for _, query := range queries {
-		if resources, ok := resourceTypesMap[query.Namespace]; ok {	
+		if resources, ok := resourceTypesMap[query.Namespace]; ok {
 			resourceTypesByRegion[query.Region] = append(resourceTypesByRegion[query.Region], resources...)
 		}
 	}
@@ -55,7 +55,7 @@ func (e *cloudWatchExecutor) parseGetMetricResourceTags(queries map[string]*clou
 		typeFiltersAdded := map[string]bool{}
 		for _, tp := range resourceTypes {
 			if _, ok := typeFiltersAdded[tp]; !ok {
-				typeFilters = append(typeFilters, aws.String(type_))
+				typeFilters = append(typeFilters, aws.String(tp))
 				typeFiltersAdded[tp] = true
 			}
 		}
@@ -133,7 +133,7 @@ func (e *cloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMe
 	for id, lr := range mdrs {
 		query := queries[id]
 
-		series, partialData, err := parseGetMetricDataTimeSeries(lr, labels[id], query, resource_tags)
+		series, partialData, err := parseGetMetricDataTimeSeries(lr, labels[id], query, resourceTags)
 		if err != nil {
 			return nil, err
 		}
@@ -193,7 +193,7 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 					}
 				}
 
-				emptySeries.Name = formatAlias(query, query.Stats, emptySeries.Tags, label, resource_tags)
+				emptySeries.Name = formatAlias(query, query.Stats, emptySeries.Tags, label, resourceTags)
 				result = append(result, &emptySeries)
 			}
 		} else {
@@ -223,7 +223,7 @@ func parseGetMetricDataTimeSeries(metricDataResults map[string]*cloudwatch.Metri
 				}
 			}
 
-			series.Name = formatAlias(query, query.Stats, series.Tags, label, resource_tags)
+			series.Name = formatAlias(query, query.Stats, series.Tags, label, resourceTags)
 
 			for j, t := range metricDataResult.Timestamps {
 				if j > 0 {
@@ -282,9 +282,9 @@ func formatAlias(query *cloudWatchQuery, stat string, dimensions map[string]stri
 		if _, ok := resourceTags[part]; !ok {
 			continue
 		}
-		
-		for key, value := range resource_tags[part] {
-			data[fmt.Sprintf("tags.%d.%s", i, key] = value
+
+		for key, value := range resourceTags[part] {
+			data[fmt.Sprintf("tags.%d.%s", i, key)] = value
 		}
 	}
 

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -61,7 +61,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query)
+			resource_tags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
 			timeSeries := (*series)[0]
 
 			So(err, ShouldBeNil)
@@ -123,7 +124,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query)
+			resource_tags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
 			timeSeries := (*series)[0]
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -184,7 +186,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query)
+			resource_tags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -221,7 +224,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query)
+			resource_tags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -261,7 +265,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded {{InstanceType}} - {{Resource}}",
 			}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query)
+			resource_tags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -304,7 +309,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{namespace}}_{{metric}}_{{stat}}",
 			}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query)
+			resource_tags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
 			timeSeries := (*series)[0]
 
 			So(err, ShouldBeNil)

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -61,8 +61,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			resource_tags := map[string]map[string]string{}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
+			resourceTags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resourceTags)
 			timeSeries := (*series)[0]
 
 			So(err, ShouldBeNil)
@@ -124,8 +124,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			resource_tags := map[string]map[string]string{}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
+			resourceTags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resourceTags)
 			timeSeries := (*series)[0]
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -186,8 +186,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			resource_tags := map[string]map[string]string{}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
+			resourceTags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resourceTags)
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -224,8 +224,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded",
 			}
-			resource_tags := map[string]map[string]string{}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
+			resourceTags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resourceTags)
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -265,8 +265,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{LoadBalancer}} Expanded {{InstanceType}} - {{Resource}}",
 			}
-			resource_tags := map[string]map[string]string{}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
+			resourceTags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resourceTags)
 
 			So(err, ShouldBeNil)
 			So(partialData, ShouldBeFalse)
@@ -309,8 +309,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 				Period: 60,
 				Alias:  "{{namespace}}_{{metric}}_{{stat}}",
 			}
-			resource_tags := map[string]map[string]string{}
-			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resource_tags)
+			resourceTags := map[string]map[string]string{}
+			series, partialData, err := parseGetMetricDataTimeSeries(mdrs, labels, query, resourceTags)
 			timeSeries := (*series)[0]
 
 			So(err, ShouldBeNil)


### PR DESCRIPTION
This PR adds support for using resource tags in the CloudWatch query alias.  This is quite useful since the CloudWatch metric label for queries with a resource dimension is the resource ID, which is not particularly human-readable.

Seems to be a fairly desired feature [0][1][2][3][4][5], and personally I couldn't see myself using the CloudWatch datasource without it (who remembers their CloudFront distribution IDs?).

Existing "solutions" (read: bodges) involve using dashboard variable queries (ec2_instance_attributes) and value groups[3], which prevents use of Alerts and only supports EC2 instances.

Resources are fetched using the `resourcegroupstaggingapi` as appropriate for the Namespace in the queries.  For example, a query in the `AWS/EC2` namespace/dimension fetches all resources of type `ec2:instance` and populates a map with their tags.  If all queries are in the same region then this is a single RGTA request for all the queries, so the performance impact is negligible.

The fetched resource tag map is then injected into the `formatAlias` data map based on the CloudWatch metric label, so that tags can be used in the query alias string.

Currently supports fetching resources for EC2 (InstanceID), CloudFront (DistributionId), ApplicationELB (LoadBalancer, TargetGroup), ECS (ClusterName, ServiceName), RDS (DBInstanceIdentifier), and S3 (BucketName).  More resources can be easily added by updating the `resourceTypesMap`, but the current set is all I'm using right now so I wouldn't have any resources to test against for the other types.

Note also that CloudWatch is somewhat inconsistent in how it constructs the metric labels, so we have to do a little feathering to make the label components consistent with the resource IDs from RGTA.  For example ELBv2 TargetGroups have an extra `targetgroup/` prefix in the CloudWatch label compared to the RGTA resource ID.

Closes #27280

[0] https://community.grafana.com/t/cloudwatch-show-servername-instead-of-instance-id/10962
[1] https://community.grafana.com/t/multiple-ec2-instances-in-grafana-dashboard/22032
[2] https://github.com/monitoringartist/grafana-aws-cloudwatch-dashboards/issues/19
[3] Comments in https://github.com/grafana/grafana/pull/8307
[4] https://github.com/grafana/grafana/issues/3478
[5] https://github.com/grafana/grafana/issues/7294