### PR TITLE
Drone: Upgrade drone-grafana-docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -160,7 +160,7 @@ steps:
   - package
 
 - name: build-docker-images
-  image: grafana/drone-grafana-docker:0.3.1
+  image: grafana/drone-grafana-docker:0.3.2
   settings:
     archs: amd64
     dry_run: true
@@ -455,7 +455,7 @@ steps:
   - package
 
 - name: build-docker-images
-  image: grafana/drone-grafana-docker:0.3.1
+  image: grafana/drone-grafana-docker:0.3.2
   settings:
     edition: oss
     password:
@@ -466,7 +466,7 @@ steps:
   - copy-packages-for-docker
 
 - name: build-docker-images-ubuntu
-  image: grafana/drone-grafana-docker:0.3.1
+  image: grafana/drone-grafana-docker:0.3.2
   settings:
     edition: oss
     password:

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -3,10 +3,13 @@ FROM ${BASE_IMAGE}
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64-musl.tar.gz"
 
+# Make sure we have Gnu tar
+RUN apk add --no-cache tar
+
 COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 
 # Change to tar xfzv to make tar print every file it extracts
-RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
+RUN mkdir /tmp/grafana && tar xzf /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
 FROM ${BASE_IMAGE}
 

--- a/packaging/docker/ubuntu.Dockerfile
+++ b/packaging/docker/ubuntu.Dockerfile
@@ -5,7 +5,7 @@ ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"
 
 COPY ${GRAFANA_TGZ} /tmp/grafana.tar.gz
 
-RUN mkdir /tmp/grafana && tar xfz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
+RUN mkdir /tmp/grafana && tar xzf /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 
 FROM ${BASE_IMAGE}
 

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,6 +1,6 @@
 build_image = 'grafana/build-container:1.2.27'
 publish_image = 'grafana/grafana-ci-deploy:1.2.6'
-grafana_docker_image = 'grafana/drone-grafana-docker:0.3.1'
+grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 alpine_image = 'alpine:3.12'
 windows_image = 'mcr.microsoft.com/windows:1809'
 grabpl_version = '0.5.13'


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the drone-grafana-docker plugin image in Drone, to try to fix Docker builds.
