### PR TITLE
DataProxy: Add additional settings for dataproxy to help with network proxy timeouts

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -130,6 +130,12 @@ logging = false
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 timeout = 30
 
+# How long the data proxy waits before sending a keepalive request, default is 30 seconds.
+keep_alive = 30
+
+# How long the data proxy keeps an idle connection open before timing out, default is 30 seconds.
+idle_conn_timeout = 90
+
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
 send_user_header = false
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -133,7 +133,7 @@ timeout = 30
 # How long the data proxy waits before sending a keepalive request, default is 30 seconds.
 keep_alive = 30
 
-# How long the data proxy keeps an idle connection open before timing out, default is 30 seconds.
+# How long the data proxy keeps an idle connection open before timing out, default is 90 seconds.
 idle_conn_timeout = 90
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -133,7 +133,7 @@ timeout = 30
 # How long the data proxy waits before sending a keepalive request. Default is 30 seconds.
 keep_alive = 30
 
-# How long the data proxy keeps an idle connection open before timing out, default is 90 seconds.
+# How long the data proxy keeps an idle connection open before timing out. Default is 90 seconds.
 idle_conn_timeout = 90
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -136,7 +136,7 @@ keep_alive = 30
 # How long the data proxy keeps an idle connection open before timing out. Default is 90 seconds.
 idle_conn_timeout = 90
 
-# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request. Default is false.
 send_user_header = false
 
 #################################### Analytics ###########################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -131,10 +131,22 @@ logging = false
 timeout = 30
 
 # How long the data proxy waits before sending a keepalive request. Default is 30 seconds.
-keep_alive = 30
+keep_alive_seconds = 30
+
+# How long the data proxy waits for a successful TLS Handshake before timing out. Default is 90 seconds.
+tls_handshake_timeout_seconds = 10
+
+# How long the data proxy will wait for a server's first response headers after
+# fully writing the request headers if the request has an "Expect: 100-continue"
+# header. A value of 0 will result in the body being sent immediately, without
+# waiting for the server to approve. Default is 1 second.
+expect_continue_timeout_seconds = 1
+
+# The maximum number of idle connections that Grafana will keep alive. Default is 100.
+max_idle_connections = 100
 
 # How long the data proxy keeps an idle connection open before timing out. Default is 90 seconds.
-idle_conn_timeout = 90
+idle_conn_timeout_seconds = 90
 
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request. Default is false.
 send_user_header = false

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -130,25 +130,25 @@ logging = false
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 timeout = 30
 
-# How long the data proxy waits before sending a keepalive request. Default is 30 seconds.
+# How many seconds the data proxy waits before sending a keepalive request.
 keep_alive_seconds = 30
 
-# How long the data proxy waits for a successful TLS Handshake before timing out. Default is 90 seconds.
+# How many seconds the data proxy waits for a successful TLS Handshake before timing out.
 tls_handshake_timeout_seconds = 10
 
-# How long the data proxy will wait for a server's first response headers after
+# How many seconds the data proxy will wait for a server's first response headers after
 # fully writing the request headers if the request has an "Expect: 100-continue"
 # header. A value of 0 will result in the body being sent immediately, without
-# waiting for the server to approve. Default is 1 second.
+# waiting for the server to approve.
 expect_continue_timeout_seconds = 1
 
-# The maximum number of idle connections that Grafana will keep alive. Default is 100.
+# The maximum number of idle connections that Grafana will keep alive.
 max_idle_connections = 100
 
-# How long the data proxy keeps an idle connection open before timing out. Default is 90 seconds.
+# How many seconds the data proxy keeps an idle connection open before timing out.
 idle_conn_timeout_seconds = 90
 
-# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request. Default is false.
+# If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request.
 send_user_header = false
 
 #################################### Analytics ###########################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -130,7 +130,7 @@ logging = false
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 timeout = 30
 
-# How long the data proxy waits before sending a keepalive request, default is 30 seconds.
+# How long the data proxy waits before sending a keepalive request. Default is 30 seconds.
 keep_alive = 30
 
 # How long the data proxy keeps an idle connection open before timing out, default is 90 seconds.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -131,7 +131,7 @@
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 ;timeout = 30
 
-# How many seconds the data proxy waits before sending a keepalive request.
+# How many seconds the data proxy waits before sending a keepalive probe request.
 ;keep_alive_seconds = 30
 
 # How many seconds the data proxy waits for a successful TLS Handshake before timing out.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -131,6 +131,24 @@
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 ;timeout = 30
 
+# How many seconds the data proxy waits before sending a keepalive request.
+;keep_alive_seconds = 30
+
+# How many seconds the data proxy waits for a successful TLS Handshake before timing out.
+;tls_handshake_timeout_seconds = 10
+
+# How many seconds the data proxy will wait for a server's first response headers after
+# fully writing the request headers if the request has an "Expect: 100-continue"
+# header. A value of 0 will result in the body being sent immediately, without
+# waiting for the server to approve.
+;expect_continue_timeout_seconds = 1
+
+# The maximum number of idle connections that Grafana will keep alive.
+;max_idle_connections = 100
+
+# How many seconds the data proxy keeps an idle connection open before timing out.
+;idle_conn_timeout_seconds = 90
+
 # If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request, default is false.
 ;send_user_header = false
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -391,23 +391,23 @@ This setting also applies to core backend HTTP data sources where query requests
 
 ### keep_alive_seconds
 
-Interval between sends of TCP keepalive requests. Default is 30 seconds.
+Interval between keep-alive probes. Default is `30` seconds. For more details check the [Dialer.KeepAlive](https://golang.org/pkg/net/#Dialer.KeepAlive) documentation.
 
 ### tls_handshake_timeout_seconds
 
-The length of time that Grafana will wait for a succussful TLS handshake with the datasource. Default is 10 seconds.
+The length of time that Grafana will wait for a succussful TLS handshake with the datasource. Default is `10` seconds. For more details check the [Transport.TLSHandshakeTimeout](https://golang.org/pkg/net/http/#Transport.TLSHandshakeTimeout) documentation.
 
 ### expect_continue_timeout_seconds
 
-The length of time that Grafana will wait for response headers after initial request headers are written and the request contains the header `Expect: 100-continue`. A value of 0 will result in the body being sent immediately. Default is 1 second.
+The length of time that Grafana will wait for a datasource’s first response headers after fully writing the request headers, if the request has an “Expect: 100-continue” header.  A value of `0` will result in the body being sent immediately. Default is `1` second. For more details check the [Transport.ExpectContinueTimeout](https://golang.org/pkg/net/http/#Transport.ExpectContinueTimeout) documentation.
 
 ### max_idle_connections
 
-The maximum number of idle connections that Grafana will maintain. Default is 100.
+The maximum number of idle connections that Grafana will maintain. Default is `100`. For more details check the [Transport.MaxIdleConns](https://golang.org/pkg/net/http/#Transport.MaxIdleConns) documentation.
 
 ### idle_conn_timeout_seconds
 
-The length of time that Grafana maintains idle connections. Default is 90 seconds.
+The length of time that Grafana maintains idle connections before closing them. Default is `90` seconds. For more details check the [Transport.IdleConnTimeout](https://golang.org/pkg/net/http/#Transport.IdleConnTimeout) documentation.
 
 ### send_user_header
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -395,7 +395,7 @@ Interval between keep-alive probes. Default is `30` seconds. For more details ch
 
 ### tls_handshake_timeout_seconds
 
-The length of time that Grafana will wait for a succussful TLS handshake with the datasource. Default is `10` seconds. For more details check the [Transport.TLSHandshakeTimeout](https://golang.org/pkg/net/http/#Transport.TLSHandshakeTimeout) documentation.
+The length of time that Grafana will wait for a successful TLS handshake with the datasource. Default is `10` seconds. For more details check the [Transport.TLSHandshakeTimeout](https://golang.org/pkg/net/http/#Transport.TLSHandshakeTimeout) documentation.
 
 ### expect_continue_timeout_seconds
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -393,7 +393,7 @@ This setting also applies to core backend HTTP data sources where query requests
 
 Interval between sends of TCP keepalive requests. Default is 30 seconds.
 
-### timeidle_conn_timeoutout
+### idle_conn_timeout
 
 The length of time that idle connections will be maintained. Default is 90 seconds.
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -403,7 +403,7 @@ The length of time that Grafana will wait for response headers after initial req
 
 ### max_idle_connections
 
-The maximim number of idle connections that Grafana will maintain. Default is 100.
+The maximum number of idle connections that Grafana will maintain. Default is 100.
 
 ### idle_conn_timeout_seconds
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -395,7 +395,7 @@ Interval between sends of TCP keepalive requests. Default is 30 seconds.
 
 ### idle_conn_timeout
 
-The length of time that idle connections will be maintained. Default is 90 seconds.
+The length of time that Grafana maintains idle connections. Default is 90 seconds.
 
 ### send_user_header
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -389,6 +389,14 @@ How long the data proxy should wait before timing out. Default is 30 seconds.
 
 This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 
+### keep_alive
+
+Interval between sends of TCP keepalive requests. Default is 30 seconds.
+
+### timeidle_conn_timeoutout
+
+The length of time that idle connections will be maintained. Default is 90 seconds.
+
 ### send_user_header
 
 If enabled and user is not anonymous, data proxy will add X-Grafana-User header with username into the request. Default is `false`.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -399,7 +399,7 @@ The length of time that Grafana will wait for a succussful TLS handshake with th
 
 ### expect_continue_timeout_seconds
 
-The length of time that Grafana will wait for response headers after initial request headers are written and the request contains the header "Expect: 100-continue". A value of 0 will result in the body being sent immediately. Default is 1 second.
+The length of time that Grafana will wait for response headers after initial request headers are written and the request contains the header `Expect: 100-continue`. A value of 0 will result in the body being sent immediately. Default is 1 second.
 
 ### max_idle_connections
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -389,11 +389,23 @@ How long the data proxy should wait before timing out. Default is 30 seconds.
 
 This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
 
-### keep_alive
+### keep_alive_seconds
 
 Interval between sends of TCP keepalive requests. Default is 30 seconds.
 
-### idle_conn_timeout
+### tls_handshake_timeout_seconds
+
+The length of time that Grafana will wait for a succussful TLS handshake with the datasource. Default is 10 seconds.
+
+### expect_continue_timeout_seconds
+
+The length of time that Grafana will wait for response headers after initial request headers are written and the request contains the header "Expect: 100-continue". A value of 0 will result in the body being sent immediately. Default is 1 second.
+
+### max_idle_connections
+
+The maximim number of idle connections that Grafana will maintain. Default is 100.
+
+### idle_conn_timeout_seconds
 
 The length of time that Grafana maintains idle connections. Default is 90 seconds.
 

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -147,12 +147,12 @@ func (ds *DataSource) GetHttpTransport() (*dataSourceTransport, error) {
 		Proxy:           http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout:   time.Duration(setting.DataProxyTimeout) * time.Second,
-			KeepAlive: 30 * time.Second,
+			KeepAlive: time.Duration(setting.DataProxyKeepAlive) * time.Second,
 		}).Dial,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       time.Duration(setting.DataProxyIdleConnTimeout) * time.Second,
 	}
 
 	dsTransport := &dataSourceTransport{

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -149,7 +149,7 @@ func (ds *DataSource) GetHttpTransport() (*dataSourceTransport, error) {
 			Timeout:   time.Duration(setting.DataProxyTimeout) * time.Second,
 			KeepAlive: time.Duration(setting.DataProxyKeepAlive) * time.Second,
 		}).Dial,
-		TLSHandshakeTimeout:   time.Duration(setting.DataProxyTlsHandshakeTimeout) * time.Second,
+		TLSHandshakeTimeout:   time.Duration(setting.DataProxyTLSHandshakeTimeout) * time.Second,
 		ExpectContinueTimeout: time.Duration(setting.DataProxyExpectContinueTimeout) * time.Second,
 		MaxIdleConns:          setting.DataProxyMaxIdleConns,
 		IdleConnTimeout:       time.Duration(setting.DataProxyIdleConnTimeout) * time.Second,

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -149,9 +149,9 @@ func (ds *DataSource) GetHttpTransport() (*dataSourceTransport, error) {
 			Timeout:   time.Duration(setting.DataProxyTimeout) * time.Second,
 			KeepAlive: time.Duration(setting.DataProxyKeepAlive) * time.Second,
 		}).Dial,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConns:          100,
+		TLSHandshakeTimeout:   time.Duration(setting.DataProxyTlsHandshakeTimeout) * time.Second,
+		ExpectContinueTimeout: time.Duration(setting.DataProxyExpectContinueTimeout) * time.Second,
+		MaxIdleConns:          setting.DataProxyMaxIdleConns,
 		IdleConnTimeout:       time.Duration(setting.DataProxyIdleConnTimeout) * time.Second,
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -79,18 +79,20 @@ var (
 	LogConfigs []util.DynMap
 
 	// Http server options
-	Protocol           Scheme
-	Domain             string
-	HttpAddr, HttpPort string
-	SshPort            int
-	CertFile, KeyFile  string
-	SocketPath         string
-	RouterLogging      bool
-	DataProxyLogging   bool
-	DataProxyTimeout   int
-	StaticRootPath     string
-	EnableGzip         bool
-	EnforceDomain      bool
+	Protocol                 Scheme
+	Domain                   string
+	HttpAddr, HttpPort       string
+	SshPort                  int
+	CertFile, KeyFile        string
+	SocketPath               string
+	RouterLogging            bool
+	DataProxyLogging         bool
+	DataProxyTimeout         int
+	DataProxyKeepAlive       int
+	DataProxyIdleConnTimeout int
+	StaticRootPath           string
+	EnableGzip               bool
+	EnforceDomain            bool
 
 	// Security settings.
 	SecretKey                         string

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -88,7 +88,7 @@ var (
 	RouterLogging                  bool
 	DataProxyLogging               bool
 	DataProxyTimeout               int
-	DataProxyTlsHandshakeTimeout   int
+	DataProxyTLSHandshakeTimeout   int
 	DataProxyExpectContinueTimeout int
 	DataProxyMaxIdleConns          int
 	DataProxyKeepAlive             int
@@ -688,7 +688,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	DataProxyLogging = dataproxy.Key("logging").MustBool(false)
 	DataProxyTimeout = dataproxy.Key("timeout").MustInt(30)
 	DataProxyKeepAlive = dataproxy.Key("keep_alive_seconds").MustInt(30)
-	DataProxyTlsHandshakeTimeout = dataproxy.Key("tls_handshake_timeout_seconds").MustInt(10)
+	DataProxyTLSHandshakeTimeout = dataproxy.Key("tls_handshake_timeout_seconds").MustInt(10)
 	DataProxyExpectContinueTimeout = dataproxy.Key("expect_continue_timeout_seconds").MustInt(1)
 	DataProxyMaxIdleConns = dataproxy.Key("max_idle_connections").MustInt(100)
 	DataProxyIdleConnTimeout = dataproxy.Key("idle_conn_timeout_seconds").MustInt(90)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -79,20 +79,23 @@ var (
 	LogConfigs []util.DynMap
 
 	// Http server options
-	Protocol                 Scheme
-	Domain                   string
-	HttpAddr, HttpPort       string
-	SshPort                  int
-	CertFile, KeyFile        string
-	SocketPath               string
-	RouterLogging            bool
-	DataProxyLogging         bool
-	DataProxyTimeout         int
-	DataProxyKeepAlive       int
-	DataProxyIdleConnTimeout int
-	StaticRootPath           string
-	EnableGzip               bool
-	EnforceDomain            bool
+	Protocol                       Scheme
+	Domain                         string
+	HttpAddr, HttpPort             string
+	SshPort                        int
+	CertFile, KeyFile              string
+	SocketPath                     string
+	RouterLogging                  bool
+	DataProxyLogging               bool
+	DataProxyTimeout               int
+	DataProxyTlsHandshakeTimeout   int
+	DataProxyExpectContinueTimeout int
+	DataProxyMaxIdleConns          int
+	DataProxyKeepAlive             int
+	DataProxyIdleConnTimeout       int
+	StaticRootPath                 string
+	EnableGzip                     bool
+	EnforceDomain                  bool
 
 	// Security settings.
 	SecretKey                         string
@@ -684,6 +687,11 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	dataproxy := iniFile.Section("dataproxy")
 	DataProxyLogging = dataproxy.Key("logging").MustBool(false)
 	DataProxyTimeout = dataproxy.Key("timeout").MustInt(30)
+	DataProxyKeepAlive = dataproxy.Key("keep_alive_seconds").MustInt(30)
+	DataProxyTlsHandshakeTimeout = dataproxy.Key("tls_handshake_timeout_seconds").MustInt(10)
+	DataProxyExpectContinueTimeout = dataproxy.Key("expect_continue_timeout_seconds").MustInt(1)
+	DataProxyMaxIdleConns = dataproxy.Key("max_idle_connections").MustInt(100)
+	DataProxyIdleConnTimeout = dataproxy.Key("idle_conn_timeout_seconds").MustInt(90)
 	cfg.SendUserHeader = dataproxy.Key("send_user_header").MustBool(false)
 
 	if err := readSecuritySettings(iniFile, cfg); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds in two new settings, dataproxy.keep_alive and dataproxy.idle_conn_timeout. These will allow users more control over the dataproxy connections and allow them to modify the settings to deal with network requirements.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #27839 

