### PR TITLE
Toolkit: Add --coverage flag to plugin build command

### DIFF
--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -100,6 +100,10 @@ Available options:
 
 This command creates a production-ready build of your plugin.
 
+Available options:
+
+- `--coverage` - Reports code coverage after the test step of the build.
+
 ## FAQ
 
 ### Which version of grafana-toolkit should I use?

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -139,8 +139,9 @@ export const run = (includeInternalScripts = false) => {
   program
     .command('plugin:build')
     .description('Prepares plugin dist package')
+    .option('--coverage', 'Run code coverage', false)
     .action(async cmd => {
-      await execTask(pluginBuildTask)({ coverage: false, silent: true });
+      await execTask(pluginBuildTask)({ coverage: cmd.coverage, silent: true });
     });
 
   program


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an optional `--coverage` flag, which defaults to `false`. If provided, will run a coverage report after the test step of the build script.

**Which issue(s) this PR fixes**:

Fixes #27623 

**Special notes for your reviewer**:

Please let me know if I missed anything! :)