### PR TITLE
Docs: Fix sidebar link typo for "Filter table columns"

### DIFF
--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -213,7 +213,7 @@
             link: /panels/visualizations/table/
           - link: /panels/visualizations/table/table-field-options/
             name: Table field options
-          - link: /panels/visualizations/tables/filter-table-columns/
+          - link: /panels/visualizations/table/filter-table-columns/
             name: Filter table columns
         - link: /panels/visualizations/text-panel/
           name: Text


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

In the [overview page](https://grafana.com/docs/grafana/latest/panels/visualizations/table/) for the Panels/Visualizations/Table section, under the "Display options" header the two links to the two other sub-pages are working. However, on the sidebar, the [link for "Filter table columns"](https://grafana.com/docs/grafana/latest/panels/visualizations/tables/filter-table-columns/) returns a 404. It seems that it is due to a typo of `/tables/` in the URL instead of `/table/`.

The working URL for the page is: https://grafana.com/docs/grafana/latest/panels/visualizations/table/filter-table-columns/

This change was introduced in #27689 where the page was added.

**Which issue(s) this PR fixes**:

None, very small typo fix so I'm submitting a PR directly.

**Special notes for your reviewer**:

None.