### PR TITLE
Update bot comments

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -3,7 +3,7 @@
     "type": "label",
     "name": "type/question",
     "action": "close",
-    "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/). See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
+    "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/)."
   },
   {
     "type": "comment",
@@ -16,6 +16,6 @@
     "type": "label",
     "name": "type/duplicate",
     "action": "close",
-    "comment": "Thanks for creating this issue! We figured it's covering the same as another one we already have. Thus, we closed this one as a duplicate. See also our [issue reporting](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md#report-bugs) guidelines.\n\nHappy Coding!"
+    "comment": "Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue."
   }
 ]

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -3,7 +3,7 @@
     "type": "label",
     "name": "type/question",
     "action": "close",
-    "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/)."
+    "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/). To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {
     "type": "comment",
@@ -16,6 +16,6 @@
     "type": "label",
     "name": "type/duplicate",
     "action": "close",
-    "comment": "Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue."
+    "comment": "Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue.\n\nTo avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   }
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the comments for the grafanabot.

**Special notes for your reviewer**:

A couple of things that we might want to put back, but clarified/rephrased:

- “See also our issue reporting”: Why should they see this? Are we insinuating that they should’ve read the guidelines before posting? Are we suggesting that they might want to report a bug instead?
- “Happy coding”: The user that created the issue might not be a programmer. If we want to sign off the comment, we should have something that’s applicable to any contributor.