### PR TITLE
FieldDisplayName: Make field display names unique if field name exists more than once

### DIFF
--- a/packages/grafana-data/src/dataframe/ArrowDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/ArrowDataFrame.test.ts
@@ -43,7 +43,7 @@ describe('Read/Write arrow Table to DataFrame', () => {
       ],
     });
 
-    const table = grafanaDataFrameToArrowTable(frame);
+    const table = grafanaDataFrameToArrowTable(frame, true);
     expect(table.length).toEqual(frame.length);
 
     // Now back to DataFrame

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -54,18 +54,18 @@ describe('Check field state calculations (displayName and id)', () => {
     expect(title).toEqual('Series A Field 1');
   });
 
-  it('should add field index to name if field name exists more than once', () => {
+  it('should add field name count to name if it exists more than once and is equal to TIME_SERIES_VALUE_FIELD_NAME', () => {
     const title = checkScenario({
       frames: [
         toDataFrame({
-          fields: [{ name: 'Value' }, { name: 'Value' }],
+          fields: [{ name: TIME_SERIES_VALUE_FIELD_NAME }, { name: TIME_SERIES_VALUE_FIELD_NAME }],
         }),
       ],
     });
     const title2 = checkScenario({
       frames: [
         toDataFrame({
-          fields: [{ name: 'Value' }, { name: 'Value' }],
+          fields: [{ name: TIME_SERIES_VALUE_FIELD_NAME }, { name: TIME_SERIES_VALUE_FIELD_NAME }],
         }),
       ],
       fieldIndex: 1,
@@ -75,7 +75,7 @@ describe('Check field state calculations (displayName and id)', () => {
     expect(title2).toEqual('Value 2');
   });
 
-  it('should add field index to name if field name exists more than once', () => {
+  it('should add field name count to name if field name exists more than once', () => {
     const title2 = checkScenario({
       frames: [
         toDataFrame({

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -54,6 +54,40 @@ describe('Check field state calculations (displayName and id)', () => {
     expect(title).toEqual('Series A Field 1');
   });
 
+  it('should add field index to name if field name exists more than once', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          fields: [{ name: 'Value' }, { name: 'Value' }],
+        }),
+      ],
+    });
+    const title2 = checkScenario({
+      frames: [
+        toDataFrame({
+          fields: [{ name: 'Value' }, { name: 'Value' }],
+        }),
+      ],
+      fieldIndex: 1,
+    });
+
+    expect(title).toEqual('Value 1');
+    expect(title2).toEqual('Value 2');
+  });
+
+  it('should add field index to name if field name exists more than once', () => {
+    const title2 = checkScenario({
+      frames: [
+        toDataFrame({
+          fields: [{ name: 'A' }, { name: 'A' }],
+        }),
+      ],
+      fieldIndex: 1,
+    });
+
+    expect(title2).toEqual('A 2');
+  });
+
   it('should only use label value if only one label', () => {
     const title = checkScenario({
       frames: [

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -125,7 +125,43 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     displayName = TIME_SERIES_VALUE_FIELD_NAME;
   }
 
+  // Ensure unique field name
+  if (displayName === field.name) {
+    displayName = getUniqueFieldName(field, frame);
+  }
+
   return displayName;
+}
+
+function getUniqueFieldName(field: Field, frame?: DataFrame) {
+  let dupeCount = 0;
+  let foundSelf = false;
+
+  if (frame) {
+    for (let i = 0; i < frame.fields.length; i++) {
+      const otherField = frame.fields[i];
+
+      if (field === otherField) {
+        foundSelf = true;
+
+        if (dupeCount > 0) {
+          dupeCount++;
+        }
+      } else if (field.name === otherField.name) {
+        dupeCount++;
+
+        if (foundSelf) {
+          break;
+        }
+      }
+    }
+  }
+
+  if (dupeCount) {
+    return `${field.name} ${dupeCount}`;
+  }
+
+  return field.name;
 }
 
 /**

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -146,6 +146,7 @@ function getUniqueFieldName(field: Field, frame?: DataFrame) {
 
         if (dupeCount > 0) {
           dupeCount++;
+          break;
         }
       } else if (field.name === otherField.name) {
         dupeCount++;

--- a/packages/grafana-data/src/transformations/transformers/seriesToColumns.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToColumns.test.ts
@@ -346,4 +346,55 @@ describe('SeriesToColumns Transformer', () => {
       },
     ]);
   });
+
+  it('handles duplicate field name', () => {
+    const cfg: DataTransformerConfig<SeriesToColumnsOptions> = {
+      id: DataTransformerID.seriesToColumns,
+      options: {
+        byField: 'time',
+      },
+    };
+
+    const frame1 = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1] },
+        { name: 'temperature', type: FieldType.number, values: [10] },
+      ],
+    });
+
+    const frame2 = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1] },
+        { name: 'temperature', type: FieldType.number, values: [20] },
+      ],
+    });
+
+    const filtered = transformDataFrame([cfg], [frame1, frame2])[0];
+
+    expect(filtered.fields).toEqual([
+      {
+        name: 'time',
+        state: { displayName: 'time' },
+        type: FieldType.time,
+        values: new ArrayVector([1]),
+        config: {},
+      },
+      {
+        name: 'temperature',
+        state: { displayName: 'temperature 1' },
+        type: FieldType.number,
+        values: new ArrayVector([10]),
+        config: {},
+        labels: {},
+      },
+      {
+        name: 'temperature',
+        state: { displayName: 'temperature 2' },
+        type: FieldType.number,
+        values: new ArrayVector([20]),
+        config: {},
+        labels: {},
+      },
+    ]);
+  });
 });

--- a/packages/grafana-data/src/transformations/transformers/seriesToColumns.ts
+++ b/packages/grafana-data/src/transformations/transformers/seriesToColumns.ts
@@ -68,7 +68,7 @@ export const seriesToColumnsTransformer: DataTransformerInfo<SeriesToColumnsOpti
     });
 
     for (const item of allFields) {
-      resultFrame.addField(item.newField);
+      item.newField = resultFrame.addField(item.newField);
     }
 
     const keyFieldTitle = getFieldDisplayName(resultFrame.fields[0], resultFrame);


### PR DESCRIPTION
This was a bit trickier than I thought. And not sure if this logic is correct or what side effects it has (existing transforms seem to work without modification). 

I had to modify seriesToColumns as MutableDataFrame.addField does not add the instance you pass to the function but creates a new field instance. 

Given two data frames with fields:
type, value 

Join now gives us: 

![Screenshot from 2020-10-01 14-08-05](https://user-images.githubusercontent.com/10999/94807162-8c3ff180-03ef-11eb-9157-ab0625cb8130.png)


Fixes #27781

Alternative to #27931