### PR TITLE
Transformations: Add new grouping to matrix transformer

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -25,6 +25,7 @@ export { LayoutModes, LayoutMode } from './types/layout';
 export { PanelPlugin, SetFieldConfigOptionsArgs, StandardOptionConfig } from './panel/PanelPlugin';
 export { createFieldConfigRegistry } from './panel/registryFactories';
 export { QueryRunner, QueryRunnerOptions } from './types/queryRunner';
+export { GroupingToMatrixTransformerOptions } from './transformations/transformers/groupingToMatrix';
 
 // Moved to `@grafana/schema`, in Grafana 9, this will be removed
 export * from './schema';

--- a/packages/grafana-data/src/transformations/transformers.ts
+++ b/packages/grafana-data/src/transformations/transformers.ts
@@ -19,6 +19,7 @@ import { renameByRegexTransformer } from './transformers/renameByRegex';
 import { filterByValueTransformer } from './transformers/filterByValue';
 import { histogramTransformer } from './transformers/histogram';
 import { convertFieldTypeTransformer } from './transformers/convertFieldType';
+import { groupingToMatrixTransformer } from './transformers/groupingToMatrix';
 
 export const standardTransformers = {
   noopTransformer,
@@ -43,4 +44,5 @@ export const standardTransformers = {
   renameByRegexTransformer,
   histogramTransformer,
   convertFieldTypeTransformer,
+  groupingToMatrixTransformer,
 };

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -5,13 +5,14 @@ import { toDataFrame } from '../../dataframe';
 import { transformDataFrame } from '../transformDataFrame';
 import { ArrayVector } from '../../vector';
 import { groupingToMatrixTransformer, GroupingToMatrixTransformerOptions } from './groupingToMatrix';
+import { observableTester } from '../../utils/tests/observableTester';
 
 describe('Grouping to Matrix', () => {
   beforeAll(() => {
     mockTransformationsRegistry([groupingToMatrixTransformer]);
   });
 
-  it('generate Matrix with default fields', () => {
+  it('generate Matrix with default fields', done => {
     const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
       id: DataTransformerID.groupingToMatrix,
       options: {},
@@ -25,18 +26,23 @@ describe('Grouping to Matrix', () => {
       ],
     });
 
-    const result = transformDataFrame([cfg], [seriesA]);
-    const expected: Field[] = [
-      createField('Time\\Time', FieldType.string, [1000, 1001, 1002]),
-      createField('1000', FieldType.number, [1, '', '']),
-      createField('1001', FieldType.number, ['', 2, '']),
-      createField('1002', FieldType.number, ['', '', 3]),
-    ];
+    observableTester().subscribeAndExpectOnNext({
+      observable: transformDataFrame([cfg], [seriesA]),
+      expect: result => {
+        const expected: Field[] = [
+          createField('Time\\Time', FieldType.string, [1000, 1001, 1002]),
+          createField('1000', FieldType.number, [1, '', '']),
+          createField('1001', FieldType.number, ['', 2, '']),
+          createField('1002', FieldType.number, ['', '', 3]),
+        ];
 
-    expect(unwrap(result[0].fields)).toEqual(expected);
+        expect(unwrap(result[0].fields)).toEqual(expected);
+      },
+      done,
+    });
   });
 
-  it('generate Matrix with multiple fields', () => {
+  it('generate Matrix with multiple fields', done => {
     const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
       id: DataTransformerID.groupingToMatrix,
       options: {
@@ -55,17 +61,22 @@ describe('Grouping to Matrix', () => {
       ],
     });
 
-    const result = transformDataFrame([cfg], [seriesA]);
-    const expected: Field[] = [
-      createField('Row\\Column', FieldType.string, []),
-      createField('C1', FieldType.number, [1, 4, '']),
-      createField('C2', FieldType.number, [5, '', '']),
-    ];
+    observableTester().subscribeAndExpectOnNext({
+      observable: transformDataFrame([cfg], [seriesA]),
+      expect: result => {
+        const expected: Field[] = [
+          createField('Row\\Column', FieldType.string, ['R1', 'R2']),
+          createField('C1', FieldType.number, [1, 4]),
+          createField('C2', FieldType.number, [5, '']),
+        ];
 
-    expect(unwrap(result[0].fields)).toEqual(expected);
+        expect(unwrap(result[0].fields)).toEqual(expected);
+      },
+      done,
+    });
   });
 
-  it('generate Matrix with multiple fields and value type', () => {
+  it('generate Matrix with multiple fields and value type', done => {
     const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
       id: DataTransformerID.groupingToMatrix,
       options: {
@@ -84,14 +95,19 @@ describe('Grouping to Matrix', () => {
       ],
     });
 
-    const result = transformDataFrame([cfg], [seriesA]);
-    const expected: Field[] = [
-      createField('Row\\Column', FieldType.string, []),
-      createField('C1', FieldType.number, [1, 4, ''], { units: 'celsius' }),
-      createField('C2', FieldType.number, [5, '', ''], { units: 'celsius' }),
-    ];
+    observableTester().subscribeAndExpectOnNext({
+      observable: transformDataFrame([cfg], [seriesA]),
+      expect: result => {
+        const expected: Field[] = [
+          createField('Row\\Column', FieldType.string, ['R1', 'R2']),
+          createField('C1', FieldType.number, [1, 4], { units: 'celsius' }),
+          createField('C2', FieldType.number, [5, ''], { units: 'celsius' }),
+        ];
 
-    expect(unwrap(result[0].fields)).toEqual(expected);
+        expect(unwrap(result[0].fields)).toEqual(expected);
+      },
+      done,
+    });
   });
 });
 

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -4,7 +4,7 @@ import { DataTransformerID } from './ids';
 import { toDataFrame } from '../../dataframe';
 import { transformDataFrame } from '../transformDataFrame';
 import { ArrayVector } from '../../vector';
-import { groupingToMatrixTransformer, groupingToMatrixTransformerOptions } from './groupingToMatrix';
+import { groupingToMatrixTransformer, GroupingToMatrixTransformerOptions } from './groupingToMatrix';
 
 describe('Grouping to Matrix', () => {
   beforeAll(() => {
@@ -55,7 +55,7 @@ describe('Grouping to Matrix', () => {
       ],
     });
 
-    const result = transformDataFrame([cfg], [seriesA, seriesB]);
+    const result = transformDataFrame([cfg], [seriesA]);
     const expected: Field[] = [
       createField('Row\\Column', FieldType.string, []),
       createField('C1', FieldType.number, [1, 4, '']),
@@ -84,7 +84,7 @@ describe('Grouping to Matrix', () => {
       ],
     });
 
-    const result = transformDataFrame([cfg], [seriesA, seriesB]);
+    const result = transformDataFrame([cfg], [seriesA]);
     const expected: Field[] = [
       createField('Row\\Column', FieldType.string, []),
       createField('C1', FieldType.number, [1, 4, ''], { units: 'celsius' }),

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -129,28 +129,42 @@ describe('Grouping to Matrix', () => {
 
     await expect(transformDataFrame([cfg], [seriesA])).toEmitValuesWith((received) => {
       const processed = received[0];
-      const expected: Field[] = [
-        {
-          name: 'Row\\Column',
-          type: FieldType.string,
-          values: new ArrayVector(['R1', 'R2']),
-          config: {},
-        },
-        {
-          name: 'C1',
-          type: FieldType.number,
-          values: new ArrayVector([1, 4]),
-          config: { units: 'celsius' },
-        },
-        {
-          name: 'C2',
-          type: FieldType.number,
-          values: new ArrayVector([5, '']),
-          config: { units: 'celsius' },
-        },
-      ];
 
-      expect(processed[0].fields).toEqual(expected);
+      expect(processed[0].fields).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "config": Object {},
+            "name": "Row\\\\Column",
+            "type": "string",
+            "values": Array [
+              "R1",
+              "R2",
+            ],
+          },
+          Object {
+            "config": Object {
+              "units": "celsius",
+            },
+            "name": "C1",
+            "type": "number",
+            "values": Array [
+              1,
+              4,
+            ],
+          },
+          Object {
+            "config": Object {
+              "units": "celsius",
+            },
+            "name": "C2",
+            "type": "number",
+            "values": Array [
+              5,
+              "",
+            ],
+          },
+        ]
+      `);
     });
   });
 });

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -1,0 +1,111 @@
+import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
+import { DataTransformerConfig, Field, FieldType } from '../../types';
+import { DataTransformerID } from './ids';
+import { toDataFrame } from '../../dataframe';
+import { transformDataFrame } from '../transformDataFrame';
+import { ArrayVector } from '../../vector';
+import { groupingToMatrixTransformer, groupingToMatrixTransformerOptions } from './groupingToMatrix';
+
+describe('Grouping to Matrix', () => {
+  beforeAll(() => {
+    mockTransformationsRegistry([groupingToMatrixTransformer]);
+  });
+
+  it('generate Matrix with default fields', () => {
+    const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
+      id: DataTransformerID.groupingToMatrix,
+      options: {},
+    };
+
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000, 1001, 1002] },
+        { name: 'Value', type: FieldType.number, values: [1, 2, 3] },
+      ],
+    });
+
+    const result = transformDataFrame([cfg], [seriesA]);
+    const expected: Field[] = [
+      createField('Time\\Time', FieldType.string, [1000, 1001, 1002]),
+      createField('1000', FieldType.number, [1, '', '']),
+      createField('1001', FieldType.number, ['', 2, '']),
+      createField('1002', FieldType.number, ['', '', 3]),
+    ];
+
+    expect(unwrap(result[0].fields)).toEqual(expected);
+  });
+
+  it('generate Matrix with multiple fields', () => {
+    const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
+      id: DataTransformerID.groupingToMatrix,
+      options: {
+        columnField: 'Column',
+        rowField: 'Row',
+        valueField: 'Temp',
+      },
+    };
+
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'Column', type: FieldType.string, values: ['C1', 'C1', 'C2'] },
+        { name: 'Row', type: FieldType.string, values: ['R1', 'R2', 'R1'] },
+        { name: 'Temp', type: FieldType.number, values: [1, 4, 5] },
+      ],
+    });
+
+    const result = transformDataFrame([cfg], [seriesA, seriesB]);
+    const expected: Field[] = [
+      createField('Row\\Column', FieldType.string, []),
+      createField('C1', FieldType.number, [1, 4, '']),
+      createField('C2', FieldType.number, [5, '', '']),
+    ];
+
+    expect(unwrap(result[0].fields)).toEqual(expected);
+  });
+
+  it('generate Matrix with multiple fields and value type', () => {
+    const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
+      id: DataTransformerID.groupingToMatrix,
+      options: {
+        columnField: 'Column',
+        rowField: 'Row',
+        valueField: 'Temp',
+      },
+    };
+
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'Column', type: FieldType.string, values: ['C1', 'C1', 'C2'] },
+        { name: 'Row', type: FieldType.string, values: ['R1', 'R2', 'R1'] },
+        { name: 'Temp', type: FieldType.number, values: [1, 4, 5], config: { units: 'celsius' } },
+      ],
+    });
+
+    const result = transformDataFrame([cfg], [seriesA, seriesB]);
+    const expected: Field[] = [
+      createField('Row\\Column', FieldType.string, []),
+      createField('C1', FieldType.number, [1, 4, ''], { units: 'celsius' }),
+      createField('C2', FieldType.number, [5, '', ''], { units: 'celsius' }),
+    ];
+
+    expect(unwrap(result[0].fields)).toEqual(expected);
+  });
+});
+
+const createField = (name: string, type: FieldType, values: any[], config = {}): Field => {
+  return { name, type, values: new ArrayVector(values), config, labels: undefined };
+};
+
+const unwrap = (fields: Field[]): Field[] => {
+  return fields.map(field =>
+    createField(
+      field.name,
+      field.type,
+      field.values.toArray().map((value: any) => value),
+      field.config
+    )
+  );
+};

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -1,6 +1,6 @@
 import { map } from 'rxjs/operators';
 
-import { DataFrame, DataTransformerInfo, Field, FieldType } from '../../types';
+import { DataFrame, DataTransformerInfo, Field, FieldType, Vector } from '../../types';
 import { DataTransformerID } from './ids';
 import { MutableDataFrame } from '../../dataframe';
 import { getFieldDisplayName } from '../../field/fieldState';
@@ -47,8 +47,8 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
           return data;
         }
 
-        const columnValues = [...new Set(keyColumnField.values.toArray())];
-        const rowValues = [...new Set(keyRowField.values.toArray())];
+        const columnValues = uniqueValues(keyColumnField.values);
+        const rowValues = uniqueValues(keyRowField.values);
 
         const matrixValues: { [key: string]: { [key: string]: any } } = {};
 
@@ -91,6 +91,16 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
       })
     ),
 };
+
+function uniqueValues(values: Vector): any[] {
+  const unique = new Set();
+
+  for (let index = 0; index < values.length; index++) {
+    unique.add(values.get(index));
+  }
+
+  return Array.from(unique);
+}
 
 function findKeyField(frame: DataFrame, matchTitle: string): Field | null {
   for (let fieldIndex = 0; fieldIndex < frame.fields.length; fieldIndex++) {

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -24,9 +24,10 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
     rowField: DEFAULT_ROW_FIELD,
     valueField: DEFAULT_VALUE_FIELD,
   },
-  operator: options => source =>
+
+  operator: (options) => (source) =>
     source.pipe(
-      map(data => {
+      map((data) => {
         const columnFieldMatch = options.columnField || DEFAULT_COLUMN_FIELD;
         const rowFieldMatch = options.rowField || DEFAULT_ROW_FIELD;
         const valueFieldMatch = options.valueField || DEFAULT_VALUE_FIELD;

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -1,0 +1,107 @@
+import { DataFrame, DataTransformerInfo, Field, FieldType } from '../../types';
+import { DataTransformerID } from './ids';
+import { MutableDataFrame } from '../../dataframe';
+import { getFieldDisplayName } from '../../field/fieldState';
+
+export interface GroupingToMatrixTransformerOptions {
+  columnField?: string;
+  rowField?: string;
+  valueField?: string;
+}
+
+const DEFAULT_COLUMN_FIELD = 'Time';
+const DEFAULT_ROW_FIELD = 'Time';
+const DEFAULT_VALUE_FIELD = 'Value';
+
+export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTransformerOptions> = {
+  id: DataTransformerID.groupingToMatrix,
+  name: 'Grouping to Matrix',
+  description: 'Groups series by field and return a matrix visualisation',
+  defaultOptions: {
+    columnField: DEFAULT_COLUMN_FIELD,
+    rowField: DEFAULT_ROW_FIELD,
+    valueField: DEFAULT_VALUE_FIELD,
+  },
+  transformer: options => (data: DataFrame[]) => {
+    const columnFieldMatch = options.columnField || DEFAULT_COLUMN_FIELD;
+    const rowFieldMatch = options.rowField || DEFAULT_ROW_FIELD;
+    const valueFieldMatch = options.valueField || DEFAULT_VALUE_FIELD;
+
+    // Accept only single queries
+    if (data.length !== 1) {
+      return data;
+    }
+
+    const frame = data[0];
+    const keyColumnField = findKeyField(frame, columnFieldMatch);
+    const keyRowField = findKeyField(frame, rowFieldMatch);
+    const valueField = findKeyField(frame, valueFieldMatch);
+    const rowColumnField = `${rowFieldMatch}\\${columnFieldMatch}`;
+
+    if (!keyColumnField || !keyRowField || !valueField) {
+      return data;
+    }
+
+    const columnValues = [...new Set(keyColumnField.values.toArray())];
+    const rowValues = [...new Set(keyRowField.values.toArray())];
+
+    const matrixValues: { [key: string]: { [key: string]: any } } = {};
+
+    for (let index = 0; index < valueField.values.length; index++) {
+      const columnName = keyColumnField.values.get(index);
+      const rowName = keyRowField.values.get(index);
+      const value = valueField.values.get(index);
+
+      if (!matrixValues[columnName]) {
+        matrixValues[columnName] = {};
+      }
+
+      matrixValues[columnName][rowName] = value;
+    }
+
+    // FIELDS TO ADD
+    // FIELD[0]:
+    //  NAME: ROW/COLUMN
+    //  VALUES: FIELD[ROW] -> VALUES
+    // FIELD[1..N]:
+    //  NAME: FIELD[COLUMN] -> VALUES[N]
+    //  VALUES: FIELD[ROW][COLUMN] -> VALUE
+
+    const resultFrame = new MutableDataFrame();
+
+    resultFrame.addField({
+      name: rowColumnField,
+      values: rowValues,
+      type: FieldType.string,
+    });
+
+    for (const columnName of columnValues) {
+      let values = [];
+      for (const rowName of rowValues) {
+        const value = matrixValues[columnName][rowName] ?? '';
+        values.push(value);
+      }
+
+      resultFrame.addField({
+        name: columnName,
+        values: values,
+        config: valueField.config,
+        type: valueField.type,
+      });
+    }
+
+    return [resultFrame];
+  },
+};
+
+function findKeyField(frame: DataFrame, matchTitle: string): Field | null {
+  for (let fieldIndex = 0; fieldIndex < frame.fields.length; fieldIndex++) {
+    const field = frame.fields[fieldIndex];
+
+    if (matchTitle === getFieldDisplayName(field)) {
+      return field;
+    }
+  }
+
+  return null;
+}

--- a/packages/grafana-data/src/transformations/transformers/ids.ts
+++ b/packages/grafana-data/src/transformations/transformers/ids.ts
@@ -31,4 +31,5 @@ export enum DataTransformerID {
   heatmap = 'heatmap',
   spatial = 'spatial',
   extractFields = 'extractFields',
+  groupingToMatrix = 'groupingToMatrix',
 }

--- a/public/app/features/transformers/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/GroupingToMatrixTransformerEditor.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { DataTransformerID, standardTransformers, TransformerRegistyItem, TransformerUIProps } from '@grafana/data';
+import { Input } from '@grafana/ui';
+import { GroupingToMatrixTransformerOptions } from '@grafana/data/src/transformations/transformers/groupingToMatrix';
+
+export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<GroupingToMatrixTransformerOptions>> = ({
+  input,
+  options,
+  onChange,
+}) => {
+  return (
+    <div className="gf-form-inline">
+      <div className="gf-form gf-form--grow">
+        <div className="gf-form-label width-8">Column</div>
+        <Input
+          className="width-18"
+          placeholder="Choose Column Field"
+          value={options.columnField ?? ''}
+          onChange={input => {
+            onChange({
+              ...options,
+              columnField: input.currentTarget.value,
+            });
+          }}
+        />
+      </div>
+      <div className="gf-form gf-form--grow">
+        <div className="gf-form-label width-8">Row</div>
+        <Input
+          className="width-18"
+          placeholder="Choose Row Field"
+          value={options.rowField ?? ''}
+          onChange={input => {
+            onChange({
+              ...options,
+              rowField: input.currentTarget.value,
+            });
+          }}
+        />
+      </div>
+      <div className="gf-form gf-form--grow">
+        <div className="gf-form-label width-8">Value</div>
+        <Input
+          className="width-18"
+          placeholder="Choose Value Field"
+          value={options.valueField ?? ''}
+          onChange={input => {
+            onChange({
+              ...options,
+              valueField: input.currentTarget.value,
+            });
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const groupingToMatrixTransformerRegistryItem: TransformerRegistyItem<GroupingToMatrixTransformerOptions> = {
+  id: DataTransformerID.groupingToMatrix,
+  editor: GroupingToMatrixTransformerEditor,
+  transformation: standardTransformers.groupingToMatrixTransformer,
+  name: 'Grouping to matrix',
+  description: `Takes a three fields combination and produces a Matrix`,
+};

--- a/public/app/features/transformers/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/GroupingToMatrixTransformerEditor.tsx
@@ -1,62 +1,77 @@
-import React from 'react';
-import { DataTransformerID, standardTransformers, TransformerRegistyItem, TransformerUIProps } from '@grafana/data';
-import { Input } from '@grafana/ui';
+import React, { useCallback } from 'react';
+import {
+  DataTransformerID,
+  SelectableValue,
+  standardTransformers,
+  TransformerRegistryItem,
+  TransformerUIProps,
+} from '@grafana/data';
+import { Select } from '@grafana/ui';
 import { GroupingToMatrixTransformerOptions } from '@grafana/data/src/transformations/transformers/groupingToMatrix';
+import { useAllFieldNamesFromDataFrames } from './utils';
 
 export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<GroupingToMatrixTransformerOptions>> = ({
   input,
   options,
   onChange,
 }) => {
+  const fieldNames = useAllFieldNamesFromDataFrames(input).map((item: string) => ({ label: item, value: item }));
+
+  const onSelectColumn = useCallback(
+    (value: SelectableValue<string>) => {
+      onChange({
+        ...options,
+        columnField: value.value,
+      });
+    },
+    [onChange, options]
+  );
+
+  const onSelectRow = useCallback(
+    (value: SelectableValue<string>) => {
+      onChange({
+        ...options,
+        rowField: value.value,
+      });
+    },
+    [onChange, options]
+  );
+
+  const onSelectValue = useCallback(
+    (value: SelectableValue<string>) => {
+      onChange({
+        ...options,
+        valueField: value.value,
+      });
+    },
+    [onChange, options]
+  );
+
   return (
     <div className="gf-form-inline">
       <div className="gf-form gf-form--grow">
         <div className="gf-form-label width-8">Column</div>
-        <Input
-          className="width-18"
-          placeholder="Choose Column Field"
-          value={options.columnField ?? ''}
-          onChange={input => {
-            onChange({
-              ...options,
-              columnField: input.currentTarget.value,
-            });
-          }}
+        <Select
+          menuShouldPortal
+          options={fieldNames}
+          value={options.columnField}
+          onChange={onSelectColumn}
+          isClearable
         />
       </div>
       <div className="gf-form gf-form--grow">
         <div className="gf-form-label width-8">Row</div>
-        <Input
-          className="width-18"
-          placeholder="Choose Row Field"
-          value={options.rowField ?? ''}
-          onChange={input => {
-            onChange({
-              ...options,
-              rowField: input.currentTarget.value,
-            });
-          }}
-        />
+        <Select menuShouldPortal options={fieldNames} value={options.rowField} onChange={onSelectRow} isClearable />
       </div>
       <div className="gf-form gf-form--grow">
-        <div className="gf-form-label width-8">Value</div>
-        <Input
-          className="width-18"
-          placeholder="Choose Value Field"
-          value={options.valueField ?? ''}
-          onChange={input => {
-            onChange({
-              ...options,
-              valueField: input.currentTarget.value,
-            });
-          }}
-        />
+        <div className="gf-form-label width-8">Cell Value</div>
+        <Select menuShouldPortal options={fieldNames} value={options.valueField} onChange={onSelectValue} isClearable />
       </div>
     </div>
   );
 };
 
-export const groupingToMatrixTransformerRegistryItem: TransformerRegistyItem<GroupingToMatrixTransformerOptions> = {
+export const groupingToMatrixTransformerRegistryItem: TransformerRegistryItem<GroupingToMatrixTransformerOptions> = {
   id: DataTransformerID.groupingToMatrix,
   editor: GroupingToMatrixTransformerEditor,
   transformation: standardTransformers.groupingToMatrixTransformer,

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -5,9 +5,9 @@ import {
   standardTransformers,
   TransformerRegistryItem,
   TransformerUIProps,
+  GroupingToMatrixTransformerOptions,
 } from '@grafana/data';
 import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
-import { GroupingToMatrixTransformerOptions } from '@grafana/data/src/transformations/transformers/groupingToMatrix';
 import { useAllFieldNamesFromDataFrames } from '../utils';
 
 export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<GroupingToMatrixTransformerOptions>> = ({

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -62,7 +62,7 @@ export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<Grou
         <InlineField label="Row" labelWidth={8}>
           <Select menuShouldPortal options={fieldNames} value={options.rowField} onChange={onSelectRow} isClearable />
         </InlineField>
-        <InlineField label="Cell Value" labelWidth={8}>
+        <InlineField label="Cell Value" labelWidth={10}>
           <Select
             menuShouldPortal
             options={fieldNames}

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -6,9 +6,9 @@ import {
   TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
-import { Select } from '@grafana/ui';
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
 import { GroupingToMatrixTransformerOptions } from '@grafana/data/src/transformations/transformers/groupingToMatrix';
-import { useAllFieldNamesFromDataFrames } from './utils';
+import { useAllFieldNamesFromDataFrames } from '../utils';
 
 export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<GroupingToMatrixTransformerOptions>> = ({
   input,
@@ -48,30 +48,35 @@ export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<Grou
   );
 
   return (
-    <div className="gf-form-inline">
-      <div className="gf-form gf-form--grow">
-        <div className="gf-form-label width-8">Column</div>
-        <Select
-          menuShouldPortal
-          options={fieldNames}
-          value={options.columnField}
-          onChange={onSelectColumn}
-          isClearable
-        />
-      </div>
-      <div className="gf-form gf-form--grow">
-        <div className="gf-form-label width-8">Row</div>
-        <Select menuShouldPortal options={fieldNames} value={options.rowField} onChange={onSelectRow} isClearable />
-      </div>
-      <div className="gf-form gf-form--grow">
-        <div className="gf-form-label width-8">Cell Value</div>
-        <Select menuShouldPortal options={fieldNames} value={options.valueField} onChange={onSelectValue} isClearable />
-      </div>
-    </div>
+    <>
+      <InlineFieldRow>
+        <InlineField label="Column" labelWidth={8}>
+          <Select
+            menuShouldPortal
+            options={fieldNames}
+            value={options.columnField}
+            onChange={onSelectColumn}
+            isClearable
+          />
+        </InlineField>
+        <InlineField label="Row" labelWidth={8}>
+          <Select menuShouldPortal options={fieldNames} value={options.rowField} onChange={onSelectRow} isClearable />
+        </InlineField>
+        <InlineField label="Cell Value" labelWidth={8}>
+          <Select
+            menuShouldPortal
+            options={fieldNames}
+            value={options.valueField}
+            onChange={onSelectValue}
+            isClearable
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </>
   );
 };
 
-export const groupingToMatrixTransformerRegistryItem: TransformerRegistryItem<GroupingToMatrixTransformerOptions> = {
+export const groupingToMatrixTransformRegistryItem: TransformerRegistryItem<GroupingToMatrixTransformerOptions> = {
   id: DataTransformerID.groupingToMatrix,
   editor: GroupingToMatrixTransformerEditor,
   transformation: standardTransformers.groupingToMatrixTransformer,

--- a/public/app/features/transformers/standardTransformers.ts
+++ b/public/app/features/transformers/standardTransformers.ts
@@ -22,6 +22,7 @@ import { fieldLookupTransformRegistryItem } from './lookupGazetteer/FieldLookupT
 import { extractFieldsTransformRegistryItem } from './extractFields/ExtractFieldsTransformerEditor';
 import { heatmapTransformRegistryItem } from './calculateHeatmap/HeatmapTransformerEditor';
 import { spatialTransformRegistryItem } from './spatial/SpatialTransformerEditor';
+import { groupingToMatrixTransformRegistryItem } from './editors/GroupingToMatrixTransformerEditor';
 
 export const getStandardTransformers = (): Array<TransformerRegistryItem<any>> => {
   return [
@@ -48,5 +49,6 @@ export const getStandardTransformers = (): Array<TransformerRegistryItem<any>> =
     fieldLookupTransformRegistryItem,
     extractFieldsTransformRegistryItem,
     heatmapTransformRegistryItem,
+    groupingToMatrixTransformRegistryItem,
   ];
 };


### PR DESCRIPTION
**What this PR does / why we need it**: It adds a new transformer that allows to structure data in a "matrix" wise. This feature has been requested by an open issue and current implementations always miss some datasources.

Being a transformer it's kind of datasource independant and doesn't require plugin updates.

**Which issue(s) this PR fixes**:

Fixes #7169 

**Special notes for your reviewer**:

- This transformer is meant to work with the Grafana table plugin
- Adding support for variables in the transformers framework will make it much more "non editor" friendly as users may select the "columns" and "rows" from the templating.
- No big expertisement in the program language neither Grafana internals have been used for the development, so it may lack some basics.

