### PR TITLE
Allow add panel for viewers_can_edit

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -217,12 +217,12 @@ class DashNav extends PureComponent<Props> {
 
   renderRightActionsButton() {
     const { dashboard, onAddPanel } = this.props;
-    const { canSave, showSettings } = dashboard.meta;
+    const { canEdit, showSettings } = dashboard.meta;
     const { snapshot } = dashboard;
     const snapshotUrl = snapshot && snapshot.originalUrl;
 
     const buttons: ReactNode[] = [];
-    if (canSave) {
+    if (canEdit) {
       buttons.push(
         <DashNavButton
           classSuffix="save"


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

Viewer role can be changed with the Grafana server setting viewers_can_edit. If you set this to true, then users with the Viewer role can also make transient dashboard edits. right now with `viewers_can_edit`, it can modify panels but not save the changes. In this PR, propose to allow this role can create panel but not save the changes. 

