### PR TITLE
Theme: Deprecate selectThemeVariant util function

### DIFF
--- a/packages/grafana-ui/src/themes/selectThemeVariant.ts
+++ b/packages/grafana-ui/src/themes/selectThemeVariant.ts
@@ -2,6 +2,9 @@ import { GrafanaThemeType } from '@grafana/data';
 
 type VariantDescriptor = { [key in GrafanaThemeType]: string | number };
 
+/**
+ * @deprecated use theme.isLight ? or theme.isDark instead
+ */
 export const selectThemeVariant = (variants: VariantDescriptor, currentTheme?: GrafanaThemeType) => {
   return variants[currentTheme || GrafanaThemeType.Dark];
 };


### PR DESCRIPTION
* We should almost never have to use theme condition colors (use the high level colors under theme.colors instead)
* If we you need to use theme type condition to pick a color from palette consider if we are missing a high level color instead. If last restort use theme.isDark or theme.isLight  logic instead
