### PR TITLE
Docs: Update graph panel for tabs

### DIFF
--- a/docs/sources/linking/data-links.md
+++ b/docs/sources/linking/data-links.md
@@ -37,10 +37,10 @@ When creating or updating a data link, press Cmd+Space or Ctrl+Space on your key
 ## Update a data link
 
 1. On the Field tab, find the link that you want to make changes to.
-2. Click the Edit (pencil) icon to open the Edit link window.
-3. Make any necessary changes.
-4. Click **Save** to save changes and close the window.
-5. Click **Save** in the upper right to save your changes to the dashboard.
+1. Click the Edit (pencil) icon to open the Edit link window.
+1. Make any necessary changes.
+1. Click **Save** to save changes and close the window.
+1. Click **Save** in the upper right to save your changes to the dashboard.
 
 ## Delete a data link
 

--- a/docs/sources/linking/data-links.md
+++ b/docs/sources/linking/data-links.md
@@ -23,7 +23,7 @@ When creating or updating a data link, press Cmd+Space or Ctrl+Space on your key
 ## Add a data link
 
 1. Hover your cursor over the panel that you want to add a link to and then press `e`. Or click the dropdown arrow next to the panel title and then click **Edit**.
-1. On the Field tab, scroll down to the Data links section. (Panel tab for graph visualizations.)
+1. On the Field tab, scroll down to the Data links section.
 1. Expand Data links and then click **Add link**.
 1. Enter a **Title**. **Title** is a human-readable label for the link that will be displayed in the UI.
 1. Enter the **URL** you want to link to.
@@ -36,14 +36,14 @@ When creating or updating a data link, press Cmd+Space or Ctrl+Space on your key
 
 ## Update a data link
 
-1. On the Field tab, find the link that you want to make changes to. (Panel tab for graph visualizations.)
-1. Click the Edit (pencil) icon to open the Edit link window. 
-1. Make any necessary changes.
-1. Click **Save** to save changes and close the window.
-1. Click **Save** in the upper right to save your changes to the dashboard.
+1. On the Field tab, find the link that you want to make changes to.
+2. Click the Edit (pencil) icon to open the Edit link window.
+3. Make any necessary changes.
+4. Click **Save** to save changes and close the window.
+5. Click **Save** in the upper right to save your changes to the dashboard.
 
 ## Delete a data link
 
-1. On the Field tab, find the link that you want to delete. (Panel tab for graph visualizations.)
-1. Click the **X** icon next to the link you want to delete. 
+1. On the Field tab, find the link that you want to delete.
+1. Click the **X** icon next to the link you want to delete.
 1. Click **Save** in the upper right to save your changes to the dashboard.

--- a/docs/sources/linking/data-links.md
+++ b/docs/sources/linking/data-links.md
@@ -9,10 +9,8 @@ aliases = ["/docs/grafana/latest/reference/datalinks/"]
 
 Data links allow you to provide more granular context to your links. You can create links that include the series name or even the value under the cursor. For example, if your visualization showed four servers, you could add a data link to one or two of them.
 
-The link itself is accessible in different ways depending on the visualization. For the graph you need to click on a data point or line, for a panel like
+The link itself is accessible in different ways depending on the visualization. For the Graph you need to click on a data point or line, for a panel like
 Stat, Gauge, or Bar Gauge you can click anywhere on the visualization to open the context menu.
-
-> **Note:** For stat, gauge, bar gauge, and table visualizations, you add and edit data links on the Field tab. For the graph visualization, you add and edit data links on the Panel tab.
 
 You can use variables in data links to send people to a detailed dashboard with preserved data filters. For example, you could use variables to specify a time range, series, and variable selection. For more information, refer to [Data link variables]({{< relref "data-link-variables.md" >}}).
 

--- a/docs/sources/panels/field-options/standard-field-options.md
+++ b/docs/sources/panels/field-options/standard-field-options.md
@@ -18,6 +18,8 @@ For more information about applying these options, refer to:
 - [Configure all fields]({{< relref "configure-all-fields.md" >}})
 - [Configure specific fields]({{< relref "configure-specific-fields.md" >}})
 
+> **Note:** We are constantly working to add and expand options for all visualization, so all options might not be available for all visualizations. 
+
 ## Decimals
 
 Number of decimals to render value with. Leave empty for Grafana to use the number of decimals provided by the data source.

--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -16,8 +16,9 @@ This visualization is the most-used in the Grafana ecosystem. It can render as a
 
 Graph visualizations allow you to apply:
 
-- [Data transformations]({{< relref "../transformations/_index.md" >}})
 - [Alerts]({{< relref "../../alerting/alerts-overview.md" >}}) - This is the only type of visualization that allows you to set alerts.
+- [Data transformations]({{< relref "../transformations/_index.md" >}})
+- [Field options and overrides]({{< relref "../field-options/_index.md" >}})
 - [Thresholds]({{< relref "../thresholds.md" >}})
 
 ## Display options


### PR DESCRIPTION
This content adds information about the Field and Override tabs in the Graph panel, which were added sometime after Grafana 7.0.

It also removes inaccuracies about where to add data links in the Graph panel.

When this PR is merged, the content should be correct.