### PR TITLE
Punctuation/language fix for Prometheus data source addition page.

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -37,7 +37,7 @@ const HttpAccessHelp = () => (
     <p>
       Access mode controls how requests to the data source will be handled.
       <strong>
-        <i>Server</i>
+        &nbsp<i>Server</i>
       </strong>{' '}
       should be the preferred way if nothing else stated.
     </p>

--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -39,7 +39,7 @@ const HttpAccessHelp = () => (
       <strong>
         &nbsp<i>Server</i>
       </strong>{' '}
-      should be the preferred way if nothing else stated.
+      should be the preferred way if nothing else is stated.
     </p>
     <div className="alert-title">Server access mode (Default):</div>
     <p>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

Done!

2. Ensure you include and run the appropriate tests as part of your Pull Request.

happy to, unclear how to do this :) doc pointer?

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixing a punctuation / spacing / language issue in a help-text:
  "Access mode controls how requests to the data source will be handled.Server should
  be the preferred way if nothing else stated."

becomes:
  "Access mode controls how requests to the data source will be handled. Server should
   be the preferred way if nothing else is stated."                                        ^
                                                           ^^^

**Which issue(s) this PR fixes**:

none, I can open one but it seemed silly for a small english language fix :)

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

