### PR TITLE
Elasticsearch: Exclude pipeline aggregations from order by options

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -246,7 +246,7 @@ export function getMovingAvgSettings(model: any, filtered: boolean) {
 export function getOrderByOptions(target: any) {
   const metricRefs: any[] = [];
   _.each(target.metrics, metric => {
-    if (metric.type !== 'count') {
+    if (metric.type !== 'count' && !isPipelineAgg(metric.type)) {
       metricRefs.push({ text: describeMetric(metric), value: metric.id });
     }
   });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes a bug with the Elasticsearch datasource user experience. Elasticsearch is unable to sort by pipeline aggregations because they are only executed in the reduce phase on the coordinating node and so you do not have the information on the shard in order to be able to sort the shards buckets to pick the top N to send to the coordinating node.

Before

![image](https://user-images.githubusercontent.com/41702/97498481-8293a600-1929-11eb-9b9f-3fd3d6176c49.png)

After

![image](https://user-images.githubusercontent.com/41702/97498540-a1923800-1929-11eb-84d3-dde014cb99cc.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #19206 

**Special notes for your reviewer**:

None

