### PR TITLE
CloudWatch: Slight performance improvement

### DIFF
--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -53,7 +53,7 @@ func (e *cloudWatchExecutor) transformRequestQueriesToCloudWatchQueries(requestQ
 	return cloudwatchQueries, nil
 }
 
-func (e *cloudWatchExecutor) transformQueryResponseToQueryResult(cloudwatchResponses []*cloudwatchResponse) map[string]*tsdb.QueryResult {
+func (e *cloudWatchExecutor) transformQueryResponsesToQueryResult(cloudwatchResponses []*cloudwatchResponse) map[string]*tsdb.QueryResult {
 	responsesByRefID := make(map[string][]*cloudwatchResponse)
 	refIDs := sort.StringSlice{}
 	for _, res := range cloudwatchResponses {

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -46,7 +46,7 @@ func (e *cloudWatchExecutor) parseResponse(metricDataOutputs []*cloudwatch.GetMe
 		}
 	}
 
-	cloudWatchResponses := make([]*cloudwatchResponse, 0)
+	cloudWatchResponses := make([]*cloudwatchResponse, 0, len(mdrs))
 	for id, lr := range mdrs {
 		query := queries[id]
 		frames, partialData, err := parseMetricResults(lr, labels[id], query)

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -97,7 +97,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, queryCo
 			}
 
 			cloudwatchResponses = append(cloudwatchResponses, responses...)
-			res := e.transformQueryResponseToQueryResult(cloudwatchResponses)
+			res := e.transformQueryResponsesToQueryResult(cloudwatchResponses)
 			for _, queryRes := range res {
 				resultChan <- queryRes
 			}


### PR DESCRIPTION
Make slight CloudWatch performance improvement by specifying an array slice capacity. Also rename a function to reflect that it takes a collection of responses.