### PR TITLE
Dashboard: remove usage of Legacyforms

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -70,7 +70,6 @@ export const getSwitchStyles = stylesFactory((theme: GrafanaTheme) => {
           transition: transform 0.2s cubic-bezier(0.19, 1, 0.22, 1);
         }
       }
-    }
     `,
   };
 });
@@ -103,3 +102,5 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
     );
   }
 );
+
+Switch.displayName = 'Switch';

--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -75,14 +75,14 @@ export const getSwitchStyles = stylesFactory((theme: GrafanaTheme) => {
 });
 
 export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
-  ({ value, checked, disabled = false, onChange, ...inputProps }, ref) => {
+  ({ value, checked, disabled = false, onChange, id, ...inputProps }, ref) => {
     if (checked) {
       deprecationWarning('Switch', 'checked prop', 'value');
     }
 
     const theme = useTheme();
     const styles = getSwitchStyles(theme);
-    const switchIdRef = useRef(uniqueId('switch-'));
+    const switchIdRef = useRef(id ? id : uniqueId('switch-'));
 
     return (
       <div className={cx(styles.switch)}>

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Input, LegacyForms, TimeZonePicker, Tooltip } from '@grafana/ui';
+import { InlineField, Input, Switch, TimeZonePicker, Tooltip } from '@grafana/ui';
 import { rangeUtil, TimeZone } from '@grafana/data';
 import isEmpty from 'lodash/isEmpty';
 import { selectors } from '@grafana/e2e-selectors';
@@ -87,12 +87,9 @@ export class TimePickerSettings extends PureComponent<Props, State> {
           </div>
 
           <div className="gf-form">
-            <LegacyForms.Switch
-              labelClass="width-7"
-              label="Hide time picker"
-              checked={this.props.timePickerHidden ?? false}
-              onChange={this.onHideTimePickerChange}
-            />
+            <InlineField labelWidth={14} label="Hide time picker">
+              <Switch value={this.props.timePickerHidden ?? false} onChange={this.onHideTimePickerChange} />
+            </InlineField>
           </div>
         </div>
       </div>

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -88,7 +88,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
 
           <div className="gf-form">
             <InlineField labelWidth={14} label="Hide time picker">
-              <Switch value={this.props.timePickerHidden ?? false} onChange={this.onHideTimePickerChange} />
+              <Switch value={!!this.props.timePickerHidden} onChange={this.onHideTimePickerChange} />
             </InlineField>
           </div>
         </div>

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -82,10 +82,18 @@ export class ShareEmbed extends PureComponent<Props, State> {
           <div className="share-modal-content">
             <div className="gf-form-group">
               <InlineField labelWidth={24} label="Current time range">
-                <Switch value={useCurrentTimeRange} onChange={this.onUseCurrentTimeRangeChange} />
+                <Switch
+                  id="share-current-time-range"
+                  value={useCurrentTimeRange}
+                  onChange={this.onUseCurrentTimeRangeChange}
+                />
               </InlineField>
               <InlineField labelWidth={24} label="Template variables">
-                <Switch value={includeTemplateVars} onChange={this.onIncludeTemplateVarsChange} />
+                <Switch
+                  id="share-template-variables"
+                  value={includeTemplateVars}
+                  onChange={this.onIncludeTemplateVarsChange}
+                />
               </InlineField>
               <InlineField labelWidth={24} label="Theme">
                 <Select width={20} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -80,16 +80,17 @@ export class ShareEmbed extends PureComponent<Props, State> {
         <div className="share-modal-header">
           <Icon name="link" className="share-modal-big-icon" size="xxl" />
           <div className="share-modal-content">
-            <InlineField labelWidth={24} label="Current time range">
-              <Switch value={useCurrentTimeRange} onChange={this.onUseCurrentTimeRangeChange} />
-            </InlineField>
-            <InlineField labelWidth={24} label="Template variables">
-              <Switch value={includeTemplateVars} onChange={this.onIncludeTemplateVarsChange} />
-            </InlineField>
-            <InlineField labelWidth={24} label="Theme">
-              <Select width={10} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
-            </InlineField>
-
+            <div className="gf-form-group">
+              <InlineField labelWidth={24} label="Current time range">
+                <Switch value={useCurrentTimeRange} onChange={this.onUseCurrentTimeRangeChange} />
+              </InlineField>
+              <InlineField labelWidth={24} label="Template variables">
+                <Switch value={includeTemplateVars} onChange={this.onIncludeTemplateVarsChange} />
+              </InlineField>
+              <InlineField labelWidth={24} label="Theme">
+                <Select width={20} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
+              </InlineField>
+            </div>
             <p className="share-modal-info-text">
               The html code below can be pasted and included in another web page. Unless anonymous access is enabled,
               the user viewing that page need to be signed into grafana for the graph to load.

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
-import { LegacyForms, Icon } from '@grafana/ui';
-const { Select, Switch } = LegacyForms;
+import { Select, Switch, Icon, InlineField } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { buildIframeHtml } from './utils';
@@ -81,24 +80,15 @@ export class ShareEmbed extends PureComponent<Props, State> {
         <div className="share-modal-header">
           <Icon name="link" className="share-modal-big-icon" size="xxl" />
           <div className="share-modal-content">
-            <div className="gf-form-group">
-              <Switch
-                labelClass="width-12"
-                label="Current time range"
-                checked={useCurrentTimeRange}
-                onChange={this.onUseCurrentTimeRangeChange}
-              />
-              <Switch
-                labelClass="width-12"
-                label="Template variables"
-                checked={includeTemplateVars}
-                onChange={this.onIncludeTemplateVarsChange}
-              />
-              <div className="gf-form">
-                <label className="gf-form-label width-12">Theme</label>
-                <Select width={10} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
-              </div>
-            </div>
+            <InlineField labelWidth={24} label="Current time range">
+              <Switch value={useCurrentTimeRange} onChange={this.onUseCurrentTimeRangeChange} />
+            </InlineField>
+            <InlineField labelWidth={24} label="Template variables">
+              <Switch value={includeTemplateVars} onChange={this.onIncludeTemplateVarsChange} />
+            </InlineField>
+            <InlineField labelWidth={24} label="Theme">
+              <Select width={10} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
+            </InlineField>
 
             <p className="share-modal-info-text">
               The html code below can be pasted and included in another web page. Unless anonymous access is enabled,

--- a/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
@@ -92,7 +92,7 @@ export class ShareExport extends PureComponent<Props, State> {
         <div className="share-modal-header">
           <Icon name="cloud-upload" size="xxl" className="share-modal-big-icon" />
           <div className="share-modal-content">
-            <InlineField labelWidth={16} label="Export for sharing externally">
+            <InlineField labelWidth={32} label="Export for sharing externally">
               <Switch value={shareExternally} onChange={this.onShareExternallyChange} />
             </InlineField>
             <div className="gf-form-button-row">

--- a/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { saveAs } from 'file-saver';
-import { Button, LegacyForms, Icon } from '@grafana/ui';
-const { Switch } = LegacyForms;
+import { Button, InlineField, Switch, Icon } from '@grafana/ui';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { DashboardExporter } from 'app/features/dashboard/components/DashExportModal';
 import { appEvents } from 'app/core/core';
@@ -93,13 +92,9 @@ export class ShareExport extends PureComponent<Props, State> {
         <div className="share-modal-header">
           <Icon name="cloud-upload" size="xxl" className="share-modal-big-icon" />
           <div className="share-modal-content">
-            <Switch
-              labelClass="width-16"
-              label="Export for sharing externally"
-              checked={shareExternally}
-              onChange={this.onShareExternallyChange}
-            />
-
+            <InlineField labelWidth={16} label="Export for sharing externally">
+              <Switch value={shareExternally} onChange={this.onShareExternallyChange} />
+            </InlineField>
             <div className="gf-form-button-row">
               <Button variant="primary" onClick={this.onSaveAsFile}>
                 Save to file

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -111,16 +111,24 @@ export class ShareLink extends PureComponent<Props, State> {
             </p>
             <div className="gf-form-group">
               <InlineField labelWidth={24} label="Current time range">
-                <Switch value={useCurrentTimeRange} onChange={this.onUseCurrentTimeRangeChange} />
+                <Switch
+                  id="share-current-time-range"
+                  value={useCurrentTimeRange}
+                  onChange={this.onUseCurrentTimeRangeChange}
+                />
               </InlineField>
               <InlineField labelWidth={24} label="Template variables">
-                <Switch value={includeTemplateVars} onChange={this.onIncludeTemplateVarsChange} />
+                <Switch
+                  id="share-template-vars"
+                  value={includeTemplateVars}
+                  onChange={this.onIncludeTemplateVarsChange}
+                />
               </InlineField>
               <InlineField labelWidth={24} label="Theme">
                 <Select width={20} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
               </InlineField>
               <InlineField labelWidth={24} label="Shorten URL">
-                <Switch value={useShortUrl} onChange={this.onUrlShorten} />
+                <Switch id="share-shorten-url" value={useShortUrl} onChange={this.onUrlShorten} />
               </InlineField>
             </div>
             <div>

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
-import { LegacyForms, ClipboardButton, Icon, InfoBox, Input } from '@grafana/ui';
-const { Select, Switch } = LegacyForms;
+import { InlineField, Select, Switch, ClipboardButton, Icon, InfoBox, Input } from '@grafana/ui';
 import { SelectableValue, PanelModel, AppEvents } from '@grafana/data';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { buildImageUrl, buildShareUrl } from './utils';
@@ -111,23 +110,18 @@ export class ShareLink extends PureComponent<Props, State> {
               Create a direct link to this dashboard or panel, customized with the options below.
             </p>
             <div className="gf-form-group">
-              <Switch
-                labelClass="width-12"
-                label="Current time range"
-                checked={useCurrentTimeRange}
-                onChange={this.onUseCurrentTimeRangeChange}
-              />
-              <Switch
-                labelClass="width-12"
-                label="Template variables"
-                checked={includeTemplateVars}
-                onChange={this.onIncludeTemplateVarsChange}
-              />
-              <div className="gf-form">
-                <label className="gf-form-label width-12">Theme</label>
-                <Select width={10} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
-              </div>
-              <Switch labelClass="width-12" label="Shorten URL" checked={useShortUrl} onChange={this.onUrlShorten} />
+              <InlineField labelWidth={24} label="Current time range">
+                <Switch value={useCurrentTimeRange} onChange={this.onUseCurrentTimeRangeChange} />
+              </InlineField>
+              <InlineField labelWidth={24} label="Template variables">
+                <Switch value={includeTemplateVars} onChange={this.onIncludeTemplateVarsChange} />
+              </InlineField>
+              <InlineField labelWidth={24} label="Theme">
+                <Select width={20} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
+              </InlineField>
+              <InlineField labelWidth={24} label="Shorten URL">
+                <Switch value={useShortUrl} onChange={this.onUrlShorten} />
+              </InlineField>
             </div>
             <div>
               <div className="gf-form-group">

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -272,7 +272,7 @@ export class ShareSnapshot extends PureComponent<Props, State> {
           </div>
         </div>
 
-        <div className="pull-right" ng-if="step === 2" style={{ padding: '5px' }}>
+        <div className="pull-right" style={{ padding: '5px' }}>
           Did you make a mistake?{' '}
           <LinkButton variant="link" target="_blank" onClick={this.deleteSnapshot}>
             delete snapshot.
@@ -286,8 +286,8 @@ export class ShareSnapshot extends PureComponent<Props, State> {
     return (
       <div className="share-modal-header">
         <p className="share-modal-info-text">
-          The snapshot has now been deleted. If it you have already accessed it once, It might take up to an hour before
-          it is removed from browser caches or CDN caches.
+          The snapshot has now been deleted. If you have already accessed it once, it might take up to an hour before it
+          is removed from browser caches or CDN caches.
         </p>
       </div>
     );

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -1,13 +1,11 @@
 import React, { PureComponent } from 'react';
-import { Button, ClipboardButton, Icon, Spinner, LegacyForms, LinkButton } from '@grafana/ui';
+import { Button, ClipboardButton, Icon, Spinner, Select, Input, LinkButton, InlineField } from '@grafana/ui';
 import { AppEvents, SelectableValue } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { appEvents } from 'app/core/core';
 import { VariableRefresh } from '../../../variables/types';
-
-const { Select, Input } = LegacyForms;
 
 const snapshotApiUrl = '/api/snapshots';
 
@@ -222,14 +220,12 @@ export class ShareSnapshot extends PureComponent<Props, State> {
           </p>
         </div>
         <div className="gf-form-group share-modal-options">
-          <div className="gf-form" ng-if="step === 1">
-            <label className="gf-form-label width-12">Snapshot name</label>
-            <Input width={15} value={snapshotName} onChange={this.onSnapshotNameChange} />
-          </div>
-          <div className="gf-form" ng-if="step === 1">
-            <label className="gf-form-label width-12">Expire</label>
-            <Select width={15} options={expireOptions} value={selectedExpireOption} onChange={this.onExpireChange} />
-          </div>
+          <InlineField labelWidth={24} label="Snapshot name">
+            <Input width={30} value={snapshotName} onChange={this.onSnapshotNameChange} />
+          </InlineField>
+          <InlineField labelWidth={24} label="Expire">
+            <Select width={30} options={expireOptions} value={selectedExpireOption} onChange={this.onExpireChange} />
+          </InlineField>
         </div>
 
         <p className="share-modal-info-text">
@@ -237,10 +233,9 @@ export class ShareSnapshot extends PureComponent<Props, State> {
         </p>
 
         <div className="gf-form-group share-modal-options">
-          <div className="gf-form">
-            <span className="gf-form-label width-12">Timeout (seconds)</span>
-            <Input type="number" width={15} value={timeoutSeconds} onChange={this.onTimeoutChange} />
-          </div>
+          <InlineField labelWidth={24} label="Timeout (seconds)">
+            <Input type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} />
+          </InlineField>
         </div>
 
         <div className="gf-form-button-row">

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -1,5 +1,15 @@
 import React, { PureComponent } from 'react';
-import { Button, ClipboardButton, Icon, Spinner, Select, Input, LinkButton, InlineField } from '@grafana/ui';
+import {
+  Button,
+  ClipboardButton,
+  Icon,
+  Spinner,
+  Select,
+  Input,
+  LinkButton,
+  InlineField,
+  InlineFieldRow,
+} from '@grafana/ui';
 import { AppEvents, SelectableValue } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
@@ -219,24 +229,24 @@ export class ShareSnapshot extends PureComponent<Props, State> {
             URL. Share wisely.
           </p>
         </div>
-        <div className="gf-form-group share-modal-options">
+        <InlineFieldRow className="share-modal-options">
           <InlineField labelWidth={24} label="Snapshot name">
             <Input width={30} value={snapshotName} onChange={this.onSnapshotNameChange} />
           </InlineField>
           <InlineField labelWidth={24} label="Expire">
             <Select width={30} options={expireOptions} value={selectedExpireOption} onChange={this.onExpireChange} />
           </InlineField>
-        </div>
+        </InlineFieldRow>
 
         <p className="share-modal-info-text">
           You may need to configure the timeout value if it takes a long time to collect your dashboard's metrics.
         </p>
 
-        <div className="gf-form-group share-modal-options">
+        <InlineFieldRow className="share-modal-options">
           <InlineField labelWidth={24} label="Timeout (seconds)">
             <Input type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} />
           </InlineField>
-        </div>
+        </InlineFieldRow>
 
         <div className="gf-form-button-row">
           <Button className="width-10" variant="primary" disabled={isLoading} onClick={this.createSnapshot()}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes any remaining usage of LegacyForms from the dashboard feature folder in favour of using the next gen form components. It also adds a `displayName` to the `<Switch />` grafana-ui component for debugging purposes and fixes an issue where passing an `id` to `<Switch />` wouldn't propagate to both the `id` and `htmlFor` attributes.

| Before | After |
| --- | --- |
| <img width="482" alt="Screenshot 2020-10-30 at 17 01 18" src="https://user-images.githubusercontent.com/73201/97729830-60d62280-1ad3-11eb-96c5-d6f999781424.png"> | <img width="486" alt="Screenshot 2020-10-30 at 17 02 51" src="https://user-images.githubusercontent.com/73201/97729935-7f3c1e00-1ad3-11eb-982a-6b7cf534cde8.png"> |

**Special notes for your reviewer**:
The changes in `QueryOptions` introduces new styling for the invalid states of some inputs. I'm not sure if this is the right direction or if we should introduce the `invalid` legacy class on the component as an interim step instead.


