### PR TITLE
API: Enrich add user to org endpoints with user ID in the response

### DIFF
--- a/docs/sources/http_api/org.md
+++ b/docs/sources/http_api/org.md
@@ -212,7 +212,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
 
-{"message":"User added to organization"}
+{"message":"User added to organization","userId":1}
 ```
 
 ## Admin Organizations API
@@ -463,7 +463,7 @@ Content-Type: application/json
 HTTP/1.1 200
 Content-Type: application/json
 
-{"message":"User added to organization"}
+{"message":"User added to organization", "userId": 1}
 ```
 
 ### Update Users in Organization

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -123,7 +123,10 @@ func inviteExistingUserToOrg(c *models.ReqContext, user *models.User, inviteDto 
 		}
 	}
 
-	return Success(fmt.Sprintf("Existing Grafana user %s added to org %s", user.NameOrFallback(), c.OrgName))
+	return JSON(200, util.DynMap{
+		"message": fmt.Sprintf("Existing Grafana user %s added to org %s", user.NameOrFallback(), c.OrgName),
+		"userId":  user.Id,
+	})
 }
 
 func RevokeInvite(c *models.ReqContext) Response {

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -4,6 +4,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // POST /api/org/users
@@ -35,12 +36,18 @@ func addOrgUserHelper(cmd models.AddOrgUserCommand) Response {
 
 	if err := bus.Dispatch(&cmd); err != nil {
 		if err == models.ErrOrgUserAlreadyAdded {
-			return Error(409, "User is already member of this organization", nil)
+			return JSON(409, util.DynMap{
+				"message": "User is already member of this organization",
+				"userId":  cmd.UserId,
+			})
 		}
 		return Error(500, "Could not add user to organization", err)
 	}
 
-	return Success("User added to organization")
+	return JSON(200, util.DynMap{
+		"message": "User added to organization",
+		"userId":  cmd.UserId,
+	})
 }
 
 // GET /api/org/users


### PR DESCRIPTION
**What this PR does / why we need it**:
Enrich following endpoints to return the ID of the added user:
- `POST /api/org/invites` (if user exists)
- `POST /api/orgs/:orgId/users`
- `POST /api/org/users`

**Special notes for your reviewer**:
It makes it easier to have access to the resource ID for auditing without any breaking change or important information leakage. 

