### PR TITLE
Automation: Adds github action to collect issue metrics

### DIFF
--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -1,0 +1,22 @@
+name: Collect metrics when issue is closed
+on:
+  issues:
+    types: [opened, closed]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run metrics collector
+        uses: ./actions/metrics-collector
+        with:
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}


### PR DESCRIPTION
Added a very simple action to collect metrics when issues are closed & opened:

https://github.com/grafana/grafana-github-actions/blob/main/metrics-collector/index.ts

This action runs when issues are opened & closed. 

Next step would be to have this run like very 10minutes as well and collect number of unlabeled issues, number of "needs investigation" and number of "needs more info". So we can track that over time. And collect number of issues in milestones! 