### PR TITLE
Automation: Adds github automation commands, and base architecture to build more automation on

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1,0 +1,22 @@
+[
+    {
+      "type": "label",
+      "name": "*question",
+      "action": "close",
+      "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/. See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
+    },
+    {
+      "type": "comment",
+      "name": "duplicate",
+      "allowUsers": [],
+      "action": "updateLabels",
+      "addLabel": "*duplicate"
+    },
+    {
+		"type": "label",
+		"name": "*duplicate",
+		"action": "close",
+		"comment": "Thanks for creating this issue! We figured it's covering the same as another one we already have. Thus, we closed this one as a duplicate. See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
+	}
+  ]
+  

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1,22 +1,21 @@
 [
-    {
-      "type": "label",
-      "name": "*question",
-      "action": "close",
-      "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/. See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
-    },
-    {
-      "type": "comment",
-      "name": "duplicate",
-      "allowUsers": [],
-      "action": "updateLabels",
-      "addLabel": "*duplicate"
-    },
-    {
-		"type": "label",
-		"name": "*duplicate",
-		"action": "close",
-		"comment": "Thanks for creating this issue! We figured it's covering the same as another one we already have. Thus, we closed this one as a duplicate. See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
-	}
-  ]
-  
+  {
+    "type": "label",
+    "name": "type/question",
+    "action": "close",
+    "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/. See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
+  },
+  {
+    "type": "comment",
+    "name": "duplicate",
+    "allowUsers": [],
+    "action": "updateLabels",
+    "addLabel": "*duplicate"
+  },
+  {
+    "type": "label",
+    "name": "type/duplicate",
+    "action": "close",
+    "comment": "Thanks for creating this issue! We figured it's covering the same as another one we already have. Thus, we closed this one as a duplicate. See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
+  }
+]

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -10,7 +10,7 @@
     "name": "duplicate",
     "allowUsers": [],
     "action": "updateLabels",
-    "addLabel": "*duplicate"
+    "addLabel": "type/duplicate"
   },
   {
     "type": "label",

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Run Commands
         uses: ./actions/commands
         with:
-          token: ${{secrets.GRAFANA_ISSUE_TRIAGE_BOT_TOKEN}}
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}
           config-path: commands

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,0 +1,24 @@
+name: Run commands when issues are labeled or comments added
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:
+          token: ${{secrets.GRAFANA_ISSUE_TRIAGE_BOT_TOKEN}}
+          config-path: commands


### PR DESCRIPTION
This adds the first very basic automation commands to close issues labeled type/question and type/duplicate. 

The exciting part is the foundation for adding more actions that can record metrics and perform further automation. Specifically interested in automating creating cherry pick PRs for each PR merged with cherry pick label. So we always have a fully backported release branch ready for release. 

Github action commands:
https://github.com/grafana/grafana-github-actions

In that repo there is telemetry collection that we can hook into, but commented out for now as we need to replace it with sending metrics and logs to Grafana cloud 

Based on: 
https://github.com/microsoft/vscode-github-triage-actions