### PR TITLE
TemplateSrv: Fix interpolating strings with object variables

### DIFF
--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -687,4 +687,35 @@ describe('templateSrv', () => {
       expect(target).toBe('2020-07');
     });
   });
+
+  describe('handle objects gracefully', () => {
+    beforeEach(() => {
+      initTemplateSrv([{ type: 'query', name: 'test', current: { value: { test: 'A' } } }]);
+    });
+
+    it('should not pass object to custom function', () => {
+      let passedValue: any = null;
+      _templateSrv.replace('this.${test}.filters', {}, (value: any) => {
+        passedValue = value;
+      });
+
+      expect(passedValue).toBe('[object Object]');
+    });
+  });
+
+  describe('handle objects gracefully and call toString if defined', () => {
+    beforeEach(() => {
+      const value = { test: 'A', toString: () => 'hello' };
+      initTemplateSrv([{ type: 'query', name: 'test', current: { value } }]);
+    });
+
+    it('should not pass object to custom function', () => {
+      let passedValue: any = null;
+      _templateSrv.replace('this.${test}.filters', {}, (value: any) => {
+        passedValue = value;
+      });
+
+      expect(passedValue).toBe('hello');
+    });
+  });
 });

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -112,6 +112,15 @@ export class TemplateSrv implements BaseTemplateSrv {
     // for some scopedVars there is no variable
     variable = variable || {};
 
+    if (value === null || value === undefined) {
+      return '';
+    }
+
+    // if it's an object transform value to string
+    if (!Array.isArray(value) && typeof value === 'object') {
+      value = `${value}`;
+    }
+
     if (typeof format === 'function') {
       return format(value, variable, this.formatValue);
     }


### PR DESCRIPTION
Fixes issue in custom value format functions that expects a string or array of strings.
When using our new built in `__user` variable for example that is an object
these custom value formats can crash.

This ensures that we always transform the variable to a string before passing
it to a formatter.

Fixes #28125
