### PR TITLE
Graph: Prevent legend from overflowing container

### DIFF
--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -8,7 +8,7 @@
       flex-direction: row;
 
       .graph-legend {
-        flex: 0 1 10px;
+        flex: 1 1 10px;
         max-height: 100%;
       }
 
@@ -46,10 +46,11 @@
 
 .graph-legend {
   display: flex;
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   max-height: 35%;
   margin: 0;
   text-align: center;
+  overflow-y: auto;
   padding-top: 6px;
   position: relative;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The introduction of Safari 14 appears to have broken the overflow styling currently used for the Graph panel legend causing the legends to overflow their container. This PR addresses this styling bug. Looking at the safari 14 [changelog](https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes#Performance) I'm assuming it's a side effect of `Implemented asynchronous scrolling for overflow: scroll, and <iframe> on macOS.`.

**Which issue(s) this PR fixes**:
Fixes #27676

**Special notes for your reviewer**:
The `flex-grow` change was required due to `overflow-y` property addition so the legend could fill all available space whether in vertical or right sided layout. Fix tested in Chrome, Safari and Firefox and their mobile emulators.

| Before | After |
| --- | --- |
| <img width="500" alt="before" src="https://user-images.githubusercontent.com/73201/95983442-e6927680-0e21-11eb-917e-d872ad241fb6.png"> | <img width="500" alt="after" src="https://user-images.githubusercontent.com/73201/95983454-eb572a80-0e21-11eb-8469-9a74f2f93a38.png"> |

