### PR TITLE
scripts/ci-frontend-metrics.sh: Fix execution

### DIFF
--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -eo pipefail
-
 echo -e "Collecting code stats (typescript errors & more)"
 
 ERROR_COUNT_LIMIT=580

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 echo -e "Collecting code stats (typescript errors & more)"
 
 ERROR_COUNT_LIMIT=580


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix master build by rectifying a mistake in scripts/ci-frontend-metrics.sh, that made it exit halfway with a silent error.