### PR TITLE
Docker:  Use root group in the custom Dockerfile

### DIFF
--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -6,10 +6,11 @@ USER root
 
 ARG GF_INSTALL_IMAGE_RENDERER_PLUGIN="false"
 
+ARG GF_GID="0"
 ENV GF_PATHS_PLUGINS="/var/lib/grafana-plugins"
 
 RUN mkdir -p "$GF_PATHS_PLUGINS" && \
-    chown -R grafana:grafana "$GF_PATHS_PLUGINS"
+    chown -R grafana:${GF_GID} "$GF_PATHS_PLUGINS"
 
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \

--- a/packaging/docker/custom/ubuntu.Dockerfile
+++ b/packaging/docker/custom/ubuntu.Dockerfile
@@ -9,10 +9,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ARG GF_INSTALL_IMAGE_RENDERER_PLUGIN="false"
 
+ARG GF_GID="0"
 ENV GF_PATHS_PLUGINS="/var/lib/grafana-plugins"
 
 RUN mkdir -p "$GF_PATHS_PLUGINS" && \
-    chown -R grafana:grafana "$GF_PATHS_PLUGINS"
+    chown -R grafana:${GF_GID} "$GF_PATHS_PLUGINS"
 
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
     apt-get update && \


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

After switching to the root user group `$GF_GUID=0` (#27813) in the main Dockerfile I have troubles with building custom Docker container with pre installed Image Renderer plugin:

```bash
$ docker build --no-cache \
--build-arg "GRAFANA_VERSION=latest" \
--build-arg "GF_INSTALL_IMAGE_RENDERER_PLUGIN=true" \
-t grafana-custom -f Dockerfile .
Sending build context to Docker daemon   5.12kB
Step 1/12 : ARG GRAFANA_VERSION="latest"
Step 2/12 : FROM grafana/grafana:${GRAFANA_VERSION}
 ---> 39005577217b
Step 3/12 : USER root
 ---> Using cache
 ---> 29cacf97219a
Step 4/12 : ARG GF_INSTALL_IMAGE_RENDERER_PLUGIN="false"
 ---> Using cache
 ---> 5e68ab19e310
Step 5/12 : ENV GF_PATHS_PLUGINS="/var/lib/grafana-plugins"
 ---> Using cache
 ---> 1456c917aa6a
Step 6/12 : RUN mkdir -p "$GF_PATHS_PLUGINS" &&     chown -R grafana:grafana "$GF_PATHS_PLUGINS"
 ---> Running in 5324e5a5a495
chown: unknown user/group grafana:grafana
The command '/bin/sh -c mkdir -p "$GF_PATHS_PLUGINS" &&     chown -R grafana:grafana "$GF_PATHS_PLUGINS"' returned a non-zero code: 1
```

I've made a quick fix resolving that issue.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

