### PR TITLE
grafana/ui: fix spacing between icon and text in tab

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -68,7 +68,8 @@ const getTabStyles = stylesFactory((theme: GrafanaTheme) => {
       color: ${colors.text};
       cursor: pointer;
 
-      svg {
+      svg,
+      i.fa {
         margin-right: ${theme.spacing.sm};
       }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

`Tab` component adds a margin between icon and label, but only if icon is SVG. This PR updates styling to also incldue font awesome icons. It's an issue for some of our plugins, pointed out by @oanamangiurea 

Before:

![before](https://user-images.githubusercontent.com/847684/97407711-bf4ca680-1903-11eb-8e21-f0f8a89bbf53.png)

After:

![after](https://user-images.githubusercontent.com/847684/97407729-c5db1e00-1903-11eb-8223-1f099fa5118d.png)