### PR TITLE
Explore: table result should not override display property

### DIFF
--- a/public/app/features/explore/utils/ResultProcessor.test.ts
+++ b/public/app/features/explore/utils/ResultProcessor.test.ts
@@ -197,6 +197,24 @@ describe('ResultProcessor', () => {
         expect(result.fields[1].values.toArray()).toEqual([4, 5, 6]);
         expect(result.fields[2].values.toArray()).toEqual([4, 5, 6]);
       });
+
+      it('should not override fields display property when filled', () => {
+        const { resultProcessor, dataFrames } = testContext({
+          dataFrames: [
+            toDataFrame({
+              name: 'A-series',
+              refId: 'A',
+              fields: [{ name: 'Text', type: FieldType.string, values: ['someText'] }],
+            }),
+          ],
+        });
+        const displayFunctionMock = jest.fn();
+        dataFrames[0].fields[0].display = displayFunctionMock;
+
+        const data = resultProcessor.getTableResult();
+
+        expect(data?.fields[0].display).toBe(displayFunctionMock);
+      });
     });
 
     describe('when calling getLogsResult', () => {

--- a/public/app/features/explore/utils/ResultProcessor.ts
+++ b/public/app/features/explore/utils/ResultProcessor.ts
@@ -99,11 +99,13 @@ export class ResultProcessor {
 
     // set display processor
     for (const field of data.fields) {
-      field.display = getDisplayProcessor({
-        field,
-        theme: config.theme,
-        timeZone: this.timeZone,
-      });
+      field.display =
+        field.display ??
+        getDisplayProcessor({
+          field,
+          theme: config.theme,
+          timeZone: this.timeZone,
+        });
     }
 
     return data;


### PR DESCRIPTION
**What this PR does / why we need it**:

There could be cases when one would like to use the display field in the field config in explore for table view.