### PR TITLE
StatPanel: Fix problem where string values where always green

### DIFF
--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -146,7 +146,7 @@ export const getStandardFieldConfigs = () => {
         { value: 80, color: 'red' },
       ],
     },
-    shouldApply: field => field.type === FieldType.number || field.type === FieldType.string,
+    shouldApply: () => true,
     category: ['Thresholds'],
     getItemsCount: value => (value ? value.steps.length : 0),
   };

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -146,7 +146,7 @@ export const getStandardFieldConfigs = () => {
         { value: 80, color: 'red' },
       ],
     },
-    shouldApply: field => field.type === FieldType.number,
+    shouldApply: field => field.type === FieldType.number || field.type === FieldType.string,
     category: ['Thresholds'],
     getItemsCount: value => (value ? value.steps.length : 0),
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
As the issue describes, thresholds are only applied to numeric values right now (makes sense) but it also means that if you change the base color, string values will be green despite what you set the base color to.

**Which issue(s) this PR fixes**:

Fixes #27516

**Special notes for your reviewer**:
This is a proposed solution and to be honest I'm not sure if we should use thresholds this way? And should we include all FieldTypes?
