### PR TITLE
Chore: use visualization name in field config header

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -317,7 +317,7 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
 
         for (const customProp of builder.getRegistry().list()) {
           customProp.isCustom = true;
-          customProp.category = ['Custom options'].concat(customProp.category || []);
+          customProp.category = [`${this.meta.name} options`].concat(customProp.category || []);
           // need to do something to make the custom items not conflict with standard ones
           // problem is id (registry index) is used as property path
           // so sort of need a property path on the FieldPropertyEditorItem


### PR DESCRIPTION
In looking at the confusion around table docs, I think the section heading is not helping much.  We should use the panel name for the heading of "custom" config.  The "custom" name is useful for plugin developers, but not end-users

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/705951/93120330-0e9e8680-f678-11ea-979c-c4bb304b9b82.png" width=350/> | <img src="https://user-images.githubusercontent.com/705951/93120253-ed3d9a80-f677-11ea-884e-86011c0dc18e.png" width=350/> |



