### PR TITLE
CloudWatch: Update list of AmazonMQ metrics and dimensions

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -43,7 +43,7 @@ var customMetricsMetricsMap = make(map[string]map[string]map[string]*customMetri
 var customMetricsDimensionsMap = make(map[string]map[string]map[string]*customMetricsCache)
 var metricsMap = map[string][]string{
 	"AWS/ACMPrivateCA":      {"CRLGenerated", "Failure", "MisconfiguredCRLBucket", "Success", "Time"},
-	"AWS/AmazonMQ":          {"ConsumerCount", "CpuCreditBalance", "CpuUtilization", "CurrentConnectionsCount", "DequeueCount", "DispatchCount", "EnqueueCount", "EnqueueTime", "ExpiredCount", "HeapUsage", "InflightCount", "JournalFilesForFastRecovery", "JournalFilesForFullRecovery", "MemoryUsage", "NetworkIn", "NetworkOut", "OpenTransactionsCount", "ProducerCount", "QueueSize", "StorePercentUsage", "TotalConsumerCount", "TotalMessageCount", "TotalProducerCount"},
+	"AWS/AmazonMQ":          {"BurstBalance", "ConsumerCount", "CpuCreditBalance", "CpuUtilization", "CurrentConnectionsCount", "DequeueCount", "DispatchCount", "EnqueueCount", "EnqueueTime", "EstablishedConnectionsCount", "ExpiredCount", "HeapUsage", "InactiveDurableTopicSubscribersCount", "InFlightCount", "JobSchedulerStorePercentUsage", "JournalFilesForFastRecovery", "JournalFilesForFullRecovery", "MemoryUsage", "NetworkIn", "NetworkOut", "OpenTransactionCount", "ProducerCount", "QueueSize", "ReceiveCount", "StorePercentUsage", "TempPercentUsage", "TotalConsumerCount", "TotalDequeueCount", "TotalEnqueueCount", "TotalMessageCount", "TotalProducerCount", "VolumeReadOps", "VolumeWriteOps"},
 	"AWS/ApiGateway":        {"4XXError", "5XXError", "CacheHitCount", "CacheMissCount", "Count", "IntegrationLatency", "Latency"},
 	"AWS/AppStream":         {"ActualCapacity", "AvailableCapacity", "CapacityUtilization", "DesiredCapacity", "InUseCapacity", "InsufficientCapacityError", "PendingCapacity", "RunningCapacity"},
 	"AWS/AppSync":           {"4XXError", "5XXError", "Latency"},
@@ -137,7 +137,7 @@ var metricsMap = map[string][]string{
 
 var dimensionsMap = map[string][]string{
 	"AWS/ACMPrivateCA":      {},
-	"AWS/AmazonMQ":          {"Broker", "Queue", "Topic"},
+	"AWS/AmazonMQ":          {"Broker", "NetworkConnector", "Queue", "Topic"},
 	"AWS/ApiGateway":        {"ApiName", "Method", "Resource", "Stage"},
 	"AWS/AppStream":         {"Fleet"},
 	"AWS/AppSync":           {"GraphQLAPIId"},


### PR DESCRIPTION
Update list of AmazonMQ metrics and Dimensions based on the current list
from the official AWS documentation.

Also, change InflightCount to InFlightCount.


**What this PR does / why we need it**:

List of metrics and dimensions is outdated, also InflightCount is now called InFlighCount (or always was like this)

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

List of metrics and dimensions comes from https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-logging-monitoring-cloudwatch.html
