### PR TITLE
Annotations: check for null or undefined fields before conversion

### DIFF
--- a/public/app/features/annotations/standardAnnotationSupport.test.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.test.ts
@@ -5,9 +5,9 @@ describe('DataFrame to annotations', () => {
   test('simple conversion', () => {
     const frame = toDataFrame({
       fields: [
-        { type: FieldType.time, values: [1, 2, 3] },
-        { name: 'first string field', values: ['t1', 't2', 't3'] },
-        { name: 'tags', values: ['aaa,bbb', 'bbb,ccc', 'zyz'] },
+        { type: FieldType.time, values: [1, 2, 3, 4, 5] },
+        { name: 'first string field', values: ['t1', 't2', 't3', null, undefined] },
+        { name: 'tags', values: ['aaa,bbb', 'bbb,ccc', 'zyz', null, undefined] },
       ],
     });
 
@@ -36,6 +36,12 @@ describe('DataFrame to annotations', () => {
           ],
           "text": "t3",
           "time": 3,
+        },
+        Object {
+          "time": 4,
+        },
+        Object {
+          "time": 5,
         },
       ]
     `);

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -175,8 +175,8 @@ export function getAnnotationsFromData(data: DataFrame[], options?: AnnotationEv
         }
       }
 
-      if (v !== undefined) {
-        if (f.split) {
+      if (!(v === null || v === undefined)) {
+        if (v && f.split) {
           v = (v as string).split(',');
         }
         (anno as any)[f.key] = v;


### PR DESCRIPTION
In 7.2, we are adding a method to automatically convert DataFrame to annotations -- if the frame returns a null field value, rather than undefined, it will break the tags extraction.

