### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Documentation owner: Diana Payton
-/docs/ @oddlittlebird
-/contribute/ @oddlittlebird  @marcusolsson
+/docs/ @oddlittlebird @achatterjee-grafana
+/contribute/ @oddlittlebird  @marcusolsson @achatterjee-grafana
 
 
 # Backend code


### PR DESCRIPTION
Makes @achatterjee-grafana one of the codeowners for /docs and /contribute