### PR TITLE
WIP: Backend: Introduce update handler mechanism

### DIFF
--- a/pkg/tsdb/query_endpoint.go
+++ b/pkg/tsdb/query_endpoint.go
@@ -19,7 +19,7 @@ func init() {
 	registry = make(map[string]GetTsdbQueryEndpointFn)
 }
 
-func getTsdbQueryEndpointFor(dsInfo *models.DataSource) (TsdbQueryEndpoint, error) {
+func GetTsdbQueryEndpointFor(dsInfo *models.DataSource) (TsdbQueryEndpoint, error) {
 	if fn, exists := registry[dsInfo.Type]; exists {
 		executor, err := fn(dsInfo)
 		if err != nil {

--- a/pkg/tsdb/request.go
+++ b/pkg/tsdb/request.go
@@ -9,7 +9,7 @@ import (
 type HandleRequestFunc func(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery) (*Response, error)
 
 func HandleRequest(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery) (*Response, error) {
-	endpoint, err := getTsdbQueryEndpointFor(dsInfo)
+	endpoint, err := GetTsdbQueryEndpointFor(dsInfo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Creating this PR  purely as a starting point for discussion.
As far as I can tell, there is currently no way to execute an action on the backend in response to a datasource being updated, something which would be useful for caching pieces of data that rely on data source properties. For example in the case of the CloudWatch data source, it would be useful to fetch and cache an account ID when the corresponding datasource is updated.
Mainly I want to see if the approach implemented in this PR is the way to go about solving this issue, and would love to hear the perspective of those with more backend knowledge.
