### PR TITLE
Docs: Add reference to plugin examples

### DIFF
--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -38,6 +38,7 @@ Ready to learn more? Check out our other tutorials:
 
 - [Build a panel plugin with D3.js]({{< relref "../../../../../tutorials/build-a-panel-plugin-with-d3.md" >}})
 
+
 ### Guides
 
 Improve an existing plugin with one of our guides:
@@ -60,6 +61,10 @@ Deepen your knowledge through a series of high-level overviews of plugin concept
 ### UI library
 
 Explore the many UI components in our [Grafana UI library](https://developers.grafana.com/ui).
+
+### Examples
+
+For inspiration, check out our [plugin examples](https://github.com/grafana/grafana-plugin-examples).
 
 ### API reference
 

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -38,7 +38,6 @@ Ready to learn more? Check out our other tutorials:
 
 - [Build a panel plugin with D3.js]({{< relref "../../../../../tutorials/build-a-panel-plugin-with-d3.md" >}})
 
-
 ### Guides
 
 Improve an existing plugin with one of our guides:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add reference to the plugin examples, from the plugin development overview.