### PR TITLE
Plugin page: Fix dom validation warning

### DIFF
--- a/public/app/features/plugins/PluginPage.tsx
+++ b/public/app/features/plugins/PluginPage.tsx
@@ -316,14 +316,14 @@ class PluginPage extends PureComponent<Props, State> {
         urlTitle="Read more about plugins signing"
         url="https://grafana.com/docs/grafana/latest/plugins/plugin-signature-verification/"
       >
-        <p>
-          <PluginSignatureBadge
-            status={plugin.meta.signature}
-            className={css`
-              margin-top: 0;
-            `}
-          />
-        </p>
+        <PluginSignatureBadge
+          status={plugin.meta.signature}
+          className={css`
+            margin-top: 0;
+          `}
+        />
+        <br />
+        <br />
         <p>
           Grafana Labs checks each plugin to verify that it has a valid digital signature. Plugin signature verification
           is part of our security measures to ensure plugins are safe and trustworthy.


### PR DESCRIPTION
Fixes the following warning:
![image](https://user-images.githubusercontent.com/2376619/97857741-7c714100-1cfe-11eb-9bc1-fb049f775124.png)
