### PR TITLE
RFC/POC/WIP: Exemplar and annotation support

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -15,6 +15,12 @@ export enum LoadingState {
   Error = 'Error',
 }
 
+export enum DataTopic {
+  Data = 'data', // or undefined
+  Annotations = 'annotations',
+  Exemplars = 'exemplars',
+}
+
 export type PreferredVisualisationType = 'graph' | 'table' | 'logs' | 'trace';
 
 export interface QueryResultMeta {
@@ -32,6 +38,12 @@ export interface QueryResultMeta {
 
   /** Currently used to show results in Explore only in preferred visualisation option */
   preferredVisualisationType?: PreferredVisualisationType;
+
+  /**
+   * Optionally identify which topic the frame should be assigned to.
+   * A value specified in the response will override what the request asked for.
+   */
+  dataTopic?: DataTopic;
 
   /**
    * This is the raw query sent to the underlying system.  All macros and templating

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -16,7 +16,6 @@ export enum LoadingState {
 }
 
 export enum DataTopic {
-  Data = 'data', // or undefined
   Annotations = 'annotations',
   Exemplars = 'exemplars',
 }

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -4,7 +4,7 @@ import { GrafanaPlugin, PluginMeta } from './plugin';
 import { PanelData } from './panel';
 import { LogRowModel } from './logs';
 import { AnnotationEvent, AnnotationSupport } from './annotations';
-import { KeyValue, LoadingState, TableData, TimeSeries } from './data';
+import { KeyValue, LoadingState, TableData, TimeSeries, DataTopic } from './data';
 import { DataFrame, DataFrameDTO } from './dataFrame';
 import { RawTimeRange, TimeRange } from './time';
 import { ScopedVars } from './ScopedVars';
@@ -401,6 +401,11 @@ export interface DataQuery {
    * Specify the query flavor
    */
   queryType?: string;
+
+  /**
+   * The data topic resuls should be attached to
+   */
+  dataTopic?: DataTopic;
 
   /**
    * For mixed data sources the selected datasource is on the query level.

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -27,6 +27,12 @@ export interface PanelData {
   /** Contains data frames with field overrides applied */
   series: DataFrame[];
 
+  /** A list of annotation items */
+  annotations?: DataFrame[];
+
+  /** A list of exemplar data */
+  exemplars?: DataFrame[];
+
   /** Request contains the queries and properties sent to the datasource */
   request?: DataQueryRequest;
 

--- a/public/app/features/dashboard/state/runRequest.ts
+++ b/public/app/features/dashboard/state/runRequest.ts
@@ -120,7 +120,7 @@ export function runRequest(datasource: DataSourceApi, request: DataQueryRequest)
   // Build a map of possible query targets
   let queryTopics: KeyValue<DataTopic> | undefined = undefined;
   for (const target of request.targets) {
-    if (target.dataTopic && target.dataTopic !== DataTopic.Data) {
+    if (target.dataTopic) {
       if (!queryTopics) {
         queryTopics = {};
       }

--- a/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_ctrl.ts
@@ -290,7 +290,7 @@ export class HeatmapCtrl extends MetricsPanelCtrl {
 
   // This should only be called from the snapshot callback
   onSnapshotLoad(dataList: LegacyResponseData[]) {
-    this.onDataFramesReceived(getProcessedDataFrames(dataList));
+    this.onDataFramesReceived(getProcessedDataFrames(dataList).series);
   }
 
   // Directly support DataFrame

--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -151,7 +151,7 @@ class SingleStatCtrl extends MetricsPanelCtrl {
   }
 
   onSnapshotLoad(dataList: LegacyResponseData[]) {
-    this.onFramesReceived(getProcessedDataFrames(dataList));
+    this.onFramesReceived(getProcessedDataFrames(dataList).series);
   }
 
   onFramesReceived(frames: DataFrame[]) {


### PR DESCRIPTION
This is a super quick/dirty stab at how we may support exemplars and annotations.

This:
1. Adds the idea of a `data topic` that can be attached to the query or the result metadata
2. runRequest will set the dataTopic on results where the query should point to a channel
3. preProcessPanelData will move each topic to its own propety

3 is super debatable what the best path is.  With this route, we don't need special handling for "i want annotations/exemplars", but it may complicate (or improve!) other areas like applying transformations and series overrides.  We may want these configured by topic anyway

