### PR TITLE
Code owner: Add marcusolsson as code owner for plugin docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 # Documentation owner: Diana Payton
 /docs/ @oddlittlebird @achatterjee-grafana
 /contribute/ @oddlittlebird  @marcusolsson @achatterjee-grafana
-
+/docs/sources/developers/plugins/ @marcusolsson
 
 # Backend code
 *.go @grafana/backend-platform


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds @marcusolsson as code owner for plugin documentation.