### PR TITLE
DataLinks: Respects display name and adds field quoting

### DIFF
--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -76,7 +76,7 @@ const valueVars = [
 ];
 
 const buildLabelPath = (label: string) => {
-  return label.indexOf('.') > -1 || label.trim().indexOf(' ') > -1 ? `["${label}"]` : `.${label}`;
+  return label.includes('.') || label.trim().includes(' ') ? `["${label}"]` : `.${label}`;
 };
 
 export const getPanelLinksVariableSuggestions = (): VariableSuggestion[] => [

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -5,22 +5,23 @@ import coreModule from 'app/core/core_module';
 import { getConfig } from 'app/core/config';
 import {
   DataFrame,
+  DataLink,
   DataLinkBuiltInVars,
+  DataLinkClickEvent,
   deprecationWarning,
   Field,
   FieldType,
+  getFieldDisplayName,
   KeyValue,
   LinkModel,
   locationUtil,
+  PanelPlugin,
   ScopedVars,
+  textUtil,
+  urlUtil,
   VariableOrigin,
   VariableSuggestion,
   VariableSuggestionsScope,
-  urlUtil,
-  textUtil,
-  DataLink,
-  PanelPlugin,
-  DataLinkClickEvent,
 } from '@grafana/data';
 
 const timeRangeVars = [
@@ -75,7 +76,7 @@ const valueVars = [
 ];
 
 const buildLabelPath = (label: string) => {
-  return label.indexOf('.') > -1 ? `["${label}"]` : `.${label}`;
+  return label.indexOf('.') > -1 || label.trim().indexOf(' ') > -1 ? `["${label}"]` : `.${label}`;
 };
 
 export const getPanelLinksVariableSuggestions = (): VariableSuggestion[] => [
@@ -126,33 +127,35 @@ const getFieldVars = (dataFrames: DataFrame[]) => {
   ];
 };
 
-const getDataFrameVars = (dataFrames: DataFrame[]) => {
+export const getDataFrameVars = (dataFrames: DataFrame[]) => {
   let numeric: Field | undefined = undefined;
   let title: Field | undefined = undefined;
   const suggestions: VariableSuggestion[] = [];
   const keys: KeyValue<true> = {};
 
-  for (const df of dataFrames) {
-    for (const f of df.fields) {
-      if (keys[f.name]) {
+  for (const frame of dataFrames) {
+    for (const field of frame.fields) {
+      const displayName = getFieldDisplayName(field, frame, dataFrames);
+
+      if (keys[displayName]) {
         continue;
       }
 
       suggestions.push({
-        value: `__data.fields[${f.name}]`,
-        label: `${f.name}`,
-        documentation: `Formatted value for ${f.name} on the same row`,
+        value: `__data.fields${buildLabelPath(displayName)}`,
+        label: `${displayName}`,
+        documentation: `Formatted value for ${displayName} on the same row`,
         origin: VariableOrigin.Fields,
       });
 
-      keys[f.name] = true;
+      keys[displayName] = true;
 
-      if (!numeric && f.type === FieldType.number) {
-        numeric = f;
+      if (!numeric && field.type === FieldType.number) {
+        numeric = { ...field, name: displayName };
       }
 
-      if (!title && f.config.displayName && f.config.displayName !== f.name) {
-        title = f;
+      if (!title && field.config.displayName && field.config.displayName !== field.name) {
+        title = { ...field, name: displayName };
       }
     }
   }
@@ -168,13 +171,13 @@ const getDataFrameVars = (dataFrames: DataFrame[]) => {
 
   if (numeric) {
     suggestions.push({
-      value: `__data.fields[${numeric.name}].numeric`,
+      value: `__data.fields${buildLabelPath(numeric.name)}.numeric`,
       label: `Show numeric value`,
       documentation: `the numeric field value`,
       origin: VariableOrigin.Fields,
     });
     suggestions.push({
-      value: `__data.fields[${numeric.name}].text`,
+      value: `__data.fields${buildLabelPath(numeric.name)}.text`,
       label: `Show text value`,
       documentation: `the text value`,
       origin: VariableOrigin.Fields,
@@ -183,7 +186,7 @@ const getDataFrameVars = (dataFrames: DataFrame[]) => {
 
   if (title) {
     suggestions.push({
-      value: `__data.fields[${title.config.displayName}]`,
+      value: `__data.fields${buildLabelPath(title.name)}`,
       label: `Select by title`,
       documentation: `Use the title to pick the field`,
       origin: VariableOrigin.Fields,


### PR DESCRIPTION
**What this PR does / why we need it**:
Firstly, this PR switches from using `field.name` to the actual `displayName` for the field. Secondly displayName containing `.` or ` ` are decorated with quotes.

**Which issue(s) this PR fixes**:
Fixes #26545

**Special notes for your reviewer**:

