### PR TITLE
Drone: Add Slack failure notifier

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -276,6 +276,17 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
+- name: slack
+  image: plugins/slack
+  settings:
+    channel: grafana-ci-failures
+    template: "Build {{build.number}} failed: {{build.link}}"
+    webhook:
+      from_secret: slack_webhook
+  when:
+    status:
+    - failure
+
 - name: trigger-enterprise-downstream
   image: grafana/drone-downstream
   settings:
@@ -641,6 +652,17 @@ steps:
   - mv grabpl bin
   environment:
     DOCKERIZE_VERSION: 0.6.1
+
+- name: slack
+  image: plugins/slack
+  settings:
+    channel: grafana-ci-failures
+    template: "Build {{build.number}} failed: {{build.link}}"
+    webhook:
+      from_secret: slack_webhook
+  when:
+    status:
+    - failure
 
 - name: publish-packages
   image: grafana/grafana-ci-deploy:1.2.6


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Slack failure notifier to Drone. Not added for PR builds for now, since the Slack webhook could easily be leaked, until we protect the Drone configuration.
