### PR TITLE
Migration: Remove LegacyForms from dashboard folder permissions

### DIFF
--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -43,6 +43,7 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme) => {
       font-size: ${theme.typography.size.sm};
       color: ${theme.colors.textWeak};
       white-space: normal;
+      line-height: ${theme.typography.lineHeight.md};
     `,
     optionBody: css`
       label: grafana-select-option-body;

--- a/public/app/core/components/PermissionList/AddPermission.tsx
+++ b/public/app/core/components/PermissionList/AddPermission.tsx
@@ -63,7 +63,6 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
   };
 
   onPermissionChanged = (permission: SelectableValue<PermissionLevel>) => {
-    console.log(permission);
     this.setState({ permission: permission.value! });
   };
 
@@ -87,7 +86,7 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
     const newItem = this.state;
     const pickerClassName = 'min-width-20';
     const isValid = this.isValid();
-    console.log(newItem);
+
     return (
       <div className="cta-form">
         <button className="cta-form__close btn btn-transparent" onClick={onCancel}>
@@ -124,7 +123,6 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
                   value={this.state.permission}
                   options={dashboardPermissionLevels}
                   onChange={this.onPermissionChanged}
-                  isOpen
                   width={25}
                 />
               </InlineField>

--- a/public/app/core/components/PermissionList/AddPermission.tsx
+++ b/public/app/core/components/PermissionList/AddPermission.tsx
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
+import { css } from 'emotion';
+import config from 'app/core/config';
 import { UserPicker } from 'app/core/components/Select/UserPicker';
 import { TeamPicker, Team } from 'app/core/components/Select/TeamPicker';
-import { Button, Form, InlineField, InlineFieldRow, Icon, Select } from '@grafana/ui';
-import { SelectableValue } from '@grafana/data';
+import { Button, Form, HorizontalGroup, Icon, Select, stylesFactory } from '@grafana/ui';
+import { GrafanaTheme, SelectableValue } from '@grafana/data';
 import { User } from 'app/types';
 import {
   dashboardPermissionLevels,
@@ -86,6 +88,7 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
     const newItem = this.state;
     const pickerClassName = 'min-width-20';
     const isValid = this.isValid();
+    const styles = getStyles(config.theme);
 
     return (
       <div className="cta-form">
@@ -95,46 +98,47 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
         <h5>Add Permission For</h5>
         <Form maxWidth="none" onSubmit={this.onSubmit}>
           {() => (
-            <InlineFieldRow>
-              <InlineField>
-                <Select
-                  isSearchable={false}
-                  value={this.state.type}
-                  options={dashboardAclTargets}
-                  onChange={this.onTypeChanged}
-                />
-              </InlineField>
+            <HorizontalGroup>
+              <Select
+                isSearchable={false}
+                value={this.state.type}
+                options={dashboardAclTargets}
+                onChange={this.onTypeChanged}
+              />
 
               {newItem.type === AclTarget.User ? (
-                <InlineField>
-                  <UserPicker onSelected={this.onUserSelected} className={pickerClassName} />
-                </InlineField>
+                <UserPicker onSelected={this.onUserSelected} className={pickerClassName} />
               ) : null}
 
               {newItem.type === AclTarget.Team ? (
-                <InlineField>
-                  <TeamPicker onSelected={this.onTeamSelected} className={pickerClassName} />
-                </InlineField>
+                <TeamPicker onSelected={this.onTeamSelected} className={pickerClassName} />
               ) : null}
 
-              <InlineField>
-                <Select
-                  isSearchable={false}
-                  value={this.state.permission}
-                  options={dashboardPermissionLevels}
-                  onChange={this.onPermissionChanged}
-                  width={25}
-                />
-              </InlineField>
+              <span className={styles.label}>Can</span>
+
+              <Select
+                isSearchable={false}
+                value={this.state.permission}
+                options={dashboardPermissionLevels}
+                onChange={this.onPermissionChanged}
+                width={25}
+              />
               <Button data-save-permission type="submit" disabled={!isValid}>
                 Save
               </Button>
-            </InlineFieldRow>
+            </HorizontalGroup>
           )}
         </Form>
       </div>
     );
   }
 }
+
+const getStyles = stylesFactory((theme: GrafanaTheme) => ({
+  label: css`
+    color: ${theme.colors.textBlue};
+    font-weight: bold;
+  `,
+}));
 
 export default AddPermissions;

--- a/public/app/core/components/PermissionList/AddPermission.tsx
+++ b/public/app/core/components/PermissionList/AddPermission.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { UserPicker } from 'app/core/components/Select/UserPicker';
 import { TeamPicker, Team } from 'app/core/components/Select/TeamPicker';
-import { LegacyForms, Icon } from '@grafana/ui';
+import { Button, Form, InlineField, InlineFieldRow, Icon, Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { User } from 'app/types';
 import {
@@ -12,7 +12,6 @@ import {
   NewDashboardAclItem,
   OrgRole,
 } from 'app/types/acl';
-const { Select } = LegacyForms;
 
 export interface Props {
   onAddPermission: (item: NewDashboardAclItem) => void;
@@ -38,8 +37,8 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
     };
   }
 
-  onTypeChanged = (evt: any) => {
-    const type = evt.target.value as AclTarget;
+  onTypeChanged = (item: any) => {
+    const type = item.value as AclTarget;
 
     switch (type) {
       case AclTarget.User:
@@ -64,11 +63,11 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
   };
 
   onPermissionChanged = (permission: SelectableValue<PermissionLevel>) => {
+    console.log(permission);
     this.setState({ permission: permission.value! });
   };
 
-  onSubmit = async (evt: React.SyntheticEvent) => {
-    evt.preventDefault();
+  onSubmit = async () => {
     await this.props.onAddPermission(this.state);
     this.setState(this.getCleanState());
   };
@@ -88,56 +87,53 @@ class AddPermissions extends Component<Props, NewDashboardAclItem> {
     const newItem = this.state;
     const pickerClassName = 'min-width-20';
     const isValid = this.isValid();
+    console.log(newItem);
     return (
-      <div className="gf-form-inline cta-form">
+      <div className="cta-form">
         <button className="cta-form__close btn btn-transparent" onClick={onCancel}>
           <Icon name="times" />
         </button>
-        <form name="addPermission" onSubmit={this.onSubmit}>
-          <h5>Add Permission For</h5>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <div className="gf-form-select-wrapper">
-                <select className="gf-form-input gf-size-auto" value={newItem.type} onChange={this.onTypeChanged}>
-                  {dashboardAclTargets.map((option, idx) => {
-                    return (
-                      <option key={idx} value={option.value}>
-                        {option.text}
-                      </option>
-                    );
-                  })}
-                </select>
-              </div>
-            </div>
+        <h5>Add Permission For</h5>
+        <Form maxWidth="none" onSubmit={this.onSubmit}>
+          {() => (
+            <InlineFieldRow>
+              <InlineField>
+                <Select
+                  isSearchable={false}
+                  value={this.state.type}
+                  options={dashboardAclTargets}
+                  onChange={this.onTypeChanged}
+                />
+              </InlineField>
 
-            {newItem.type === AclTarget.User ? (
-              <div className="gf-form">
-                <UserPicker onSelected={this.onUserSelected} className={pickerClassName} />
-              </div>
-            ) : null}
+              {newItem.type === AclTarget.User ? (
+                <InlineField>
+                  <UserPicker onSelected={this.onUserSelected} className={pickerClassName} />
+                </InlineField>
+              ) : null}
 
-            {newItem.type === AclTarget.Team ? (
-              <div className="gf-form">
-                <TeamPicker onSelected={this.onTeamSelected} className={pickerClassName} />
-              </div>
-            ) : null}
+              {newItem.type === AclTarget.Team ? (
+                <InlineField>
+                  <TeamPicker onSelected={this.onTeamSelected} className={pickerClassName} />
+                </InlineField>
+              ) : null}
 
-            <div className="gf-form">
-              <Select
-                isSearchable={false}
-                options={dashboardPermissionLevels}
-                onChange={this.onPermissionChanged}
-                className="gf-form-select-box__control--menu-right"
-              />
-            </div>
-
-            <div className="gf-form">
-              <button data-save-permission className="btn btn-primary" type="submit" disabled={!isValid}>
+              <InlineField>
+                <Select
+                  isSearchable={false}
+                  value={this.state.permission}
+                  options={dashboardPermissionLevels}
+                  onChange={this.onPermissionChanged}
+                  isOpen
+                  width={25}
+                />
+              </InlineField>
+              <Button data-save-permission type="submit" disabled={!isValid}>
                 Save
-              </button>
-            </div>
-          </div>
-        </form>
+              </Button>
+            </InlineFieldRow>
+          )}
+        </Form>
       </div>
     );
   }

--- a/public/app/core/components/PermissionList/DisabledPermissionListItem.tsx
+++ b/public/app/core/components/PermissionList/DisabledPermissionListItem.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
-import { LegacyForms, Icon } from '@grafana/ui';
+import { Select, Icon } from '@grafana/ui';
 import { dashboardPermissionLevels } from 'app/types/acl';
-const { Select } = LegacyForms;
 
 export interface Props {
   item: any;
@@ -28,7 +27,7 @@ export default class DisabledPermissionListItem extends Component<Props, any> {
             <Select
               options={dashboardPermissionLevels}
               onChange={() => {}}
-              isDisabled={true}
+              disabled={true}
               className="gf-form-select-box__control--menu-right"
               value={currentPermissionLevel}
             />

--- a/public/app/core/components/PermissionList/DisabledPermissionListItem.tsx
+++ b/public/app/core/components/PermissionList/DisabledPermissionListItem.tsx
@@ -28,7 +28,6 @@ export default class DisabledPermissionListItem extends Component<Props, any> {
               options={dashboardPermissionLevels}
               onChange={() => {}}
               disabled={true}
-              className="gf-form-select-box__control--menu-right"
               value={currentPermissionLevel}
             />
           </div>

--- a/public/app/core/components/PermissionList/PermissionListItem.tsx
+++ b/public/app/core/components/PermissionList/PermissionListItem.tsx
@@ -1,9 +1,8 @@
 import React, { PureComponent } from 'react';
-import { LegacyForms, Icon } from '@grafana/ui';
+import { Select, Icon } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { dashboardPermissionLevels, DashboardAcl, PermissionLevel } from 'app/types/acl';
 import { FolderInfo } from 'app/types';
-const { Select } = LegacyForms;
 
 const setClassNameHelper = (inherited: boolean) => {
   return inherited ? 'gf-form-disabled' : '';
@@ -75,16 +74,14 @@ export default class PermissionsListItem extends PureComponent<Props> {
         </td>
         <td className="query-keyword">Can</td>
         <td>
-          <div className="gf-form">
-            <Select
-              isSearchable={false}
-              options={dashboardPermissionLevels}
-              onChange={this.onPermissionChanged}
-              isDisabled={item.inherited}
-              className="gf-form-select-box__control--menu-right"
-              value={currentPermissionLevel}
-            />
-          </div>
+          <Select
+            isSearchable={false}
+            options={dashboardPermissionLevels}
+            onChange={this.onPermissionChanged}
+            disabled={item.inherited}
+            value={currentPermissionLevel}
+            width={25}
+          />
         </td>
         <td>
           {!item.inherited ? (

--- a/public/app/core/components/PermissionList/PermissionsInfo.tsx
+++ b/public/app/core/components/PermissionList/PermissionsInfo.tsx
@@ -1,13 +1,11 @@
 ﻿import React from 'react';
 
-export default () => {
-  return (
-    <div className="">
-      <h5>What are Permissions?</h5>
-      <p>
-        An Access Control List (ACL) model is used to limit access to Dashboard Folders. A user or a Team can be
-        assigned permissions for a folder or for a single dashboard.
-      </p>
-    </div>
-  );
-};
+export default () => (
+  <div>
+    <h5>What are Permissions?</h5>
+    <p>
+      An Access Control List (ACL) model is used to limit access to Dashboard Folders. A user or a Team can be assigned
+      permissions for a folder or for a single dashboard.
+    </p>
+  </div>
+);

--- a/public/app/core/components/Select/TeamPicker.tsx
+++ b/public/app/core/components/Select/TeamPicker.tsx
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import _ from 'lodash';
-import { LegacyForms } from '@grafana/ui';
+import { AsyncSelect } from '@grafana/ui';
 import { debounce } from 'lodash';
 import { getBackendSrv } from '@grafana/runtime';
-const { AsyncSelect } = LegacyForms;
 
 export interface Team {
   id: number;
@@ -72,7 +71,7 @@ export class TeamPicker extends Component<Props, State> {
           onChange={onSelected}
           className={className}
           placeholder="Select a team"
-          noOptionsMessage={() => 'No teams found'}
+          noOptionsMessage="No teams found"
         />
       </div>
     );

--- a/public/app/types/acl.ts
+++ b/public/app/types/acl.ts
@@ -77,7 +77,7 @@ export enum AclTarget {
 
 export interface AclTargetInfo {
   value: AclTarget;
-  text: string;
+  label: string;
 }
 
 export const dataSourceAclLevels = [
@@ -85,10 +85,10 @@ export const dataSourceAclLevels = [
 ];
 
 export const dashboardAclTargets: AclTargetInfo[] = [
-  { value: AclTarget.Team, text: 'Team' },
-  { value: AclTarget.User, text: 'User' },
-  { value: AclTarget.Viewer, text: 'Everyone With Viewer Role' },
-  { value: AclTarget.Editor, text: 'Everyone With Editor Role' },
+  { value: AclTarget.Team, label: 'Team' },
+  { value: AclTarget.User, label: 'User' },
+  { value: AclTarget.Viewer, label: 'Everyone With Viewer Role' },
+  { value: AclTarget.Editor, label: 'Everyone With Editor Role' },
 ];
 
 export const dashboardPermissionLevels: DashboardPermissionInfo[] = [


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes the usage of LegacyForms from Dashboard Folder Permissions view. It also restricts the line-height of the grafana-ui `<Select>` component option descriptions as wrapping components / css classes were affecting it.

<img width="980" alt="Screenshot 2020-10-27 at 13 09 35" src="https://user-images.githubusercontent.com/73201/97299722-b6050080-1855-11eb-9635-07d07635304e.png">

