### PR TITLE
DataProxy: Ignore empty URL's in plugin routes

### DIFF
--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -22,22 +22,24 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		SecureJsonData: ds.SecureJsonData.Decrypt(),
 	}
 
-	interpolatedURL, err := InterpolateString(route.URL, data)
-	if err != nil {
-		logger.Error("Error interpolating proxy url", "error", err)
-		return
-	}
+	if len(route.URL) > 0 {
+		interpolatedURL, err := InterpolateString(route.URL, data)
+		if err != nil {
+			logger.Error("Error interpolating proxy url", "error", err)
+			return
+		}
 
-	routeURL, err := url.Parse(interpolatedURL)
-	if err != nil {
-		logger.Error("Error parsing plugin route url", "error", err)
-		return
-	}
+		routeURL, err := url.Parse(interpolatedURL)
+		if err != nil {
+			logger.Error("Error parsing plugin route url", "error", err)
+			return
+		}
 
-	req.URL.Scheme = routeURL.Scheme
-	req.URL.Host = routeURL.Host
-	req.Host = routeURL.Host
-	req.URL.Path = util.JoinURLFragments(routeURL.Path, proxyPath)
+		req.URL.Scheme = routeURL.Scheme
+		req.URL.Host = routeURL.Host
+		req.Host = routeURL.Host
+		req.URL.Path = util.JoinURLFragments(routeURL.Path, proxyPath)
+	}
 
 	if err := addQueryString(req, route, data); err != nil {
 		logger.Error("Failed to render plugin URL query string", "error", err)

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -68,7 +68,7 @@ func TestDSRouteRule(t *testing.T) {
 						},
 					},
 					{
-						Path: "api/restricted",
+						Path:    "api/restricted",
 						ReqRole: models.ROLE_ADMIN,
 					},
 				},
@@ -120,14 +120,13 @@ func TestDSRouteRule(t *testing.T) {
 				})
 			})
 
-			Convey("When matching route path with no url", func () {
-
+			Convey("When matching route path with no url", func() {
 				proxy, err := NewDataSourceProxy(ds, plugin, ctx, "", &setting.Cfg{})
 				So(err, ShouldBeNil)
 				proxy.route = plugin.Routes[4]
 				ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.route, proxy.ds)
 
-				Convey("Should not replace request url", func () {
+				Convey("Should not replace request url", func() {
 					So(req.URL.String(), ShouldEqual, "http://localhost/asd")
 				})
 			})

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -67,6 +67,10 @@ func TestDSRouteRule(t *testing.T) {
 							{Name: "x-header", Content: "my secret {{.SecureJsonData.key}}"},
 						},
 					},
+					{
+						Path: "api/restricted",
+						ReqRole: models.ROLE_ADMIN,
+					},
 				},
 			}
 
@@ -113,6 +117,18 @@ func TestDSRouteRule(t *testing.T) {
 				Convey("should add headers and interpolate the url with query string parameters", func() {
 					So(req.URL.String(), ShouldEqual, "https://dynamic.grafana.com/some/method?apiKey=123")
 					So(req.Header.Get("x-header"), ShouldEqual, "my secret 123")
+				})
+			})
+
+			Convey("When matching route path with no url", func () {
+
+				proxy, err := NewDataSourceProxy(ds, plugin, ctx, "", &setting.Cfg{})
+				So(err, ShouldBeNil)
+				proxy.route = plugin.Routes[4]
+				ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.route, proxy.ds)
+
+				Convey("Should not replace request url", func () {
+					So(req.URL.String(), ShouldEqual, "http://localhost/asd")
 				})
 			})
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
If a datasource plugin defines routes with no `url` property,  datasource proxy will replace request schema & host with empty strings, resulting in an invalid request and 502 being returned. I believe It should instead keep the original schema & host, same as plugin proxy.
This PR adds a check to see if `route.url` is empty, and in such case does not modify request schema & host.

Use case: restrict some paths and/or http methods to certain roles without overwriting the host & schema.
Needed for alerting ui plugin: https://github.com/grafana/alerting-ui-plugin/issues/113

Example `plugin.json`:

```json
{
  "type": "datasource",
  "name": "Alert Manager",
  "id": "grafana-alertmanager-datasource",
  "metrics": false,
  "routes": [
    {
      "method": "POST",
      "reqRole": "Editor"
    },
    {
      "method": "PUT",
      "reqRole": "Editor"
    },
    {
      "method": "DELETE",
      "reqRole": "Editor"
    }
  ],
...
```

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

