### PR TITLE
Build: fixing failing build by adding missing dependency to rollup config

### DIFF
--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -79,6 +79,7 @@ const buildCjsPackage = ({ env }) => {
             'Cell',
             'useResizeColumns',
             'useAbsoluteLayout',
+            'useFilters',
           ],
           '../../node_modules/react-is/index.js': ['isValidElementType', 'isContextConsumer'],
         },


### PR DESCRIPTION
**What this PR does / why we need it**:
When we try to publish the grafana-ui package rollup can't complete because we have not registered the `useFilters` hook from 'react-table' in the rollup config. I added that dependency to the config which will resolve the issue.
