### PR TITLE
Orgs: Remove organisations deprecation notice from backend

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -104,40 +104,11 @@ func (ss *SqlStore) Init() error {
 	ss.addAlertNotificationUidByIdHandler()
 	ss.addPreferencesQueryAndCommandHandlers()
 
-	err = ss.logOrgsNotice()
-	if err != nil {
-		return err
-	}
-
 	if ss.skipEnsureDefaultOrgAndUser {
 		return nil
 	}
 
 	return ss.ensureMainOrgAndAdminUser()
-}
-
-func (ss *SqlStore) logOrgsNotice() error {
-	type targetCount struct {
-		Count int64
-	}
-
-	return ss.WithDbSession(context.Background(), func(session *DBSession) error {
-		resp := make([]*targetCount, 0)
-		if err := session.SQL("select count(id) as Count from org").Find(&resp); err != nil {
-			return err
-		}
-
-		if resp[0].Count > 1 {
-			ss.log.Warn(`[Deprecation notice]`)
-			ss.log.Warn(`Fewer than 1% of Grafana installations use organizations, and we feel that most of those`)
-			ss.log.Warn(`users would have a better experience using Teams instead. As such, we are considering de-emphasizing`)
-			ss.log.Warn(`and eventually deprecating Organizations in a future Grafana release. If you would like to provide`)
-			ss.log.Warn(`feedback or describe your need, please do so in the issue linked below`)
-			ss.log.Warn(`https://github.com/grafana/grafana/issues/24588`)
-		}
-
-		return nil
-	})
 }
 
 func (ss *SqlStore) ensureMainOrgAndAdminUser() error {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
As we have decided to preserve multi-org support, we should remove the org deprecation warning from the backend logs

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/27769


