### PR TITLE
Alerting: Adds support for overriding 'dedup_key' via alert tags when using the Pagerduty notifier

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -132,7 +132,7 @@ This might break custom event rules in your PagerDuty rules if you rely on the f
 Move any existing rules using `custom_details.myMetric` to `custom_details.queries.myMetric`.
 This behavior will become the default in a future version of Grafana.
 
->Using `dedup_key` tag will override grafana generated `dedup_key` with a custom key.
+> Using `dedup_key` tag will override grafana generated `dedup_key` with a custom key.
 ### Webhook
 
 The webhook notification is a simple way to send information about a state change over HTTP to a custom endpoint.

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -125,7 +125,7 @@ Severity | Level for dynamic notifications, default is `critical` (1)
 Auto resolve incidents | Resolve incidents in PagerDuty once the alert goes back to ok
 Message in details | Removes the Alert message from the PD summary field and puts it into custom details instead (2)
 
->**Note:** The tags `Severity`, `Class`, `Group`, `dedup_key` and `Component` have special meaning in the [Pagerduty Common Event Format - PD-CEF](https://support.pagerduty.com/docs/pd-cef). If an alert panel defines these tag keys, then they are transposed to the root of the event sent to Pagerduty. This means they will be available within the Pagerduty UI and Filtering tools. A Severity tag set on an alert overrides the global Severity set on the notification channel if it's a valid level.
+>**Note:** The tags `Severity`, `Class`, `Group`, `dedup_key`, and `Component` have special meaning in the [Pagerduty Common Event Format - PD-CEF](https://support.pagerduty.com/docs/pd-cef). If an alert panel defines these tag keys, then they are transposed to the root of the event sent to Pagerduty. This means they will be available within the Pagerduty UI and Filtering tools. A Severity tag set on an alert overrides the global Severity set on the notification channel if it's a valid level.
 
 >Using Message In Details will change the structure of the `custom_details` field in the PagerDuty Event.
 This might break custom event rules in your PagerDuty rules if you rely on the fields in `payload.custom_details`.

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -125,13 +125,14 @@ Severity | Level for dynamic notifications, default is `critical` (1)
 Auto resolve incidents | Resolve incidents in PagerDuty once the alert goes back to ok
 Message in details | Removes the Alert message from the PD summary field and puts it into custom details instead (2)
 
->**Note:** The tags `Severity`, `Class`, `Group`, and `Component` have special meaning in the [Pagerduty Common Event Format - PD-CEF](https://support.pagerduty.com/docs/pd-cef). If an alert panel defines these tag keys, then they are transposed to the root of the event sent to Pagerduty. This means they will be available within the Pagerduty UI and Filtering tools. A Severity tag set on an alert overrides the global Severity set on the notification channel if it's a valid level.
+>**Note:** The tags `Severity`, `Class`, `Group`, `dedup_key` and `Component` have special meaning in the [Pagerduty Common Event Format - PD-CEF](https://support.pagerduty.com/docs/pd-cef). If an alert panel defines these tag keys, then they are transposed to the root of the event sent to Pagerduty. This means they will be available within the Pagerduty UI and Filtering tools. A Severity tag set on an alert overrides the global Severity set on the notification channel if it's a valid level.
 
 >Using Message In Details will change the structure of the `custom_details` field in the PagerDuty Event.
 This might break custom event rules in your PagerDuty rules if you rely on the fields in `payload.custom_details`.
 Move any existing rules using `custom_details.myMetric` to `custom_details.queries.myMetric`.
 This behavior will become the default in a future version of Grafana.
 
+>Using `dedup_key` tag will override grafana generated `dedup_key` with a custom key.
 ### Webhook
 
 The webhook notification is a simple way to send information about a state change over HTTP to a custom endpoint.

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -2,6 +2,7 @@ package notifiers
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -269,6 +270,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 						{Key: "class", Value: "aClass"},
 						{Key: "component", Value: "aComponent"},
 						{Key: "severity", Value: "warning"},
+						{Key: "dedup_key", Value: "key-" + strings.Repeat("x", 260)},
 					},
 				})
 				evalContext.ImagePublicURL = "http://somewhere.com/omg_dont_panic.png"
@@ -282,7 +284,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				diff := cmp.Diff(map[string]interface{}{
 					"client":       "Grafana",
 					"client_url":   "",
-					"dedup_key":    "alertId-0",
+					"dedup_key":    "key-" + strings.Repeat("x", 250),
 					"event_action": "trigger",
 					"links": []interface{}{
 						map[string]interface{}{
@@ -297,6 +299,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 							"class":     "aClass",
 							"component": "aComponent",
 							"severity":  "warning",
+							"dedup_key": "key-" + strings.Repeat("x", 250),
 							"keyOnly":   "",
 						},
 						"severity":  "warning",


### PR DESCRIPTION
- [X] Added ability to override PagerDuty 'dedup_key' via Alert tags

- [X] Updated unit tests

- [X] Updated Documentation

**What this PR does / why we need it**:

Changes from this PR allows user to override weak Grafana generated `dedup_key` on their own.
It can avoid incorrect PagerDuty incidents de-duplication. A possible issue is described [here](https://github.com/grafana/grafana/issues/26863l)

**Which issue(s) this PR fixes**:

This PR has been raised to fix Grafana issue [#26863 ](https://github.com/grafana/grafana/issues/26863)
 
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/26863



