### PR TITLE
Elasticsearch: Add Scripted Metric Aggregation

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -123,6 +123,10 @@ Some metric aggregations are called Pipeline aggregations, for example, *Moving 
 
 ![](/img/docs/elasticsearch/pipeline_metrics_editor.png)
 
+## Scripting Language
+
+From Elasticsearch v5.0 and above, the default scripting language changed to *Painless*. For this scripting language, variables are referenced using params.<var>. For Elasticsearch version before v5.0, the default scripting language is *Groovy*, and variables are referenced using <var>. 
+
 ## Templating
 
 Instead of hard-coding things like server, application and sensor name in your metric queries you can use variables in their place.

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -123,10 +123,10 @@ Some metric aggregations are called Pipeline aggregations, for example, *Moving 
 
 ![](/img/docs/elasticsearch/pipeline_metrics_editor.png)
 
-## Scripting Language
+## Scripting language
 
-Elasticsearch v5.0 and above uses *Painless* as the default scripting language. Variables are referenced using `params.<var>`. 
-Elasticsearch pre-v5.0 uses *Groovy* as the default scripting language if not changed. For *Groovy*, `<var>` is used to reference a variable.
+Elasticsearch v5.0 and above uses Painless as the default scripting language. Variables are referenced using `params.<var>`. 
+Elasticsearch pre-v5.0 uses Groovy as the default scripting language if not changed. For Groovy, `<var>` is used to reference a variable.
 
 ## Templating
 

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -125,7 +125,8 @@ Some metric aggregations are called Pipeline aggregations, for example, *Moving 
 
 ## Scripting Language
 
-From Elasticsearch v5.0 and above, the default scripting language changed to *Painless*. For this scripting language, variables are referenced using params.<var>. For Elasticsearch version before v5.0, the default scripting language is *Groovy*, and variables are referenced using <var>. 
+Elasticsearch v5.0 and above uses *Painless* as the default scripting language. Variables are referenced using params.<var>. 
+Elasticsearch pre-v5.0 uses *Groovy* as the default scripting language if not changed. For *Groovy*, <var> is used to reference a variable.
 
 ## Templating
 

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -125,8 +125,8 @@ Some metric aggregations are called Pipeline aggregations, for example, *Moving 
 
 ## Scripting Language
 
-Elasticsearch v5.0 and above uses *Painless* as the default scripting language. Variables are referenced using params.<var>. 
-Elasticsearch pre-v5.0 uses *Groovy* as the default scripting language if not changed. For *Groovy*, <var> is used to reference a variable.
+Elasticsearch v5.0 and above uses *Painless* as the default scripting language. Variables are referenced using `params.<var>`. 
+Elasticsearch pre-v5.0 uses *Groovy* as the default scripting language if not changed. For *Groovy*, `<var>` is used to reference a variable.
 
 ## Templating
 

--- a/pkg/tsdb/elasticsearch/models.go
+++ b/pkg/tsdb/elasticsearch/models.go
@@ -36,19 +36,20 @@ type MetricAgg struct {
 }
 
 var metricAggType = map[string]string{
-	"count":          "Count",
-	"avg":            "Average",
-	"sum":            "Sum",
-	"max":            "Max",
-	"min":            "Min",
-	"extended_stats": "Extended Stats",
-	"percentiles":    "Percentiles",
-	"cardinality":    "Unique Count",
-	"moving_avg":     "Moving Average",
-	"cumulative_sum": "Cumulative Sum",
-	"derivative":     "Derivative",
-	"bucket_script":  "Bucket Script",
-	"raw_document":   "Raw Document",
+	"count":           "Count",
+	"avg":             "Average",
+	"sum":             "Sum",
+	"max":             "Max",
+	"min":             "Min",
+	"extended_stats":  "Extended Stats",
+	"percentiles":     "Percentiles",
+	"cardinality":     "Unique Count",
+	"scripted_metric": "Scripted Metric",
+	"moving_avg":      "Moving Average",
+	"cumulative_sum":  "Cumulative Sum",
+	"derivative":      "Derivative",
+	"bucket_script":   "Bucket Script",
+	"raw_document":    "Raw Document",
 }
 
 var extendedStats = map[string]string{

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.ts
@@ -15,6 +15,7 @@ export class ElasticMetricAggCtrl {
     const metricAggs: ElasticsearchAggregation[] = $scope.target.metrics;
     $scope.metricAggTypes = queryDef.getMetricAggTypes($scope.esVersion);
     $scope.extendedStats = queryDef.extendedStats;
+    $scope.scriptedMetricOptions = queryDef.scriptedMetricOptions;
     $scope.pipelineAggOptions = [];
     $scope.modelSettingsValues = {};
 
@@ -76,6 +77,14 @@ export class ElasticMetricAggCtrl {
         case 'percentiles': {
           $scope.agg.settings.percents = $scope.agg.settings.percents || [25, 50, 75, 95, 99];
           $scope.settingsLinkText = 'Values: ' + $scope.agg.settings.percents.join(',');
+          break;
+        }
+        case 'scripted_metric': {
+          $scope.settingsLinkText = 'Settings';
+          for (const key in queryDef.scriptedMetricOptions) {
+            let opt = queryDef.scriptedMetricOptions[key];
+            $scope.agg.settings[opt.value] = $scope.agg.settings[opt.value] || '';
+          }
           break;
         }
         case 'extended_stats': {
@@ -175,7 +184,9 @@ export class ElasticMetricAggCtrl {
       ) {
         $scope.target.bucketAggs = [queryDef.defaultBucketAgg()];
       }
-
+      if ($scope.agg.type === 'scripted_metric') {
+        delete $scope.agg.field;
+      }
       $scope.showVariables = queryDef.isPipelineAggWithMultipleBucketPaths($scope.agg.type);
       $scope.updatePipelineAggOptions();
       $scope.onChange();

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.ts
@@ -15,7 +15,7 @@ export class ElasticMetricAggCtrl {
     const metricAggs: ElasticsearchAggregation[] = $scope.target.metrics;
     $scope.metricAggTypes = queryDef.getMetricAggTypes($scope.esVersion);
     $scope.extendedStats = queryDef.extendedStats;
-    $scope.scriptedMetricOptions = queryDef.scriptedMetricOptions;
+    $scope.scriptedMetricParams = queryDef.getScriptedMetricParams($scope.esVersion);
     $scope.pipelineAggOptions = [];
     $scope.modelSettingsValues = {};
 
@@ -79,14 +79,6 @@ export class ElasticMetricAggCtrl {
           $scope.settingsLinkText = 'Values: ' + $scope.agg.settings.percents.join(',');
           break;
         }
-        case 'scripted_metric': {
-          $scope.settingsLinkText = 'Settings';
-          for (const key in queryDef.scriptedMetricOptions) {
-            let opt = queryDef.scriptedMetricOptions[key];
-            $scope.agg.settings[opt.value] = $scope.agg.settings[opt.value] || '';
-          }
-          break;
-        }
         case 'extended_stats': {
           if (_.keys($scope.agg.meta).length === 0) {
             $scope.agg.meta.std_deviation_bounds_lower = true;
@@ -106,6 +98,10 @@ export class ElasticMetricAggCtrl {
           );
 
           $scope.settingsLinkText = 'Stats: ' + stats.join(', ');
+          break;
+        }
+        case 'scripted_metric': {
+          $scope.settingsLinkText = 'Scripts';
           break;
         }
         case 'moving_avg': {
@@ -185,6 +181,8 @@ export class ElasticMetricAggCtrl {
         $scope.target.bucketAggs = [queryDef.defaultBucketAgg()];
       }
       if ($scope.agg.type === 'scripted_metric') {
+        // show because some options are required
+        $scope.showOptions = true;
         delete $scope.agg.field;
       }
       $scope.showVariables = queryDef.isPipelineAggWithMultipleBucketPaths($scope.agg.type);

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -121,51 +121,15 @@
     </div>
   </div>
 
-  <div ng-if="agg.type === 'scripted_metric' && esVersion < 70">
-    <div class="gf-form offset-width-7">
-      <label class="gf-form-label width-10">Init</label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.init" ng-blur="onChangeInternal()" spellcheck='false'>
-    </div>
-    <div class="gf-form offset-width-7">
+  <div ng-if="agg.type === 'scripted_metric'">
+    <div ng-repeat="param in scriptedMetricParams" class="gf-form offset-width-7">
       <label class="gf-form-label width-10">
-        Map
-          <info-popover mode="right-normal">
-            map_script is a required parameter.
-          </info-popover>
-      </label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.map" ng-blur="onChangeInternal()" spellcheck='false'>
-    </div>
-    <div class="gf-form offset-width-7">
-      <label class="gf-form-label width-10">Combine</label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.combine" ng-blur="onChangeInternal()" spellcheck='false'>
-    </div>
-    <div class="gf-form offset-width-7">
-      <label class="gf-form-label width-10">Reduce</label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.reduce" ng-blur="onChangeInternal()" spellcheck='false'>
-    </div>
-  </div>
-
-  <div ng-if="agg.type === 'scripted_metric' && esVersion >= 70">
-    <div class="gf-form offset-width-7">
-      <label class="gf-form-label width-10">
-        Init
-        <info-popover mode="right-normal">
-          init_script is an optional parameter.
+        {{param.text}}
+        <info-popover ng-if="!param.required" mode="right-normal">
+          This field is optional.
         </info-popover>
       </label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.init" ng-blur="onChangeInternal()" spellcheck='false'>
-    </div>
-    <div class="gf-form offset-width-7">
-      <label class="gf-form-label width-10">Map</label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.map" ng-blur="onChangeInternal()" spellcheck='false'>
-    </div>
-    <div class="gf-form offset-width-7">
-      <label class="gf-form-label width-10">Combine</label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.combine" ng-blur="onChangeInternal()" spellcheck='false'>
-    </div>
-    <div class="gf-form offset-width-7">
-      <label class="gf-form-label width-10">Reduce</label>
-      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.reduce" ng-blur="onChangeInternal()" spellcheck='false'>
+      <input type="text" class="gf-form-input" empty-to-null ng-model="agg.settings[param.value]" ng-blur="onChangeInternal()" spellcheck='false'>
     </div>
   </div>
 

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -121,6 +121,54 @@
     </div>
   </div>
 
+  <div ng-if="agg.type === 'scripted_metric' && esVersion < 70">
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">Init</label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.init" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">
+        Map
+          <info-popover mode="right-normal">
+            map_script is a required parameter.
+          </info-popover>
+      </label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.map" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">Combine</label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.combine" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">Reduce</label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.reduce" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+  </div>
+
+  <div ng-if="agg.type === 'scripted_metric' && esVersion >= 70">
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">
+        Init
+        <info-popover mode="right-normal">
+          init_script is an optional parameter.
+        </info-popover>
+      </label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.init" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">Map</label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.map" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">Combine</label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.combine" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+    <div class="gf-form offset-width-7">
+      <label class="gf-form-label width-10">Reduce</label>
+      <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.reduce" ng-blur="onChangeInternal()" spellcheck='false'>
+    </div>
+  </div>
+
   <div class="gf-form offset-width-7" ng-if="aggDef.supportsInlineScript">
     <label class="gf-form-label width-10">Script</label>
     <input type="text" class="gf-form-input max-width-12" empty-to-null ng-model="agg.inlineScript" ng-blur="onChangeInternal()" spellcheck='false' placeholder="_value * 1">

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -315,7 +315,7 @@ export class ElasticQueryBuilder {
           }
         }
       } else {
-        metricAgg = { field: metric.field };
+        metricAgg = metric.type === 'scripted_metric' ? {} : { field: metric.field };
       }
 
       for (const prop in metric.settings) {

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -52,6 +52,12 @@ export const metricAggTypes = [
     supportsMissing: true,
   },
   {
+    text: 'Scripted Metric',
+    value: 'scripted_metric',
+    requiresField: false,
+    minVersion: 2,
+  },
+  {
     text: 'Moving Average',
     value: 'moving_avg',
     requiresField: false,
@@ -91,6 +97,13 @@ export const bucketAggTypes = [
   { text: 'Geo Hash Grid', value: 'geohash_grid', requiresField: true },
   { text: 'Date Histogram', value: 'date_histogram', requiresField: true },
   { text: 'Histogram', value: 'histogram', requiresField: true },
+];
+
+export const scriptedMetricOptions = [
+  { text: 'Init', value: 'init_script' },
+  { text: 'Map', value: 'map_script' },
+  { text: 'Combine', value: 'combine_script' },
+  { text: 'Reduce', value: 'reduce_script' },
 ];
 
 export const orderByOptions = [

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -99,7 +99,7 @@ export const bucketAggTypes = [
   { text: 'Histogram', value: 'histogram', requiresField: true },
 ];
 
-export const scriptedMetricOptions = [
+export const scriptedMetricParams = [
   { text: 'Init', value: 'init_script' },
   { text: 'Map', value: 'map_script' },
   { text: 'Combine', value: 'combine_script' },
@@ -241,6 +241,24 @@ export function getPipelineAggOptions(target: ElasticsearchQuery, metric?: Elast
   }
   const ancestors = getAncestors(target, metric);
   return metrics.filter(m => !ancestors.includes(m.id)).map(m => ({ text: describeMetric(m), value: m.id }));
+}
+
+export function getScriptedMetricParams(esVersion: any) {
+  return _.map(scriptedMetricParams, param => {
+    let required;
+    switch (param.value) {
+      case 'map_script':
+        required = true;
+        break;
+      case 'combine_script':
+      case 'reduce_script':
+        required = typeof esVersion === 'number' ? esVersion >= 70 : true;
+        break;
+      default:
+        required = false;
+    }
+    return { ...param, required };
+  });
 }
 
 export function getMovingAvgSettings(model: any, filtered: boolean) {

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -267,28 +267,6 @@ describe('ElasticQueryBuilder', () => {
         expect(firstLevel.aggs['4']).not.toBe(undefined);
         expect(firstLevel.aggs['4'].scripted_metric).not.toBe(undefined);
         expect(firstLevel.aggs['4'].scripted_metric.field).toBe(undefined);
-      });
-
-      it('with scripted_metric', () => {
-        const query = builder.build({
-          metrics: [
-            {
-              id: '4',
-              settings: {
-                init_script: 'state.transactions = []',
-                map_script:
-                  'state.transactions.add(doc.type.value == "sale" ? doc.amount.value : -1 * doc.amount.value)',
-                combine_script: 'double profit = 0; for (t in state.transactions) { profit += t } return profit',
-                reduce_script: 'double profit = 0; for (a in states) { profit += a } return profit',
-              },
-              type: 'scripted_metric',
-            },
-          ],
-          bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '2' }],
-        });
-
-        const firstLevel = query.aggs['2'];
-
         expect(firstLevel.aggs['4'].scripted_metric.init_script).toBe('state.transactions = []');
         expect(firstLevel.aggs['4'].scripted_metric.map_script).toBe(
           'state.transactions.add(doc.type.value == "sale" ? doc.amount.value : -1 * doc.amount.value)'

--- a/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
@@ -122,6 +122,14 @@ describe('ElasticQueryDef', () => {
         expect(result).toBe(false);
       });
     });
+
+    describe('Scripted Metric', () => {
+      const result = queryDef.isPipelineAgg('scripted_metric');
+
+      test('is not pipe line metric', () => {
+        expect(result).toBe(false);
+      });
+    });
   });
 
   describe('isPipelineAggWithMultipleBucketPaths', () => {
@@ -135,6 +143,14 @@ describe('ElasticQueryDef', () => {
 
     describe('moving_avg', () => {
       const result = queryDef.isPipelineAggWithMultipleBucketPaths('moving_avg');
+
+      test('should not have multiple bucket paths support', () => {
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('scripted_metric', () => {
+      const result = queryDef.isPipelineAggWithMultipleBucketPaths('scripted_metric');
 
       test('should not have multiple bucket paths support', () => {
         expect(result).toBe(false);
@@ -157,13 +173,13 @@ describe('ElasticQueryDef', () => {
 
     describe('using esversion 2', () => {
       test('should get pipeline aggs', () => {
-        expect(queryDef.getMetricAggTypes(2).length).toBe(15);
+        expect(queryDef.getMetricAggTypes(2).length).toBe(16);
       });
     });
 
     describe('using esversion 5', () => {
       test('should get pipeline aggs', () => {
-        expect(queryDef.getMetricAggTypes(5).length).toBe(15);
+        expect(queryDef.getMetricAggTypes(5).length).toBe(16);
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
@@ -183,4 +183,42 @@ describe('ElasticQueryDef', () => {
       });
     });
   });
+
+  describe('scripted metric agg parameters depending on esverison', () => {
+    describe('using esversion undefined', () => {
+      test('scripted metric aggs requires all three parameters', () => {
+        const response = queryDef.getScriptedMetricParams(undefined);
+        expect(response).toEqual([
+          { required: false, text: 'Init', value: 'init_script' },
+          { required: true, text: 'Map', value: 'map_script' },
+          { required: true, text: 'Combine', value: 'combine_script' },
+          { required: true, text: 'Reduce', value: 'reduce_script' },
+        ]);
+      });
+    });
+
+    describe('using esversion before 7.0', () => {
+      test('scripted metric aggs requires only map_script parameters', () => {
+        const response = queryDef.getScriptedMetricParams(60);
+        expect(response).toEqual([
+          { required: false, text: 'Init', value: 'init_script' },
+          { required: true, text: 'Map', value: 'map_script' },
+          { required: false, text: 'Combine', value: 'combine_script' },
+          { required: false, text: 'Reduce', value: 'reduce_script' },
+        ]);
+      });
+    });
+
+    describe('using esversion after 7.0', () => {
+      test('scripted metric aggs requires all three parameters', () => {
+        const response = queryDef.getScriptedMetricParams(70);
+        expect(response).toEqual([
+          { required: false, text: 'Init', value: 'init_script' },
+          { required: true, text: 'Map', value: 'map_script' },
+          { required: true, text: 'Combine', value: 'combine_script' },
+          { required: true, text: 'Reduce', value: 'reduce_script' },
+        ]);
+      });
+    });
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
@@ -123,7 +123,7 @@ describe('ElasticQueryDef', () => {
       });
     });
 
-    describe('Scripted Metric', () => {
+    describe('scripted_metric', () => {
       const result = queryDef.isPipelineAgg('scripted_metric');
 
       test('is not pipe line metric', () => {


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR adds support for Scripted Metrics Aggregation in Grafana’s Elasticsearch query editor. This option will give users the capability to define and execute their own metric aggregation using init/map/combine/reduce scripts, ultimately allowing more flexibility when calculating metrics. 

A new option **Scripted Metric** will be added under Metric in the Elasticsearch Query Editor. Users can fill out the four script parameters (init_script, map_script, combine_script, reduce_scrip) to get the desired metric output.  
Depending on the Elasticsearch version, different script parameters are required. All Elasticsearch version before v6.8 only requires map_script to be filled. However, from Elasticsearch v7.0, only init_script is optional, while all other script parameters are required. A pop-over will be presented in the user interface to clearly notify which script fields are optional depending on the version being used. 

<img width="579" alt="Screen Shot 2020-10-23 at 6 36 52 PM" src="https://user-images.githubusercontent.com/43913498/97064942-c3bd3c00-155e-11eb-964c-211ab1fc1307.png">

The current structure of the plugin is such that queries are sent to Elasticsearch whenever the query editor is updated, with query validation left as Elasticsearch’s responsibility. Query errors are returned from Elasticsearch and displayed to the user. There are two categories of errors that the user should be able to receive from the scripted metric aggregation fields: the user is either missing a required field, or the scripts failed at compile-time or runtime in Elasticsearch. Note that since queries are sent on every update, the user will immediately receive the missing field requirement error upon selecting scripted metric aggregation. This is intentional and consistent with the behaviour of the Bucket Script option. 

**Which issue(s) this PR fixes:**
Resolves Grafana [issue 3441](https://github.com/grafana/grafana/issues/3441)

cc: @alolita 