### PR TITLE
Elasticsearch: Add support for date_nanos type

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -384,6 +384,7 @@ describe('ElasticDatasource', function(this: any) {
                   properties: {
                     '@timestamp': { type: 'date' },
                     __timestamp: { type: 'date' },
+                    '@timestampnano': { type: 'date_nanos' },
                     beat: {
                       properties: {
                         name: {
@@ -431,6 +432,7 @@ describe('ElasticDatasource', function(this: any) {
       expect(fields).toEqual([
         '@timestamp',
         '__timestamp',
+        '@timestampnano',
         'beat.name.raw',
         'beat.name',
         'beat.hostname',
@@ -460,7 +462,7 @@ describe('ElasticDatasource', function(this: any) {
       });
 
       const fields = _.map(fieldObjects, 'text');
-      expect(fields).toEqual(['@timestamp', '__timestamp']);
+      expect(fields).toEqual(['@timestamp', '__timestamp', '@timestampnano']);
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -453,6 +453,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
         integer: 'number',
         long: 'number',
         date: 'date',
+        date_nanos: 'date',
         string: 'string',
         text: 'string',
         scaled_float: 'number',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds `date_nanos` support to elasticsearch datasource. previously `date_nanos` fields were not considered as date fields.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #20963

