### PR TITLE
Explore: Fix showing of Prometheus data in Query inspector

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -51,6 +51,8 @@ export const Tab = React.forwardRef<HTMLLIElement, TabProps>(
   }
 );
 
+Tab.displayName = 'Tab';
+
 const getTabStyles = stylesFactory((theme: GrafanaTheme) => {
   const colors = theme.colors;
 

--- a/public/app/features/explore/ExploreQueryInspector.test.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ExploreId } from 'app/types';
+import { ExploreDrawer } from 'app/features/explore/ExploreDrawer';
+import { TabbedContainer } from '@grafana/ui';
+import { ExploreQueryInspector, Props } from './ExploreQueryInspector';
+
+jest.mock('../dashboard/components/Inspector/styles', () => ({
+  getPanelInspectorStyles: () => ({}),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: () => ({
+    getInspectorStream: jest.fn().mockResolvedValue({
+      status: 1,
+      statusText: 'a',
+      ok: true,
+      headers: {} as any,
+      redirected: false,
+      type: 'basic',
+      url: 'www',
+      config: {
+        url: 'www',
+      },
+    }),
+  }),
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    user: { orgId: 1 },
+  },
+}));
+
+const setup = (propOverrides?: Partial<Props>) => {
+  const props: Props = {
+    loading: false,
+    width: 100,
+    exploreId: ExploreId.left,
+    onClose: jest.fn(),
+  };
+
+  Object.assign(props, propOverrides);
+
+  const wrapper = shallow(<ExploreQueryInspector {...props} />);
+  return wrapper;
+};
+
+describe('ExploreQueryInspector', () => {
+  it('should render reseizable ExploreDrawer component', () => {
+    const wrapper = setup();
+    expect(wrapper.find(ExploreDrawer)).toHaveLength(1);
+  });
+  it('should have 2 tabs', () => {
+    const wrapper = setup();
+    const tabbedContainer = wrapper.find(TabbedContainer) as any;
+    expect(tabbedContainer.props().tabs.length).toBe(2);
+  });
+});

--- a/public/app/features/explore/ExploreQueryInspector.test.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { Observable } from 'rxjs';
 import { ExploreId } from 'app/types';
 import { ExploreDrawer } from 'app/features/explore/ExploreDrawer';
-import { TabbedContainer, Button } from '@grafana/ui';
+import { TabbedContainer, Button, Tab } from '@grafana/ui';
 import { TimeRange, LoadingState } from '@grafana/data';
 import { ExploreQueryInspector, Props } from './ExploreQueryInspector';
 
@@ -69,17 +69,21 @@ describe('ExploreQueryInspector', () => {
     const wrapper = setup();
     expect(wrapper.find(ExploreDrawer)).toHaveLength(1);
   });
-  it('should render reseizable TabbedContainer component', () => {
+  it('should render 2 Tabs component', () => {
     const wrapper = setup();
-    expect(wrapper.find(TabbedContainer)).toHaveLength(1);
+    expect(wrapper.find(Tab)).toHaveLength(2);
   });
-  it('should have collected query data', () => {
+  it('should be possible to switch between tabs and see tab-specific content', () => {
     const wrapper = setup();
     const queryInspctorTab = wrapper.find('[aria-label="Tab Query Inspector"]');
     queryInspctorTab.simulate('click');
-    expect(wrapper.html()).toContain('Expand all');
+    expect(
+      wrapper.find(Button).findWhere(n => {
+        return n.text() === 'Expand all' && n.type() === Button;
+      })
+    ).toHaveLength(1);
   });
-  it('should have collected query data', () => {
+  it('should display query data', () => {
     const wrapper = setup();
     const queryInspectorTab = wrapper.find('[aria-label="Tab Query Inspector"]');
     queryInspectorTab.simulate('click');

--- a/public/app/features/explore/ExploreQueryInspector.test.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.test.tsx
@@ -3,9 +3,29 @@ import { mount } from 'enzyme';
 import { Observable } from 'rxjs';
 import { ExploreId } from 'app/types';
 import { ExploreDrawer } from 'app/features/explore/ExploreDrawer';
-import { TabbedContainer, Button, Tab } from '@grafana/ui';
+import { Button, Tab } from '@grafana/ui';
 import { TimeRange, LoadingState } from '@grafana/data';
 import { ExploreQueryInspector, Props } from './ExploreQueryInspector';
+
+const response = (hideFromInspector = false) => ({
+  status: 1,
+  statusText: '',
+  ok: true,
+  headers: {} as any,
+  redirected: false,
+  type: 'basic',
+  url: '',
+  request: {} as any,
+  data: {
+    test: {
+      testKey: 'Very unique test value',
+    },
+  },
+  config: {
+    url: '',
+    hideFromInspector,
+  },
+});
 
 jest.mock('../dashboard/components/Inspector/styles', () => ({
   getPanelInspectorStyles: () => ({}),
@@ -15,26 +35,8 @@ jest.mock('app/core/services/backend_srv', () => ({
   getBackendSrv: () => ({
     getInspectorStream: () =>
       new Observable(subscriber => {
-        const response = {
-          status: 1,
-          statusText: '',
-          ok: true,
-          headers: {} as any,
-          redirected: false,
-          type: 'basic',
-          url: '',
-          request: {} as any,
-          data: {
-            test: {
-              testKey: 'Very unique test value',
-            },
-          },
-          config: {
-            url: '',
-            hideFromInspector: false,
-          },
-        };
-        subscriber.next(response);
+        subscriber.next(response());
+        subscriber.next(response(true));
       }) as any,
   }),
 }));
@@ -72,16 +74,6 @@ describe('ExploreQueryInspector', () => {
   it('should render 2 Tabs component', () => {
     const wrapper = setup();
     expect(wrapper.find(Tab)).toHaveLength(2);
-  });
-  it('should be possible to switch between tabs and see tab-specific content', () => {
-    const wrapper = setup();
-    const queryInspctorTab = wrapper.find('[aria-label="Tab Query Inspector"]');
-    queryInspctorTab.simulate('click');
-    expect(
-      wrapper.find(Button).findWhere(n => {
-        return n.text() === 'Expand all' && n.type() === Button;
-      })
-    ).toHaveLength(1);
   });
   it('should display query data', () => {
     const wrapper = setup();

--- a/public/app/features/explore/ExploreQueryInspector.test.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.test.tsx
@@ -46,12 +46,12 @@ const setup = () => {
 describe('ExploreQueryInspector', () => {
   it('should render closable drawer component', () => {
     setup();
-    expect(screen.getAllByTitle(/close query inspector/i)).toHaveLength(1);
+    expect(screen.getByTitle(/close query inspector/i)).toBeInTheDocument();
   });
   it('should render 2 Tabs', () => {
     setup();
-    expect(screen.getAllByLabelText(/tab stats/i)).toHaveLength(1);
-    expect(screen.getAllByLabelText(/tab query inspector/i)).toHaveLength(1);
+    expect(screen.getByLabelText(/tab stats/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/tab query inspector/i)).toBeInTheDocument();
   });
   it('should display query data', () => {
     setup();

--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -14,9 +14,9 @@ import { InspectStatsTab } from '../dashboard/components/Inspector/InspectStatsT
 import { getPanelInspectorStyles } from '../dashboard/components/Inspector/styles';
 
 function stripPropsFromResponse(response: any) {
-  // ignore silent requests
+  // ignore silent requests and return early
   if (response.config?.hideFromInspector) {
-    return {};
+    return;
   }
 
   const clonedResponse = { ...response }; // clone - dont modify the response
@@ -57,7 +57,7 @@ function stripPropsFromResponse(response: any) {
   return clonedResponse;
 }
 
-interface Props {
+export interface Props {
   loading: boolean;
   width: number;
   exploreId: ExploreId;
@@ -65,7 +65,7 @@ interface Props {
   onClose: () => void;
 }
 
-function ExploreQueryInspector(props: Props) {
+export function ExploreQueryInspector(props: Props) {
   const [formattedJSON, setFormattedJSON] = useState({});
 
   const getTextForClipboard = () => {
@@ -98,7 +98,9 @@ function ExploreQueryInspector(props: Props) {
       .getInspectorStream()
       .subscribe(resp => {
         const strippedResponse = stripPropsFromResponse(resp);
-        setResponse(strippedResponse);
+        if (strippedResponse) {
+          setResponse(strippedResponse);
+        }
       });
 
     return () => {

--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -57,7 +57,7 @@ function stripPropsFromResponse(response: any) {
   return clonedResponse;
 }
 
-export interface Props {
+interface Props {
   loading: boolean;
   width: number;
   exploreId: ExploreId;

--- a/public/app/features/explore/ExploreQueryInspector.tsx
+++ b/public/app/features/explore/ExploreQueryInspector.tsx
@@ -110,7 +110,6 @@ export function ExploreQueryInspector(props: Props) {
 
   const haveData = response && Object.keys(response).length > 0;
   const styles = getPanelInspectorStyles();
-
   const statsTab: TabConfig = {
     label: 'Stats',
     value: 'stats',


### PR DESCRIPTION
**What this PR does / why we need it**:
When running Prometheus queries in Explore, the request and response wasn't shown in Inspector panel because if we have received response with `hideFromInspector === true` after, the result was overwritten. This PR fixes it. 

**Fixed:** 
![after](https://user-images.githubusercontent.com/30407135/95504479-13233a00-09ad-11eb-8ef8-d5489bd62976.gif)

**Before:**
![before](https://user-images.githubusercontent.com/30407135/95504619-51205e00-09ad-11eb-9a5d-9bc4db70ee6f.gif)



