### PR TITLE
Grafana/ui: auto focus threshold editor input

### DIFF
--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
@@ -38,7 +38,7 @@ interface State {
 }
 
 export class ThresholdsEditor extends PureComponent<Props, State> {
-  private inputRef: React.RefObject<HTMLInputElement>;
+  private latestThresholdInputRef: HTMLInputElement | null;
 
   constructor(props: Props) {
     super(props);
@@ -47,8 +47,12 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
     steps[0].value = -Infinity;
 
     this.state = { steps };
-    this.inputRef = React.createRef();
+    this.latestThresholdInputRef = null;
   }
+
+  setLatestThresholdInputRef = (node: HTMLInputElement | null) => {
+    this.latestThresholdInputRef = node;
+  };
 
   onAddThreshold = () => {
     const { steps } = this.state;
@@ -71,8 +75,8 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
     sortThresholds(newThresholds);
 
     this.setState({ steps: newThresholds }, () => {
-      if (this.inputRef.current) {
-        this.inputRef.current.focus();
+      if (this.latestThresholdInputRef) {
+        this.latestThresholdInputRef.focus();
       }
       this.onChange();
     });
@@ -144,7 +148,7 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
     });
   };
 
-  renderInput(threshold: ThresholdWithKey, styles: ThresholdStyles) {
+  renderInput(threshold: ThresholdWithKey, styles: ThresholdStyles, idx: number) {
     const isPercent = this.props.thresholds.mode === ThresholdsMode.Percentage;
 
     if (!isFinite(threshold.value)) {
@@ -175,7 +179,11 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
         key={isPercent.toString()}
         onChange={(event: ChangeEvent<HTMLInputElement>) => this.onChangeThresholdValue(event, threshold)}
         value={threshold.value}
-        ref={this.inputRef}
+        ref={node => {
+          if (idx === 0) {
+            this.setLatestThresholdInputRef(node);
+          }
+        }}
         onBlur={this.onBlur}
         prefix={
           <div className={styles.inputPrefix}>
@@ -217,9 +225,9 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
                 {steps
                   .slice(0)
                   .reverse()
-                  .map(threshold => (
+                  .map((threshold, idx) => (
                     <div className={styles.item} key={`${threshold.key}`}>
-                      {this.renderInput(threshold, styles)}
+                      {this.renderInput(threshold, styles, idx)}
                     </div>
                   ))}
               </div>

--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
@@ -38,6 +38,8 @@ interface State {
 }
 
 export class ThresholdsEditor extends PureComponent<Props, State> {
+  private inputRef: React.RefObject<HTMLInputElement>;
+
   constructor(props: Props) {
     super(props);
 
@@ -45,6 +47,7 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
     steps[0].value = -Infinity;
 
     this.state = { steps };
+    this.inputRef = React.createRef();
   }
 
   onAddThreshold = () => {
@@ -67,7 +70,12 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
     const newThresholds = [...steps, add];
     sortThresholds(newThresholds);
 
-    this.setState({ steps: newThresholds }, this.onChange);
+    this.setState({ steps: newThresholds }, () => {
+      if (this.inputRef.current) {
+        this.inputRef.current.focus();
+      }
+      this.onChange();
+    });
   };
 
   onRemoveThreshold = (threshold: ThresholdWithKey) => {
@@ -167,7 +175,7 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
         key={isPercent.toString()}
         onChange={(event: ChangeEvent<HTMLInputElement>) => this.onChangeThresholdValue(event, threshold)}
         value={threshold.value}
-        autoFocus
+        ref={this.inputRef}
         onBlur={this.onBlur}
         prefix={
           <div className={styles.inputPrefix}>
@@ -209,13 +217,11 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
                 {steps
                   .slice(0)
                   .reverse()
-                  .map(threshold => {
-                    return (
-                      <div className={styles.item} key={`${threshold.key}`}>
-                        {this.renderInput(threshold, styles)}
-                      </div>
-                    );
-                  })}
+                  .map(threshold => (
+                    <div className={styles.item} key={`${threshold.key}`}>
+                      {this.renderInput(threshold, styles)}
+                    </div>
+                  ))}
               </div>
 
               <div>

--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
@@ -167,6 +167,7 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
         key={isPercent.toString()}
         onChange={(event: ChangeEvent<HTMLInputElement>) => this.onChangeThresholdValue(event, threshold)}
         value={threshold.value}
+        autoFocus
         onBlur={this.onBlur}
         prefix={
           <div className={styles.inputPrefix}>

--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
@@ -280,7 +280,6 @@ const getStyles = stylesFactory(
       wrapper: css`
         display: flex;
         flex-direction: column;
-        // margin-bottom: -${theme.spacing.formSpacingBase * 2}px;
       `,
       thresholds: css`
         display: flex;

--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
@@ -38,7 +38,7 @@ interface State {
 }
 
 export class ThresholdsEditor extends PureComponent<Props, State> {
-  private latestThresholdInputRef: HTMLInputElement | null;
+  private latestThresholdInputRef: React.RefObject<HTMLInputElement>;
 
   constructor(props: Props) {
     super(props);
@@ -47,12 +47,8 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
     steps[0].value = -Infinity;
 
     this.state = { steps };
-    this.latestThresholdInputRef = null;
+    this.latestThresholdInputRef = React.createRef();
   }
-
-  setLatestThresholdInputRef = (node: HTMLInputElement | null) => {
-    this.latestThresholdInputRef = node;
-  };
 
   onAddThreshold = () => {
     const { steps } = this.state;
@@ -75,8 +71,8 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
     sortThresholds(newThresholds);
 
     this.setState({ steps: newThresholds }, () => {
-      if (this.latestThresholdInputRef) {
-        this.latestThresholdInputRef.focus();
+      if (this.latestThresholdInputRef.current) {
+        this.latestThresholdInputRef.current.focus();
       }
       this.onChange();
     });
@@ -179,11 +175,7 @@ export class ThresholdsEditor extends PureComponent<Props, State> {
         key={isPercent.toString()}
         onChange={(event: ChangeEvent<HTMLInputElement>) => this.onChangeThresholdValue(event, threshold)}
         value={threshold.value}
-        ref={node => {
-          if (idx === 0) {
-            this.setLatestThresholdInputRef(node);
-          }
-        }}
+        ref={idx === 0 ? this.latestThresholdInputRef : null}
         onBlur={this.onBlur}
         prefix={
           <div className={styles.inputPrefix}>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the UX of the new threshold editor by autofocusing a new threshold input so that the user can set a value straight away.

![Kapture 2020-10-19 at 11 52 14](https://user-images.githubusercontent.com/73201/96430844-fa175600-1202-11eb-8b36-4cfaccacd4d4.gif)


**Which issue(s) this PR fixes**:
Fixes #25479

**Special notes for your reviewer**:
Cleaned up the commented out `margin-bottom` to silence stylelint.
