### PR TITLE
StatPanels: Change default stats option to "Last (not null)"

### DIFF
--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -59,7 +59,7 @@ export function addStandardDataReduceOptions(
     name: 'Calculation',
     description: 'Choose a reducer function / calculation',
     editor: standardEditorsRegistry.get('stats-picker').editor as any,
-    defaultValue: [ReducerID.mean],
+    defaultValue: [ReducerID.lastNotNull],
     // Hides it when all values mode is on
     showIf: currentConfig => currentConfig.reduceOptions.values === false,
   });


### PR DESCRIPTION
This PR changes the default calculation from "mean" to "last (not null)" for the stats panels:
* stat
* gauge
* bar gauge

NOTE: this would not change the behavior for anything that is already saved, just what happens when you start editing a new panel.

I'm not sure trained people are on this behavior, so this may be a big deal :man_shrugging:  -- In general I am skeptical of calculating the average value across a set of search results.  It *may* be meaningful, but the mean of some aggregate values is often undefined.  

Thoughts?

