### PR TITLE
Docs: Fix typo and clarify need for query editor

### DIFF
--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -83,7 +83,7 @@ const regionEvent: AnnotationEvent = {
 
 Let users write custom annotation queries to only display the annotation events they care about, by adding a _query editor_. You only need to build a query editor if you want to let users query or filter annotations.
 
-> **Note**: Annotation query editors have yet to receive support for React. The instructions here are given for Angular. Fortunately, you can run Angular even in a plugin otherwise written using React. This section will be updated once React support for annotation queries editors is available.
+> **Note:** Annotation query editors have yet to receive support for React. The instructions here are given for Angular. Fortunately, you can run Angular even in a plugin otherwise written using React. This section will be updated once React support for annotation queries editors is available.
 
 1. Create a file called `AnnotationQueryEditor.ts` in the `src` directory, with the following content.
 

--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -15,7 +15,7 @@ Handling annotation queries is similar to how you'd handle a metrics query. The 
 
 ## Add annotations support to your data source
 
-To add logs support to an existing data source, you need to:
+To add support for annotations to an existing data source, you need to:
 
 - Enable annotations support
 - Override the `annotationQuery` method
@@ -81,7 +81,7 @@ const regionEvent: AnnotationEvent = {
 
 ## Build a annotation query editor
 
-Let users write custom annotation queries to only display the annotation events they care about, by adding a _query editor_.
+Let users write custom annotation queries to only display the annotation events they care about, by adding a _query editor_. You only need to build a query editor if you want to let users query or filter annotations.
 
 > **Note**: Annotation query editors have yet to receive support for React. The instructions here are given for Angular. Fortunately, you can run Angular even in a plugin otherwise written using React. This section will be updated once React support for annotation queries editors is available.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the "Add support for annotations" buide by fixing a typo and clarifying when you need to build a custom query editor.