### PR TITLE
Chore: eslint plugin react hooks fix in jeager

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+node_modules
+compiled
+build
+vendor
+devenv
+data
+dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
   "root": true,
   "overrides": [
     {
-      "files": ["packages/**/*.{ts,tsx}", "public/app/**/*.{ts,tsx}"],
+      "files": ["packages/grafana-ui/**/*.{ts,tsx}", "public/app/**/*.{ts,tsx}"],
       "rules": {
         "react-hooks/rules-of-hooks": "off",
         "react-hooks/exhaustive-deps": "off"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "e2e:debug": "./e2e/start-and-run-suite debug",
     "e2e:dev": "./e2e/start-and-run-suite dev",
     "jest": "jest --notify --watch",
-    "lint": "eslint . --ext .js,.tsx,.ts --cache --ignore-path .gitignore --ignore-pattern devenv",
+    "lint": "eslint . --ext .js,.tsx,.ts --cache",
     "jest-ci": "mkdir -p reports/junit && export JEST_JUNIT_OUTPUT_DIR=reports/junit && jest --ci --reporters=default --reporters=jest-junit -w ${TEST_MAX_WORKERS:-100%}",
     "lint:fix": "yarn lint --fix",
     "packages:build": "lerna run clean && lerna run build --ignore @grafana-plugins/input-datasource",

--- a/packages/grafana-toolkit/.eslintrc
+++ b/packages/grafana-toolkit/.eslintrc
@@ -1,5 +1,14 @@
 {
   "rules": {
     "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime"] }]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["./**/*.{ts,tsx}"],
+      "rules": {
+        "react-hooks/rules-of-hooks": "off",
+        "react-hooks/exhaustive-deps": "off"
+      }
+    }
+  ]
 }

--- a/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
@@ -160,14 +160,13 @@ export const HEADER_ITEMS = [
   {
     key: 'timestamp',
     label: 'Trace Start',
-    renderer: (trace: Trace) => {
-      const styles = getStyles(useTheme());
+    renderer: (trace: Trace, styles?: ReturnType<typeof getStyles>) => {
       const dateStr = formatDatetime(trace.startTime);
       const match = dateStr.match(/^(.+)(:\d\d\.\d+)$/);
       return match ? (
-        <span className={styles.TracePageHeaderOverviewItemValue}>
+        <span className={styles?.TracePageHeaderOverviewItemValue}>
           {match[1]}
-          <span className={styles.TracePageHeaderOverviewItemValueDetail}>{match[2]}</span>
+          <span className={styles?.TracePageHeaderOverviewItemValueDetail}>{match[2]}</span>
         </span>
       ) : (
         dateStr
@@ -219,21 +218,25 @@ export default function TracePageHeader(props: TracePageHeaderEmbedProps) {
     hideSearchButtons,
   } = props;
 
+  const styles = getStyles(useTheme());
+  const links = useMemo(() => {
+    if (!trace) {
+      return [];
+    }
+    return getTraceLinks(trace);
+  }, [trace]);
+
   if (!trace) {
     return null;
   }
-
-  const links = useMemo(() => getTraceLinks(trace), [trace]);
 
   const summaryItems =
     !hideSummary &&
     !slimView &&
     HEADER_ITEMS.map(item => {
       const { renderer, ...rest } = item;
-      return { ...rest, value: renderer(trace) };
+      return { ...rest, value: renderer(trace, styles) };
     });
-
-  const styles = getStyles(useTheme());
 
   const title = (
     <h1 className={cx(styles.TracePageHeaderTitle, canCollapse && styles.TracePageHeaderTitleCollapsible)}>

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
@@ -96,10 +96,12 @@ type AccordianKeyValuesProps = {
 // export for tests
 export function KeyValuesSummary(props: { data?: TraceKeyValuePair[] }) {
   const { data } = props;
+  const styles = getStyles(useTheme());
+
   if (!Array.isArray(data) || !data.length) {
     return null;
   }
-  const styles = getStyles(useTheme());
+
   return (
     <ul className={styles.summary}>
       {data.map((item, i) => (


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr changes eslint to use eslintignore instead of gitignore so enterprise components can be checked as well.
Add override config to grafana-toolkit so the rule is turned off there.
Fix issues in jaeger-ui-components.