### PR TITLE
Graph: only show range warning when all data is outside time range

### DIFF
--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -271,35 +271,35 @@ export class GraphCtrl extends MetricsPanelCtrl {
       };
     }
 
-    // Look for data points outside time range
+    // If any data is in range, do not return an error
     for (const series of this.seriesList) {
       if (!series.isOutsideRange) {
-        continue;
+        return undefined;
       }
-
-      const dataWarning: DataWarning = {
-        title: 'Data outside time range',
-        tip: 'Can be caused by timezone mismatch or missing time filter in query',
-      };
-
-      const range = getDataTimeRange(this.dataList);
-
-      if (range) {
-        dataWarning.actionText = 'Zoom to data';
-        dataWarning.action = () => {
-          getLocationSrv().update({
-            partial: true,
-            query: {
-              from: range.from,
-              to: range.to,
-            },
-          });
-        };
-      }
-
-      return dataWarning;
     }
-    return undefined;
+
+    // All data is outside the time range
+    const dataWarning: DataWarning = {
+      title: 'Data outside time range',
+      tip: 'Can be caused by timezone mismatch or missing time filter in query',
+    };
+
+    const range = getDataTimeRange(this.dataList);
+
+    if (range) {
+      dataWarning.actionText = 'Zoom to data';
+      dataWarning.action = () => {
+        getLocationSrv().update({
+          partial: true,
+          query: {
+            from: range.from,
+            to: range.to,
+          },
+        });
+      };
+    }
+
+    return dataWarning;
   }
 
   onRender() {


### PR DESCRIPTION
Fixes #26279

We currently show a warning with an action when *any* series in the results is outside the time range.  This changes the logic to only show an error when *all* data is outside the time range.

I added this to 7.2 because it is minor and causes weird behavior with some non-timeseries data sources