### PR TITLE
backend-plugins: point to request Headers in the wrapper

### DIFF
--- a/pkg/plugins/backendplugin/coreplugin/query_endpoint_adapter.go
+++ b/pkg/plugins/backendplugin/coreplugin/query_endpoint_adapter.go
@@ -59,6 +59,7 @@ func (a *queryEndpointAdapter) Query(ctx context.Context, ds *models.DataSource,
 			DataSourceInstanceSettings: instanceSettings,
 		},
 		Queries: []backend.DataQuery{},
+		Headers: query.Headers,
 	}
 
 	for _, q := range query.Queries {

--- a/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
+++ b/pkg/plugins/datasource/wrapper/datasource_plugin_wrapper_v2.go
@@ -59,6 +59,7 @@ func (tw *DatasourcePluginWrapperV2) Query(ctx context.Context, ds *models.DataS
 			DataSourceInstanceSettings: backend.ToProto().DataSourceInstanceSettings(instanceSettings),
 		},
 		Queries: []*pluginv2.DataQuery{},
+		Headers: query.Headers,
 	}
 
 	for _, q := range query.Queries {


### PR DESCRIPTION
**What this PR does / why we need it**:
Points to the headers of a tsdb.Query from a QueryDataRequest so they are copied to protobuf and sent to a plugin.

**Special notes for your reviewer**:
In particular, this is so the plugin can see the `FromAlert` header:

https://github.com/grafana/grafana/blob/2e4191afca44c1eb303c096c25f6f98c21066614/pkg/services/alerting/conditions/query.go#L216-L234

@marefr, are there any headers they I should make sure are not relayed to the plugin (security maybe?). If that is the case I can make a copy and exclude those.