### PR TITLE
Drone: Don't ignore failure to publish next NPM packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -531,7 +531,6 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  failure: ignore
   depends_on:
   - end-to-end-tests
 

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -755,7 +755,6 @@ def release_next_npm_packages_step(edition):
                 'from_secret': 'npm_token',
             },
         },
-        'failure': 'ignore',
         'commands': [
             'npx lerna bootstrap',
             'echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc',


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure Drone to _not_ ignore failure to publish next NPM packages, since this step works now and it's better to be notified if it fails.

NB: We might want to implement retries for this step (in the build pipeline tool), to avoid random failures.
