### PR TITLE
devenv: Add docker load test which authenticates with API key

### DIFF
--- a/devenv/docker/loadtest/README.md
+++ b/devenv/docker/loadtest/README.md
@@ -53,6 +53,12 @@ Run auth proxy test:
 $ ./run.sh -c auth_proxy_test
 ```
 
+Run API key test (option `-k` must be a valid `admin` API key)
+
+```bash
+$ ./run.sh -c auth_token_test -k "<api key here>"
+```
+
 
 Example output:
 

--- a/devenv/docker/loadtest/annotations_by_tag_test.js
+++ b/devenv/docker/loadtest/annotations_by_tag_test.js
@@ -21,7 +21,7 @@ export const setup = () => {
 };
 
 export default data => {
-  client.withOrgId(data.orgId)
+  client.withOrgId(data.orgId);
 
   group('annotation by tag test', () => {
     if (__ITER === 0) {

--- a/devenv/docker/loadtest/auth_key_test.js
+++ b/devenv/docker/loadtest/auth_key_test.js
@@ -11,12 +11,12 @@ let endpoint = __ENV.URL || 'http://localhost:3000';
 
 let apiKey = __ENV.API_KEY;
 if (!apiKey) {
-  throw new Error('This script requires the API key argument -k to be defined.')
+  throw new Error('This script requires the API key argument -k to be defined.');
 }
 const client = createBearerAuthClient(endpoint, apiKey);
 
 export const setup = () => {
-  let authClient = createBearerAuthClient(endpoint, apiKey)
+  const authClient = createBearerAuthClient(endpoint, apiKey);
 
   const orgId = createTestOrgIfNotExists(authClient);
   authClient.withOrgId(orgId);

--- a/devenv/docker/loadtest/auth_token_slow_test.js
+++ b/devenv/docker/loadtest/auth_token_slow_test.js
@@ -13,15 +13,17 @@ const client = createClient(endpoint);
 export const setup = () => {
   const basicAuthClient = createBasicAuthClient(endpoint, 'admin', 'admin');
   const orgId = createTestOrgIfNotExists(basicAuthClient);
+  basicAuthClient.withOrgId(orgId);
   const datasourceId = createTestdataDatasourceIfNotExists(basicAuthClient);
-  client.withOrgId(orgId);
   return {
-    orgId: orgId,
-    datasourceId: datasourceId,
+    orgId,
+    datasourceId,
   };
 };
 
 export default data => {
+  client.withOrgId(data.orgId);
+
   group(`user auth token slow test (queries between 1 and ${slowQuery} seconds)`, () => {
     if (__ITER === 0) {
       group('user authenticates through ui with username and password', () => {

--- a/devenv/docker/loadtest/auth_token_test.js
+++ b/devenv/docker/loadtest/auth_token_test.js
@@ -2,7 +2,6 @@ import { sleep, check, group } from 'k6';
 import { createClient, createBasicAuthClient } from './modules/client.js';
 import { createTestOrgIfNotExists, createTestdataDatasourceIfNotExists } from './modules/util.js';
 
-
 export let options = {
   noCookiesReset: true,
 };
@@ -21,7 +20,6 @@ export const setup = () => {
     datasourceId,
   };
 };
-
 
 export default data => {
   client.withOrgId(data.orgId);

--- a/devenv/docker/loadtest/auth_token_test.js
+++ b/devenv/docker/loadtest/auth_token_test.js
@@ -2,6 +2,7 @@ import { sleep, check, group } from 'k6';
 import { createClient, createBasicAuthClient } from './modules/client.js';
 import { createTestOrgIfNotExists, createTestdataDatasourceIfNotExists } from './modules/util.js';
 
+
 export let options = {
   noCookiesReset: true,
 };
@@ -12,15 +13,19 @@ const client = createClient(endpoint);
 export const setup = () => {
   const basicAuthClient = createBasicAuthClient(endpoint, 'admin', 'admin');
   const orgId = createTestOrgIfNotExists(basicAuthClient);
+  basicAuthClient.withOrgId(orgId);
   const datasourceId = createTestdataDatasourceIfNotExists(basicAuthClient);
-  client.withOrgId(orgId);
+
   return {
-    orgId: orgId,
-    datasourceId: datasourceId,
+    orgId,
+    datasourceId,
   };
 };
 
+
 export default data => {
+  client.withOrgId(data.orgId);
+
   group('user auth token test', () => {
     if (__ITER === 0) {
       group('user authenticates through ui with username and password', () => {

--- a/devenv/docker/loadtest/modules/client.js
+++ b/devenv/docker/loadtest/modules/client.js
@@ -17,6 +17,10 @@ export const DatasourcesEndpoint = class DatasourcesEndpoint {
     this.httpClient = httpClient;
   }
 
+  getAll() {
+    return this.httpClient.get('/datasources');
+  }
+
   getById(id) {
     return this.httpClient.get(`/datasources/${id}`);
   }
@@ -177,6 +181,25 @@ export class BasicAuthClient extends BaseClient {
   }
 }
 
+export class BearerAuthClient extends BaseClient {
+  constructor(url, subUrl, token) {
+    super(url, subUrl);
+    this.token = token;
+  }
+
+  withUrl(subUrl) {
+    let c = new BearerAuthClient(this.url, subUrl, this.token);
+    c.onBeforeRequest = this.onBeforeRequest;
+    return c;
+  }
+
+  beforeRequest(params) {
+    params = params || {};
+    params.headers = params.headers || {};
+    params.headers['Authorization']  = `Bearer ${this.token}`;
+  }
+}
+
 export const createClient = url => {
   return new GrafanaClient(new BaseClient(url, ''));
 };
@@ -184,3 +207,7 @@ export const createClient = url => {
 export const createBasicAuthClient = (url, username, password) => {
   return new GrafanaClient(new BasicAuthClient(url, '', username, password));
 };
+
+export const createBearerAuthClient = (url, token) => {
+  return new GrafanaClient(new BearerAuthClient(url, '', token));
+}

--- a/devenv/docker/loadtest/modules/util.js
+++ b/devenv/docker/loadtest/modules/util.js
@@ -1,19 +1,25 @@
 export const createTestOrgIfNotExists = client => {
   let orgId = 0;
+
   let res = client.orgs.getByName('k6');
   if (res.status === 404) {
     res = client.orgs.create('k6');
     if (res.status !== 200) {
       throw new Error('Expected 200 response status when creating org');
     }
-    orgId = res.json().orgId;
-  } else {
-    orgId = res.json().id;
+    return res.json().orgId;
   }
 
-  client.withOrgId(orgId);
-  return orgId;
+  // This can happen e.g. in Hosted Grafana instances, where even admins
+  // cannot see organisations
+  if (res.status !== 200) {
+    console.info(`unable to get orgs from instance, continuing with default orgId ${orgId}`);
+    return orgId;
+  }
+
+  return res.json().id;
 };
+
 
 export const createTestdataDatasourceIfNotExists = client => {
   const payload = {
@@ -26,9 +32,10 @@ export const createTestdataDatasourceIfNotExists = client => {
   let res = client.datasources.getByName(payload.name);
   if (res.status === 404) {
     res = client.datasources.create(payload);
-    if (res.status !== 200) {
-      throw new Error('Expected 200 response status when creating datasource');
-    }
+  }
+
+  if (res.status !== 200) {
+    throw new Error(`expected 200 response status when creating datasource, got ${res.status}`);
   }
 
   return res.json().id;

--- a/devenv/docker/loadtest/run.sh
+++ b/devenv/docker/loadtest/run.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 PWD=$(pwd)
 
@@ -9,10 +9,11 @@ run() {
   testcase='auth_token_test'
   slowQuery=''
   out=''
+  apiKey=''
 
-  while getopts ":d:u:v:c:s:o:" o; do
+  while getopts ":d:u:v:c:s:o:k:" o; do
     case "${o}" in
-				d)
+        d)
             duration=${OPTARG}
             ;;
         u)
@@ -27,14 +28,18 @@ run() {
         s)
             slowQuery=${OPTARG}
             ;;
-        o)  out=${OPTARG}
+        o)  
+            out=${OPTARG}
+            ;;
+        k)
+            apiKey=${OPTARG}
             ;;
 
     esac
 	done
 	shift $((OPTIND-1))
 
-  docker run -t --network=host -v $PWD:/src -e URL=$url -e SLOW_QUERY=$slowQuery -e K6_OUT=$out --rm -i loadimpact/k6:master run --vus $vus --duration $duration src/$testcase.js
+  docker run -t --network=host -v $PWD:/src -e URL=$url -e SLOW_QUERY=$slowQuery -e K6_OUT=$out -e API_KEY=$apiKey --rm -i loadimpact/k6:master run --vus $vus --duration $duration src/$testcase.js
 }
 
 run "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

This provides for a use case where we wanted to authenticate with a Grafana instance with an API Key.

Also:
- Edit load tests to assign the orgId in the default function, as the setup function is only called once for all VUs and therefore the change is not persisted to each VU.
- Remove side effect from orgId setup function and explicitly set orgId in setup client

**Which issue(s) this PR fixes**:

There's no issue for this PR.

**Special notes for your reviewer**:

Functionality of all existing test cases is unchanged. Verify the new test by generating an Admin-level API key in your grafana instance and providing it as a value for the `-k` flag.