### PR TITLE
Chore: latest.json for v7.2.0-beta1

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
   "stable": "7.1.5",
-  "testing": "7.1.5"
+  "testing": "7.2.0-beta1"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated `latest.json` so testing to point to the `v7.2.0-beta1` release.
