### PR TITLE
Update Contribute/Architecture/Services documentation

### DIFF
--- a/contribute/architecture/services.md
+++ b/contribute/architecture/services.md
@@ -40,7 +40,7 @@ func init() {
 }
 ```
 
-`init` functions are only run whenever a package is imported, so we also need to import the package in the application. In the `server.go` file under `pkg/cmd/grafana-server`, import the package we just created:
+`init` functions are only run whenever a package is imported, so we also need to import the package in the application. In the `server.go` file under `pkg/server`, import the package we just created:
 
 ```go
 import _ "github.com/grafana/grafana/pkg/services/mysvc"


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the [Contribute/Architecture/Services documentation](https://github.com/grafana/grafana/blob/master/contribute/architecture/services.md) which had a deprecated file reference.

**Which issue(s) this PR fixes**:

Fixes #27705

