### PR TITLE
fixed: First time dropdown box rendering showing only 1000 pieces

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -78,6 +78,10 @@ const updateOptions = (state: OptionsPickerState): OptionsPickerState => {
 
     return { ...option, selected };
   });
+  if (Array.isArray(state.options) && state.options.length > OPTIONS_LIMIT) {
+    const options = state.options;
+    state.options = options.slice(0, OPTIONS_LIMIT);
+  }
   return state;
 };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
First render of the drop-down box, showing only 1000 pieces of data
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #
When the drop-down box has a large amount of data, such as 20000, the first click on the drop-down menu will cause rendering delay
**Special notes for your reviewer**:

