### PR TITLE
Plugins: Compose filesystem paths with filepath.Join

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -338,7 +337,7 @@ func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) Response {
 
 	filePath := hs.Cfg.DefaultHomeDashboardPath
 	if filePath == "" {
-		filePath = path.Join(hs.Cfg.StaticRootPath, "dashboards/home.json")
+		filePath = filepath.Join(hs.Cfg.StaticRootPath, "dashboards/home.json")
 	}
 
 	file, err := os.Open(filePath)

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,7 +55,7 @@ func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) (*macaron.Macaron, *HT
 	m := macaron.New()
 	m.Use(middleware.GetContextHandler(nil, nil, nil))
 	m.Use(macaron.Renderer(macaron.RenderOptions{
-		Directory:  path.Join(setting.StaticRootPath, "views"),
+		Directory:  filepath.Join(setting.StaticRootPath, "views"),
 		IndentJSON: true,
 		Delims:     macaron.Delims{Left: "[[", Right: "]]"},
 	}))

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"sync"
 
 	"github.com/grafana/grafana/pkg/services/live"
@@ -331,7 +332,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	}
 
 	m.Use(macaron.Renderer(macaron.RenderOptions{
-		Directory:  path.Join(setting.StaticRootPath, "views"),
+		Directory:  filepath.Join(setting.StaticRootPath, "views"),
 		IndentJSON: macaron.Env != macaron.PROD,
 		Delims:     macaron.Delims{Left: "[[", Right: "]]"},
 	}))

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -2,7 +2,7 @@ package plugins
 
 import (
 	"encoding/json"
-	"path"
+	"path/filepath"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -45,7 +45,7 @@ func (p *DataSourcePlugin) Load(decoder *json.Decoder, base *PluginBase, backend
 
 	if p.Backend {
 		cmd := ComposePluginStartCommand(p.Executable)
-		fullpath := path.Join(p.PluginDir, cmd)
+		fullpath := filepath.Join(p.PluginDir, cmd)
 		factory := grpcplugin.NewBackendPlugin(p.Id, fullpath, grpcplugin.PluginStartFuncs{
 			OnLegacyStart: p.onLegacyPluginStart,
 			OnStart:       p.onPluginStart,

--- a/pkg/plugins/frontend_plugin.go
+++ b/pkg/plugins/frontend_plugin.go
@@ -54,8 +54,8 @@ func (fp *FrontendPluginBase) setPathsBasedOnApp(app *AppPlugin) {
 
 func (fp *FrontendPluginBase) handleModuleDefaults() {
 	if isExternalPlugin(fp.PluginDir) {
-		fp.Module = path.Join("plugins", fp.Id, "module")
-		fp.BaseUrl = path.Join("public/plugins", fp.Id)
+		fp.Module = filepath.Join("plugins", fp.Id, "module")
+		fp.BaseUrl = filepath.Join("public/plugins", fp.Id)
 		return
 	}
 
@@ -66,8 +66,8 @@ func (fp *FrontendPluginBase) handleModuleDefaults() {
 	currentDir := filepath.Base(fp.PluginDir)
 	// use path package for the following statements
 	// because these are not file paths
-	fp.Module = path.Join("app/plugins", fp.Type, currentDir, "module")
-	fp.BaseUrl = path.Join("public/app/plugins", fp.Type, currentDir)
+	fp.Module = filepath.Join("app/plugins", fp.Type, currentDir, "module")
+	fp.BaseUrl = filepath.Join("public/app/plugins", fp.Type, currentDir)
 }
 
 func isExternalPlugin(pluginDir string) bool {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -79,7 +78,7 @@ func (pm *PluginManager) Init() error {
 
 	pm.log.Info("Starting plugin search")
 
-	plugDir := path.Join(setting.StaticRootPath, "app/plugins")
+	plugDir := filepath.Join(setting.StaticRootPath, "app/plugins")
 	pm.log.Debug("Scanning core plugin directory", "dir", plugDir)
 	if err := pm.scan(plugDir, false); err != nil {
 		return errutil.Wrapf(err, "failed to scan core plugin directory '%s'", plugDir)

--- a/pkg/plugins/renderer_plugin.go
+++ b/pkg/plugins/renderer_plugin.go
@@ -3,7 +3,7 @@ package plugins
 import (
 	"context"
 	"encoding/json"
-	"path"
+	"path/filepath"
 
 	pluginModel "github.com/grafana/grafana-plugin-model/go/renderer"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -34,7 +34,7 @@ func (r *RendererPlugin) Load(decoder *json.Decoder, base *PluginBase, backendPl
 	r.backendPluginManager = backendPluginManager
 
 	cmd := ComposePluginStartCommand("plugin_start")
-	fullpath := path.Join(r.PluginDir, cmd)
+	fullpath := filepath.Join(r.PluginDir, cmd)
 	factory := grpcplugin.NewRendererPlugin(r.Id, fullpath, grpcplugin.PluginStartFuncs{
 		OnLegacyStart: r.onLegacyPluginStart,
 		OnStart:       r.onPluginStart,

--- a/pkg/plugins/transform_plugin.go
+++ b/pkg/plugins/transform_plugin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strconv"
 
 	sdkgrpcplugin "github.com/grafana/grafana-plugin-sdk-go/backend/grpcplugin"
@@ -38,7 +38,7 @@ func (p *TransformPlugin) Load(decoder *json.Decoder, base *PluginBase, backendP
 	}
 
 	cmd := ComposePluginStartCommand(p.Executable)
-	fullpath := path.Join(p.PluginDir, cmd)
+	fullpath := filepath.Join(p.PluginDir, cmd)
 	factory := grpcplugin.NewBackendPlugin(p.Id, fullpath, grpcplugin.PluginStartFuncs{
 		OnStart: p.onPluginStart,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug I saw in plugins code of using `path.Join` instead of `filepath.Join` to join filesystem paths. Also fixing it in some other spots I saw.
