### PR TITLE
Devenv: Fix Prometheus basic auth proxy

### DIFF
--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/Dockerfile
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.19.3-alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY htpasswd /etc/nginx/htpasswd

--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/docker-compose.yaml
@@ -2,6 +2,6 @@
 # http://prometheus:9090 (Prometheus inside the docker compose)
 
   nginxproxy:
-    build: docker/blocks/nginx_proxy
+    build: docker/blocks/prometheus_basic_auth_proxy
     ports:
       - "10090:10090"

--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/docker-compose.yaml
@@ -3,4 +3,5 @@
 
   nginxproxy:
     build: docker/blocks/nginx_proxy
-    network_mode: host
+    ports:
+      - "10090:10090"

--- a/devenv/docker/blocks/prometheus_basic_auth_proxy/nginx.conf
+++ b/devenv/docker/blocks/prometheus_basic_auth_proxy/nginx.conf
@@ -2,6 +2,7 @@ events { }
 
 http {
   server {
+    error_log stderr info;
 
     listen 10090;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I found out that the Docker block devenv/docker/blocks/prometheus_basic_auth_proxy doesn't currently work, since it's misconfigured to use the Dockerfile from devenv/docker/blocks/nginx_proxy.

This PR rectifies the block to use the right Dockerfile and also pins the base image version, to ensure reproducibility.
