### PR TITLE
BackendSrv: Uses credentials, deprecates withCredentials & defaults to same-origin

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -62,8 +62,12 @@ export type BackendSrvRequest = {
   params?: Record<string, any>;
 
   /**
-   * Indicates whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests.
-   * In addition, this flag is also used to indicate when cookies are to be ignored in the response.
+   * The credentials read-only property of the Request interface indicates whether the user agent should send cookies from the other domain in the case of cross-origin requests.
+   */
+  credentials?: RequestCredentials;
+
+  /**
+   * @deprecated withCredentials is deprecated in favor of credentials
    */
   withCredentials?: boolean;
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
The sad news is that older Edge (prob Safari, Firefox, Chrome too) have not been able to login to Grafana since 6.7.0-beta1 when we replaced Angulars `$http` with `fetch`. The good news is that this PR fixes this (verified in older Edge browser). We credit most of the work in this PR to @yangliuyu, thank you for finding a solution to this.

Snagged from MDN:
![image](https://user-images.githubusercontent.com/562238/92237090-0ba4d880-eeb7-11ea-807f-2878206aa66d.png)

Replaces: https://github.com/grafana/grafana/pull/27153 because it was branched off from the wrong branch.

**Which issue(s) this PR fixes**:
Fixes #27007
Fixes #25507

**Special notes for your reviewer**:

