### PR TITLE
API: return resource ID for auth key creation, folder permissions update and user invite complete endpoints

### DIFF
--- a/docs/sources/http_api/auth.md
+++ b/docs/sources/http_api/auth.md
@@ -128,7 +128,7 @@ Error statuses:
 HTTP/1.1 200
 Content-Type: application/json
 
-{"name":"mykey","key":"eyJrIjoiWHZiSWd3NzdCYUZnNUtibE9obUpESmE3bzJYNDRIc0UiLCJuIjoibXlrZXkiLCJpZCI6MX1="}
+{"name":"mykey","key":"eyJrIjoiWHZiSWd3NzdCYUZnNUtibE9obUpESmE3bzJYNDRIc0UiLCJuIjoibXlrZXkiLCJpZCI6MX1=","id":1}
 ```
 
 ## Delete API Key

--- a/docs/sources/http_api/folder_permissions.md
+++ b/docs/sources/http_api/folder_permissions.md
@@ -138,7 +138,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
 Content-Length: 35
 
-{"message":"Folder permissions updated"}
+{"message":"Folder permissions updated","id":1,"title":"Department ABC"}
 ```
 
 Status Codes:

--- a/pkg/api/apikey.go
+++ b/pkg/api/apikey.go
@@ -80,8 +80,10 @@ func (hs *HTTPServer) AddAPIKey(c *models.ReqContext, cmd models.AddApiKeyComman
 	}
 
 	result := &dtos.NewApiKeyResult{
+		ID:   cmd.Result.Id,
 		Name: cmd.Result.Name,
-		Key:  newKeyInfo.ClientSecret}
+		Key:  newKeyInfo.ClientSecret,
+	}
 
 	return JSON(200, result)
 }

--- a/pkg/api/dtos/apikey.go
+++ b/pkg/api/dtos/apikey.go
@@ -1,6 +1,7 @@
 package dtos
 
 type NewApiKeyResult struct {
+	ID   int64  `json:"id"`
 	Name string `json:"name"`
 	Key  string `json:"key"`
 }

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func GetFolderPermissionList(c *models.ReqContext) Response {
@@ -109,5 +110,9 @@ func UpdateFolderPermissions(c *models.ReqContext, apiCmd dtos.UpdateDashboardAc
 		return Error(500, "Failed to create permission", err)
 	}
 
-	return Success("Folder permissions updated")
+	return JSON(200, util.DynMap{
+		"message": "Folder permissions updated",
+		"id":      folder.Id,
+		"title":   folder.Title,
+	})
 }

--- a/pkg/api/folder_permission_test.go
+++ b/pkg/api/folder_permission_test.go
@@ -125,6 +125,10 @@ func TestFolderPermissionApiEndpoint(t *testing.T) {
 			updateFolderPermissionScenario("When calling POST on", "/api/folders/uid/permissions", "/api/folders/:uid/permissions", cmd, func(sc *scenarioContext) {
 				callUpdateFolderPermissions(sc)
 				So(sc.resp.Code, ShouldEqual, 200)
+				respJSON, err := simplejson.NewJson(sc.resp.Body.Bytes())
+				So(err, ShouldBeNil)
+				So(respJSON.Get("id").MustInt(), ShouldEqual, 1)
+				So(respJSON.Get("title").MustString(), ShouldEqual, "Folder")
 			})
 
 			Reset(func() {

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -211,7 +211,10 @@ func (hs *HTTPServer) CompleteInvite(c *models.ReqContext, completeInvite dtos.C
 	metrics.MApiUserSignUpCompleted.Inc()
 	metrics.MApiUserSignUpInvite.Inc()
 
-	return Success("User created and logged in")
+	return JSON(200, util.DynMap{
+		"message": "User created and logged in",
+		"id":      user.Id,
+	})
 }
 
 func updateTempUserStatus(code string, status models.TempUserStatus) (bool, Response) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enrich following endpoints to return the ID of the created / updated resource:
- `POST /api/auth/keys`
- `POST /api/folders/:uid/permissions`
- `POST /api/user/invite/complete`

**Special notes for your reviewer**:
It makes it easier to have access to the resource ID for auditing without any breaking change or important information leakage. 

