### PR TITLE
Time format: 0 seconds is a number

### DIFF
--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.test.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.test.ts
@@ -12,6 +12,7 @@ import {
   toDurationInHoursMinutesSeconds,
   toDurationInDaysHoursMinutesSeconds,
   toNanoSeconds,
+  toSeconds,
 } from './dateTimeFormatters';
 import { formattedValueToString } from './valueFormats';
 import { toUtc, dateTime } from '../datetime/moment_wrapper';
@@ -329,5 +330,13 @@ describe('to nanoseconds', () => {
     const tenDays = toNanoSeconds(864000000000000);
     expect(tenDays.text).toBe('10');
     expect(tenDays.suffix).toBe(' day');
+  });
+});
+
+describe('seconds', () => {
+  it('should show 0 as 0', () => {
+    const zeroSeconds = toSeconds(0);
+    expect(zeroSeconds.text).toBe('0');
+    expect(zeroSeconds.suffix).toBe(' s');
   });
 });

--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -102,6 +102,9 @@ export function toSeconds(size: number, decimals?: DecimalCount, scaledDecimals?
   if (size === null) {
     return { text: '' };
   }
+  if (size === 0) {
+    return { text: '0 s' };
+  }
 
   // Less than 1 µs, divide in ns
   if (Math.abs(size) < 0.000001) {

--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -102,6 +102,8 @@ export function toSeconds(size: number, decimals?: DecimalCount, scaledDecimals?
   if (size === null) {
     return { text: '' };
   }
+
+  // If 0, use s unit instead of ns
   if (size === 0) {
     return { text: '0', suffix: ' s' };
   }

--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -103,7 +103,7 @@ export function toSeconds(size: number, decimals?: DecimalCount, scaledDecimals?
     return { text: '' };
   }
   if (size === 0) {
-    return { text: '0 s' };
+    return { text: '0', suffix: ' s' };
   }
 
   // Less than 1 µs, divide in ns


### PR DESCRIPTION
When formatting a value, e.g., in the Stat panel, with a unit of Seconds,
Grafana chooses "NaN ns" when attempting to format 0 seconds.

0, however, is a number; and a quantity of 0 seconds is a perfectly
cromulent notion.  A quantity of 0 seconds should be presented as "0 s"
rather than "NaN ns"

```
>> Test Suites: 494 passed, 494 total
>> Tests:       6 skipped, 4061 passed, 4067 total
>> Snapshots:   179 passed, 179 total
>> Time:        167.998 s
>> Ran all test suites.

Running "no-only-tests" task

Running "no-focus-convey-tests" task

Done.
✨  Done in 227.62s.
```

**What this PR does / why we need it**:
Renders `select 0` as "0 s" when unit is Seconds  /  Because `select 0` does not return `NaN ns` when interpreted as "seconds."

**Special notes for your reviewer**:
A quick pass through every other time option shows them rendering 0 as "0 <unit>" as a reasonable person might otherwise naively assume.  S is special.

Before:
![image](https://user-images.githubusercontent.com/3454741/92177516-80afd980-edf5-11ea-99c0-cf1775bd7200.png)


After:
![image](https://user-images.githubusercontent.com/3454741/92177531-87d6e780-edf5-11ea-8a1b-872401d3436a.png)
