### PR TITLE
Automation: Add sending metrics to Grafana Cloud

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -20,5 +20,6 @@ jobs:
       - name: Run Commands
         uses: ./actions/commands
         with:
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
           config-path: commands


### PR DESCRIPTION

Added support for sending metrics to our new github actions automation commands:
https://github.com/grafana/grafana-github-actions/commit/61a89878eec2cae0159d9b81e9c15cf6b38e2000