### PR TITLE
Explore: Expand template variables when redirecting from dashboard panel

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -137,7 +137,8 @@ export default class CloudMonitoringDatasource extends DataSourceApi<CloudMonito
     const queries = options.targets
       .map(this.migrateQuery)
       .filter(this.shouldRunQuery)
-      .map(q => this.prepareTimeSeriesQuery(q, options));
+      .map(q => this.prepareTimeSeriesQuery(q, options.scopedVars))
+      .map(q => ({ ...q, intervalMs: options.intervalMs, type: 'timeSeriesQuery' }));
 
     if (queries.length > 0) {
       const { data } = await this.api.post({
@@ -309,13 +310,13 @@ export default class CloudMonitoringDatasource extends DataSourceApi<CloudMonito
     return query;
   }
 
-  interpolateProps(object: { [key: string]: any } = {}, scopedVars: ScopedVars = {}): { [key: string]: any } {
+  interpolateProps<T extends Record<string, any>>(object: T, scopedVars: ScopedVars = {}): T {
     return Object.entries(object).reduce((acc, [key, value]) => {
       return {
         ...acc,
         [key]: value && _.isString(value) ? this.templateSrv.replace(value, scopedVars) : value,
       };
-    }, {});
+    }, {} as T);
   }
 
   shouldRunQuery(query: CloudMonitoringQuery): boolean {
@@ -335,14 +336,12 @@ export default class CloudMonitoringDatasource extends DataSourceApi<CloudMonito
 
   prepareTimeSeriesQuery(
     { metricQuery, refId, queryType, sloQuery }: CloudMonitoringQuery,
-    { scopedVars, intervalMs }: DataQueryRequest<CloudMonitoringQuery>
-  ) {
+    scopedVars: ScopedVars
+  ): CloudMonitoringQuery {
     return {
       datasourceId: this.id,
       refId,
       queryType,
-      intervalMs: intervalMs,
-      type: 'timeSeriesQuery',
       metricQuery: {
         ...this.interpolateProps(metricQuery, scopedVars),
         projectName: this.templateSrv.replace(
@@ -352,8 +351,12 @@ export default class CloudMonitoringDatasource extends DataSourceApi<CloudMonito
         groupBys: this.interpolateGroupBys(metricQuery.groupBys || [], scopedVars),
         view: metricQuery.view || 'FULL',
       },
-      sloQuery: this.interpolateProps(sloQuery, scopedVars),
+      sloQuery: sloQuery && this.interpolateProps(sloQuery, scopedVars),
     };
+  }
+
+  interpolateVariablesInQueries(queries: CloudMonitoringQuery[], scopedVars: ScopedVars): CloudMonitoringQuery[] {
+    return queries.map(query => this.prepareTimeSeriesQuery(query, scopedVars));
   }
 
   interpolateFilters(filters: string[], scopedVars: ScopedVars) {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -992,12 +992,19 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
   interpolateMetricsQueryVariables(
     query: CloudWatchMetricsQuery,
     scopedVars: ScopedVars
-  ): Pick<CloudWatchMetricsQuery, 'alias' | 'metricName' | 'namespace' | 'period'> {
+  ): Pick<CloudWatchMetricsQuery, 'alias' | 'metricName' | 'namespace' | 'period' | 'dimensions'> {
     return {
       alias: this.replace(query.alias, scopedVars),
       metricName: this.replace(query.metricName, scopedVars),
       namespace: this.replace(query.namespace, scopedVars),
       period: this.replace(query.period, scopedVars),
+      dimensions: Object.entries(query.dimensions).reduce((prev, [key, value]) => {
+        if (Array.isArray(value)) {
+          return { ...prev, [key]: value };
+        }
+
+        return { ...prev, [this.replace(key, scopedVars)]: this.replace(value, scopedVars) };
+      }, {}),
     };
   }
 }

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -39,6 +39,7 @@ import {
   MetricQuery,
   MetricRequest,
   TSDBResponse,
+  isCloudWatchLogsQuery,
 } from './types';
 import { from, Observable, of, merge, zip } from 'rxjs';
 import { catchError, finalize, map, mergeMap, tap, concatMap, scan, share, repeat, takeWhile } from 'rxjs/operators';
@@ -927,12 +928,12 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
   }
 
   replace(
-    target: string,
-    scopedVars: ScopedVars | undefined,
+    target?: string,
+    scopedVars?: ScopedVars,
     displayErrorIfIsMultiTemplateVariable?: boolean,
     fieldName?: string
   ) {
-    if (displayErrorIfIsMultiTemplateVariable) {
+    if (displayErrorIfIsMultiTemplateVariable && !!target) {
       const variable = this.templateSrv
         .getVariables()
         .find(({ name }) => name === this.templateSrv.getVariableName(target));
@@ -973,6 +974,32 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
       metricsQueries,
     };
   };
+
+  interpolateVariablesInQueries(queries: CloudWatchQuery[], scopedVars: ScopedVars): CloudWatchQuery[] {
+    if (!queries.length) {
+      return queries;
+    }
+
+    return queries.map(query => ({
+      ...query,
+      region: this.getActualRegion(this.replace(query.region, scopedVars)),
+      expression: this.replace(query.expression, scopedVars),
+
+      ...(!isCloudWatchLogsQuery(query) && this.interpolateMetricsQueryVariables(query, scopedVars)),
+    }));
+  }
+
+  interpolateMetricsQueryVariables(
+    query: CloudWatchMetricsQuery,
+    scopedVars: ScopedVars
+  ): Pick<CloudWatchMetricsQuery, 'alias' | 'metricName' | 'namespace' | 'period'> {
+    return {
+      alias: this.replace(query.alias, scopedVars),
+      metricName: this.replace(query.metricName, scopedVars),
+      namespace: this.replace(query.namespace, scopedVars),
+      period: this.replace(query.period, scopedVars),
+    };
+  }
 }
 
 function withTeardown<T = any>(observable: Observable<T>, onUnsubscribe: () => void): Observable<T> {

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -732,16 +732,18 @@ describe('CloudWatchDatasource', () => {
         alias: `$${variableName}`,
         metricName: `$${variableName}`,
         namespace: `$${variableName}`,
-        dimensions: {},
+        dimensions: {
+          [`$${variableName}`]: `$${variableName}`,
+        },
         matchExact: false,
         statistics: [],
       };
 
       ctx.ds.interpolateVariablesInQueries([logQuery], {});
 
-      // We interpolate `expression`, `region`, `period`, `alias`, `metricName` and `nameSpace` in CloudWatchMetricsQuery
+      // We interpolate `expression`, `region`, `period`, `alias`, `metricName`, `nameSpace` and `dimensions` in CloudWatchMetricsQuery
       expect(ctx.mockedTemplateSrv.replace).toHaveBeenCalledWith(`$${variableName}`, {});
-      expect(ctx.mockedTemplateSrv.replace).toHaveBeenCalledTimes(6);
+      expect(ctx.mockedTemplateSrv.replace).toHaveBeenCalledTimes(8);
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -10,13 +10,20 @@ import {
   DataQueryErrorType,
 } from '@grafana/data';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { CloudWatchLogsQueryStatus, CloudWatchMetricsQuery, CloudWatchQuery, LogAction } from '../types';
+import {
+  CloudWatchLogsQueryStatus,
+  CloudWatchMetricsQuery,
+  CloudWatchQuery,
+  LogAction,
+  CloudWatchLogsQuery,
+} from '../types';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { convertToStoreState } from '../../../../../test/helpers/convertToStoreState';
 import { getTemplateSrvDependencies } from 'test/helpers/getTemplateSrvDependencies';
 import { of, interval } from 'rxjs';
 import { CustomVariableModel, VariableHide } from '../../../../features/variables/types';
+import { TimeSrvStub } from '../../../../../test/specs/helpers';
 
 import * as rxjsUtils from '../utils/rxjs/increasingInterval';
 
@@ -674,6 +681,67 @@ describe('CloudWatchDatasource', () => {
           expect(requestParams.queries[0].region).toBe(instanceSettings.jsonData.defaultRegion);
           done();
         });
+    });
+  });
+
+  describe('When interpolating variables', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      ctx.mockedTemplateSrv = {
+        replace: jest.fn(),
+      };
+
+      ctx.ds = new CloudWatchDatasource(
+        instanceSettings,
+        ctx.mockedTemplateSrv,
+        (new TimeSrvStub() as unknown) as TimeSrv
+      );
+    });
+
+    it('should return an empty array if no queries are provided', () => {
+      expect(ctx.ds.interpolateVariablesInQueries([], {})).toHaveLength(0);
+    });
+
+    it('should replace correct variables in CloudWatchLogsQuery', () => {
+      const variableName = 'someVar';
+      const logQuery: CloudWatchLogsQuery = {
+        id: 'someId',
+        refId: 'someRefId',
+        queryMode: 'Logs',
+        expression: `$${variableName}`,
+        region: `$${variableName}`,
+      };
+
+      ctx.ds.interpolateVariablesInQueries([logQuery], {});
+
+      // We interpolate `expression` and `region` in CloudWatchLogsQuery
+      expect(ctx.mockedTemplateSrv.replace).toHaveBeenCalledWith(`$${variableName}`, {});
+      expect(ctx.mockedTemplateSrv.replace).toHaveBeenCalledTimes(2);
+    });
+
+    it('should replace correct variables in CloudWatchMetricsQuery', () => {
+      const variableName = 'someVar';
+      const logQuery: CloudWatchMetricsQuery = {
+        id: 'someId',
+        refId: 'someRefId',
+        queryMode: 'Metrics',
+        expression: `$${variableName}`,
+        region: `$${variableName}`,
+        period: `$${variableName}`,
+        alias: `$${variableName}`,
+        metricName: `$${variableName}`,
+        namespace: `$${variableName}`,
+        dimensions: {},
+        matchExact: false,
+        statistics: [],
+      };
+
+      ctx.ds.interpolateVariablesInQueries([logQuery], {});
+
+      // We interpolate `expression`, `region`, `period`, `alias`, `metricName` and `nameSpace` in CloudWatchMetricsQuery
+      expect(ctx.mockedTemplateSrv.replace).toHaveBeenCalledWith(`$${variableName}`, {});
+      expect(ctx.mockedTemplateSrv.replace).toHaveBeenCalledTimes(6);
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -1,7 +1,7 @@
 import { DataQuery, SelectableValue, DataSourceJsonData } from '@grafana/data';
 
 export interface CloudWatchMetricsQuery extends DataQuery {
-  queryMode: 'Metrics';
+  queryMode?: 'Metrics';
 
   id: string;
   region: string;
@@ -43,6 +43,9 @@ export interface CloudWatchLogsQuery extends DataQuery {
 }
 
 export type CloudWatchQuery = CloudWatchMetricsQuery | CloudWatchLogsQuery;
+
+export const isCloudWatchLogsQuery = (cloudwatchQuery: CloudWatchQuery): cloudwatchQuery is CloudWatchLogsQuery =>
+  (cloudwatchQuery as CloudWatchLogsQuery).queryMode === 'Logs';
 
 export interface AnnotationQuery extends CloudWatchMetricsQuery {
   prefixMatching: boolean;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -9,6 +9,7 @@ import {
   DataSourceInstanceSettings,
   DataQueryResponseData,
   LoadingState,
+  ScopedVars,
 } from '@grafana/data';
 import { Observable, of, from } from 'rxjs';
 import { DataSourceWithBackend } from '@grafana/runtime';
@@ -254,5 +255,11 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
 
   getSubscriptions() {
     return this.azureMonitorDatasource.getSubscriptions();
+  }
+
+  interpolateVariablesInQueries(queries: AzureMonitorQuery[], scopedVars: ScopedVars): AzureMonitorQuery[] {
+    return queries.map(
+      query => this.pseudoDatasource[query.queryType].applyTemplateVariables(query, scopedVars) as AzureMonitorQuery
+    );
   }
 }

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import _ from 'lodash';
-import { dateMath, DataQueryRequest, DataSourceApi } from '@grafana/data';
+import { dateMath, DataQueryRequest, DataSourceApi, ScopedVars } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { OpenTsdbOptions, OpenTsdbQuery } from './types';
@@ -491,6 +491,17 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
         });
       }
     });
+  }
+
+  interpolateVariablesInQueries(queries: OpenTsdbQuery[], scopedVars: ScopedVars): OpenTsdbQuery[] {
+    if (!queries.length) {
+      return queries;
+    }
+
+    return queries.map(query => ({
+      ...query,
+      metric: this.templateSrv.replace(query.metric, scopedVars),
+    }));
   }
 
   convertToTSDBTime(date: any, roundUp: any, timezone: any) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a continuation of https://github.com/grafana/grafana/pull/19582, implementing variable expansion for the following data sources:

- [X] Opentsdb
- [x] Stackdriver
- [X] Cloudwatch
- [x] Azure monitor

**Which issue(s) this PR fixes**:

Fixes #19602

**Special notes for your reviewer**:

There are some fields in some data sources that are not being interpolated as of now. I'll investigate a bit more and create another PR in case.

**EDIT:**
This https://github.com/grafana/grafana/pull/27459 will also make sure that dimension filters are going to be interpolated correctly in Azure
