### PR TITLE
Auth: When auth.basic.enabled is set to false do not use grafana auth.

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -287,7 +287,7 @@
 # How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
 ;token_rotation_interval_minutes = 10
 
-# Set to true to disable the Grafana DB based login, useful if you are using LDAP, defaults to false
+# Set to true to disable the Grafana built-in username/password authentication. Useful if you are using LDAP. Defaults to false.
 ;disable_login = false
 
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -278,14 +278,17 @@
 # Login cookie name
 ;login_cookie_name = grafana_session
 
-# The maximum lifetime (duration) an authenticated user can be inactive before being required to login at next visit. Default is 7 days (7d). This setting should be expressed as a duration, e.g. 5m (minutes), 6h (hours), 10d (days), 2w (weeks), 1M (month). The lifetime resets at each successful token rotation 
-;login_maximum_inactive_lifetime_duration = 
+# The maximum lifetime (duration) an authenticated user can be inactive before being required to login at next visit. Default is 7 days (7d). This setting should be expressed as a duration, e.g. 5m (minutes), 6h (hours), 10d (days), 2w (weeks), 1M (month). The lifetime resets at each successful token rotation
+;login_maximum_inactive_lifetime_duration =
 
 # The maximum lifetime (duration) an authenticated user can be logged in since login time before being required to login. Default is 30 days (30d). This setting should be expressed as a duration, e.g. 5m (minutes), 6h (hours), 10d (days), 2w (weeks), 1M (month).
-;login_maximum_lifetime_duration = 
+;login_maximum_lifetime_duration =
 
 # How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
 ;token_rotation_interval_minutes = 10
+
+# Set to true to disable the Grafana DB based login, useful if you are using LDAP, defaults to false
+;disable_login = false
 
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
 ;disable_login_form = false

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -197,7 +197,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 	}
 	if err != nil {
 		response = Error(401, "Invalid username or password", err)
-		if err == login.ErrInvalidCredentials || err == login.ErrTooManyLoginAttempts || err == models.ErrUserNotFound {
+		if err == login.ErrInvalidCredentials || err == login.ErrTooManyLoginAttempts || err == models.ErrUserNotFound || err == login.ErrNoAuthProvider {
 			return response
 		}
 

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -40,8 +40,8 @@ func AuthenticateUser(query *models.LoginUserQuery) error {
 		return err
 	}
 
-	basicAuthEnabled, err := loginUsingGrafanaDB(query)
-	if basicAuthEnabled && (err == nil || (err != models.ErrUserNotFound && err != ErrInvalidCredentials && err != ErrUserDisabled)) {
+	loginEnabled, err := loginUsingGrafanaDB(query)
+	if loginEnabled && (err == nil || (err != models.ErrUserNotFound && err != ErrInvalidCredentials && err != ErrUserDisabled)) {
 		query.AuthModule = "grafana"
 		return err
 	}
@@ -57,7 +57,7 @@ func AuthenticateUser(query *models.LoginUserQuery) error {
 			err = ldapErr
 		}
 	}
-	if !basicAuthEnabled && !ldapEnabled {
+	if !loginEnabled && !ldapEnabled {
 		return ErrNoAuthProvider
 	}
 

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -41,7 +41,7 @@ func AuthenticateUser(query *models.LoginUserQuery) error {
 	}
 
 	basicAuthEnabled, err := loginUsingGrafanaDB(query)
-	if err == nil || (err != models.ErrUserNotFound && err != ErrInvalidCredentials && err != ErrUserDisabled) {
+	if basicAuthEnabled && (err == nil || (err != models.ErrUserNotFound && err != ErrInvalidCredentials && err != ErrUserDisabled)) {
 		query.AuthModule = "grafana"
 		return err
 	}

--- a/pkg/login/grafana_login.go
+++ b/pkg/login/grafana_login.go
@@ -25,7 +25,7 @@ var validatePassword = func(providedPassword string, userPassword string, userSa
 }
 
 var loginUsingGrafanaDB = func(query *models.LoginUserQuery) (bool, error) {
-	if isLoginDisabled() {
+	if setting.DisableLogin {
 		return false, nil
 	}
 	userQuery := models.GetUserByLoginQuery{LoginOrEmail: query.Username}

--- a/pkg/login/grafana_login.go
+++ b/pkg/login/grafana_login.go
@@ -5,12 +5,9 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
-
-// isLoginDisabled checks if Basic Auth is enabled
-var isLoginDisabled = auth.IsLoginDisabled
 
 var validatePassword = func(providedPassword string, userPassword string, userSalt string) error {
 	passwordHashed, err := util.EncodePassword(providedPassword, userSalt)

--- a/pkg/login/grafana_login.go
+++ b/pkg/login/grafana_login.go
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// isBasicAuthEnabled checks if Basic Auth is enabled
-var isBasicAuthEnabled = auth.IsBasicAuthEnabled
+// isLoginDisabled checks if Basic Auth is enabled
+var isLoginDisabled = auth.IsLoginDisabled
 
 var validatePassword = func(providedPassword string, userPassword string, userSalt string) error {
 	passwordHashed, err := util.EncodePassword(providedPassword, userSalt)
@@ -25,7 +25,7 @@ var validatePassword = func(providedPassword string, userPassword string, userSa
 }
 
 var loginUsingGrafanaDB = func(query *models.LoginUserQuery) (bool, error) {
-	if !isBasicAuthEnabled() {
+	if isLoginDisabled() {
 		return false, nil
 	}
 	userQuery := models.GetUserByLoginQuery{LoginOrEmail: query.Username}

--- a/pkg/login/grafana_login_test.go
+++ b/pkg/login/grafana_login_test.go
@@ -13,7 +13,7 @@ import (
 func TestGrafanaLogin(t *testing.T) {
 	Convey("Login using Grafana DB", t, func() {
 		grafanaLoginScenario("When login with non-existing user", func(sc *grafanaLoginScenarioContext) {
-			setting.BasicAuthEnabled = true
+			setting.DisableLogin = false
 			sc.withNonExistingUser()
 			enabled, err := loginUsingGrafanaDB(sc.loginUserQuery)
 
@@ -35,7 +35,7 @@ func TestGrafanaLogin(t *testing.T) {
 		})
 
 		grafanaLoginScenario("When login with invalid credentials", func(sc *grafanaLoginScenarioContext) {
-			setting.BasicAuthEnabled = true
+			setting.DisableLogin = false
 			sc.withInvalidPassword()
 			enabled, err := loginUsingGrafanaDB(sc.loginUserQuery)
 
@@ -57,7 +57,7 @@ func TestGrafanaLogin(t *testing.T) {
 		})
 
 		grafanaLoginScenario("When login with valid credentials", func(sc *grafanaLoginScenarioContext) {
-			setting.BasicAuthEnabled = true
+			setting.DisableLogin = false
 			sc.withValidCredentials()
 			enabled, err := loginUsingGrafanaDB(sc.loginUserQuery)
 
@@ -81,7 +81,7 @@ func TestGrafanaLogin(t *testing.T) {
 		})
 
 		grafanaLoginScenario("When login with disabled user", func(sc *grafanaLoginScenarioContext) {
-			setting.BasicAuthEnabled = true
+			setting.DisableLogin = false
 			sc.withDisabledUser()
 			enabled, err := loginUsingGrafanaDB(sc.loginUserQuery)
 
@@ -102,8 +102,8 @@ func TestGrafanaLogin(t *testing.T) {
 			})
 		})
 
-		grafanaLoginScenario("When basic auth is disabled", func(sc *grafanaLoginScenarioContext) {
-			setting.BasicAuthEnabled = false
+		grafanaLoginScenario("When login is disabled", func(sc *grafanaLoginScenarioContext) {
+			setting.DisableLogin = true
 			sc.withDisabledUser()
 			enabled, err := loginUsingGrafanaDB(sc.loginUserQuery)
 

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -41,6 +41,10 @@ func IsBasicAuthEnabled() bool {
 	return setting.BasicAuthEnabled
 }
 
+func IsLoginDisabled() bool {
+	return setting.DisableLogin
+}
+
 func (s *UserAuthTokenService) ActiveTokenCount(ctx context.Context) (int64, error) {
 	var count int64
 	var err error

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -37,14 +37,6 @@ func (s *UserAuthTokenService) Init() error {
 	return nil
 }
 
-func IsBasicAuthEnabled() bool {
-	return setting.BasicAuthEnabled
-}
-
-func IsLoginDisabled() bool {
-	return setting.DisableLogin
-}
-
 func (s *UserAuthTokenService) ActiveTokenCount(ctx context.Context) (int64, error) {
 	var count int64
 	var err error

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -37,6 +37,10 @@ func (s *UserAuthTokenService) Init() error {
 	return nil
 }
 
+func IsBasicAuthEnabled() bool {
+	return setting.BasicAuthEnabled
+}
+
 func (s *UserAuthTokenService) ActiveTokenCount(ctx context.Context) (int64, error) {
 	var count int64
 	var err error

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -129,6 +129,7 @@ var (
 	LoginHint               string
 	PasswordHint            string
 	DefaultTheme            string
+	DisableLogin            bool
 	DisableLoginForm        bool
 	DisableSignoutMenu      bool
 	SignoutRedirectUrl      string
@@ -984,6 +985,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 		cfg.TokenRotationIntervalMinutes = 2
 	}
 
+	DisableLogin = auth.Key("disable_login").MustBool(false)
 	DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
 	OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)


### PR DESCRIPTION
**What this PR does / why we need it**:
When LDAP auth is enabled and Basic auth is disabled it is still possible to log into a user that was created in the Grafana DB before LDAP was enabled. Now the grafana login will check to see if basic auth is enabled before checking the user against the database and return false if not enabled. If neither basic auth or ldap auth are enabled it will also return an error stating that there is no authentication provider enabled.

**Which issue(s) this PR fixes**:

Fixes #19964 



