### PR TITLE
Dashboard: Fix navigation from one SoloPanelPage to another one

### DIFF
--- a/public/app/features/dashboard/containers/SoloPanelPage.test.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SoloPanelPage, Props } from './SoloPanelPage';
+import { Props as DashboardPanelProps } from '../dashgrid/DashboardPanel';
+import { DashboardModel } from '../state';
+import { DashboardRouteInfo } from 'app/types';
+
+jest.mock('app/features/dashboard/components/DashboardSettings/SettingsCtrl', () => ({}));
+jest.mock('app/features/dashboard/dashgrid/DashboardPanel', () => {
+  class DashboardPanel extends React.Component<DashboardPanelProps> {
+    render() {
+      // In this test we only check whether a new panel has arrived in the props
+      return <>{this.props.panel?.title}</>;
+    }
+  }
+
+  return { DashboardPanel };
+});
+
+interface ScenarioContext {
+  dashboard?: DashboardModel | null;
+  secondaryDashboard?: DashboardModel | null;
+  setDashboard: (overrides?: any, metaOverrides?: any) => void;
+  setSecondaryDashboard: (overrides?: any, metaOverrides?: any) => void;
+  mount: (propOverrides?: Partial<Props>) => void;
+  rerender: (propOverrides?: Partial<Props>) => void;
+  setup: (fn: () => void) => void;
+}
+
+function getTestDashboard(overrides?: any, metaOverrides?: any): DashboardModel {
+  const data = Object.assign(
+    {
+      title: 'My dashboard',
+      panels: [
+        {
+          id: 1,
+          type: 'graph',
+          title: 'My graph',
+          gridPos: { x: 0, y: 0, w: 1, h: 1 },
+        },
+      ],
+    },
+    overrides
+  );
+
+  const meta = Object.assign({ canSave: true, canEdit: true }, metaOverrides);
+  return new DashboardModel(data, meta);
+}
+
+function soloPanelPageScenario(description: string, scenarioFn: (ctx: ScenarioContext) => void) {
+  describe(description, () => {
+    let setupFn: () => void;
+
+    const ctx: ScenarioContext = {
+      setup: fn => {
+        setupFn = fn;
+      },
+      setDashboard: (overrides?: any, metaOverrides?: any) => {
+        ctx.dashboard = getTestDashboard(overrides, metaOverrides);
+      },
+      setSecondaryDashboard: (overrides?: any, metaOverrides?: any) => {
+        ctx.secondaryDashboard = getTestDashboard(overrides, metaOverrides);
+      },
+      mount: (propOverrides?: Partial<Props>) => {
+        const props: Props = {
+          urlSlug: 'my-dash',
+          $scope: {},
+          urlUid: '11',
+          urlPanelId: '1',
+          $injector: {},
+          routeInfo: DashboardRouteInfo.Normal,
+          initDashboard: jest.fn(),
+          dashboard: null,
+        };
+
+        Object.assign(props, propOverrides);
+
+        ctx.dashboard = props.dashboard;
+        let { rerender } = render(<SoloPanelPage {...props} />);
+        // prop updates will be submitted by rerendering the same component with different props
+        ctx.rerender = (newProps: Partial<Props>) => {
+          Object.assign(props, newProps);
+          rerender(<SoloPanelPage {...props} />);
+        };
+      },
+      rerender: () => {
+        // will be replaced while mount() is called
+      },
+    };
+
+    beforeEach(() => {
+      setupFn();
+    });
+
+    scenarioFn(ctx);
+  });
+}
+
+describe('SoloPanelPage', () => {
+  soloPanelPageScenario('Given initial state', ctx => {
+    ctx.setup(() => {
+      ctx.mount();
+    });
+
+    it('Should render nothing', () => {
+      expect(screen.queryByText(/Loading/)).not.toBeNull();
+    });
+  });
+
+  soloPanelPageScenario('Dashboard init completed ', ctx => {
+    ctx.setup(() => {
+      ctx.mount();
+      ctx.setDashboard();
+      expect(ctx.dashboard).not.toBeNull();
+      // the componentDidMount will change the dashboard prop to the new dashboard
+      // emulate this by rerendering with new props
+      ctx.rerender({ dashboard: ctx.dashboard });
+    });
+
+    it('Should render dashboard grid', async () => {
+      // check if the panel title has arrived in the DashboardPanel mock
+      expect(screen.queryByText(/My graph/)).not.toBeNull();
+    });
+  });
+
+  soloPanelPageScenario('When user navigates to other SoloPanelPage', ctx => {
+    ctx.setup(() => {
+      ctx.mount();
+      ctx.setDashboard({ uid: 1, panels: [{ id: 1, type: 'graph', title: 'Panel 1' }] });
+      ctx.setSecondaryDashboard({ uid: 2, panels: [{ id: 1, type: 'graph', title: 'Panel 2' }] });
+    });
+
+    it('Should show other graph', () => {
+      // check that the title in the DashboardPanel has changed
+      ctx.rerender({ dashboard: ctx.dashboard });
+      expect(screen.queryByText(/Panel 1/)).not.toBeNull();
+      ctx.rerender({ dashboard: ctx.secondaryDashboard });
+      expect(screen.queryByText(/Panel 1/)).toBeNull();
+      expect(screen.queryByText(/Panel 2/)).not.toBeNull();
+    });
+  });
+});

--- a/public/app/features/dashboard/containers/SoloPanelPage.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.tsx
@@ -57,8 +57,8 @@ export class SoloPanelPage extends Component<Props, State> {
       return;
     }
 
-    // we just got the dashboard!
-    if (!prevProps.dashboard) {
+    // we just got a new dashboard
+    if (!prevProps.dashboard || prevProps.dashboard.uid !== dashboard.uid) {
       const panelId = parseInt(urlPanelId, 10);
 
       // need to expand parent row if this panel is inside a row

--- a/public/app/features/dashboard/containers/SoloPanelPage.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.tsx
@@ -13,7 +13,7 @@ import { initDashboard } from '../state/initDashboard';
 import { StoreState, DashboardRouteInfo } from 'app/types';
 import { PanelModel, DashboardModel } from 'app/features/dashboard/state';
 
-interface Props {
+export interface Props {
   urlPanelId: string;
   urlUid?: string;
   urlSlug?: string;
@@ -25,7 +25,7 @@ interface Props {
   dashboard: DashboardModel | null;
 }
 
-interface State {
+export interface State {
   panel: PanelModel | null;
   notFound: boolean;
 }


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The panel on the SoloPanelPage did not update after an internal navigation to another SoloPanelPage. The reason is that, because the props apparently are retained, in the `componentDidUpdate` function it was assumed that the dashboard was already fully loaded.

**Which issue(s) this PR fixes**: 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #28574 

**Special notes for your reviewer**:
I also added a test case, as there was none for the SoloPanelPage. I hope that it is helpful