### PR TITLE
Table: don't format React components values

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEventHandler } from 'react';
+import React, { FC, MouseEventHandler, ReactElement } from 'react';
 import { DisplayValue, Field, formattedValueToString, LinkModel } from '@grafana/data';
 
 import { TableCellDisplayMode, TableCellProps } from './types';
@@ -10,7 +10,14 @@ export const DefaultCell: FC<TableCellProps> = props => {
   const { field, cell, tableStyles, row, cellProps } = props;
 
   const displayValue = field.display!(cell.value);
-  const value = formattedValueToString(displayValue);
+
+  let value: string | ReactElement;
+  if (React.isValidElement(cell.value)) {
+    value = cell.value;
+  } else {
+    value = formattedValueToString(displayValue);
+  }
+
   const cellStyle = getCellStyle(tableStyles, field, displayValue);
   const showFilters = field.config.filterable;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add a check in the `DefaultCell` component to not format React component values.

**Special notes for your reviewer:**:
With the [recent](https://github.com/grafana/grafana/pull/27306) string formatting update in the `DefaultCell` component, it wasn't possible to use the `Table` component with React components in cell like below: 
![image](https://user-images.githubusercontent.com/35176601/95460948-e7389200-0975-11eb-9335-4b11295ce61a.png)

It was displayed like this:
![image](https://user-images.githubusercontent.com/35176601/95460997-f91a3500-0975-11eb-9b61-299fbea8d4f0.png)



