### PR TITLE
Toolkit: clean node_modules/@grafana/data/node_modules in prepare

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -37,6 +37,10 @@ const copyIfNonExistent = (srcPath: string, destPath: string) =>
 
 export const prepare = useSpinner<void>('Preparing', async () => {
   await Promise.all([
+    // Remove local dependencies for @grafana/data/node_modules
+    // See: https://github.com/grafana/grafana/issues/26748
+    rimraf(resolvePath(__dirname, 'node_modules/@grafana/data/node_modules')),
+
     // Copy only if local tsconfig does not exist.  Otherwise this will work, but have odd behavior
     copyIfNonExistent(
       resolvePath(__dirname, '../../config/tsconfig.plugin.local.json'),


### PR DESCRIPTION
Fixes #26748  (i think... without understanding the root cause)

