### PR TITLE
grafana-toolkit: Remove stale reference to grafana-build-container

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/nodeVersionChecker.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/nodeVersionChecker.ts
@@ -67,7 +67,6 @@ const nodeVersionCheckerRunner: TaskRunner<NodeVersionCheckerOptions> = async ()
 
   console.log(chalk.yellow('--------------------------------------------------------------------'));
   console.log(chalk.yellow('All node versions seem ok.'));
-  console.log(chalk.yellow(`also if you changed the engine version in ${packageJsonFile}`));
   console.log(chalk.yellow('--------------------------------------------------------------------'));
 };
 

--- a/packages/grafana-toolkit/src/cli/tasks/nodeVersionChecker.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/nodeVersionChecker.ts
@@ -67,7 +67,6 @@ const nodeVersionCheckerRunner: TaskRunner<NodeVersionCheckerOptions> = async ()
 
   console.log(chalk.yellow('--------------------------------------------------------------------'));
   console.log(chalk.yellow('All node versions seem ok.'));
-  console.log(chalk.yellow("Don't forget to sync https://github.com/grafana/grafana-build-container"));
   console.log(chalk.yellow(`also if you changed the engine version in ${packageJsonFile}`));
   console.log(chalk.yellow('--------------------------------------------------------------------'));
 };


### PR DESCRIPTION
Remove stale reference to outdated repo.