### PR TITLE
Notifications: UX tweak to redesign of form and sections to make it left aligned and cleaner

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
+++ b/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
@@ -17,10 +17,10 @@ export const CollapsableSection: FC<Props> = ({ label, isOpen, children }) => {
   return (
     <div>
       <div onClick={() => toggleOpen(!open)} className={styles.header}>
-        <Icon name={open ? 'angle-down' : 'angle-right'} size="xl" />
         {label}
+        <Icon name={open ? 'angle-down' : 'angle-right'} size="xl" />
       </div>
-      <div className={styles.content}>{open && children}</div>
+      {open && <div className={styles.content}>{children}</div>}
     </div>
   );
 };
@@ -32,7 +32,7 @@ const collapsableSectionStyles = (theme: GrafanaTheme) => {
       cursor: pointer;
     `,
     content: css`
-      padding: ${theme.spacing.md} 0 ${theme.spacing.md} ${theme.spacing.md};
+      padding: ${theme.spacing.md} 0;
     `,
   };
 };

--- a/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
+++ b/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, useState } from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
 import { useStyles } from '../../themes';
 import { Icon } from '..';
@@ -13,12 +13,18 @@ export interface Props {
 export const CollapsableSection: FC<Props> = ({ label, isOpen, children }) => {
   const [open, toggleOpen] = useState<boolean>(isOpen);
   const styles = useStyles(collapsableSectionStyles);
+  const headerClass = cx({
+    [styles.header]: true,
+    [styles.headerCollapsed]: !open,
+  });
+
+  const tooltip = `Click to ${open ? 'collapse' : 'expand'}`;
 
   return (
     <div>
-      <div onClick={() => toggleOpen(!open)} className={styles.header}>
+      <div onClick={() => toggleOpen(!open)} className={headerClass} title={tooltip}>
         {label}
-        <Icon name={open ? 'angle-down' : 'angle-right'} size="xl" />
+        <Icon name={open ? 'angle-down' : 'angle-right'} size="xl" className={styles.icon} />
       </div>
       {open && <div className={styles.content}>{children}</div>}
     </div>
@@ -28,8 +34,16 @@ export const CollapsableSection: FC<Props> = ({ label, isOpen, children }) => {
 const collapsableSectionStyles = (theme: GrafanaTheme) => {
   return {
     header: css`
+      display: flex;
+      justify-content: space-between;
       font-size: ${theme.typography.size.lg};
       cursor: pointer;
+    `,
+    headerCollapsed: css`
+      border-bottom: 1px solid ${theme.colors.border2};
+    `,
+    icon: css`
+      color: ${theme.colors.textWeak};
     `,
     content: css`
       padding: ${theme.spacing.md} 0;

--- a/public/app/features/alerting/EditNotificationChannelPage.tsx
+++ b/public/app/features/alerting/EditNotificationChannelPage.tsx
@@ -86,7 +86,7 @@ export class EditNotificationChannelPage extends PureComponent<Props> {
           <h2 className="page-sub-heading">Edit notification channel</h2>
           {notificationChannel && notificationChannel.id > 0 ? (
             <Form
-              width={600}
+              maxWidth={600}
               onSubmit={this.onSubmit}
               defaultValues={{
                 ...notificationChannel,

--- a/public/app/features/alerting/NewNotificationChannelPage.tsx
+++ b/public/app/features/alerting/NewNotificationChannelPage.tsx
@@ -52,7 +52,7 @@ class NewNotificationChannelPage extends PureComponent<Props> {
       <Page navModel={navModel}>
         <Page.Contents>
           <h2 className="page-sub-heading">New notification channel</h2>
-          <Form onSubmit={this.onSubmit} validateOn="onChange" defaultValues={defaultValues}>
+          <Form onSubmit={this.onSubmit} validateOn="onChange" defaultValues={defaultValues} maxWidth={600}>
             {({ register, errors, control, getValues, watch }) => {
               const selectedChannel = notificationChannelTypes.find(c => c.value === getValues().type.value);
 

--- a/public/app/features/alerting/components/BasicSettings.tsx
+++ b/public/app/features/alerting/components/BasicSettings.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { SelectableValue } from '@grafana/data';
-import { CollapsableSection, Field, Input, InputControl, Select } from '@grafana/ui';
+import { Field, Input, InputControl, Select } from '@grafana/ui';
 import { NotificationChannelOptions } from './NotificationChannelOptions';
 import { NotificationSettingsProps } from './NotificationChannelForm';
 import { NotificationChannelSecureFields, NotificationChannelType } from '../../../types';
@@ -23,7 +23,7 @@ export const BasicSettings: FC<Props> = ({
   resetSecureField,
 }) => {
   return (
-    <CollapsableSection label="Channel" isOpen>
+    <>
       <Field label="Name" invalid={!!errors.name} error={errors.name && errors.name.message}>
         <Input name="name" ref={register({ required: 'Name is required' })} />
       </Field>
@@ -39,6 +39,6 @@ export const BasicSettings: FC<Props> = ({
         errors={errors}
         control={control}
       />
-    </CollapsableSection>
+    </>
   );
 };

--- a/public/app/features/alerting/components/NotificationChannelForm.tsx
+++ b/public/app/features/alerting/components/NotificationChannelForm.tsx
@@ -105,7 +105,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     formContainer: css``,
     formItem: css`
       flex-grow: 1;
-      padding-top: ${theme.spacing.lg};
+      padding-top: ${theme.spacing.md};
     `,
     formButtons: css`
       padding-top: ${theme.spacing.xl};

--- a/public/app/features/alerting/components/NotificationChannelForm.tsx
+++ b/public/app/features/alerting/components/NotificationChannelForm.tsx
@@ -41,9 +41,14 @@ export const NotificationChannelForm: FC<Props> = ({
   }, []);
 
   const currentFormValues = getValues();
-  return selectedChannel ? (
-    <>
-      <div className={styles.basicSettings}>
+
+  if (!selectedChannel) {
+    return <Spinner />;
+  }
+
+  return (
+    <div className={styles.formContainer}>
+      <div className={styles.formItem}>
         <BasicSettings
           selectedChannel={selectedChannel}
           channels={selectableChannels}
@@ -54,8 +59,10 @@ export const NotificationChannelForm: FC<Props> = ({
           errors={errors}
           control={control}
         />
-        {/* If there are no non-required fields, don't render this section*/}
-        {selectedChannel.options.filter(o => !o.required).length > 0 && (
+      </div>
+      {/* If there are no non-required fields, don't render this section*/}
+      {selectedChannel.options.filter(o => !o.required).length > 0 && (
+        <div className={styles.formItem}>
           <ChannelSettings
             selectedChannel={selectedChannel}
             secureFields={secureFields}
@@ -65,7 +72,9 @@ export const NotificationChannelForm: FC<Props> = ({
             errors={errors}
             control={control}
           />
-        )}
+        </div>
+      )}
+      <div className={styles.formItem}>
         <NotificationSettings
           imageRendererAvailable={imageRendererAvailable}
           currentFormValues={currentFormValues}
@@ -74,27 +83,32 @@ export const NotificationChannelForm: FC<Props> = ({
           control={control}
         />
       </div>
-      <HorizontalGroup>
-        <Button type="submit">Save</Button>
-        <Button type="button" variant="secondary" onClick={() => onTestChannel(getValues({ nest: true }))}>
-          Test
-        </Button>
-        <a href="/alerting/notifications">
-          <Button type="button" variant="secondary">
-            Back
+      <div className={styles.formButtons}>
+        <HorizontalGroup>
+          <Button type="submit">Save</Button>
+          <Button type="button" variant="secondary" onClick={() => onTestChannel(getValues({ nest: true }))}>
+            Test
           </Button>
-        </a>
-      </HorizontalGroup>
-    </>
-  ) : (
-    <Spinner />
+          <a href="/alerting/notifications">
+            <Button type="button" variant="secondary">
+              Back
+            </Button>
+          </a>
+        </HorizontalGroup>
+      </div>
+    </div>
   );
 };
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
-    basicSettings: css`
-      margin-bottom: ${theme.spacing.xl};
+    formContainer: css``,
+    formItem: css`
+      flex-grow: 1;
+      padding-top: ${theme.spacing.lg};
+    `,
+    formButtons: css`
+      padding-top: ${theme.spacing.xl};
     `,
   };
 });

--- a/public/app/features/alerting/components/NotificationChannelOptions.tsx
+++ b/public/app/features/alerting/components/NotificationChannelOptions.tsx
@@ -59,9 +59,14 @@ export const NotificationChannelOptions: FC<Props> = ({
               <Input
                 readOnly={true}
                 value="Configured"
-                addonAfter={
-                  <Button onClick={() => onResetSecureField(option.propertyName)} variant="secondary" type="button">
-                    Reset
+                suffix={
+                  <Button
+                    onClick={() => onResetSecureField(option.propertyName)}
+                    variant="link"
+                    type="button"
+                    size="sm"
+                  >
+                    Clear
                   </Button>
                 }
               />


### PR DESCRIPTION
Was not super happy with the new design, felt the sections and indentation made it more messy / unaligned than it needed to be. 

Before:
![Screenshot from 2020-09-09 15-48-45](https://user-images.githubusercontent.com/10999/92607398-5f972f00-f2b4-11ea-955e-434df6c8a518.png)

After:
![Screenshot from 2020-09-09 15-58-19](https://user-images.githubusercontent.com/10999/92608187-56f32880-f2b5-11ea-8a38-021d8e233317.png)

Changes
* Collapsable section headings: moved caret to the right so there is need for indentation, now all headings are left-aligned and aligned with form/content 
* Removed top collapsable section & heading as it felt unnecessary to have two headings back to back 
* Tweaked the reset action for saved secret fields from button to link and from addon to suffix (inset in input), and from reset -> clear 
* Increased width, I would like to reduce widths of some inputs so they are not all 100% width but that require component changes and model changes (InputControl does not support width). So postponing that to limit scope for this change 

A saved secret field looked like this before
![Screenshot from 2020-09-09 15-53-31](https://user-images.githubusercontent.com/10999/92607622-a1c07080-f2b4-11ea-9c97-dcd21dea6301.png)
