### PR TITLE
Variables: hides dropdown before refreshing starts

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
@@ -192,9 +192,9 @@ describe('options picker actions', () => {
         toggleOption({ option: options[1], forceSelect: true, clearOthers }),
         setCurrentVariableValue(toVariablePayload(variable, { option })),
         changeVariableProp(toVariablePayload(variable, { propName: 'queryValue', propValue: '' })),
+        hideOptions(),
         setCurrentVariableValue(toVariablePayload(variable, { option })),
-        updateLocation({ query: { 'var-Constant': ['B'] } }),
-        hideOptions()
+        updateLocation({ query: { 'var-Constant': ['B'] } })
       );
     });
   });
@@ -265,9 +265,9 @@ describe('options picker actions', () => {
       tester.thenDispatchedActionsShouldEqual(
         setCurrentVariableValue(toVariablePayload(variable, { option })),
         changeVariableProp(toVariablePayload(variable, { propName: 'queryValue', propValue: '' })),
+        hideOptions(),
         setCurrentVariableValue(toVariablePayload(variable, { option })),
-        updateLocation({ query: { 'var-Constant': [] } }),
-        hideOptions()
+        updateLocation({ query: { 'var-Constant': [] } })
       );
     });
   });
@@ -297,9 +297,9 @@ describe('options picker actions', () => {
       tester.thenDispatchedActionsShouldEqual(
         setCurrentVariableValue(toVariablePayload(variable, { option })),
         changeVariableProp(toVariablePayload(variable, { propName: 'queryValue', propValue: 'C' })),
+        hideOptions(),
         setCurrentVariableValue(toVariablePayload(variable, { option })),
-        updateLocation({ query: { 'var-Constant': [] } }),
-        hideOptions()
+        updateLocation({ query: { 'var-Constant': [] } })
       );
     });
   });

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -82,14 +82,15 @@ export const commitChangesToVariable = (): ThunkResult<void> => {
     dispatch(setCurrentVariableValue(toVariablePayload(existing, currentPayload)));
     dispatch(changeVariableProp(toVariablePayload(existing, searchQueryPayload)));
     const updated = getVariable<VariableWithMultiSupport>(picker.id, getState());
+    dispatch(hideOptions());
 
     if (getCurrentText(existing) === getCurrentText(updated)) {
-      return dispatch(hideOptions());
+      return;
     }
 
     const adapter = variableAdapters.get(updated.type);
     await adapter.setValue(updated, updated.current, true);
-    return dispatch(hideOptions());
+    return;
   };
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With slow variable queries the dropdown is opened until the user either clicks somewhere else or the variable refreshing is complete. This PR closes the picker as soon as possible.

**Which issue(s) this PR fixes**:
Relates #27746

**Special notes for your reviewer**:
One way to test this is PR is to:

1. Start a slow proxy (60s delay on every data source request) with `make devenv sources=slow_proxy_mac,prometheus`
2. Import this [dashboard](https://gist.github.com/hugohaggmark/067a470d697f91828c9b282836765d07)

