### PR TITLE
ImageRendering: Fix rendering panel using shared query in png, PDF reports and embedded scenarios 

### DIFF
--- a/e2e/suite1/specs/solo-route.spec.ts
+++ b/e2e/suite1/specs/solo-route.spec.ts
@@ -2,7 +2,7 @@ import { e2e } from '@grafana/e2e';
 
 e2e.scenario({
   describeName: 'Solo Route',
-  itName: 'Can view panes with shared queries in fullsceen',
+  itName: 'Can view panels with shared queries in fullsceen',
   addScenarioDataSource: false,
   addScenarioDashBoard: false,
   skipScenario: false,

--- a/e2e/suite1/specs/solo-route.spec.ts
+++ b/e2e/suite1/specs/solo-route.spec.ts
@@ -1,0 +1,17 @@
+import { e2e } from '@grafana/e2e';
+
+e2e.scenario({
+  describeName: 'Solo Route',
+  itName: 'Can view panes with shared queries in fullsceen',
+  addScenarioDataSource: false,
+  addScenarioDashBoard: false,
+  skipScenario: false,
+  scenario: () => {
+    // open Panel Tests - Bar Gauge
+    e2e.pages.SoloPanel.visit('ZqZnVvFZz/datasource-tests-shared-queries?orgId=1&panelId=4');
+
+    e2e()
+      .get('canvas')
+      .should('have.length', 6);
+  },
+});

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -133,4 +133,7 @@ export const Pages = {
       navBar: () => '.explore-toolbar',
     },
   },
+  SoloPanel: {
+    url: (page: string) => `/d-solo/${page}`,
+  },
 };

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -116,7 +116,6 @@ export class PanelModel implements DataConfigSource {
   collapsed?: boolean;
 
   panels?: any;
-  soloMode?: boolean;
   targets: DataQuery[];
   transformations?: DataTransformerConfig[];
   datasource: string | null;
@@ -142,6 +141,7 @@ export class PanelModel implements DataConfigSource {
   isViewing: boolean;
   isEditing: boolean;
   isInView: boolean;
+
   hasRefreshed: boolean;
   events: Emitter;
   cacheTimeout?: any;

--- a/public/app/plugins/datasource/dashboard/runSharedRequest.ts
+++ b/public/app/plugins/datasource/dashboard/runSharedRequest.ts
@@ -26,7 +26,6 @@ export function runSharedRequest(options: QueryRunnerOptions): Observable<PanelD
       return undefined;
     }
 
-    const currentPanel = dashboard.getPanelById(options.panelId)!;
     const listenToPanel = dashboard.getPanelById(listenToPanelId);
 
     if (!listenToPanel) {
@@ -43,7 +42,7 @@ export function runSharedRequest(options: QueryRunnerOptions): Observable<PanelD
 
     // If we are in fullscreen the other panel will not execute any queries
     // So we have to trigger it from here
-    if (currentPanel.isViewing || currentPanel.isEditing) {
+    if (!listenToPanel.isInView) {
       const { datasource, targets } = listenToPanel;
       const modified = {
         ...options,


### PR DESCRIPTION
When rendering a solo route the isViewing or isEditing is both false so the logic of triggering the source panel query did not work. Setting isViewing to true did not work as it triggers special classes that affects height of panel. 

But using panel.isInView did fix this and it also fixes another bug where shared panel query did work if the source panel is out of view (scroll to see it). 

* Adds E2E test scenario for solo route & shared query 

Fixes #27522