### PR TITLE
Docs: Add view settings and view stats

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -17,6 +17,8 @@ Grafana has a number of configuration options that you can specify in a `.ini` c
 
 > **Note:** You must restart Grafana for any configuration changes to take effect.
 
+To see all settings currently applied to the Grafana server, refer to [View server settings]({{< relref "view-server-settings.md" >}}).
+
 ## Config file locations
 
 _Do not_ change `defaults.ini`! Grafana defaults are stored in this file. Depending on your OS, make all configuration changes in either `custom.ini` or `grafana.ini`.
@@ -89,9 +91,7 @@ export GF_PLUGIN_GRAFANA_IMAGE_RENDERER_RENDERING_IGNORE_HTTPS_ERRORS=true
 
 ## Variable expansion
 
-> Only available in Grafana 7.1+.
-
-> For any changes to `conf/grafana.ini` (or corresponding environment variables) to take effect, you must restart Grafana.
+> **Note:** Only available in Grafana 7.1+.
 
 If any of your options contains the expression `$__<provider>{<argument>}`
 or `${<environment variable>}`, then they will be processed by Grafana's

--- a/docs/sources/administration/view-server-settings.md
+++ b/docs/sources/administration/view-server-settings.md
@@ -1,0 +1,26 @@
++++
+title = "View server settings"
+description = "How to view server settings in the Grafana UI"
+keywords = ["grafana", "configuration", "server", "settings"]
+type = "docs"
+[menu.docs]
+name = "Configuration"
+identifier = "config"
+parent = "admin"
+weight = 350
++++
+
+# View Grafana server settings
+
+If you are a Grafana server admin, then you can use the Settings tab to view the settings applied to your Grafana server by the [Configuration]({{< relref "configuration.md" >}}) file and any environmental variables.
+
+> **Note:** Only Grafana server admins can access the **Server Admin** menu. For more information about about admin permissions, refer to [Grafana server admin]({{< relref "../permissions/_index.md" >}}).
+
+## View server settings
+
+1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
+1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click the **Settings** tab.
+
+## Available settings
+
+For a full list of server settings, refer to [Configuration]({{< relref "configuration.md" >}}).

--- a/docs/sources/administration/view-server-settings.md
+++ b/docs/sources/administration/view-server-settings.md
@@ -12,7 +12,7 @@ weight = 350
 
 # View Grafana server settings
 
-If you are a Grafana server admin, then you can use the Settings tab to view the settings applied to your Grafana server by the [Configuration]({{< relref "configuration.md" >}}) file and any environmental variables.
+If you are a Grafana server admin, then you can use the Settings tab to view the settings applied to your Grafana server by the [Configuration]({{< relref "configuration.md#config-file-locations" >}}) file and any environmental variables.
 
 > **Note:** Only Grafana server admins can access the **Server Admin** menu. For more information about about admin permissions, refer to [Grafana server admin]({{< relref "../permissions/_index.md" >}}).
 

--- a/docs/sources/administration/view-server-stats.md
+++ b/docs/sources/administration/view-server-stats.md
@@ -42,13 +42,9 @@ The following statistics are displayed in the Stats tab:
 
 ## Counting users
 
-If a user belongs to several organizations, then that user is counted once for each organization as a user in the highest role for each organization.
+If a user belongs to several organizations, then that user is counted once for each organization as a user in the highest organization role they are assigned.
 
-For example, if Sofia is a Viewer in three organizations, an Editor in two organizations, and and Admin in three organizations, then she would be reflected in the stats as:
+For example, if Sofia is a Viewer in two organizations, an Editor in two organizations, and and Admin in three organizations, then she would be reflected in the stats as:
 
-- Total users     8
-- Total admins    3
-- Total editors   2
-- Total viewers   3
-
-The same is true for Active users counts as well.
+- Total users     1
+- Total admins    1

--- a/docs/sources/administration/view-server-stats.md
+++ b/docs/sources/administration/view-server-stats.md
@@ -42,9 +42,9 @@ The following statistics are displayed in the Stats tab:
 
 ## Counting users
 
-If a user belongs to several organizations, then that user is counted once for each organization as a user in the highest organization role they are assigned.
+If a user belongs to several organizations, then that user is counted once as a user in the highest organization role they are assigned, regardless of how many organizations the user belongs to.
 
-For example, if Sofia is a Viewer in two organizations, an Editor in two organizations, and and Admin in three organizations, then she would be reflected in the stats as:
+For example, if Sofia is a Viewer in two organizations, an Editor in two organizations, and Admin in three organizations, then she would be reflected in the stats as:
 
 - Total users     1
 - Total admins    1

--- a/docs/sources/administration/view-server-stats.md
+++ b/docs/sources/administration/view-server-stats.md
@@ -1,3 +1,4 @@
++++
 title = "View server stats"
 type = "docs"
 keywords = ["grafana", "server", "statistics"]
@@ -14,7 +15,7 @@ If you are a Grafana server admin, then you can view useful statistics about you
 ## View server stats
 
 1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
-1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click **Stats**.
+1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click the **Stats** tab.
 
 ## Available stats
 

--- a/docs/sources/administration/view-server-stats.md
+++ b/docs/sources/administration/view-server-stats.md
@@ -1,0 +1,38 @@
+title = "View server stats"
+type = "docs"
+keywords = ["grafana", "server", "statistics"]
+[menu.docs]
+weight = 1150
++++
+
+# View Grafana server stats
+
+If you are a Grafana server admin, then you can view useful statistics about your Grafana server in the Stats tab.
+
+> **Note:** Only Grafana server admins can access the **Server Admin** menu. For more information about about admin permissions, refer to [Grafana server admin]({{< relref "../permissions/_index.md" >}}).
+
+## View server stats
+
+1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
+1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click **Stats**.
+
+## Available stats
+
+The following statistics are displayed in the Stats tab:
+
+- Total users
+- Total admins
+- Total editors
+- Total viewers
+- Active users (seen last 30 days)
+- Active admins (seen last 30 days)
+- Active editors (seen last 30 days)
+- Active viewers (seen last 30 days)
+- Active sessions
+- Total dashboards
+- Total orgs
+- Total playlists
+- Total snapshots
+- Total dashboard tags
+- Total starred dashboards
+- Total alerts

--- a/docs/sources/administration/view-server-stats.md
+++ b/docs/sources/administration/view-server-stats.md
@@ -22,10 +22,12 @@ If you are a Grafana server admin, then you can view useful statistics about you
 The following statistics are displayed in the Stats tab:
 
 - Total users
+  **Note:** Total users = Total admins + Total editors + Total viewers
 - Total admins
 - Total editors
 - Total viewers
 - Active users (seen last 30 days)
+  **Note:** Active users = Active admins + Active editors + Active viewers
 - Active admins (seen last 30 days)
 - Active editors (seen last 30 days)
 - Active viewers (seen last 30 days)
@@ -37,3 +39,16 @@ The following statistics are displayed in the Stats tab:
 - Total dashboard tags
 - Total starred dashboards
 - Total alerts
+
+## Counting users
+
+If a user belongs to several organizations, then that user is counted once for each organization as a user in the highest role for each organization.
+
+For example, if Sofia is a Viewer in three organizations, an Editor in two organizations, and and Admin in three organizations, then she would be reflected in the stats as:
+
+- Total users     8
+- Total admins    3
+- Total editors   2
+- Total viewers   3
+
+The same is true for Active users counts as well.

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -56,6 +56,8 @@
       link: /administration/preferences/
     - name: Configuration
       link: /administration/configuration/
+    - name: View server settings
+      link: /administration/view-server-settings/
     - name: Configure Docker image
       link: /administration/configure-docker/
     - name: Security
@@ -106,7 +108,7 @@
       link: /administration/cli/
     - name: Internal metrics
       link: /administration/metrics/
-    - name: View server strategies
+    - name: View server stats
       link: /administration/view-server-stats/
     - name: Jaeger instrumentation
       link: /administration/jaeger-instrumentation/

--- a/docs/sources/menu.yaml
+++ b/docs/sources/menu.yaml
@@ -106,6 +106,8 @@
       link: /administration/cli/
     - name: Internal metrics
       link: /administration/metrics/
+    - name: View server strategies
+      link: /administration/view-server-stats/
     - name: Jaeger instrumentation
       link: /administration/jaeger-instrumentation/
     - name: Set up Grafana for high availability


### PR DESCRIPTION
Starting to fill gaps in our Administration documentation. This adds instructions for the Stats and Settings tab in the Server Admin menu.