### PR TITLE
Removed auto-capitalization from the login form

### DIFF
--- a/public/app/core/components/Login/LoginForm.tsx
+++ b/public/app/core/components/Login/LoginForm.tsx
@@ -33,6 +33,7 @@ export const LoginForm: FC<Props> = ({ children, onSubmit, isLoggingIn, password
               <Input
                 autoFocus
                 name="user"
+                autocapitalize="none"
                 ref={register({ required: 'Email or username is required' })}
                 placeholder={loginHint}
                 aria-label={selectors.pages.Login.username}

--- a/public/app/core/components/Login/LoginForm.tsx
+++ b/public/app/core/components/Login/LoginForm.tsx
@@ -33,7 +33,7 @@ export const LoginForm: FC<Props> = ({ children, onSubmit, isLoggingIn, password
               <Input
                 autoFocus
                 name="user"
-                autocapitalize="none"
+                autoCapitalize="none"
                 ref={register({ required: 'Email or username is required' })}
                 placeholder={loginHint}
                 aria-label={selectors.pages.Login.username}


### PR DESCRIPTION
**What this PR does / why we need it**:  
On mobile browsers, by default most keyboards will auto capitalize the first letter of the email/username, which is case sensitive.  
This PR fixes that.

**Which issue(s) this PR fixes**:
Auto capitalization of the login form in mobile phones.


