### PR TITLE
Explore/Actions: Stop loadExploreDatasourcesAndSetDatasource from running twice

### DIFF
--- a/public/app/features/explore/state/actions.ts
+++ b/public/app/features/explore/state/actions.ts
@@ -263,7 +263,6 @@ export function loadExploreDatasourcesAndSetDatasource(
 
     if (exploreDatasources.length >= 1) {
       await dispatch(changeDatasource(exploreId, datasourceName, { importQueries: true }));
-      dispatch(runQueries(exploreId));
     } else {
       dispatch(loadDatasourceMissingAction({ exploreId }));
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
A change was [previously made](https://github.com/grafana/grafana/pull/26704) that would run queries if the `changeDatasource` action was dispatched with the `importQueries` option enabled. However, the `loadExploreDatasourcesAndSetDatasource` action ran queries after changing datasources with the above action and option, so queries were getting run twice on loading explore / browser refresh. This PR removes the dispatch of `runQueries` in `loadExploreDatasourcesAndSetDatasource`, so queries should only be run once now.

