### PR TITLE
InfluxDB/Flux: Fix for Alerts on InfluxDB Flux datasources only use the first series

### DIFF
--- a/pkg/tsdb/influxdb/flux/query_models.go
+++ b/pkg/tsdb/influxdb/flux/query_models.go
@@ -83,6 +83,12 @@ func getQueryModelTSDB(query *tsdb.Query, timeRange *tsdb.TimeRange, dsInfo *mod
 		To:   endTime,
 	}
 	model.MaxDataPoints = query.MaxDataPoints
+	if model.MaxDataPoints == 0 {
+		model.MaxDataPoints = 10000 // 10k/series should be a reasonable place to abort!
+	}
 	model.Interval = time.Millisecond * time.Duration(query.IntervalMs)
+	if model.Interval.Milliseconds() == 0 {
+		model.Interval = time.Millisecond // 1ms
+	}
 	return model, nil
 }


### PR DESCRIPTION
Fixes #27218

Alerting queries do not send interval or maxDataPoints, this picks reasonable defaults, but a better solution should send it for alert queries.

With this change, I now see:
![image](https://user-images.githubusercontent.com/705951/92536056-8dfe0700-f1ed-11ea-9696-f7724d7ad40d.png)
