### PR TITLE
Automation: New label command to close issue that has no new info & activity 

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -22,6 +22,6 @@
     "type": "label",
     "name": "no new info",
     "action": "close",
-    "comment": "This issue has been closed because it needs more information and has not had recent activity. Please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "comment": "We've closed this issue since it needs more information and hasn't had any activity recently. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   }, 
 ]

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -22,6 +22,6 @@
     "type": "label",
     "name": "no new info",
     "action": "close",
-    "comment": "This issue has been closed because it needs more information and has not had recent activity. please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "comment": "This issue has been closed because it needs more information and has not had recent activity. Please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   }, 
 ]

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -17,5 +17,11 @@
     "name": "type/duplicate",
     "action": "close",
     "comment": "Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue.\n\nTo avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
-  }
+  },
+  {
+    "type": "label",
+    "name": "no new info",
+    "action": "close",
+    "comment": "This issue has been closed because it needs more information and has not had recent activity. please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+  }, 
 ]

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -22,6 +22,6 @@
     "type": "label",
     "name": "no new info",
     "action": "close",
-    "comment": "We've closed this issue since it needs more information and hasn't had any activity recently. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
-  }, 
+    "comment": "We've closed this issue since it needs more information and hasn't had any activity recently. We can re-open it after you you add more information. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+  }
 ]


### PR DESCRIPTION
Adds a label command "no new info" 

That closes issue with standard message. 

We could also add an automated scheduled task that does this automatically: 
https://github.com/microsoft/vscode/blob/master/.github/workflows/needs-more-info-closer.yml

