### PR TITLE
setting: Fix tests on Mac

### DIFF
--- a/pkg/setting/date_formats.go
+++ b/pkg/setting/date_formats.go
@@ -22,18 +22,17 @@ type DateFormatIntervals struct {
 	Year   string `json:"year"`
 }
 
-const LocalBrowserTimezone = "browser"
+const localBrowserTimezone = "browser"
 
-func valueAsTimezone(section *ini.Section, keyName string, defaultValue string) (string, error) {
-	timezone := section.Key(keyName).MustString(defaultValue)
-
-	if timezone == LocalBrowserTimezone {
-		return LocalBrowserTimezone, nil
+func valueAsTimezone(section *ini.Section, keyName string) (string, error) {
+	timezone := section.Key(keyName).MustString(localBrowserTimezone)
+	if timezone == localBrowserTimezone {
+		return localBrowserTimezone, nil
 	}
 
 	location, err := time.LoadLocation(timezone)
 	if err != nil {
-		return LocalBrowserTimezone, err
+		return localBrowserTimezone, err
 	}
 
 	return location.String(), nil
@@ -50,7 +49,7 @@ func (cfg *Cfg) readDateFormats() {
 	cfg.DateFormats.Interval.Year = "YYYY"
 	cfg.DateFormats.UseBrowserLocale = dateFormats.Key("date_format_use_browser_locale").MustBool(false)
 
-	timezone, err := valueAsTimezone(dateFormats, "default_timezone", LocalBrowserTimezone)
+	timezone, err := valueAsTimezone(dateFormats, "default_timezone")
 	if err != nil {
 		cfg.Logger.Warn("Unknown timezone as default_timezone", "err", err)
 	}

--- a/pkg/setting/date_formats_test.go
+++ b/pkg/setting/date_formats_test.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/ini.v1"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValueAsTimezone(t *testing.T) {
@@ -15,23 +16,21 @@ func TestValueAsTimezone(t *testing.T) {
 	}{
 		"browser":          {"browser", false},
 		"UTC":              {"UTC", false},
-		"utc":              {"browser", true},
 		"Amsterdam":        {"browser", true},
-		"europe/amsterdam": {"browser", true},
 		"Europe/Amsterdam": {"Europe/Amsterdam", false},
 	}
 
 	sec, err := ini.Empty().NewSection("test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	key, err := sec.NewKey("test", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for input, expected := range tests {
 		key.SetValue(input)
 
-		output, err := valueAsTimezone(sec, "test", "default")
+		output, err := valueAsTimezone(sec, "test")
 
-		assert.Equal(t, expected.hasErr, err != nil, "Invalid has err for input: %s err: %v", input, err)
-		assert.Equal(t, expected.output, output, "Invalid output for input: %s", input)
+		assert.Equal(t, expected.hasErr, err != nil, "Invalid has err for input %q: %s", input, err)
+		assert.Equal(t, expected.output, output, "Invalid output for input %q", input)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Tests for `setting.valueAsTimezone` fail because they expect locations in the wrong case, e.g. "utc", to fail when calling [time.LoadLocation](https://golang.org/pkg/time/#LoadLocation). That does happen on Linux, but not on macOS Catalina. The test suite is broken for me on Mac without this fix.

I think the right thing to do is to remove the test cases expecting case sensitive locations to fail.
