### PR TITLE
Cloudwatch: Fix regression with profile datasource field

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -115,7 +115,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const { options } = this.props;
     const secureJsonData = (options.secureJsonData || {}) as CloudWatchSecureJsonData;
     let profile = options.jsonData.profile;
-    if (!profile) {
+    if (profile === undefined) {
       profile = options.database;
     }
 

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -24,7 +24,6 @@ export type Props = DataSourcePluginOptionsEditorProps<CloudWatchJsonData, Cloud
 
 export interface State {
   regions: SelectableValue[];
-  profile: string;
 }
 
 export class ConfigEditor extends PureComponent<Props, State> {
@@ -33,7 +32,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
 
     this.state = {
       regions: [],
-      profile: '',
     };
   }
 
@@ -45,14 +43,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
       if (isCanceled) {
         console.warn('Cloud Watch ConfigEditor has unmounted, initialization was canceled');
       }
-    });
-
-    let profile = this.props.options.jsonData.profile;
-    if (!profile) {
-      profile = this.props.options.database;
-    }
-    this.setState({
-      profile: profile,
     });
   }
 
@@ -124,6 +114,10 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const { regions } = this.state;
     const { options } = this.props;
     const secureJsonData = (options.secureJsonData || {}) as CloudWatchSecureJsonData;
+    let profile = options.jsonData.profile;
+    if (!profile) {
+      profile = options.database;
+    }
 
     return (
       <>
@@ -160,7 +154,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
                   <Input
                     className="width-30"
                     placeholder="default"
-                    value={options.jsonData.profile}
+                    value={profile}
                     onChange={onUpdateDatasourceJsonDataOption(this.props, 'profile')}
                   />
                 </div>

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -24,6 +24,7 @@ export type Props = DataSourcePluginOptionsEditorProps<CloudWatchJsonData, Cloud
 
 export interface State {
   regions: SelectableValue[];
+  profile: string;
 }
 
 export class ConfigEditor extends PureComponent<Props, State> {
@@ -32,6 +33,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
 
     this.state = {
       regions: [],
+      profile: '',
     };
   }
 
@@ -43,6 +45,14 @@ export class ConfigEditor extends PureComponent<Props, State> {
       if (isCanceled) {
         console.warn('Cloud Watch ConfigEditor has unmounted, initialization was canceled');
       }
+    });
+
+    let profile = this.props.options.jsonData.profile;
+    if (!profile) {
+      profile = this.props.options.database;
+    }
+    this.setState({
+      profile: profile,
     });
   }
 
@@ -114,10 +124,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const { regions } = this.state;
     const { options } = this.props;
     const secureJsonData = (options.secureJsonData || {}) as CloudWatchSecureJsonData;
-    let profile = options.jsonData.profile;
-    if (!profile) {
-      profile = options.database;
-    }
 
     return (
       <>
@@ -154,7 +160,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
                   <Input
                     className="width-30"
                     placeholder="default"
-                    value={profile}
+                    value={options.jsonData.profile}
                     onChange={onUpdateDatasourceJsonDataOption(this.props, 'profile')}
                   />
                 </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes the regression shown in [this](https://drive.google.com/file/d/1r-PnfsbVtM7XDbIKg5gq2tj3LiFMla05/view?usp=sharing) video caused by [this](https://github.com/grafana/grafana/pull/27684) when both the old `database` field and the new one `profile` (under JSON data) are present and try to change the profile.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

