### PR TITLE
Table: Fix image cell mode so that it works with value mappings

### DIFF
--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -2,11 +2,13 @@ import React, { FC } from 'react';
 import { TableCellProps } from './types';
 
 export const ImageCell: FC<TableCellProps> = props => {
-  const { cell, tableStyles, cellProps } = props;
+  const { field, cell, tableStyles, cellProps } = props;
+
+  const displayValue = field.display!(cell.value);
 
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>
-      <img src={cell.value} className={tableStyles.imageCell} />
+      <img src={displayValue.text} className={tableStyles.imageCell} />
     </div>
   );
 };


### PR DESCRIPTION
Fixes #28576

Now image cell mode works if you for example map a value range to a text that contains a URL  (or Base64 encoded image)
