### PR TITLE
Plugins: Implement testDatasource for Jaeger

### DIFF
--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -89,9 +89,8 @@ describe('when performing testDataSource', () => {
         const response = await ds.testDatasource();
         expect(response.status).toEqual('error');
         expect(response.message).toBe(
-          'Data source connected, but no services received. '+
-          'Verify that Jaeger is configured properly.'
-         );
+          'Data source connected, but no services received. Verify that Jaeger is configured properly.'
+        );
       });
     });
   });
@@ -137,9 +136,7 @@ describe('when performing testDataSource', () => {
         const ds = new JaegerDatasource(defaultSettings);
         const response = await ds.testDatasource();
         expect(response.status).toEqual('error');
-        expect(response.message).toBe(
-          'Jaeger: Bad gateway. 502. {\"errors\":[\"Could not connect to Jaeger backend\"]}'
-         );
+        expect(response.message).toBe('Jaeger: Bad gateway. 502. {"errors":["Could not connect to Jaeger backend"]}');
       });
     });
   });

--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -53,6 +53,106 @@ describe('JaegerDatasource', () => {
   });
 });
 
+describe('when performing testDataSource', () => {
+  describe('and call succeeds', () => {
+    it('should return successfully', async () => {
+      const backendSrvMock = makeTestDatasourceMock(
+        Promise.resolve({
+          statusText: 'OK',
+          status: 200,
+          data: {
+            data: ['service1'],
+          },
+        })
+      );
+
+      await withMockedBackendSrv(backendSrvMock, async () => {
+        const ds = new JaegerDatasource(defaultSettings);
+        const response = await ds.testDatasource();
+        expect(response.status).toEqual('success');
+        expect(response.message).toBe('Data source connected and services found.');
+      });
+    });
+  });
+
+  describe('and call succeeds, but returns no services', () => {
+    it('should display an error', async () => {
+      const backendSrvMock = makeTestDatasourceMock(
+        Promise.resolve({
+          statusText: 'OK',
+          status: 200,
+        })
+      );
+
+      await withMockedBackendSrv(backendSrvMock, async () => {
+        const ds = new JaegerDatasource(defaultSettings);
+        const response = await ds.testDatasource();
+        expect(response.status).toEqual('error');
+        expect(response.message).toBe(
+          'Data source connected, but no services received. '+
+          'Verify that Jaeger is configured properly.'
+         );
+      });
+    });
+  });
+
+  describe('and call returns error with message', () => {
+    it('should return the formatted error', async () => {
+      const backendSrvMock = {
+        datasourceRequest(options: BackendSrvRequest): Promise<any> {
+          return Promise.reject({
+            statusText: 'Not found',
+            status: 404,
+            data: {
+              message: '404 page not found',
+            },
+          });
+        },
+      } as BackendSrv;
+
+      await withMockedBackendSrv(backendSrvMock, async () => {
+        const ds = new JaegerDatasource(defaultSettings);
+        const response = await ds.testDatasource();
+        expect(response.status).toEqual('error');
+        expect(response.message).toBe('Jaeger: Not found. 404. 404 page not found');
+      });
+    });
+  });
+
+  describe('and call returns error without message', () => {
+    it('should return JSON error', async () => {
+      const backendSrvMock = {
+        datasourceRequest(options: BackendSrvRequest): Promise<any> {
+          return Promise.reject({
+            statusText: 'Bad gateway',
+            status: 502,
+            data: {
+              errors: ['Could not connect to Jaeger backend'],
+            },
+          });
+        },
+      } as BackendSrv;
+
+      await withMockedBackendSrv(backendSrvMock, async () => {
+        const ds = new JaegerDatasource(defaultSettings);
+        const response = await ds.testDatasource();
+        expect(response.status).toEqual('error');
+        expect(response.message).toBe(
+          'Jaeger: Bad gateway. 502. {\"errors\":[\"Could not connect to Jaeger backend\"]}'
+         );
+      });
+    });
+  });
+});
+
+function makeTestDatasourceMock(result: Promise<any>) {
+  return {
+    datasourceRequest(options: BackendSrvRequest): Promise<any> {
+      return result;
+    },
+  } as BackendSrv;
+}
+
 function makeBackendSrvMock(traceId: string) {
   return {
     datasourceRequest(options: BackendSrvRequest): Promise<any> {


### PR DESCRIPTION
**What this PR does / why we need it**: This PR implements the `testDatasource` method for the Jaeger datasource plugin. This functionality is useful when configuring the datasource to verify that it is working.

**Which issue(s) this PR fixes**: #28837 

Fixes #28837 

**Special notes for your reviewer**: The implementation is largely copied from the [Loki datasource plugin](https://github.com/grafana/grafana/blob/8e9181e7d1e9920c25558ad847cabdc1c84c15d7/public/app/plugins/datasource/loki/datasource.ts#L435-L474).

In addition to the unit tests, I manually verified the behavior against a local instance of Jaeger:

Misconfiguration leading to 502 response with error:
![jaeger-bad-gateway](https://user-images.githubusercontent.com/814226/98469846-fb0f2800-21af-11eb-8904-b90788731e37.png)

Misconfiguring leading to 200 response but no services:
![jaeger-no-services](https://user-images.githubusercontent.com/814226/98469847-fba7be80-21af-11eb-9f28-1429bdb1fffb.png)

Success:
![jaeger-success](https://user-images.githubusercontent.com/814226/98469848-fba7be80-21af-11eb-9627-a093fc5d8463.png)

