### PR TITLE
CloudWatch: Fix loading custom credentials profile

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -161,6 +161,7 @@ Since not all datasources have the same configuration settings we only have the 
 | assumeRoleArn           | string  | Cloudwatch                                                       | ARN of Assume Role                                                                          |
 | defaultRegion           | string  | Cloudwatch                                                       | AWS region                                                                                  |
 | customMetricsNamespaces | string  | Cloudwatch                                                       | Namespaces of Custom Metrics                                                                |
+| profile                 | string  | Cloudwatch                                                       | Custom credentials profile
 | tsdbVersion             | string  | OpenTSDB                                                         | Version                                                                                     |
 | tsdbResolution          | string  | OpenTSDB                                                         | Resolution                                                                                  |
 | sslmode                 | string  | PostgreSQL                                                       | SSLmode. 'disable', 'require', 'verify-ca' or 'verify-full'                                 |

--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -372,7 +372,7 @@ It's now possible to configure data sources using config files with Grafana's pr
 
 Here are some provisioning examples for this data source.
 
-### Using a credentials file
+### Using credentials profile name (non default) 
 
 ```yaml
 apiVersion: 1
@@ -384,6 +384,7 @@ datasources:
       authType: credentials
       defaultRegion: eu-west-2
       customMetricsNamespaces: 'CWAgent,CustomNameSpace'
+      profile: secondary
 ```
 
 ### Using `accessKey` and `secretKey`

--- a/docs/sources/features/datasources/cloudwatch.md
+++ b/docs/sources/features/datasources/cloudwatch.md
@@ -372,7 +372,7 @@ It's now possible to configure data sources using config files with Grafana's pr
 
 Here are some provisioning examples for this data source.
 
-### Using credentials profile name (non default) 
+### Using credentials profile name (non-default) 
 
 ```yaml
 apiVersion: 1

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -486,6 +486,7 @@ export interface MetricFindValue {
 export interface DataSourceJsonData {
   authType?: string;
   defaultRegion?: string;
+  profile?: string;
 }
 
 /**

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -294,9 +294,14 @@ func (e *cloudWatchExecutor) getDSInfo(region string) *datasourceInfo {
 	accessKey := decrypted["accessKey"]
 	secretKey := decrypted["secretKey"]
 
+	profile := e.DataSource.JsonData.Get("profile").MustString()
+	if profile == "" {
+		profile = e.DataSource.Database // legacy support
+	}
+
 	return &datasourceInfo{
 		Region:        region,
-		Profile:       e.DataSource.Database,
+		Profile:       profile,
 		AuthType:      authType,
 		AssumeRoleArn: assumeRoleArn,
 		ExternalID:    externalID,

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -151,7 +151,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
                   <Input
                     className="width-30"
                     placeholder="default"
-                    value={options.jsonData.database}
+                    value={options.database}
                     onChange={onUpdateDatasourceOption(this.props, 'database')}
                   />
                 </div>

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -114,7 +114,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const { regions } = this.state;
     const { options } = this.props;
     const secureJsonData = (options.secureJsonData || {}) as CloudWatchSecureJsonData;
-    var profile = options.jsonData.profile;
+    let profile = options.jsonData.profile;
     if (!profile) {
       profile = options.database;
     }

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -4,7 +4,6 @@ const { Select, Input } = LegacyForms;
 import {
   DataSourcePluginOptionsEditorProps,
   onUpdateDatasourceJsonDataOptionSelect,
-  onUpdateDatasourceOption,
   onUpdateDatasourceResetOption,
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceSecureJsonDataOption,
@@ -115,6 +114,10 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const { regions } = this.state;
     const { options } = this.props;
     const secureJsonData = (options.secureJsonData || {}) as CloudWatchSecureJsonData;
+    var profile = options.jsonData.profile;
+    if (!profile) {
+      profile = options.database;
+    }
 
     return (
       <>
@@ -151,8 +154,8 @@ export class ConfigEditor extends PureComponent<Props, State> {
                   <Input
                     className="width-30"
                     placeholder="default"
-                    value={options.database}
-                    onChange={onUpdateDatasourceOption(this.props, 'database')}
+                    value={profile}
+                    onChange={onUpdateDatasourceJsonDataOption(this.props, 'profile')}
                   />
                 </div>
               </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
I configure a cloudwatch datasource using a custom (non default) credential profile. I can save and test successfully the datasource but when I reopen it the custom credential profile is not loaded (although it is included in the respective API for getting the datasource details)

This information is not saved in datasource JSON data (as it is expected) but in the datasource [`database`](https://github.com/grafana/grafana/blob/43ef052d5711f9b4c0447b052f25642f965e8a2c/pkg/tsdb/cloudwatch/cloudwatch.go#L299) field.

This fix stores it in JSON settings and handles the migration between old/new field.

<img width="1332" alt="Screenshot 2020-09-21 at 18 45 55" src="https://user-images.githubusercontent.com/1632407/93789679-d4665380-fc3a-11ea-8fc0-201c1c1c040c.png">
<img width="1332" alt="Screenshot 2020-09-21 at 18 46 46" src="https://user-images.githubusercontent.com/1632407/93789690-d7614400-fc3a-11ea-9d61-0a987a6a5f56.png">

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
I have tested provisioning with the old and the new field as well like:
```
  - name: cloudwatch-custom-profile-legacy
    type: cloudwatch
    editable: true
    database: other
    jsonData:
      authType: credentials
      defaultRegion: us-east-2

  - name: cloudwatch-custom-profile
    type: cloudwatch
    editable: true
    jsonData:
      authType: credentials
      defaultRegion: us-east-2
      profile: other
```