### PR TITLE
Gauge: making sure threshold panel json is correct before render

### DIFF
--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.test.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.test.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent } from 'react';
 import { mount } from 'enzyme';
-import { Threshold, ThresholdsConfig, ThresholdsMode } from '@grafana/data';
+import { ThresholdsMode } from '@grafana/data';
 import { ThresholdsEditor, Props, thresholdsWithoutKey } from './ThresholdsEditor';
 import { colors } from '../../utils';
 import { mockThemeContext } from '../../themes/ThemeContext';

--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.test.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.test.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent } from 'react';
 import { mount } from 'enzyme';
-import { ThresholdsMode } from '@grafana/data';
+import { Threshold, ThresholdsConfig, ThresholdsMode } from '@grafana/data';
 import { ThresholdsEditor, Props, thresholdsWithoutKey } from './ThresholdsEditor';
 import { colors } from '../../utils';
 import { mockThemeContext } from '../../themes/ThemeContext';
@@ -183,6 +183,30 @@ describe('ThresholdsEditor', () => {
       });
 
       instance.onBlur();
+
+      expect(getCurrentThresholds(instance).steps).toEqual([
+        { value: -Infinity, color: '#7EB26D' },
+        { value: 75, color: '#6ED0E0' },
+        { value: 78, color: '#EAB839' },
+      ]);
+    });
+  });
+
+  describe('on load with invalid steps', () => {
+    it('should exclude invalid steps and render a proper list', () => {
+      const { instance } = setup({
+        thresholds: {
+          mode: ThresholdsMode.Absolute,
+          steps: [
+            { value: -Infinity, color: '#7EB26D', key: 1 },
+            { value: 75, color: '#6ED0E0', key: 2 },
+            { color: '#7EB26D', key: 3 } as any,
+            { value: 78, color: '#EAB839', key: 4 },
+            { value: null, color: '#7EB26D', key: 5 } as any,
+            { value: null, color: '#7EB26D', key: 6 } as any,
+          ],
+        },
+      });
 
       expect(getCurrentThresholds(instance).steps).toEqual([
         { value: -Infinity, color: '#7EB26D' },

--- a/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
+++ b/packages/grafana-ui/src/components/ThresholdsEditorNew/ThresholdsEditor.tsx
@@ -18,6 +18,7 @@ import { RadioButtonGroup } from '../Forms/RadioButtonGroup/RadioButtonGroup';
 import { Button } from '../Button';
 import { FullWidthButtonContainer } from '../Button/FullWidthButtonContainer';
 import { Label } from '../Forms/Label';
+import { isNumber } from 'lodash';
 
 const modes: Array<SelectableValue<ThresholdsMode>> = [
   { value: ThresholdsMode.Absolute, label: 'Absolute', description: 'Pick thresholds based on the absolute values' },
@@ -249,13 +250,15 @@ function toThresholdsWithKey(steps?: Threshold[]): ThresholdWithKey[] {
     steps = [{ value: -Infinity, color: 'green' }];
   }
 
-  return steps.map(t => {
-    return {
-      color: t.color,
-      value: t.value === null ? -Infinity : t.value,
-      key: counter++,
-    };
-  });
+  return steps
+    .filter((t, i) => isNumber(t.value) || i === 0)
+    .map(t => {
+      return {
+        color: t.color,
+        value: t.value === null ? -Infinity : t.value,
+        key: counter++,
+      };
+    });
 }
 
 export function thresholdsWithoutKey(thresholds: ThresholdsConfig, steps: ThresholdWithKey[]): ThresholdsConfig {


### PR DESCRIPTION
**What this PR does / why we need it**:
For some reason the author to the following issue: #27146 manage to get an invalid panel json structure saved regarding the thresholds values. It caused the threshold list to stop working. I added a filter to prevent this from happening.

**Which issue(s) this PR fixes**:
Fixes #27146

**Special notes for your reviewer**:
Can I add this as a migration script instead? Or is this good enough?
