### PR TITLE
BootData: Fix nav tree sort regression

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -327,10 +327,6 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 		Children:     []*dtos.NavLink{},
 	})
 
-	sort.SliceStable(navTree, func(i, j int) bool {
-		return navTree[i].SortWeight < navTree[j].SortWeight
-	})
-
 	return navTree, nil
 }
 
@@ -433,6 +429,10 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 	}
 
 	hs.HooksService.RunIndexDataHooks(&data, c)
+
+	sort.SliceStable(data.NavTree, func(i, j int) bool {
+		return data.NavTree[i].SortWeight < data.NavTree[j].SortWeight
+	})
 
 	return &data, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
#26395 introduced a regression regarding sort order of nav tree
items set in Grafana boot data and used for rendering the sidemenu.
This fixes so that sort happens after RunIndexDataHooks is called
in case the hook make changes to the nav tree.

This resolves correct placement of the Enterprise reporting nav tree item.

**Which issue(s) this PR fixes**:
Ref #26395 

**Special notes for your reviewer**:

