### PR TITLE
Chore: Remove leftover console.log

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/utils/query/ScrollQLParser.js
+++ b/public/app/plugins/datasource/cloudwatch/utils/query/ScrollQLParser.js
@@ -2664,7 +2664,6 @@ StatsGroupFieldIdContext.prototype.fieldId = function() {
   return this.getTypedRuleContext(FieldIdContext, 0);
 };
 StatsGroupFieldIdContext.prototype.enterRule = function(listener) {
-  console.log(this);
   if (listener instanceof ScrollQLParserListener) {
     listener.enterStatsGroupFieldId(this);
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes a leftover call to `console.log` in `ScrollQLParser.js`.