### PR TITLE
PanelEditor: fix button position when dragging row

### DIFF
--- a/public/app/features/dashboard/panel_editor/QueryEditorRows.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRows.tsx
@@ -108,6 +108,7 @@ export class QueryEditorRows extends PureComponent<Props> {
                     inMixedMode={props.datasource.meta.mixed}
                   />
                 ))}
+                {provided.placeholder}
               </div>
             );
           }}


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds a placeholder to new Query Editor rows in order to maintain the structure of the page while dragging queries.

Which issue(s) this PR fixes:
Fixes #27638

Special notes for your reviewer:
I've attached a gif of the fix. Let me know if you think an automated test is necessary as well.
![button-position](https://user-images.githubusercontent.com/6405944/93691000-89aed500-fa9c-11ea-8aaf-8ead99d6ee44.gif)


Sorry, had to create another PR, as my username was not attached to my git profile on this machine.