### PR TITLE
Chore: Fixes strict typescript issues and counts remaining 

### DIFF
--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -6,7 +6,7 @@ import { DataQuery } from './datasource';
  */
 export interface DataLinkClickEvent<T = any> {
   origin: T;
-  scopedVars: ScopedVars;
+  scopedVars?: ScopedVars;
   e?: any; // mouse|react event
 }
 

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -283,7 +283,7 @@ export class LinkSrv implements LinkService {
   /**
    * Returns LinkModel which is basically a DataLink with all values interpolated through the templateSrv.
    */
-  getDataLinkUIModel = <T>(link: DataLink, scopedVars: ScopedVars, origin: T): LinkModel<T> => {
+  getDataLinkUIModel = <T>(link: DataLink, scopedVars: ScopedVars | undefined, origin: T): LinkModel<T> => {
     const params: KeyValue = {};
     const timeRangeUrl = urlUtil.toUrlParams(this.timeSrv.timeRangeForUrl());
 

--- a/public/app/plugins/panel/table-old/editor.ts
+++ b/public/app/plugins/panel/table-old/editor.ts
@@ -9,8 +9,8 @@ export class TablePanelEditorCtrl {
   fontSizes: any;
   addColumnSegment: any;
   getColumnNames: any;
-  canSetColumns: boolean;
-  columnsHelpMessage: string;
+  canSetColumns = false;
+  columnsHelpMessage = '';
 
   /** @ngInject */
   constructor($scope: any, private uiSegmentSrv: any) {

--- a/public/app/plugins/panel/table-old/specs/renderer.test.ts
+++ b/public/app/plugins/panel/table-old/specs/renderer.test.ts
@@ -477,7 +477,7 @@ describe('when rendering table with different patterns', () => {
 });
 
 describe('when rendering cells with different alignment options', () => {
-  const cases = [
+  const cases: Array<[string, boolean, string | null, string]> = [
     //align, preserve fmt, color mode, expected
     ['', false, null, '<td>42</td>'],
     ['invalid_option', false, null, '<td>42</td>'],

--- a/public/test/mocks/datasource_srv.ts
+++ b/public/test/mocks/datasource_srv.ts
@@ -25,7 +25,6 @@ export class DatasourceSrvMock {
 
 export class MockDataSourceApi extends DataSourceApi {
   result: DataQueryResponse = { data: [] };
-  queryResolver: Promise<DataQueryResponse>;
 
   constructor(name?: string, result?: DataQueryResponse, meta?: any, private error: string | null = null) {
     super({ name: name ? name : 'MockDataSourceApi' } as DataSourceInstanceSettings);
@@ -37,10 +36,6 @@ export class MockDataSourceApi extends DataSourceApi {
   }
 
   query(request: DataQueryRequest): Promise<DataQueryResponse> {
-    if (this.queryResolver) {
-      return this.queryResolver;
-    }
-
     if (this.error) {
       return Promise.reject(this.error);
     }


### PR DESCRIPTION
Even though strictNullChecks are done we have some remaining strict checks that are not on in core but in @grafan/data etc (they are all compiled with --strict true, where all strict checks are enabled). 

The remaining strict checks: 
- strictBindCallApply (8) 
- strictFunctionTypes (285 errors, can be tricky)
- strictPropertyInitialization (261 errors, relativly easy to fix)