### PR TITLE
Webpack: Split out unicons and bizcharts

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -1,7 +1,6 @@
 // Libraries
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, Suspense } from 'react';
 import tinycolor from 'tinycolor2';
-import { Chart, Geom } from 'bizcharts';
 
 // Utils
 import { formattedValueToString, DisplayValue, getColorForTheme } from '@grafana/data';
@@ -12,6 +11,16 @@ import { BigValueColorMode, Props, BigValueJustifyMode, BigValueTextMode } from 
 
 const LINE_HEIGHT = 1.2;
 const MAX_TITLE_SIZE = 30;
+
+const Chart = React.lazy(async () => {
+  const { Chart } = await import(/* webpackChunkName: "bizcharts" */ 'bizcharts');
+  return { default: Chart };
+});
+
+const Geom = React.lazy(async () => {
+  const { Geom } = await import(/* webpackChunkName: "bizcharts" */ 'bizcharts');
+  return { default: Geom };
+});
 
 export abstract class BigValueLayout {
   titleFontSize: number;
@@ -165,17 +174,19 @@ export abstract class BigValueLayout {
     }
 
     return (
-      <Chart
-        height={this.chartHeight}
-        width={this.chartWidth}
-        data={data}
-        animate={false}
-        padding={[4, 0, 0, 0]}
-        scale={scales}
-        style={this.getChartStyles()}
-      >
-        {this.renderGeom()}
-      </Chart>
+      <Suspense fallback={<div>Loading chart...</div>}>
+        <Chart
+          height={this.chartHeight}
+          width={this.chartWidth}
+          data={data}
+          animate={false}
+          padding={[4, 0, 0, 0]}
+          scale={scales}
+          style={this.getChartStyles()}
+        >
+          {this.renderGeom()}
+        </Chart>
+      </Suspense>
     );
   }
 
@@ -208,10 +219,10 @@ export abstract class BigValueLayout {
     lineStyle.stroke = lineColor;
 
     return (
-      <>
+      <Suspense fallback={<div>Loading chart...</div>}>
         <Geom type="area" position="time*value" size={0} color={fillColor} style={lineStyle} shape="smooth" />
         <Geom type="line" position="time*value" size={1} color={lineColor} style={lineStyle} shape="smooth" />
-      </>
+      </Suspense>
     );
   }
 

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -180,6 +180,12 @@ module.exports = {
       chunks: 'all',
       minChunks: 1,
       cacheGroups: {
+        unicons: {
+          test: /[\\/]node_modules[\\/]@iconscout[\\/]react-unicons[\\/].*[jt]sx?$/,
+          chunks: 'initial',
+          priority: 20,
+          enforce: true,
+        },
         moment: {
           test: /[\\/]node_modules[\\/]moment[\\/].*[jt]sx?$/,
           chunks: 'initial',


### PR DESCRIPTION
**What this PR does / why we need it**:
- Split unicons out into a separate chunk
- Split `Chart` and `Geom` bizcharts components out using [`React.lazy`](https://reactjs.org/docs/code-splitting.html#reactlazy)

Lighthouse stats (with grafana server set to use http2):
Performance: 60 -> 62
First Contentful Paint: 2.5s -> 2.4s
Speed Index: 2.5s ->  2.4s
Largest Contentful Paint: 3.0s -> 2.8s
Time to Interactive: 2.6s -> 2.6s
