### PR TITLE
Variables: Adds named capture groups to variable regex

### DIFF
--- a/docs/sources/variables/filter-variables-with-regex.md
+++ b/docs/sources/variables/filter-variables-with-regex.md
@@ -79,4 +79,30 @@ demo.robustperception.io:9090
 demo.robustperception.io:9093
 demo.robustperception.io:9100
 ```
+
+## Filter and use named text and value capture groups
+
+This can be useful if the display text should differ from the value.
+
+List of options:
+
+```text
+kube_pod_labels{label_description="a-descriptive-name-for-pod1",namespace="default",pod="pod1"}
+kube_pod_labels{label_description="the-second-pod",namespace="default",pod="pod2"}
+kube_pod_labels{label_description="a-special-pod",namespace="default",pod="pod3"}
+```
+
+Regex:
+
+```regex
+/pod="(?<value>[^"]+)|label_description="(?<text>[^"]+)/g
+```
+
+Result:
+
+```text
+value   text
+pod1    a-descriptive-name-for-pod1
+pod2    the-second-pod
+pod3    a-sepcial-pod
 ```

--- a/docs/sources/variables/filter-variables-with-regex.md
+++ b/docs/sources/variables/filter-variables-with-regex.md
@@ -80,29 +80,34 @@ demo.robustperception.io:9093
 demo.robustperception.io:9100
 ```
 
-## Filter and use named text and value capture groups
+## Filter and modify using named text and value capture groups
 
-This can be useful if the display text should differ from the value.
+Using named capture groups it is possible to capture separate 'text' and 'value' parts from the options returned by the variable query. This allows the variable dropdown to contain a friendly name for each value that can be selected.
 
-List of options:
+For example, when querying the `node_hwmon_chip_names` prometheus metric the `chip_name` is a lot friendlier that the `chip` value. So the following variable query result:
 
 ```text
-kube_pod_labels{label_description="a-descriptive-name-for-pod1",namespace="default",pod="pod1"}
-kube_pod_labels{label_description="the-second-pod",namespace="default",pod="pod2"}
-kube_pod_labels{label_description="a-special-pod",namespace="default",pod="pod3"}
+node_hwmon_chip_names{chip="0000:d7:00_0_0000:d8:00_0",chip_name="enp216s0f0np0"} 1
+node_hwmon_chip_names{chip="0000:d7:00_0_0000:d8:00_1",chip_name="enp216s0f0np1"} 1
+node_hwmon_chip_names{chip="0000:d7:00_0_0000:d8:00_2",chip_name="enp216s0f0np2"} 1
+node_hwmon_chip_names{chip="0000:d7:00_0_0000:d8:00_3",chip_name="enp216s0f0np3"} 1
 ```
 
-Regex:
+Passed through the following Regex:
 
 ```regex
-/pod="(?<value>[^"]+)|label_description="(?<text>[^"]+)/g
+/chip_name="(?<text>[^"]+)|chip="(?<value>[^"]+)/g
 ```
 
-Result:
+Would produce the following dropdown:
 
 ```text
-value   text
-pod1    a-descriptive-name-for-pod1
-pod2    the-second-pod
-pod3    a-sepcial-pod
+Display Name          Value
+------------          -------------------------
+enp216s0f0np0         0000:d7:00_0_0000:d8:00_0
+enp216s0f0np1         0000:d7:00_0_0000:d8:00_1
+enp216s0f0np2         0000:d7:00_0_0000:d8:00_2
+enp216s0f0np3         0000:d7:00_0_0000:d8:00_3
 ```
+
+**NOTE:** only `text` and `value` capture group names are supported.

--- a/docs/sources/variables/filter-variables-with-regex.md
+++ b/docs/sources/variables/filter-variables-with-regex.md
@@ -82,9 +82,9 @@ demo.robustperception.io:9100
 
 ## Filter and modify using named text and value capture groups
 
-Using named capture groups it is possible to capture separate 'text' and 'value' parts from the options returned by the variable query. This allows the variable dropdown to contain a friendly name for each value that can be selected.
+Using named capture groups, you can capture separate 'text' and 'value' parts from the options returned by the variable query. This allows the variable drop-down list to contain a friendly name for each value that can be selected.
 
-For example, when querying the `node_hwmon_chip_names` prometheus metric the `chip_name` is a lot friendlier that the `chip` value. So the following variable query result:
+For example, when querying the `node_hwmon_chip_names` Prometheus metric, the `chip_name` is a lot friendlier that the `chip` value. So the following variable query result:
 
 ```text
 node_hwmon_chip_names{chip="0000:d7:00_0_0000:d8:00_0",chip_name="enp216s0f0np0"} 1
@@ -99,7 +99,7 @@ Passed through the following Regex:
 /chip_name="(?<text>[^"]+)|chip="(?<value>[^"]+)/g
 ```
 
-Would produce the following dropdown:
+Would produce the following drop-down list:
 
 ```text
 Display Name          Value

--- a/docs/sources/variables/filter-variables-with-regex.md
+++ b/docs/sources/variables/filter-variables-with-regex.md
@@ -110,4 +110,4 @@ enp216s0f0np2         0000:d7:00_0_0000:d8:00_2
 enp216s0f0np3         0000:d7:00_0_0000:d8:00_3
 ```
 
-**NOTE:** only `text` and `value` capture group names are supported.
+**Note:** Only `text` and `value` capture group names are supported.

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -193,14 +193,26 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
           <div className="gf-form">
             <InlineFormLabel
               width={10}
-              tooltip={'Optional, if you want to extract part of a series name or metric node segment.'}
+              tooltip={
+                <div>
+                  Optional, if you want to extract part of a series name or metric node segment. Named capture groups
+                  can be used to separate the display text and value (
+                  <a
+                    href="https://grafana.com/docs/grafana/latest/variables/filter-variables-with-regex#filter-and-modify-using-named-text-and-value-capture-groups"
+                    target="__blank"
+                  >
+                    see examples
+                  </a>
+                  ).
+                </div>
+              }
             >
               Regex
             </InlineFormLabel>
             <input
               type="text"
               className="gf-form-input"
-              placeholder="/.*-(.*)-.*/"
+              placeholder="/.*-(?<text>.*)-(?<value>.*)-.*/"
               value={this.state.regex ?? this.props.variable.regex}
               onChange={this.onRegExChange}
               onBlur={this.onRegExBlur}

--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -199,7 +199,7 @@ describe('queryVariableReducer', () => {
         });
     });
 
-    it('unmatached value capture returns empty state', () => {
+    it('unmatched value capture returns empty state', () => {
       const regex = '/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/gi';
       const { initialState } = getVariableTestContext(adapter, { includeAll: false, regex });
       const metrics = [createMetric('A{somelabel="atext",something="avalue"}'), createMetric('B')];

--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -199,10 +199,29 @@ describe('queryVariableReducer', () => {
         });
     });
 
-    it('unmatched value capture returns empty state', () => {
+    it('unmatched value capture will use text capture', () => {
       const regex = '/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/gi';
       const { initialState } = getVariableTestContext(adapter, { includeAll: false, regex });
-      const metrics = [createMetric('A{somelabel="atext",something="avalue"}'), createMetric('B')];
+      const metrics = [createMetric('A{somelabel="atext",somename="avalue"}'), createMetric('B')];
+      const update = { results: metrics, templatedRegex: regex };
+      const payload = toVariablePayload({ id: '0', type: 'query' }, update);
+
+      reducerTester<VariablesState>()
+        .givenReducer(queryVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateVariableOptions(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          '0': ({
+            ...initialState[0],
+            options: [{ text: 'atext', value: 'atext', selected: false }],
+          } as unknown) as QueryVariableModel,
+        });
+    });
+
+    it('unmatched text capture and unmatched value capture returns empty state', () => {
+      const regex = '/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/gi';
+      const { initialState } = getVariableTestContext(adapter, { includeAll: false, regex });
+      const metrics = [createMetric('A{someother="atext",something="avalue"}'), createMetric('B')];
       const update = { results: metrics, templatedRegex: regex };
       const payload = toVariablePayload({ id: '0', type: 'query' }, update);
 

--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -141,6 +141,84 @@ describe('queryVariableReducer', () => {
     });
   });
 
+  describe('when updateVariableOptions is dispatched and includeAll is false and regex is set and uses capture groups', () => {
+    it('normal regex should capture in order matches', () => {
+      const regex = '/somelabel="(?<text>[^"]+).*somevalue="(?<value>[^"]+)/i';
+      const { initialState } = getVariableTestContext(adapter, { includeAll: false, regex });
+      const metrics = [createMetric('A{somelabel="atext",somevalue="avalue"}'), createMetric('B')];
+      const update = { results: metrics, templatedRegex: regex };
+      const payload = toVariablePayload({ id: '0', type: 'query' }, update);
+
+      reducerTester<VariablesState>()
+        .givenReducer(queryVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateVariableOptions(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          '0': ({
+            ...initialState[0],
+            options: [{ text: 'atext', value: 'avalue', selected: false }],
+          } as unknown) as QueryVariableModel,
+        });
+    });
+
+    it('global regex should capture out of order matches', () => {
+      const regex = '/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/gi';
+      const { initialState } = getVariableTestContext(adapter, { includeAll: false, regex });
+      const metrics = [createMetric('A{somelabel="atext",somevalue="avalue"}'), createMetric('B')];
+      const update = { results: metrics, templatedRegex: regex };
+      const payload = toVariablePayload({ id: '0', type: 'query' }, update);
+
+      reducerTester<VariablesState>()
+        .givenReducer(queryVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateVariableOptions(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          '0': ({
+            ...initialState[0],
+            options: [{ text: 'atext', value: 'avalue', selected: false }],
+          } as unknown) as QueryVariableModel,
+        });
+    });
+
+    it('unmatched text capture will use value capture', () => {
+      const regex = '/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/gi';
+      const { initialState } = getVariableTestContext(adapter, { includeAll: false, regex });
+      const metrics = [createMetric('A{somename="atext",somevalue="avalue"}'), createMetric('B')];
+      const update = { results: metrics, templatedRegex: regex };
+      const payload = toVariablePayload({ id: '0', type: 'query' }, update);
+
+      reducerTester<VariablesState>()
+        .givenReducer(queryVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateVariableOptions(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          '0': ({
+            ...initialState[0],
+            options: [{ text: 'avalue', value: 'avalue', selected: false }],
+          } as unknown) as QueryVariableModel,
+        });
+    });
+
+    it('unmatached value capture returns empty state', () => {
+      const regex = '/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/gi';
+      const { initialState } = getVariableTestContext(adapter, { includeAll: false, regex });
+      const metrics = [createMetric('A{somelabel="atext",something="avalue"}'), createMetric('B')];
+      const update = { results: metrics, templatedRegex: regex };
+      const payload = toVariablePayload({ id: '0', type: 'query' }, update);
+
+      reducerTester<VariablesState>()
+        .givenReducer(queryVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateVariableOptions(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          '0': ({
+            ...initialState[0],
+            options: [{ text: 'None', value: '', selected: false, isNone: true }],
+          } as unknown) as QueryVariableModel,
+        });
+    });
+  });
+
   describe('when updateVariableTags is dispatched', () => {
     it('then state should be correct', () => {
       const { initialState } = getVariableTestContext(adapter);

--- a/public/app/features/variables/query/reducer.ts
+++ b/public/app/features/variables/query/reducer.ts
@@ -87,18 +87,14 @@ const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
 };
 
 const getAllMatches = (str: string, regex: RegExp): any => {
-  let results = {};
+    const results = {};
   let matches;
 
-  if (regex.global) {
-    while ((matches = regex.exec(str))) {
-      _.merge(results, matches);
-    }
-  } else {
-    if ((matches = regex.exec(str))) {
-      _.merge(results, matches);
-    }
-  }
+  do {
+    matches = regex.exec(str);
+    _.merge(results, matches);
+  } while (regex.global && matches);
+
   return results;
 };
 

--- a/public/app/features/variables/query/reducer.ts
+++ b/public/app/features/variables/query/reducer.ts
@@ -86,6 +86,22 @@ const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
   return options;
 };
 
+const getAllMatches = (str: string, regex: RegExp): any => {
+  let results = {};
+  let matches;
+
+  if (regex.global) {
+    while ((matches = regex.exec(str))) {
+      _.merge(results, matches);
+    }
+  } else {
+    if ((matches = regex.exec(str))) {
+      _.merge(results, matches);
+    }
+  }
+  return results;
+};
+
 const metricNamesToVariableValues = (variableRegEx: string, sort: VariableSort, metricNames: any[]) => {
   let regex, i, matches;
   let options: VariableOption[] = [];
@@ -109,13 +125,24 @@ const metricNamesToVariableValues = (variableRegEx: string, sort: VariableSort, 
     }
 
     if (regex) {
-      matches = regex.exec(value);
-      if (!matches) {
+      matches = getAllMatches(value, regex);
+
+      if (_.isEmpty(matches)) {
         continue;
       }
-      if (matches.length > 1) {
-        value = matches[1];
-        text = matches[1];
+
+      if (matches.groups && matches.groups.value) {
+        value = matches.groups.value;
+      } else if (matches.groups && matches.groups.hasOwnProperty('value')) {
+        continue;
+      } else if (matches['1']) {
+        value = matches['1'];
+      }
+
+      if (matches.groups && matches.groups.text) {
+        text = matches.groups.text;
+      } else {
+        text = value;
       }
     }
 

--- a/public/app/features/variables/query/reducer.ts
+++ b/public/app/features/variables/query/reducer.ts
@@ -87,7 +87,7 @@ const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
 };
 
 const getAllMatches = (str: string, regex: RegExp): any => {
-    const results = {};
+  const results = {};
   let matches;
 
   do {
@@ -127,18 +127,17 @@ const metricNamesToVariableValues = (variableRegEx: string, sort: VariableSort, 
         continue;
       }
 
-      if (matches.groups && matches.groups.value) {
+      if (matches.groups && matches.groups.value && matches.groups.text) {
         value = matches.groups.value;
-      } else if (matches.groups && matches.groups.hasOwnProperty('value')) {
-        continue;
+        text = matches.groups.text;
+      } else if (matches.groups && matches.groups.value) {
+        value = matches.groups.value;
+        text = value;
+      } else if (matches.groups && matches.groups.text) {
+        text = matches.groups.text;
+        value = text;
       } else if (matches['1']) {
         value = matches['1'];
-      }
-
-      if (matches.groups && matches.groups.text) {
-        text = matches.groups.text;
-      } else {
-        text = value;
       }
     }
 


### PR DESCRIPTION
This PR allows 'text' and 'value' named capture groups to be specified in the regular expression for variable queries so that distinct values and display text can be extracted. This is simliar the __text and __value functionality available if using a SQL datasource but should work for all datasources - especially Prometheus, which is the tested use case. 

Fixes #21076
Fixes #12039