### PR TITLE
Loki: Update refId for instant queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -137,7 +137,15 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
         }
 
         return {
-          data: [lokiResultsToTableModel(response.data.data.result, responseListLength, target.refId, meta, true)],
+          data: [
+            lokiResultsToTableModel(
+              response.data.data.result,
+              responseListLength,
+              `${target.refId}_instant`,
+              meta,
+              true
+            ),
+          ],
           key: `${target.refId}_instant`,
         };
       }),


### PR DESCRIPTION
**What this PR does / why we need it**:
More information in #27860. This PR fixes the refId for Loki instant queries so transformation ** Filter data by query** can be used. 

**Fixed:** 
![image](https://user-images.githubusercontent.com/30407135/94720203-74fff600-0354-11eb-910e-a63207eb0c36.png)

**Current master:**
![image](https://user-images.githubusercontent.com/30407135/94788740-4f1a3600-03d4-11eb-8c07-a4abfe0f9752.png)

**Which issue(s) this PR fixes**:
Fixes #27860


