### PR TITLE
Added content based on Ximena's recommendations.

### DIFF
--- a/docs/sources/packages_api
+++ b/docs/sources/packages_api
@@ -1,0 +1,1 @@
+/frontend-docs/packages_api

--- a/docs/sources/sharing/share-panel.md
+++ b/docs/sources/sharing/share-panel.md
@@ -10,13 +10,18 @@ draft = "true"
 
 # Share a panel
 
-Click a panel title to open the panel menu, then click share in the panel menu to open the Share Panel dialog. Here you have access to a link that will take you to exactly this panel with the current time range and selected template variables. Here are some of the ways you can share a panel.
+To share a panel
+
+1. Click a panel title to open the panel menu.
+1. Click share in the panel menu to open the Share Panel dialog.
+
+ Here you have access to a link that will take you to exactly this panel with the current time range and selected template variables. Here are some of the ways you can share a panel.
 
 ## Publish snapshots
 
 You can publish snapshots to your local instance or to [snapshot.raintank.io](http://snapshot.raintank.io). The latter is a free service provided by [Raintank](http://raintank.io), that allows you to publish dashboard snapshots to an external Grafana instance. The same rules still apply, anyone with the link can view it. You can set an expiration time if you want the snapshot to be removed after a certain time period.
 
-{{< docs-imagebox img="/img/docs/v50/share_panel_modal.png" max-width="700px" >}}
+{{< docs-imagebox img="/img/docs/panels/Share_a_panel.png" max-width="700px" >}}
 
 ## Direct Link Rendered Image
 

--- a/docs/sources/sharing/share-panel.md
+++ b/docs/sources/sharing/share-panel.md
@@ -19,7 +19,9 @@ To share a panel
 
 ## Publish snapshots
 
-You can publish snapshots to your local instance or to [snapshot.raintank.io](http://snapshot.raintank.io). The latter is a free service provided by [Raintank](http://raintank.io), that allows you to publish dashboard snapshots to an external Grafana instance. The same rules still apply, anyone with the link can view it. You can set an expiration time if you want the snapshot to be removed after a certain time period.
+You can publish snapshots to your local instance or to [snapshot.raintank.io](http://snapshot.raintank.io). The latter is a free service provided by [Raintank](http://raintank.io), that allows you to publish dashboard snapshots to an external Grafana instance.
+
+Anyone with the link can view it. You can optionally set an expiration time if you want the snapshot to be removed after a certain time period.
 
 {{< docs-imagebox img="/img/docs/panels/Share_a_panel.png" max-width="700px" >}}
 

--- a/docs/sources/sharing/share-panel.md
+++ b/docs/sources/sharing/share-panel.md
@@ -10,7 +10,13 @@ draft = "true"
 
 # Share a panel
 
-Click a panel title to open the panel menu, then click share in the panel menu to open the Share Panel dialog. Here you have access to a link that will take you to exactly this panel with the current time range and selected template variables. Below are ways to share a panel.
+Click a panel title to open the panel menu, then click share in the panel menu to open the Share Panel dialog. Here you have access to a link that will take you to exactly this panel with the current time range and selected template variables. Here are some of the ways you can share a panel.
+
+## Publish snapshots
+
+You can publish snapshots to your local instance or to [snapshot.raintank.io](http://snapshot.raintank.io). The latter is a free service provided by [Raintank](http://raintank.io), that allows you to publish dashboard snapshots to an external Grafana instance. The same rules still apply, anyone with the link can view it. You can set an expiration time if you want the snapshot to be removed after a certain time period.
+
+{{< docs-imagebox img="/img/docs/v50/share_panel_modal.png" max-width="700px" >}}
 
 ## Direct Link Rendered Image
 


### PR DESCRIPTION
Updated "Share a Panel" topic.

Added section "Publish Snapshots" and a new image (image added to website repo: Add new image #2748).

From Ximena, for whom I created the PR: 

The doc mentions Embed Panel and Direct Link but really should be a section for the Snapshot option which is the easiest of them all. ...

There's technically 3 ways to share a panel so having all 3 in that doc makes sense. IMHO "Publish Snapshots" should be at the top due to how 1-2-3 easy it is to do.


