### PR TITLE
Performance: Make onChange passed to query editors non-anonymous

### DIFF
--- a/public/app/features/dashboard/panel_editor/QueryEditorRows.tsx
+++ b/public/app/features/dashboard/panel_editor/QueryEditorRows.tsx
@@ -42,27 +42,26 @@ export class QueryEditorRows extends PureComponent<Props> {
     panel.refresh();
   };
 
-  onChangeQuery(query: DataQuery, index: number) {
+  onChangeQuery = (query: DataQuery) => {
     const { queries, onChangeQueries } = this.props;
 
-    const old = queries[index];
+    // Assuming datasources won't mutate queries, we find the index of the query that was updated.
+    const prevQueryIndex = queries.findIndex((_, i, oldQueries) => oldQueries[i] !== queries[i]);
 
-    // ensure refId & datasource are maintained
-    query.refId = old.refId;
-    if (old.datasource) {
-      query.datasource = old.datasource;
-    }
-
-    // update query in array
     onChangeQueries(
       queries.map((item, itemIndex) => {
-        if (itemIndex === index) {
-          return query;
+        if (itemIndex === prevQueryIndex) {
+          // ensure refId & datasource are maintained
+          return {
+            ...query,
+            refId: queries[prevQueryIndex].refId,
+            datasource: queries[prevQueryIndex].datasource,
+          };
         }
         return item;
       })
     );
-  }
+  };
 
   onDragEnd = (result: DropResult) => {
     const { queries, onChangeQueries, panel } = this.props;
@@ -102,7 +101,7 @@ export class QueryEditorRows extends PureComponent<Props> {
                     dashboard={props.dashboard}
                     data={props.data}
                     query={query}
-                    onChange={query => this.onChangeQuery(query, index)}
+                    onChange={this.onChangeQuery}
                     onRemoveQuery={this.onRemoveQuery}
                     onAddQuery={this.onAddQuery}
                     inMixedMode={props.datasource.meta.mixed}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
the `onChange` handler is currently an anonymous function, this prevents query editors to opt-out from rerendering (eg. using `memo`), this is particularly important when on edit mode a dashboard is set to refresh automatically.

this change avoids passing an anonymous function to the query editors while retaining *almost* the same functionality. The only difference is that in order for this to work, query editors are required to mutate the whole query object every time they need to update a query (which imho would be a good practice to enforce anyway) but maybe there are better solutions.

eg:
```ts
// this won't work anymore
const MyEditor = ({query, onChange}) => {
  // [...]
  query.query = 'SELECT * FROM ...';
  onChange(query);
}

// this will:
const MyEditor = ({query, onChange}) => {
  // [...]
  query.query = 'SELECT * FROM ...';
  onChange({ ...query });
}
```

On the new Elastic Search datasource (being worked on) opting out from rerendering gives the folowing improvement:
(the benchmark is far from great and might need more iterations)
MacbookPro 2020, i5, Chrome, 4x CPU slowdown:
Before
<img width="163" alt="before" src="https://user-images.githubusercontent.com/1170767/96974949-c6de0b00-1511-11eb-9cbc-c69865f00433.png">

After:
<img width="165" alt="after" src="https://user-images.githubusercontent.com/1170767/96974947-c5acde00-1511-11eb-9bf2-ec4bb65202a0.png">

Flame chart (Query editor not re-rendering):
<img width="200" alt="Screenshot 2020-10-05 at 23 44 10" src="https://user-images.githubusercontent.com/1170767/96974950-c776a180-1511-11eb-8b58-c5cf1b8f4983.png">


Note that this won't automatically improve performance of every query editor as each one of them needs to manually opt-ot from rerendering ignoring props that are not relevant for them, as there are still other props that change at every render (like `timeRange` for instance) 



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:



