### PR TITLE
Bugfix: improved the way of checking if browser supports Intl.DateTimeFormat

### DIFF
--- a/packages/grafana-data/src/datetime/formats.ts
+++ b/packages/grafana-data/src/datetime/formats.ts
@@ -88,7 +88,7 @@ export function localTimeFormat(
   locale?: string | string[] | null,
   fallback?: string
 ): string {
-  if (!window.Intl) {
+  if (missingIntlDateTimeFormatSupport()) {
     return fallback ?? DEFAULT_SYSTEM_DATE_FORMAT;
   }
 
@@ -115,3 +115,7 @@ export function localTimeFormat(
 }
 
 export const systemDateFormats = new SystemDateFormatsState();
+
+const missingIntlDateTimeFormatSupport = (): boolean => {
+  return !('DateTimeFormat' in Intl) || !('formatToParts' in Intl.DateTimeFormat.prototype);
+};


### PR DESCRIPTION
**What this PR does / why we need it**:
I am improving the check if the browser supports Intl.DateTimeFormat. If it doesn't we will fallback to the default format. I looked into adding a polyfill for this but it was little bang for a too big buck. You can see that PR here: https://github.com/grafana/grafana/pull/28082

**Which issue(s) this PR fixes**:
Fixes #28070

**Special notes for your reviewer**:
I need help verifying this on a Samsung TV.
