### PR TITLE
Cloud monitoring: Add REDUCE_MEAN reducer for cumulative metrics

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/Aggregations.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Aggregations.test.tsx
@@ -62,7 +62,7 @@ describe('Aggregations', () => {
         const { options } = wrapper.find(Segment).props() as any;
         const [, aggGroup] = options;
 
-        expect(aggGroup.options.length).toEqual(10);
+        expect(aggGroup.options.length).toEqual(11);
         expect(aggGroup.options.map((o: any) => o.value)).toEqual(expect.arrayContaining(['REDUCE_NONE']));
       });
     });

--- a/public/app/plugins/datasource/cloud-monitoring/constants.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/constants.ts
@@ -152,7 +152,7 @@ export const aggOptions = [
     text: 'mean',
     value: 'REDUCE_MEAN',
     valueTypes: [ValueTypes.INT64, ValueTypes.DOUBLE, ValueTypes.MONEY, ValueTypes.DISTRIBUTION],
-    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA],
+    metricKinds: [MetricKind.GAUGE, MetricKind.DELTA, MetricKind.CUMULATIVE],
   },
   {
     text: 'min',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In [this](https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/blob/3a36e65321a8c95260ab092a54b26049ce9fbaec/dashboards/compute/gke-cluster-monitoring.json#L139) google sample dashboard `REDUCE_MEAN` reducer is used for a cumulative metric kind.
In grafana we didn't support this:
![Screenshot 2020-10-12 at 13 39 43](https://user-images.githubusercontent.com/1632407/95737959-26762400-0c91-11eb-9297-8b523046a296.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

