### PR TITLE
Plugins: Fix descendent frontend plugin signature validation

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -373,7 +373,6 @@ func (scanner *PluginScanner) IsBackendOnlyPlugin(pluginType string) bool {
 
 // validateSignature validates a plugin's signature.
 func (s *PluginScanner) validateSignature(plugin *PluginBase) *PluginError {
-	// If the plugin has a parent plugin
 	if plugin.Root != nil {
 		// If a descendant plugin with invalid signature, set signature to that of root
 		if plugin.IsCorePlugin || plugin.Signature == PluginSignatureInternal {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -373,17 +373,7 @@ func (scanner *PluginScanner) IsBackendOnlyPlugin(pluginType string) bool {
 
 // validateSignature validates a plugin's signature.
 func (s *PluginScanner) validateSignature(plugin *PluginBase) *PluginError {
-	// For the time being, we choose to only require back-end plugins to be signed
-	// NOTE: the state is calculated again when setting metadata on the object
-	if !plugin.Backend || !s.requireSigned {
-		return nil
-	}
-
-	if plugin.Signature == PluginSignatureValid {
-		s.log.Debug("Plugin has valid signature", "id", plugin.Id)
-		return nil
-	}
-
+	// If the plugin has a parent plugin
 	if plugin.Root != nil {
 		// If a descendant plugin with invalid signature, set signature to that of root
 		if plugin.IsCorePlugin || plugin.Signature == PluginSignatureInternal {
@@ -401,6 +391,17 @@ func (s *PluginScanner) validateSignature(plugin *PluginBase) *PluginError {
 	} else {
 		s.log.Debug("Non-valid plugin Signature", "pluginID", plugin.Id, "pluginDir", plugin.PluginDir,
 			"state", plugin.Signature)
+	}
+
+	// For the time being, we choose to only require back-end plugins to be signed
+	// NOTE: the state is calculated again when setting metadata on the object
+	if !plugin.Backend || !s.requireSigned {
+		return nil
+	}
+
+	if plugin.Signature == PluginSignatureValid {
+		s.log.Debug("Plugin has valid signature", "id", plugin.Id)
+		return nil
 	}
 
 	switch plugin.Signature {

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -373,6 +373,11 @@ func (scanner *PluginScanner) IsBackendOnlyPlugin(pluginType string) bool {
 
 // validateSignature validates a plugin's signature.
 func (s *PluginScanner) validateSignature(plugin *PluginBase) *PluginError {
+	if plugin.Signature == PluginSignatureValid {
+		s.log.Debug("Plugin has valid signature", "id", plugin.Id)
+		return nil
+	}
+
 	if plugin.Root != nil {
 		// If a descendant plugin with invalid signature, set signature to that of root
 		if plugin.IsCorePlugin || plugin.Signature == PluginSignatureInternal {
@@ -395,11 +400,6 @@ func (s *PluginScanner) validateSignature(plugin *PluginBase) *PluginError {
 	// For the time being, we choose to only require back-end plugins to be signed
 	// NOTE: the state is calculated again when setting metadata on the object
 	if !plugin.Backend || !s.requireSigned {
-		return nil
-	}
-
-	if plugin.Signature == PluginSignatureValid {
-		s.log.Debug("Plugin has valid signature", "id", plugin.Id)
 		return nil
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Frontend plugins (or non-backend however you want to look at it), that are nested within a plugin, unless they have a MANIFEST.txt - will get marked as `unsigned` by default. Later in the validation process we check the current plugin's signature status, and since it's non backend we exit and don't update the status. Thanks to @aknuds1's [fix](https://github.com/grafana/grafana/issues/27364) for a related issue, we just need to move the check for plugin nesting sooner as this will recognize the plugin can inherit a signature, and should do so - preventing us from maintaining the `unsigned` status which shows up on the frontend


TLDR; It moves the logic for checking for root plugin signature earlier as currently it exits too soon while checking if the plugin is backend or not.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #
https://github.com/grafana/grafana/issues/28629

