### PR TITLE
Elasticsearch: Fix localized dates in index pattern

### DIFF
--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -79,6 +79,10 @@ export const setLocale = (language: string) => {
   moment.locale(language);
 };
 
+export const getLocale = () => {
+  return moment.locale();
+};
+
 export const getLocaleData = (): DateTimeLocale => {
   return moment.localeData();
 };

--- a/public/app/plugins/datasource/elasticsearch/index_pattern.ts
+++ b/public/app/plugins/datasource/elasticsearch/index_pattern.ts
@@ -9,11 +9,15 @@ const intervalMap: any = {
 };
 
 export class IndexPattern {
+  private dateLocale = 'en';
+
   constructor(private pattern: any, private interval?: string) {}
 
   getIndexForToday() {
     if (this.interval) {
-      return toUtc().format(this.pattern);
+      return toUtc()
+        .locale(this.dateLocale)
+        .format(this.pattern);
     } else {
       return this.pattern;
     }
@@ -35,7 +39,7 @@ export class IndexPattern {
     const indexList = [];
 
     while (start.valueOf() <= endEpoch) {
-      indexList.push(start.format(this.pattern));
+      indexList.push(start.locale(this.dateLocale).format(this.pattern));
       start.add(1, intervalInfo.amount);
     }
 

--- a/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
@@ -1,14 +1,28 @@
 ///<amd-dependency path="test/specs/helpers" name="helpers" />
 
 import { IndexPattern } from '../index_pattern';
-import { toUtc } from '@grafana/data';
+import { toUtc, getLocale, setLocale } from '@grafana/data';
 
 describe('IndexPattern', () => {
+  const originalLocale = getLocale();
+  afterEach(() => setLocale(originalLocale));
+
   describe('when getting index for today', () => {
     test('should return correct index name', () => {
       const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
       const expected = 'asd-' + toUtc().format('YYYY.MM.DD');
 
+      expect(pattern.getIndexForToday()).toBe(expected);
+    });
+
+    test('should format date using western arabic numerals regardless of locale', () => {
+      setLocale('ar_SA'); // saudi-arabic, formatting for YYYY.MM.DD looks like "٢٠٢٠.٠٩.٠٣"
+      const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
+      const expected =
+        'asd-' +
+        toUtc()
+          .locale('en')
+          .format('YYYY.MM.DD');
       expect(pattern.getIndexForToday()).toBe(expected);
     });
   });
@@ -25,6 +39,17 @@ describe('IndexPattern', () => {
 
     describe('daily', () => {
       test('should return correct index list', () => {
+        const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
+        const from = new Date(1432940523000);
+        const to = new Date(1433153106000);
+
+        const expected = ['asd-2015.05.29', 'asd-2015.05.30', 'asd-2015.05.31', 'asd-2015.06.01'];
+
+        expect(pattern.getIndexList(from, to)).toEqual(expected);
+      });
+
+      test('should format date using western arabic numerals regardless of locale', () => {
+        setLocale('ar_SA'); // saudi-arabic, formatting for YYYY.MM.DD looks like "٢٠٢٠.٠٩.٠٣"
         const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
         const from = new Date(1432940523000);
         const to = new Date(1433153106000);


### PR DESCRIPTION
**What this PR does / why we need it**:
Dates in elasticsearch index patterns are formatted using moment with whatever locale is currently set on it, depending on user's system. Some locales, like saudi-arabic (`ar-SA`) produce non-western-arabic numeric characters, for example `logstash-٢.١٧-.‎٥` instead of `logstash-2017-05-17`. This causes non existing index to be referenced. Changes in this PR force `en` locale for the index pattern date.

**Which issue(s) this PR fixes**:

Fixes #8403

**Special notes for your reviewer**:

