### PR TITLE
AzureMonitor: Pass through null values instead of setting 0

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -288,7 +288,7 @@ func (e *AzureMonitorDatasource) parseResponse(queryRes *tsdb.QueryResult, amr A
 			labels[md.Name.LocalizedValue] = md.Value
 		}
 
-		frame := data.NewFrameOfFieldTypes("", len(series.Data), data.FieldTypeTime, data.FieldTypeFloat64)
+		frame := data.NewFrameOfFieldTypes("", len(series.Data), data.FieldTypeTime, data.FieldTypeNullableFloat64)
 		frame.RefID = query.RefID
 		dataField := frame.Fields[1]
 		dataField.Name = amr.Value[0].Name.LocalizedValue
@@ -314,7 +314,7 @@ func (e *AzureMonitorDatasource) parseResponse(queryRes *tsdb.QueryResult, amr A
 		requestedAgg := query.Params.Get("aggregation")
 
 		for i, point := range series.Data {
-			var value float64
+			var value *float64
 			switch requestedAgg {
 			case "Average":
 				value = point.Average

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/stretchr/testify/require"
+	ptr "github.com/xorcare/pointer"
 )
 
 func TestAzureMonitorBuildQueries(t *testing.T) {
@@ -199,8 +200,8 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC), 5, time.Minute)),
-					data.NewField("Percentage CPU", nil, []float64{
-						2.0875, 2.1525, 2.155, 3.6925, 2.44,
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(2.0875), ptr.Float64(2.1525), ptr.Float64(2.155), ptr.Float64(3.6925), ptr.Float64(2.44),
 					}).SetConfig(&data.FieldConfig{Unit: "percent"})),
 			},
 		},
@@ -219,8 +220,8 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 13, 29, 0, 0, time.UTC), 5, time.Minute)),
-					data.NewField("Percentage CPU", nil, []float64{
-						8.26, 8.7, 14.82, 10.07, 8.52,
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(8.26), ptr.Float64(8.7), ptr.Float64(14.82), ptr.Float64(10.07), ptr.Float64(8.52),
 					}).SetConfig(&data.FieldConfig{Unit: "percent"})),
 			},
 		},
@@ -239,8 +240,8 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 14, 26, 0, 0, time.UTC), 5, time.Minute)),
-					data.NewField("Percentage CPU", nil, []float64{
-						3.07, 2.92, 2.87, 2.27, 2.52,
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(3.07), ptr.Float64(2.92), ptr.Float64(2.87), ptr.Float64(2.27), ptr.Float64(2.52),
 					}).SetConfig(&data.FieldConfig{Unit: "percent"})),
 			},
 		},
@@ -259,8 +260,8 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 14, 43, 0, 0, time.UTC), 5, time.Minute)),
-					data.NewField("Percentage CPU", nil, []float64{
-						1.51, 2.38, 1.69, 2.27, 1.96,
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(1.51), ptr.Float64(2.38), ptr.Float64(1.69), ptr.Float64(2.27), ptr.Float64(1.96),
 					}).SetConfig(&data.FieldConfig{Unit: "percent"})),
 			},
 		},
@@ -279,8 +280,8 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 14, 44, 0, 0, time.UTC), 5, time.Minute)),
-					data.NewField("Percentage CPU", nil, []float64{
-						4, 4, 4, 4, 4,
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(4), ptr.Float64(4), ptr.Float64(4), ptr.Float64(4), ptr.Float64(4),
 					}).SetConfig(&data.FieldConfig{Unit: "percent"})),
 			},
 		},
@@ -300,19 +301,19 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "PageBlob"},
-						[]float64{3, 3, 3, 3, 3, 0}).SetConfig(&data.FieldConfig{Unit: "short"})),
+						[]*float64{ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), nil}).SetConfig(&data.FieldConfig{Unit: "short"})),
 
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "BlockBlob"},
-						[]float64{1, 1, 1, 1, 1, 0}).SetConfig(&data.FieldConfig{Unit: "short"})),
+						[]*float64{ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), nil}).SetConfig(&data.FieldConfig{Unit: "short"})),
 
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "Azure Data Lake Storage"},
-						[]float64{0, 0, 0, 0, 0, 0}).SetConfig(&data.FieldConfig{Unit: "short"})),
+						[]*float64{ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), nil}).SetConfig(&data.FieldConfig{Unit: "short"})),
 			},
 		},
 		{
@@ -331,8 +332,8 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 13, 29, 0, 0, time.UTC), 5, time.Minute)),
-					data.NewField("Percentage CPU", nil, []float64{
-						8.26, 8.7, 14.82, 10.07, 8.52,
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(8.26), ptr.Float64(8.7), ptr.Float64(14.82), ptr.Float64(10.07), ptr.Float64(8.52),
 					}).SetConfig(&data.FieldConfig{Unit: "percent", DisplayName: "custom grafanastaging Microsoft.Compute/virtualMachines grafana Percentage CPU"})),
 			},
 		},
@@ -353,20 +354,20 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "PageBlob"},
-						[]float64{3, 3, 3, 3, 3, 0}).SetConfig(&data.FieldConfig{Unit: "short", DisplayName: "blobtype=PageBlob"})),
+						[]*float64{ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), nil}).SetConfig(&data.FieldConfig{Unit: "short", DisplayName: "blobtype=PageBlob"})),
 
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
-					data.NewField("Blob Count", data.Labels{"blobtype": "BlockBlob"}, []float64{
-						1, 1, 1, 1, 1, 0,
+					data.NewField("Blob Count", data.Labels{"blobtype": "BlockBlob"}, []*float64{
+						ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), nil,
 					}).SetConfig(&data.FieldConfig{Unit: "short", DisplayName: "blobtype=BlockBlob"})),
 
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
-					data.NewField("Blob Count", data.Labels{"blobtype": "Azure Data Lake Storage"}, []float64{
-						0, 0, 0, 0, 0, 0,
+					data.NewField("Blob Count", data.Labels{"blobtype": "Azure Data Lake Storage"}, []*float64{
+						ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), nil,
 					}).SetConfig(&data.FieldConfig{Unit: "short", DisplayName: "blobtype=Azure Data Lake Storage"})),
 			},
 		},
@@ -387,21 +388,21 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					data.NewField("", nil,
 						makeDates(time.Date(2020, 06, 30, 9, 58, 0, 0, time.UTC), 3, time.Hour)),
 					data.NewField("Blob Capacity", data.Labels{"blobtype": "PageBlob", "tier": "Standard"},
-						[]float64{675530, 675530, 675530}).SetConfig(
+						[]*float64{ptr.Float64(675530), ptr.Float64(675530), ptr.Float64(675530)}).SetConfig(
 						&data.FieldConfig{Unit: "decbytes", DisplayName: "danieltest {Blob Type=PageBlob, Tier=Standard}"})),
 
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2020, 06, 30, 9, 58, 0, 0, time.UTC), 3, time.Hour)),
 					data.NewField("Blob Capacity", data.Labels{"blobtype": "BlockBlob", "tier": "Hot"},
-						[]float64{0, 0, 0}).SetConfig(
+						[]*float64{ptr.Float64(0), ptr.Float64(0), ptr.Float64(0)}).SetConfig(
 						&data.FieldConfig{Unit: "decbytes", DisplayName: "danieltest {Blob Type=BlockBlob, Tier=Hot}"})),
 
 				data.NewFrame("",
 					data.NewField("", nil,
 						makeDates(time.Date(2020, 06, 30, 9, 58, 0, 0, time.UTC), 3, time.Hour)),
 					data.NewField("Blob Capacity", data.Labels{"blobtype": "Azure Data Lake Storage", "tier": "Cool"},
-						[]float64{0, 0, 0}).SetConfig(
+						[]*float64{ptr.Float64(0), ptr.Float64(0), ptr.Float64(0)}).SetConfig(
 						&data.FieldConfig{Unit: "decbytes", DisplayName: "danieltest {Blob Type=Azure Data Lake Storage, Tier=Cool}"})),
 			},
 		},
@@ -421,8 +422,8 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				data.NewFrame("",
 					data.NewField("", nil,
 						[]time.Time{time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC)}),
-					data.NewField("Percentage CPU", nil, []float64{
-						2.0875,
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(2.0875),
 					}).SetConfig(&data.FieldConfig{DisplayName: "custom"})),
 			},
 		},

--- a/pkg/tsdb/azuremonitor/types.go
+++ b/pkg/tsdb/azuremonitor/types.go
@@ -42,11 +42,11 @@ type AzureMonitorResponse struct {
 			} `json:"metadatavalues"`
 			Data []struct {
 				TimeStamp time.Time `json:"timeStamp"`
-				Average   float64   `json:"average,omitempty"`
-				Total     float64   `json:"total,omitempty"`
-				Count     float64   `json:"count,omitempty"`
-				Maximum   float64   `json:"maximum,omitempty"`
-				Minimum   float64   `json:"minimum,omitempty"`
+				Average   *float64  `json:"average,omitempty"`
+				Total     *float64  `json:"total,omitempty"`
+				Count     *float64  `json:"count,omitempty"`
+				Maximum   *float64  `json:"maximum,omitempty"`
+				Minimum   *float64  `json:"minimum,omitempty"`
 			} `json:"data"`
 		} `json:"timeseries"`
 	} `json:"value"`


### PR DESCRIPTION
**What this PR does / why we need it**:
For the Azure Monitor service in the Azure Monitor datasource, if values were null the backend set them to zero. They will now be null instead.

Before:
![image](https://user-images.githubusercontent.com/1692624/95499232-fff37880-0972-11eb-86c3-ad01f274f070.png)

After:
![image](https://user-images.githubusercontent.com/1692624/95499244-0681f000-0973-11eb-94e6-2520244a3cd8.png)

(One could still use "Null point mode: null as zero" if one wants to make it look like it did before)


**Which issue(s) this PR fixes**:

Fixes #28001

**Special notes for your reviewer**:

