### PR TITLE
Elasticsearch: Fix handling of errors when testing data source

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -338,12 +338,8 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       },
       (err: any) => {
         console.error(err);
-        if (err.data && err.data.error) {
-          let message = angular.toJson(err.data.error);
-          if (err.data.error.reason) {
-            message = err.data.error.reason;
-          }
-          return { status: 'error', message: message };
+        if (err.message) {
+          return { status: 'error', message: err.message };
         } else {
           return { status: 'error', message: err.status };
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
#24999 changed the error response payload, but the test data source
was not adapted to this change and broke the feature of displaying
any errors to the user in the UI. This change should resolve this
problem.

**Which issue(s) this PR fixes**:
Ref #24999
Ref #28481 

**Special notes for your reviewer**:
Found when testing #28481 