### PR TITLE
OAuth: Configurable user name attribute

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -442,6 +442,7 @@ scopes = user:email
 email_attribute_name = email:primary
 email_attribute_path =
 login_attribute_path =
+name_attribute_path =
 role_attribute_path =
 id_token_attribute_name =
 auth_url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -432,6 +432,7 @@
 ;email_attribute_name = email:primary
 ;email_attribute_path =
 ;login_attribute_path =
+;name_attribute_path =
 ;id_token_attribute_name =
 ;auth_url = https://foo.bar/login/oauth/authorize
 ;token_url = https://foo.bar/login/oauth/access_token

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -80,6 +80,8 @@ Customize user login using `login_attribute_path` configuration option. Order of
 
 You can customize the attribute name used to extract the ID token from the returned OAuth token with the `id_token_attribute_name` option.
 
+Customize user's displayed name using `name_attribute_path` configuration option. Order of operations is the same as for the `login_attribute_path` option.
+
 ## Set up OAuth2 with Auth0
 
 1. Create a new Client in Auth0

--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -80,8 +80,6 @@ Customize user login using `login_attribute_path` configuration option. Order of
 
 You can customize the attribute name used to extract the ID token from the returned OAuth token with the `id_token_attribute_name` option.
 
-Customize user's displayed name using `name_attribute_path` configuration option. Order of operations is the same as for the `login_attribute_path` option.
-
 ## Set up OAuth2 with Auth0
 
 1. Create a new Client in Auth0

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -250,7 +250,7 @@ func (s *SocialGenericOAuth) extractFromToken(token *oauth2.Token) *UserInfoJson
 
 	data.rawJSON = rawJSON
 	data.source = "token"
-	s.log.Debug("Received id_token", "raw_json", string(data.rawJSON), "data", data)
+	s.log.Debug("Received id_token", "raw_json", string(data.rawJSON), "data", data.String())
 	return &data
 }
 
@@ -272,7 +272,7 @@ func (s *SocialGenericOAuth) extractFromAPI(client *http.Client) *UserInfoJson {
 
 	data.rawJSON = rawJSON
 	data.source = "API"
-	s.log.Debug("Received user info response from API", "raw_json", string(rawJSON), "data", data)
+	s.log.Debug("Received user info response from API", "raw_json", string(rawJSON), "data", data.String())
 	return &data
 }
 

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -24,7 +24,6 @@ type SocialGenericOAuth struct {
 	emailAttributeName   string
 	emailAttributePath   string
 	loginAttributePath   string
-	nameAttributeName    string
 	nameAttributePath    string
 	roleAttributePath    string
 	idTokenAttributeName string
@@ -110,9 +109,6 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 
 		if userInfo.Name == "" {
 			userInfo.Name = s.extractUserName(data)
-			if userInfo.Name != "" {
-				s.log.Debug("Set user info name from extracted name", "name", userInfo.Name)
-			}
 		}
 
 		if userInfo.Login == "" {
@@ -313,14 +309,6 @@ func (s *SocialGenericOAuth) extractUserName(data *UserInfoJson) string {
 		} else if name != "" {
 			s.log.Debug("Setting user info name from nameAttributePath", "nameAttributePath", s.nameAttributePath)
 			return name
-		}
-	}
-
-	if s.nameAttributeName != "" {
-		names, ok := data.Attributes[s.nameAttributeName]
-		if ok && len(names) != 0 {
-			s.log.Debug("Setting user info name from nameAttributeName", "nameAttributeName", s.nameAttributeName)
-			return names[0]
 		}
 	}
 

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -428,6 +428,104 @@ func TestUserInfoSearchesForLogin(t *testing.T) {
 	})
 }
 
+func TestUserInfoSearchesForName(t *testing.T) {
+	t.Run("Given a generic OAuth provider", func(t *testing.T) {
+		provider := SocialGenericOAuth{
+			SocialBase: &SocialBase{
+				log: log.NewWithLevel("generic_oauth_test", log15.LvlDebug),
+			},
+			nameAttributePath: "name",
+		}
+
+		tests := []struct {
+			Name              string
+			ResponseBody      interface{}
+			OAuth2Extra       interface{}
+			NameAttributePath string
+			ExpectedName      string
+		}{
+			{
+				Name: "Given a valid id_token, a valid name path, no API response, use id_token",
+				OAuth2Extra: map[string]interface{}{
+					// { "name": "John Doe", "login": "johndoe", "email": "john.doe@example.com" }
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb2dpbiI6ImpvaG5kb2UiLCJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwibmFtZSI6IkpvaG4gRG9lIn0.oMsXH0mHxUSYMXh6FonZIWh8LgNIcYbKRLSO1bwnfSI",
+				},
+				NameAttributePath: "name",
+				ExpectedName:      "John Doe",
+			},
+			{
+				Name: "Given a valid id_token, no name path, no API response, use id_token",
+				OAuth2Extra: map[string]interface{}{
+					// { "name": "John Doe", "login": "johndoe", "email": "john.doe@example.com" }
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb2dpbiI6ImpvaG5kb2UiLCJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwibmFtZSI6IkpvaG4gRG9lIn0.oMsXH0mHxUSYMXh6FonZIWh8LgNIcYbKRLSO1bwnfSI",
+				},
+				NameAttributePath: "",
+				ExpectedName:      "John Doe",
+			},
+			{
+				Name: "Given no id_token, a valid name path, a valid API response, use API response",
+				ResponseBody: map[string]interface{}{
+					"user_name": "John Doe",
+					"login":     "johndoe",
+					"email":     "john.doe@example.com",
+				},
+				NameAttributePath: "user_name",
+				ExpectedName:      "John Doe",
+			},
+			{
+				Name: "Given no id_token, no name path, a valid API response, use API response",
+				ResponseBody: map[string]interface{}{
+					"display_name": "John Doe",
+					"login":        "johndoe",
+				},
+				NameAttributePath: "",
+				ExpectedName:      "John Doe",
+			},
+			{
+				Name: "Given no id_token, a name path, a valid API response without a name, use API response",
+				ResponseBody: map[string]interface{}{
+					"display_name": "John Doe",
+					"username":     "john.doe",
+				},
+				NameAttributePath: "name",
+				ExpectedName:      "John Doe",
+			},
+			{
+				Name:              "Given no id_token, a valid name path, no API response, no data",
+				NameAttributePath: "name",
+				ExpectedName:      "",
+			},
+		}
+
+		for _, test := range tests {
+			provider.nameAttributePath = test.NameAttributePath
+			t.Run(test.Name, func(t *testing.T) {
+				body, err := json.Marshal(test.ResponseBody)
+				require.NoError(t, err)
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Header().Set("Content-Type", "application/json")
+					t.Log("Writing fake API response body", "body", test.ResponseBody)
+					_, err = w.Write(body)
+					require.NoError(t, err)
+				}))
+				provider.apiUrl = ts.URL
+				staticToken := oauth2.Token{
+					AccessToken:  "",
+					TokenType:    "",
+					RefreshToken: "",
+					Expiry:       time.Now(),
+				}
+
+				token := staticToken.WithExtra(test.OAuth2Extra)
+				actualResult, err := provider.UserInfo(ts.Client(), token)
+				require.NoError(t, err)
+				require.Equal(t, test.ExpectedName, actualResult.Name)
+			})
+		}
+	})
+}
+
 func TestPayloadCompression(t *testing.T) {
 	provider := SocialGenericOAuth{
 		SocialBase: &SocialBase{

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -181,7 +181,6 @@ func NewOAuthService() {
 				apiUrl:               info.ApiUrl,
 				emailAttributeName:   info.EmailAttributeName,
 				emailAttributePath:   info.EmailAttributePath,
-				nameAttributeName:    sec.Key("name_attribute_name").String(),
 				nameAttributePath:    sec.Key("name_attribute_path").String(),
 				roleAttributePath:    info.RoleAttributePath,
 				loginAttributePath:   sec.Key("login_attribute_path").String(),

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -181,6 +181,8 @@ func NewOAuthService() {
 				apiUrl:               info.ApiUrl,
 				emailAttributeName:   info.EmailAttributeName,
 				emailAttributePath:   info.EmailAttributePath,
+				nameAttributeName:    sec.Key("name_attribute_name").String(),
+				nameAttributePath:    sec.Key("name_attribute_path").String(),
 				roleAttributePath:    info.RoleAttributePath,
 				loginAttributePath:   sec.Key("login_attribute_path").String(),
 				idTokenAttributeName: sec.Key("id_token_attribute_name").String(),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds configuration options for specifying custom attribute name or path for user name.

**Which issue(s) this PR fixes**:
This PR fixes #28224 

**Special notes for your reviewer**:

