### PR TITLE
Annotations: Fixes issue with showing error notice for cancelled annotation queries

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -342,6 +342,7 @@ export class BackendSrv implements BackendService {
         // in throwIfEmpty we'll then throw an cancelled error and then we'll return the correct result in the catchError or rethrow
         throwIfEmpty(() => ({
           type: DataQueryErrorType.Cancelled,
+          cancelled: true,
           data: null,
           status: this.HTTP_REQUEST_CANCELED,
           statusText: 'Request was aborted',

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -353,6 +353,7 @@ describe('backendSrv', () => {
 
         expect(slowError).toEqual({
           type: DataQueryErrorType.Cancelled,
+          cancelled: true,
           data: null,
           status: -1,
           statusText: 'Request was aborted',


### PR DESCRIPTION
Looks like the cancelled property on request errors got lost in the backendSrv refactoring or a follow-up PR. 

This fixes  #27527