### PR TITLE
Units: added support to handle negative fractional numbers.

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -1,4 +1,4 @@
-import { getDisplayProcessor, getRawDisplayProcessor } from './displayProcessor';
+import { getDecimalsForValue, getDisplayProcessor, getRawDisplayProcessor } from './displayProcessor';
 import { DisplayProcessor, DisplayValue } from '../types/displayValue';
 import { MappingType, ValueMapping } from '../types/valueMapping';
 import { FieldConfig, FieldType, ThresholdsMode } from '../types';
@@ -327,5 +327,23 @@ describe('getRawDisplayProcessor', () => {
     const result = processor(value);
 
     expect(result).toEqual({ text: expected, numeric: null });
+  });
+});
+
+describe('getDecimalsForValue', () => {
+  it.each`
+    value                   | expected
+    ${0}                    | ${0}
+    ${13.37}                | ${0}
+    ${-13.37}               | ${0}
+    ${12679.3712345811212}  | ${0}
+    ${-12679.3712345811212} | ${0}
+    ${0.3712345}            | ${2}
+    ${-0.37123458}          | ${2}
+    ${-0.04671994403853774} | ${3}
+    ${0.04671994403853774}  | ${3}
+  `('should return correct suggested decimal count', ({ value, expected }) => {
+    const result = getDecimalsForValue(value);
+    expect(result.decimals).toEqual(expected);
   });
 });

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -143,7 +143,7 @@ export function getDecimalsForValue(value: number, decimalOverride?: DecimalCoun
     return { decimals: decimalOverride, scaledDecimals: null };
   }
 
-  let dec = -Math.floor(Math.log(value) / Math.LN10) + 1;
+  let dec = -Math.floor(Math.log(Math.abs(value)) / Math.LN10) + 1;
   const magn = Math.pow(10, -dec);
   const norm = value / magn; // norm is between 1.0 and 10.0
   let size;


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #28814

**Special notes for your reviewer**:
`Math.log` will return `NaN` if it is passed a negative number. Fixing this by first applying `Math.abs`.
