### PR TITLE
Chore: Pin nginx base image in nginx proxy Dockerfiles

### DIFF
--- a/devenv/docker/blocks/nginx_proxy/Dockerfile
+++ b/devenv/docker/blocks/nginx_proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.19.3-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY htpasswd /etc/nginx/htpasswd

--- a/devenv/docker/blocks/nginx_proxy_mac/Dockerfile
+++ b/devenv/docker/blocks/nginx_proxy_mac/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.19.3-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY htpasswd /etc/nginx/htpasswd


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin nginx base image in nginx proxy Dockerfiles, so we are at a known working version (not pinning the image can lead to random failure at some point in time).