### PR TITLE
WIP: CloudWatch Logs queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/russellhaering/goxmldsig v0.0.0-20200902171629-2e1fbc2c5593 // indirect
+	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1
 	github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	cloud.google.com/go/storage v1.8.0
 	github.com/BurntSushi/toml v0.3.1
 	github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f
-	github.com/aws/aws-sdk-go v1.33.12
+	github.com/aws/aws-sdk-go v1.34.26
 	github.com/benbjohnson/clock v0.0.0-20161215174838-7dc76406b6d3
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/centrifugal/centrifuge v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -1040,6 +1040,7 @@ github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e/go.mod h1:gi+0
 github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/satori/go.uuid v0.0.0-20160603004225-b111a074d5ef/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU
 github.com/aws/aws-sdk-go v1.33.5/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.12 h1:eydMoSwfrSTD9PWKUJOiDL7+/UwDW8AjInUGVE5Llh4=
 github.com/aws/aws-sdk-go v1.33.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.34.26 h1:tw4nsSfGvCDnXt2xPe8NkxIrDui+asAWinMknPLEf80=
+github.com/aws/aws-sdk-go v1.34.26/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -337,6 +337,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// metrics
 		apiRoute.Post("/tsdb/query", bind(dtos.MetricRequest{}), Wrap(hs.QueryMetrics))
+		apiRoute.Any("/tsdb/wsquery", bind(dtos.MetricRequest{}), Wrap(hs.QueryMetricsWS))
 		apiRoute.Get("/tsdb/testdata/scenarios", Wrap(GetTestDataScenarios))
 		apiRoute.Get("/tsdb/testdata/gensql", reqGrafanaAdmin, Wrap(GenerateSQLTestData))
 		apiRoute.Get("/tsdb/testdata/random-walk", Wrap(GetTestDataRandomWalk))

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -22,7 +22,7 @@ type WebsocketResponse struct {
 	ChannelName string `json:"channelName"`
 }
 
-type RequestRun struct {
+type ResultProvider struct {
 	Channel     chan *tsdb.QueryResult
 	ChannelName string
 }
@@ -209,8 +209,9 @@ func (hs *HTTPServer) QueryMetricsWS(c *models.ReqContext, reqDto dtos.MetricReq
 		return Error(500, "Metric request error", err)
 	}
 
-	channelName := uuid.Must(uuid.NewV4()).String()
-	hs.SocketChannel <- &RequestRun{
+	channelPrefix := "ds/" + ds.Name + "/"
+	channelName := channelPrefix + uuid.Must(uuid.NewV4()).String()
+	hs.SocketChannel <- &ResultProvider{
 		ChannelName: channelName,
 		Channel:     channel,
 	}

--- a/pkg/tsdb/query_endpoint.go
+++ b/pkg/tsdb/query_endpoint.go
@@ -11,6 +11,10 @@ type TsdbQueryEndpoint interface {
 	Query(ctx context.Context, ds *models.DataSource, query *TsdbQuery) (*Response, error)
 }
 
+type TsdbWebSocketQueryEndpoint interface {
+	WebSocketQuery(ctx context.Context, ds *models.DataSource, query *TsdbQuery, channel chan *QueryResult) error
+}
+
 var registry map[string]GetTsdbQueryEndpointFn
 
 type GetTsdbQueryEndpointFn func(dsInfo *models.DataSource) (TsdbQueryEndpoint, error)

--- a/public/app/plugins/datasource/cloudwatch/plugin.json
+++ b/public/app/plugins/datasource/cloudwatch/plugin.json
@@ -7,6 +7,7 @@
   "logs": true,
   "alerting": true,
   "annotations": true,
+  "live": true,
   "includes": [
     { "type": "dashboard", "name": "EC2", "path": "dashboards/ec2.json" },
     { "type": "dashboard", "name": "EBS", "path": "dashboards/EBS.json" },

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -30,6 +30,7 @@ export enum CloudWatchLogsQueryStatus {
   Complete = 'Complete',
   Failed = 'Failed',
   Cancelled = 'Cancelled',
+  Timeout = 'Timeout',
 }
 
 export interface CloudWatchLogsQuery extends DataQuery {


### PR DESCRIPTION
**What this PR does / why we need it**:
Amazon CloudWatch Logs imposes certain limits, or quotas, on the usage of various API endpoints and features. One of these limits is the limit on query concurrency, which has a default of 4, but can be increased to 10 on request. If a user attempts to start a query while the maximum number of concurrent queries are running, an error will be returned. In order to prevent CloudWatch Logs panels, or CloudWatch Logs queries sent in Explore, from returning errors in the case where the concurrent queries limit is reached, it is necessary to implement a queueing system that only dispatches a “Start Query” request when we are under the concurrent query limit.
In service of this, this PR changes the architecture of the CloudWatch datasource from one that periodically sends `GetQueryResults` proxied through the grafana backend, to a websocket based architecture using the currently in-progress Grafana Live feature.
A lot of the design in this PR is exploratory and experimental, and in fact is broken right now as parts need to be rewritten to accommodate some recent changes to Grafana Live, but most of the main ideas are there.

See #27969 