### PR TITLE
CloudWatch: Fix passing of namespace for getting custom metrics #28075

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -41,6 +41,17 @@ type customMetricsCache struct {
 
 var customMetricsMetricsMap = make(map[string]*customMetricsCache)
 var customMetricsDimensionsMap = make(map[string]*customMetricsCache)
+
+type props struct {
+	region    string
+	profile   string
+	namespace string
+}
+
+func (p props) toArray() []string {
+	return []string{p.profile, p.region, p.namespace}
+}
+
 var metricsMap = map[string][]string{
 	"AWS/ACMPrivateCA":            {"CRLGenerated", "Failure", "MisconfiguredCRLBucket", "Success", "Time"},
 	"AWS/AmazonMQ":                {"BurstBalance", "ConsumerCount", "CpuCreditBalance", "CpuUtilization", "CurrentConnectionsCount", "DequeueCount", "DispatchCount", "EnqueueCount", "EnqueueTime", "EstablishedConnectionsCount", "ExpiredCount", "HeapUsage", "InactiveDurableTopicSubscribersCount", "InFlightCount", "JobSchedulerStorePercentUsage", "JournalFilesForFastRecovery", "JournalFilesForFullRecovery", "MemoryUsage", "NetworkIn", "NetworkOut", "OpenTransactionCount", "ProducerCount", "QueueSize", "ReceiveCount", "StorePercentUsage", "TempPercentUsage", "TotalConsumerCount", "TotalDequeueCount", "TotalEnqueueCount", "TotalMessageCount", "TotalProducerCount", "VolumeReadOps", "VolumeWriteOps"},
@@ -389,7 +400,9 @@ func (e *cloudWatchExecutor) handleGetMetrics(ctx context.Context, parameters *s
 	} else {
 		var err error
 		dsInfo := e.getDSInfo(region)
-		if namespaceMetrics, err = e.getMetricsForCustomMetrics(region, namespace, dsInfo.Profile); err != nil {
+
+		p := props{region: region, namespace: namespace, profile: dsInfo.Profile}
+		if namespaceMetrics, err = e.getMetricsForCustomMetrics(p); err != nil {
 			return nil, errutil.Wrap("unable to call AWS API", err)
 		}
 	}
@@ -417,7 +430,8 @@ func (e *cloudWatchExecutor) handleGetDimensions(ctx context.Context, parameters
 		var err error
 		dsInfo := e.getDSInfo(region)
 
-		if dimensionValues, err = e.getDimensionsForCustomMetrics(region, namespace, dsInfo.Profile); err != nil {
+		p := props{region: region, namespace: namespace, profile: dsInfo.Profile}
+		if dimensionValues, err = e.getDimensionsForCustomMetrics(p); err != nil {
 			return nil, errutil.Wrap("unable to call AWS API", err)
 		}
 	}
@@ -702,14 +716,14 @@ func (e *cloudWatchExecutor) resourceGroupsGetResources(region string, filters [
 	return &resp, nil
 }
 
-func (e *cloudWatchExecutor) getAllMetrics(region string, namespace string) (cloudwatch.ListMetricsOutput, error) {
-	client, err := e.getCWClient(region)
+func (e *cloudWatchExecutor) getAllMetrics(props props) (cloudwatch.ListMetricsOutput, error) {
+	client, err := e.getCWClient(props.region)
 	if err != nil {
 		return cloudwatch.ListMetricsOutput{}, err
 	}
 
 	params := &cloudwatch.ListMetricsInput{
-		Namespace: aws.String(namespace),
+		Namespace: aws.String(props.namespace),
 	}
 
 	plog.Debug("Listing metrics pages")
@@ -732,13 +746,13 @@ func (e *cloudWatchExecutor) getAllMetrics(region string, namespace string) (clo
 
 var metricsCacheLock sync.Mutex
 
-func (e *cloudWatchExecutor) getMetricsForCustomMetrics(region, namespace, profile string) ([]string, error) {
-	plog.Debug("Getting metrics for custom metrics", "region", region, "namespace", namespace)
+func (e *cloudWatchExecutor) getMetricsForCustomMetrics(props props) ([]string, error) {
+	plog.Debug("Getting metrics for custom metrics", "region", props.region, "namespace", props.namespace, "profile", props.profile)
 	metricsCacheLock.Lock()
 	defer metricsCacheLock.Unlock()
 
 	bldr := strings.Builder{}
-	for i, s := range []string{profile, region, namespace} {
+	for i, s := range props.toArray() {
 		if i != 0 {
 			bldr.WriteString(":")
 		}
@@ -754,7 +768,7 @@ func (e *cloudWatchExecutor) getMetricsForCustomMetrics(region, namespace, profi
 	if customMetricsMetricsMap[cacheKey].Expire.After(time.Now()) {
 		return customMetricsMetricsMap[cacheKey].Cache, nil
 	}
-	result, err := e.getAllMetrics(region, namespace)
+	result, err := e.getAllMetrics(props)
 	if err != nil {
 		return []string{}, err
 	}
@@ -775,12 +789,12 @@ func (e *cloudWatchExecutor) getMetricsForCustomMetrics(region, namespace, profi
 
 var dimensionsCacheLock sync.Mutex
 
-func (e *cloudWatchExecutor) getDimensionsForCustomMetrics(region, namespace, profile string) ([]string, error) {
+func (e *cloudWatchExecutor) getDimensionsForCustomMetrics(props props) ([]string, error) {
 	dimensionsCacheLock.Lock()
 	defer dimensionsCacheLock.Unlock()
 
 	bldr := strings.Builder{}
-	for i, s := range []string{profile, region, namespace} {
+	for i, s := range props.toArray() {
 		if i != 0 {
 			bldr.WriteString(":")
 		}
@@ -796,7 +810,7 @@ func (e *cloudWatchExecutor) getDimensionsForCustomMetrics(region, namespace, pr
 	if customMetricsDimensionsMap[cacheKey].Expire.After(time.Now()) {
 		return customMetricsDimensionsMap[cacheKey].Cache, nil
 	}
-	result, err := e.getAllMetrics(region, namespace)
+	result, err := e.getAllMetrics(props)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -39,8 +39,8 @@ type customMetricsCache struct {
 	Cache  []string
 }
 
-var customMetricsMetricsMap = make(map[string]*customMetricsCache)
-var customMetricsDimensionsMap = make(map[string]*customMetricsCache)
+var customMetricsMetricsMap = make(map[string]map[string]map[string]*customMetricsCache)
+var customMetricsDimensionsMap = make(map[string]map[string]map[string]*customMetricsCache)
 var metricsMap = map[string][]string{
 	"AWS/ACMPrivateCA":            {"CRLGenerated", "Failure", "MisconfiguredCRLBucket", "Success", "Time"},
 	"AWS/AmazonMQ":                {"BurstBalance", "ConsumerCount", "CpuCreditBalance", "CpuUtilization", "CurrentConnectionsCount", "DequeueCount", "DispatchCount", "EnqueueCount", "EnqueueTime", "EstablishedConnectionsCount", "ExpiredCount", "HeapUsage", "InactiveDurableTopicSubscribersCount", "InFlightCount", "JobSchedulerStorePercentUsage", "JournalFilesForFastRecovery", "JournalFilesForFullRecovery", "MemoryUsage", "NetworkIn", "NetworkOut", "OpenTransactionCount", "ProducerCount", "QueueSize", "ReceiveCount", "StorePercentUsage", "TempPercentUsage", "TotalConsumerCount", "TotalDequeueCount", "TotalEnqueueCount", "TotalMessageCount", "TotalProducerCount", "VolumeReadOps", "VolumeWriteOps"},
@@ -388,8 +388,7 @@ func (e *cloudWatchExecutor) handleGetMetrics(ctx context.Context, parameters *s
 		}
 	} else {
 		var err error
-		dsInfo := e.getDSInfo(region)
-		if namespaceMetrics, err = e.getMetricsForCustomMetrics(region, namespace, dsInfo.Profile); err != nil {
+		if namespaceMetrics, err = e.getMetricsForCustomMetrics(region, namespace); err != nil {
 			return nil, errutil.Wrap("unable to call AWS API", err)
 		}
 	}
@@ -416,8 +415,9 @@ func (e *cloudWatchExecutor) handleGetDimensions(ctx context.Context, parameters
 	} else {
 		var err error
 		dsInfo := e.getDSInfo(region)
+		dsInfo.Namespace = namespace
 
-		if dimensionValues, err = e.getDimensionsForCustomMetrics(region, namespace, dsInfo.Profile); err != nil {
+		if dimensionValues, err = e.getDimensionsForCustomMetrics(region, namespace); err != nil {
 			return nil, errutil.Wrap("unable to call AWS API", err)
 		}
 	}
@@ -708,8 +708,11 @@ func (e *cloudWatchExecutor) getAllMetrics(region string, namespace string) (clo
 		return cloudwatch.ListMetricsOutput{}, err
 	}
 
+	dsInfo := e.getDSInfo(region)
+	dsInfo.Namespace = namespace
+
 	params := &cloudwatch.ListMetricsInput{
-		Namespace: aws.String(namespace),
+		Namespace: aws.String(dsInfo.Namespace),
 	}
 
 	plog.Debug("Listing metrics pages")
@@ -732,88 +735,88 @@ func (e *cloudWatchExecutor) getAllMetrics(region string, namespace string) (clo
 
 var metricsCacheLock sync.Mutex
 
-func (e *cloudWatchExecutor) getMetricsForCustomMetrics(region, namespace, profile string) ([]string, error) {
+func (e *cloudWatchExecutor) getMetricsForCustomMetrics(region string, namespace string) ([]string, error) {
 	plog.Debug("Getting metrics for custom metrics", "region", region, "namespace", namespace)
 	metricsCacheLock.Lock()
 	defer metricsCacheLock.Unlock()
 
-	bldr := strings.Builder{}
-	for i, s := range []string{profile, region, namespace} {
-		if i != 0 {
-			bldr.WriteString(":")
-		}
-		bldr.WriteString(strings.ReplaceAll(s, ":", `\:`))
-	}
-	cacheKey := bldr.String()
+	dsInfo := e.getDSInfo(region)
+	dsInfo.Namespace = namespace
 
-	if _, ok := customMetricsMetricsMap[cacheKey]; !ok {
-		customMetricsMetricsMap[cacheKey] = &customMetricsCache{}
-		customMetricsMetricsMap[cacheKey].Cache = make([]string, 0)
+	if _, ok := customMetricsMetricsMap[dsInfo.Profile]; !ok {
+		customMetricsMetricsMap[dsInfo.Profile] = make(map[string]map[string]*customMetricsCache)
+	}
+	if _, ok := customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region]; !ok {
+		customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region] = make(map[string]*customMetricsCache)
+	}
+	if _, ok := customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace]; !ok {
+		customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace] = &customMetricsCache{}
+		customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache = make([]string, 0)
 	}
 
-	if customMetricsMetricsMap[cacheKey].Expire.After(time.Now()) {
-		return customMetricsMetricsMap[cacheKey].Cache, nil
+	if customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Expire.After(time.Now()) {
+		return customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, nil
 	}
 	result, err := e.getAllMetrics(region, namespace)
 	if err != nil {
 		return []string{}, err
 	}
 
-	customMetricsMetricsMap[cacheKey].Cache = make([]string, 0)
-	customMetricsMetricsMap[cacheKey].Expire = time.Now().Add(5 * time.Minute)
+	customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache = make([]string, 0)
+	customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Expire = time.Now().Add(5 * time.Minute)
 
 	for _, metric := range result.Metrics {
-		if isDuplicate(customMetricsMetricsMap[cacheKey].Cache, *metric.MetricName) {
+		if isDuplicate(customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, *metric.MetricName) {
 			continue
 		}
-		customMetricsMetricsMap[cacheKey].Cache = append(
-			customMetricsMetricsMap[cacheKey].Cache, *metric.MetricName)
+		customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache = append(
+			customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, *metric.MetricName)
 	}
 
-	return customMetricsMetricsMap[cacheKey].Cache, nil
+	return customMetricsMetricsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, nil
 }
 
 var dimensionsCacheLock sync.Mutex
 
-func (e *cloudWatchExecutor) getDimensionsForCustomMetrics(region, namespace, profile string) ([]string, error) {
+func (e *cloudWatchExecutor) getDimensionsForCustomMetrics(region string, namespace string) ([]string, error) {
 	dimensionsCacheLock.Lock()
 	defer dimensionsCacheLock.Unlock()
 
-	bldr := strings.Builder{}
-	for i, s := range []string{profile, region, namespace} {
-		if i != 0 {
-			bldr.WriteString(":")
-		}
-		bldr.WriteString(strings.ReplaceAll(s, ":", `\:`))
-	}
-	cacheKey := bldr.String()
+	dsInfo := e.getDSInfo(region)
+	dsInfo.Namespace = namespace
 
-	if _, ok := customMetricsDimensionsMap[cacheKey]; !ok {
-		customMetricsDimensionsMap[cacheKey] = &customMetricsCache{}
-		customMetricsDimensionsMap[cacheKey].Cache = make([]string, 0)
+	if _, ok := customMetricsDimensionsMap[dsInfo.Profile]; !ok {
+		customMetricsDimensionsMap[dsInfo.Profile] = make(map[string]map[string]*customMetricsCache)
+	}
+	if _, ok := customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region]; !ok {
+		customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region] = make(map[string]*customMetricsCache)
+	}
+	if _, ok := customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace]; !ok {
+		customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace] = &customMetricsCache{}
+		customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache = make([]string, 0)
 	}
 
-	if customMetricsDimensionsMap[cacheKey].Expire.After(time.Now()) {
-		return customMetricsDimensionsMap[cacheKey].Cache, nil
+	if customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Expire.After(time.Now()) {
+		return customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, nil
 	}
 	result, err := e.getAllMetrics(region, namespace)
 	if err != nil {
 		return []string{}, err
 	}
-	customMetricsDimensionsMap[cacheKey].Cache = make([]string, 0)
-	customMetricsDimensionsMap[cacheKey].Expire = time.Now().Add(5 * time.Minute)
+	customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache = make([]string, 0)
+	customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Expire = time.Now().Add(5 * time.Minute)
 
 	for _, metric := range result.Metrics {
 		for _, dimension := range metric.Dimensions {
-			if isDuplicate(customMetricsDimensionsMap[cacheKey].Cache, *dimension.Name) {
+			if isDuplicate(customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, *dimension.Name) {
 				continue
 			}
-			customMetricsDimensionsMap[cacheKey].Cache = append(
-				customMetricsDimensionsMap[cacheKey].Cache, *dimension.Name)
+			customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache = append(
+				customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, *dimension.Name)
 		}
 	}
 
-	return customMetricsDimensionsMap[cacheKey].Cache, nil
+	return customMetricsDimensionsMap[dsInfo.Profile][dsInfo.Region][dsInfo.Namespace].Cache, nil
 }
 
 func isDuplicate(nameList []string, target string) bool {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes a bug that omits the cloudwatch custom metrics namespace value from getting passed to the ListMetricsPages  api call.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #28075

**Special notes for your reviewer**:

No modifications were made to the existing unit test as it already covers the lines that were modified in this PR.  The unit test didn't catch this problem since the aws cloudwatch api calls are mocked. I have functionally tested the changes locally and it does resolve the issue.
