### PR TITLE
Forms: Increase default form width from 400 to 600

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Form.tsx
+++ b/packages/grafana-ui/src/components/Forms/Form.tsx
@@ -21,7 +21,7 @@ export function Form<T>({
   validateFieldsOnMount,
   children,
   validateOn = 'onSubmit',
-  maxWidth = 400,
+  maxWidth = 600,
   ...htmlProps
 }: FormProps<T>) {
   const { handleSubmit, register, errors, control, triggerValidation, getValues, formState, watch } = useForm<T>({


### PR DESCRIPTION
Feel like many forms are to narrow, so increased the width to 600. 

The enterprise reporting form could need some tweaks so that not all inputs grow to full width. 

Before: 
![Screenshot from 2020-09-21 15-31-52](https://user-images.githubusercontent.com/10999/93772900-ad4e5880-fc1f-11ea-91bf-f732fd444ecf.png)

After:
![Screenshot from 2020-09-21 15-32-00](https://user-images.githubusercontent.com/10999/93772916-b2130c80-fc1f-11ea-9040-3f30596a1f47.png)

