### PR TITLE
Explore: adds a page title to Explore

### DIFF
--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataSourceApi, LoadingState, toUtc, DataQueryError, DataQueryRequest, CoreApp } from '@grafana/data';
+import { DataSourceApi, LoadingState, toUtc, DataQueryError, DataQueryRequest, CoreApp, NavModel } from '@grafana/data';
 import { getFirstNonQueryRowSpecificError } from 'app/core/utils/explore';
 import { ExploreId } from 'app/types/explore';
 import { shallow } from 'enzyme';
@@ -111,6 +111,14 @@ const dummyProps: ExploreProps = {
   showLogs: true,
   showTable: true,
   showTrace: true,
+  navModel: {
+    main: {
+      text: 'Explore',
+    },
+    node: {
+      text: 'Explore',
+    },
+  } as NavModel,
 };
 
 const setupErrors = (hasRefId?: boolean) => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -94,7 +94,7 @@ interface ConnectedProps {
   navModel: NavModel;
 }
 
-export interface ExploreProps {
+export interface ExploreProps extends ConnectedProps {
   changeSize: typeof changeSize;
   datasourceInstance: DataSourceApi | null;
   datasourceMissing: boolean;
@@ -137,8 +137,6 @@ export interface ExploreProps {
   showTrace: boolean;
 }
 
-type Props = ExploreProps & ConnectedProps;
-
 enum ExploreDrawer {
   RichHistory,
   QueryInspector,
@@ -172,11 +170,11 @@ interface ExploreState {
  * The result viewers determine some of the query options sent to the datasource, e.g.,
  * `format`, to indicate eventual transformations by the datasources' result transformers.
  */
-export class Explore extends React.PureComponent<Props, ExploreState> {
+export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
   el: any;
   exploreEvents: Emitter;
 
-  constructor(props: Props) {
+  constructor(props: ExploreProps) {
     super(props);
     this.exploreEvents = new Emitter();
     this.state = {
@@ -477,7 +475,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
 const ensureQueriesMemoized = memoizeOne(ensureQueries);
 const getTimeRangeFromUrlMemoized = memoizeOne(getTimeRangeFromUrl);
 
-function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partial<Props> {
+function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partial<ExploreProps> {
   const explore = state.explore;
   const { split, syncedTimes } = explore;
   const item: ExploreItemState = explore[exploreId];


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a page title to Explore.

**Which issue(s) this PR fixes**:

Fixes #27387 

**Special notes for your reviewer**:

1. Open Grafana.
2. Navigate to Explore.
3. Check the page title on the browsers' tab.

Probably it's gonna be worth it to use a custom `getTitleFromNavModel` method so the title is not `Explore: Explore - Grafana` - maybe we should add a datasource name there?