### PR TITLE
Docs: Updated table docs, moved annotations notice down

### DIFF
--- a/docs/sources/panels/visualizations/table-panel.md
+++ b/docs/sources/panels/visualizations/table-panel.md
@@ -37,8 +37,6 @@ In the **Field** tab you can set table specific display options that will affect
 
 ### Column alignment
 
-This custom field option applies only to table visualizations.
-
 Choose how Grafana should align cell contents:
 
 - Auto (default)
@@ -48,15 +46,11 @@ Choose how Grafana should align cell contents:
 
 ### Column width
 
-This custom field option applies only to table visualizations.
-
 By default, Grafana automatically calculates the column width based on the cell contents. In this field option, can override the setting and define the width for all columns in pixels.
 
 For example, if you enter `100` in the field, then when you click outside the field, all the columns will be set to 100 pixels wide.
 
 #### Cell display mode
-
-This custom field option applies only to table visualizations.
 
 By default, Grafana automatically chooses display settings. You can override the settings by choosing one of the following options to change all fields.
 

--- a/docs/sources/panels/visualizations/table-panel.md
+++ b/docs/sources/panels/visualizations/table-panel.md
@@ -69,4 +69,4 @@ string create a field override and add a unit property with the `string` unit.
 
 ### Annotations
 
-> **Note:** Annotations are not currently supported in the new table panel.
+Annotations are not currently supported in the new table panel. This might be added back in a future release.

--- a/docs/sources/panels/visualizations/table-panel.md
+++ b/docs/sources/panels/visualizations/table-panel.md
@@ -15,8 +15,6 @@ The table panel is very flexible, supporting multiple modes for time series and 
 
 {{< figure src="/img/docs/v72/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
-> **Note:** Annotations are not currently supported in the table panel.
-
 ## Data and field options
 
 Table visualizations allow you to apply:
@@ -74,3 +72,7 @@ By default, Grafana automatically chooses display settings. You can override the
 
 Grafana can sometime be too aggressive in parsing strings and displaying them as numbers. To make Grafana show the original
 string create a field override and add a unit property with the `string` unit.
+
+### Annotations
+
+> **Note:** Annotations are not currently supported in the new table panel.


### PR DESCRIPTION
Just noticed this notice at the top of this page, it felt out of place and distracting. So moved it down to a new section at the bottom. 

![Screenshot from 2020-09-22 16-06-11](https://user-images.githubusercontent.com/10999/93893125-94ac7400-fced-11ea-9ce3-29f5ce96f642.png)
