### PR TITLE
grafana-toolkit: avoid path.resolve with globby in moveStaticFiles

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/package.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/package.build.ts
@@ -3,7 +3,6 @@ import execa = require('execa');
 import * as fs from 'fs';
 // @ts-ignore
 import * as path from 'path';
-import { resolve as resolvePath } from 'path';
 import chalk from 'chalk';
 import { useSpinner } from '../utils/useSpinner';
 import { Task, TaskRunner } from './task';
@@ -89,13 +88,13 @@ const moveFiles = () => {
   })();
 };
 
-const moveStaticFiles = async (pkg: any, cwd: string) => {
+const moveStaticFiles = async (pkg: any) => {
   if (pkg.name.endsWith('/ui')) {
-    const staticFiles = await globby(resolvePath(process.cwd(), 'src/**/*.+(png|svg|gif|jpg)'));
+    const staticFiles = await globby('src/**/*.{png,svg,gif,jpg}');
     return useSpinner<void>(`Moving static files`, async () => {
       const promises = staticFiles.map(file => {
         return new Promise((resolve, reject) => {
-          fs.copyFile(file, `${cwd}/compiled/${file.replace(`${cwd}/src`, '')}`, (err: any) => {
+          fs.copyFile(file, file.replace(/^src/, 'compiled'), (err: any) => {
             if (err) {
               reject(err);
               return;
@@ -130,7 +129,7 @@ const buildTaskRunner: TaskRunner<PackageBuildOptions> = async ({ scope }) => {
 
       await clean();
       await compile();
-      await moveStaticFiles(pkg, cwd);
+      await moveStaticFiles(pkg);
       await rollup();
       await preparePackage(pkg);
       await moveFiles();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

During `grafana-toolkit package:build`, we would move all SVG files from `src/` to `compiled/` (#24258). This involves calling `globby(path.resolve(cwd, 'src/**/*.+(png|svg|gif|jpg)'))`. Unfortunately, on Windows this resolves into something like `X:\grafana\packages\grafana-ui\src\**\*.+(png|svg|gif|jpg)` which is *not* a valid glob pattern (see mrmlnc/fast-glob#237). This makes globby to silently return an empty array, and causes #27668 since none of the SVG files are copied into `compiled/`.

This PR simply removed the `cwd` interpolation since it is already in the correct working directory:

https://github.com/grafana/grafana/blob/232ad5c42e2ae89e3ade9b17e80cb75bf47f7a5b/packages/grafana-toolkit/src/cli/tasks/package.build.ts#L126

This PR additionally replaces the extglob pattern `*.+(png|svg|gif|jpg)` by the brace pattern `*.{png,svg,gif,jpg}` since the former would also match `wut.pngsvggifjpg`.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #27668 

**Special notes for your reviewer**:

