### PR TITLE
Loki: Run instant query only in Explore

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1,7 +1,15 @@
 import { of, Subject } from 'rxjs';
 import { first, last, take } from 'rxjs/operators';
 import { omit } from 'lodash';
-import { AnnotationQueryRequest, DataFrame, DataQueryResponse, dateTime, FieldCache, TimeRange } from '@grafana/data';
+import {
+  AnnotationQueryRequest,
+  CoreApp,
+  DataFrame,
+  DataQueryResponse,
+  dateTime,
+  FieldCache,
+  TimeRange,
+} from '@grafana/data';
 import { BackendSrvRequest, FetchResponse } from '@grafana/runtime';
 
 import LokiDatasource from './datasource';
@@ -134,7 +142,7 @@ describe('LokiDatasource', () => {
       observableTester().subscribeAndExpectOnComplete<DataQueryResponse>({
         observable: ds.query(options).pipe(take(1)),
         expect: () => {
-          expect(fetchMock.mock.calls.length).toBe(2);
+          expect(fetchMock.mock.calls.length).toBe(1);
           expect(fetchMock.mock.calls[0][0].url).toContain(`limit=${expectedLimit}`);
         },
         done,
@@ -175,10 +183,11 @@ describe('LokiDatasource', () => {
   });
 
   describe('when querying', () => {
-    it('should run range and instant query', done => {
+    it('should run range and instant query in Explore', done => {
       const ds = createLokiDSForTests();
       const options = getQueryOptions<LokiQuery>({
         targets: [{ expr: '{job="grafana"}', refId: 'B' }],
+        app: CoreApp.Explore,
       });
 
       ds.runInstantQuery = jest.fn(() => of({ data: [] }));
@@ -194,10 +203,29 @@ describe('LokiDatasource', () => {
       });
     });
 
-    it('should return series data', done => {
+    it('should run only range query in Dashboard', done => {
+      const ds = createLokiDSForTests();
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: '{job="grafana"}', refId: 'B' }],
+      });
+
+      ds.runInstantQuery = jest.fn(() => of({ data: [] }));
+      ds.runRangeQuery = jest.fn(() => of({ data: [] }));
+
+      observableTester().subscribeAndExpectOnComplete<DataQueryResponse>({
+        observable: ds.query(options),
+        expect: () => {
+          expect(ds.runRangeQuery).toBeCalled();
+        },
+        done,
+      });
+    });
+
+    it('should return series data for both queries in Explore', done => {
       const ds = createLokiDSForTests();
       const options = getQueryOptions<LokiQuery>({
         targets: [{ expr: '{job="grafana"} |= "foo"', refId: 'B' }],
+        app: CoreApp.Explore,
       });
 
       observableTester().subscribeAndExpectOnNext<DataQueryResponse>({
@@ -213,6 +241,28 @@ describe('LokiDatasource', () => {
 
       observableTester().subscribeAndExpectOnNext<DataQueryResponse>({
         observable: ds.query(options).pipe(last()), // last result always comes from runRangeQuery
+        expect: res => {
+          const dataFrame = res.data[0] as DataFrame;
+          const fieldCache = new FieldCache(dataFrame);
+          expect(fieldCache.getFieldByName('line')?.values.get(0)).toBe('hello');
+          expect(dataFrame.meta?.limit).toBe(20);
+          expect(dataFrame.meta?.searchWords).toEqual(['foo']);
+        },
+        done,
+      });
+
+      fetchStream.next(testResponse);
+      fetchStream.next(omit(testResponse, 'data.status'));
+    });
+
+    it('should return series data for range query in Dashboard', done => {
+      const ds = createLokiDSForTests();
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: '{job="grafana"} |= "foo"', refId: 'B' }],
+      });
+
+      observableTester().subscribeAndExpectOnNext<DataQueryResponse>({
+        observable: ds.query(options).pipe(first()), // first result will come from runRangeQuery
         expect: res => {
           const dataFrame = res.data[0] as DataFrame;
           const fieldCache = new FieldCache(dataFrame);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -94,13 +94,12 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
         expr: this.templateSrv.replace(target.expr, options.scopedVars, this.interpolateQueryExpr),
       }));
 
-    filteredTargets.forEach(target => {
-      // Run instant queries only in Explore
+    for (const target of filteredTargets) {
       if (options.app === CoreApp.Explore) {
         subQueries.push(this.runInstantQuery(target, options, filteredTargets.length));
       }
       subQueries.push(this.runRangeQuery(target, options, filteredTargets.length));
-    });
+    }
 
     // No valid targets, return the empty result to save a round trip.
     if (isEmpty(subQueries)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Following up on https://github.com/grafana/grafana/issues/27860 and our discussion, this PR removes running of instant queries in dashboard (regression in 7.2 by https://github.com/grafana/grafana/pull/27213)

Fixes https://github.com/grafana/grafana/issues/27860

