### PR TITLE
CircleCI: Fix master pipeline wrt front-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -860,16 +860,13 @@ jobs:
           command: |
             if [[ -n $CIRCLE_TAG ]]; then
               # A release build
-              /tmp/grabpl test-frontend --github-token "${GITHUB_GRAFANABOT_TOKEN}" --edition << parameters.edition >> \
-                $CIRCLE_TAG
+              ./scripts/circle-test-frontend.sh --edition << parameters.edition >> $CIRCLE_TAG
             elif [[ $CIRCLE_BRANCH == "chore/test-release-pipeline" ]]; then
               # We're testing the release pipeline
-              /tmp/grabpl test-frontend --github-token "${GITHUB_GRAFANABOT_TOKEN}" --edition << parameters.edition >> \
-                v7.0.0-test
+              ./scripts/circle-test-frontend.sh --edition << parameters.edition >> v7.0.0-test
             else
               # A master build
-              /tmp/grabpl test-frontend --github-token "${GITHUB_GRAFANABOT_TOKEN}" --edition << parameters.edition >> \
-                --build-id $CIRCLE_WORKFLOW_ID
+              ./scripts/circle-test-frontend.sh --edition << parameters.edition >> --build-id $CIRCLE_WORKFLOW_ID
             fi
       - store_test_results:
           path: reports/junit

--- a/scripts/circle-test-frontend.sh
+++ b/scripts/circle-test-frontend.sh
@@ -7,10 +7,7 @@ start=$(date +%s)
 
 export TEST_MAX_WORKERS=2
 
-exit_if_fail yarn run prettier:check
-exit_if_fail yarn run packages:typecheck
-exit_if_fail yarn run typecheck
-exit_if_fail yarn run test
+/tmp/grabpl test-frontend --github-token "${GITHUB_GRAFANABOT_TOKEN}" $*
 
 end=$(date +%s)
 seconds=$((end - start))

--- a/scripts/circle-test-frontend.sh
+++ b/scripts/circle-test-frontend.sh
@@ -7,7 +7,7 @@ start=$(date +%s)
 
 export TEST_MAX_WORKERS=2
 
-/tmp/grabpl test-frontend --github-token "${GITHUB_GRAFANABOT_TOKEN}" $*
+/tmp/grabpl test-frontend --github-token "${GITHUB_GRAFANABOT_TOKEN}" "$@"
 
 end=$(date +%s)
 seconds=$((end - start))


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fix CircleCI master pipeline, by ensuring only two parallel front-end test workers. This is configured in scripts/circle-test-frontend.sh, so reintroducing its usage (it was dropped in a previous revision, since grabpl was necessary for enterprise).