### PR TITLE
Chore: Add Windows CI build environment Dockerfile

### DIFF
--- a/scripts/build/ci-build-windows/Dockerfile
+++ b/scripts/build/ci-build-windows/Dockerfile
@@ -1,0 +1,36 @@
+# This has to correspond to the version the Drone runners have
+FROM mcr.microsoft.com/windows:1809
+
+WORKDIR C:\\App
+
+RUN powershell Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+RUN powershell Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+# Scoop first of all needs git to update itself
+# Run Scoop under PowerShell since it can otherwise fail
+RUN powershell -Command scoop install git@2.28.0.windows.1
+RUN powershell -Command scoop install go@1.15.2 unzip@6.00
+
+# Install diffutils, in case we need them
+RUN powershell (New-Object Net.WebClient).DownloadFile(\
+  \"https://sourceforge.net/projects/gnuwin32/files/diffutils/2.8.7-1/diffutils-2.8.7-1-bin.zip\", \
+  \"diffutils-bin.zip\")
+RUN powershell (New-Object Net.WebClient).DownloadFile(\
+  \"https://sourceforge.net/projects/gnuwin32/files/diffutils/2.8.7-1/diffutils-2.8.7-1-dep.zip\", \
+  \"diffutils-dep.zip\")
+RUN mkdir -p "C:\Program Files (x86)\GnuWin32"
+RUN cd "C:\Program Files (x86)\GnuWin32" && unzip C:\App\diffutils-dep.zip && unzip C:\App\diffutils-bin.zip
+
+RUN powershell (New-Object Net.WebClient).DownloadFile(\
+  \"https://github.com/golangci/golangci-lint/releases/download/v1.31.0/golangci-lint-1.31.0-windows-amd64.zip\", \
+  \"golangci-lint.zip\")
+RUN powershell (Get-FileHash golangci-lint.zip -Algorithm SHA256).Hash -eq \
+  \"6CE6B1D3207A63256D82FBBAC80BB9E85D7705EC1A408F005DFE324457C54966\"
+RUN unzip golangci-lint.zip
+RUN powershell -Command mv golangci-lint-1.31.0-windows-amd64\golangci-lint.exe .
+
+RUN powershell -Command scoop cache rm '*'
+
+RUN powershell -Command mkdir -p $(Split-Path -Path $profile)
+RUN powershell Set-Content -Path $profile -Value '$env:Path += \";C:\App;C:\Program files (x86)\GnuWin32\bin\"'
+
+ENTRYPOINT ["cmd"]

--- a/scripts/build/ci-build-windows/Magefile.go
+++ b/scripts/build/ci-build-windows/Magefile.go
@@ -1,0 +1,27 @@
+//+build mage
+
+package main
+
+import (
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+const imageName = "grafana/ci-build-windows:0.1.5"
+
+// Build builds the Docker image.
+func Build() error {
+	if err := sh.RunV("docker", "build", "-t", imageName, "."); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Publish publishes the Docker image.
+func Publish() error {
+	mg.Deps(Build)
+	return sh.RunV("docker", "push", imageName)
+}
+
+var Default = Build

--- a/scripts/build/ci-build-windows/README.md
+++ b/scripts/build/ci-build-windows/README.md
@@ -1,0 +1,15 @@
+# Windows Build Docker Image
+This directory contains a Dockerfile for building a Windows based image containing
+our CI build environment.
+
+To build the Docker image:
+
+```
+mage
+```
+
+To publish the Docker image:
+
+```
+mage publish
+```


### PR DESCRIPTION
Add Dockerfile for Windows CI build environment. Using it to build Docker image for testing grafana/build-pipeline under Drone.