### PR TITLE
Stats: Use more efficient SQL and add timeouts

### DIFF
--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -59,7 +59,7 @@ func TestStatsDataAccess(t *testing.T) {
 			MustUpdate: true,
 			Active:     true,
 		}
-		err := GetUserStats(&query)
+		err := GetUserStats(context.Background(), &query)
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), query.Result.Users)
 		assert.Equal(t, int64(1), query.Result.Admins)
@@ -133,6 +133,6 @@ func populateDB(t *testing.T) {
 		MustUpdate: true,
 		Active:     true,
 	}
-	err = GetUserStats(&query)
+	err = GetUserStats(context.Background(), &query)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

`LEFT JOIN` causes `O(n*m)` operations, whereas `INNER JOIN` allows us to stay within `O(n)`.

I created 19000 users, a hundred organizations and ~90000 (1/10th of reporters amount) org-user connections in a local MySQL and get responses nearly instantaneously locally, but when running `explain` and comparing the INNER vs LEFT join it is clear that the inner join is preferable regardless of this.

In case _that_ doesn't work, I am also adding a cap for when Grafana will give up counting users to ensure reasonable performance.

**Which issue(s) this PR fixes**:

Fixes #27339 
