### PR TITLE
Use read_api scope for GitLab OAuth

### DIFF
--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -31,9 +31,9 @@ instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
 http://203.0.113.31:3000/login/gitlab
 ```
 
-Finally, select *api* as the *Scope* and submit the form. Note that if you're
+Finally, select *read_api* as the *Scope* and submit the form. Note that if you're
 not going to use GitLab groups for authorization (i.e. not setting
-`allowed_groups`, see below), you can select *read_user* instead of *api* as
+`allowed_groups`, see below), you can select *read_user* instead of *read_api* as
 the *Scope*, thus giving a more restricted access to your GitLab API.
 
 You'll get an *Application Id* and a *Secret* in return; we'll call them


### PR DESCRIPTION
Hi Team!

`read_api` seems to be the minimal scope currently which can be used, it shall be preferred over `api` which grants complete read/write access.

- https://gitlab.com/gitlab-org/gitlab/-/merge_requests/28944#note_322904691
- https://gitlab.com/gitlab-org/gitlab/-/issues/21909

![gitlab_scopes](https://user-images.githubusercontent.com/30344579/94839149-23b03f00-0406-11eb-85c0-e531c60ab2a1.png)

`read_api` is also more permissive than required apparently, `openid`/`profile` seem to be the way forward: https://github.com/grafana/grafana/issues/25573

Thanks!