### PR TITLE
Docs: Corrected incorrect uses of (setup|set up)

### DIFF
--- a/docs/sources/administration/set-up-for-high-availability.md
+++ b/docs/sources/administration/set-up-for-high-availability.md
@@ -1,5 +1,5 @@
 +++
-title = "Setup Grafana for high availability"
+title = "Set up Grafana for high availability"
 type = "docs"
 keywords = ["grafana", "tutorials", "HA", "high availability"]
 aliases = ["/docs/grafana/latest/tutorials/ha_setup/"]
@@ -18,7 +18,7 @@ and other persistent data. So the default embedded SQLite database will not work
 
 ## Configure multiple servers to use the same database
 
-First, you need to setup MySQL or Postgres on another server and configure Grafana to use that database.
+First, you need to set up MySQL or Postgres on another server and configure Grafana to use that database.
 You can find the configuration for doing that in the [[database]]({{< relref "../administration/configuration.md#database" >}}) section in the Grafana config.
 Grafana will now persist all long term data in the database. How to configure the database for high availability is out of scope for this guide. We recommend finding an expert on for the database you're using.
 

--- a/docs/sources/guides/whats-new-in-v4-6.md
+++ b/docs/sources/guides/whats-new-in-v4-6.md
@@ -23,7 +23,7 @@ You can now add annotation events and regions right from the graph panel! Just h
 
 ### Cloudwatch
 
-Cloudwatch now supports alerting. Setup alert rules for any Cloudwatch metric!
+Cloudwatch now supports alerting. Set up alert rules for any Cloudwatch metric!
 
 {{< docs-imagebox img="/img/docs/v46/cloudwatch_alerting.png"  max-width= "800px" >}}
 

--- a/docs/sources/guides/whats-new-in-v4.md
+++ b/docs/sources/guides/whats-new-in-v4.md
@@ -53,7 +53,7 @@ of another alert in your conditions, and `Time Of Day`.
 {{< imgbox max-width="40%" img="/img/docs/v4/slack_notification.png" caption="Alerting Slack Notification" >}}
 
 Alerting would not be very useful if there was no way to send notifications when rules trigger and change state. You
-can setup notifications of different types. We currently have `Slack`, `PagerDuty`, `Email` and `Webhook` with more in the
+can set up notifications of different types. We currently have `Slack`, `PagerDuty`, `Email` and `Webhook` with more in the
 pipe that will be added during beta period. The notifications can then be added to your alert rules.
 If you have configured an external image store in the grafana.ini config file (s3, webdav, and azure_blob options available)
 you can get very rich notifications with an image of the graph and the metric

--- a/docs/sources/guides/whats-new-in-v5.md
+++ b/docs/sources/guides/whats-new-in-v5.md
@@ -20,8 +20,8 @@ This is the most substantial update that Grafana has ever seen. This article wil
 - [Dashboard Folders]({{< relref "#dashboard-folders" >}}) helps you keep your dashboards organized.
 - [Permissions]({{< relref "#dashboard-folders" >}}) on folders and dashboards helps manage larger Grafana installations.
 - [Group users into teams]({{< relref "#teams" >}}) and use them in the new permission system.
-- [Data source provisioning]({{< relref "#data-sources" >}}) makes it possible to setup data sources via config files.
-- [Dashboard provisioning]({{< relref "#dashboards" >}}) makes it possible to setup dashboards via config files.
+- [Data source provisioning]({{< relref "#data-sources" >}}) makes it possible to set up data sources via config files.
+- [Dashboard provisioning]({{< relref "#dashboards" >}}) makes it possible to set up dashboards via config files.
 - [Persistent dashboard URL's]({{< relref "#dashboard-model-persistent-url-s-and-api-changes" >}}) makes it possible to rename dashboards without breaking links.
 - [Graphite Tags and Integrated Function Docs]({{< relref "#graphite-tags-integrated-function-docs" >}}).
 
@@ -106,7 +106,7 @@ and alerts as well.
 
 ### Data sources
 
-Data sources can now be setup using config files. These data sources are by default not editable from the Grafana GUI.
+Data sources can now be set up using config files. These data sources are by default not editable from the Grafana GUI.
 It's also possible to update and delete data sources from the config file. More info in the [data source provisioning docs](/administration/provisioning/#datasources).
 
 ### Dashboards

--- a/docs/sources/http_api/create-api-tokens-for-org.md
+++ b/docs/sources/http_api/create-api-tokens-for-org.md
@@ -9,7 +9,7 @@ weight = 150
 
 # Create API tokens and dashboards for an organization
 
-Use the Grafana API to setup new Grafana organizations or to add dynamically generated dashboards to an existing organization.
+Use the Grafana API to set up new Grafana organizations or to add dynamically generated dashboards to an existing organization.
 
 ## Authentication
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
There are a few cases in the docs where "setup" and "set up" are used incorrectly, this (hopefully) corrects them.  

**Which issue(s) this PR fixes**:
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #27819 

**Special notes for your reviewer**:
Very new to FOSS so apologies in advance for any poor PR etiquette
I only looked at the docs folder with the below command, if I should include more folders please let me know!
```shell
$ grep -EIirw "(set up|setup)" docs
```