### PR TITLE
Docs: Use selinux relabelling on docker containers to build docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,22 +3,22 @@
 IMAGE = grafana/grafana-docs-dev:latest
 CONTENT_PATH = /hugo/content/docs/grafana/latest
 LOCAL_STATIC_PATH = ../../website/static
-PORT = 3002:3002 
+PORT = 3002:3002
 
 docs:
 	docker pull $(IMAGE)
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p $(PORT) --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE)
 
 docs-no-pull:
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p $(PORT) --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z -p $(PORT) --rm -it $(IMAGE)
 
 docs-test:
 	docker pull $(IMAGE)
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) --rm -it $(IMAGE) /bin/bash -c 'make prod'
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z --rm -it $(IMAGE) /bin/bash -c 'make prod'
 
 # expects that you have grafana/website checked out in same path as the grafana repo.
 docs-local-static:
 	docker pull $(IMAGE)
 	if [ ! -d "$(LOCAL_STATIC_PATH)" ]; then echo "local path (website project) $(LOCAL_STATIC_PATH) not found"]; exit 1; fi
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) \
-		-v $(shell pwd)/$(LOCAL_STATIC_PATH):/hugo/static -p $(PORT) --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH):Z \
+		-v $(shell pwd)/$(LOCAL_STATIC_PATH):/hugo/static:Z -p $(PORT) --rm -it $(IMAGE)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Makes `make docs` work on Linux boxes with SELinux enabled.

**Which issue(s) this PR fixes**: None created

**Special notes for your reviewer**:

Docker needs to be instructed to do SELinux relabelling to have the bind mount work. See: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

This is done by simply adding `:Z` to the bind mount.

**NOTE**: I do not know what happens on non-SELinux-enabled machines. It's possible we'd need to set the flags conditionally only if SELinux is detected. If someone could test on a non-SELinux-enabled machine that would be very helpful. I'd be happy to code up the conditionality if it's the case.