### PR TITLE
Drone: Don't build Windows installers for version branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2510,7 +2510,6 @@ steps:
   - gcloud auth activate-service-account --key-file=gcpkey.json
   - rm gcpkey.json
   - cp C:\App\nssm-2.24.zip .
-  - .\grabpl.exe windows-installer --edition oss --build-id $$env:DRONE_BUILD_NUMBER
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -2834,7 +2833,6 @@ steps:
   - gcloud auth activate-service-account --key-file=gcpkey.json
   - rm gcpkey.json
   - cp C:\App\nssm-2.24.zip .
-  - .\grabpl.exe windows-installer --edition enterprise --build-id $$env:DRONE_BUILD_NUMBER
   environment:
     GCP_KEY:
       from_secret: gcp_key

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -884,12 +884,12 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
             'gcloud auth activate-service-account --key-file=gcpkey.json',
             'rm gcpkey.json',
             'cp C:\\App\\nssm-2.24.zip .',
-            '.\\grabpl.exe windows-installer --edition {}{} {}'.format(edition, bucket_part, ver_part),
         ]
         if (ver_mode == 'master' and (edition != 'enterprise' or is_downstream)) or ver_mode in (
             'release', 'test-release',
         ):
             installer_commands.extend([
+                '.\\grabpl.exe windows-installer --edition {}{} {}'.format(edition, bucket_part, ver_part),
                 '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
                 'gsutil cp $$fname gs://{}/{}/{}/'.format(bucket, edition, dir),
                 'gsutil cp "$$fname.sha256" gs://{}/{}/{}/'.format(bucket, edition, dir),


### PR DESCRIPTION
**What this PR does / why we need it**:
Modify Drone config to not build Windows installers for version branches, since the required zip archives aren't uploaded. The builds break without this change.
