### PR TITLE
Explore: Fix cut off icon

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -183,7 +183,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
           <td className={cx({ [style.logsRowLevel]: !hasError })}>
             {hasError && (
               <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">
-                <Icon className={style.logIconError} name="exclamation-triangle" size="sm" />
+                <Icon className={style.logIconError} name="exclamation-triangle" size="xs" />
               </Tooltip>
             )}
           </td>

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -114,12 +114,12 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
         top: 1px;
         bottom: 1px;
         width: 3px;
+        left: 4px;
         background-color: ${logColor};
       }
     `,
     logIconError: css`
       color: ${theme.palette.red};
-      margin-left: -5px;
     `,
     logsRowToggleDetails: css`
       label: logs-row-toggle-details__level;


### PR DESCRIPTION
Connected to https://github.com/grafana/grafana/pull/28359 (noticed on production Explore)
After:
![image](https://user-images.githubusercontent.com/30407135/96759953-fdfcd100-13d8-11eb-867a-42df4c44eb08.png)


Before:
![image](https://user-images.githubusercontent.com/30407135/96759880-e45b8980-13d8-11eb-9b88-fc9555605322.png)
