### PR TITLE
Mixin: Only ignore the file in the grafana mixin root folder

### DIFF
--- a/grafana-mixin/.gitignore
+++ b/grafana-mixin/.gitignore
@@ -1,3 +1,3 @@
-alerts.yaml
-rules.yaml
+/alerts.yaml
+/rules.yaml
 dashboards_out


### PR DESCRIPTION
`rules.yaml` and `alerts.yaml` was added before the `.gitignore` file. When pulling this mixin it would be possible to vendor the files into another repo. 
