### PR TITLE
Chore: adding platform independent typings for e2e tests.

### DIFF
--- a/e2e/suite1/specs/query-editor.spec.ts
+++ b/e2e/suite1/specs/query-editor.spec.ts
@@ -29,7 +29,7 @@ e2e.scenario({
 
     cy.contains(queryText.slice(0, -1)).should('be.visible');
 
-    e2e.components.QueryField.container().type('{ctrl}z');
+    e2e.components.QueryField.container().type(e2e.typings.undo());
 
     cy.contains(queryText).should('be.visible');
   },

--- a/packages/grafana-e2e/src/index.ts
+++ b/packages/grafana-e2e/src/index.ts
@@ -8,6 +8,7 @@ import { getScenarioContext, setScenarioContext } from './support/scenarioContex
 import { e2eFactory } from './support';
 import { selectors } from '@grafana/e2e-selectors';
 import * as flows from './flows';
+import * as typings from './typings';
 
 const e2eObject = {
   env: (args: string) => Cypress.env(args),
@@ -16,6 +17,7 @@ const e2eObject = {
   imgSrcToBlob: (url: string) => Cypress.Blob.imgSrcToBlob(url),
   scenario: (args: ScenarioArguments) => e2eScenario(args),
   pages: e2eFactory({ selectors: selectors.pages }),
+  typings,
   components: e2eFactory({ selectors: selectors.components }),
   flows,
   getScenarioContext,

--- a/packages/grafana-e2e/src/typings/index.ts
+++ b/packages/grafana-e2e/src/typings/index.ts
@@ -1,0 +1,1 @@
+export { undo } from './undo';

--- a/packages/grafana-e2e/src/typings/undo.ts
+++ b/packages/grafana-e2e/src/typings/undo.ts
@@ -1,16 +1,17 @@
-const platforms = {
-  osx: 'darwin',
-  windows: 'win32',
-  linux: 'linux',
-  aix: 'aix',
-  freebsd: 'freebsd',
-  openbsd: 'openbsd',
-  sunos: 'sunos',
-};
+// https://nodejs.org/api/os.html#os_os_platform
+enum Platform {
+  osx = 'darwin',
+  windows = 'win32',
+  linux = 'linux',
+  aix = 'aix',
+  freebsd = 'freebsd',
+  openbsd = 'openbsd',
+  sunos = 'sunos',
+}
 
 export const undo = () => {
   switch (Cypress.platform) {
-    case platforms.osx:
+    case Platform.osx:
       return '{cmd}z';
     default:
       return '{ctrl}z';

--- a/packages/grafana-e2e/src/typings/undo.ts
+++ b/packages/grafana-e2e/src/typings/undo.ts
@@ -1,0 +1,18 @@
+const platforms = {
+  osx: 'darwin',
+  windows: 'win32',
+  linux: 'linux',
+  aix: 'aix',
+  freebsd: 'freebsd',
+  openbsd: 'openbsd',
+  sunos: 'sunos',
+};
+
+export const undo = () => {
+  switch (Cypress.platform) {
+    case platforms.osx:
+      return '{cmd}z';
+    default:
+      return '{ctrl}z';
+  }
+};


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to this PR, when running the end-to-end tests locally, they would fail depending on what platform you run them on. If running on linux or windows they will succeed. But if you are running them on OSX they will fail.

The reason is that in one of the tests we wanted to do an undo action in a text field. The issue in the test was that it did a `{ctrl}z` which works on Windows and Linux. But on OSX it should be `{cmd}z`.

This PR resolves this by extracting that logic into a function that checks what platform we are running the tests for.

