### PR TITLE
Added "Publish snapshots" section to "Share a panel" topic.

### DIFF
--- a/docs/sources/dashboards/share-panel.md
+++ b/docs/sources/dashboards/share-panel.md
@@ -10,7 +10,20 @@ weight = 600
 
 # Share a panel
 
-Click a panel title to open the panel menu, then click share in the panel menu to open the Share Panel dialog. Here you have access to a link that will take you to exactly this panel with the current time range and selected template variables. Below are ways to share a panel.
+To share a panel
+
+1. Click a panel title to open the panel menu.
+1. Click share in the panel menu to open the Share Panel dialog.
+
+ Here you have access to a link that will take you to exactly this panel with the current time range and selected template variables. Here are some of the ways you can share a panel.
+
+## Publish snapshots
+
+You can publish snapshots to your local instance or to [snapshot.raintank.io](http://snapshot.raintank.io). The latter is a free service provided by [Raintank](http://raintank.io), that allows you to publish dashboard snapshots to an external Grafana instance.
+
+Anyone with the link can view it. You can optionally set an expiration time if you want the snapshot to be removed after a certain time period.
+
+{{< docs-imagebox img="/img/docs/panels/Share_a_panel.png" max-width="700px" >}}
 
 ## Direct Link Rendered Image
 


### PR DESCRIPTION
Updated "Share a Panel" topic, this is take 3! Diana and I found some issues and resolved them.

Added section "Publish Snapshots" and a new image (image added to website repo: Add new image #2748).

From Ximena, for whom I created the PR:

The doc mentions Embed Panel and Direct Link but really should be a section for the Snapshot option which is the easiest of them all. ...

There's technically 3 ways to share a panel so having all 3 in that doc makes sense. IMHO "Publish Snapshots" should be at the top due to how 1-2-3 easy it is to do.