### PR TITLE
Drone: Don't build on Windows for PRs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -233,32 +233,6 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: windows-pr
-
-platform:
-  os: windows
-  arch: amd64
-  version: 1809
-
-steps:
-- name: identify-runner
-  image: mcr.microsoft.com/windows:1809
-  commands:
-  - echo $env:DRONE_RUNNER_NAME
-
-- name: initialize
-  image: grafana/ci-wix:0.1.1
-  commands:
-  - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.20/windows/grabpl.exe -OutFile grabpl.exe
-
-trigger:
-  event:
-  - pull_request
-
----
-kind: pipeline
-type: docker
 name: build-master
 
 platform:

--- a/scripts/pr.star
+++ b/scripts/pr.star
@@ -19,7 +19,6 @@ load(
     'build_docker_images_step',
     'postgres_integration_tests_step',
     'mysql_integration_tests_step',
-    'get_windows_steps',
     'benchmark_ldap_step',
     'ldap_service',
     'integration_test_services',
@@ -50,7 +49,6 @@ def pr_pipelines(edition):
         postgres_integration_tests_step(),
         mysql_integration_tests_step(),
     ]
-    windows_steps = get_windows_steps(edition=edition, ver_mode=ver_mode)
     if edition == 'enterprise':
         steps.append(benchmark_ldap_step())
         services.append(ldap_service())
@@ -60,10 +58,6 @@ def pr_pipelines(edition):
     return [
         pipeline(
             name='test-pr', edition=edition, trigger=trigger, services=services, steps=steps,
-            ver_mode=ver_mode,
-        ),
-        pipeline(
-            name='windows-pr', edition=edition, trigger=trigger, steps=windows_steps, platform='windows',
             ver_mode=ver_mode,
         ),
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable building of PRs on Windows, since it can really slow them down, due to us having few and slow Windows runners.

