### PR TITLE
Bump rxjs to 6.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "regenerator-runtime": "0.13.3",
     "reselect": "4.0.0",
     "rst2html": "github:thoward/rst2html#990cb89",
-    "rxjs": "6.6.2",
+    "rxjs": "6.6.3",
     "search-query-parser": "1.5.4",
     "slate": "0.47.8",
     "slate-plain-serializer": "0.7.10",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -26,7 +26,7 @@
     "@types/d3-interpolate": "^1.3.1",
     "apache-arrow": "0.16.0",
     "lodash": "4.17.19",
-    "rxjs": "6.6.2",
+    "rxjs": "6.6.3",
     "xss": "1.0.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24051,10 +24051,10 @@ rxjs@6.5.5, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
-  integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
+rxjs@6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Addresses https://github.com/grafana/grafana/issues/28395

There is a rxjs type mismatch in https://github.com/grafana/grafana-starter-datasource-backend. It seems to be caused by concurrently package installing rxjs@6.6.3 while grafana-data requires 6.6.2. When aligning the versions the problem is gone.

@hugohaggmark @torkelo not sure if we want to include this in a patch release. As a temporary workaround until 7.4 is released I can force the toolkit starter template to resolve rxjs@6.6.2. This should not influence the way toolkit(which has dependency conconcurrently) works. WDYT?