### PR TITLE
port fix for gap in stacked null values

### DIFF
--- a/public/vendor/flot/jquery.flot.stack.js
+++ b/public/vendor/flot/jquery.flot.stack.js
@@ -83,17 +83,14 @@ charts or filled areas).
                 l = newpoints.length;
 
                 if (i < points.length && points[i] == null) {
-                    // copy gaps
-                    for (m = 0; m < ps; ++m)
-                        newpoints.push(points[i + m]);
-                    i += ps;
-                }
-                else if (i >= points.length) {
                     // take the remaining points from the previous series
                     for (m = 0; m < ps; ++m)
                         newpoints.push(otherpoints[j + m]);
                     if (withbottom)
                         newpoints[l + 2] = otherpoints[j + accumulateOffset];
+                    i += ps;
+                }
+                else if (i >= points.length) {
                     j += otherps;
                 }
                 else if (j >= otherpoints.length) {


### PR DESCRIPTION
This is a port of a fix I made for Prometheus:

https://github.com/prometheus/prometheus/issues/7973

In grafana, the issue is referenced as
https://github.com/grafana/grafana/issues/9294

The result is not perfect and I don't have any tests to offer, but I
hope someone else can take this over and move it further.

Before:

![gap1](https://user-images.githubusercontent.com/291750/94210526-45259e00-fecf-11ea-9bcc-101c050b326c.png)


After:

![gap2](https://user-images.githubusercontent.com/291750/94210532-49ea5200-fecf-11ea-9e16-8127e78ba109.png)


Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

