### PR TITLE
Fix: Adding additional settings for dataproxy to accommodate network proxy issues

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -130,6 +130,12 @@ logging = false
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 timeout = 30
 
+# How long the data proxy waits before sending a keepalive request, default is 30 seconds.
+keep_alive = 30
+
+# How long the data proxy keeps an idle connection open before timing out, default is 30 seconds.
+idle_conn_timeout = 90
+
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
 send_user_header = false
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -133,7 +133,7 @@ timeout = 30
 # How long the data proxy waits before sending a keepalive request, default is 30 seconds.
 keep_alive = 30
 
-# How long the data proxy keeps an idle connection open before timing out, default is 30 seconds.
+# How long the data proxy keeps an idle connection open before timing out, default is 90 seconds.
 idle_conn_timeout = 90
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -393,7 +393,7 @@ This setting also applies to core backend HTTP data sources where query requests
 
 Interval between sends of TCP keepalive requests. Default is 30 seconds.
 
-### timeidle_conn_timeoutout
+### idle_conn_timeout
 
 The length of time that idle connections will be maintained. Default is 90 seconds.
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -389,6 +389,14 @@ How long the data proxy should wait before timing out. Default is 30 seconds.
 
 This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 
+### keep_alive
+
+Interval between sends of TCP keepalive requests. Default is 30 seconds.
+
+### timeidle_conn_timeoutout
+
+The length of time that idle connections will be maintained. Default is 90 seconds.
+
 ### send_user_header
 
 If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request. Default is `false`.

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -147,12 +147,12 @@ func (ds *DataSource) GetHttpTransport() (*dataSourceTransport, error) {
 		Proxy:           http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(setting.DataProxyTimeout) * time.Second,
-			KeepAlive: 30 * time.Second,
+			KeepAlive: time.Duration(setting.DataProxyKeepAlive) * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       time.Duration(setting.DataProxyIdleConnTimeout) * time.Second,
 	}
 
 	dsTransport := &dataSourceTransport{

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -79,18 +79,20 @@ var (
 	LogConfigs []util.DynMap
 
 	// Http server options
-	Protocol           Scheme
-	Domain             string
-	HttpAddr, HttpPort string
-	SshPort            int
-	CertFile, KeyFile  string
-	SocketPath         string
-	RouterLogging      bool
-	DataProxyLogging   bool
-	DataProxyTimeout   int
-	StaticRootPath     string
-	EnableGzip         bool
-	EnforceDomain      bool
+	Protocol                 Scheme
+	Domain                   string
+	HttpAddr, HttpPort       string
+	SshPort                  int
+	CertFile, KeyFile        string
+	SocketPath               string
+	RouterLogging            bool
+	DataProxyLogging         bool
+	DataProxyTimeout         int
+	DataProxyKeepAlive       int
+	DataProxyIdleConnTimeout int
+	StaticRootPath           string
+	EnableGzip               bool
+	EnforceDomain            bool
 
 	// Security settings.
 	SecretKey                         string


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds in two new settings, dataproxy.keep_alive and dataproxy.idle_conn_timeout. These will allow users more control over the dataproxy connections and allow them to modify the settings to deal with network requirements.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #27839 

