### PR TITLE
FieldColor: Remove inverted color scheme

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -74,13 +74,6 @@ export const fieldColorModeRegistry = new Registry<FieldColorMode>(() => {
       colors: ['dark-blue', 'super-light-yellow', 'dark-red'],
     }),
     new FieldColorSchemeMode({
-      id: 'continuous-RdYlBl',
-      name: 'Red-Yellow-Blue',
-      isContinuous: true,
-      isByValue: true,
-      colors: ['dark-red', 'super-light-yellow', 'dark-blue'],
-    }),
-    new FieldColorSchemeMode({
       id: 'continuous-YlRd',
       name: 'Yellow-Red',
       isContinuous: true,


### PR DESCRIPTION
Remove the inverted color scheme. Think we might add these in a different way in the future with an "invert option" but that requires a more custom color scheme selector UX. 