### PR TITLE
Plugins: Fix plugin URL paths on Windows

### DIFF
--- a/pkg/plugins/frontend_plugin.go
+++ b/pkg/plugins/frontend_plugin.go
@@ -55,7 +55,7 @@ func (fp *FrontendPluginBase) setPathsBasedOnApp(app *AppPlugin) {
 func (fp *FrontendPluginBase) handleModuleDefaults() {
 	if isExternalPlugin(fp.PluginDir) {
 		fp.Module = filepath.Join("plugins", fp.Id, "module")
-		fp.BaseUrl = filepath.Join("public/plugins", fp.Id)
+		fp.BaseUrl = path.Join("public/plugins", fp.Id)
 		return
 	}
 
@@ -67,7 +67,7 @@ func (fp *FrontendPluginBase) handleModuleDefaults() {
 	// use path package for the following statements
 	// because these are not file paths
 	fp.Module = filepath.Join("app/plugins", fp.Type, currentDir, "module")
-	fp.BaseUrl = filepath.Join("public/app/plugins", fp.Type, currentDir)
+	fp.BaseUrl = path.Join("public/app/plugins", fp.Type, currentDir)
 }
 
 func isExternalPlugin(pluginDir string) bool {

--- a/pkg/plugins/frontend_plugin.go
+++ b/pkg/plugins/frontend_plugin.go
@@ -54,7 +54,7 @@ func (fp *FrontendPluginBase) setPathsBasedOnApp(app *AppPlugin) {
 
 func (fp *FrontendPluginBase) handleModuleDefaults() {
 	if isExternalPlugin(fp.PluginDir) {
-		fp.Module = filepath.Join("plugins", fp.Id, "module")
+		fp.Module = path.Join("plugins", fp.Id, "module")
 		fp.BaseUrl = path.Join("public/plugins", fp.Id)
 		return
 	}
@@ -66,7 +66,7 @@ func (fp *FrontendPluginBase) handleModuleDefaults() {
 	currentDir := filepath.Base(fp.PluginDir)
 	// use path package for the following statements
 	// because these are not file paths
-	fp.Module = filepath.Join("app/plugins", fp.Type, currentDir, "module")
+	fp.Module = path.Join("app/plugins", fp.Type, currentDir, "module")
 	fp.BaseUrl = path.Join("public/app/plugins", fp.Type, currentDir)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix plugin URL paths on Windows.

Agnès discovered that plugin URLs had backslashes in them on Windows, and it looks to me as if this should be the culprits.