### PR TITLE
Grafana-UI: export FieldArray

### DIFF
--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -158,6 +158,7 @@ export { FieldValidationMessage } from './Forms/FieldValidationMessage';
 export { InlineField } from './Forms/InlineField';
 export { InlineLabel } from './Forms/InlineLabel';
 export { InlineFieldRow } from './Forms/InlineFieldRow';
+export { FieldArray } from './Forms/FieldArray';
 
 export { default as resetSelectStyles } from './Select/resetSelectStyles';
 export * from './Select/Select';


### PR DESCRIPTION
**What this PR does / why we need it**:
The lately added `<FieldArray />` component could be quite useful to create repeaters inside forms, however unfortunately it's not exported yet. This PR is fixing that.

[FieldArray in Storybook &rarr;](https://developers.grafana.com/ui/latest/index.html?path=/story/forms-fieldarray--simple)


