### PR TITLE
Graph: Fix for graph size not taking up full height or width  

### DIFF
--- a/public/sass/components/_panel_graph.scss
+++ b/public/sass/components/_panel_graph.scss
@@ -8,8 +8,9 @@
       flex-direction: row;
 
       .graph-legend {
-        flex: 1 1 10px;
+        flex: 0 1 10px;
         max-height: 100%;
+        overflow-y: initial;
       }
 
       .graph-legend-series {
@@ -46,7 +47,7 @@
 
 .graph-legend {
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   max-height: 35%;
   margin: 0;
   text-align: center;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an alternative solution to the safari 14 overflow bug originally handled in https://github.com/grafana/grafana/pull/28254 which introduced layout bugs.

**Which issue(s) this PR fixes**:
Fixes #27676 

**Special notes for your reviewer**:

Graphs now look like the following screenshots...

<img width="600" alt="Screenshot 2020-10-16 at 11 11 38" src="https://user-images.githubusercontent.com/73201/96241659-c63df580-0fa2-11eb-885d-6d75920a2eb3.png">

<img width="600" alt="Screenshot 2020-10-16 at 11 11 24" src="https://user-images.githubusercontent.com/73201/96241647-c211d800-0fa2-11eb-989c-0e3abcb36b87.png">


