### PR TITLE
InfluxDB/flux: support queries without a time

### DIFF
--- a/pkg/tsdb/influxdb/flux/query_models.go
+++ b/pkg/tsdb/influxdb/flux/query_models.go
@@ -66,14 +66,15 @@ func getQueryModelTSDB(query *tsdb.Query, timeRange *tsdb.TimeRange, dsInfo *mod
 	if model.Options.Organization == "" {
 		model.Options.Organization = dsInfo.JsonData.Get("organization").MustString("")
 	}
+
 	startTime, err := timeRange.ParseFrom()
-	if err != nil {
-		return nil, err
+	if err != nil && timeRange.From != "" {
+		return nil, fmt.Errorf("error reading startTime: %w", err)
 	}
 
 	endTime, err := timeRange.ParseTo()
-	if err != nil {
-		return nil, err
+	if err != nil && timeRange.To != "" {
+		return nil, fmt.Errorf("error reading endTime: %w", err)
 	}
 
 	// Copy directly from the well typed query

--- a/public/app/plugins/datasource/influxdb/components/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/FluxQueryEditor.tsx
@@ -60,7 +60,7 @@ v1.measurements(bucket: v.bucket)`,
     label: 'Schema Exploration: (fields)',
     description: 'Return every possible key in a single table',
     value: `from(bucket: v.bucket)
-  |> range(start: v.timeRangeStart, stop:timeRangeStop)
+  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)
   |> keys()
   |> keep(columns: ["_value"])
   |> group()


### PR DESCRIPTION
Extracted from #26634

There are a few context where a query is sent without a valid time -- this happens for template variable queries that execute before the dashboard has loaded (and have no time context)

In normal plugins this is fine and the times just initialize to whatever time initializes to.  In the flux plugin, it throws an error, but should not