### PR TITLE
Form: Add a form context consumer component

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Form.tsx
+++ b/packages/grafana-ui/src/components/Forms/Form.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLProps, useEffect } from 'react';
-import { useForm, Mode, OnSubmit, DeepPartial } from 'react-hook-form';
+import { useForm, Mode, OnSubmit, DeepPartial, FormContext } from 'react-hook-form';
 import { FormAPI } from '../../types';
 import { css } from 'emotion';
 
@@ -24,7 +24,17 @@ export function Form<T>({
   maxWidth = 400,
   ...htmlProps
 }: FormProps<T>) {
-  const { handleSubmit, register, errors, control, triggerValidation, getValues, formState, watch } = useForm<T>({
+  const {
+    handleSubmit,
+    register,
+    errors,
+    control,
+    triggerValidation,
+    getValues,
+    formState,
+    watch,
+    ...otherFormMethods
+  } = useForm<T>({
     mode: validateOn,
     defaultValues,
   });
@@ -36,15 +46,27 @@ export function Form<T>({
   }, []);
 
   return (
-    <form
-      className={css`
-        max-width: ${maxWidth}px;
-        width: 100%;
-      `}
-      onSubmit={handleSubmit(onSubmit)}
-      {...htmlProps}
+    <FormContext
+      handleSubmit={handleSubmit}
+      register={register}
+      errors={errors}
+      control={control}
+      triggerValidation={triggerValidation}
+      getValues={getValues}
+      formState={formState}
+      watch={watch}
+      {...otherFormMethods}
     >
-      {children({ register, errors, control, getValues, formState, watch })}
-    </form>
+      <form
+        className={css`
+          max-width: ${maxWidth}px;
+          width: 100%;
+        `}
+        onSubmit={handleSubmit(onSubmit)}
+        {...htmlProps}
+      >
+        {children({ register, errors, control, getValues, formState, watch })}
+      </form>
+    </FormContext>
   );
 }

--- a/packages/grafana-ui/src/components/Forms/FormContextConsumer.mdx
+++ b/packages/grafana-ui/src/components/Forms/FormContextConsumer.mdx
@@ -1,0 +1,40 @@
+import { Meta, Props } from '@storybook/addon-docs/blocks';
+import { FormContextConsumer } from './FormContextConsumer';
+
+<Meta title="MDX|FormContextConsumer" component={FormContextConsumer} />
+
+# FormContextConsumer
+
+`FormContextConsumer` provides a way to access form utility methods in a nested part of the component heirarchy without having to use prop drilling. It exposes the functionality from `useFormContext` in [react-hook-form](https://react-hook-form.com/api#useFormContext). `FormContextConsumer` must be wrapped at some level by a `<Form>` element.
+
+### Usage
+
+```jsx
+import { Form, FormContextConsumer, Input, FieldSet, Field } from '@grafana/ui';
+
+<Form onSubmit={values => console.log('Submit', values)}>
+  {() => (
+    <div>
+      <FormContextConsumer>
+        {({ register }) => {
+          return (
+            <FieldSet label="Details">
+              <Field label="Name">
+                <Input ref={register} name="name" />
+              </Field>
+              <Field label="Email">
+                <Input ref={register} name="email" />
+              </Field>
+            </FieldSet>
+          );
+        }}
+      </FormContextConsumer>
+      <Button variant="primary">Save</Button>
+    </div>
+  )}
+</Form>;
+```
+
+### Props
+
+<Props of={FormContextConsumer} />

--- a/packages/grafana-ui/src/components/Forms/FormContextConsumer.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/FormContextConsumer.story.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
+import { Input, Form, FieldSet, Field } from '@grafana/ui';
+import { FormContextConsumer } from './FormContextConsumer';
+import mdx from './FormContextConsumer.mdx';
+import { Button } from '../Button';
+
+export default {
+  title: 'Forms/FormContextConsumer',
+  component: FormContextConsumer,
+  decorators: [withCenteredStory],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const basic = () => {
+  return (
+    <Form onSubmit={values => console.log('Submit', values)}>
+      {() => (
+        <div>
+          <FormContextConsumer>
+            {({ register }) => {
+              return (
+                <FieldSet label="Details">
+                  <Field label="Name">
+                    <Input ref={register({ required: true })} name="name" />
+                  </Field>
+                  <Field label="Email">
+                    <Input ref={register({ required: true })} name="email" />
+                  </Field>
+                </FieldSet>
+              );
+            }}
+          </FormContextConsumer>
+          <Button variant="primary">Save</Button>
+        </div>
+      )}
+    </Form>
+  );
+};

--- a/packages/grafana-ui/src/components/Forms/FormContextConsumer.tsx
+++ b/packages/grafana-ui/src/components/Forms/FormContextConsumer.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+import { useFormContext, FormContextValues } from 'react-hook-form';
+
+export interface Props {
+  children: (formMethods: FormContextValues) => JSX.Element;
+}
+
+export const FormContextConsumer: FC<Props> = ({ children }) => {
+  const formMethods = useFormContext();
+  return children({ ...formMethods });
+};


### PR DESCRIPTION

**What this PR does / why we need it**:
Exposes `FormContext` functionality in `react-hook-form`. This allows folks to get access to form methods in deeply nested forms without prop drilling. I'm not 100% sure we _need_ this, it might be wedding our components too closely to `react-hook-form` if that's a concern, but I think it's a conversation worth having. Thanks for checking it out!
