### PR TITLE
Fixes #27989 - support periods in ES annotation field names

### DIFF
--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -193,6 +193,8 @@ for annotation events.
 | Text     | Event description field.                                                                                                                   |
 | Tags     | Optional field name to use for event tags (can be an array or a CSV string).                                                               |
 
+Note: field names with dot characters (i.e. `.`) must be surrounded in quotes. For example: `item."field.with.dots".value`
+
 ## Querying Logs (BETA)
 
 > Only available in Grafana v6.3+.


### PR DESCRIPTION
This fix allows  elasticsearch annotation fields to have periods in field names. Users must use quotes around the fields with periods to prevent resolving sub-object fields.

For example
```
my."field.with.dots".value
```

Fixes #27989

This change allows users to reference fields with dots in them in the Elasticsearch annotation configuration by adding quotes around the portions of the value that should not have periods resolved as sub-objects.


Notes:

I adapted some code from another project in this PR and it may have to be re-written to be compatible with whatever open-source licensing requirements that code had. This is kind of a draft / proof-of-concept. If this looks good I can re-write the code.

Also, I couldn't find any tests that exercise the annotation query code. If it exists and I missed it let me know and I'll add some coverage for this change.