### PR TITLE
Stat panel: Adds option to always show sparkline

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -26,6 +26,10 @@ export enum BigValueGraphMode {
   Line = 'line',
   Area = 'area',
 }
+export enum BigValueShowGraphMode {
+  Adaptive = 'adaptive',
+  Always = 'always',
+}
 
 export enum BigValueJustifyMode {
   Auto = 'auto',
@@ -60,6 +64,8 @@ export interface Props extends Themeable {
   colorMode: BigValueColorMode;
   /** Show a graph behind/under the value */
   graphMode: BigValueGraphMode;
+  /** Show a graph */
+  showGraphMode: BigValueShowGraphMode;
   /** Auto justify value and text or center it */
   justifyMode?: BigValueJustifyMode;
   /** Factors that should influence the positioning of the text  */

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
@@ -1,5 +1,11 @@
-import { Props, BigValueColorMode, BigValueGraphMode } from './BigValue';
-import { buildLayout, StackedWithChartLayout, WideWithChartLayout } from './BigValueLayout';
+import { BigValueColorMode, BigValueGraphMode, BigValueShowGraphMode, Props } from './BigValue';
+import {
+  buildLayout,
+  StackedWithChartLayout,
+  StackedWithNoChartLayout,
+  WideNoChartLayout,
+  WideWithChartLayout,
+} from './BigValueLayout';
 import { getTheme } from '../../themes';
 
 function getProps(propOverrides?: Partial<Props>): Props {
@@ -47,6 +53,54 @@ describe('BigValueLayout', () => {
         })
       );
       expect(layout).toBeInstanceOf(WideWithChartLayout);
+    });
+  });
+
+  describe('when rendering small layout', () => {
+    describe('when show graph adaptive mode on', () => {
+      it('should auto select to stacked layout', () => {
+        const layout = buildLayout(
+          getProps({
+            width: 200,
+            height: 90,
+          })
+        );
+        expect(layout).toBeInstanceOf(StackedWithNoChartLayout);
+      });
+
+      it('should auto select to wide layout', () => {
+        const layout = buildLayout(
+          getProps({
+            width: 300,
+            height: 40,
+          })
+        );
+        expect(layout).toBeInstanceOf(WideNoChartLayout);
+      });
+    });
+
+    describe('when show graph always mode on', () => {
+      it('should auto select to stacked layout', () => {
+        const layout = buildLayout(
+          getProps({
+            showGraphMode: BigValueShowGraphMode.Always,
+            width: 200,
+            height: 90,
+          })
+        );
+        expect(layout).toBeInstanceOf(StackedWithChartLayout);
+      });
+
+      it('should auto select to wide layout', () => {
+        const layout = buildLayout(
+          getProps({
+            showGraphMode: BigValueShowGraphMode.Always,
+            width: 300,
+            height: 40,
+          })
+        );
+        expect(layout).toBeInstanceOf(WideWithChartLayout);
+      });
     });
   });
 });

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -4,11 +4,11 @@ import tinycolor from 'tinycolor2';
 import { Chart, Geom } from 'bizcharts';
 
 // Utils
-import { formattedValueToString, DisplayValue, getColorForTheme } from '@grafana/data';
+import { DisplayValue, formattedValueToString, getColorForTheme } from '@grafana/data';
 import { calculateFontSize } from '../../utils/measureText';
 
 // Types
-import { BigValueColorMode, Props, BigValueJustifyMode, BigValueTextMode } from './BigValue';
+import { BigValueColorMode, BigValueJustifyMode, BigValueShowGraphMode, BigValueTextMode, Props } from './BigValue';
 import { getTextColorForBackground } from '../../utils';
 
 const LINE_HEIGHT = 1.2;
@@ -432,11 +432,11 @@ export class StackedWithNoChartLayout extends BigValueLayout {
 }
 
 export function buildLayout(props: Props): BigValueLayout {
-  const { width, height, sparkline } = props;
+  const { width, height, sparkline, showGraphMode } = props;
   const useWideLayout = width / height > 2.5;
 
   if (useWideLayout) {
-    if (height > 50 && !!sparkline) {
+    if (showGraphMode === BigValueShowGraphMode.Always || (height > 50 && !!sparkline)) {
       return new WideWithChartLayout(props);
     } else {
       return new WideNoChartLayout(props);
@@ -444,7 +444,7 @@ export function buildLayout(props: Props): BigValueLayout {
   }
 
   // stacked layouts
-  if (height > 100 && !!sparkline) {
+  if (showGraphMode === BigValueShowGraphMode.Always || (height > 100 && !!sparkline)) {
     return new StackedWithChartLayout(props);
   } else {
     return new StackedWithNoChartLayout(props);

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -65,6 +65,7 @@ export {
   BigValueColorMode,
   BigValueSparkline,
   BigValueGraphMode,
+  BigValueShowGraphMode,
   BigValueJustifyMode,
   BigValueTextMode,
 } from './BigValue/BigValue';

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -53,6 +53,7 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
         sparkline={sparkline}
         colorMode={options.colorMode}
         graphMode={options.graphMode}
+        showGraphMode={options.showGraphMode}
         justifyMode={options.justifyMode}
         textMode={this.getTextMode()}
         alignmentFactors={alignmentFactors}

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -51,6 +51,18 @@ export const plugin = new PanelPlugin<StatPanelOptions>(StatPanel)
         },
       })
       .addRadio({
+        path: 'showGraphMode',
+        name: 'Show graph',
+        description: 'Control if the graph should be always visible or hide when there is not enough space',
+        defaultValue: 'adaptive',
+        settings: {
+          options: [
+            { value: 'adaptive', label: 'Adaptive' },
+            { value: 'always', label: 'Always' },
+          ],
+        },
+      })
+      .addRadio({
         path: 'justifyMode',
         name: 'Alignment mode',
         description: 'Value & title posititioning',

--- a/public/app/plugins/panel/stat/types.ts
+++ b/public/app/plugins/panel/stat/types.ts
@@ -4,6 +4,7 @@ import {
   BigValueGraphMode,
   BigValueJustifyMode,
   BigValueTextMode,
+  BigValueShowGraphMode,
 } from '@grafana/ui';
 import {
   ReducerID,
@@ -17,6 +18,7 @@ import { PanelOptionsEditorBuilder } from '@grafana/data';
 // Structure copied from angular
 export interface StatPanelOptions extends SingleStatBaseOptions {
   graphMode: BigValueGraphMode;
+  showGraphMode: BigValueShowGraphMode;
   colorMode: BigValueColorMode;
   justifyMode: BigValueJustifyMode;
   textMode: BigValueTextMode;


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/21760

Adds new Stat panel display option to config whether or not the sparkline should be automatically hidden:
![image](https://user-images.githubusercontent.com/2376619/98095736-3a293a80-1e8b-11eb-8b9b-c47825ba179d.png)

When set to **adaptive**(default) it will behave as currently, when set to **always** it will always show the graph regardless of the panel size.


