### PR TITLE
Dashboard: Fixed issue accessing horizontal table scrollbar when placed at bottom of dashboard

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -315,6 +315,7 @@ export class DashboardPage extends PureComponent<Props, State> {
             autoHeightMin="100%"
             setScrollTop={this.setScrollTop}
             scrollTop={updateScrollTop}
+            hideHorizontalTrack={true}
             updateAfterMountMs={500}
             className="custom-scrollbar--page"
           >

--- a/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
+++ b/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`DashboardPage Dashboard init completed  Should render dashboard grid 1`
       autoHideDuration={200}
       autoHideTimeout={200}
       className="custom-scrollbar--page"
+      hideHorizontalTrack={true}
       hideTracksWhenNotNeeded={false}
       setScrollTop={[Function]}
       updateAfterMountMs={500}
@@ -470,6 +471,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
       autoHideDuration={200}
       autoHideTimeout={200}
       className="custom-scrollbar--page"
+      hideHorizontalTrack={true}
       hideTracksWhenNotNeeded={false}
       setScrollTop={[Function]}
       updateAfterMountMs={500}

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -17,8 +17,8 @@
 }
 
 .dashboard-content {
-  padding: $dashboard-padding $dashboard-padding 0 $dashboard-padding;
-  height: 100%;
+  padding: $dashboard-padding;
+  flex-grow: 1;
 }
 
 div.flot-text {


### PR DESCRIPTION
Fixes issue with horizontal scrollbar in table being unusable when placed at bottom of dashboard. Was caused by dashboard horizontal scrollbar being ontop of it.

Also fixed missing bottom padding for dashboard-content

Fixes #28228
