### PR TITLE
CloudWatch: Add 'EventBusName' dimension to CloudWatch 'AWS/Events' namespace

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -173,7 +173,7 @@ var dimensionsMap = map[string][]string{
 	"AWS/ElasticInference":        {"ElasticInferenceAcceleratorId", "InstanceId"},
 	"AWS/ElasticMapReduce":        {"ClusterId", "JobFlowId", "JobId"},
 	"AWS/ElasticTranscoder":       {"Operation", "PipelineId"},
-	"AWS/Events":                  {"RuleName"},
+	"AWS/Events":                  {"EventBusName", "RuleName"},
 	"AWS/FSx":                     {"FileSystemId"},
 	"AWS/Firehose":                {"DeliveryStreamName"},
 	"AWS/GameLift":                {"FleetId", "InstanceType", "MatchmakingConfigurationName", "MatchmakingConfigurationName-RuleName", "MetricGroups", "OperatingSystem", "QueueName"},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->


## WIP: Needs comment on issue #27202 before merging

**What this PR does / why we need it**:

Adds `EventBusName` dimension to `AWS/Events` namespace as it is a listed metric when running `aws cloudwatch list-metrics --namespace "AWS/Events"`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #27202

**Special notes for your reviewer**:

See comment at bottom of issue; official [AWS docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatch-Events-Monitoring-CloudWatch-Metrics.html) don't list this metric so have suggested the OP contacts AWS support for clarification