### PR TITLE
Postgres: Support request cancellation properly (Uses new backendSrv.fetch Observable request API)

### DIFF
--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { getBackendSrv } from '@grafana/runtime';
 import { DataQueryResponse, ScopedVars } from '@grafana/data';
 
@@ -8,9 +9,8 @@ import PostgresQuery from 'app/plugins/datasource/postgres/postgres_query';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 //Types
-import { PostgresQueryForInterpolation } from './types';
+import { PostgresMetricFindValue, PostgresQueryForInterpolation } from './types';
 import { getSearchFilterScopedVar } from '../../../features/variables/utils';
-import { map } from 'rxjs/operators';
 
 export class PostgresDatasource {
   id: any;
@@ -34,7 +34,7 @@ export class PostgresDatasource {
     this.interval = (instanceSettings.jsonData || {}).timeInterval || '1m';
   }
 
-  interpolateVariable = (value: string, variable: { multi: any; includeAll: any }) => {
+  interpolateVariable = (value: string | string[], variable: { multi: any; includeAll: any }) => {
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
         return this.queryModel.quoteLiteral(value);
@@ -133,7 +133,10 @@ export class PostgresDatasource {
       .toPromise();
   }
 
-  metricFindQuery(query: string, optionalOptions: { variable?: any; searchFilter?: string }) {
+  metricFindQuery(
+    query: string,
+    optionalOptions: { variable?: any; searchFilter?: string }
+  ): Promise<PostgresMetricFindValue[]> {
     let refId = 'tempvar';
     if (optionalOptions && optionalOptions.variable && optionalOptions.variable.name) {
       refId = optionalOptions.variable.name;

--- a/public/app/plugins/datasource/postgres/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource.test.ts
@@ -8,7 +8,6 @@ import { backendSrv } from 'app/core/services/backend_srv'; // will use the vers
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { initialCustomVariableModelState } from '../../../../features/variables/custom/reducer';
 import { TimeSrv } from '../../../../features/dashboard/services/TimeSrv';
-import { describe } from '../../../../../test/lib/common';
 import { observableTester } from '../../../../../test/helpers/observableTester';
 
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/plugins/datasource/postgres/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource.test.ts
@@ -1,8 +1,15 @@
-import { PostgresDatasource } from '../datasource';
+import { of } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { FetchResponse } from '@grafana/runtime';
 import { dateTime, toUtc } from '@grafana/data';
+
+import { PostgresDatasource } from '../datasource';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { initialCustomVariableModelState } from '../../../../features/variables/custom/reducer';
+import { TimeSrv } from '../../../../features/dashboard/services/TimeSrv';
+import { describe } from '../../../../../test/lib/common';
+import { observableTester } from '../../../../../test/helpers/observableTester';
 
 jest.mock('@grafana/runtime', () => ({
   ...((jest.requireActual('@grafana/runtime') as unknown) as object),
@@ -10,76 +17,270 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('PostgreSQLDatasource', () => {
-  const datasourceRequestMock = jest.spyOn(backendSrv, 'datasourceRequest');
-
-  beforeEach(() => {
+  const fetchMock = jest.spyOn(backendSrv, 'fetch');
+  const setupTestContext = (data: any) => {
     jest.clearAllMocks();
-  });
+    fetchMock.mockImplementation(() => of(createFetchResponse(data)));
 
-  const instanceSettings = { name: 'postgresql' };
-
-  const templateSrv: TemplateSrv = new TemplateSrv();
-  const raw = {
-    from: toUtc('2018-04-25 10:00'),
-    to: toUtc('2018-04-25 11:00'),
-  };
-  const ctx = {
-    timeSrvMock: {
+    const templateSrv: TemplateSrv = new TemplateSrv();
+    const raw = {
+      from: toUtc('2018-04-25 10:00'),
+      to: toUtc('2018-04-25 11:00'),
+    };
+    const timeSrvMock = ({
       timeRange: () => ({
         from: raw.from,
         to: raw.to,
         raw: raw,
       }),
-    },
-  } as any;
+    } as unknown) as TimeSrv;
+    const variable = { ...initialCustomVariableModelState };
+    const postgres = new PostgresDatasource({ name: 'postgresql' }, templateSrv, timeSrvMock);
 
-  beforeEach(() => {
-    ctx.ds = new PostgresDatasource(instanceSettings, templateSrv, ctx.timeSrvMock);
-  });
+    return { postgres, templateSrv, timeSrvMock, variable };
+  };
 
-  describe('When performing annotationQuery', () => {
-    let results: any;
+  // https://rxjs-dev.firebaseapp.com/guide/testing/marble-testing
+  const runMarbleTest = (args: {
+    options: any;
+    values: { [marble: string]: FetchResponse };
+    marble: string;
+    expectedValues: { [marble: string]: any };
+    expectedMarble: string;
+  }) => {
+    const { expectedValues, expectedMarble, options, values, marble } = args;
+    const scheduler: TestScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
 
-    const annotationName = 'MyAnno';
+    const { postgres } = setupTestContext({});
 
-    const options = {
-      annotation: {
-        name: annotationName,
-        rawQuery: 'select time, title, text, tags from table;',
-      },
-      range: {
-        from: dateTime(1432288354),
-        to: dateTime(1432288401),
-      },
-    };
+    scheduler.run(({ cold, expectObservable }) => {
+      const source = cold(marble, values);
+      jest.clearAllMocks();
+      fetchMock.mockImplementation(() => source);
 
-    const response = {
-      results: {
-        MyAnno: {
-          refId: annotationName,
-          tables: [
+      const result = postgres.query(options);
+      expectObservable(result).toBe(expectedMarble, expectedValues);
+    });
+  };
+
+  describe('When performing a time series query', () => {
+    it('should transform response correctly', () => {
+      const options = {
+        range: {
+          from: dateTime(1432288354),
+          to: dateTime(1432288401),
+        },
+        targets: [
+          {
+            format: 'time_series',
+            rawQuery: true,
+            rawSql: 'select time, metric from grafana_metric',
+            refId: 'A',
+            datasource: 'gdev-postgres',
+          },
+        ],
+      };
+
+      const data = {
+        results: {
+          A: {
+            refId: 'A',
+            meta: {
+              executedQueryString: 'select time, metric from grafana_metric',
+              rowCount: 0,
+            },
+            series: [
+              {
+                name: 'America',
+                points: [[30.226249741223704, 1599643351085]],
+              },
+            ],
+            tables: null,
+            dataframes: null,
+          },
+        },
+      };
+
+      const values = { a: createFetchResponse(data) };
+      const marble = '-a|';
+      const expectedMarble = '-a|';
+      const expectedValues = {
+        a: {
+          data: [
             {
-              columns: [{ text: 'time' }, { text: 'text' }, { text: 'tags' }],
-              rows: [
-                [1432288355, 'some text', 'TagA,TagB'],
-                [1432288390, 'some text2', ' TagB , TagC'],
-                [1432288400, 'some text3'],
-              ],
+              datapoints: [[30.226249741223704, 1599643351085]],
+              meta: {
+                executedQueryString: 'select time, metric from grafana_metric',
+                rowCount: 0,
+              },
+              refId: 'A',
+              target: 'America',
             },
           ],
         },
-      },
-    };
+      };
 
-    beforeEach(() => {
-      datasourceRequestMock.mockImplementation(options => Promise.resolve({ data: response, status: 200 }));
+      runMarbleTest({ options, marble, values, expectedMarble, expectedValues });
+    });
+  });
 
-      ctx.ds.annotationQuery(options).then((data: any) => {
-        results = data;
+  describe('When performing a table query', () => {
+    it('should transform response correctly', () => {
+      const options = {
+        range: {
+          from: dateTime(1432288354),
+          to: dateTime(1432288401),
+        },
+        targets: [
+          {
+            format: 'table',
+            rawQuery: true,
+            rawSql: 'select time, metric, value from grafana_metric',
+            refId: 'A',
+            datasource: 'gdev-postgres',
+          },
+        ],
+      };
+
+      const data = {
+        results: {
+          A: {
+            refId: 'A',
+            meta: {
+              executedQueryString: 'select time, metric, value from grafana_metric',
+              rowCount: 1,
+            },
+            series: null,
+            tables: [
+              {
+                columns: [
+                  {
+                    text: 'time',
+                  },
+                  {
+                    text: 'metric',
+                  },
+                  {
+                    text: 'value',
+                  },
+                ],
+                rows: [[1599643351085, 'America', 30.226249741223704]],
+              },
+            ],
+            dataframes: null,
+          },
+        },
+      };
+
+      const values = { a: createFetchResponse(data) };
+      const marble = '-a|';
+      const expectedMarble = '-a|';
+      const expectedValues = {
+        a: {
+          data: [
+            {
+              columns: [
+                {
+                  text: 'time',
+                },
+                {
+                  text: 'metric',
+                },
+                {
+                  text: 'value',
+                },
+              ],
+              rows: [[1599643351085, 'America', 30.226249741223704]],
+              type: 'table',
+              refId: 'A',
+              meta: {
+                executedQueryString: 'select time, metric, value from grafana_metric',
+                rowCount: 1,
+              },
+            },
+          ],
+        },
+      };
+
+      runMarbleTest({ options, marble, values, expectedMarble, expectedValues });
+    });
+  });
+
+  describe('When performing a query with hidden target', () => {
+    it('should return empty result and backendSrv.fetch should not be called', done => {
+      const options = {
+        range: {
+          from: dateTime(1432288354),
+          to: dateTime(1432288401),
+        },
+        targets: [
+          {
+            format: 'table',
+            rawQuery: true,
+            rawSql: 'select time, metric, value from grafana_metric',
+            refId: 'A',
+            datasource: 'gdev-postgres',
+            hide: true,
+          },
+        ],
+      };
+
+      const { postgres } = setupTestContext({});
+
+      observableTester().subscribeAndExpectOnNext({
+        observable: postgres.query(options),
+        expect: value => {
+          expect(value).toEqual({ data: [] });
+        },
+      });
+
+      observableTester().subscribeAndExpectOnComplete({
+        observable: postgres.query(options),
+        expect: () => {
+          expect(fetchMock).not.toHaveBeenCalled();
+        },
+        done,
       });
     });
+  });
 
-    it('should return annotation list', () => {
+  describe('When performing annotationQuery', () => {
+    it('should return annotation list', async () => {
+      const annotationName = 'MyAnno';
+      const options = {
+        annotation: {
+          name: annotationName,
+          rawQuery: 'select time, title, text, tags from table;',
+        },
+        range: {
+          from: dateTime(1432288354),
+          to: dateTime(1432288401),
+        },
+      };
+      const data = {
+        results: {
+          MyAnno: {
+            refId: annotationName,
+            tables: [
+              {
+                columns: [{ text: 'time' }, { text: 'text' }, { text: 'tags' }],
+                rows: [
+                  [1432288355, 'some text', 'TagA,TagB'],
+                  [1432288390, 'some text2', ' TagB , TagC'],
+                  [1432288400, 'some text3'],
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      const { postgres } = setupTestContext(data);
+
+      const results = await postgres.annotationQuery(options);
+
       expect(results.length).toBe(3);
 
       expect(results[0].text).toBe('some text');
@@ -94,38 +295,33 @@ describe('PostgreSQLDatasource', () => {
   });
 
   describe('When performing metricFindQuery', () => {
-    let results: any;
-    const query = 'select * from atable';
-    const response = {
-      results: {
-        tempvar: {
-          meta: {
-            rowCount: 3,
-          },
-          refId: 'tempvar',
-          tables: [
-            {
-              columns: [{ text: 'title' }, { text: 'text' }],
-              rows: [
-                ['aTitle', 'some text'],
-                ['aTitle2', 'some text2'],
-                ['aTitle3', 'some text3'],
-              ],
+    it('should return list of all column values', async () => {
+      const query = 'select * from atable';
+      const data = {
+        results: {
+          tempvar: {
+            meta: {
+              rowCount: 3,
             },
-          ],
+            refId: 'tempvar',
+            tables: [
+              {
+                columns: [{ text: 'title' }, { text: 'text' }],
+                rows: [
+                  ['aTitle', 'some text'],
+                  ['aTitle2', 'some text2'],
+                  ['aTitle3', 'some text3'],
+                ],
+              },
+            ],
+          },
         },
-      },
-    };
+      };
 
-    beforeEach(() => {
-      datasourceRequestMock.mockImplementation(options => Promise.resolve({ data: response, status: 200 }));
+      const { postgres } = setupTestContext(data);
 
-      ctx.ds.metricFindQuery(query).then((data: any) => {
-        results = data;
-      });
-    });
+      const results = await postgres.metricFindQuery(query, {});
 
-    it('should return list of all column values', () => {
       expect(results.length).toBe(6);
       expect(results[0].text).toBe('aTitle');
       expect(results[5].text).toBe('some text3');
@@ -133,124 +329,117 @@ describe('PostgreSQLDatasource', () => {
   });
 
   describe('When performing metricFindQuery with $__searchFilter and a searchFilter is given', () => {
-    let results: any;
-    let calledWith: any = {};
-    const query = "select title from atable where title LIKE '$__searchFilter'";
-    const response = {
-      results: {
-        tempvar: {
-          meta: {
-            rowCount: 3,
-          },
-          refId: 'tempvar',
-          tables: [
-            {
-              columns: [{ text: 'title' }, { text: 'text' }],
-              rows: [
-                ['aTitle', 'some text'],
-                ['aTitle2', 'some text2'],
-                ['aTitle3', 'some text3'],
-              ],
+    it('should return list of all column values', async () => {
+      const query = "select title from atable where title LIKE '$__searchFilter'";
+      const data = {
+        results: {
+          tempvar: {
+            meta: {
+              rowCount: 3,
             },
-          ],
+            refId: 'tempvar',
+            tables: [
+              {
+                columns: [{ text: 'title' }, { text: 'text' }],
+                rows: [
+                  ['aTitle', 'some text'],
+                  ['aTitle2', 'some text2'],
+                  ['aTitle3', 'some text3'],
+                ],
+              },
+            ],
+          },
         },
-      },
-    };
+      };
 
-    beforeEach(() => {
-      datasourceRequestMock.mockImplementation(options => {
-        calledWith = options;
-        return Promise.resolve({ data: response, status: 200 });
-      });
+      const { postgres } = setupTestContext(data);
 
-      ctx.ds.metricFindQuery(query, { searchFilter: 'aTit' }).then((data: any) => {
-        results = data;
-      });
-    });
+      const results = await postgres.metricFindQuery(query, { searchFilter: 'aTit' });
 
-    it('should return list of all column values', () => {
-      expect(datasourceRequestMock).toBeCalledTimes(1);
-      expect(calledWith.data.queries[0].rawSql).toBe("select title from atable where title LIKE 'aTit%'");
-      expect(results.length).toBe(6);
+      expect(fetchMock).toBeCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0].data.queries[0].rawSql).toBe(
+        "select title from atable where title LIKE 'aTit%'"
+      );
+      expect(results).toEqual([
+        { text: 'aTitle' },
+        { text: 'some text' },
+        { text: 'aTitle2' },
+        { text: 'some text2' },
+        { text: 'aTitle3' },
+        { text: 'some text3' },
+      ]);
     });
   });
 
   describe('When performing metricFindQuery with $__searchFilter but no searchFilter is given', () => {
-    let results: any;
-    let calledWith: any = {};
-    const query = "select title from atable where title LIKE '$__searchFilter'";
-    const response = {
-      results: {
-        tempvar: {
-          meta: {
-            rowCount: 3,
-          },
-          refId: 'tempvar',
-          tables: [
-            {
-              columns: [{ text: 'title' }, { text: 'text' }],
-              rows: [
-                ['aTitle', 'some text'],
-                ['aTitle2', 'some text2'],
-                ['aTitle3', 'some text3'],
-              ],
+    it('should return list of all column values', async () => {
+      const query = "select title from atable where title LIKE '$__searchFilter'";
+      const data = {
+        results: {
+          tempvar: {
+            meta: {
+              rowCount: 3,
             },
-          ],
+            refId: 'tempvar',
+            tables: [
+              {
+                columns: [{ text: 'title' }, { text: 'text' }],
+                rows: [
+                  ['aTitle', 'some text'],
+                  ['aTitle2', 'some text2'],
+                  ['aTitle3', 'some text3'],
+                ],
+              },
+            ],
+          },
         },
-      },
-    };
+      };
 
-    beforeEach(() => {
-      datasourceRequestMock.mockImplementation(options => {
-        calledWith = options;
-        return Promise.resolve({ data: response, status: 200 });
-      });
+      const { postgres } = setupTestContext(data);
 
-      ctx.ds.metricFindQuery(query, {}).then((data: any) => {
-        results = data;
-      });
-    });
+      const results = await postgres.metricFindQuery(query, {});
 
-    it('should return list of all column values', () => {
-      expect(datasourceRequestMock).toBeCalledTimes(1);
-      expect(calledWith.data.queries[0].rawSql).toBe("select title from atable where title LIKE '%'");
-      expect(results.length).toBe(6);
+      expect(fetchMock).toBeCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0].data.queries[0].rawSql).toBe("select title from atable where title LIKE '%'");
+      expect(results).toEqual([
+        { text: 'aTitle' },
+        { text: 'some text' },
+        { text: 'aTitle2' },
+        { text: 'some text2' },
+        { text: 'aTitle3' },
+        { text: 'some text3' },
+      ]);
     });
   });
 
   describe('When performing metricFindQuery with key, value columns', () => {
-    let results: any;
-    const query = 'select * from atable';
-    const response = {
-      results: {
-        tempvar: {
-          meta: {
-            rowCount: 3,
-          },
-          refId: 'tempvar',
-          tables: [
-            {
-              columns: [{ text: '__value' }, { text: '__text' }],
-              rows: [
-                ['value1', 'aTitle'],
-                ['value2', 'aTitle2'],
-                ['value3', 'aTitle3'],
-              ],
+    it('should return list of as text, value', async () => {
+      const query = 'select * from atable';
+      const data = {
+        results: {
+          tempvar: {
+            meta: {
+              rowCount: 3,
             },
-          ],
+            refId: 'tempvar',
+            tables: [
+              {
+                columns: [{ text: '__value' }, { text: '__text' }],
+                rows: [
+                  ['value1', 'aTitle'],
+                  ['value2', 'aTitle2'],
+                  ['value3', 'aTitle3'],
+                ],
+              },
+            ],
+          },
         },
-      },
-    };
+      };
 
-    beforeEach(() => {
-      datasourceRequestMock.mockImplementation(options => Promise.resolve({ data: response, status: 200 }));
+      const { postgres } = setupTestContext(data);
 
-      ctx.ds.metricFindQuery(query).then((data: any) => {
-        results = data;
-      });
-    });
+      const results = await postgres.metricFindQuery(query, {});
 
-    it('should return list of as text, value', () => {
       expect(results.length).toBe(3);
       expect(results[0].text).toBe('aTitle');
       expect(results[0].value).toBe('value1');
@@ -260,39 +449,33 @@ describe('PostgreSQLDatasource', () => {
   });
 
   describe('When performing metricFindQuery with key, value columns and with duplicate keys', () => {
-    let results: any;
-    const query = 'select * from atable';
-    const response = {
-      results: {
-        tempvar: {
-          meta: {
-            rowCount: 3,
-          },
-          refId: 'tempvar',
-          tables: [
-            {
-              columns: [{ text: '__text' }, { text: '__value' }],
-              rows: [
-                ['aTitle', 'same'],
-                ['aTitle', 'same'],
-                ['aTitle', 'diff'],
-              ],
+    it('should return list of unique keys', async () => {
+      const query = 'select * from atable';
+      const data = {
+        results: {
+          tempvar: {
+            meta: {
+              rowCount: 3,
             },
-          ],
+            refId: 'tempvar',
+            tables: [
+              {
+                columns: [{ text: '__text' }, { text: '__value' }],
+                rows: [
+                  ['aTitle', 'same'],
+                  ['aTitle', 'same'],
+                  ['aTitle', 'diff'],
+                ],
+              },
+            ],
+          },
         },
-      },
-    };
+      };
 
-    beforeEach(() => {
-      datasourceRequestMock.mockImplementation(options => Promise.resolve({ data: response, status: 200 }));
+      const { postgres } = setupTestContext(data);
 
-      ctx.ds.metricFindQuery(query).then((data: any) => {
-        results = data;
-      });
-      //ctx.$rootScope.$apply();
-    });
+      const results = await postgres.metricFindQuery(query, {});
 
-    it('should return list of unique keys', () => {
       expect(results.length).toBe(1);
       expect(results[0].text).toBe('aTitle');
       expect(results[0].value).toBe('same');
@@ -300,47 +483,49 @@ describe('PostgreSQLDatasource', () => {
   });
 
   describe('When interpolating variables', () => {
-    beforeEach(() => {
-      ctx.variable = { ...initialCustomVariableModelState };
-    });
-
     describe('and value is a string', () => {
       it('should return an unquoted value', () => {
-        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).toEqual('abc');
+        const { postgres, variable } = setupTestContext({});
+        expect(postgres.interpolateVariable('abc', variable)).toEqual('abc');
       });
     });
 
     describe('and value is a number', () => {
       it('should return an unquoted value', () => {
-        expect(ctx.ds.interpolateVariable(1000, ctx.variable)).toEqual(1000);
+        const { postgres, variable } = setupTestContext({});
+        expect(postgres.interpolateVariable(1000, variable)).toEqual(1000);
       });
     });
 
     describe('and value is an array of strings', () => {
       it('should return comma separated quoted values', () => {
-        expect(ctx.ds.interpolateVariable(['a', 'b', 'c'], ctx.variable)).toEqual("'a','b','c'");
+        const { postgres, variable } = setupTestContext({});
+        expect(postgres.interpolateVariable(['a', 'b', 'c'], variable)).toEqual("'a','b','c'");
       });
     });
 
     describe('and variable allows multi-value and is a string', () => {
       it('should return a quoted value', () => {
-        ctx.variable.multi = true;
-        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).toEqual("'abc'");
+        const { postgres, variable } = setupTestContext({});
+        variable.multi = true;
+        expect(postgres.interpolateVariable('abc', variable)).toEqual("'abc'");
       });
     });
 
     describe('and variable contains single quote', () => {
       it('should return a quoted value', () => {
-        ctx.variable.multi = true;
-        expect(ctx.ds.interpolateVariable("a'bc", ctx.variable)).toEqual("'a''bc'");
-        expect(ctx.ds.interpolateVariable("a'b'c", ctx.variable)).toEqual("'a''b''c'");
+        const { postgres, variable } = setupTestContext({});
+        variable.multi = true;
+        expect(postgres.interpolateVariable("a'bc", variable)).toEqual("'a''bc'");
+        expect(postgres.interpolateVariable("a'b'c", variable)).toEqual("'a''b''c'");
       });
     });
 
     describe('and variable allows all and is a string', () => {
       it('should return a quoted value', () => {
-        ctx.variable.includeAll = true;
-        expect(ctx.ds.interpolateVariable('abc', ctx.variable)).toEqual("'abc'");
+        const { postgres, variable } = setupTestContext({});
+        variable.includeAll = true;
+        expect(postgres.interpolateVariable('abc', variable)).toEqual("'abc'");
       });
     });
   });
@@ -363,11 +548,14 @@ describe('PostgreSQLDatasource', () => {
         rawSql,
         rawQuery: true,
       };
+      const { templateSrv, postgres } = setupTestContext({});
+
       templateSrv.init([
         { type: 'query', name: 'summarize', current: { value: '1m' } },
         { type: 'query', name: 'host', current: { value: 'a' } },
       ]);
-      expect(ctx.ds.targetContainsTemplate(query)).toBeTruthy();
+
+      expect(postgres.targetContainsTemplate(query)).toBeTruthy();
     });
 
     it('given query that only contains global template variable it should return false', () => {
@@ -386,11 +574,26 @@ describe('PostgreSQLDatasource', () => {
         rawSql,
         rawQuery: true,
       };
+      const { templateSrv, postgres } = setupTestContext({});
+
       templateSrv.init([
         { type: 'query', name: 'summarize', current: { value: '1m' } },
         { type: 'query', name: 'host', current: { value: 'a' } },
       ]);
-      expect(ctx.ds.targetContainsTemplate(query)).toBeFalsy();
+
+      expect(postgres.targetContainsTemplate(query)).toBeFalsy();
     });
   });
+});
+
+const createFetchResponse = <T>(data: T): FetchResponse<T> => ({
+  data,
+  status: 200,
+  url: 'http://localhost:3000/api/query',
+  config: { url: 'http://localhost:3000/api/query' },
+  type: 'basic',
+  statusText: 'Ok',
+  redirected: false,
+  headers: ({} as unknown) as Headers,
+  ok: true,
 });

--- a/public/app/plugins/datasource/postgres/types.ts
+++ b/public/app/plugins/datasource/postgres/types.ts
@@ -1,7 +1,13 @@
+import { MetricFindValue } from '@grafana/data';
+
 export interface PostgresQueryForInterpolation {
   alias?: any;
   format?: any;
   rawSql?: any;
   refId?: any;
   hide?: any;
+}
+
+export interface PostgresMetricFindValue extends MetricFindValue {
+  value?: string;
 }

--- a/public/test/helpers/observableTester.ts
+++ b/public/test/helpers/observableTester.ts
@@ -9,6 +9,11 @@ interface SubscribeAndExpectOnNext<T> extends ObservableTester<T> {
   expect: (value: T) => void;
 }
 
+interface SubscribeAndExpectOnNextAndComplete<T> extends ObservableTester<T> {
+  expectOnNext: (value: T) => void;
+  expectOnComplete: () => void;
+}
+
 interface SubscribeAndExpectOnComplete<T> extends ObservableTester<T> {
   expect: () => void;
 }
@@ -47,6 +52,33 @@ export const observableTester = () => {
     });
   };
 
+  const subscribeAndExpectOnNextAndComplete = <T>({
+    observable,
+    expectOnComplete,
+    expectOnNext,
+    done,
+  }: SubscribeAndExpectOnNextAndComplete<T>): void => {
+    observable.subscribe({
+      next: (value: T) => {
+        try {
+          expectOnNext(value);
+          done();
+        } catch (err) {
+          done.fail(err);
+        }
+      },
+      error: err => done.fail(err),
+      complete: () => {
+        try {
+          expectOnComplete();
+          done();
+        } catch (err) {
+          done.fail(err);
+        }
+      },
+    });
+  };
+
   const subscribeAndExpectOnError = <T>({ observable, expect, done }: SubscribeAndExpectOnError<T>): void => {
     observable.subscribe({
       next: () => {},
@@ -64,5 +96,10 @@ export const observableTester = () => {
     });
   };
 
-  return { subscribeAndExpectOnNext, subscribeAndExpectOnComplete, subscribeAndExpectOnError };
+  return {
+    subscribeAndExpectOnNext,
+    subscribeAndExpectOnComplete,
+    subscribeAndExpectOnNextAndComplete,
+    subscribeAndExpectOnError,
+  };
 };


### PR DESCRIPTION
What this PR does / why we need it:
This PR replaces the usage of datasourceRequest in the Postgres data source with fetch and updates tests accordingly.

Which issue(s) this PR fixes:
Fixes #

Relates #27222

Special notes for your reviewer:
The tests where missing test cases for the `query` method so I tried to run some [marble tests](https://rxjs-dev.firebaseapp.com/guide/testing/marble-testing) in this PR to test Observables. Let me know what you think about that :) 
