### PR TITLE
Chore: fix jsdoc desc and return

### DIFF
--- a/packages/grafana-ui/src/utils/ansicolor.ts
+++ b/packages/grafana-ui/src/utils/ansicolor.ts
@@ -434,7 +434,7 @@ export default class Colors {
   }
 
   /**
-   * @desc installs String prototype extensions
+   * @description installs String prototype extensions
    * @example
    * require ('ansicolor').nice
    * console.log ('foo'.bright.red)
@@ -455,17 +455,17 @@ export default class Colors {
   }
 
   /**
-   * @desc parses a string containing ANSI escape codes
-   * @return {Colors} parsed representation.
+   * @description parses a string containing ANSI escape codes
+   * @returns {Colors} parsed representation.
    */
   static parse(s: string) {
     return new Colors(s).parsed;
   }
 
   /**
-   * @desc strips ANSI codes from a string
+   * @description strips ANSI codes from a string
    * @param {string} s a string containing ANSI escape codes.
-   * @return {string} clean string.
+   * @returns {string} clean string.
    */
   static strip(s: string) {
     return s.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]/g, ''); // hope V8 caches the regexp

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/utils.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/utils.tsx
@@ -40,7 +40,7 @@ export function createViewedBoundsFunc(viewRange: { min: number; max: number; vi
    * View bounds function
    * @param  {number} start     The start of the sub-range.
    * @param  {number} end       The end of the sub-range.
-   * @return {Object}           The resultant range.
+   * @returns {Object}           The resultant range.
    */
   return (start: number, end: number) => ({
     start: (start - viewMin) / viewWindow,
@@ -55,7 +55,7 @@ export function createViewedBoundsFunc(viewRange: { min: number; max: number; vi
  * @param  {any}    value The tag value to match.
  * @param  {{tags}} span  An object with a `tags` property of { key, value }
  *                        items.
- * @return {boolean}      True if a match was found.
+ * @returns {boolean}      True if a match was found.
  */
 export function spanHasTag(key: string, value: any, span: TraceSpan) {
   if (!Array.isArray(span.tags) || !span.tags.length) {
@@ -80,7 +80,7 @@ export const isErrorSpan = (span: TraceSpan) => isErrorBool(span) || isErrorStr(
  * @param      {number}   parentSpanIndex  The index of the parent span - only
  *                                         subsequent spans with depth less than
  *                                         the parent span will be checked.
- * @return     {boolean}  Returns `true` if a descendant contains an error tag.
+ * @returns     {boolean}  Returns `true` if a descendant contains an error tag.
  */
 export function spanContainsErredSpan(spans: TraceSpan[], parentSpanIndex: number) {
   const { depth } = spans[parentSpanIndex];

--- a/packages/jaeger-ui-components/src/model/span.tsx
+++ b/packages/jaeger-ui-components/src/model/span.tsx
@@ -17,7 +17,7 @@ import { TraceSpan } from '@grafana/data';
 /**
  * Searches the span.references to find 'CHILD_OF' reference type or returns null.
  * @param  {TraceSpan} span The span whose parent is to be returned.
- * @return {TraceSpan|null} The parent span if there is one, null otherwise.
+ * @returns {TraceSpan|null} The parent span if there is one, null otherwise.
  */
 export function getParent(span: TraceSpan) {
   const parentRef = span.references ? span.references.find(ref => ref.refType === 'CHILD_OF') : null;

--- a/packages/jaeger-ui-components/src/utils/color-generator.tsx
+++ b/packages/jaeger-ui-components/src/utils/color-generator.tsx
@@ -62,7 +62,7 @@ class ColorGenerator {
   /**
    * Retrieve the RGB values associated with a key. Adds the key and associates
    * it with a color if the key is not recognized.
-   * @return {number[]} An array of three ints [0, 255] representing a color.
+   * @returns {number[]} An array of three ints [0, 255] representing a color.
    */
   getRgbColorByKey(key: string): [number, number, number] {
     const i = this._getColorIndex(key);

--- a/packages/jaeger-ui-components/src/utils/date.tsx
+++ b/packages/jaeger-ui-components/src/utils/date.tsx
@@ -31,7 +31,7 @@ export const DEFAULT_MS_PRECISION = Math.log10(ONE_MILLISECOND);
  * @param {number} timestamp
  * @param {number} initialTimestamp
  * @param {number} totalDuration
- * @return {number} 0-100 percentage
+ * @returns {number} 0-100 percentage
  */
 export function getPercentageOfDuration(duration: number, totalDuration: number) {
   return (duration / totalDuration) * 100;
@@ -42,7 +42,7 @@ const quantizeDuration = (duration: number, floatPrecision: number, conversionFa
 
 /**
  * @param {number} duration (in microseconds)
- * @return {string} formatted, unit-labelled string with time in milliseconds
+ * @returns {string} formatted, unit-labelled string with time in milliseconds
  */
 export function formatDate(duration: number) {
   return moment(duration / ONE_MILLISECOND).format(STANDARD_DATE_FORMAT);
@@ -50,7 +50,7 @@ export function formatDate(duration: number) {
 
 /**
  * @param {number} duration (in microseconds)
- * @return {string} formatted, unit-labelled string with time in milliseconds
+ * @returns {string} formatted, unit-labelled string with time in milliseconds
  */
 export function formatTime(duration: number) {
   return moment(duration / ONE_MILLISECOND).format(STANDARD_TIME_FORMAT);
@@ -58,7 +58,7 @@ export function formatTime(duration: number) {
 
 /**
  * @param {number} duration (in microseconds)
- * @return {string} formatted, unit-labelled string with time in milliseconds
+ * @returns {string} formatted, unit-labelled string with time in milliseconds
  */
 export function formatDatetime(duration: number) {
   return moment(duration / ONE_MILLISECOND).format(STANDARD_DATETIME_FORMAT);
@@ -66,7 +66,7 @@ export function formatDatetime(duration: number) {
 
 /**
  * @param {number} duration (in microseconds)
- * @return {string} formatted, unit-labelled string with time in milliseconds
+ * @returns {string} formatted, unit-labelled string with time in milliseconds
  */
 export function formatMillisecondTime(duration: number) {
   const targetDuration = quantizeDuration(duration, DEFAULT_MS_PRECISION, ONE_MILLISECOND);
@@ -75,7 +75,7 @@ export function formatMillisecondTime(duration: number) {
 
 /**
  * @param {number} duration (in microseconds)
- * @return {string} formatted, unit-labelled string with time in seconds
+ * @returns {string} formatted, unit-labelled string with time in seconds
  */
 export function formatSecondTime(duration: number) {
   const targetDuration = quantizeDuration(duration, DEFAULT_MS_PRECISION, ONE_SECOND);

--- a/packages/jaeger-ui-components/src/utils/number.tsx
+++ b/packages/jaeger-ui-components/src/utils/number.tsx
@@ -24,7 +24,7 @@
  *
  * @param {number} number
  * @param {number} precision
- * @return {number} number at new floating precision
+ * @returns {number} number at new floating precision
  */
 export function toFloatPrecision(number: number, precision: number): number {
   const log10Length = Math.floor(Math.log10(Math.abs(number))) + 1;

--- a/public/app/features/explore/slate-plugins/prism/index.tsx
+++ b/public/app/features/explore/slate-plugins/prism/index.tsx
@@ -30,7 +30,7 @@ export default function PrismPlugin({ definition, language }: { definition: any;
      * Render a Slate mark with appropriate CSS class names
      *
      * @param {Object} props
-     * @return {Element}
+     * @returns {Element}
      */
 
     renderDecoration(props: any, editor: Editor, next: () => any): JSX.Element {
@@ -47,7 +47,7 @@ export default function PrismPlugin({ definition, language }: { definition: any;
      * Decorate code blocks with Prism.js highlighting.
      *
      * @param {Node} node
-     * @return {Array}
+     * @returns {Array}
      */
 
     decorateNode(node: any, editor: Editor, next: () => any): any[] {

--- a/public/app/plugins/panel/heatmap/heatmap_data_converter.ts
+++ b/public/app/plugins/panel/heatmap/heatmap_data_converter.ts
@@ -88,7 +88,7 @@ function parseHistogramLabel(label: string): number {
 /**
  * Convert buckets into linear array of "cards" - objects, represented heatmap elements.
  * @param  {Object} buckets
- * @return {Object}          Array of "card" objects and stats
+ * @returns {Object}          Array of "card" objects and stats
  */
 function convertToCards(buckets: any, hideZero = false): { cards: HeatmapCard[]; cardStats: HeatmapCardStats } {
   let min = 0,
@@ -136,7 +136,7 @@ function convertToCards(buckets: any, hideZero = false): { cards: HeatmapCard[];
  *
  * @param  {Object} buckets  Heatmap buckets
  * @param  {Number} minValue Minimum series value
- * @return {Object}          Transformed buckets
+ * @returns {Object}          Transformed buckets
  */
 function mergeZeroBuckets(buckets: any, minValue: number) {
   _.forEach(buckets, xBucket => {
@@ -177,7 +177,7 @@ function mergeZeroBuckets(buckets: any, minValue: number) {
 
 /**
  * Convert set of time series into heatmap buckets
- * @return {Object}    Heatmap object:
+ * @returns {Object}    Heatmap object:
  * {
  *   xBucketBound_1: {
  *     x: xBucketBound_1,


### PR DESCRIPTION
This fixes a few easy errors I see when trying to get my builds to pass CI:

![image](https://user-images.githubusercontent.com/705951/96513074-62236780-1216-11eb-8043-11efef44c85c.png)

`@desc` >> `@description
`@return` >> `@returns