### PR TITLE
consistent panel link when panel repeat is used

### DIFF
--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -113,6 +113,7 @@ export interface PanelModel<TOptions = any> {
   /** Version of the panel plugin */
   pluginVersion?: string;
   scopedVars?: ScopedVars;
+  repeatPanelId?: number;
 }
 
 /**

--- a/public/app/features/dashboard/components/ShareModal/utils.ts
+++ b/public/app/features/dashboard/components/ShareModal/utils.ts
@@ -31,6 +31,12 @@ export function buildParams(
 
   if (panel && !params.editPanel) {
     params.viewPanel = panel.id;
+    if (panel.scopedVars) {
+      Object.entries(panel.scopedVars).forEach(([key, value]) => {
+        params[`var-${key}`] = value.value;
+        params.viewPanel = panel.repeatPanelId;
+      });
+    }
   } else {
     delete params.viewPanel;
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This bug cause error when open link or render panel image.
Could be critical bug if user create dynamic dashboard by panel repeat.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/27946

**Special notes for your reviewer**:
By fixing variable value by scoped variable, panel count becomes only one, and repeatedPanelId should point correct panel.
The panel repeat key variable is overwrited when link is shared, this behavior is changed.
