### PR TITLE
Docs: Clarify status of annotation list panel

### DIFF
--- a/public/app/plugins/panel/annolist/README.md
+++ b/public/app/plugins/panel/annolist/README.md
@@ -2,3 +2,5 @@
 
 This Annotations List panel is **included** with Grafana.
 
+However, it is presently in alpha and is not accessible unless alpha panels are [enabled in Grafana settings](https://grafana.com/docs/grafana/latest/administration/configuration/#enable_alpha)
+


### PR DESCRIPTION
It is confusing as the marketplace plugin is deprecated, and this page indicates that it is **included**, but it is not visible/discoverable by default.

**What this PR does / why we need it**: Simple documentation change to save future Grafana users confusion

**Which issue(s) this PR fixes**: https://github.com/grafana/grafana/issues/27662

Fixes #27662 