### PR TITLE
pkg/api/dashboard: Remove welcome panel on provisioned home dashboard

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -336,8 +336,10 @@ func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) Response {
 	}
 
 	filePath := hs.Cfg.DefaultHomeDashboardPath
+	var use_default_path bool = false
 	if filePath == "" {
 		filePath = filepath.Join(hs.Cfg.StaticRootPath, "dashboards/home.json")
+		use_default_path = true
 	}
 
 	file, err := os.Open(filePath)
@@ -356,7 +358,7 @@ func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) Response {
 		return Error(500, "Failed to load home dashboard", err)
 	}
 
-	if c.HasUserRole(models.ROLE_ADMIN) && !c.HasHelpFlag(models.HelpFlagGettingStartedPanelDismissed) {
+	if use_default_path && c.HasUserRole(models.ROLE_ADMIN) && !c.HasHelpFlag(models.HelpFlagGettingStartedPanelDismissed) {
 		addGettingStartedPanelToHomeDashboard(dash.Dashboard)
 	}
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -336,10 +336,10 @@ func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) Response {
 	}
 
 	filePath := hs.Cfg.DefaultHomeDashboardPath
-	var use_default_path bool = false
+	useDefaultPath := false
 	if filePath == "" {
 		filePath = filepath.Join(hs.Cfg.StaticRootPath, "dashboards/home.json")
-		use_default_path = true
+		useDefaultPath = true
 	}
 
 	file, err := os.Open(filePath)
@@ -358,7 +358,7 @@ func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) Response {
 		return Error(500, "Failed to load home dashboard", err)
 	}
 
-	if use_default_path && c.HasUserRole(models.ROLE_ADMIN) && !c.HasHelpFlag(models.HelpFlagGettingStartedPanelDismissed) {
+	if useDefaultPath && c.HasUserRole(models.ROLE_ADMIN) && !c.HasHelpFlag(models.HelpFlagGettingStartedPanelDismissed) {
 		addGettingStartedPanelToHomeDashboard(dash.Dashboard)
 	}
 


### PR DESCRIPTION
It is possible to set the default home dashboard from the configuration.
    
If someone sets the home dashboard, there is no need to add the getting started panel.

After this patch, the blue getting started panel is no longer part of the home dashboard.

Fixes #26447