### PR TITLE
devenv: Upgrade MSSQL Docker image

### DIFF
--- a/devenv/docker/blocks/mssql/build/Dockerfile
+++ b/devenv/docker/blocks/mssql/build/Dockerfile
@@ -1,5 +1,12 @@
-FROM mcr.microsoft.com/mssql/server:2017-CU4-ubuntu
+FROM mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-18.04
 WORKDIR /usr/setup
-COPY . /usr/setup
-RUN chmod +x /usr/setup/setup.sh
+COPY setup.sh setup.sql.template entrypoint.sh ./
+
+USER root
+
+RUN chmod +x setup.sh
+RUN chown -R mssql ./
+
+USER mssql
+
 CMD /bin/bash ./entrypoint.sh

--- a/devenv/docker/blocks/mssql/build/setup.sh
+++ b/devenv/docker/blocks/mssql/build/setup.sh
@@ -1,4 +1,5 @@
 #/bin/bash
+set -eo pipefail
 
 #wait for the SQL Server to come up
 sleep 15s


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade MSSQL Docker image in devenv block to version 2019. I figure there's no reason to stay on 2017?