### PR TITLE
Runtime: Fix handling of short-lived background services

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -179,10 +179,10 @@ func (s *Server) Run() (err error) {
 			}
 
 			err := service.Run(s.context)
-			// Mark that we are in shutdown mode
-			// So no more services are started
-			s.shutdownInProgress = true
 			if err != nil {
+				// Mark that we are in shutdown mode
+				// So no more services are started
+				s.shutdownInProgress = true
 				if err != context.Canceled {
 					// Server has crashed.
 					s.log.Error("Stopped "+descriptor.Name, "reason", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves shutdown mode flag setting so that shutdown mode is not triggered when services shut down without returning an error.

**Which issue(s) this PR fixes**:

Fixes [#26364](https://github.com/grafana/grafana/issues/26364)

