### PR TITLE
Chore: Fix flaky sqlstore annotation test

### DIFF
--- a/pkg/services/sqlstore/annotation.go
+++ b/pkg/services/sqlstore/annotation.go
@@ -35,7 +35,7 @@ func (r *SqlAnnotationRepo) Save(item *annotations.Item) error {
 	return inTransaction(func(sess *DBSession) error {
 		tags := models.ParseTagPairs(item.Tags)
 		item.Tags = models.JoinTagPairs(tags)
-		item.Created = time.Now().UnixNano() / int64(time.Millisecond)
+		item.Created = timeNow().UnixNano() / int64(time.Millisecond)
 		item.Updated = item.Created
 		if item.Epoch == 0 {
 			item.Epoch = item.Created
@@ -81,7 +81,7 @@ func (r *SqlAnnotationRepo) Update(item *annotations.Item) error {
 			return errors.New("Annotation not found")
 		}
 
-		existing.Updated = time.Now().UnixNano() / int64(time.Millisecond)
+		existing.Updated = timeNow().UnixNano() / int64(time.Millisecond)
 		existing.Text = item.Text
 
 		if item.Epoch != 0 {

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAnnotations(t *testing.T) {
+	mockTimeNow()
+	defer resetTimeNow()
 	InitTestDB(t)
 
 	Convey("Testing annotation saving/loading", t, func() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Use mockable `timeNow` so that update annotation integration test can ensure that `Created` is less than `Updated` for item.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26524

**Special notes for your reviewer**:

`timeNow` is defined in https://github.com/grafana/grafana/blob/1646de454046606e4a526e83b05d21e440e65c23/pkg/services/sqlstore/alert.go#L13-L14

`mockTimeNow` is defined in https://github.com/grafana/grafana/blob/1646de454046606e4a526e83b05d21e440e65c23/pkg/services/sqlstore/alert_test.go#L14-L22

`resetTimeNow` is defined in https://github.com/grafana/grafana/blob/1646de454046606e4a526e83b05d21e440e65c23/pkg/services/sqlstore/alert_test.go#L24-L26

What do you think @aknuds1?