### PR TITLE
API: replace SendLoginLogCommand with LoginHook

### DIFF
--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -18,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -318,6 +318,7 @@ func TestLoginPostRedirect(t *testing.T) {
 	hs := &HTTPServer{
 		log:              &FakeLogger{},
 		Cfg:              setting.NewCfg(),
+		HooksService:     &hooks.HooksService{},
 		License:          &licensing.OSSLicensingService{},
 		AuthTokenService: auth.NewFakeUserAuthTokenService(),
 	}
@@ -591,22 +592,23 @@ func setupAuthProxyLoginTest(enableLoginToken bool) *scenarioContext {
 	return sc
 }
 
-type loginLogTestReceiver struct {
-	cmd *models.SendLoginLogCommand
+type loginHookTest struct {
+	info *models.LoginInfo
 }
 
-func (r *loginLogTestReceiver) SaveLoginLog(ctx context.Context, cmd *models.SendLoginLogCommand) error {
-	r.cmd = cmd
-	return nil
+func (r *loginHookTest) LoginHook(loginInfo *models.LoginInfo, req *models.ReqContext) {
+	r.info = loginInfo
 }
 
-func TestLoginPostSendLoginLog(t *testing.T) {
+func TestLoginPostRunLokingHook(t *testing.T) {
 	sc := setupScenarioContext("/login")
+	hookService := &hooks.HooksService{}
 	hs := &HTTPServer{
 		log:              log.New("test"),
 		Cfg:              setting.NewCfg(),
 		License:          &licensing.OSSLicensingService{},
 		AuthTokenService: auth.NewFakeUserAuthTokenService(),
+		HooksService:     hookService,
 	}
 
 	sc.defaultHandler = Wrap(func(w http.ResponseWriter, c *models.ReqContext) Response {
@@ -617,28 +619,26 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 		return hs.LoginPost(c, cmd)
 	})
 
-	testReceiver := loginLogTestReceiver{}
-	bus.AddHandlerCtx("login-log-receiver", testReceiver.SaveLoginLog)
-
-	type sendLoginLogCase struct {
-		desc       string
-		authUser   *models.User
-		authModule string
-		authErr    error
-		cmd        models.SendLoginLogCommand
-	}
+	testHook := loginHookTest{}
+	hookService.AddLoginHook(testHook.LoginHook)
 
 	testUser := &models.User{
 		Id:    42,
 		Email: "",
 	}
 
-	testCases := []sendLoginLogCase{
+	testCases := []struct {
+		desc       string
+		authUser   *models.User
+		authModule string
+		authErr    error
+		info       models.LoginInfo
+	}{
 		{
 			desc:    "invalid credentials",
 			authErr: login.ErrInvalidCredentials,
-			cmd: models.SendLoginLogCommand{
-				LogAction:  "login",
+			info: models.LoginInfo{
+				AuthModule: "",
 				HTTPStatus: 401,
 				Error:      login.ErrInvalidCredentials,
 			},
@@ -646,8 +646,8 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 		{
 			desc:    "user disabled",
 			authErr: login.ErrUserDisabled,
-			cmd: models.SendLoginLogCommand{
-				LogAction:  "login",
+			info: models.LoginInfo{
+				AuthModule: "",
 				HTTPStatus: 401,
 				Error:      login.ErrUserDisabled,
 			},
@@ -656,8 +656,8 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 			desc:       "valid Grafana user",
 			authUser:   testUser,
 			authModule: "grafana",
-			cmd: models.SendLoginLogCommand{
-				LogAction:  "login-grafana",
+			info: models.LoginInfo{
+				AuthModule: "grafana",
 				User:       testUser,
 				HTTPStatus: 200,
 			},
@@ -666,8 +666,8 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 			desc:       "valid LDAP user",
 			authUser:   testUser,
 			authModule: "ldap",
-			cmd: models.SendLoginLogCommand{
-				LogAction:  "login-ldap",
+			info: models.LoginInfo{
+				AuthModule: "ldap",
 				User:       testUser,
 				HTTPStatus: 200,
 			},
@@ -685,15 +685,15 @@ func TestLoginPostSendLoginLog(t *testing.T) {
 			sc.m.Post(sc.url, sc.defaultHandler)
 			sc.fakeReqNoAssertions("POST", sc.url).exec()
 
-			cmd := testReceiver.cmd
-			assert.Equal(t, c.cmd.LogAction, cmd.LogAction)
-			assert.Equal(t, "admin", cmd.LoginUsername)
-			assert.Equal(t, c.cmd.HTTPStatus, cmd.HTTPStatus)
-			assert.Equal(t, c.cmd.Error, cmd.Error)
+			info := testHook.info
+			assert.Equal(t, c.info.AuthModule, info.AuthModule)
+			assert.Equal(t, "admin", info.Query.Username)
+			assert.Equal(t, c.info.HTTPStatus, info.HTTPStatus)
+			assert.Equal(t, c.info.Error, info.Error)
 
-			if c.cmd.User != nil {
-				require.NotEmpty(t, cmd.User)
-				assert.Equal(t, c.cmd.User.Id, cmd.User.Id)
+			if c.info.User != nil {
+				require.NotEmpty(t, info.User)
+				assert.Equal(t, c.info.User.Id, info.User.Id)
 			}
 		})
 	}

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -687,7 +687,7 @@ func TestLoginPostRunLokingHook(t *testing.T) {
 
 			info := testHook.info
 			assert.Equal(t, c.info.AuthModule, info.AuthModule)
-			assert.Equal(t, "admin", info.Query.Username)
+			assert.Equal(t, "admin", info.LoginUsername)
 			assert.Equal(t, c.info.HTTPStatus, info.HTTPStatus)
 			assert.Equal(t, c.info.Error, info.Error)
 

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -36,6 +36,15 @@ type ExternalUserInfo struct {
 	IsDisabled     bool
 }
 
+type LoginInfo struct {
+	AuthModule   string
+	User         *User
+	ExternalUser ExternalUserInfo
+	Query        *LoginUserQuery
+	HTTPStatus   int
+	Error        error
+}
+
 // ---------------------
 // COMMANDS
 
@@ -63,16 +72,6 @@ type UpdateAuthInfoCommand struct {
 
 type DeleteAuthInfoCommand struct {
 	UserAuth *UserAuth
-}
-
-type SendLoginLogCommand struct {
-	ReqContext    *ReqContext
-	LogAction     string
-	User          *User
-	ExternalUser  *ExternalUserInfo
-	LoginUsername string
-	HTTPStatus    int
-	Error         error
 }
 
 // ----------------------

--- a/pkg/models/user_auth.go
+++ b/pkg/models/user_auth.go
@@ -37,12 +37,12 @@ type ExternalUserInfo struct {
 }
 
 type LoginInfo struct {
-	AuthModule   string
-	User         *User
-	ExternalUser ExternalUserInfo
-	Query        *LoginUserQuery
-	HTTPStatus   int
-	Error        error
+	AuthModule    string
+	User          *User
+	ExternalUser  ExternalUserInfo
+	LoginUsername string
+	HTTPStatus    int
+	Error         error
 }
 
 // ---------------------

--- a/pkg/services/hooks/hooks.go
+++ b/pkg/services/hooks/hooks.go
@@ -8,8 +8,11 @@ import (
 
 type IndexDataHook func(indexData *dtos.IndexViewData, req *models.ReqContext)
 
+type LoginHook func(loginInfo *models.LoginInfo, req *models.ReqContext)
+
 type HooksService struct {
 	indexDataHooks []IndexDataHook
+	loginHooks     []LoginHook
 }
 
 func init() {
@@ -27,5 +30,15 @@ func (srv *HooksService) AddIndexDataHook(hook IndexDataHook) {
 func (srv *HooksService) RunIndexDataHooks(indexData *dtos.IndexViewData, req *models.ReqContext) {
 	for _, hook := range srv.indexDataHooks {
 		hook(indexData, req)
+	}
+}
+
+func (srv *HooksService) AddLoginHook(hook LoginHook) {
+	srv.loginHooks = append(srv.loginHooks, hook)
+}
+
+func (srv *HooksService) RunLoginHook(loginInfo *models.LoginInfo, req *models.ReqContext) {
+	for _, hook := range srv.loginHooks {
+		hook(loginInfo, req)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace the `SendLoginLogCommand` sent when a user logs in (successfuly or not) by a `LoginHook`. It's a more generic solution allowing to set multiple services to register to this hook and take actions independently

