### PR TITLE
Docs: Update Elasticsearch and InfluxDB logs info

### DIFF
--- a/docs/sources/features/datasources/elasticsearch.md
+++ b/docs/sources/features/datasources/elasticsearch.md
@@ -197,13 +197,8 @@ for annotation events.
 
 > Only available in Grafana v6.3+.
 
-Querying and displaying log data from Elasticsearch is available via [Explore]({{< relref "../../explore" >}}).
-
-![](/img/docs/v63/elasticsearch_explore_logs.png)
-
-Select the Elasticsearch data source, change to Logs using the Metrics/Logs switcher, and then optionally enter a lucene query into the query field to filter the log messages.
-
-Finally, press the `Enter` key or the `Run Query` button to display your logs.
+Querying and displaying log data from Elasticsearch is available in [Explore]({{< relref "../../explore" >}}), and in the [logs panel]({{< relref "../../panels/visualizations/logs-panel.md" >}}) in dashboards. 
+Select the Elasticsearch data source, and then optionally enter a lucene query to display your logs.
 
 ### Log Queries
 

--- a/docs/sources/features/datasources/influxdb.md
+++ b/docs/sources/features/datasources/influxdb.md
@@ -180,12 +180,8 @@ You can view the interpolated version of a query with the Query Inspector.
 
 > Only available in Grafana v6.3+.
 
-Querying and displaying log data from InfluxDB is available via [Explore]({{< relref "../../explore" >}}).
-
-![](/img/docs/v63/influxdb_explore_logs.png)
-
-Select the InfluxDB data source, change to Logs using the Metrics/Logs switcher,
-and then use the `Measurements/Fields` button to display your logs.
+Querying and displaying log data from InfluxDB is available in [Explore]({{< relref "../../explore" >}}), and in the [logs panel]({{< relref "../../panels/visualizations/logs-panel.md" >}}) in dashboards. 
+Select the InfluxDB data source, and then enter a query to display your logs.
 
 ### Log Queries
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a note to the Elasticsearch and InfluxDB data source documentation informing users of Grafana 7.1 [update](https://grafana.com/docs/grafana/latest/guides/whats-new-in-v7-1/#explore-modes-unified) where query modes were unified and the metrics/logs switcher was removed.

**Which issue(s) this PR fixes**:

Fixes [#27215](https://github.com/grafana/grafana/issues/27215)

