### PR TITLE
Developer guide: Update wrt. Windows

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -78,8 +78,8 @@ When you log in for the first time, Grafana asks you to change your password.
 
 The Grafana backend includes SQLite which requires GCC to compile. So in order to compile Grafana on Windows you need to install GCC. We recommend [TDM-GCC](http://tdm-gcc.tdragon.net/download). Eventually, if you use [Scoop](https://scoop.sh), you can install GCC through that.
 
-In order to use the `make` command above, you need to install [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm) and use it in a Unix shell (f.ex. Git Bash). 
-If you don't want to install these and just want to build the back-end, you can do it as follows: `go run build.go build`. The Grafana binaries will be in bin\\windows-amd64.
+You can simply build the back-end as follows: `go run build.go build`. The Grafana binaries will be in bin\\windows-amd64.
+Alternately, if you wish to use the `make` command, install [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm) and use it in a Unix shell (f.ex. Git Bash). 
 
 ## Test Grafana
 

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -78,7 +78,8 @@ When you log in for the first time, Grafana asks you to change your password.
 
 The Grafana backend includes SQLite which requires GCC to compile. So in order to compile Grafana on Windows you need to install GCC. We recommend [TDM-GCC](http://tdm-gcc.tdragon.net/download). Eventually, if you use [Scoop](https://scoop.sh), you can install GCC through that.
 
-Unlike on Unix, unless you use a Unix shell (f.ex. Git Bash), you shouldn't use Make on Windows. Instead build the back-end as follows: `go run build.go build`. The Grafana binaries will be in bin\\windows-amd64.
+In order to use the `make` command above, you need to install [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm) and use it in a Unix shell (f.ex. Git Bash). 
+If you don't want to install these and just want to build the back-end, you can do it as follows: `go run build.go build`. The Grafana binaries will be in bin\\windows-amd64.
 
 ## Test Grafana
 

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -76,7 +76,9 @@ When you log in for the first time, Grafana asks you to change your password.
 
 #### Building on Windows
 
-The Grafana backend includes Sqlite3 which requires GCC to compile. So in order to compile Grafana on Windows you need to install GCC. We recommend [TDM-GCC](http://tdm-gcc.tdragon.net/download).
+The Grafana backend includes SQLite which requires GCC to compile. So in order to compile Grafana on Windows you need to install GCC. We recommend [TDM-GCC](http://tdm-gcc.tdragon.net/download). Eventually, if you use [Scoop](https://scoop.sh), you can install GCC through that.
+
+Unlike on Unix, unless you use a Unix shell (f.ex. Git Bash), you shouldn't use Make on Windows. Instead build the back-end as follows: `go run build.go build`. The Grafana binaries will be in bin\\windows-amd64.
 
 ## Test Grafana
 
@@ -96,6 +98,13 @@ If you're developing for the backend, run the tests with the standard Go tool:
 
 ```
 go test -v ./pkg/...
+```
+
+#### On Windows
+Running the backend tests on Windows currently needs some tweaking, so use the build.go script:
+
+```
+go run build.go test
 ```
 
 ### Run end-to-end tests


### PR DESCRIPTION
**What this PR does / why we need it**:
Update developer guide with better instructions on how to build on Windows. I found out that building with Make isn't really an option on Windows, unless you use e.g. Git Bash. Running tests directly (`go test`) also doesn't currently work due to a linking error, so I instruct Windows users to go via build.go (`go run build.go test`).
