### PR TITLE
PanelEdit: Vertically align padding for panel edit option group body

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsGroup.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsGroup.tsx
@@ -162,7 +162,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, isExpanded: boolean, isNes
     ),
     body: cx(
       css`
-        padding: ${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.xl} ${theme.spacing.sm};
+        padding: ${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.sm} ${theme.spacing.xl};
       `,
       isNested &&
         css`

--- a/public/app/features/dashboard/components/PanelEditor/OptionsGroup.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsGroup.tsx
@@ -162,7 +162,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, isExpanded: boolean, isNes
     ),
     body: cx(
       css`
-        padding: 0 ${theme.spacing.md} ${theme.spacing.md} ${theme.spacing.xl};
+        padding: ${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.xl} ${theme.spacing.sm};
       `,
       isNested &&
         css`


### PR DESCRIPTION
The 0 top and 16px below padding looked a bit off, felt 8px above and below looks better

