### PR TITLE
main-view hidden when search is opened

### DIFF
--- a/public/app/features/search/components/SearchWrapper.tsx
+++ b/public/app/features/search/components/SearchWrapper.tsx
@@ -4,9 +4,10 @@ import { UrlQueryMap } from '@grafana/data';
 import { getLocationQuery } from 'app/core/selectors/location';
 import { updateLocation } from 'app/core/reducers/location';
 import { connectWithStore } from 'app/core/utils/connectWithReduxStore';
-import { StoreState } from 'app/types';
+import { CoreEvents, StoreState } from 'app/types';
 import DashboardSearch from './DashboardSearch';
 import { defaultQueryParams } from '../reducers/searchQueryReducer';
+import appEvents from 'app/core/app_events';
 
 interface OwnProps {
   search?: string | null;
@@ -35,7 +36,9 @@ export const SearchWrapper: FC<Props> = memo(({ search, folder, updateLocation }
         partial: true,
       });
     }
+    appEvents.emit(CoreEvents.toggleSearchOpened);
   };
+  isOpen && appEvents.emit(CoreEvents.toggleSearchOpened);
 
   return isOpen ? <DashboardSearch onCloseSearch={closeSearch} folder={folder} /> : null;
 });

--- a/public/app/features/search/components/SearchWrapper.tsx
+++ b/public/app/features/search/components/SearchWrapper.tsx
@@ -36,9 +36,8 @@ export const SearchWrapper: FC<Props> = memo(({ search, folder, updateLocation }
         partial: true,
       });
     }
-    appEvents.emit(CoreEvents.toggleSearchOpened);
   };
-  isOpen && appEvents.emit(CoreEvents.toggleSearchOpened);
+  appEvents.emit(isOpen ? CoreEvents.searchOpened : CoreEvents.searchClosed);
 
   return isOpen ? <DashboardSearch onCloseSearch={closeSearch} folder={folder} /> : null;
 });

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -182,8 +182,12 @@ export function grafanaAppDirective(
         elem.toggleClass('view-mode--playlist', false);
       });
 
-      appEvents.on(CoreEvents.toggleSearchOpened, () => {
-        body.toggleClass('search-opened');
+      appEvents.on(CoreEvents.searchOpened, () => {
+        body.addClass('search-opened');
+      });
+
+      appEvents.on(CoreEvents.searchClosed, () => {
+        body.removeClass('search-opened');
       });
 
       // tooltip removal fix

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -182,6 +182,10 @@ export function grafanaAppDirective(
         elem.toggleClass('view-mode--playlist', false);
       });
 
+      appEvents.on(CoreEvents.toggleSearchOpened, () => {
+        body.toggleClass('search-opened');
+      });
+
       // tooltip removal fix
       // manage page classes
       let pageClass: string;

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -125,6 +125,8 @@ export const graphHoverClear = eventFactory('graph-hover-clear');
 export const toggleSidemenuMobile = eventFactory('toggle-sidemenu-mobile');
 export const toggleSidemenuHidden = eventFactory('toggle-sidemenu-hidden');
 
+export const toggleSearchOpened = eventFactory('toggle-search-opened');
+
 export const playlistStarted = eventFactory('playlist-started');
 export const playlistStopped = eventFactory('playlist-stopped');
 

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -125,7 +125,8 @@ export const graphHoverClear = eventFactory('graph-hover-clear');
 export const toggleSidemenuMobile = eventFactory('toggle-sidemenu-mobile');
 export const toggleSidemenuHidden = eventFactory('toggle-sidemenu-hidden');
 
-export const toggleSearchOpened = eventFactory('toggle-search-opened');
+export const searchOpened = eventFactory('search-opened');
+export const searchClosed = eventFactory('search-closed');
 
 export const playlistStarted = eventFactory('playlist-started');
 export const playlistStopped = eventFactory('playlist-stopped');

--- a/public/sass/layout/_page.scss
+++ b/public/sass/layout/_page.scss
@@ -14,6 +14,12 @@
   background: $page-bg;
 }
 
+.search-opened {
+  .main-view {
+    visibility: hidden;
+  }
+}
+
 .page-explore,
 .page-dashboard {
   .main-view {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Alerts has higher z-index than content in search-wrapper and when alert appears on dashboard and user open the search, alert is still visible and covers space. Due to the fact that changing the z-index may cause a lot of problems, I propose to make all main-view hidden when search is open
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #28266 

**Special notes for your reviewer**:

