### PR TITLE
Docs: Fixing v51 link

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v5-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-1.md
@@ -42,7 +42,7 @@ Version | User    | User ID
 < 5.1   | grafana | 104
 >= 5.1  | grafana | 472
 
-Please read the [updated documentation](/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later) which includes migration instructions and more information.
+Please read the [updated documentation](/installation/docker/#migrate-to-v51-or-later) which includes migration instructions and more information.
 
 ## Prometheus
 

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -18,7 +18,7 @@ if [ ! -r "$GF_PATHS_HOME" ]; then
 fi
 
 if [ $PERMISSIONS_OK -eq 1 ]; then
-    echo "You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later"
+    echo "You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migrate-to-v51-or-later"
 fi
 
 if [ ! -d "$GF_PATHS_PLUGINS" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

The "What's new in v5.1" doc had an HTML anchor to an element that has changed, so it has to be changed where it's referenced.

It used to be:
/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later

and now it is:
/installation/docker/#migrate-to-v51-or-later

It changed on c344a3a66e47c180867fb77a869774b69af18a89