### PR TITLE
Drone: Ignore failure to publish front-end metrics

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -348,6 +348,7 @@ steps:
   environment:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
+  failure: ignore
   depends_on:
   - initialize
 

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -478,6 +478,7 @@ def frontend_metrics_step(edition):
                 'from_secret': 'grafana_misc_stats_api_key',
             },
         },
+        'failure': 'ignore',
         'commands': [
             './scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}',
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:
In Drone, ignore when publishing front-end metrics fails. Sometimes the API call fails, and it shouldn't break the whole build, since it isn't a crucial step.