### PR TITLE
SharedQuery: Error when switching to -- Dashboard -- data source caused "no data" no matter what source panel was selected

### DIFF
--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -93,11 +93,13 @@ export class PanelQueryRunner {
         if (withFieldConfig) {
           // Apply field defaults & overrides
           const fieldConfig = this.dataConfigSource.getFieldOverrideOptions();
+          const timeZone = data.request?.timezone ?? 'browser';
+
           if (fieldConfig) {
             processedData = {
               ...processedData,
               series: applyFieldOverrides({
-                timeZone: data.request!.timezone,
+                timeZone: timeZone,
                 autoMinMax: true,
                 data: processedData.series,
                 ...fieldConfig,

--- a/public/app/plugins/datasource/dashboard/runSharedRequest.ts
+++ b/public/app/plugins/datasource/dashboard/runSharedRequest.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 import { QueryRunnerOptions } from 'app/features/dashboard/state/PanelQueryRunner';
 import { DashboardQuery, SHARED_DASHBODARD_QUERY } from './types';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
-import { LoadingState, DefaultTimeRange, DataQuery, PanelData, DataSourceApi } from '@grafana/data';
+import { LoadingState, DefaultTimeRange, DataQuery, PanelData, DataSourceApi, DataQueryRequest } from '@grafana/data';
 
 export function isSharedDashboardQuery(datasource: string | DataSourceApi | null) {
   if (!datasource) {
@@ -71,6 +71,7 @@ function getQueryError(msg: string): PanelData {
   return {
     state: LoadingState.Error,
     series: [],
+    request: {} as DataQueryRequest,
     error: { message: msg },
     timeRange: DefaultTimeRange,
   };


### PR DESCRIPTION
Think this was introduced when we added timezone but not sure.

When first switching to -- Dashboard -- data source the runSharedQuery throws a query error when there is no panel selected. 
https://github.com/grafana/grafana/blob/master/public/app/plugins/datasource/dashboard/runSharedRequest.ts#L25 

but without a request on the query error made the getData() observable throw error and cancel the subscription  (and no refresh would get it back as we reuse it) 