### PR TITLE
Explore: Show results of Prometheus instant queries in formatted table

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1868,7 +1868,7 @@ describe('prepareTargets', () => {
     });
 
     describe('when query type Instant is selected', () => {
-      it('then it should just add targets', () => {
+      it('then it should target and modify its format to table', () => {
         const target: PromQuery = {
           refId: 'A',
           expr: 'up',
@@ -1894,7 +1894,7 @@ describe('prepareTargets', () => {
           start,
           step: 1,
         });
-        expect(activeTargets[0]).toEqual(target);
+        expect(activeTargets[0]).toEqual({ ...target, format: 'table' });
       });
     });
   });

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -237,6 +237,12 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
           this.createQuery(instantTarget, options, start, end),
           this.createQuery(rangeTarget, options, start, end)
         );
+      } else if (target.instant && options.app === CoreApp.Explore) {
+        // If running only instant query in Explore, format as table
+        const instantTarget: any = cloneDeep(target);
+        instantTarget.format = 'table';
+        queries.push(this.createQuery(instantTarget, options, start, end));
+        activeTargets.push(instantTarget);
       } else {
         queries.push(this.createQuery(target, options, start, end));
         activeTargets.push(target);


### PR DESCRIPTION
**What this PR does / why we need it**:
As @gouthamve has noticed, after updating the Prometheus query editor in https://github.com/grafana/grafana/pull/27026, we have kept formatting of instant queries as table only when running `Both` queries. However, to correctly visualise result in table, we need to keep formatting of instant queries as table also when running  only `Instant` queries in Explore.

This PR fixes this.

**Before:** 

![image](https://user-images.githubusercontent.com/30407135/94160105-93fa1600-fe84-11ea-887e-7e6edcffe2f7.png)


**After:**

![image](https://user-images.githubusercontent.com/30407135/94160008-7c229200-fe84-11ea-9c31-aa43e423af93.png)

