### PR TITLE
Live: updated the reference to use lazy loaded Monaco in code editor.

### DIFF
--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -19,7 +19,7 @@ import { TablePanel } from '../table/TablePanel';
 import { LivePanelOptions, MessageDisplayMode } from './types';
 import { config, getGrafanaLiveSrv, MeasurementCollector } from '@grafana/runtime';
 import { css, cx } from 'emotion';
-import CodeEditor from '@grafana/ui/src/components/Monaco/CodeEditor';
+import { CodeEditor } from '@grafana/ui';
 
 interface Props extends PanelProps<LivePanelOptions> {}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we are importing the CodeEditor in a way that will include the Monaco editor by default in Grafana core. We should change to a proper import statement to load the component using the lazy loading of the Monaco editor.

