### PR TITLE
Plugins: Fix loading of backend plugins

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -1,10 +1,7 @@
 package metrics
 
 import (
-	"errors"
-	"fmt"
 	"runtime"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -591,28 +588,4 @@ func newCounterStartingAtZero(opts prometheus.CounterOpts, labelValues ...string
 	counter.Add(0)
 
 	return counter
-}
-
-// SanitizeLabelName removes all invalid chars from the label name.
-// If the label name is empty or contains only invalid chars, it
-// will return an error.
-func SanitizeLabelName(name string) (string, error) {
-	if len(name) == 0 {
-		return "", errors.New("label name cannot be empty")
-	}
-
-	out := strings.Builder{}
-	for i, b := range name {
-		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0) {
-			out.WriteRune(b)
-		} else if b == ' ' {
-			out.WriteRune('_')
-		}
-	}
-
-	if out.Len() == 0 {
-		return "", fmt.Errorf("label name only contains invalid chars: %q", name)
-	}
-
-	return out.String(), nil
 }

--- a/pkg/infra/metrics/metricutil/utils.go
+++ b/pkg/infra/metrics/metricutil/utils.go
@@ -1,0 +1,31 @@
+package metricutil
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SanitizeLabelName removes all invalid chars from the label name.
+// If the label name is empty or contains only invalid chars, it
+// will return an error.
+func SanitizeLabelName(name string) (string, error) {
+	if len(name) == 0 {
+		return "", errors.New("label name cannot be empty")
+	}
+
+	out := strings.Builder{}
+	for i, b := range name {
+		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0) {
+			out.WriteRune(b)
+		} else if b == ' ' {
+			out.WriteRune('_')
+		}
+	}
+
+	if out.Len() == 0 {
+		return "", fmt.Errorf("label name only contains invalid chars: %q", name)
+	}
+
+	return out.String(), nil
+}

--- a/pkg/infra/metrics/metricutil/utils_test.go
+++ b/pkg/infra/metrics/metricutil/utils_test.go
@@ -1,4 +1,4 @@
-package metrics
+package metricutil
 
 import (
 	"testing"

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -73,7 +73,7 @@ type dataSourceTransport struct {
 
 func instrumentRoundtrip(datasourceName string, next http.RoundTripper) promhttp.RoundTripperFunc {
 	return promhttp.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
-		datasourceLabelName, err := metrics.SanitizeLabelName(datasourceName)
+		datasourceLabelName, err := metricutil.SanitizeLabelName(datasourceName)
 		// if the datasource named cannot be turned into a prometheus
 		// label we will skip instrumenting these metrics.
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The referenced PR introduced a new dependency/import graph by importing the infra/metrics package to the models package. This broke the order of which services are registered with our dependency injection library and made the backend plugin manager crash.

**Which issue(s) this PR fixes**:
Ref #27921 

**Special notes for your reviewer**: