### PR TITLE
CloudWatch Logs: Change how we measure query progress

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -336,7 +336,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
         ({ failures, prevRecordsMatched }, frames) => {
           failures++;
           for (const frame of frames) {
-            const recordsMatched = frame.meta?.stats?.find(stat => stat.displayName === 'Records matched')?.value!;
+            const recordsMatched = frame.meta?.stats?.find(stat => stat.displayName === 'Records scanned')?.value!;
             if (recordsMatched > (prevRecordsMatched[frame.refId!] ?? 0)) {
               failures = 0;
             }

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -186,23 +186,23 @@ describe('CloudWatchDatasource', () => {
 
     it('should stop querying when no more data received a number of times in a row', async () => {
       const fakeFrames = genMockFrames(20);
-      const initialRecordsMatched = fakeFrames[0].meta!.stats!.find(stat => stat.displayName === 'Records matched')!
+      const initialRecordsMatched = fakeFrames[0].meta!.stats!.find(stat => stat.displayName === 'Records scanned')!
         .value!;
       for (let i = 1; i < 4; i++) {
         fakeFrames[i].meta!.stats = [
           {
-            displayName: 'Records matched',
+            displayName: 'Records scanned',
             value: initialRecordsMatched,
           },
         ];
       }
 
-      const finalRecordsMatched = fakeFrames[9].meta!.stats!.find(stat => stat.displayName === 'Records matched')!
+      const finalRecordsMatched = fakeFrames[9].meta!.stats!.find(stat => stat.displayName === 'Records scanned')!
         .value!;
       for (let i = 10; i < fakeFrames.length; i++) {
         fakeFrames[i].meta!.stats = [
           {
-            displayName: 'Records matched',
+            displayName: 'Records scanned',
             value: finalRecordsMatched,
           },
         ];
@@ -1198,7 +1198,7 @@ function genMockFrames(numResponses: number): DataFrame[] {
         },
         stats: [
           {
-            displayName: 'Records matched',
+            displayName: 'Records scanned',
             value: (i + 1) * recordIncrement,
           },
         ],


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/28902

For timeout we look at query progress and if there are multiple consecutive checks where no progress is made we timed out the query. We used Records matched variable which probably isn't a best measure of progress as query does not have to match any records.