### PR TITLE
Api: Add /healthz endpoint for health checks

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -437,7 +437,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Delete("/api/snapshots/:key", reqEditorRole, Wrap(DeleteDashboardSnapshot))
 
 	// Health check
-	r.Get("/api/health", hs.healthHandler)
+	r.Get("/api/health", hs.apiHealthHandler)
+	r.Get("/healthz", hs.healthzHandler)
 
 	r.Get("/*", reqSignedIn, hs.Index)
 }

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -375,12 +375,19 @@ func (hs *HTTPServer) metricsEndpoint(ctx *macaron.Context) {
 		ServeHTTP(ctx.Resp, ctx.Req.Request)
 }
 
-func (hs *HTTPServer) healthHandler(ctx *macaron.Context) {
-	notHeadOrGet := ctx.Req.Method != http.MethodGet && ctx.Req.Method != http.MethodHead
-	if notHeadOrGet || ctx.Req.URL.Path != "/api/health" {
-		return
+// healthzHandler always return 200 - Ok if Grafana's web server is running
+func (hs *HTTPServer) healthzHandler(ctx *macaron.Context) {
+	ctx.WriteHeader(200)
+	_, err := ctx.Resp.Write([]byte("Ok"))
+	if err != nil {
+		hs.log.Error("could not write to response", "err", err)
 	}
+}
 
+// apiHealthHandler will return ok if Grafana's web server is running and it
+// can access the database. If the database cannot be access it will return
+// http status code 503.
+func (hs *HTTPServer) apiHealthHandler(ctx *macaron.Context) {
 	data := simplejson.New()
 	data.Set("database", "ok")
 	if !hs.Cfg.AnonymousHideVersion {


### PR DESCRIPTION
kuberentes (and I'm sure other orchestrators does as well) support two
kind of checks. readiness checks and liveness checks. Grafanas current
`/api/health` endpoint requires database access which might not
always be required for the instance to be considered active.

ref https://github.com/grafana/grafana/issues/3302