### PR TITLE
Instrumentation: Adds environment_info metric 

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -673,8 +673,8 @@ basic_auth_password =
 # Metrics environment info adds dimensions to the `grafana_environment_info` metric, which 
 # can exposes more information about the grafana instance.
 [metrics.environment_info]
-; exampleLabel1 = exampleValue1
-; exampleLabel2 = exampleValue2
+#exampleLabel1 = exampleValue1
+#exampleLabel2 = exampleValue2
 
 # Send internal Grafana metrics to graphite
 [metrics.graphite]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -670,6 +670,12 @@ disable_total_stats = false
 basic_auth_username =
 basic_auth_password =
 
+# Metrics environment info adds dimensions to the `grafana_environment_info` metric, which 
+# can exposes more information about the grafana instance.
+[metrics.environment_info]
+; exampleLabel1 = exampleValue1
+; exampleLabel2 = exampleValue2
+
 # Send internal Grafana metrics to graphite
 [metrics.graphite]
 # Enable by setting the address setting (ex localhost:2003)

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -671,7 +671,7 @@ basic_auth_username =
 basic_auth_password =
 
 # Metrics environment info adds dimensions to the `grafana_environment_info` metric, which 
-# can exposes more information about the grafana instance.
+# can expose more information about the Grafana instance.
 [metrics.environment_info]
 #exampleLabel1 = exampleValue1
 #exampleLabel2 = exampleValue2

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -667,8 +667,8 @@
 # Metrics environment info adds dimensions to the `grafana_environment_info` metric, which 
 # can exposes more information about the grafana instance.
 [metrics.environment_info]
-; exampleLabel1 = exampleValue1
-; exampleLabel2 = exampleValue2
+#exampleLabel1 = exampleValue1
+#exampleLabel2 = exampleValue2
 
 # Send internal metrics to Graphite
 [metrics.graphite]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -665,7 +665,7 @@
 ; basic_auth_password =
 
 # Metrics environment info adds dimensions to the `grafana_environment_info` metric, which 
-# can exposes more information about the grafana instance.
+# can expose more information about the Grafana instance.
 [metrics.environment_info]
 #exampleLabel1 = exampleValue1
 #exampleLabel2 = exampleValue2

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -664,6 +664,12 @@
 ; basic_auth_username =
 ; basic_auth_password =
 
+# Metrics environment info adds dimensions to the `grafana_environment_info` metric, which 
+# can exposes more information about the grafana instance.
+[metrics.environment_info]
+; exampleLabel1 = exampleValue1
+; exampleLabel2 = exampleValue2
+
 # Send internal metrics to Graphite
 [metrics.graphite]
 # Enable by setting the address setting (ex localhost:2003)

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -399,7 +399,7 @@ The length of time that Grafana will wait for a successful TLS handshake with th
 
 ### expect_continue_timeout_seconds
 
-The length of time that Grafana will wait for a datasource’s first response headers after fully writing the request headers, if the request has an “Expect: 100-continue” header.  A value of `0` will result in the body being sent immediately. Default is `1` second. For more details check the [Transport.ExpectContinueTimeout](https://golang.org/pkg/net/http/#Transport.ExpectContinueTimeout) documentation.
+The length of time that Grafana will wait for a datasource’s first response headers after fully writing the request headers, if the request has an “Expect: 100-continue” header. A value of `0` will result in the body being sent immediately. Default is `1` second. For more details check the [Transport.ExpectContinueTimeout](https://golang.org/pkg/net/http/#Transport.ExpectContinueTimeout) documentation.
 
 ### max_idle_connections
 
@@ -625,7 +625,7 @@ Default is `false`.
 
 ### user_invite_max_lifetime_duration
 
-The duration in time a user invitation remains valid before expiring. 
+The duration in time a user invitation remains valid before expiring.
 This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week).
 Default is `24h` (24 hours). The minimum supported duration is `15m` (15 minutes).
 
@@ -1074,6 +1074,15 @@ If set to `true`, then total stats generation (`stat_totals_*` metrics) is disab
 If both are set, then basic authentication is required to access the metrics endpoint.
 
 <hr>
+
+## [metrics.environment_info]
+
+Adds dimensions to the `grafana_environment_info` metric, which can exposes more information about the grafana instance.
+
+```
+; exampleLabel1 = exampleValue1
+; exampleLabel2 = exampleValue2
+```
 
 ## [metrics.graphite]
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1077,7 +1077,7 @@ If both are set, then basic authentication is required to access the metrics end
 
 ## [metrics.environment_info]
 
-Adds dimensions to the `grafana_environment_info` metric, which can exposes more information about the grafana instance.
+Adds dimensions to the `grafana_environment_info` metric, which can expose more information about the Grafana instance.
 
 ```
 ; exampleLabel1 = exampleValue1

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -513,6 +513,26 @@ func SetBuildInformation(version, revision, branch string) {
 	grafanaBuildVersion.WithLabelValues(version, revision, branch, runtime.Version(), edition).Set(1)
 }
 
+// SetEnvironmentInformation exposes environment values provided by the operators as an `_info` metrics.
+// If there are no environment metrics labels configured, this metric will not be exposed.
+func SetEnvironmentInformation(labels map[string]string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	grafanaEnvironmentInfo := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "environment_info",
+		Help:        "A metric with a constant '1' value labeled by environment information about rhe running instance.",
+		Namespace:   ExporterName,
+		ConstLabels: labels,
+	})
+
+	prometheus.MustRegister(grafanaEnvironmentInfo)
+
+	grafanaEnvironmentInfo.Set(1)
+	return nil
+}
+
 func SetPluginBuildInformation(pluginID, pluginType, version string) {
 	grafanaPluginBuildInfoDesc.WithLabelValues(pluginID, pluginType, version).Set(1)
 }

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -513,7 +513,7 @@ func SetBuildInformation(version, revision, branch string) {
 	grafanaBuildVersion.WithLabelValues(version, revision, branch, runtime.Version(), edition).Set(1)
 }
 
-// SetEnvironmentInformation exposes environment values provided by the operators as an `_info` metrics.
+// SetEnvironmentInformation exposes environment values provided by the operators as an `_info` metric.
 // If there are no environment metrics labels configured, this metric will not be exposed.
 func SetEnvironmentInformation(labels map[string]string) error {
 	if len(labels) == 0 {
@@ -522,7 +522,7 @@ func SetEnvironmentInformation(labels map[string]string) error {
 
 	grafanaEnvironmentInfo := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:        "environment_info",
-		Help:        "A metric with a constant '1' value labeled by environment information about rhe running instance.",
+		Help:        "A metric with a constant '1' value labeled by environment information about the running instance.",
 		Namespace:   ExporterName,
 		ConstLabels: labels,
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	_ "github.com/grafana/grafana/pkg/infra/metrics"
 	_ "github.com/grafana/grafana/pkg/infra/remotecache"
 	_ "github.com/grafana/grafana/pkg/infra/serverlock"
@@ -117,6 +118,9 @@ func (s *Server) init(cfg *Config) error {
 
 	s.loadConfiguration()
 	s.writePIDFile()
+	if err := metrics.SetEnvironmentInformation(s.cfg.MetricsGrafanaEnvironmentInfo); err != nil {
+		return err
+	}
 
 	login.Init()
 	social.NewOAuthService()


### PR DESCRIPTION
This metric can be used by the operator to expose more meta info metrics about the Grafana instance. 
In our case, we would add `database_id` and `plan` as labels.

Signed-off-by: bergquist <carl.bergquist@gmail.com>

