### PR TITLE
Grafana/Live: Adds function for retrieving promise-bound live srv

### DIFF
--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -80,10 +80,13 @@ export const getGrafanaLiveSrv = (): GrafanaLiveSrv => singletonInstance;
  * @experimental
  * @public
  */
-export const getConnectedLiveSrv = (): Promise<GrafanaLiveSrv> => {
-  return new Promise(resolve => {
+export const getConnectedLiveSrv = (): Promise<GrafanaLiveSrv> =>
+  new Promise(resolve => {
+    if (singletonInstance.isConnected()) {
+      return resolve(singletonInstance);
+    }
+
     singletonInstance.addListener('connect', () => {
       resolve(singletonInstance);
     });
   });
-};

--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -48,6 +48,8 @@ export interface GrafanaLiveSrv {
    * Send data to a channel.  This feature is disabled for most channels and will return an error
    */
   publish<T>(channel: string, data: any): Promise<T>;
+
+  addListener(event: string | symbol, listener: (...args: any[]) => void): void;
 }
 
 let singletonInstance: GrafanaLiveSrv;
@@ -70,3 +72,18 @@ export const setGrafanaLiveSrv = (instance: GrafanaLiveSrv) => {
  * @public
  */
 export const getGrafanaLiveSrv = (): GrafanaLiveSrv => singletonInstance;
+
+/**
+ * Returns a promise that resolves with the {@link GrafanaLiveSrv} once it has
+ * connected
+ *
+ * @experimental
+ * @public
+ */
+export const getConnectedLiveSrv = (): Promise<GrafanaLiveSrv> => {
+  return new Promise(resolve => {
+    singletonInstance.addListener('connect', () => {
+      resolve(singletonInstance);
+    });
+  });
+};

--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -30,6 +30,11 @@ export interface GrafanaLiveSrv {
   isConnected(): boolean;
 
   /**
+   * Resolves when the server is connected
+   */
+  waitUntilConnected(): Promise<void>;
+
+  /**
    * Listen for changes to the connection state
    */
   getConnectionState(): Observable<boolean>;
@@ -48,8 +53,6 @@ export interface GrafanaLiveSrv {
    * Send data to a channel.  This feature is disabled for most channels and will return an error
    */
   publish<T>(channel: string, data: any): Promise<T>;
-
-  addListener(event: string | symbol, listener: (...args: any[]) => void): void;
 }
 
 let singletonInstance: GrafanaLiveSrv;
@@ -80,13 +83,7 @@ export const getGrafanaLiveSrv = (): GrafanaLiveSrv => singletonInstance;
  * @experimental
  * @public
  */
-export const getConnectedLiveSrv = (): Promise<GrafanaLiveSrv> =>
-  new Promise(resolve => {
-    if (singletonInstance.isConnected()) {
-      return resolve(singletonInstance);
-    }
-
-    singletonInstance.addListener('connect', () => {
-      resolve(singletonInstance);
-    });
-  });
+export const getConnectedLiveSrv = async () => {
+  await singletonInstance.waitUntilConnected();
+  return singletonInstance;
+};

--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -30,19 +30,15 @@ export interface GrafanaLiveSrv {
   isConnected(): boolean;
 
   /**
-   * Resolves when the server is connected
-   */
-  waitUntilConnected(): Promise<void>;
-
-  /**
    * Listen for changes to the connection state
    */
   getConnectionState(): Observable<boolean>;
 
   /**
-   * Configure a channel with the given setup
+   * Configure a channel with the given setup. The returned observable emits when
+   * the server connects or if it is already connected.
    */
-  initChannel<T>(channel: string, handler: ChannelHandler<T>): void;
+  initChannel<T>(channel: string, handler: ChannelHandler<T>): Observable<void>;
 
   /**
    * Subscribe to activity on a given channel
@@ -75,15 +71,3 @@ export const setGrafanaLiveSrv = (instance: GrafanaLiveSrv) => {
  * @public
  */
 export const getGrafanaLiveSrv = (): GrafanaLiveSrv => singletonInstance;
-
-/**
- * Returns a promise that resolves with the {@link GrafanaLiveSrv} once it has
- * connected
- *
- * @experimental
- * @public
- */
-export const getConnectedLiveSrv = async () => {
-  await singletonInstance.waitUntilConnected();
-  return singletonInstance;
-};

--- a/public/app/features/admin/LivePanel.tsx
+++ b/public/app/features/admin/LivePanel.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Unsubscribable, PartialObserver } from 'rxjs';
-import { getConnectedLiveSrv } from '@grafana/runtime';
+import { getGrafanaLiveSrv } from '@grafana/runtime';
+import { tap } from 'rxjs/operators';
 
 interface Props {
   channel: string;
@@ -38,11 +39,10 @@ export class LivePanel extends PureComponent<Props, State> {
       this.subscription = undefined;
     }
 
-    getConnectedLiveSrv().then(srv => {
-      const stream = srv.getChannelStream(this.props.channel);
-      this.subscription = stream.subscribe(this.observer);
-      this.setState({ connected: true, count: 0, lastTime: 0, lastBody: '' });
-    });
+    const stream = getGrafanaLiveSrv()
+      .getChannelStream(this.props.channel)
+      .pipe(tap(() => this.setState({ connected: true, count: 0, lastTime: 0, lastBody: '' })));
+    this.subscription = stream.subscribe(this.observer);
   };
 
   componentDidMount = () => {

--- a/public/app/features/admin/LivePanel.tsx
+++ b/public/app/features/admin/LivePanel.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Unsubscribable, PartialObserver } from 'rxjs';
-import { getGrafanaLiveSrv } from '@grafana/runtime';
+import { getConnectedLiveSrv } from '@grafana/runtime';
 
 interface Props {
   channel: string;
@@ -38,15 +38,11 @@ export class LivePanel extends PureComponent<Props, State> {
       this.subscription = undefined;
     }
 
-    const srv = getGrafanaLiveSrv();
-    if (srv.isConnected()) {
+    getConnectedLiveSrv().then(srv => {
       const stream = srv.getChannelStream(this.props.channel);
       this.subscription = stream.subscribe(this.observer);
       this.setState({ connected: true, count: 0, lastTime: 0, lastBody: '' });
-      return;
-    }
-    console.log('Not yet connected... try again...');
-    setTimeout(this.startSubscription, 200);
+    });
   };
 
   componentDidMount = () => {

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -107,6 +107,19 @@ class CentrifugeSrv implements GrafanaLiveSrv {
   }
 
   /**
+   * Resolves when the server is connected
+   */
+  waitUntilConnected(): Promise<void> {
+    return new Promise(resolve => {
+      if (this.isConnected()) {
+        return resolve();
+      }
+
+      this.centrifuge.addListener('connect', () => resolve());
+    });
+  }
+
+  /**
    * Listen for changes to the connection state
    */
   getConnectionState() {
@@ -149,10 +162,6 @@ class CentrifugeSrv implements GrafanaLiveSrv {
    */
   publish<T>(channel: string, data: any): Promise<T> {
     return this.centrifuge.publish(channel, data);
-  }
-
-  addListener(event: string | symbol, listener: (...args: any[]) => void): void {
-    this.centrifuge.addListener(event, listener);
   }
 }
 

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -150,6 +150,10 @@ class CentrifugeSrv implements GrafanaLiveSrv {
   publish<T>(channel: string, data: any): Promise<T> {
     return this.centrifuge.publish(channel, data);
   }
+
+  addListener(event: string | symbol, listener: (...args: any[]) => void): void {
+    this.centrifuge.addListener(event, listener);
+  }
 }
 
 const noopChannelHandler: ChannelHandler = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a function, `getConnectedLiveSrv`, that returns a promise which resolves with the singleton live srv instance once it has connected. This should help simplify usage of the live srv in certain instances (as with LivePanel.tsx)

