### PR TITLE
Units: add new flow unit for cubic meters/hour (m³/h)

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -959,6 +959,10 @@
               "value": "flowcms"
             },
             {
+              "text": "Cubic meters/hour (m³/h)",
+              "value": "flowcmh"
+            },
+            {
               "text": "Cubic feet/sec (cfs)",
               "value": "flowcfs"
             },
@@ -2058,6 +2062,10 @@
               "value": "flowcms"
             },
             {
+              "text": "Cubic meters/hour (m³/h)",
+              "value": "flowcmh"
+            },
+            {
               "text": "Cubic feet/sec (cfs)",
               "value": "flowcfs"
             },
@@ -3135,6 +3143,10 @@
             {
               "text": "Cubic meters/sec (cms)",
               "value": "flowcms"
+            },
+            {
+              "text": "Cubic meters/hour (m³/h)",
+              "value": "flowcmh"
             },
             {
               "text": "Cubic feet/sec (cfs)",

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -959,6 +959,10 @@
               "value": "flowcms"
             },
             {
+              "text": "Cubic meters/hour (m³/h)",
+              "value": "flowcmh"
+            },
+            {
               "text": "Cubic feet/sec (cfs)",
               "value": "flowcfs"
             },
@@ -2058,6 +2062,10 @@
               "value": "flowcms"
             },
             {
+              "text": "Cubic meters/hour (m³/h)",
+              "value": "flowcmh"
+            },
+            {
               "text": "Cubic feet/sec (cfs)",
               "value": "flowcfs"
             },
@@ -3135,6 +3143,10 @@
             {
               "text": "Cubic meters/sec (cms)",
               "value": "flowcms"
+            },
+            {
+              "text": "Cubic meters/hour (m³/h)",
+              "value": "flowcmh"
             },
             {
               "text": "Cubic feet/sec (cfs)",

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -226,6 +226,7 @@ export const getCategories = (): ValueFormatCategory[] => [
     formats: [
       { name: 'Gallons/min (gpm)', id: 'flowgpm', fn: toFixedUnit('gpm') },
       { name: 'Cubic meters/sec (cms)', id: 'flowcms', fn: toFixedUnit('cms') },
+      { name: 'Cubic meters/hour (m³/h)', id: 'flowcmh', fn: toFixedUnit('m³/h') },
       { name: 'Cubic feet/sec (cfs)', id: 'flowcfs', fn: toFixedUnit('cfs') },
       { name: 'Cubic feet/min (cfm)', id: 'flowcfm', fn: toFixedUnit('cfm') },
       { name: 'Litre/hour', id: 'litreh', fn: toFixedUnit('L/h') },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new flow unit for cubic meters/hour (m³/h).

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/16843

**Special notes for your reviewer**:
I've considered using the specific unicode symbol for cubic meters (㎥), but then decided to use the better readable "m³". So it's also in line with the existing usage of "m²".
