### PR TITLE
API: add login username in SendLoginLogCommand

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -181,6 +181,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 			ReqContext: c,
 			LogAction:  action,
 			User:       user,
+			LoginUser:  cmd.User,
 			HTTPStatus: response.status,
 			Error:      err,
 		})

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -178,12 +178,12 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 			err = errors.New(response.errMessage)
 		}
 		hs.SendLoginLog(&models.SendLoginLogCommand{
-			ReqContext: c,
-			LogAction:  action,
-			User:       user,
-			LoginUser:  cmd.User,
-			HTTPStatus: response.status,
-			Error:      err,
+			ReqContext:    c,
+			LogAction:     action,
+			User:          user,
+			LoginUsername: cmd.User,
+			HTTPStatus:    response.status,
+			Error:         err,
 		})
 	}()
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -687,7 +687,7 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 
 			cmd := testReceiver.cmd
 			assert.Equal(t, c.cmd.LogAction, cmd.LogAction)
-			assert.Equal(t, c.cmd.LoginUser, "admin")
+			assert.Equal(t, c.cmd.LoginUsername, "admin")
 			assert.Equal(t, c.cmd.HTTPStatus, cmd.HTTPStatus)
 			assert.Equal(t, c.cmd.Error, cmd.Error)
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -687,7 +687,7 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 
 			cmd := testReceiver.cmd
 			assert.Equal(t, c.cmd.LogAction, cmd.LogAction)
-			assert.Equal(t, c.cmd.LoginUsername, "admin")
+			assert.Equal(t, "admin", cmd.LoginUsername)
 			assert.Equal(t, c.cmd.HTTPStatus, cmd.HTTPStatus)
 			assert.Equal(t, c.cmd.Error, cmd.Error)
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -687,6 +687,7 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 
 			cmd := testReceiver.cmd
 			assert.Equal(t, c.cmd.LogAction, cmd.LogAction)
+			assert.Equal(t, c.cmd.LoginUser, "admin")
 			assert.Equal(t, c.cmd.HTTPStatus, cmd.HTTPStatus)
 			assert.Equal(t, c.cmd.Error, cmd.Error)
 

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -66,13 +66,13 @@ type DeleteAuthInfoCommand struct {
 }
 
 type SendLoginLogCommand struct {
-	ReqContext   *ReqContext
-	LogAction    string
-	User         *User
-	ExternalUser *ExternalUserInfo
-	LoginUser    string
-	HTTPStatus   int
-	Error        error
+	ReqContext    *ReqContext
+	LogAction     string
+	User          *User
+	ExternalUser  *ExternalUserInfo
+	LoginUsername string
+	HTTPStatus    int
+	Error         error
 }
 
 // ----------------------

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -70,6 +70,7 @@ type SendLoginLogCommand struct {
 	LogAction    string
 	User         *User
 	ExternalUser *ExternalUserInfo
+	LoginUser    string
 	HTTPStatus   int
 	Error        error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the username used for Grafana login in the `SendLoginLogCommand`. It's useful information when the login fails with a "user is disabled", "user lockout" or "invalid username and password" error. 

**Special notes for reviewers:**
I'm not sure about the labels I should use for this to be in 7.3.
