### PR TITLE
TestData: multiple arrow requests should return multiple frames

### DIFF
--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -198,7 +198,9 @@ function runArrowFile(target: TestDataQuery, req: DataQueryRequest<TestDataQuery
   if (target.stringInput && target.stringInput.length > 10) {
     try {
       const table = base64StringToArrowTable(target.stringInput);
-      data = [arrowTableToDataFrame(table)];
+      const frame = arrowTableToDataFrame(table);
+      frame.refId = target.refId;
+      data = [frame];
     } catch (e) {
       console.warn('Error reading saved arrow', e);
       const error = toDataQueryError(e);
@@ -206,7 +208,7 @@ function runArrowFile(target: TestDataQuery, req: DataQueryRequest<TestDataQuery
       return of({ state: LoadingState.Error, error, data });
     }
   }
-  return of({ state: LoadingState.Done, data });
+  return of({ state: LoadingState.Done, data, key: req.requestId + target.refId });
 }
 
 function runGrafanaAPI(target: TestDataQuery, req: DataQueryRequest<TestDataQuery>): Observable<DataQueryResponse> {


### PR DESCRIPTION
Fix a bug where only one result is returned from multiple queries.  When the refId and `key` are set, both frames are returned:

![image](https://user-images.githubusercontent.com/705951/96655925-8f921300-12f3-11eb-8f58-8d6ec4f5baff.png)
