### PR TITLE
Azure Datasource: WIP - Using data proxy timeout as Prefer header

### DIFF
--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
@@ -229,6 +229,7 @@ func (e *ApplicationInsightsDatasource) createRequest(ctx context.Context, dsInf
 	}
 
 	req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s", setting.BuildVersion))
+	req.Header.Set("Prefer", fmt.Sprintf("wait=%d", setting.DataProxyTimeout))
 
 	pluginproxy.ApplyRoute(ctx, req, proxyPass, appInsightsRoute, dsInfo)
 

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -212,6 +212,7 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, dsInfo 
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s", setting.BuildVersion))
+	req.Header.Set("Prefer", fmt.Sprintf("wait=%d", setting.DataProxyTimeout))
 
 	// find plugin
 	plugin, ok := plugins.DataSources[dsInfo.Type]

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -248,6 +248,7 @@ func (e *AzureMonitorDatasource) createRequest(ctx context.Context, dsInfo *mode
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s", setting.BuildVersion))
+	req.Header.Set("Prefer", fmt.Sprintf("wait=%d", setting.DataProxyTimeout))
 
 	pluginproxy.ApplyRoute(ctx, req, proxyPass, azureMonitorRoute, dsInfo)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a Prefer header to Azure Monitor data source HTTP requests, which allows passing the Data Proxy timeout setting to the Azure Monitor API.

For example, the default data proxy time of '30 seconds' will be passed as 

Prefer: wait=30

which will reduce the query timeout [from 3 minutes to 30 seconds](https://dev.loganalytics.io/documentation/Using-the-API/Timeouts).


**Which issue(s) this PR fixes**:

Fixes #28199

**Special notes for your reviewer**:

