### PR TITLE
Explore/Loki: Update docs and cheatsheet

### DIFF
--- a/docs/sources/explore/index.md
+++ b/docs/sources/explore/index.md
@@ -155,6 +155,10 @@ Along with metrics, Explore allows you to investigate your logs with the followi
 - [InfluxDB](../datasources/influxdb)
 - [Elasticsearch](../datasources/elasticsearch)
 
+### Logs visualization
+
+Results of log queries are shown as histograms in graph and individual logs are displayed below. If datasource does not send histogram data for the requested time range, the logs model computes a timeseries based on the log row counts bucketed by an automcatically calculated time interval. The start of histogram is anchored by the first log row's timestamp from the result. The end of the timeseries is anchored to the timepicker's **To** range.
+
 ### Visualization options
 
 You can customize how logs are displayed and select which columns are shown.

--- a/docs/sources/explore/index.md
+++ b/docs/sources/explore/index.md
@@ -157,7 +157,7 @@ Along with metrics, Explore allows you to investigate your logs with the followi
 
 ### Logs visualization
 
-Results of log queries are shown as histograms in graph and individual logs are displayed below. If datasource does not send histogram data for the requested time range, the logs model computes a timeseries based on the log row counts bucketed by an automcatically calculated time interval. The start of histogram is anchored by the first log row's timestamp from the result. The end of the timeseries is anchored to the timepicker's **To** range.
+Results of log queries are shown as histograms in graph and individual logs are displayed below. If datasource does not send histogram data for the requested time range, the logs model computes a time series based on the log row counts bucketed by an automatically calculated time interval and the start of histogram is then anchored by the first log row's timestamp from the result. The end of the time series is anchored to the timepicker's **To** range.
 
 ### Visualization options
 

--- a/docs/sources/explore/index.md
+++ b/docs/sources/explore/index.md
@@ -157,7 +157,7 @@ Along with metrics, Explore allows you to investigate your logs with the followi
 
 ### Logs visualization
 
-Results of log queries are shown as histograms in graph and individual logs are displayed below. If datasource does not send histogram data for the requested time range, the logs model computes a time series based on the log row counts bucketed by an automatically calculated time interval and the start of histogram is then anchored by the first log row's timestamp from the result. The end of the time series is anchored to the timepicker's **To** range.
+Results of log queries are shown as histograms in the graph and individual logs are displayed below. If the data source does not send histogram data for the requested time range, the logs model computes a time series based on the log row counts bucketed by an automatically calculated time interval and the start of the histogram is then anchored by the first log row's timestamp from the result. The end of the time series is anchored to the time picker's **To** range.
 
 ### Visualization options
 

--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -9,6 +9,12 @@ const EXAMPLES_LIMIT = 5;
 
 const LOGQL_EXAMPLES = [
   {
+    title: 'Log pipeline',
+    expression: '{job="mysql"} |= "metrics" | logfmt | duration > 10s',
+    label:
+      'This query targets the MySQL job, filters out logs that don’t contain the word metrics and then parses each log line to extract more labels and filters with them.',
+  },
+  {
     title: 'Count over time',
     expression: 'count_over_time({job="mysql"}[5m])',
     label: 'This query counts all the log lines within the last five minutes for the MySQL job.',

--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -12,7 +12,7 @@ const LOGQL_EXAMPLES = [
     title: 'Log pipeline',
     expression: '{job="mysql"} |= "metrics" | logfmt | duration > 10s',
     label:
-      'This query targets the MySQL job, filters out logs that don’t contain the word metrics and then parses each log line to extract more labels and filters with them.',
+      'This query targets the MySQL job, filters out logs that don’t contain the word "metrics" and parses each log line to extract more labels and filters with them.',
   },
   {
     title: 'Count over time',


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates documentation related to:
- #25027 Logs: Use result range instead of time picker range for log histogram
- #27884 Loki: LogQL v2 support

