### PR TITLE
Automation: Add backport github action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,26 @@
+name: Backport PR Creator
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/backport
+        with:
+          metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          labelsToAdd: "backport"
+          title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
Figured we can start testing this and figure out some details and improvements along the way. 

If you label a PR with `backport v7.3.x` the bot will try to backport it and open a PR with `v7.3.x` as base. 

For now let's make sure both main PR that goes to master & backport PR are in the same milestone. And the main PR will have `add to changelog` label, not the backport. 

Having both in the same milestone feels awkward to me. But feels like the least disruptive change right now. We can keep everything the same. This should just lead to less PRs to manually cherry pick for 7.3.0 stable. 

