### PR TITLE
PanelEditor: Prevents adding transformations in panels with alerts

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PanelNotSupported, Props } from './PanelNotSupported';
+import { updateLocation } from '../../../../core/actions';
+import { PanelEditorTabId } from './types';
+
+const setupTestContext = (options: Partial<Props>) => {
+  const defaults: Props = {
+    message: '',
+    dispatch: jest.fn(),
+  };
+
+  const props = { ...defaults, ...options };
+  render(<PanelNotSupported {...props} />);
+
+  return { props };
+};
+
+describe('PanelNotSupported', () => {
+  describe('when component is mounted', () => {
+    it('then the supplied message should be shown', () => {
+      setupTestContext({ message: 'Expected message' });
+
+      expect(screen.getByRole('heading', { name: /expected message/i })).toBeInTheDocument();
+    });
+
+    it('then the back to queries button should exist', () => {
+      setupTestContext({ message: 'Expected message' });
+
+      expect(screen.getByRole('button', { name: /go back to queries/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('when the back to queries button is clicked', () => {
+    it('then correct action should be dispatched', () => {
+      const {
+        props: { dispatch },
+      } = setupTestContext({});
+
+      userEvent.click(screen.getByRole('button', { name: /go back to queries/i }));
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith(updateLocation({ query: { tab: PanelEditorTabId.Query }, partial: true }));
+    });
+  });
+});

--- a/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
@@ -1,0 +1,33 @@
+import React, { FC, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { Dispatch } from 'redux';
+import { Button, VerticalGroup } from '@grafana/ui';
+
+import { Layout } from '@grafana/ui/src/components/Layout/Layout';
+import { PanelEditorTabId } from './types';
+import { updateLocation } from '../../../../core/actions';
+
+export interface Props {
+  message: string;
+  dispatch?: Dispatch;
+}
+
+export const PanelNotSupported: FC<Props> = ({ message, dispatch: propsDispatch }) => {
+  const dispatch = propsDispatch ? propsDispatch : useDispatch();
+  const onBackToQueries = useCallback(() => {
+    dispatch(updateLocation({ query: { tab: PanelEditorTabId.Query }, partial: true }));
+  }, [dispatch]);
+
+  return (
+    <Layout justify="center" style={{ marginTop: '100px' }}>
+      <VerticalGroup spacing="md">
+        <h2>{message}</h2>
+        <div>
+          <Button size="md" variant="secondary" icon="arrow-left" onClick={onBackToQueries}>
+            Go back to Queries
+          </Button>
+        </div>
+      </VerticalGroup>
+    </Layout>
+  );
+};

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Alert,
   Button,
   Container,
   CustomScrollbar,
@@ -10,14 +11,14 @@ import {
   VerticalGroup,
 } from '@grafana/ui';
 import {
+  DataFrame,
   DataTransformerConfig,
+  DocsId,
   GrafanaTheme,
+  PanelData,
   SelectableValue,
   standardTransformersRegistry,
   transformDataFrame,
-  DataFrame,
-  PanelData,
-  DocsId,
 } from '@grafana/data';
 import { TransformationOperationRow } from './TransformationOperationRow';
 import { Card, CardProps } from '../../../../core/components/Card/Card';
@@ -27,6 +28,8 @@ import { Unsubscribable } from 'rxjs';
 import { PanelModel } from '../../state';
 import { getDocsLink } from 'app/core/utils/docsLinks';
 import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
+import { PanelNotSupported } from '../PanelEditor/PanelNotSupported';
+import { AppNotificationSeverity } from '../../../../types';
 
 interface TransformationsEditorProps {
   panel: PanelModel;
@@ -285,14 +288,27 @@ export class TransformationsEditor extends React.PureComponent<TransformationsEd
   }
 
   render() {
+    const {
+      panel: { alert },
+    } = this.props;
     const { transformations } = this.state;
 
     const hasTransforms = transformations.length > 0;
+
+    if (!hasTransforms && alert) {
+      return <PanelNotSupported message="Transformations can't be used on a panel with existing alerts" />;
+    }
 
     return (
       <CustomScrollbar autoHeightMin="100%">
         <Container padding="md">
           <div aria-label={selectors.components.TransformTab.content}>
+            {hasTransforms && alert ? (
+              <Alert
+                severity={AppNotificationSeverity.Error}
+                title="Transformations can't be used on a panel with alerts"
+              />
+            ) : null}
             {!hasTransforms && this.renderNoAddedTransformsState()}
             {hasTransforms && this.renderTransformationEditors()}
             {hasTransforms && this.renderTransformationSelector()}


### PR DESCRIPTION
**What this PR does / why we need it**:
Before:
![image](https://user-images.githubusercontent.com/562238/93892432-d0930980-fcec-11ea-9e09-4e65d4b8e3df.png)

After:
![image](https://user-images.githubusercontent.com/562238/93892252-a04b6b00-fcec-11ea-9e6e-7d3474ec1a1a.png)

When there is already transformations and alerts in a panel model
![image](https://user-images.githubusercontent.com/562238/93892355-beb16680-fcec-11ea-86d1-ff6a9954596d.png)


**Which issue(s) this PR fixes**:
Fixes #25681

**Special notes for your reviewer**:

