### PR TITLE
TextPanel: Fixes problems where text panel would show old content

### DIFF
--- a/public/app/plugins/panel/text/textPanelMigrationHandler.test.ts
+++ b/public/app/plugins/panel/text/textPanelMigrationHandler.test.ts
@@ -8,12 +8,30 @@ describe('textPanelMigrationHandler', () => {
       const panel: any = {
         content: '<span>Hello World<span>',
         mode: 'html',
+        options: {},
       };
 
       const result = textPanelMigrationHandler(panel);
 
       expect(result.content).toEqual('<span>Hello World<span>');
       expect(result.mode).toEqual('html');
+      expect(panel.content).toBeUndefined();
+      expect(panel.mode).toBeUndefined();
+    });
+  });
+
+  describe('when invoked and previous version 7.1 or later', () => {
+    it('then not migrate options', () => {
+      const panel: any = {
+        content: '<span>Hello World<span>',
+        mode: 'html',
+        options: { content: 'New content' },
+        pluginVersion: '7.1.0',
+      };
+
+      const result = textPanelMigrationHandler(panel);
+
+      expect(result.content).toEqual('New content');
     });
   });
 

--- a/public/app/plugins/panel/text/textPanelMigrationHandler.ts
+++ b/public/app/plugins/panel/text/textPanelMigrationHandler.ts
@@ -2,19 +2,27 @@ import { PanelModel } from '@grafana/data';
 import { TextMode, TextOptions } from './types';
 
 export const textPanelMigrationHandler = (panel: PanelModel<TextOptions>): Partial<TextOptions> => {
+  const previousVersion = parseFloat(panel.pluginVersion || '6.1');
+  let options = panel.options;
+
   // Migrates old Angular based text panel props to new props
   if (panel.hasOwnProperty('content') && panel.hasOwnProperty('mode')) {
-    const oldTextPanel: { content: string; mode: string } = (panel as unknown) as any;
+    const oldTextPanel: any = panel as any;
     const content = oldTextPanel.content;
-    const mode = (oldTextPanel.mode as unknown) as TextMode;
+    const mode = oldTextPanel.mode as TextMode;
 
-    return { content, mode };
+    delete oldTextPanel.content;
+    delete oldTextPanel.mode;
+
+    if (previousVersion < 7.1) {
+      options = { content, mode };
+    }
   }
 
   // The 'text' mode has been removed so we need to update any panels still using it to markdown
-  if (panel.options.mode !== 'html' && panel.options.mode !== 'markdown') {
-    return { content: panel.options.content, mode: 'markdown' };
+  if (options.mode !== 'html' && options.mode !== 'markdown') {
+    options = { ...options, mode: 'markdown' };
   }
 
-  return panel.options;
+  return options;
 };


### PR DESCRIPTION
Fixes #28640

Problem was that the migration from old angular text panel to new did not clean up properties. So when loading a panel that
had been updated and saved in 7.1 it worked but the content prop from the old angular panel was still there. So when
updating to Grafana v7.3 the migration handler would run and detect the old angular content prop and use that instead of the new
options.content.

This change changes the migration logic to only use the old prop when panel version is older than 7.1 (when react text panel was introduced)
Also handled removal of old props and handles the combo of fixing old text mode for angular panels as well (ie so both migration logic steps are done if needed)
