### PR TITLE
CI: Notify failures in separate pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -276,17 +276,6 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
-- name: slack
-  image: plugins/slack
-  settings:
-    channel: grafana-ci-failures
-    template: "Build {{build.number}} failed: {{build.link}}"
-    webhook:
-      from_secret: slack_webhook
-  when:
-    status:
-    - failure
-
 - name: trigger-enterprise-downstream
   image: grafana/drone-downstream
   settings:
@@ -652,17 +641,6 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
-- name: slack
-  image: plugins/slack
-  settings:
-    channel: grafana-ci-failures
-    template: "Build {{build.number}} failed: {{build.link}}"
-    webhook:
-      from_secret: slack_webhook
-  when:
-    status:
-    - failure
-
 - name: publish-packages
   image: grafana/grafana-ci-deploy:1.2.6
   commands:
@@ -682,5 +660,32 @@ trigger:
 depends_on:
 - build-master
 - windows-master
+
+---
+kind: pipeline
+type: docker
+name: notify-master
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: slack
+  image: plugins/slack
+  settings:
+    channel: grafana-ci-notifications
+    template: "Build {{build.number}} failed: {{build.link}}"
+    webhook:
+      from_secret: slack_webhook
+
+trigger:
+  status:
+  - failure
+
+depends_on:
+- build-master
+- windows-master
+- publish-master
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -680,6 +680,10 @@ steps:
       from_secret: slack_webhook
 
 trigger:
+  branch:
+  - master
+  event:
+  - push
   status:
   - failure
 

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -146,7 +146,7 @@ def master_pipelines(edition):
             depends_on=['build-master', 'windows-master',], install_deps=False, version_mode=version_mode,
         ))
 
-        notifyTrigger = { 'status': ['failure'] }
+        notifyTrigger = dict(trigger, status = ['failure'])
         pipelines.append(notifyPipeline(
             name='notify-master', slackChannel='grafana-ci-notifications', trigger=notifyTrigger,
             depends_on=['build-master', 'windows-master', 'publish-master'],

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -146,9 +146,9 @@ def master_pipelines(edition):
             depends_on=['build-master', 'windows-master',], install_deps=False, version_mode=version_mode,
         ))
 
-        notifyTrigger = dict(trigger, status = ['failure'])
+        notify_trigger = dict(trigger, status = ['failure'])
         pipelines.append(notifyPipeline(
-            name='notify-master', slackChannel='grafana-ci-notifications', trigger=notifyTrigger,
+            name='notify-master', slackChannel='grafana-ci-notifications', trigger=notify_trigger,
             depends_on=['build-master', 'windows-master', 'publish-master'],
         ))
     if edition == 'enterprise':

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -171,6 +171,12 @@ def master_pipelines(edition):
             version_mode=version_mode,
         ))
 
+        notify_trigger = dict(trigger, status = ['failure'])
+        pipelines.append(notifyPipeline(
+            name='notify-master-downstream', slack_channel='grafana-enterprise-ci-notifications', trigger=notify_trigger,
+            depends_on=['build-master-downstream', 'windows-master-downstream', 'publish-master-downstream'],
+        ))
+
     return pipelines
 
 def pipeline(

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -147,7 +147,7 @@ def master_pipelines(edition):
         ))
 
         notify_trigger = dict(trigger, status = ['failure'])
-        pipelines.append(notifyPipeline(
+        pipelines.append(notify_pipeline(
             name='notify-master', slack_channel='grafana-ci-notifications', trigger=notify_trigger,
             depends_on=['build-master', 'windows-master', 'publish-master'],
         ))
@@ -172,7 +172,7 @@ def master_pipelines(edition):
         ))
 
         notify_trigger = dict(trigger, status = ['failure'])
-        pipelines.append(notifyPipeline(
+        pipelines.append(notify_pipeline(
             name='notify-master-downstream', slack_channel='grafana-enterprise-ci-notifications', trigger=notify_trigger,
             depends_on=['build-master-downstream', 'windows-master-downstream', 'publish-master-downstream'],
         ))
@@ -216,7 +216,7 @@ def pipeline(
 
     return pipeline
 
-def notifyPipeline(name, slack_channel, trigger, depends_on=[]):
+def notify_pipeline(name, slack_channel, trigger, depends_on=[]):
     return {
         'kind': 'pipeline',
         'type': 'docker',

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -148,7 +148,7 @@ def master_pipelines(edition):
 
         notify_trigger = dict(trigger, status = ['failure'])
         pipelines.append(notifyPipeline(
-            name='notify-master', slackChannel='grafana-ci-notifications', trigger=notify_trigger,
+            name='notify-master', slack_channel='grafana-ci-notifications', trigger=notify_trigger,
             depends_on=['build-master', 'windows-master', 'publish-master'],
         ))
     if edition == 'enterprise':
@@ -210,7 +210,7 @@ def pipeline(
 
     return pipeline
 
-def notifyPipeline(name, slackChannel, trigger, depends_on=[]):
+def notifyPipeline(name, slack_channel, trigger, depends_on=[]):
     return {
         'kind': 'pipeline',
         'type': 'docker',
@@ -221,7 +221,7 @@ def notifyPipeline(name, slackChannel, trigger, depends_on=[]):
         'name': name,
         'trigger': trigger,
         'steps': [
-            slack_step(slackChannel),
+            slack_step(slack_channel),
         ],
         'depends_on': depends_on,
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes slack notifications to execute in a separate pipeline, triggered by failure and depending on the other master  pipelines.