### PR TITLE
OAuth: Able to skip auto login

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -83,7 +83,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 
 	urlParams := c.Req.URL.Query()
 	if _, disableAutoLogin := urlParams["disableAutoLogin"]; disableAutoLogin {
-		hs.log.Info("Using internal login, skipping OAuth auto login")
+		hs.log.Debug("Auto login manually disabled")
 		c.HTML(200, getViewIndex(), viewData)
 		return
 	}

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -82,7 +82,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 	}
 
 	urlParams := c.Req.URL.Query()
-	if _, isInternal := urlParams["internal"]; isInternal {
+	if _, disableAutoLogin := urlParams["disableAutoLogin"]; disableAutoLogin {
 		hs.log.Info("Using internal login, skipping OAuth auto login")
 		c.HTML(200, getViewIndex(), viewData)
 		return

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -81,6 +81,13 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 		return
 	}
 
+	urlParams := c.Req.URL.Query()
+	if _, isInternal := urlParams["internal"]; isInternal {
+		hs.log.Info("Using internal login, skipping OAuth auto login")
+		c.HTML(200, getViewIndex(), viewData)
+		return
+	}
+
 	enabledOAuths := make(map[string]interface{})
 	for key, oauth := range setting.OAuthService.OAuthInfos {
 		enabledOAuths[key] = map[string]string{"name": oauth.Name}

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -512,7 +512,7 @@ func TestLoginInternal(t *testing.T) {
 	}
 
 	sc.defaultHandler = Wrap(func(c *models.ReqContext) {
-		c.Req.URL.RawQuery = "internal=true"
+		c.Req.URL.RawQuery = "disableAutoLogin=true"
 		hs.LoginView(c)
 	})
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -504,6 +504,8 @@ func TestLoginInternal(t *testing.T) {
 	mockSetIndexViewData()
 	defer resetSetIndexViewData()
 
+	mockViewIndex()
+	defer resetViewIndex()
 	sc := setupScenarioContext("/login")
 	hs := &HTTPServer{
 		Cfg:     setting.NewCfg(),

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -500,6 +500,39 @@ func TestLoginOAuthRedirect(t *testing.T) {
 	assert.Equal(t, location[0], "/login/github")
 }
 
+func TestLoginInternal(t *testing.T) {
+	mockSetIndexViewData()
+	defer resetSetIndexViewData()
+
+	sc := setupScenarioContext("/login")
+	hs := &HTTPServer{
+		Cfg:     setting.NewCfg(),
+		License: &licensing.OSSLicensingService{},
+		log:     &FakeLogger{},
+	}
+
+	sc.defaultHandler = Wrap(func(c *models.ReqContext) {
+		c.Req.URL.RawQuery = "internal=true"
+		hs.LoginView(c)
+	})
+
+	setting.OAuthService = &setting.OAuther{}
+	setting.OAuthService.OAuthInfos = make(map[string]*setting.OAuthInfo)
+	setting.OAuthService.OAuthInfos["github"] = &setting.OAuthInfo{
+		ClientId:     "fake",
+		ClientSecret: "fakefake",
+		Enabled:      true,
+		AllowSignup:  true,
+		Name:         "github",
+	}
+	setting.OAuthAutoLogin = true
+	sc.m.Get(sc.url, sc.defaultHandler)
+	sc.fakeReqNoAssertions("GET", sc.url).exec()
+
+	// Shouldn't redirect to the OAuth login URL
+	assert.Equal(t, sc.resp.Code, 200)
+}
+
 func TestAuthProxyLoginEnableLoginTokenDisabled(t *testing.T) {
 	sc := setupAuthProxyLoginTest(false)
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -508,7 +508,7 @@ func TestLoginInternal(t *testing.T) {
 	hs := &HTTPServer{
 		Cfg:     setting.NewCfg(),
 		License: &licensing.OSSLicensingService{},
-		log:     &FakeLogger{},
+		log:     log.New("test"),
 	}
 
 	sc.defaultHandler = Wrap(func(c *models.ReqContext) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds special `internal` param to the login path which makes it possible to disable OAuth auto login and log in with internal grafana user. Usage: `grafana.example.com/login?disableAutoLogin` or `grafana.example.com/login?disableAutoLogin=true`.

**Which issue(s) this PR fixes**:

Fixes #25993

**Special notes for your reviewer**:

In order to prevent duplicated user sessions, all OAuth providers (and SAML also in the Enterprise) disabled when `internal` flag used.