### PR TITLE
Server: Don't clutter trace.Stop by exiting

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -38,7 +38,6 @@ import (
 var version = "5.0.0"
 var commit = "NA"
 var buildBranch = "master"
-
 var buildstamp string
 
 type exitWithCode struct {

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -33,10 +34,20 @@ import (
 	_ "github.com/grafana/grafana/pkg/tsdb/testdatasource"
 )
 
-var version = "5.0.0"
-var commit = "NA"
-var buildBranch = "master"
+const version = "5.0.0"
+const commit = "NA"
+const buildBranch = "master"
+
 var buildstamp string
+
+type exitWithCode struct {
+	reason string
+	code   int
+}
+
+func (e exitWithCode) Error() string {
+	return e.reason
+}
 
 func main() {
 	var (
@@ -82,6 +93,23 @@ func main() {
 		}()
 	}
 
+	if err := executeServer(*configFile, *homePath, *pidFile, *packaging, traceDiagnostics); err != nil {
+		code := 1
+		var ewc exitWithCode
+		if errors.As(err, &ewc) {
+			code = ewc.code
+		}
+		if code != 0 {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		}
+
+		os.Exit(code)
+	}
+}
+
+func executeServer(configFile, homePath, pidFile, packaging string, traceDiagnostics *tracingDiagnostics) error {
+	defer log.Close()
+
 	if traceDiagnostics.enabled {
 		fmt.Println("diagnostics: tracing enabled", "file", traceDiagnostics.file)
 		f, err := os.Create(traceDiagnostics.file)
@@ -97,8 +125,8 @@ func main() {
 		defer trace.Stop()
 	}
 
-	buildstampInt64, _ := strconv.ParseInt(buildstamp, 10, 64)
-	if buildstampInt64 == 0 {
+	buildstampInt64, err := strconv.ParseInt(buildstamp, 10, 64)
+	if err != nil || buildstampInt64 == 0 {
 		buildstampInt64 = time.Now().Unix()
 	}
 
@@ -107,30 +135,29 @@ func main() {
 	setting.BuildStamp = buildstampInt64
 	setting.BuildBranch = buildBranch
 	setting.IsEnterprise = extensions.IsEnterprise
-	setting.Packaging = validPackaging(*packaging)
+	setting.Packaging = validPackaging(packaging)
 
 	metrics.SetBuildInformation(version, commit, buildBranch)
 
 	s, err := server.New(server.Config{
-		ConfigFile: *configFile, HomePath: *homePath, PidFile: *pidFile,
+		ConfigFile: configFile, HomePath: homePath, PidFile: pidFile,
 		Version: version, Commit: commit, BuildBranch: buildBranch,
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	go listenToSystemSignals(s)
 
-	err = s.Run()
-	code := 0
-	if err != nil {
-		code = s.ExitCode(err)
+	if err := s.Run(); err != nil {
+		code := s.ExitCode(err)
+		return exitWithCode{
+			reason: err.Error(),
+			code:   code,
+		}
 	}
-	trace.Stop()
-	log.Close()
 
-	os.Exit(code)
+	return nil
 }
 
 func validPackaging(packaging string) string {

--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -34,9 +34,10 @@ import (
 	_ "github.com/grafana/grafana/pkg/tsdb/testdatasource"
 )
 
-const version = "5.0.0"
-const commit = "NA"
-const buildBranch = "master"
+// The following variables cannot be constants, since they can be overridden through the -X link flag
+var version = "5.0.0"
+var commit = "NA"
+var buildBranch = "master"
 
 var buildstamp string
 
@@ -118,8 +119,7 @@ func executeServer(configFile, homePath, pidFile, packaging string, traceDiagnos
 		}
 		defer f.Close()
 
-		err = trace.Start(f)
-		if err != nil {
+		if err := trace.Start(f); err != nil {
 			panic(err)
 		}
 		defer trace.Stop()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a minor issue that was pointed out by the latest version of gocritic, i.e. that the server clutters a deferred call to `trace.Stop` by calling `os.Exit` in the same function. I've solved it by moving the deferred call into a utility function, and calling `os.Exit` in the caller instead.

