### PR TITLE
Alerting: Ensuring LINE Notify notifications are sent for all alert states

### DIFF
--- a/pkg/services/alerting/notifiers/line.go
+++ b/pkg/services/alerting/notifiers/line.go
@@ -72,7 +72,6 @@ func (ln *LineNotifier) createAlert(evalContext *alerting.EvalContext) error {
 	}
 
 	form := url.Values{}
-	// body := fmt.Sprintf("%s - %s\n%s", evalContext.Rule.Name, ruleURL, evalContext.Rule.Message)
 	body := fmt.Sprintf("%s - %s\n", evalContext.GetNotificationTitle(), ruleURL)
 	form.Add("message", body)
 

--- a/pkg/services/alerting/notifiers/line.go
+++ b/pkg/services/alerting/notifiers/line.go
@@ -59,11 +59,8 @@ type LineNotifier struct {
 // Notify send an alert notification to LINE
 func (ln *LineNotifier) Notify(evalContext *alerting.EvalContext) error {
 	ln.log.Info("Executing line notification", "ruleId", evalContext.Rule.ID, "notification", ln.Name)
-	if evalContext.Rule.State == models.AlertStateAlerting {
-		return ln.createAlert(evalContext)
-	}
 
-	return nil
+	return ln.createAlert(evalContext)
 }
 
 func (ln *LineNotifier) createAlert(evalContext *alerting.EvalContext) error {
@@ -75,7 +72,8 @@ func (ln *LineNotifier) createAlert(evalContext *alerting.EvalContext) error {
 	}
 
 	form := url.Values{}
-	body := fmt.Sprintf("%s - %s\n%s", evalContext.Rule.Name, ruleURL, evalContext.Rule.Message)
+	// body := fmt.Sprintf("%s - %s\n%s", evalContext.Rule.Name, ruleURL, evalContext.Rule.Message)
+	body := fmt.Sprintf("%s - %s\n", evalContext.GetNotificationTitle(), ruleURL)
 	form.Add("message", body)
 
 	if ln.NeedsImage() && evalContext.ImagePublicURL != "" {

--- a/pkg/services/alerting/notifiers/line.go
+++ b/pkg/services/alerting/notifiers/line.go
@@ -72,7 +72,7 @@ func (ln *LineNotifier) createAlert(evalContext *alerting.EvalContext) error {
 	}
 
 	form := url.Values{}
-	body := fmt.Sprintf("%s - %s\n", evalContext.GetNotificationTitle(), ruleURL)
+	body := fmt.Sprintf("%s - %s\n%s", evalContext.GetNotificationTitle(), ruleURL, evalContext.Rule.Message)
 	form.Add("message", body)
 
 	if ln.NeedsImage() && evalContext.ImagePublicURL != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

LINE Notifications only work for alerts. The "OK" notifications does not get sent. Other notifiers (email, Slack) do send both "[Alerting]" as well as "[OK]" notifications.

**Which issue(s) this PR fixes**:

Fixes LINE Notifications now OK notifications too. Also the notification contains the "[Alerting]" resp. "[OK]" like email and Slack do.

Fixes specific issue https://github.com/grafana/grafana/issues/12781

**Special notes for your reviewer**:

I compared other notifiers and none seem to have the problem of missing "OK" notifications. I guess LINE is not used a lot.
