### PR TITLE
CircleCI: Ensure only 2 Jest workers for frontend tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -832,7 +832,6 @@ jobs:
 
   test-frontend:
     executor: node
-    resource_class: large
     steps:
       - checkout
       - run:
@@ -854,10 +853,7 @@ jobs:
       - run:
           name: frontend tests
           command: |
-            yarn run ci:test-frontend
-            if [[ $CIRCLE_BRANCH == "master" ]]; then
-              ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics ${GRAFANA_MISC_STATS_API_KEY}
-            fi
+            ./scripts/circle-test-backend.sh
       - store_test_results:
           path: reports/junit
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -832,6 +832,7 @@ jobs:
 
   test-frontend:
     executor: node
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
**What this PR does / why we need it**:
Solve OOM issues by ensuring only two Jest workers for front-end tests.
