### PR TITLE
Templating: Replace all '$tag' in tag values query

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -119,7 +119,7 @@ const fetchTagValues = (tagText: string): ThunkResult<Promise<string[]>> => {
     const variable = getVariable<QueryVariableModel>(picker.id, getState());
 
     const datasource = await getDataSourceSrv().get(variable.datasource ?? '');
-    const query = variable.tagValuesQuery.replace('$tag', tagText);
+    const query = variable.tagValuesQuery.replace(/\$tag/g, tagText);
     const options = { range: getTimeRange(variable), variable };
 
     if (!datasource.metricFindQuery) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows use of multiple `$tag` in tag values query.
Before this change only the first `$tag` would be replaced with value.

This PR allows users to use queries such as:
```
SHOW TAG VALUES FROM "test" WITH KEY = "host" WHERE $timeFilter AND ("tag1" =~ /^$tag$/ OR "tag2" =~ /^$tag$/)
```