### PR TITLE
grafana/ui: Do not bundle jQuery

### DIFF
--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -35,6 +35,7 @@ const buildCjsPackage = ({ env }) => {
       'monaco-editor', // Monaco should not be used directly
       'monaco-editor/esm/vs/editor/editor.api', // Monaco should not be used directly
       'react-monaco-editor',
+      'jquery', // required to use jquery.plot, which is assigned externally
     ],
     plugins: [
       commonjs({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When using the [pre-built `@grafana/ui` package on npmjs](https://www.npmjs.com/package/@grafana/ui), the `Gauge` component will always fail due to `jquery.plot` being undefined, *even if* the vendored flot is used.

The reason is that `@grafana/ui` has bundled its own copy of jQuery, which is distinct from the global jQuery. Flot can only define `$.plot` on the global jQuery, so components inside `@grafana/ui` using its own copy of jQuery can't see `$.plot` at all.

This PR marks `jquery` as an external dependency so `rollup` will properly require the external jQuery rather than copying it into final product.

**Which issue(s) this PR fixes**: 

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #22257

**Special notes for your reviewer**:

