### PR TITLE
CI: Upgrade build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ executors:
       - image: srclosson/grafana-plugin-ci-e2e:latest
   grafana-build:
     docker:
-      - image: grafana/build-container:1.2.26
+      - image: grafana/build-container:1.2.27
   grafana-publish:
     docker:
       - image: grafana/grafana-ci-deploy:1.2.5

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v$${GRABPL_VERSION}/grabpl
   - chmod +x grabpl
@@ -29,7 +29,7 @@ steps:
     GRABPL_VERSION: 0.5.9
 
 - name: lint-backend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -41,7 +41,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -49,7 +49,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -64,7 +64,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
@@ -73,7 +73,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -82,7 +82,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
   depends_on:
@@ -91,7 +91,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
@@ -99,7 +99,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
@@ -107,7 +107,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
   depends_on:
@@ -120,7 +120,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   detach: true
   commands:
   - ./e2e/start-server
@@ -138,7 +138,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - yarn storybook:build
   depends_on:
@@ -154,7 +154,7 @@ steps:
   - initialize
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - cp dist/*.tar.gz packaging/docker/
   depends_on:
@@ -170,7 +170,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -187,7 +187,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -238,7 +238,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v$${GRABPL_VERSION}/grabpl
   - chmod +x grabpl
@@ -253,7 +253,7 @@ steps:
     GRABPL_VERSION: 0.5.9
 
 - name: lint-backend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -265,7 +265,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -273,7 +273,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -288,7 +288,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl test-backend
   - ./bin/grabpl integration-tests
@@ -297,7 +297,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -306,7 +306,7 @@ steps:
   - initialize
 
 - name: frontend-metrics
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
   environment:
@@ -316,7 +316,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
@@ -325,7 +325,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
@@ -333,7 +333,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
@@ -341,7 +341,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id $DRONE_BUILD_NUMBER --no-pull-enterprise
   depends_on:
@@ -354,7 +354,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   detach: true
   commands:
   - ./e2e/start-server
@@ -372,7 +372,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - yarn storybook:build
   depends_on:
@@ -400,7 +400,7 @@ steps:
   - initialize
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - cp dist/*.tar.gz packaging/docker/
   depends_on:
@@ -424,7 +424,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -441,7 +441,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -457,7 +457,7 @@ steps:
   - test-frontend
 
 - name: release-next-npm-packages
-  image: grafana/build-container:1.2.26
+  image: grafana/build-container:1.2.27
   commands:
   - npx lerna bootstrap
   - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,4 +1,4 @@
-build_image = 'grafana/build-container:1.2.26'
+build_image = 'grafana/build-container:1.2.27'
 publish_image = 'grafana/grafana-ci-deploy:1.2.6'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.2.0'
 alpine_image = 'alpine:3.12'


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade build image for Drone and CircleCI. Only upgrades golangci-lint to latest minor version, plus Node and Yarn to latest patch versions.
