### PR TITLE
CI: Add GCC to Windows Docker image

### DIFF
--- a/scripts/build/ci-build-windows/Dockerfile
+++ b/scripts/build/ci-build-windows/Dockerfile
@@ -21,12 +21,12 @@ RUN mkdir -p "C:\Program Files (x86)\GnuWin32"
 RUN cd "C:\Program Files (x86)\GnuWin32" && unzip C:\App\diffutils-dep.zip && unzip C:\App\diffutils-bin.zip
 
 RUN powershell (New-Object Net.WebClient).DownloadFile(\
-  \"https://github.com/golangci/golangci-lint/releases/download/v1.31.0/golangci-lint-1.31.0-windows-amd64.zip\", \
+  \"https://github.com/golangci/golangci-lint/releases/download/v1.32.0/golangci-lint-1.32.0-windows-amd64.zip\", \
   \"golangci-lint.zip\")
 RUN powershell (Get-FileHash golangci-lint.zip -Algorithm SHA256).Hash -eq \
-  \"6CE6B1D3207A63256D82FBBAC80BB9E85D7705EC1A408F005DFE324457C54966\"
+  \"97a69c2a153cd4285b7000b327aa6e77b694534e7463cbd1b77481c22b6113cf\"
 RUN unzip golangci-lint.zip
-RUN powershell -Command mv golangci-lint-1.31.0-windows-amd64\golangci-lint.exe .
+RUN powershell -Command mv golangci-lint-1.32.0-windows-amd64\golangci-lint.exe .
 
 RUN powershell -Command scoop cache rm '*'
 

--- a/scripts/build/ci-build-windows/Dockerfile
+++ b/scripts/build/ci-build-windows/Dockerfile
@@ -7,8 +7,8 @@ RUN powershell Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
 RUN powershell Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 # Scoop first of all needs git to update itself
 # Run Scoop under PowerShell since it can otherwise fail
-RUN powershell -Command scoop install git@2.28.0.windows.1
-RUN powershell -Command scoop install go@1.15.2 unzip@6.00
+RUN powershell -Command scoop install git@2.29.1.windows.1
+RUN powershell -Command scoop install go@1.15.3 unzip@6.00 gcc@9.3.0-2
 
 # Install diffutils, in case we need them
 RUN powershell (New-Object Net.WebClient).DownloadFile(\


### PR DESCRIPTION
**What this PR does / why we need it**:
Add GCC to Windows Docker image used for CI, so we can build Grafana on Windows (during CI). GCC is required for CGo, which Grafana is dependent on.