### PR TITLE
CloudWatch/Logs: Adds metadata to grouped CloudWatch logs dataframe

### DIFF
--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -175,6 +175,7 @@ func groupResults(results *data.Frame, groupingFieldNames []string) ([]*data.Fra
 		if _, exists := groupedDataFrames[groupKey]; !exists {
 			newFrame := results.EmptyCopy()
 			newFrame.Name = groupKey
+			newFrame.Meta = results.Meta
 			groupedDataFrames[groupKey] = newFrame
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously data frame metadata was stripped when results were being grouped, which could cause issues. This PR fixes that.

