### PR TITLE
Chore: Set timezone for tests to non utc.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 // We set this specifically for 2 reasons.
-// 1. It's makes sense for both CI tests and local tests to behave the same so issues are found earlier
+// 1. It makes sense for both CI tests and local tests to behave the same so issues are found earlier
 // 2. Any wrong timezone handling could be hidden if we use UTC/GMT local time (which would happen in CI).
 process.env.TZ = 'Pacific/Easter';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
-process.env.TZ = 'UTC';
+// We set this specifically for 2 reasons.
+// 1. It's makes sense for both CI tests and local tests to behave the same so issues are found earlier
+// 2. Any wrong timezone handling could be hidden if we use UTC/GMT local time (which would happen in CI).
+process.env.TZ = 'Pacific/Easter';
 
 module.exports = {
   verbose: false,

--- a/packages/grafana-data/src/datetime/timezones.test.ts
+++ b/packages/grafana-data/src/datetime/timezones.test.ts
@@ -2,28 +2,25 @@ import { getTimeZoneInfo } from './timezones';
 import { setTimeZoneResolver } from './common';
 
 describe('getTimeZoneInfo', () => {
-  // global timezone is set to UTC, see jest-config.js file
+  // global timezone is set to Pacific/Easter, see jest-config.js file
 
   describe('IANA canonical name of the timezone', () => {
     it('should resolve for default timezone', () => {
       setTimeZoneResolver(() => 'browser');
       const result = getTimeZoneInfo('', Date.now());
-      expect(result?.ianaName).toBe('Africa/Abidjan');
+      expect(result?.ianaName).toBe('Pacific/Easter');
     });
 
     it('should resolve for browser timezone', () => {
-      // global timezone is set to UTC
       const result = getTimeZoneInfo('browser', Date.now());
-      expect(result?.ianaName).toBe('Africa/Abidjan');
+      expect(result?.ianaName).toBe('Pacific/Easter');
     });
     it('should resolve for utc timezone', () => {
-      // global timezone is set to UTC
       const result = getTimeZoneInfo('utc', Date.now());
       expect(result?.ianaName).toBe('UTC');
     });
 
     it('should resolve for given timezone', () => {
-      // global timezone is set to UTC
       const result = getTimeZoneInfo('Europe/Warsaw', Date.now());
       expect(result?.ianaName).toBe('Europe/Warsaw');
     });


### PR DESCRIPTION
Set the test timezone to something else than UTC. Using Pacific/Easter because it has DST, is 6h diff (should be more noticeable) and is something that probably has little chance that somebody from Grafana lives there so nobody should feel as getting preferential treatment :).

Otherwise the comment sums the reasoning for non UTC timezone
// 1. It makes sense for both CI tests and local tests to behave the same so issues are found earlier
// 2. Any wrong timezone handling could be hidden if we use UTC/GMT local time (which would happen in CI).