### PR TITLE
Elasticsearch: Fix ad-hoc filter support for Raw Data query and new table panel

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -580,6 +580,9 @@ const createEmptyDataFrame = (
   const series = new MutableDataFrame({ fields: [] });
 
   series.addField({
+    config: {
+      filterable: true,
+    },
     name: timeField,
     type: FieldType.time,
   });
@@ -615,6 +618,9 @@ const createEmptyDataFrame = (
     }
 
     series.addField({
+      config: {
+        filterable: true,
+      },
       name: propName,
       type: FieldType.string,
     }).parse = (v: any) => {

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1152,6 +1152,47 @@ describe('ElasticResponse', () => {
     });
   });
 
+  describe('Raw Data Query', () => {
+    beforeEach(() => {
+      targets = [
+        {
+          refId: 'A',
+          metrics: [{ type: 'raw_data', id: '1' }],
+          bucketAggs: [],
+        },
+      ];
+
+      response = {
+        responses: [
+          {
+            hits: {
+              total: {
+                relation: 'eq',
+                value: 1,
+              },
+              hits: [
+                {
+                  _id: '1',
+                  _type: '_doc',
+                  _index: 'index',
+                  _source: { sourceProp: 'asd' },
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      result = new ElasticResponse(targets, response).getTimeSeries();
+    });
+
+    it('should create dataframes with filterable fields', () => {
+      for (const field of result.data[0].fields) {
+        expect(field.config.filterable).toBe(true);
+      }
+    });
+  });
+
   describe('simple logs query and count', () => {
     const targets: any = [
       {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds support for Ad-Hoc filter when displaying Raw Data queries in the new TablePanel.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #28054

**Special notes for your reviewer**:
Seems like numeric values are not handled correctly when using ad-hoc filters (https://github.com/grafana/grafana/issues/10710), I'm investigating on how to solve this and I'll create another PR.

