### PR TITLE
Alerting: remove obsolete notifiers (after user confirmation)

### DIFF
--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -225,6 +225,18 @@ export class AlertTabCtrl {
       // fallback to using id if uid is missing
       if (!model) {
         model = _.find(this.notifications, { id: addedNotification.id });
+        if (!model) {
+          appEvents.emit(CoreEvents.showConfirmModal, {
+            title: 'Notifier with invalid ID is detected',
+            text: `Do you want to delete notifier with invalid ID: ${addedNotification.id} from the dashboard JSON?`,
+            icon: 'trash-alt',
+            confirmText: 'Delete',
+            yesText: 'Delete',
+            onConfirm: async () => {
+              this.removeNotification(addedNotification);
+            },
+          });
+        }
       }
 
       if (model && model.isDefault === false) {

--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -229,6 +229,7 @@ export class AlertTabCtrl {
           appEvents.emit(CoreEvents.showConfirmModal, {
             title: 'Notifier with invalid ID is detected',
             text: `Do you want to delete notifier with invalid ID: ${addedNotification.id} from the dashboard JSON?`,
+            text2: 'After successful deletion, make sure to save the dashboard for storing the update JSON.',
             icon: 'trash-alt',
             confirmText: 'Delete',
             yesText: 'Delete',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Following #28162 that detects n the backend obsolete alert notifiers when a dashboard is saved,
this fix introduces a confirmation modal for removing the invalid notifier
when a user navigates to the alert tab and an obsolete notifier is detected.

![Screenshot 2020-10-12 at 12 39 48](https://user-images.githubusercontent.com/1632407/95733440-ce3c2380-0c8a-11eb-907c-04bdf4d9c755.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
The reason that a dashboard can contain invalid notifiers it that
when the notifier is deleted, the notifier references are not deleted from the dashboard JSON as well.