### PR TITLE
Graph: Preseve existing data links in field config when loading dashboard

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -203,6 +203,7 @@ export class PanelModel implements DataConfigSource {
   getOptions() {
     return this.options;
   }
+
   getFieldConfig() {
     return this.fieldConfig;
   }
@@ -309,6 +310,7 @@ export class PanelModel implements DataConfigSource {
     if (plugin.angularConfigCtrl) {
       return;
     }
+
     this.options = _.mergeWith({}, plugin.defaults, this.options || {}, (objValue: any, srcValue: any): any => {
       if (_.isArray(srcValue)) {
         return srcValue;

--- a/public/app/plugins/panel/graph/GraphMigrations.test.ts
+++ b/public/app/plugins/panel/graph/GraphMigrations.test.ts
@@ -128,7 +128,7 @@ describe('Graph Panel Migrations', () => {
   });
 
   it('from 7.1 it should preserve existing fieldConfig', () => {
-    const panel = {
+    const panel = ({
       id: 1,
       fieldConfig: {
         defaults: {
@@ -141,7 +141,7 @@ describe('Graph Panel Migrations', () => {
         },
         overrides: [],
       },
-    } as PanelModel;
+    } as unknown) as PanelModel;
 
     graphPanelMigrationHandler(panel as PanelModel);
     const fieldConfig = (panel as any).fieldConfig as FieldConfigSource;

--- a/public/app/plugins/panel/graph/GraphMigrations.test.ts
+++ b/public/app/plugins/panel/graph/GraphMigrations.test.ts
@@ -126,4 +126,25 @@ describe('Graph Panel Migrations', () => {
     const link = fieldSource.defaults.links![0];
     expect(link.url).toEqual('THE DRILLDOWN URL');
   });
+
+  it('from 7.1 it should preserve existing fieldConfig', () => {
+    const panel = {
+      id: 1,
+      fieldConfig: {
+        defaults: {
+          links: [
+            {
+              title: 'Details',
+              url: '/link',
+            },
+          ],
+        },
+        overrides: [],
+      },
+    } as PanelModel;
+
+    graphPanelMigrationHandler(panel as PanelModel);
+    const fieldConfig = (panel as any).fieldConfig as FieldConfigSource;
+    expect(fieldConfig.defaults.links).toHaveLength(1);
+  });
 });

--- a/public/app/plugins/panel/graph/GraphMigrations.ts
+++ b/public/app/plugins/panel/graph/GraphMigrations.ts
@@ -4,7 +4,7 @@ import { PanelModel, FieldConfigSource, DataLink } from '@grafana/data';
  * Called when upgrading from a previously saved versoin
  */
 export const graphPanelMigrationHandler = (panel: PanelModel<any>): Partial<any> => {
-  const fieldOptions: FieldConfigSource = {
+  const fieldConfig: FieldConfigSource = panel.fieldConfig ?? {
     defaults: {},
     overrides: [],
   };
@@ -13,12 +13,12 @@ export const graphPanelMigrationHandler = (panel: PanelModel<any>): Partial<any>
 
   // Move <7.1 dataLinks to the field section
   if (options.dataLinks) {
-    fieldOptions.defaults.links = options.dataLinks as DataLink[];
+    fieldConfig.defaults.links = options.dataLinks as DataLink[];
     delete options.dataLinks;
   }
 
   // Mutate the original panel state (only necessary because it is angular)
   panel.options = options;
-  panel.fieldConfig = fieldOptions;
+  panel.fieldConfig = fieldConfig;
   return options;
 };


### PR DESCRIPTION
Fixes #26592 

The Graph migration handler is executed for graphs created in 7.1.0 after upgrading to 7.1.x and the migration handler did not take into consideration existing field config. 