### PR TITLE
Elasticsearch: Increase maximum geohash aggregation precision to 12

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/bucket_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/bucket_agg.ts
@@ -144,8 +144,8 @@ export class ElasticBucketAggCtrl {
           break;
         }
         case 'geohash_grid': {
-          // limit precision to 7
-          settings.precision = Math.max(Math.min(settings.precision, 7), 1);
+          // limit precision to 12
+          settings.precision = Math.max(Math.min(settings.precision, 12), 1);
           settingsLinkText = 'Precision: ' + settings.precision;
           break;
         }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Since version 2 Elasticsearch supports precision for geohash grid aggregation up to 12 (was 7 in <2).
This PR just changes the maximum allowed precision from 7 to 12.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #16188


