### PR TITLE
AzureMonitor: Change filterDimensions property to match what is stored

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -135,12 +135,12 @@ func (e *AzureMonitorDatasource) buildQueries(queries []*tsdb.Query, timeRange *
 
 		dimSB := strings.Builder{}
 
-		if dimension != "" && dimensionFilter != "" && dimension != "None" && len(azJSONModel.DimensionsFilters) == 0 {
+		if dimension != "" && dimensionFilter != "" && dimension != "None" && len(azJSONModel.DimensionFilters) == 0 {
 			dimSB.WriteString(fmt.Sprintf("%s eq '%s'", dimension, dimensionFilter))
 		} else {
-			for i, filter := range azJSONModel.DimensionsFilters {
+			for i, filter := range azJSONModel.DimensionFilters {
 				dimSB.WriteString(filter.String())
-				if i != len(azJSONModel.DimensionsFilters)-1 {
+				if i != len(azJSONModel.DimensionFilters)-1 {
 					dimSB.WriteString(" and ")
 				}
 			}

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -381,10 +381,16 @@ func formatAzureMonitorLegendKey(alias string, resourceName string, metricName s
 		}
 
 		if metaPartName == "dimensionname" {
+			if len(keys) == 0 {
+				return []byte{}
+			}
 			return []byte(keys[0])
 		}
 
 		if metaPartName == "dimensionvalue" {
+			if len(keys) == 0 {
+				return []byte{}
+			}
 			return []byte(lowerLabels[keys[0]])
 		}
 

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -86,9 +86,9 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 		{
 			name: "has dimensionFilter*s* property with one dimension",
 			azureMonitorVariedProperties: map[string]interface{}{
-				"timeGrain":         "PT1M",
-				"dimensionsFilters": []azureMonitorDimensionFilter{{"blob", "eq", "*"}},
-				"top":               "30",
+				"timeGrain":        "PT1M",
+				"dimensionFilters": []azureMonitorDimensionFilter{{"blob", "eq", "*"}},
+				"top":              "30",
 			},
 			queryIntervalMS:         400000,
 			expectedInterval:        "PT1M",
@@ -97,9 +97,9 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 		{
 			name: "has dimensionFilter*s* property with two dimensions",
 			azureMonitorVariedProperties: map[string]interface{}{
-				"timeGrain":         "PT1M",
-				"dimensionsFilters": []azureMonitorDimensionFilter{{"blob", "eq", "*"}, {"tier", "eq", "*"}},
-				"top":               "30",
+				"timeGrain":        "PT1M",
+				"dimensionFilters": []azureMonitorDimensionFilter{{"blob", "eq", "*"}, {"tier", "eq", "*"}},
+				"top":              "30",
 			},
 			queryIntervalMS:         400000,
 			expectedInterval:        "PT1M",

--- a/pkg/tsdb/azuremonitor/types.go
+++ b/pkg/tsdb/azuremonitor/types.go
@@ -98,7 +98,7 @@ type azureMonitorJSONQuery struct {
 		TimeGrain           string  `json:"timeGrain"`
 		Top                 string  `json:"top"`
 
-		DimensionsFilters []azureMonitorDimensionFilter `json:"dimensionsFilters"` // new model
+		DimensionFilters []azureMonitorDimensionFilter `json:"dimensionFilters"` // new model
 	} `json:"azureMonitor"`
 	Subscription string `json:"subscription"`
 }
@@ -112,7 +112,11 @@ type azureMonitorDimensionFilter struct {
 }
 
 func (a azureMonitorDimensionFilter) String() string {
-	return fmt.Sprintf("%v %v '%v'", a.Dimension, a.Operator, a.Filter)
+	filter := "*"
+	if a.Filter != "" {
+		filter = a.Filter
+	}
+	return fmt.Sprintf("%v %v '%v'", a.Dimension, a.Operator, filter)
 }
 
 // insightsJSONQuery is the frontend JSON query model for an Azure Application Insights query.

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -69,7 +69,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
     const aggregation = templateSrv.replace(item.aggregation, scopedVars);
     const top = templateSrv.replace(item.top || '', scopedVars);
 
-    const dimensionsFilters = item.dimensionFilters
+    const dimensionFilters = item.dimensionFilters
       .filter(f => f.dimension && f.dimension !== 'None')
       .map(f => {
         const filter = templateSrv.replace(f.filter ?? '', scopedVars);
@@ -94,7 +94,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
         metricNamespace:
           metricNamespace && metricNamespace !== defaultDropdownValue ? metricNamespace : metricDefinition,
         aggregation: aggregation,
-        dimensionsFilters,
+        dimensionFilters,
         top: top || '10',
         alias: item.alias,
         format: target.format,


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the `dimensionsFilters`  property to `dimensionsFilter` in the Azure Monitor Datasource's AzureMonitor service to make what is sent to match the saved model.

Before this, the property that the backend was expecting was not available in the case of alerting, where the stored model is fetched.

