### PR TITLE
Loki: Visually distinguish error logs for LogQL2

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -27,6 +27,7 @@ export enum LogLevel {
   unknown = 'unknown',
 }
 
+// Used for meta information in logs view in Explore
 export enum LogsMetaKind {
   Number,
   String,

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -31,6 +31,7 @@ export enum LogsMetaKind {
   Number,
   String,
   LabelsMap,
+  Error,
 }
 
 export enum LogsSortOrder {

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -27,7 +27,7 @@ export enum LogLevel {
   unknown = 'unknown',
 }
 
-// Used for meta information in logs view in Explore
+// Used for meta information such as common labels or returned log rows in logs view in Explore
 export enum LogsMetaKind {
   Number,
   String,

--- a/packages/grafana-data/src/utils/logs.test.ts
+++ b/packages/grafana-data/src/utils/logs.test.ts
@@ -9,6 +9,7 @@ import {
   calculateStats,
   getLogLevelFromKey,
   sortLogsResult,
+  checkLogsError,
 } from './logs';
 
 describe('getLoglevel()', () => {
@@ -350,5 +351,17 @@ describe('sortLogsResult', () => {
         hasUniqueLabels: false,
       });
     });
+  });
+});
+
+describe('checkLogsError()', () => {
+  const log = ({
+    labels: {
+      __error__: 'Error Message',
+      foo: 'boo',
+    },
+  } as any) as LogRowModel;
+  test('should return correct error if error is present', () => {
+    expect(checkLogsError(log)).toBe({ hasError: true, errorMessage: 'Error Message' });
   });
 });

--- a/packages/grafana-data/src/utils/logs.test.ts
+++ b/packages/grafana-data/src/utils/logs.test.ts
@@ -362,6 +362,6 @@ describe('checkLogsError()', () => {
     },
   } as any) as LogRowModel;
   test('should return correct error if error is present', () => {
-    expect(checkLogsError(log)).toBe({ hasError: true, errorMessage: 'Error Message' });
+    expect(checkLogsError(log)).toStrictEqual({ hasError: true, errorMessage: 'Error Message' });
   });
 });

--- a/packages/grafana-data/src/utils/logs.ts
+++ b/packages/grafana-data/src/utils/logs.ts
@@ -210,3 +210,16 @@ export const sortLogsResult = (logsResult: LogsModel | null, sortOrder: LogsSort
 
 export const sortLogRows = (logRows: LogRowModel[], sortOrder: LogsSortOrder) =>
   sortOrder === LogsSortOrder.Ascending ? logRows.sort(sortInAscendingOrder) : logRows.sort(sortInDescendingOrder);
+
+// Currently supports only error condition in Loki logs
+export const checkLogsError = (logRow: LogRowModel): { hasError: boolean; error?: string } => {
+  if (logRow.labels.__error__) {
+    return {
+      hasError: true,
+      error: logRow.labels.__error__,
+    };
+  }
+  return {
+    hasError: false,
+  };
+};

--- a/packages/grafana-data/src/utils/logs.ts
+++ b/packages/grafana-data/src/utils/logs.ts
@@ -212,11 +212,11 @@ export const sortLogRows = (logRows: LogRowModel[], sortOrder: LogsSortOrder) =>
   sortOrder === LogsSortOrder.Ascending ? logRows.sort(sortInAscendingOrder) : logRows.sort(sortInDescendingOrder);
 
 // Currently supports only error condition in Loki logs
-export const checkLogsError = (logRow: LogRowModel): { hasError: boolean; error?: string } => {
+export const checkLogsError = (logRow: LogRowModel): { hasError: boolean; errorMessage?: string } => {
   if (logRow.labels.__error__) {
     return {
       hasError: true,
-      error: logRow.labels.__error__,
+      errorMessage: logRow.labels.__error__,
     };
   }
   return {

--- a/packages/grafana-ui/src/components/Logs/LogDetails.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.test.tsx
@@ -45,6 +45,12 @@ describe('LogDetails', () => {
       expect(wrapper.text().includes('key1label1key2label2')).toBe(true);
     });
   });
+  describe('when log row has error', () => {
+    it('should not render log level border', () => {
+      const wrapper = setup({ hasError: true }, undefined);
+      expect(wrapper.find({ 'aria-label': 'Log level' }).html()).not.toContain('logs-row__level');
+    });
+  });
   describe('when row entry has parsable fields', () => {
     it('should render heading ', () => {
       const wrapper = setup(undefined, { entry: 'test=successful' });

--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -100,7 +100,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
         onMouseLeave={onMouseLeave}
       >
         {showDuplicates && <td />}
-        <td className={levelClassName} />
+        <td className={levelClassName} aria-label="Log level" />
         <td colSpan={4}>
           <div className={style.logDetailsContainer}>
             <table className={style.logDetailsTable}>

--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -91,7 +91,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const fields = getAllFields(row, getFieldLinks);
     const parsedFieldsAvailable = fields && fields.length > 0;
     // If logs with error, we are not showing the level color
-    const levelClassName = !hasError ? cx(style.logsRowLevel, styles.logsRowLevelDetails) : '';
+    const levelClassName = cx(!hasError && [style.logsRowLevel, styles.logsRowLevelDetails]);
 
     return (
       <tr

--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -28,6 +28,7 @@ export interface Props extends Themeable {
   showDuplicates: boolean;
   getRows: () => LogRowModel[];
   className?: string;
+  hasError?: boolean;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   onClickFilterLabel?: (key: string, value: string) => void;
@@ -70,6 +71,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const {
       row,
       theme,
+      hasError,
       onClickFilterOutLabel,
       onClickFilterLabel,
       getRows,
@@ -88,6 +90,8 @@ class UnThemedLogDetails extends PureComponent<Props> {
     const labelsAvailable = Object.keys(labels).length > 0;
     const fields = getAllFields(row, getFieldLinks);
     const parsedFieldsAvailable = fields && fields.length > 0;
+    // If logs with error, we are not showing the level color
+    const levelClassName = !hasError ? cx(style.logsRowLevel, styles.logsRowLevelDetails) : '';
 
     return (
       <tr
@@ -96,7 +100,7 @@ class UnThemedLogDetails extends PureComponent<Props> {
         onMouseLeave={onMouseLeave}
       >
         {showDuplicates && <td />}
-        <td className={cx(style.logsRowLevel, styles.logsRowLevelDetails)} />
+        <td className={levelClassName} />
         <td colSpan={4}>
           <div className={style.logDetailsContainer}>
             <table className={style.logDetailsTable}>

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -147,7 +147,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     if (checkLogsError(row).hasError) {
       this.setState({
         hasError: true,
-        errorTooltip: checkLogsError(row).error,
+        errorTooltip: checkLogsError(row).errorMessage,
       });
     }
   };

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -59,8 +59,6 @@ interface State {
   showContext: boolean;
   showDetails: boolean;
   hasHoverBackground: boolean;
-  hasError: boolean;
-  errorTooltip?: string;
 }
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
@@ -76,7 +74,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: hoverBackground;
       background-color: ${bgColor};
     `,
-    erroredLog: css`
+    errorLogRow: css`
       label: erroredLogRow;
       color: ${theme.colors.textWeak};
     `,
@@ -94,13 +92,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     showContext: false,
     showDetails: false,
     hasHoverBackground: false,
-    hasError: false,
-    errorTooltip: undefined,
   };
-
-  componentDidMount() {
-    this.setErrorAndTooltip();
-  }
 
   toggleContext = () => {
     this.setState(state => {
@@ -141,17 +133,6 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     });
   };
 
-  // Currently just 1 condition. In the future, when we have more, we can move the check to util.
-  setErrorAndTooltip = () => {
-    const { row } = this.props;
-    if (checkLogsError(row).hasError) {
-      this.setState({
-        hasError: true,
-        errorTooltip: checkLogsError(row).errorMessage,
-      });
-    }
-  };
-
   renderTimeStamp(epochMs: number) {
     return dateTimeFormat(epochMs, {
       timeZone: this.props.timeZone,
@@ -182,12 +163,13 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       theme,
       getFieldLinks,
     } = this.props;
-    const { showDetails, showContext, hasHoverBackground, hasError, errorTooltip } = this.state;
+    const { showDetails, showContext, hasHoverBackground } = this.state;
     const style = getLogRowStyles(theme, row.logLevel);
     const styles = getStyles(theme);
+    const { errorMessage, hasError } = checkLogsError(row);
     const logRowBackground = cx(style.logsRow, {
       [styles.hoverBackground]: hasHoverBackground,
-      [styles.erroredLog]: hasError,
+      [styles.errorLogRow]: hasError,
     });
 
     return (
@@ -200,7 +182,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           )}
           <td className={cx({ [style.logsRowLevel]: !hasError })}>
             {hasError && (
-              <Tooltip content={`Error: ${errorTooltip}`} placement="right" theme="error">
+              <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">
                 <Icon className={style.logIconError} name="exclamation-triangle" size="sm" />
               </Tooltip>
             )}

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -72,6 +72,10 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: hoverBackground;
       background-color: ${bgColor};
     `,
+    erroredLog: css`
+      label: erroredLogRow;
+      color: ${theme.colors.textFaint};
+    `,
   };
 });
 /**
@@ -127,6 +131,14 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     });
   };
 
+  // Error condition to change color of logs. If more conditions, we can then move it to utils.
+  checkErrorCondition = (row: LogRowModel) => {
+    if (row.labels.__error__) {
+      return true;
+    }
+    return false;
+  };
+
   renderTimeStamp(epochMs: number) {
     return dateTimeFormat(epochMs, {
       timeZone: this.props.timeZone,
@@ -160,7 +172,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     const { showDetails, showContext, hasHoverBackground } = this.state;
     const style = getLogRowStyles(theme, row.logLevel);
     const styles = getStyles(theme);
-    const hoverBackground = cx(style.logsRow, { [styles.hoverBackground]: hasHoverBackground });
+    const logHasError = this.checkErrorCondition(row);
+    const hoverBackground = cx(style.logsRow, {
+      [styles.hoverBackground]: hasHoverBackground,
+      [styles.erroredLog]: logHasError,
+    });
 
     return (
       <>
@@ -169,6 +185,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           onMouseEnter={this.addHoverBackground}
           onMouseLeave={this.clearHoverBackground}
           onClick={this.toggleDetails}
+          title={logHasError ? `Error: ${row.labels.__error__}` : undefined}
         >
           {showDuplicates && (
             <td className={style.logsRowDuplicates}>

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -9,6 +9,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
   let logColor = selectThemeVariant({ light: theme.palette.gray5, dark: theme.palette.gray2 }, theme.type);
   const borderColor = selectThemeVariant({ light: theme.palette.gray5, dark: theme.palette.gray2 }, theme.type);
   const bgColor = selectThemeVariant({ light: theme.palette.gray5, dark: theme.palette.dark4 }, theme.type);
+  const bgColorLogRow = selectThemeVariant({ light: theme.palette.gray7, dark: theme.palette.dark2 }, theme.type);
   const context = css`
     label: context;
     visibility: hidden;
@@ -92,7 +93,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       }
 
       &:hover {
-        background: ${theme.colors.bodyBg};
+        background: ${bgColorLogRow};
       }
     `,
     logsRowDuplicates: css`
@@ -115,6 +116,10 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
         width: 3px;
         background-color: ${logColor};
       }
+    `,
+    logIconError: css`
+      color: ${theme.palette.red};
+      margin-left: -5px;
     `,
     logsRowToggleDetails: css`
       label: logs-row-toggle-details__level;

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -9,7 +9,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
   let logColor = selectThemeVariant({ light: theme.palette.gray5, dark: theme.palette.gray2 }, theme.type);
   const borderColor = selectThemeVariant({ light: theme.palette.gray5, dark: theme.palette.gray2 }, theme.type);
   const bgColor = selectThemeVariant({ light: theme.palette.gray5, dark: theme.palette.dark4 }, theme.type);
-  const bgColorLogRow = selectThemeVariant({ light: theme.palette.gray7, dark: theme.palette.dark2 }, theme.type);
+  const hoverBgColor = selectThemeVariant({ light: theme.palette.gray7, dark: theme.palette.dark2 }, theme.type);
   const context = css`
     label: context;
     visibility: hidden;
@@ -93,7 +93,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       }
 
       &:hover {
-        background: ${bgColorLogRow};
+        background: ${hoverBgColor};
       }
     `,
     logsRowDuplicates: css`

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -428,9 +428,9 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
 
     if (!errorMetaAdded && series.meta?.custom?.error) {
       meta.push({
-        label: 'Error',
+        label: '',
         value: series.meta?.custom.error,
-        kind: LogsMetaKind.String,
+        kind: LogsMetaKind.Error,
       });
       errorMetaAdded = true;
     }

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -419,10 +419,21 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
   // Hack to print loki stats in Explore. Should be using proper stats display via drawer in Explore (rework in 7.1)
   let totalBytes = 0;
   const queriesVisited: { [refId: string]: boolean } = {};
+  // To add just 1 error message
+  let errorMetaAdded = false;
 
   for (const series of logSeries) {
     const totalBytesKey = series.meta?.custom?.lokiQueryStatKey;
     const { refId } = series; // Stats are per query, keeping track by refId
+
+    if (!errorMetaAdded && series.meta?.custom?.error) {
+      meta.push({
+        label: 'Error',
+        value: series.meta?.custom.error,
+        kind: LogsMetaKind.String,
+      });
+      errorMetaAdded = true;
+    }
 
     if (refId && !queriesVisited[refId]) {
       if (totalBytesKey && series.meta?.stats) {

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -40,6 +40,8 @@ function renderMetaItem(value: any, kind: LogsMetaKind) {
         <LogLabels labels={value} />
       </span>
     );
+  } else if (kind === LogsMetaKind.Error) {
+    return <span className="logs-meta-item__error">{value}</span>;
   }
   return value;
 }

--- a/public/app/features/explore/MetaInfoText.tsx
+++ b/public/app/features/explore/MetaInfoText.tsx
@@ -15,6 +15,10 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => ({
     margin-right: ${theme.spacing.d};
     display: flex;
     align-items: baseline;
+
+    .logs-meta-item__error {
+      color: ${theme.palette.red};
+    }
   `,
   metaLabel: css`
     margin-right: calc(${theme.spacing.d} / 2);

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -325,6 +325,10 @@ export function lokiStreamsToDataframes(
     const dataFrame = lokiStreamResultToDataFrame(stream, reverse);
     enhanceDataFrame(dataFrame, config);
 
+    if (meta.custom && dataFrame.fields.some(f => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {
+      meta.custom.error = "Wasn't able to parse all logs";
+    }
+
     return {
       ...dataFrame,
       refId: target.refId,

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -326,7 +326,7 @@ export function lokiStreamsToDataframes(
     enhanceDataFrame(dataFrame, config);
 
     if (meta.custom && dataFrame.fields.some(f => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {
-      meta.custom.error = "Wasn't able to parse all logs";
+      meta.custom.error = 'Error when parsing some of the logs';
     }
 
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:
In LogQL2, when querying with a given pipeline such as `{app="foo"} | logfmt | duration > 240ms` multiple kind of errors for each line could happens, for instance if the line is not in logfmt or if the value duration label is not a duration. In Loki we don't filter out those log line, this would be confusing and dangerous to filter line that failed to be processed. Instead we add a label `__ error __`, however with the current UI it's not clear this is happening. 

To inform users about this, we are making those lines more pale and on tooltip you can see the content of `__error__`. That way it's clear that they are not being considered. We are also adding error message on top informing users about the fact, that some of the logs were errored. 

![image](https://user-images.githubusercontent.com/30407135/96447328-0656df80-1212-11eb-9f3a-3c0b8a6578fd.png)
