### PR TITLE
GithubMetrics: Move metrics collector queries to config

### DIFF
--- a/.github/metrics-collector.json
+++ b/.github/metrics-collector.json
@@ -1,0 +1,28 @@
+{
+  "queries": [
+    {
+      "name": "type_bug",
+      "query": "label:\"type/bug\" is:open"
+    },
+    {
+      "name": "needs_investigation",
+      "query": "label:\"needs investigation\" is:open"
+    },
+    {
+      "name": "needs_more_info",
+      "query": "label:\"needs more info\" is:open"
+    },
+    {
+      "name": "unlabeled",
+      "query": "is:open is:issue no:label"
+    },
+    {
+      "name": "open_prs",
+      "query": "is:open is:pr"
+    },
+    {
+      "name": "milestone_7_4_open",
+      "query": "is:open is:issue milestone:7.4"
+    }
+  ]
+}

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
-          config-path: commands
+          configPath: commands

--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -8,7 +8,7 @@
 #
 # https://github.com/grafana/grafana-github-actions/blob/main/metrics-collector/index.ts
 #
-name: Github issue metrics collection 
+name: Github issue metrics collection
 on:
   schedule:
     - cron: "*/10 * * * *"
@@ -32,3 +32,4 @@ jobs:
         with:
           metricsWriteAPIKey: ${{secrets.GRAFANA_MISC_STATS_API_KEY}}
           token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: "metrics-collector"


### PR DESCRIPTION
In order to use the github stats collection on other repos (like loki and tempo), I have moved some of the stats config out to a file in each repo. 

Needs to be merged synced with 
https://github.com/grafana/grafana-github-actions/pull/1