### PR TITLE
Dashboard: Do not allow users without edit permission to a folder to see new dashboard page

### DIFF
--- a/public/app/routes/routes.ts
+++ b/public/app/routes/routes.ts
@@ -1,6 +1,8 @@
 import './dashboard_loaders';
 import './ReactContainer';
 import { applyRouteRegistrationHandlers } from './registry';
+import { contextSrv } from 'app/core/services/context_srv';
+
 // Pages
 import LdapPage from 'app/features/admin/ldap/LdapPage';
 import UserAdminPage from 'app/features/admin/UserAdminPage';
@@ -70,6 +72,7 @@ export function setupAngularRoutes($routeProvider: route.IRouteProvider, $locati
       routeInfo: DashboardRouteInfo.New,
       reloadOnSearch: false,
       resolve: {
+        roles: () => (contextSrv.hasEditPermissionInFolders ? [contextSrv.user.orgRole] : ['Admin']),
         component: importDashboardPage,
       },
     })


### PR DESCRIPTION
Viewers without any folder permissions could still open dashboards/new 