### PR TITLE
Chore: bumped to next version 7.3.0-pre

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["packages/*"],
-  "version": "7.2.0-pre.0"
+  "version": "7.3.0-pre.0"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "private": true,
   "name": "grafana",
-  "version": "7.2.0-pre",
+  "version": "7.3.0-pre",
   "repository": "github:grafana/grafana",
   "scripts": {
     "api-tests": "jest --notify --watch --config=devenv/e2e-api-tests/jest.js",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/data",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "description": "Grafana Data Library",
   "keywords": [
     "typescript"

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/e2e-selectors",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "description": "Grafana End-to-End Test Selectors Library",
   "keywords": [
     "cli",

--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/e2e",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "description": "Grafana End-to-End Test Library",
   "keywords": [
     "cli",
@@ -44,7 +44,7 @@
   "types": "src/index.ts",
   "dependencies": {
     "@cypress/webpack-preprocessor": "4.1.3",
-    "@grafana/e2e-selectors": "7.2.0-pre.0",
+    "@grafana/e2e-selectors": "7.3.0-pre.0",
     "@grafana/tsconfig": "^1.0.0-rc1",
     "@mochajs/json-file-reporter": "^1.2.0",
     "blink-diff": "1.0.13",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/runtime",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "description": "Grafana Runtime Library",
   "keywords": [
     "grafana",
@@ -22,8 +22,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@grafana/data": "7.2.0-pre.0",
-    "@grafana/ui": "7.2.0-pre.0",
+    "@grafana/data": "7.3.0-pre.0",
+    "@grafana/ui": "7.3.0-pre.0",
     "systemjs": "0.20.19",
     "systemjs-plugin-css": "0.1.37"
   },

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/toolkit",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "description": "Grafana Toolkit",
   "keywords": [
     "grafana",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -2,7 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/ui",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "description": "Grafana Components Library",
   "keywords": [
     "grafana",
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@emotion/core": "^10.0.27",
-    "@grafana/data": "7.2.0-pre.0",
-    "@grafana/e2e-selectors": "7.2.0-pre.0",
+    "@grafana/data": "7.3.0-pre.0",
+    "@grafana/e2e-selectors": "7.3.0-pre.0",
     "@grafana/slate-react": "0.22.9-grafana",
     "@grafana/tsconfig": "^1.0.0-rc1",
     "@iconscout/react-unicons": "1.1.4",

--- a/packages/jaeger-ui-components/package.json
+++ b/packages/jaeger-ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaegertracing/jaeger-ui-components",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -14,8 +14,8 @@
     "typescript": "3.9.3"
   },
   "dependencies": {
-    "@grafana/data": "7.2.0-pre.0",
-    "@grafana/ui": "7.2.0-pre.0",
+    "@grafana/data": "7.3.0-pre.0",
+    "@grafana/ui": "7.3.0-pre.0",
     "@types/classnames": "^2.2.7",
     "@types/deep-freeze": "^0.1.1",
     "@types/hoist-non-react-statics": "^3.3.1",

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana-plugins/input-datasource",
-  "version": "7.2.0-pre.0",
+  "version": "7.3.0-pre.0",
   "description": "Input Datasource",
   "private": true,
   "repository": {
@@ -16,9 +16,9 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grafana/data": "7.2.0-pre.0",
-    "@grafana/toolkit": "7.2.0-pre.0",
-    "@grafana/ui": "7.2.0-pre.0"
+    "@grafana/data": "7.3.0-pre.0",
+    "@grafana/toolkit": "7.3.0-pre.0",
+    "@grafana/ui": "7.3.0-pre.0"
   },
   "volta": {
     "node": "12.16.2"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumping version to 7.3.0-pre0 so all the nightly builds will be released as next version.
