### PR TITLE
Component/NewsPanel: Add rel="noopener" to NewsPanel links

### DIFF
--- a/public/app/plugins/panel/news/NewsPanel.tsx
+++ b/public/app/plugins/panel/news/NewsPanel.tsx
@@ -77,7 +77,7 @@ export class NewsPanel extends PureComponent<Props, State> {
         {news.map((item, index) => {
           return (
             <div key={index} className={styles.item}>
-              <a href={textUtil.sanitizeUrl(item.link)} target="_blank">
+              <a href={textUtil.sanitizeUrl(item.link)} target="_blank" rel="noopener">
                 <div className={styles.title}>{item.title}</div>
                 <div className={styles.date}>{dateTimeFormat(item.date, { format: 'MMM DD' })} </div>
               </a>


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `rel = "noopener"` to `NewsPanel` links as suggested by Lighthouse [best practices](https://web.dev/external-anchors-use-rel-noopener/).
