### PR TITLE
GraphNG: Update uPlot to 1.2.2 and align timestamps config with new uPlot API

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -70,7 +70,7 @@
     "react-transition-group": "4.3.0",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.1.2"
+    "uplot": "1.2.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "11.0.2",

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -15,47 +15,37 @@ import { UPlotChart } from '../uPlot/Plot';
 import { AxisSide, GraphCustomFieldConfig, PlotProps } from '../uPlot/types';
 import { useTheme } from '../../themes';
 
+const _ = null;
+
 const timeStampsConfig = [
-  [3600 * 24 * 365, '{YYYY}', 7, '{YYYY}'],
-  [3600 * 24 * 28, `{${timeFormatToTemplate(systemDateFormats.interval.month)}`, 7, '{MMM}\n{YYYY}'],
-  [
-    3600 * 24,
-    `{${timeFormatToTemplate(systemDateFormats.interval.day)}`,
-    7,
-    `${timeFormatToTemplate(systemDateFormats.interval.day)}\n${timeFormatToTemplate(systemDateFormats.interval.year)}`,
-  ],
+  //   tick incr    default          year                    month   day                   hour    min       sec   mode
+  [3600 * 24 * 365, '{YYYY}', _, _, _, _, _, _, 1],
+  [3600 * 24 * 28, `${timeFormatToTemplate(systemDateFormats.interval.month)}`, _, _, _, _, _, _, 1],
+  [3600 * 24, `${timeFormatToTemplate(systemDateFormats.interval.day)}`, `\n{YYYY}`, _, _, _, _, _, 1],
   [
     3600,
-    `{${timeFormatToTemplate(systemDateFormats.interval.minute)}`,
-    4,
-    `${timeFormatToTemplate(systemDateFormats.interval.minute)}\n${timeFormatToTemplate(
-      systemDateFormats.interval.day
-    )}`,
+    `${timeFormatToTemplate(systemDateFormats.interval.minute)}`,
+    _,
+    _,
+    `\n${timeFormatToTemplate(systemDateFormats.interval.day)}`,
+    _,
+    _,
+    _,
+    1,
   ],
   [
     60,
-    `{${timeFormatToTemplate(systemDateFormats.interval.second)}`,
-    4,
-    `${timeFormatToTemplate(systemDateFormats.interval.second)}\n${timeFormatToTemplate(
-      systemDateFormats.interval.day
-    )}`,
-  ],
-  [
+    `${timeFormatToTemplate(systemDateFormats.interval.minute)}`,
+    _,
+    _,
+    `\n${timeFormatToTemplate(systemDateFormats.interval.day)}`,
+    _,
+    _,
+    _,
     1,
-    `:{ss}`,
-    2,
-    `:{ss}\n${timeFormatToTemplate(systemDateFormats.interval.day)} ${timeFormatToTemplate(
-      systemDateFormats.interval.minute
-    )}`,
   ],
-  [
-    1e-3,
-    ':{ss}.{fff}',
-    2,
-    `:{ss}.{fff}\n${timeFormatToTemplate(systemDateFormats.interval.day)} ${timeFormatToTemplate(
-      systemDateFormats.interval.minute
-    )}`,
-  ],
+  [1, ':{ss}', _, _, _, _, `\n ${timeFormatToTemplate(systemDateFormats.interval.minute)}`, _, 1],
+  [1e-3, ':{ss}.{fff}', _, _, _, _, `\n ${timeFormatToTemplate(systemDateFormats.interval.minute)}`, _, 1],
 ];
 
 const defaultFormatter = (v: any) => (v == null ? '-' : v.toFixed(1));

--- a/yarn.lock
+++ b/yarn.lock
@@ -26813,10 +26813,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.1.2.tgz#ccdbe0987e7615d197e1dba77946a1655a823c31"
-  integrity sha512-CpQmMdafoMRR+zRSpfpMXs5mKvqgYFakcCyt7nOfh+pPeZfbxNMcCq9JFeXJcKEaWjrR6JSIiEZ01A4iFHztTQ==
+uplot@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.2.2.tgz#b8876ab55c8a76fff81673b4b48fa5f76c4d9d2b"
+  integrity sha512-FiUCvD0QB+y0YGGtzTYhvaGktsddxiIFMSRScEsd97aasfnAGhIvs6aShbaB6/TZpKa6X1qVzFWuNgwnzaWBcg==
 
 upper-case-first@^1.1.0, upper-case-first@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Ref: https://github.com/grafana/grafana/issues/27848

> update uPlot to 1.2.x and update x-axis time formatting (ref leeoniya/uPlot#303)
