### PR TITLE
MetricFindQuery: Chore - Add value prop

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -499,6 +499,7 @@ export interface QueryHint {
 
 export interface MetricFindValue {
   text: string;
+  value?: string | number;
   expandable?: boolean;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing value prop to MetricFindValue type

**Which issue(s) this PR fixes**:
Fixes #28501 


