### PR TITLE
Transformations: make sure that we copy all the values from a field when using MutableDataFrame.

### DIFF
--- a/packages/grafana-data/src/dataframe/MutableDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/MutableDataFrame.ts
@@ -110,11 +110,11 @@ export class MutableDataFrame<T = any> extends FunctionalVector<T> implements Da
     }
 
     const field: MutableField = {
+      ...f,
       name,
       type,
       config: f.config || {},
       values: this.creator(buffer),
-      labels: f.labels,
     };
 
     if (type === FieldType.other) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We have some broken tests in master and this PR fixes that by making sure that we copy all properties from a field when creating a new DataFrame by using the MutableDataFarme.
