### PR TITLE
GitHub Actions: Run metrics collector workflow every 10min

### DIFF
--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -1,7 +1,19 @@
+#
+# When triggered by the cron job it will also collect metrics for:
+#  * number of issues without label
+#  * number of issues with "needs more info"
+#  * number of issues with "needs investigation"
+#  * number of issues with label type/bug
+#  * number of open issues in current milestone
+#
+# https://github.com/grafana/grafana-github-actions/blob/main/metrics-collector/index.ts
+#
 name: Collect metrics when issue is closed
 on:
   issues:
     types: [opened, closed]
+  schedule:
+    - cron: */10 * * * * # Every 10 minutes
 
 jobs:
   main:


### PR DESCRIPTION
Added some metrics collection to the metrics collector: 

https://github.com/grafana/grafana-github-actions/blob/main/metrics-collector/index.ts

Not sure what the best frequency for this is 