### PR TITLE
ColorScheme: Add Red to Green color scheme

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -67,6 +67,13 @@ export const fieldColorModeRegistry = new Registry<FieldColorMode>(() => {
       colors: ['green', 'yellow', 'red'],
     }),
     new FieldColorSchemeMode({
+      id: 'continuous-RdYlGr',
+      name: 'Red-Yellow-Green',
+      isContinuous: true,
+      isByValue: true,
+      colors: ['red', 'yellow', 'green'],
+    }),
+    new FieldColorSchemeMode({
       id: 'continuous-BlYlRd',
       name: 'Blue-Yellow-Red',
       isContinuous: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds another ColorScheme, red to green for situations where a low value should be red and high value should be green. The use case I have is disk space (see screenshot).

![Screenshot from 2020-11-01 14-20-01](https://user-images.githubusercontent.com/946275/97804065-c64e1e80-1c4d-11eb-9f9a-ae1013247c5d.png)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

