### PR TITLE
Alerting: Fix integration key so it's stored encrypted for Pagerduty notifier

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -28,6 +28,7 @@ func init() {
 				Placeholder:  "Pagerduty Integration Key",
 				PropertyName: "integrationKey",
 				Required:     true,
+				Secure:       true,
 			},
 			{
 				Label:   "Severity",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue introduced by migration in #25980 which removed storing the Pagerduty integrating key encrypted.