### PR TITLE
Stackdriver: fix project name change regression

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
@@ -154,7 +154,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
               onBlur={onBlur}
               openMenuOnFocus={openMenuOnFocus}
               maxMenuHeight={maxMenuHeight}
-              noOptionsMessage={() => noOptionsMessage}
+              noOptionsMessage={noOptionsMessage}
               isMulti={isMulti}
               backspaceRemovesValue={backspaceRemovesValue}
               menuIsOpen={isOpen}

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
@@ -24,8 +24,8 @@ export const defaultState: State = {
   labels: {},
 };
 
-export const defaultQuery: MetricQuery = {
-  projectName: '',
+export const defaultQuery: (dataSource: CloudMonitoringDatasource) => MetricQuery = dataSource => ({
+  projectName: dataSource.getDefaultProject(),
   metricType: '',
   metricKind: '',
   valueType: '',
@@ -36,7 +36,7 @@ export const defaultQuery: MetricQuery = {
   groupBys: [],
   filters: [],
   aliasBy: '',
-};
+});
 
 function Editor({
   refId,

--- a/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
@@ -63,8 +63,8 @@ export class QueryEditor extends PureComponent<Props, State> {
 
   render() {
     const { datasource, query, onRunQuery, onChange } = this.props;
-    const metricQuery = { ...defaultQuery, ...query.metricQuery, projectName: datasource.getDefaultProject() };
-    const sloQuery = { ...defaultSLOQuery, ...query.sloQuery, projectName: datasource.getDefaultProject() };
+    const metricQuery = { ...defaultQuery(datasource), ...query.metricQuery };
+    const sloQuery = { ...defaultSLOQuery(datasource), ...query.sloQuery };
     const queryType = query.queryType || QueryType.METRICS;
     const meta = this.props.data?.series.length ? this.props.data?.series[0].meta : {};
     const usedAlignmentPeriod = meta?.alignmentPeriod;

--- a/public/app/plugins/datasource/cloud-monitoring/components/SLOQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLOQueryEditor.tsx
@@ -15,14 +15,14 @@ export interface Props {
   datasource: CloudMonitoringDatasource;
 }
 
-export const defaultQuery: SLOQuery = {
-  projectName: '',
+export const defaultQuery: (dataSource: CloudMonitoringDatasource) => SLOQuery = dataSource => ({
+  projectName: dataSource.getDefaultProject(),
   alignmentPeriod: 'cloud-monitoring-auto',
   aliasBy: '',
   selectorName: 'select_slo_health',
   serviceId: '',
   sloId: '',
-};
+});
 
 export function SLOQueryEditor({
   query,

--- a/public/app/plugins/datasource/cloud-monitoring/partials/config.html
+++ b/public/app/plugins/datasource/cloud-monitoring/partials/config.html
@@ -34,7 +34,7 @@
 
     <p>
       Detailed instructions on how to create a Service Account can be found
-      <a class="external-link" target="_blank" href="http://docs.grafana.org/datasources/cloudmonitoring/"
+      <a class="external-link" target="_blank" href="https://grafana.com/docs/grafana/latest/datasources/cloudmonitoring/"
         >in the documentation.</a
       >
     </p>


### PR DESCRIPTION
This PR fixes a regression created in 7.2 that not allowed to change the project in google cloud monitoring data source. Also fixes an issue with legacy select component that it didn't show the noOptionsMessage. Also fixes the link in the config editor because it navigated to 404.

**Which issue(s) this PR fixes**:

Fixes #27855 

