### PR TITLE
Git: Fix line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
**What this PR does / why we need it**:
Git is currently configured via .gitattributes such that files are checked out with CRLF line endings on Windows, even if I've disabled autocrlf in Git itself. I managed to solve it by adding `eol=lf` to .gitattributes.

Before the fix, I can't run `yarn start`, since `prettier` reacts to the CRLF line endings.

Would be good if others test on Windows, and give feedback on how it works for them :)
