### PR TITLE
Alerting: Ensuring notifications displayed correctly in mobile device with Google Chat

### DIFF
--- a/pkg/services/alerting/notifiers/googlechat.go
+++ b/pkg/services/alerting/notifiers/googlechat.go
@@ -196,7 +196,7 @@ func (gcn *GoogleChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	// nest the required structs
 	res1D := &outerStruct{
-		PreviewText: evalContext.GetNotificationTitle(),
+		PreviewText:  evalContext.GetNotificationTitle(),
 		FallbackText: evalContext.GetNotificationTitle(),
 		Cards: []card{
 			{

--- a/pkg/services/alerting/notifiers/googlechat.go
+++ b/pkg/services/alerting/notifiers/googlechat.go
@@ -58,6 +58,7 @@ Structs used to build a custom Google Hangouts Chat message card.
 See: https://developers.google.com/hangouts/chat/reference/message-formats/cards
 */
 type outerStruct struct {
+	PreviewText  string `json:"previewText"`
 	FallbackText string `json:"fallbackText"`
 	Cards        []card `json:"cards"`
 }
@@ -195,6 +196,7 @@ func (gcn *GoogleChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	// nest the required structs
 	res1D := &outerStruct{
+		PreviewText: evalContext.GetNotificationTitle(),
 		FallbackText: evalContext.GetNotificationTitle(),
 		Cards: []card{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:

When you receive a card notification from grafana in a Android's device with Google Chat installed, the notification isn't showd correctly. FallbackText solved this in the past, now it's better use previewText.
Very useful when a notification is received in a mobile device, the notification in a blocked screen show the previewText.


