### PR TITLE
Plugin Signature Badge: Fix typo in unsigned plugin warning

### DIFF
--- a/public/app/features/plugins/PluginSignatureBadge.tsx
+++ b/public/app/features/plugins/PluginSignatureBadge.tsx
@@ -62,7 +62,7 @@ function getSignatureDisplayModel(signature?: PluginSignatureStatus): BadgeProps
       };
     case PluginSignatureStatus.missing:
       return {
-        text: 'Missing signture',
+        text: 'Missing signature',
         icon: 'exclamation-triangle',
         color: 'red',
         tooltip: 'Missing plugin signature',


### PR DESCRIPTION
Typo fix!

**What this PR does / why we need it**: Fixes a typo on the unsigned plugin warning page.

**Which issue(s) this PR fixes**: No filed issue, I noticed it myself just now.

