### PR TITLE
Settings: Rename constants/variables to follow Go naming standards

### DIFF
--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -101,7 +101,7 @@ func Error(status int, message string, err error) *NormalResponse {
 	}
 
 	if err != nil {
-		if setting.Env != setting.PROD {
+		if setting.Env != setting.Prod {
 			data["error"] = err.Error()
 		}
 	}

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -235,7 +235,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		},
 		"featureToggles":    hs.Cfg.FeatureToggles,
 		"rendererAvailable": hs.RenderService.IsAvailable(),
-		"http2Enabled":      hs.Cfg.Protocol == setting.HTTP2,
+		"http2Enabled":      hs.Cfg.Protocol == setting.HTTP2Scheme,
 	}
 
 	return jsonObj, nil

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -106,11 +106,11 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 		Handler: hs.macaron,
 	}
 	switch setting.Protocol {
-	case setting.HTTP2:
+	case setting.HTTP2Scheme:
 		if err := hs.configureHttp2(); err != nil {
 			return err
 		}
-	case setting.HTTPS:
+	case setting.HTTPSScheme:
 		if err := hs.configureHttps(); err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	}()
 
 	switch setting.Protocol {
-	case setting.HTTP, setting.SOCKET:
+	case setting.HTTPScheme, setting.SocketScheme:
 		if err := hs.httpSrv.Serve(listener); err != nil {
 			if err == http.ErrServerClosed {
 				hs.log.Debug("server was shutdown gracefully")
@@ -146,7 +146,7 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 			}
 			return err
 		}
-	case setting.HTTP2, setting.HTTPS:
+	case setting.HTTP2Scheme, setting.HTTPSScheme:
 		if err := hs.httpSrv.ServeTLS(listener, setting.CertFile, setting.KeyFile); err != nil {
 			if err == http.ErrServerClosed {
 				hs.log.Debug("server was shutdown gracefully")
@@ -169,13 +169,13 @@ func (hs *HTTPServer) getListener() (net.Listener, error) {
 	}
 
 	switch setting.Protocol {
-	case setting.HTTP, setting.HTTPS, setting.HTTP2:
+	case setting.HTTPScheme, setting.HTTPSScheme, setting.HTTP2Scheme:
 		listener, err := net.Listen("tcp", hs.httpSrv.Addr)
 		if err != nil {
 			return nil, errutil.Wrapf(err, "failed to open listener on address %s", hs.httpSrv.Addr)
 		}
 		return listener, nil
-	case setting.SOCKET:
+	case setting.SocketScheme:
 		listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: setting.SocketPath, Net: "unix"})
 		if err != nil {
 			return nil, errutil.Wrapf(err, "failed to open listener for socket %s", setting.SocketPath)
@@ -437,7 +437,7 @@ func (hs *HTTPServer) mapStatic(m *macaron.Macaron, rootDir string, dir string, 
 		}
 	}
 
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		headers = func(c *macaron.Context) {
 			c.Resp.Header().Set("Cache-Control", "max-age=0, must-revalidate, no-cache")
 		}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -267,7 +267,7 @@ func rotateEndOfRequestFunc(ctx *models.ReqContext, authTokenService models.User
 }
 
 func WriteSessionCookie(ctx *models.ReqContext, value string, maxLifetime time.Duration) {
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		ctx.Logger.Info("New token", "unhashed token", value)
 	}
 
@@ -304,7 +304,8 @@ func AddDefaultResponseHeaders() macaron.Handler {
 
 // AddSecurityHeaders adds various HTTP(S) response headers that enable various security protections behaviors in the client's browser.
 func AddSecurityHeaders(w macaron.ResponseWriter) {
-	if (setting.Protocol == setting.HTTPS || setting.Protocol == setting.HTTP2) && setting.StrictTransportSecurity {
+	if (setting.Protocol == setting.HTTPSScheme || setting.Protocol == setting.HTTP2Scheme) &&
+		setting.StrictTransportSecurity {
 		strictHeaderValues := []string{fmt.Sprintf("max-age=%v", setting.StrictTransportSecurityMaxAge)}
 		if setting.StrictTransportSecurityPreload {
 			strictHeaderValues = append(strictHeaderValues, "preload")

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -61,7 +61,7 @@ func TestMiddleWareSecurityHeaders(t *testing.T) {
 
 		middlewareScenario(t, "middleware should add correct Strict-Transport-Security header", func(sc *scenarioContext) {
 			setting.StrictTransportSecurity = true
-			setting.Protocol = setting.HTTPS
+			setting.Protocol = setting.HTTPSScheme
 			setting.StrictTransportSecurityMaxAge = 64000
 			sc.fakeReq("GET", "/api/").exec()
 			So(sc.resp.Header().Get("Strict-Transport-Security"), ShouldEqual, "max-age=64000")

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -44,7 +44,7 @@ func resetGetTime() {
 }
 
 func TestMiddleWareSecurityHeaders(t *testing.T) {
-	setting.ERR_TEMPLATE_NAME = errorTemplate
+	setting.ErrTemplateName = errorTemplate
 
 	Convey("Given the grafana middleware", t, func() {
 		middlewareScenario(t, "middleware should get correct x-xss-protection header", func(sc *scenarioContext) {
@@ -76,7 +76,7 @@ func TestMiddleWareSecurityHeaders(t *testing.T) {
 }
 
 func TestMiddlewareContext(t *testing.T) {
-	setting.ERR_TEMPLATE_NAME = errorTemplate
+	setting.ErrTemplateName = errorTemplate
 
 	Convey("Given the grafana middleware", t, func() {
 		middlewareScenario(t, "middleware should add context to injector", func(sc *scenarioContext) {

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -130,7 +130,7 @@ func Recovery() macaron.Handler {
 				c.Data["AppSubUrl"] = setting.AppSubUrl
 				c.Data["Theme"] = setting.DefaultTheme
 
-				if setting.Env == setting.DEV {
+				if setting.Env == setting.Dev {
 					if theErr, ok := err.(error); ok {
 						c.Data["Title"] = theErr.Error()
 					}
@@ -152,7 +152,7 @@ func Recovery() macaron.Handler {
 
 					c.JSON(500, resp)
 				} else {
-					c.HTML(500, setting.ERR_TEMPLATE_NAME)
+					c.HTML(500, setting.ErrTemplateName)
 				}
 			}
 		}()

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRecoveryMiddleware(t *testing.T) {
-	setting.ERR_TEMPLATE_NAME = "error-template"
+	setting.ErrTemplateName = "error-template"
 
 	Convey("Given an api route that panics", t, func() {
 		apiURL := "/api/whatever"

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -25,7 +25,7 @@ type ReqContext struct {
 func (ctx *ReqContext) Handle(status int, title string, err error) {
 	if err != nil {
 		ctx.Logger.Error(title, "error", err)
-		if setting.Env != setting.PROD {
+		if setting.Env != setting.Prod {
 			ctx.Data["ErrorMsg"] = err
 		}
 	}
@@ -34,7 +34,7 @@ func (ctx *ReqContext) Handle(status int, title string, err error) {
 	ctx.Data["AppSubUrl"] = setting.AppSubUrl
 	ctx.Data["Theme"] = "dark"
 
-	ctx.HTML(status, setting.ERR_TEMPLATE_NAME)
+	ctx.HTML(status, setting.ErrTemplateName)
 }
 
 func (ctx *ReqContext) JsonOK(message string) {
@@ -52,7 +52,7 @@ func (ctx *ReqContext) JsonApiErr(status int, message string, err error) {
 
 	if err != nil {
 		ctx.Logger.Error(message, "error", err)
-		if setting.Env != setting.PROD {
+		if setting.Env != setting.Prod {
 			resp["error"] = err.Error()
 		}
 	}

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -294,7 +294,7 @@ func (scanner *PluginScanner) loadPlugin(pluginJsonFilePath string) error {
 						break
 					}
 				}
-				if setting.Env != setting.DEV && !allowUnsigned {
+				if setting.Env != setting.Dev && !allowUnsigned {
 					return fmt.Errorf("plugin %q is unsigned", pluginCommon.Id)
 				}
 				scanner.log.Warn("Running an unsigned backend plugin", "pluginID", pluginCommon.Id, "pluginDir", pluginCommon.PluginDir)

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -29,7 +29,7 @@ func TestPluginManager_Init(t *testing.T) {
 	setting.StaticRootPath, err = filepath.Abs("../../public/")
 	require.NoError(t, err)
 	setting.Raw = ini.Empty()
-	setting.Env = setting.PROD
+	setting.Env = setting.Prod
 
 	t.Run("Base case", func(t *testing.T) {
 		pm := &PluginManager{

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -102,7 +102,7 @@ func (s *UserAuthTokenService) CreateToken(ctx context.Context, userId int64, cl
 
 func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
 	hashedToken := hashToken(unhashedToken)
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		s.log.Debug("looking up token", "unhashed", unhashedToken, "hashed", hashedToken)
 	}
 

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -64,7 +64,7 @@ func (rs *RenderingService) Init() error {
 		// RendererCallbackUrl has already been passed, it won't generate an error.
 		u, _ := url.Parse(rs.Cfg.RendererCallbackUrl)
 		rs.domain = u.Hostname()
-	case setting.HttpAddr != setting.DEFAULT_HTTP_ADDR:
+	case setting.HttpAddr != setting.DefaultHTTPAddr:
 		rs.domain = setting.HttpAddr
 	default:
 		rs.domain = "localhost"
@@ -227,9 +227,9 @@ func (rs *RenderingService) getURL(path string) string {
 
 	protocol := setting.Protocol
 	switch setting.Protocol {
-	case setting.HTTP:
+	case setting.HTTPScheme:
 		protocol = "http"
-	case setting.HTTP2, setting.HTTPS:
+	case setting.HTTP2Scheme, setting.HTTPSScheme:
 		protocol = "https"
 	}
 

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -28,7 +28,7 @@ func TestGetUrl(t *testing.T) {
 		t.Run("And protocol HTTP configured should return expected path", func(t *testing.T) {
 			rs.Cfg.ServeFromSubPath = false
 			rs.Cfg.AppSubUrl = ""
-			setting.Protocol = setting.HTTP
+			setting.Protocol = setting.HTTPScheme
 			url := rs.getURL(path)
 			require.Equal(t, "http://localhost:3000/"+path+"&render=1", url)
 
@@ -43,7 +43,7 @@ func TestGetUrl(t *testing.T) {
 		t.Run("And protocol HTTPS configured should return expected path", func(t *testing.T) {
 			rs.Cfg.ServeFromSubPath = false
 			rs.Cfg.AppSubUrl = ""
-			setting.Protocol = setting.HTTPS
+			setting.Protocol = setting.HTTPSScheme
 			url := rs.getURL(path)
 			require.Equal(t, "https://localhost:3000/"+path+"&render=1", url)
 		})
@@ -51,7 +51,7 @@ func TestGetUrl(t *testing.T) {
 		t.Run("And protocol HTTP2 configured should return expected path", func(t *testing.T) {
 			rs.Cfg.ServeFromSubPath = false
 			rs.Cfg.AppSubUrl = ""
-			setting.Protocol = setting.HTTP2
+			setting.Protocol = setting.HTTP2Scheme
 			url := rs.getURL(path)
 			require.Equal(t, "https://localhost:3000/"+path+"&render=1", url)
 		})

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -33,11 +33,11 @@ const (
 )
 
 const (
-	redactedPassword string = "*********"
-	DefaultHTTPAddr         = "0.0.0.0"
-	Dev                     = "development"
-	Prod                    = "production"
-	Test                    = "test"
+	redactedPassword = "*********"
+	DefaultHTTPAddr  = "0.0.0.0"
+	Dev              = "development"
+	Prod             = "production"
+	Test             = "test"
 )
 
 var (

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -26,34 +26,33 @@ import (
 type Scheme string
 
 const (
-	HTTP              Scheme = "http"
-	HTTPS             Scheme = "https"
-	HTTP2             Scheme = "h2"
-	SOCKET            Scheme = "socket"
-	DEFAULT_HTTP_ADDR string = "0.0.0.0"
-	REDACTED_PASSWORD string = "*********"
+	HTTPScheme   Scheme = "http"
+	HTTPSScheme  Scheme = "https"
+	HTTP2Scheme  Scheme = "h2"
+	SocketScheme Scheme = "socket"
 )
 
 const (
-	DEV      = "development"
-	PROD     = "production"
-	TEST     = "test"
-	APP_NAME = "Grafana"
+	redactedPassword string = "*********"
+	DefaultHTTPAddr         = "0.0.0.0"
+	Dev                     = "development"
+	Prod                    = "production"
+	Test                    = "test"
 )
 
 var (
-	ERR_TEMPLATE_NAME = "error"
+	ErrTemplateName = "error"
 )
 
 // This constant corresponds to the default value for ldap_sync_ttl in .ini files
 // it is used for comparison and has to be kept in sync
 const (
-	AUTH_PROXY_SYNC_TTL = 60
+	AuthProxySyncTTL = 60
 )
 
 var (
 	// App settings.
-	Env              = DEV
+	Env              = Dev
 	AppUrl           string
 	AppSubUrl        string
 	ServeFromSubPath bool
@@ -371,7 +370,7 @@ func applyEnvVariableOverrides(file *ini.File) error {
 			if len(envValue) > 0 {
 				key.SetValue(envValue)
 				if shouldRedactKey(envKey) {
-					envValue = REDACTED_PASSWORD
+					envValue = redactedPassword
 				}
 				if shouldRedactURLKey(envKey) {
 					u, err := url.Parse(envValue)
@@ -439,7 +438,7 @@ func applyCommandLineDefaultProperties(props map[string]string, file *ini.File) 
 			if exists {
 				key.SetValue(value)
 				if shouldRedactKey(keyString) {
-					value = REDACTED_PASSWORD
+					value = redactedPassword
 				}
 				appliedCommandLineProperties = append(appliedCommandLineProperties, fmt.Sprintf("%s=%s", keyString, value))
 			}
@@ -664,7 +663,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	cfg.IsEnterprise = IsEnterprise
 	cfg.Packaging = Packaging
 
-	ApplicationName = APP_NAME
+	ApplicationName = "Grafana"
 
 	Env = valueAsString(iniFile.Section(""), "app_mode", "development")
 	InstanceName = valueAsString(iniFile.Section(""), "instance_name", "unknown_instance_name")
@@ -878,7 +877,7 @@ func (s *DynamicSection) Key(k string) *ini.Key {
 
 	key.SetValue(envValue)
 	if shouldRedactKey(envKey) {
-		envValue = REDACTED_PASSWORD
+		envValue = redactedPassword
 	}
 	s.Logger.Info("Config overridden from Environment variable", "var", fmt.Sprintf("%s=%s", envKey, envValue))
 
@@ -1015,7 +1014,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	ldapSyncVal := authProxy.Key("ldap_sync_ttl").MustInt()
 	syncVal := authProxy.Key("sync_ttl").MustInt()
 
-	if ldapSyncVal != AUTH_PROXY_SYNC_TTL {
+	if ldapSyncVal != AuthProxySyncTTL {
 		AuthProxySyncTtl = ldapSyncVal
 		cfg.Logger.Warn("[Deprecated] the configuration setting 'ldap_sync_ttl' is deprecated, please use 'sync_ttl' instead")
 	} else {
@@ -1128,26 +1127,26 @@ func readServerSettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.AppSubUrl = AppSubUrl
 	cfg.ServeFromSubPath = ServeFromSubPath
 
-	Protocol = HTTP
+	Protocol = HTTPScheme
 	protocolStr := valueAsString(server, "protocol", "http")
 
 	if protocolStr == "https" {
-		Protocol = HTTPS
+		Protocol = HTTPSScheme
 		CertFile = server.Key("cert_file").String()
 		KeyFile = server.Key("cert_key").String()
 	}
 	if protocolStr == "h2" {
-		Protocol = HTTP2
+		Protocol = HTTP2Scheme
 		CertFile = server.Key("cert_file").String()
 		KeyFile = server.Key("cert_key").String()
 	}
 	if protocolStr == "socket" {
-		Protocol = SOCKET
+		Protocol = SocketScheme
 		SocketPath = server.Key("socket").String()
 	}
 
 	Domain = valueAsString(server, "domain", "localhost")
-	HttpAddr = valueAsString(server, "http_addr", DEFAULT_HTTP_ADDR)
+	HttpAddr = valueAsString(server, "http_addr", DefaultHTTPAddr)
 	HttpPort = valueAsString(server, "http_port", "3000")
 	RouterLogging = server.Key("router_logging").MustBool(false)
 

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -153,7 +153,7 @@ func (e *AzureMonitorDatasource) buildQueries(queries []*tsdb.Query, timeRange *
 
 		target = params.Encode()
 
-		if setting.Env == setting.DEV {
+		if setting.Env == setting.Dev {
 			azlog.Debug("Azuremonitor request", "params", params)
 		}
 

--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -287,7 +287,7 @@ func (e *CloudMonitoringExecutor) buildQueries(tsdbQuery *tsdb.TsdbQuery) ([]*cl
 		sq.Target = target
 		sq.Params = params
 
-		if setting.Env == setting.DEV {
+		if setting.Env == setting.Dev {
 			slog.Debug("CloudMonitoring request", "params", params)
 		}
 

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -73,7 +73,7 @@ func (e *GraphiteExecutor) Query(ctx context.Context, dsInfo *models.DataSource,
 
 	formData["target"] = []string{target}
 
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		glog.Debug("Graphite request", "params", formData)
 	}
 
@@ -122,7 +122,7 @@ func (e *GraphiteExecutor) Query(ctx context.Context, dsInfo *models.DataSource,
 			Points: series.DataPoints,
 		})
 
-		if setting.Env == setting.DEV {
+		if setting.Env == setting.Dev {
 			glog.Debug("Graphite response", "target", series.Target, "datapoints", len(series.DataPoints))
 		}
 	}

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -64,7 +64,7 @@ func (e *InfluxDBExecutor) Query(ctx context.Context, dsInfo *models.DataSource,
 		return nil, err
 	}
 
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		glog.Debug("Influxdb query", "raw query", rawQuery)
 	}
 

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -29,7 +29,7 @@ func newMssqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoin
 	if err != nil {
 		return nil, err
 	}
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		logger.Debug("getEngine", "connection", cnnstr)
 	}
 

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -57,7 +57,7 @@ func newMysqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoin
 		cnnstr += "&tls=" + tlsConfigString
 	}
 
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		logger.Debug("getEngine", "connection", cnnstr)
 	}
 

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -50,7 +50,7 @@ func (e *OpenTsdbExecutor) Query(ctx context.Context, dsInfo *models.DataSource,
 		tsdbQuery.Queries = append(tsdbQuery.Queries, metric)
 	}
 
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		plog.Debug("OpenTsdb request", "params", tsdbQuery)
 	}
 

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -29,7 +29,7 @@ func newPostgresQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndp
 		return nil, err
 	}
 
-	if setting.Env == setting.DEV {
+	if setting.Env == setting.Dev {
 		logger.Debug("getEngine", "connection", cnnstr)
 	}
 

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -506,7 +506,7 @@ func (e *sqlQueryEndpoint) processRow(cfg *processCfg) error {
 
 		series.Points = append(series.Points, tsdb.TimePoint{value, null.FloatFrom(timestamp)})
 
-		if setting.Env == setting.DEV {
+		if setting.Env == setting.Dev {
 			e.log.Debug("Rows", "metric", metric, "time", timestamp, "value", value)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
In the settings package, rename constants and variables to follow Go [naming standards](https://github.com/golang/go/wiki/CodeReviewComments#initialisms).


