### PR TITLE
Explore: Remove redundant decodeURI and fix urls

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -48,7 +48,6 @@ describe('state functions', () => {
     });
 
     it('returns a valid Explore state from a compact URL parameter', () => {
-      // %5B"now-1h","now","Local",%7B"expr":"metric"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
       const paramValue = '["now-1h","now","Local",{"expr":"metric"},{"ui":[true,true,true,"none"]}]';
       expect(parseUrlState(paramValue)).toMatchObject({
         datasource: 'Local',
@@ -61,7 +60,6 @@ describe('state functions', () => {
     });
 
     it('should return queries if queryType is present in the url', () => {
-      //%5B"now-1h","now","x-ray-datasource",%7B"queryType":"getTraceSummaries"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
       const paramValue =
         '["now-1h","now","x-ray-datasource",{"queryType":"getTraceSummaries"},{"ui":[true,true,true,"none"]}]';
       expect(parseUrlState(paramValue)).toMatchObject({

--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -36,8 +36,7 @@ describe('state functions', () => {
     });
 
     it('returns a valid Explore state from URL parameter', () => {
-      const paramValue =
-        '%7B"datasource":"Local","queries":%5B%7B"expr":"metric"%7D%5D,"range":%7B"from":"now-1h","to":"now"%7D%7D';
+      const paramValue = '{"datasource":"Local","queries":[{"expr":"metric"}],"range":{"from":"now-1h","to":"now"}}';
       expect(parseUrlState(paramValue)).toMatchObject({
         datasource: 'Local',
         queries: [{ expr: 'metric' }],
@@ -49,9 +48,8 @@ describe('state functions', () => {
     });
 
     it('returns a valid Explore state from a compact URL parameter', () => {
-      // ["now-1h","now","Local",{"expr":"metric"},{"ui":[true,true,true,"none"]}]
-      const paramValue =
-        '%5B"now-1h","now","Local",%7B"expr":"metric"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D';
+      // %5B"now-1h","now","Local",%7B"expr":"metric"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
+      const paramValue = '["now-1h","now","Local",{"expr":"metric"},{"ui":[true,true,true,"none"]}]';
       expect(parseUrlState(paramValue)).toMatchObject({
         datasource: 'Local',
         queries: [{ expr: 'metric' }],
@@ -63,9 +61,9 @@ describe('state functions', () => {
     });
 
     it('should return queries if queryType is present in the url', () => {
-      // ["now-1h","now","x-ray-datasource",{"queryType":"getTraceSummaries"},{"ui":[true,true,true,"none"]}]
+      //%5B"now-1h","now","x-ray-datasource",%7B"queryType":"getTraceSummaries"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D
       const paramValue =
-        '%5B"now-1h","now","x-ray-datasource",%7B"queryType":"getTraceSummaries"%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D';
+        '["now-1h","now","x-ray-datasource",{"queryType":"getTraceSummaries"},{"ui":[true,true,true,"none"]}]';
       expect(parseUrlState(paramValue)).toMatchObject({
         datasource: 'x-ray-datasource',
         queries: [{ queryType: 'getTraceSummaries' }],

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -194,7 +194,7 @@ export const safeParseJson = (text?: string): any | undefined => {
   }
 
   try {
-    return JSON.parse(decodeURI(text));
+    return JSON.parse(text);
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
In parseJSON, we were using `decodeURI`, however the string that we are passing in is already decoded. This is not problem if the query doesn't contain `%`. If it does, the `decodeURI` throws the error and urlState is set to default settings. Also, we had couple tests that were counting on url encoded string. These had to be changed to decoded strings. 

As you can see below, when we updateLocation, we use `location.query` and not `location.url`, which is URI decoded. 
![image](https://user-images.githubusercontent.com/30407135/97703324-ba792580-1ab0-11eb-8355-5090fb2393b0.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/28568

**Special notes for your reviewer**:

