### PR TITLE
CloudWatch: Add missing TransitGateway dimension

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -214,7 +214,7 @@ var dimensionsMap = map[string][]string{
 	"AWS/StorageGateway":    {"GatewayId", "GatewayName", "VolumeId"},
 	"AWS/Textract":          {},
 	"AWS/ThingsGraph":       {"FlowTemplateId", "StepName", "SystemTemplateId"},
-	"AWS/TransitGateway":    {"TransitGateway"},
+	"AWS/TransitGateway":    {"TransitGateway", "TransitGatewayAttachment"},
 	"AWS/Translate":         {"LanguagePair", "Operation"},
 	"AWS/TrustedAdvisor":    {},
 	"AWS/Usage":             {"Class", "Resource", "Service", "Type"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing TransitGatewayAttachment dimension to the AWS/TransitGateway namespace, as it was missing before.
**Which issue(s) this PR fixes**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #28053 

**Special notes for your reviewer**:

