### PR TITLE
Chore: Upgrade to Go 1.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM golang:1.14.7-alpine3.12 as go-builder
+FROM golang:1.15.1-alpine3.12 as go-builder
 
 RUN apk add --no-cache gcc g++
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -16,7 +16,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM golang:1.14.7 AS go-builder
+FROM golang:1.15.1 AS go-builder
 
 WORKDIR /src/grafana
 

--- a/devenv/docker/blocks/prometheus_random_data/Dockerfile
+++ b/devenv/docker/blocks/prometheus_random_data/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image for a client_golang example.
 
 # Builder image, where we build the example.
-FROM golang:1.14.1 AS builder
+FROM golang:1.15.1 AS builder
 # Download prometheus/client_golang/examples/random first
 RUN go get github.com/prometheus/client_golang/examples/random
 WORKDIR /go/src/github.com/prometheus/client_golang

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.14
+go 1.15
 
 // Override xorm's outdated go-mssqldb dependency, since we can't upgrade to current xorm (due to breaking changes).
 // We need a more current go-mssqldb so we get rid of a version of apache/thrift with vulnerabilities.

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
@@ -2,7 +2,7 @@
 source "./deploy-common.sh"
 
 # Install Go
-filename="go1.14.linux-amd64.tar.gz"
+filename="go1.15.1.linux-amd64.tar.gz"
 get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca"
 untar_file "/tmp/$filename"
 

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -85,7 +85,7 @@ RUN mv golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64/golangci-lint /tmp/
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20200803
 
-ENV GOVERSION=1.14.7 \
+ENV GOVERSION=1.15.1 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=12.18.3-1nodesource1 \

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/go:1.14
+FROM cimg/go:1.15.1
 
 RUN git clone https://github.com/aptly-dev/aptly $GOPATH/src/github.com/aptly-dev/aptly
 RUN cd $GOPATH/src/github.com/aptly-dev/aptly && \


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade to Go 1.15.1.
