### PR TITLE
Dashboards: Delete related data (permissions, stars, tags, versions, annotations) when deleting a dashboard or a folder

### DIFF
--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -201,6 +201,14 @@ func TestDashboardDataAccess(t *testing.T) {
 				So(query.Result.Updated.IsZero(), ShouldBeFalse)
 			})
 
+			Convey("Should be able to delete empty folder", func() {
+				emptyFolder := insertTestDashboard("2 test dash folder", 1, 0, true, "prod", "webapp")
+
+				deleteCmd := &models.DeleteDashboardCommand{Id: emptyFolder.Id}
+				err := DeleteDashboard(deleteCmd)
+				So(err, ShouldBeNil)
+			})
+
 			Convey("Should be able to delete a dashboard folder and its children", func() {
 				deleteCmd := &models.DeleteDashboardCommand{Id: savedFolder.Id}
 				err := DeleteDashboard(deleteCmd)

--- a/pkg/services/sqlstore/migrations/dashboard_acl.go
+++ b/pkg/services/sqlstore/migrations/dashboard_acl.go
@@ -46,4 +46,7 @@ INSERT INTO dashboard_acl
 	`
 
 	mg.AddMigration("save default acl rules in dashboard_acl table", NewRawSqlMigration(rawSQL))
+
+	mg.AddMigration("delete acl rules for deleted dashboards and folders", NewRawSqlMigration(
+		"DELETE FROM dashboard_acl WHERE dashboard_id NOT IN (SELECT id FROM dashboard) AND dashboard_id != -1"))
 }

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -222,4 +222,7 @@ func addDashboardMigration(mg *Migrator) {
 
 	mg.AddMigration("delete tags for deleted dashboards", NewRawSqlMigration(
 		"DELETE FROM dashboard_tag WHERE dashboard_id NOT IN (SELECT id FROM dashboard)"))
+
+	mg.AddMigration("delete stars for deleted dashboards", NewRawSqlMigration(
+		"DELETE FROM star WHERE dashboard_id NOT IN (SELECT id FROM dashboard)"))
 }

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -219,4 +219,7 @@ func addDashboardMigration(mg *Migrator) {
 		Cols: []string{"title"},
 		Type: IndexType,
 	}))
+
+	mg.AddMigration("delete tags for deleted dashboards", NewRawSqlMigration(
+		"DELETE FROM dashboard_tag WHERE dashboard_id NOT IN (SELECT id FROM dashboard)"))
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -68,4 +68,7 @@ func addStarMigrations(mg *Migrator) {
 
 	mg.AddMigration("create star table", NewAddTableMigration(starV1))
 	mg.AddMigration("add unique index star.user_id_dashboard_id", NewAddIndexMigration(starV1, starV1.Indices[0]))
+
+	mg.AddMigration("delete stars for deleted dashboards", NewRawSqlMigration(
+		"DELETE FROM star WHERE dashboard_id NOT IN (SELECT id FROM dashboard)"))
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -68,7 +68,4 @@ func addStarMigrations(mg *Migrator) {
 
 	mg.AddMigration("create star table", NewAddTableMigration(starV1))
 	mg.AddMigration("add unique index star.user_id_dashboard_id", NewAddIndexMigration(starV1, starV1.Indices[0]))
-
-	mg.AddMigration("delete stars for deleted dashboards", NewRawSqlMigration(
-		"DELETE FROM star WHERE dashboard_id NOT IN (SELECT id FROM dashboard)"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does the following things:
- Delete dashboard permissions related to a dashboard when it's deleted
- Delete all the following information related to a folder's dashboards when this folder is deleted: stars, tags, versions, annotations, provisioning and permissions. This is already handled when a dashboard is deleted, so it should be handled when a folder causes the deletion of all its children.
- Add migrations to remove dashboard permissions, tags and stars related to deleted dashboards and folders (to clean up existing Grafana instance).

