### PR TITLE
Docs: Rename field configuration options page to field options

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,6 +3,10 @@
 IMAGE = grafana/docs-base:latest
 
 docs:
+	docker pull ${IMAGE}
+	docker run -v $(shell pwd)/sources:/hugo/content/docs/grafana/latest -p 3002:3002 --rm -it $(IMAGE) /bin/bash -c 'make server'
+
+docs-no-pull:
 	docker run -v $(shell pwd)/sources:/hugo/content/docs/grafana/latest -p 3002:3002 --rm -it $(IMAGE) /bin/bash -c 'make server'
 
 docs-test:

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -36,9 +36,9 @@ With Grafana 7.0, we released a new tool for making it easier to develop plugins
 
 For more information, refer to [@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit).
 
-### Field configuration options
+### Field options
 
-Grafana 7.0 introduced the concept of [_field configuration options_]({{< relref "../../panels/field-configuration-options.md#field-configuration-options" >}}), a new way of configuring your data before it gets visualized. Since this was not available in previous versions, any plugin that enables field-based configuration will not work in previous versions of Grafana.
+Grafana 7.0 introduced the concept of [_field options_]({{< relref "../../panels/field-options.md#field-options" >}}), a new way of configuring your data before it gets visualized. Since this was not available in previous versions, any plugin that enables field-based configuration will not work in previous versions of Grafana.
 
 For plugins prior to Grafana 7.0, all options are considered _Display options_. The tab for field configuration isn't available.
 
@@ -55,7 +55,7 @@ To learn more, refer to [Backend plugins]({{< relref "backend" >}}).
 There are several benefits in using the new plugin platform.
 
 - **Better performance:** Components written in React are more responsive.
-- **Support for field configuration options:** By migrating to the new data frame format, you can leverage the new field configuration options to let users customize their data and display options.
+- **Support for field options:** By migrating to the new data frame format, you can leverage the new field options to let users customize their data and display options.
 
 ## Compatibility between Grafana versions
 
@@ -73,7 +73,7 @@ For example:
 
 ### target and jsonData are unchanged
 
-The query model, `target`, and the configuration model, jsonData,  are still the same. This means that if you use the same query model and configuration for your plugin, then the migrated plugin will use existing queries and configuration. You don’t have to worry about breaking existing dashboards.
+The query model, `target`, and the configuration model, jsonData, are still the same. This means that if you use the same query model and configuration for your plugin, then the migrated plugin will use existing queries and configuration. You don’t have to worry about breaking existing dashboards.
 
 ## Migrate a plugin from Angular to React
 
@@ -120,7 +120,7 @@ interface Props extends PanelProps<SimpleOptions> {}
 
 export const MyPanel: React.FC<Props> = ({ options, data, width, height }) => {
   // ...
-}
+};
 ```
 
 ### Migrate a data source plugin

--- a/docs/sources/features/datasources/azuremonitor.md
+++ b/docs/sources/features/datasources/azuremonitor.md
@@ -119,9 +119,9 @@ Azure Monitor examples:
 - `{{ namespace }}` = replaced with the value of the Namespace (e.g. Microsoft.Compute/virtualMachines)
 - `{{ resourcename }}` = replaced with the value of the Resource Name
 - `{{ metric }}` = replaced with metric name (e.g. Percentage CPU)
-- `{{ dimensionname }}` = *Legacy as of 7.1+ (for backwards compatibility)* replaced with the first dimension's key/label (as sorted by the key/label) (e.g. blobtype)
-- `{{ dimensionvalue }}` = *Legacy as of 7.1+ (for backwards compatibility)* replaced with first dimension's value (as sorted by the key/label) (e.g. BlockBlob)
-- `{{ arbitraryDim }}` = *Available in 7.1+* replaced with the value of the corresponding dimension. (e.g. `{{ blobtype }}` becomes BlockBlob)
+- `{{ dimensionname }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with the first dimension's key/label (as sorted by the key/label) (e.g. blobtype)
+- `{{ dimensionvalue }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with first dimension's value (as sorted by the key/label) (e.g. BlockBlob)
+- `{{ arbitraryDim }}` = _Available in 7.1+_ replaced with the value of the corresponding dimension. (e.g. `{{ blobtype }}` becomes BlockBlob)
 
 ### Create template variables for Azure Monitor
 
@@ -188,10 +188,10 @@ Application Insights examples:
 
 ### Alias patterns for Application Insights
 
-- `{{ groupbyvalue }}` = *Legacy as of 7.1+ (for backwards compatibility)* replaced with the first dimension's key/label (as sorted by the key/label)
-- `{{ groupbyname }}` = *Legacy as of 7.1+ (for backwards compatibility)* replaced with first dimension's value (as sorted by the key/label) (e.g. BlockBlob)
+- `{{ groupbyvalue }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with the first dimension's key/label (as sorted by the key/label)
+- `{{ groupbyname }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with first dimension's value (as sorted by the key/label) (e.g. BlockBlob)
 - `{{ metric }}` = replaced with metric name (e.g. requests/count)
-- `{{ arbitraryDim }}` = *Available in 7.1+* replaced with the value of the corresponding dimension. (e.g. `{{ client/city }}` becomes Chicago)
+- `{{ arbitraryDim }}` = _Available in 7.1+_ replaced with the value of the corresponding dimension. (e.g. `{{ client/city }}` becomes Chicago)
 
 ### Filter expressions for Application Insights
 
@@ -289,7 +289,7 @@ The default display name format is:
 
 `metricName{dimensionName=dimensionValue,dimensionTwoName=DimensionTwoValue}`
 
-This can be customized by using the [display name field configuration option]({{< relref "../../panels/field-configuration-options.md#display-name" >}}).
+This can be customized by using the [display name field option]({{< relref "../../panels/field-options.md#display-name" >}}).
 
 ### Azure Log Analytics macros
 

--- a/docs/sources/guides/whats-new-in-v7-0.md
+++ b/docs/sources/guides/whats-new-in-v7-0.md
@@ -26,7 +26,7 @@ The main highlights are:
 - [**Explore** New tracing UI and support for visualizing Jaeger and Zipkin traces.]({{< relref "#new-tracing-ui" >}})
 - [**Enterprise** Usage insights, Presence indicator, and Auth improvements.]({{< relref "#grafana-enterprise" >}})
 - [**Transformations** Transformations and simple Math operations for all data sources.]({{< relref "#transformations" >}})
-- [**Field overrides** Automatically configure panels with data from queries.]({{< relref "#field-configuration-options-and-overrides" >}})
+- [**Field overrides** Automatically configure panels with data from queries.]({{< relref "#field-options-and-overrides" >}})
 - [**Table** New Table panel.]({{< relref "#table-panel" >}})
 - [**Plugins** New plugins platform.]({{< relref "#plugins-platform" >}})
 - [**Tutorials** New tutorials section.]({{< relref "#new-tutorials" >}})
@@ -82,7 +82,7 @@ We are also introducing a new shared data model for both time series and table d
 
 Learn more about this feature in [Transformations]({{< relref "../panels/transformations.md" >}}).
 
-## Field configuration options and overrides
+## Field options and overrides
 
 With Grafana 7.0 we are introducing a new, unified data configuration system that powers a consistent UI for setting data options across visualizations as well as making all data display settings data driven and overridable. This new option architecture and UI will make all panels have a consistent set of options and behaviors for attributes like `unit`, `min`, `max`, `thresholds`, `links`, `decimals` or `value mappings`. Not only that but all these options will share a consistent UI for specifying override rules and is extensible for custom panel specific options.
 
@@ -90,7 +90,7 @@ Up until now the overrides were available only for Graph and Table panel(via Col
 
 This feature enables even more powerful visualizations and fine grained control over how the data is displayed.
 
-Learn more about this feature in [Field configuration options]({{< relref "../panels/field-configuration-options.md" >}}).
+Learn more about this feature in [Field options]({{< relref "../panels/field-options.md" >}}).
 
 ## Inspect panels and export data to CSV
 

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -165,8 +165,8 @@
       name: Queries
     - link: /panels/transformations/
       name: Transformations
-    - link: /panels/field-configuration-options/
-      name: Field config options
+    - link: /panels/field-options/
+      name: Field options
     - link: /panels/panel-editor/
       name: Panel editor
     - name: Visualizations

--- a/docs/sources/panels/add-a-panel.md
+++ b/docs/sources/panels/add-a-panel.md
@@ -16,8 +16,8 @@ Panels allow you to show your data in visual form. This topic walks you through 
 
 1. Navigate to the dashboard you want to add a panel to.
 1. Click the **Add panel** icon.
-   
-     ![](/img/docs/panels/add-panel-icon-7-0.png)
+
+   ![](/img/docs/panels/add-panel-icon-7-0.png)
 
 1. Click **Add new panel**.
 
@@ -59,6 +59,6 @@ Our Grafana Fundamentals tutorial is a great place to start, or you can learn mo
 - Learn more about [panel editor]({{< relref "panel-editor.md" >}}) options.
 - Add more [queries]({{< relref "queries.md" >}}).
 - [Transform]({{< relref "transformations.md" >}}) your data.
-- [Configure]({{< relref "field-configuration-options.md" >}}) how your results are displayed in the visualization.
+- [Configure]({{< relref "field-options.md" >}}) how your results are displayed in the visualization.
 - If you made a graph panel, set up an [alert]({{< relref "../alerting/alerts-overview.md" >}}).
 - Create [templates and variables]({{< relref "../variables/templates-and-variables.md" >}}).

--- a/docs/sources/panels/field-options.md
+++ b/docs/sources/panels/field-options.md
@@ -1,12 +1,13 @@
 +++
-title = "Field configuration options"
+title = "Field options"
 type = "docs"
+aliases = ["/docs/grafana/latest/panels/field-configuration-options/"]
 [menu.docs]
 parent = "panels"
 weight = 300
 +++
 
-# Field configuration options
+# Field options
 
 This page explains what field options and field overrides in Grafana are and how to use them. It also includes
 [examples](#examples) if you need an idea of how this feature might be useful in the real world.
@@ -14,11 +15,11 @@ This page explains what field options and field overrides in Grafana are and how
 The data model used in Grafana, the [data frame]({{< relref "../developers/plugins/data-frames.md" >}}),
 is a columnar-oriented table structure that unifies both time series and table query results. Each column within this structure is called a _field_. A field can represent a single time series or table column.
 
-## Field configuration options and overrides
+## Field options and overrides
 
-Field configuration options allow you to change how the data is displayed in your visualizations. Options and overrides that you apply do not change the data, they change how Grafana displays the data.
+Field options allow you to change how the data is displayed in your visualizations. Options and overrides that you apply do not change the data, they change how Grafana displays the data.
 
-_Field configuration options_, both standard and custom, can be found in the **Field** tab in the panel editor. Changes on this tab apply to all fields (i.e. series/columns). For example, if you change the unit to percentage, then all fields with numeric values are displayed in percentages. [Apply a field option](#configure-all-fields).
+_Field options_, both standard and custom, can be found in the **Field** tab in the panel editor. Changes on this tab apply to all fields (i.e. series/columns). For example, if you change the unit to percentage, then all fields with numeric values are displayed in percentages. [Apply a field option](#configure-all-fields).
 
 _Field overrides_ can be added in the **Overrides** tab in the panel editor. There you can add the same options as you find in the **Field** tab, but they are only applied to specific fields. [Apply an override](#override-a-field).
 

--- a/docs/sources/panels/panel-editor.md
+++ b/docs/sources/panels/panel-editor.md
@@ -43,7 +43,6 @@ On the right side of the header are the following options:
 - **Save -** Saves the dashboard, including all changes you have made in the panel editor.
 - **Apply -** Applies changes you made and then closes the panel editor, returning you to the dashboard. You will have to save the dashboard to persist the applied changes.
 
-
 ### Visualization preview
 
 The visualization preview section contains viewing options, time range controls, the visualization preview, and (if applicable) the panel title, axes, and legend.
@@ -65,7 +64,7 @@ The section contains tabs where you enter queries, transform your data, and crea
 - **Transform tab -** Apply data transformations. For more information, refer to [Transformations]({{< relref "transformations.md" >}}).
 - **Alert tab -** Write alert rules. For more information, refer to [Create alerts]({{< relref "../alerting/create-alerts.md" >}}).
 
-### Panel and field configuration options (side pane)
+### Panel and field options (side pane)
 
 The section contains tabs where you control almost every aspect of how your data is visualized. Not all tabs are available for each visualization.
 
@@ -73,5 +72,5 @@ Features in these tabs are documented in the following topics:
 
 - [Add a panel]({{< relref "add-a-panel.md" >}}) describes basic panel settings.
 - [Visualizations]({{< relref "visualizations/_index.md" >}}) display options vary widely. They are described in the individual visualization topic.
-- [Field configuration options and overrides]({{< relref "field-configuration-options.md" >}}) allow you to control almost every aspect of your visualization, including units, value mappings, and [Thresholds]({{< relref "thresholds.md" >}}).
+- [Field options and overrides]({{< relref "field-options.md" >}}) allow you to control almost every aspect of your visualization, including units, value mappings, and [Thresholds]({{< relref "thresholds.md" >}}).
 - [Panel links]({{< relref "../linking/panel-links.md" >}}) and [Data links]({{< relref "../linking/data-links.md" >}}) help you connect your visualization to other resources.

--- a/docs/sources/panels/visualizations/bar-gauge-panel.md
+++ b/docs/sources/panels/visualizations/bar-gauge-panel.md
@@ -18,8 +18,9 @@ This panel can show one or more bar gauges depending on how many series, rows, o
 ## Data and field options
 
 Bar gauge visualizations allow you to apply:
+
 - [Data transformations]({{< relref "../transformations.md" >}})
-- [Field configuration options and overrides]({{< relref "../field-configuration-options.md" >}})
+- [Field options and overrides]({{< relref "../field-options.md" >}})
 - [Thresholds]({{< relref "../thresholds.md" >}})
 
 ## Display options

--- a/docs/sources/panels/visualizations/gauge-panel.md
+++ b/docs/sources/panels/visualizations/gauge-panel.md
@@ -18,7 +18,7 @@ Gauge is a single value panel that can repeat a gauge for every series, column o
 Gauge visualizations allow you to apply:
 
 - [Data transformations]({{< relref "../transformations.md" >}})
-- [Field configuration options and overrides]({{< relref "../field-configuration-options.md" >}})
+- [Field options and overrides]({{< relref "../field-options.md" >}})
 - [Thresholds]({{< relref "../thresholds.md" >}})
 
 ## Display options

--- a/docs/sources/panels/visualizations/stat-panel.md
+++ b/docs/sources/panels/visualizations/stat-panel.md
@@ -20,7 +20,7 @@ The Stat panel shows a one large stat value with an optional graph sparkline. Yo
 Stat visualizations allow you to apply:
 
 - [Data transformations]({{< relref "../transformations.md" >}})
-- [Field configuration options and overrides]({{< relref "../field-configuration-options.md" >}})
+- [Field options and overrides]({{< relref "../field-options.md" >}})
 - [Thresholds]({{< relref "../thresholds.md" >}})
 
 ## Automatic layout adjustment

--- a/docs/sources/panels/visualizations/table-panel.md
+++ b/docs/sources/panels/visualizations/table-panel.md
@@ -13,21 +13,23 @@ weight = 1000
 
 The table panel is very flexible, supporting multiple modes for time series and for tables, annotation, and raw JSON data. This panel also provides date formatting, value formatting, and coloring options.
 
-<img class="screenshot" src="/assets/img/features/table-panel.png">
+{{< figure src="/img/docs/v72/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
 ## Data and field options
 
 Table visualizations allow you to apply:
 
 - [Data transformations]({{< relref "../transformations.md" >}})
-- [Field configuration options and overrides]({{< relref "../field-configuration-options.md" >}})
+- [Field options and overrides]({{< relref "../field-options.md" >}})
 - [Thresholds]({{< relref "../thresholds.md" >}})
 
 ## Display options
 
 - **Show header -** Show or hide column names imported from your data source..
 
-### Custom field options
+### Field display options
+
+In the **Field** tab you can set table specific display options that will affect all columns. In the **Override** tab you can customize them per column.
 
 - [Column width](#column-width)
 - [Column alignment](#column-alignment)


### PR DESCRIPTION
This also updates the table visualization docs page header image to show the actual new table and not the old (pre 7) table.

![Screenshot from 2020-09-15 20-06-36](https://user-images.githubusercontent.com/10999/93252372-aba31180-f795-11ea-8c1f-c621305e0f3e.png)
