### PR TITLE
Chore: remove version from text panel

### DIFF
--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -6,7 +6,6 @@
   "skipDataQuery": true,
 
   "info": {
-    "version": "7.1.0",
     "author": {
       "name": "Grafana Labs",
       "url": "https://grafana.com"


### PR DESCRIPTION
builtin plugins should not specify a version