### PR TITLE
grafana/toolkit: Allow builds with lint warnings

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -103,13 +103,19 @@ export const lintPlugin = ({ fix }: Fixable = {}) =>
     }
 
     const { errorCount, results, warningCount } = report;
+    const formatter = cli.getFormatter();
 
-    if (errorCount > 0 || warningCount > 0) {
-      const formatter = cli.getFormatter();
+    if (warningCount > 0) {
       console.log('\n');
       console.log(formatter(results));
       console.log('\n');
-      throw new Error(`${errorCount + warningCount} linting errors found in ${results.length} files`);
+    }
+
+    if (errorCount > 0) {
+      console.log('\n');
+      console.log(formatter(results));
+      console.log('\n');
+      throw new Error(`${errorCount} linting errors found in ${results.length} files`);
     }
   });
 

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -105,16 +105,13 @@ export const lintPlugin = ({ fix }: Fixable = {}) =>
     const { errorCount, results, warningCount } = report;
     const formatter = cli.getFormatter();
 
-    if (warningCount > 0) {
+    if (errorCount > 0 || warningCount > 0) {
       console.log('\n');
       console.log(formatter(results));
       console.log('\n');
     }
 
     if (errorCount > 0) {
-      console.log('\n');
-      console.log(formatter(results));
-      console.log('\n');
       throw new Error(`${errorCount} linting errors found in ${results.length} files`);
     }
   });


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/23232

Lint errors will still prevent the plugin from being built.