### PR TITLE
Live: improve dashboard editing notifications

### DIFF
--- a/public/app/features/live/dashboard/DashboardChangedModal.tsx
+++ b/public/app/features/live/dashboard/DashboardChangedModal.tsx
@@ -71,6 +71,7 @@ export class DashboardChangedModal extends PureComponent<Props, State> {
         title="Dashboard Changed"
         icon="copy"
         onDismiss={this.onDismiss}
+        onClickBackdrop={() => {}}
         className={styles.modal}
       >
         <div>

--- a/public/app/features/live/dashboard/DashboardChangedModal.tsx
+++ b/public/app/features/live/dashboard/DashboardChangedModal.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Modal, stylesFactory, VerticalGroup } from '@grafana/ui';
+import { Modal, stylesFactory } from '@grafana/ui';
 import { css } from 'emotion';
 import { dashboardWatcher } from './dashboardWatcher';
 import { config } from '@grafana/runtime';
@@ -80,16 +80,14 @@ export class DashboardChangedModal extends PureComponent<Props, State> {
             <div>This dashboard has been modifed by another session</div>
           )}
           <br />
-          <VerticalGroup>
-            {options.map(opt => {
-              return (
-                <div key={opt.label} onClick={opt.action} className={styles.radioItem}>
-                  <h3>{opt.label}</h3>
-                  {opt.description}
-                </div>
-              );
-            })}
-          </VerticalGroup>
+          {options.map(opt => {
+            return (
+              <div key={opt.label} onClick={opt.action} className={styles.radioItem}>
+                <h3>{opt.label}</h3>
+                {opt.description}
+              </div>
+            );
+          })}
           <br />
         </div>
       </Modal>
@@ -104,9 +102,16 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
     radioItem: css`
       margin: 0;
-      margin-left: ${theme.spacing.md};
       font-size: ${theme.typography.size.sm};
       color: ${theme.colors.textWeak};
+      padding: 10px;
+      cursor: pointer;
+      width: 100%;
+
+      &:hover {
+        background: ${theme.colors.formCheckboxBgCheckedHover};
+        color: ${theme.colors.text};
+      }
     `,
   };
 });

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -23,6 +23,7 @@ class DashboardWatcher {
   uid?: string;
   ignoreSave?: boolean;
   editing = false;
+  lastEditing?: DashboardEvent;
 
   setEditingState(state: boolean) {
     const changed = (this.editing = state);
@@ -42,7 +43,8 @@ class DashboardWatcher {
       sessionId,
       uid: this.uid!,
       action: this.editing ? DashboardEventAction.EditingStarted : DashboardEventAction.EditingCanceled,
-      message: 'user (name)',
+      message: (window as any).grafanaBootData?.user?.name,
+      timestamp: Date.now(),
     };
     this.channel!.publish!(msg);
   }
@@ -77,6 +79,16 @@ class DashboardWatcher {
 
   ignoreNextSave() {
     this.ignoreSave = true;
+  }
+
+  getRecentEditingEvent() {
+    if (this.lastEditing && this.lastEditing.timestamp) {
+      const elapsed = Date.now() - this.lastEditing.timestamp;
+      if (elapsed > 5000) {
+        this.lastEditing = undefined;
+      }
+    }
+    return this.lastEditing;
   }
 
   observer = {
@@ -121,10 +133,15 @@ class DashboardWatcher {
               }
             } else if (showPopup) {
               if (action === DashboardEventAction.EditingStarted) {
-                appEvents.emit(AppEvents.alertWarning, [
-                  'Another session is editing this dashboard',
-                  event.message.message,
-                ]);
+                const editingEvent = event.message;
+                const recent = this.getRecentEditingEvent();
+                if (!recent || recent.message !== editingEvent.message) {
+                  appEvents.emit(AppEvents.alertWarning, [
+                    'Another session is editing this dashboard',
+                    editingEvent.message,
+                  ]);
+                }
+                this.lastEditing = editingEvent;
               }
             }
             return;

--- a/public/app/features/live/dashboard/types.ts
+++ b/public/app/features/live/dashboard/types.ts
@@ -11,4 +11,5 @@ export interface DashboardEvent {
   userId?: number;
   message?: string;
   sessionId?: string;
+  timestamp?: number;
 }


### PR DESCRIPTION
This PR makes two minor changes to the notifications:

1. adds styles to the popup
![image](https://user-images.githubusercontent.com/705951/95397568-65366380-08b8-11eb-82ef-142eb52c77d4.png)


2. only show one notification for each open session

You currently get a new notice for each session -- that can be ridiculous for those of use with poor window management skills :)

| Before | After |
|----|---|
| ![image](https://user-images.githubusercontent.com/705951/95396284-73cf4b80-08b5-11eb-85dc-01ba3ed4a79e.png) | ![image](https://user-images.githubusercontent.com/705951/95397443-11c41580-08b8-11eb-9f95-58e90828baba.png) |



