### PR TITLE
Drone: Use DRONE_COMMIT_REF to get release tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,10 +16,9 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mkdir -p bin
-  - mv grabpl bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -249,7 +248,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/windows/grabpl.exe -OutFile grabpl.exe
 
 trigger:
   event:
@@ -273,10 +272,9 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mkdir -p bin
-  - mv grabpl bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -604,7 +602,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/windows/grabpl.exe -OutFile grabpl.exe
 
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
@@ -652,10 +650,9 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mkdir -p bin
-  - mv grabpl bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
@@ -728,11 +725,11 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mkdir -p bin
-  - mv grabpl bin
-  - ./bin/grabpl verify-version ${DRONE_TAG}
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl verify-version $${DRONE_TAG}
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -796,7 +793,8 @@ steps:
 - name: build-backend
   image: grafana/build-container:1.2.27
   commands:
-  - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise $${DRONE_TAG}
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -808,7 +806,8 @@ steps:
 - name: build-frontend
   image: grafana/build-container:1.2.27
   commands:
-  - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise $${DRONE_TAG}
   depends_on:
   - initialize
   - test-frontend
@@ -827,7 +826,8 @@ steps:
 - name: package
   image: grafana/build-container:1.2.27
   commands:
-  - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign $${DRONE_TAG}
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -876,10 +876,11 @@ steps:
 - name: publish-storybook
   image: grafana/grafana-ci-deploy:1.2.6
   commands:
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
   - gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/latest
-  - gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/${DRONE_TAG}
+  - gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/$${DRONE_TAG}
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -954,7 +955,8 @@ steps:
   commands:
   - ./node_modules/.bin/lerna bootstrap
   - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
-  - ./scripts/build/release-packages.sh ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./scripts/build/release-packages.sh $${DRONE_TAG}
   environment:
     NPM_TOKEN:
       from_secret: npm_token
@@ -1022,11 +1024,12 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/windows/grabpl.exe -OutFile grabpl.exe
 
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
   commands:
+  - $$env:DRONE_TAG=$$(.\grabpl.exe parse-tag-ref ${DRONE_TAG})
   - $$gcpKey = $$env:GCP_KEY
   - "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($$gcpKey)) > gcpkey.json"
   - dos2unix gcpkey.json
@@ -1071,9 +1074,13 @@ steps:
 - name: clone
   image: alpine/git:v2.26.2
   commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
-  - git checkout ${DRONE_TAG}
+  - git checkout $${DRONE_TAG}
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1081,14 +1088,13 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
   - mv grabpl /tmp
   - mv grafana-enterprise /tmp/
-  - /tmp/grabpl init-enterprise /tmp/grafana-enterprise ${DRONE_TAG}
+  - /tmp/grabpl init-enterprise /tmp/grafana-enterprise $${DRONE_TAG}
   - mkdir bin
   - mv /tmp/grabpl bin/
-  - ./bin/grabpl verify-version ${DRONE_TAG}
+  - ./bin/grabpl verify-version $${DRONE_TAG}
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -1154,7 +1160,8 @@ steps:
 - name: build-backend
   image: grafana/build-container:1.2.27
   commands:
-  - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise $${DRONE_TAG}
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1166,7 +1173,8 @@ steps:
 - name: build-frontend
   image: grafana/build-container:1.2.27
   commands:
-  - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise $${DRONE_TAG}
   depends_on:
   - initialize
   - test-frontend
@@ -1185,7 +1193,8 @@ steps:
 - name: package
   image: grafana/build-container:1.2.27
   commands:
-  - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign $${DRONE_TAG}
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1350,9 +1359,12 @@ steps:
 - name: clone
   image: grafana/ci-wix:0.1.1
   commands:
+  - $$ProgressPreference = "SilentlyContinue"
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/windows/grabpl.exe -OutFile grabpl.exe
+  - $$env:DRONE_TAG=$$(.\grabpl.exe parse-tag-ref ${DRONE_TAG})
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
-  - git checkout ${DRONE_TAG}
+  - git checkout $$env:DRONE_TAG
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1360,8 +1372,6 @@ steps:
 - name: initialize
   image: grafana/ci-wix:0.1.1
   commands:
-  - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/windows/grabpl.exe -OutFile grabpl.exe
   - cp -r grafana-enterprise C:\App\grafana-enterprise
   - rm -r -force grafana-enterprise
   - cp grabpl.exe C:\App\grabpl.exe
@@ -1374,6 +1384,7 @@ steps:
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
   commands:
+  - $$env:DRONE_TAG=$$(.\grabpl.exe parse-tag-ref ${DRONE_TAG})
   - $$gcpKey = $$env:GCP_KEY
   - "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($$gcpKey)) > gcpkey.json"
   - dos2unix gcpkey.json
@@ -1415,19 +1426,20 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mkdir -p bin
-  - mv grabpl bin
-  - ./bin/grabpl verify-version ${DRONE_TAG}
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl verify-version $${DRONE_TAG}
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages
   image: grafana/grafana-ci-deploy:1.2.6
   commands:
-  - ./bin/grabpl publish-packages --edition oss ${DRONE_TAG}
-  - ./bin/grabpl publish-packages --edition enterprise ${DRONE_TAG}
+  - export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})
+  - ./bin/grabpl publish-packages --edition oss $${DRONE_TAG}
+  - ./bin/grabpl publish-packages --edition enterprise $${DRONE_TAG}
   environment:
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
@@ -1493,10 +1505,9 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mkdir -p bin
-  - mv grabpl bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
   - ./bin/grabpl verify-version v7.3.0-test
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -1777,7 +1788,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/windows/grabpl.exe -OutFile grabpl.exe
 
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
@@ -1826,6 +1837,9 @@ steps:
 - name: clone
   image: alpine/git:v2.26.2
   commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout master
@@ -1836,8 +1850,6 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mv grabpl /tmp
   - mv grafana-enterprise /tmp/
   - /tmp/grabpl init-enterprise /tmp/grafana-enterprise
@@ -2099,6 +2111,8 @@ steps:
 - name: clone
   image: grafana/ci-wix:0.1.1
   commands:
+  - $$ProgressPreference = "SilentlyContinue"
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/windows/grabpl.exe -OutFile grabpl.exe
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout master
@@ -2109,8 +2123,6 @@ steps:
 - name: initialize
   image: grafana/ci-wix:0.1.1
   commands:
-  - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/windows/grabpl.exe -OutFile grabpl.exe
   - cp -r grafana-enterprise C:\App\grafana-enterprise
   - rm -r -force grafana-enterprise
   - cp grabpl.exe C:\App\grabpl.exe
@@ -2164,10 +2176,9 @@ steps:
 - name: initialize
   image: grafana/build-container:1.2.27
   commands:
-  - curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.17/grabpl
-  - chmod +x grabpl
   - mkdir -p bin
-  - mv grabpl bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.18/grabpl
+  - chmod +x bin/grabpl
   - ./bin/grabpl verify-version v7.3.0-test
   environment:
     DOCKERIZE_VERSION: 0.6.1

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,4 +1,4 @@
-grabpl_version = '0.5.17'
+grabpl_version = '0.5.18'
 build_image = 'grafana/build-container:1.2.27'
 publish_image = 'grafana/grafana-ci-deploy:1.2.6'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
@@ -8,6 +8,8 @@ git_image = 'alpine/git:v2.26.2'
 dockerize_version = '0.6.1'
 wix_image = 'grafana/ci-wix:0.1.1'
 test_release_ver = 'v7.3.0-test'
+
+drone_tag_cmd = 'export DRONE_TAG=$$(./bin/grabpl parse-tag-ref ${DRONE_COMMIT_REF})'
 
 def pipeline(
     name, edition, trigger, steps, ver_mode, services=[], platform='linux', depends_on=[],
@@ -88,10 +90,19 @@ def init_steps(edition, platform, ver_mode, is_downstream=False, install_deps=Tr
             },
         ]
 
+    download_grabpl_cmds = [
+        'mkdir -p bin',
+        'curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/grabpl'.format(
+            grabpl_version
+        ),
+        'chmod +x bin/grabpl',
+    ]
     common_cmds = []
+    pre_cmds = []
 
     if ver_mode == 'release':
-        common_cmds.append('./bin/grabpl verify-version ${DRONE_TAG}')
+        pre_cmds.append(drone_tag_cmd)
+        common_cmds.append('./bin/grabpl verify-version $${DRONE_TAG}')
     elif ver_mode == 'test-release':
         common_cmds.append('./bin/grabpl verify-version {}'.format(test_release_ver))
 
@@ -112,8 +123,8 @@ def init_steps(edition, platform, ver_mode, is_downstream=False, install_deps=Tr
         ])
     if edition == 'enterprise':
         if ver_mode == 'release':
-            committish = '${DRONE_TAG}'
-            source_commit = ' ${DRONE_TAG}'
+            committish = '$${DRONE_TAG}'
+            source_commit = ' $${DRONE_TAG}'
         elif ver_mode == 'test-release':
             committish = 'master'
             source_commit = ''
@@ -133,7 +144,7 @@ def init_steps(edition, platform, ver_mode, is_downstream=False, install_deps=Tr
                         'from_secret': 'github_token',
                     },
                 },
-                'commands': [
+                'commands': download_grabpl_cmds + pre_cmds + [
                     'git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"',
                     'cd grafana-enterprise',
                     'git checkout {}'.format(committish),
@@ -148,11 +159,7 @@ def init_steps(edition, platform, ver_mode, is_downstream=False, install_deps=Tr
                 'depends_on': [
                     'clone',
                 ],
-                'commands': [
-                    'curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/grabpl'.format(
-                        grabpl_version
-                    ),
-                    'chmod +x grabpl',
+                'commands': pre_cmds + [
                     'mv grabpl /tmp',
                     'mv grafana-enterprise /tmp/',
                     '/tmp/grabpl init-enterprise /tmp/grafana-enterprise{}'.format(source_commit),
@@ -172,14 +179,7 @@ def init_steps(edition, platform, ver_mode, is_downstream=False, install_deps=Tr
             'environment': {
                 'DOCKERIZE_VERSION': dockerize_version,
             },
-            'commands': [
-                'curl -fLO https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/grabpl'.format(
-                    grabpl_version
-                ),
-                'chmod +x grabpl',
-                'mkdir -p bin',
-                'mv grabpl bin',
-            ] + common_cmds,
+            'commands': download_grabpl_cmds + pre_cmds + common_cmds,
         },
     ]
 
@@ -279,17 +279,19 @@ def publish_storybook_step(edition, ver_mode):
             'echo Testing release',
         ]
     else:
+        commands = []
         if ver_mode == 'release':
-            channels = ['latest', '${DRONE_TAG}',]
+            channels = ['latest', '$${DRONE_TAG}',]
+            commands.append(drone_tag_cmd)
         else:
             channels = ['canary',]
-        commands = [
+        commands.extend([
             'printenv GCP_KEY | base64 -d > /tmp/gcpkey.json',
             'gcloud auth activate-service-account --key-file=/tmp/gcpkey.json',
         ] + [
             'gsutil -m rsync -d -r ./packages/grafana-ui/dist/storybook gs://grafana-storybook/{}'.format(c)
             for c in channels
-        ]
+        ])
 
     return {
         'name': 'publish-storybook',
@@ -318,27 +320,34 @@ def build_backend_step(edition, ver_mode, variants=None, is_downstream=False):
                 'from_secret': 'github_token',
             },
         }
-        cmd = './bin/grabpl build-backend --jobs 8 --edition {} --github-token $${{GITHUB_TOKEN}} --no-pull-enterprise ${{DRONE_TAG}}'.format(
-            edition,
-        )
+        cmds = [
+            drone_tag_cmd,
+            './bin/grabpl build-backend --jobs 8 --edition {} --github-token $${{GITHUB_TOKEN}} --no-pull-enterprise $${{DRONE_TAG}}'.format(
+                edition,
+            ),
+        ]
     elif ver_mode == 'test-release':
         env = {
             'GITHUB_TOKEN': {
                 'from_secret': 'github_token',
             },
         }
-        cmd = './bin/grabpl build-backend --jobs 8 --edition {} --github-token $${{GITHUB_TOKEN}} --no-pull-enterprise {}'.format(
-            edition, test_release_ver,
-        )
+        cmds = [
+            './bin/grabpl build-backend --jobs 8 --edition {} --github-token $${{GITHUB_TOKEN}} --no-pull-enterprise {}'.format(
+                edition, test_release_ver,
+            ),
+        ]
     else:
         if not is_downstream:
             build_no = '${DRONE_BUILD_NUMBER}'
         else:
             build_no = '$${SOURCE_BUILD_NUMBER}'
         env = {}
-        cmd = './bin/grabpl build-backend --jobs 8 --edition {} --build-id {}{} --no-pull-enterprise'.format(
-            edition, build_no, variants_str,
-        )
+        cmds = [
+            './bin/grabpl build-backend --jobs 8 --edition {} --build-id {}{} --no-pull-enterprise'.format(
+                edition, build_no, variants_str,
+            ),
+        ]
 
     return {
         'name': 'build-backend',
@@ -349,9 +358,7 @@ def build_backend_step(edition, ver_mode, variants=None, is_downstream=False):
             'test-backend',
         ],
         'environment': env,
-        'commands': [
-            cmd,
-        ],
+        'commands': cmds,
     }
 
 def build_frontend_step(edition, ver_mode, is_downstream=False):
@@ -362,14 +369,21 @@ def build_frontend_step(edition, ver_mode, is_downstream=False):
 
     # TODO: Use percentage for num jobs
     if ver_mode == 'release':
-        cmd = './bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps ' + \
-            '--edition {} --no-pull-enterprise ${{DRONE_TAG}}'.format(edition)
+        cmds = [
+            drone_tag_cmd,
+            './bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps ' + \
+                '--edition {} --no-pull-enterprise $${{DRONE_TAG}}'.format(edition),
+        ]
     elif ver_mode == 'test-release':
-        cmd = './bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps ' + \
-            '--edition {} --no-pull-enterprise {}'.format(edition, test_release_ver)
+        cmds = [
+            './bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps ' + \
+                '--edition {} --no-pull-enterprise {}'.format(edition, test_release_ver),
+            ]
     else:
-        cmd = './bin/grabpl build-frontend --jobs 8 --no-install-deps --edition {} '.format(edition) + \
-            '--build-id {} --no-pull-enterprise'.format(build_no)
+        cmds = [
+            './bin/grabpl build-frontend --jobs 8 --no-install-deps --edition {} '.format(edition) + \
+                '--build-id {} --no-pull-enterprise'.format(build_no),
+        ]
 
     return {
         'name': 'build-frontend',
@@ -378,9 +392,7 @@ def build_frontend_step(edition, ver_mode, is_downstream=False):
             'initialize',
             'test-frontend',
         ],
-        'commands': [
-            cmd,
-        ],
+        'commands': cmds,
     }
 
 def build_frontend_docs_step(edition):
@@ -542,22 +554,29 @@ def package_step(edition, ver_mode, variants=None, is_downstream=False):
 
     # TODO: Use percentage for jobs
     if ver_mode == 'release':
-        cmd = '{}./bin/grabpl package --jobs 8 --edition {} '.format(test_args, edition) + \
-            '--github-token $${{GITHUB_TOKEN}} --no-pull-enterprise{} ${{DRONE_TAG}}'.format(
-                sign_args
-            )
+        cmds = [
+            drone_tag_cmd,
+            '{}./bin/grabpl package --jobs 8 --edition {} '.format(test_args, edition) + \
+                '--github-token $${{GITHUB_TOKEN}} --no-pull-enterprise{} $${{DRONE_TAG}}'.format(
+                    sign_args
+                ),
+        ]
     elif ver_mode == 'test-release':
-        cmd = '{}./bin/grabpl package --jobs 8 --edition {} '.format(test_args, edition) + \
-            '--github-token $${{GITHUB_TOKEN}} --no-pull-enterprise{} {}'.format(
-                sign_args, test_release_ver,
-            )
+        cmds = [
+            '{}./bin/grabpl package --jobs 8 --edition {} '.format(test_args, edition) + \
+                '--github-token $${{GITHUB_TOKEN}} --no-pull-enterprise{} {}'.format(
+                    sign_args, test_release_ver,
+                ),
+        ]
     else:
         if not is_downstream:
             build_no = '${DRONE_BUILD_NUMBER}'
         else:
             build_no = '$${SOURCE_BUILD_NUMBER}'
-        cmd = '{}./bin/grabpl package --jobs 8 --edition {} '.format(test_args, edition) + \
-            '--build-id {} --no-pull-enterprise{}{}'.format(build_no, variants_str, sign_args)
+        cmds = [
+            '{}./bin/grabpl package --jobs 8 --edition {} '.format(test_args, edition) + \
+                '--build-id {} --no-pull-enterprise{}{}'.format(build_no, variants_str, sign_args),
+        ]
 
     return {
         'name': 'package',
@@ -572,9 +591,7 @@ def package_step(edition, ver_mode, variants=None, is_downstream=False):
             'shellcheck',
         ],
         'environment': env,
-        'commands': [
-            cmd,
-        ],
+        'commands': cmds,
     }
 
 def e2e_tests_server_step():
@@ -827,17 +844,23 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
     else:
         source_commit = ' $$env:SOURCE_COMMIT'
 
+    pre_cmds = []
+    if ver_mode == 'release':
+        pre_cmds.append('$$env:DRONE_TAG=$$(.\\grabpl.exe parse-tag-ref ${DRONE_TAG})')
     sfx = ''
     if edition == 'enterprise':
         sfx = '-enterprise'
+    init_cmds = []
+    if edition != 'enterprise':
+        init_cmds.extend([
+            '$$ProgressPreference = "SilentlyContinue"',
+            'Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/windows/grabpl.exe -OutFile grabpl.exe'.format(grabpl_version),
+        ])
     steps = [
         {
             'name': 'initialize',
             'image': wix_image,
-            'commands': [
-                '$$ProgressPreference = "SilentlyContinue"',
-                'Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/windows/grabpl.exe -OutFile grabpl.exe'.format(grabpl_version),
-            ],
+            'commands': init_cmds,
         },
     ]
     if (ver_mode == 'master' and (edition != 'enterprise' or is_downstream)) or ver_mode in ('release', 'test-release'):
@@ -879,7 +902,7 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
                     'from_secret': 'gcp_key',
                 },
             },
-            'commands': installer_commands,
+            'commands': pre_cmds + installer_commands,
             'depends_on': [
                 'initialize',
             ],
@@ -887,17 +910,21 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
 
     if edition == 'enterprise':
         if ver_mode == 'release':
-            committish = '${DRONE_TAG}'
+            committish = '$$env:DRONE_TAG'
         elif ver_mode == 'test-release':
             committish = 'master'
         else:
             committish = '$$env:DRONE_COMMIT'
         # For enterprise, we have to clone both OSS and enterprise and merge the latter into the former
-        clone_commands = [
+        download_grabpl_cmds = [
+            '$$ProgressPreference = "SilentlyContinue"',
+            'Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/windows/grabpl.exe -OutFile grabpl.exe'.format(grabpl_version),
+        ]
+        clone_cmds = [
             'git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"',
         ]
         if not is_downstream:
-            clone_commands.extend([
+            clone_cmds.extend([
                 'cd grafana-enterprise',
                 'git checkout {}'.format(committish),
             ])
@@ -909,7 +936,7 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
                     'from_secret': 'github_token',
                 },
             },
-            'commands': clone_commands,
+            'commands': download_grabpl_cmds + pre_cmds + clone_cmds,
         })
         steps[1]['depends_on'] = [
             'clone',

--- a/scripts/release.star
+++ b/scripts/release.star
@@ -29,6 +29,7 @@ load(
     'publish_packages_step',
     'notify_pipeline',
     'integration_test_services',
+    'drone_tag_cmd',
 )
 
 def release_npm_packages_step(edition, ver_mode):
@@ -40,7 +41,7 @@ def release_npm_packages_step(edition, ver_mode):
         'echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc',
     ]
     if ver_mode == 'release':
-        commands.append('./scripts/build/release-packages.sh ${DRONE_TAG}')
+        commands.extend([drone_tag_cmd, './scripts/build/release-packages.sh $${DRONE_TAG}',])
 
     return {
         'name': 'release-npm-packages',
@@ -139,8 +140,9 @@ def release_pipelines():
                     },
                 },
                 'commands': [
-                    './bin/grabpl publish-packages --edition oss ${DRONE_TAG}',
-                    './bin/grabpl publish-packages --edition enterprise ${DRONE_TAG}',
+                    drone_tag_cmd,
+                    './bin/grabpl publish-packages --edition oss $${DRONE_TAG}',
+                    './bin/grabpl publish-packages --edition enterprise $${DRONE_TAG}',
                 ],
             },
         ], depends_on=[p['name'] for p in oss_pipelines + enterprise_pipelines], install_deps=False,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Drone release pipeline, by making it use $DRONE_COMMIT_REF to get release tag, as $DRONE_TAG shouldn't be set (because we don't use tag event trigger).
