### PR TITLE
Backend: Adds route for well-known change password URL

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -26,6 +26,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r := hs.RouteRegister
 
 	// not logged in views
+	r.Get("/", reqSignedIn, hs.Index)
 	r.Get("/logout", hs.Logout)
 	r.Post("/login", quota("session"), bind(dtos.LoginCommand{}), Wrap(hs.LoginPost))
 	r.Get("/login/:name", quota("session"), hs.OAuthLogin)
@@ -35,6 +36,7 @@ func (hs *HTTPServer) registerRoutes() {
 	// authed views
 	r.Get("/profile/", reqSignedIn, hs.Index)
 	r.Get("/profile/password", reqSignedIn, hs.Index)
+	r.Get("/.well-known/change-password", RedirectToChangePassword)
 	r.Get("/profile/switch-org/:id", reqSignedIn, hs.ChangeActiveOrgAndRedirectToHome)
 	r.Get("/org/", reqOrgAdmin, hs.Index)
 	r.Get("/org/new", reqGrafanaAdmin, hs.Index)
@@ -442,6 +444,4 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/api/snapshots/:key", Wrap(GetDashboardSnapshot))
 	r.Get("/api/snapshots-delete/:deleteKey", reqSnapshotPublicModeOrSignedIn, Wrap(DeleteDashboardSnapshotByDeleteKey))
 	r.Delete("/api/snapshots/:key", reqEditorRole, Wrap(DeleteDashboardSnapshot))
-
-	r.Get("/*", reqSignedIn, hs.Index)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -73,6 +73,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/d/:uid", reqSignedIn, redirectFromLegacyPanelEditURL, hs.Index)
 	r.Get("/dashboard/db/:slug", reqSignedIn, redirectFromLegacyDashboardURL, hs.Index)
 	r.Get("/dashboard/script/*", reqSignedIn, hs.Index)
+	r.Get("/dashboard/new", reqSignedIn, hs.Index)
 	r.Get("/dashboard-solo/snapshot/*", hs.Index)
 	r.Get("/d-solo/:uid/:slug", reqSignedIn, hs.Index)
 	r.Get("/d-solo/:uid", reqSignedIn, hs.Index)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -26,7 +26,6 @@ func (hs *HTTPServer) registerRoutes() {
 	r := hs.RouteRegister
 
 	// not logged in views
-	r.Get("/", reqSignedIn, hs.Index)
 	r.Get("/logout", hs.Logout)
 	r.Post("/login", quota("session"), bind(dtos.LoginCommand{}), Wrap(hs.LoginPost))
 	r.Get("/login/:name", quota("session"), hs.OAuthLogin)
@@ -34,6 +33,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/invite/:code", hs.Index)
 
 	// authed views
+	r.Get("/", reqSignedIn, hs.Index)
 	r.Get("/profile/", reqSignedIn, hs.Index)
 	r.Get("/profile/password", reqSignedIn, hs.Index)
 	r.Get("/.well-known/change-password", redirectToChangePassword)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -36,7 +36,7 @@ func (hs *HTTPServer) registerRoutes() {
 	// authed views
 	r.Get("/profile/", reqSignedIn, hs.Index)
 	r.Get("/profile/password", reqSignedIn, hs.Index)
-	r.Get("/.well-known/change-password", RedirectToChangePassword)
+	r.Get("/.well-known/change-password", redirectToChangePassword)
 	r.Get("/profile/switch-org/:id", reqSignedIn, hs.ChangeActiveOrgAndRedirectToHome)
 	r.Get("/org/", reqOrgAdmin, hs.Index)
 	r.Get("/org/new", reqGrafanaAdmin, hs.Index)

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -288,7 +288,7 @@ func (hs *HTTPServer) applyRoutes() {
 	// then custom app proxy routes
 	hs.initAppPluginRoutes(hs.macaron)
 	// lastly not found route
-	hs.macaron.NotFound(hs.NotFoundHandler)
+	hs.macaron.NotFound(middleware.ReqSignedIn, hs.NotFoundHandler)
 }
 
 func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -250,7 +250,7 @@ func ChangeUserPassword(c *models.ReqContext, cmd models.ChangeUserPasswordComma
 	return Success("User password changed")
 }
 
-// GET /.well-known/change-password
+// RedirectToChangePassword handles GET /.well-known/change-password.
 func RedirectToChangePassword(c *models.ReqContext) {
 	c.Redirect("/profile/password", 302)
 }

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -250,6 +250,11 @@ func ChangeUserPassword(c *models.ReqContext, cmd models.ChangeUserPasswordComma
 	return Success("User password changed")
 }
 
+// GET /.well-known/change-password
+func RedirectToChangePassword(c *models.ReqContext) {
+	c.Redirect("/profile/password", 302)
+}
+
 // GET /api/users
 func SearchUsers(c *models.ReqContext) Response {
 	query, err := searchUser(c)

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -250,8 +250,8 @@ func ChangeUserPassword(c *models.ReqContext, cmd models.ChangeUserPasswordComma
 	return Success("User password changed")
 }
 
-// RedirectToChangePassword handles GET /.well-known/change-password.
-func RedirectToChangePassword(c *models.ReqContext) {
+// redirectToChangePassword handles GET /.well-known/change-password.
+func redirectToChangePassword(c *models.ReqContext) {
 	c.Redirect("/profile/password", 302)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the [well-known](https://en.wikipedia.org/wiki/List_of_/.well-known/_services_offered_by_webservers) `/.well-known/change-password` URL, which browsers can use to point a user to the change password page if, for example, their password is compromised.

**Special notes for your reviewer**:
Previously unsupported routes were handled in `api.go` with the following:
```
r.Get("/*", reqSignedIn, hs.Index)
```

meaning that the not found handler established in `http_server.go` was never used, and consequently unsupported routes returned with HTTP status 200 rather than 404. Support for the well-known change-password URL relies on the web server returning status 404 for unknown routes, so I've change the route handling logic slightly in service of this.

More info on this topic: https://web.dev/change-password-url/