### PR TITLE
Automation: Update backport github action trigger

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport PR Creator
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled


### PR DESCRIPTION
It seems like GitHub has solved the problem of running github actions on PRs from forks with access to secrets. 

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks

If I change the event that triggers it to pull_request_target the action is run in the context of the base instead of the merged PR branch

Verified that this works on forks now:
https://github.com/grafana/github-actions-testrepo/pull/11