### PR TITLE
Fix: Dynamically add ShowWhen fields to the form watch

### DIFF
--- a/public/app/features/alerting/components/NotificationChannelForm.tsx
+++ b/public/app/features/alerting/components/NotificationChannelForm.tsx
@@ -36,9 +36,22 @@ export const NotificationChannelForm: FC<Props> = ({
 }) => {
   const styles = getStyles(useTheme());
 
+  /*
+   Finds fields that have dependencies on other fields and removes duplicates.
+   Needs to be prefixed with settings.
+  */
+  const fieldsToWatch =
+    new Set(
+      selectedChannel?.options
+        .filter(o => o.showWhen.field)
+        .map(option => {
+          return `settings.${option.showWhen.field}`;
+        })
+    ) || [];
+
   useEffect(() => {
-    watch(['type', 'settings.priority', 'sendReminder', 'uploadImage']);
-  }, []);
+    watch(['type', 'sendReminder', 'uploadImage', ...fieldsToWatch]);
+  }, [fieldsToWatch]);
 
   const currentFormValues = getValues();
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Dynamically add fields to be watched by the Form component.

**Which issue(s) this PR fixes**:

Fixes #28132

**Special notes for your reviewer**:

