### PR TITLE
Chore: Rewrite test helpers from GoConvey to stdlib

### DIFF
--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -32,7 +32,7 @@ func TestAlertingDataAccess(t *testing.T) {
 	Convey("Testing Alerting data access", t, func() {
 		InitTestDB(t)
 
-		testDash := insertTestDashboard("dashboard with alerts", 1, 0, false, "alert")
+		testDash := insertTestDashboard(t, "dashboard with alerts", 1, 0, false, "alert")
 		evalData, _ := simplejson.NewJson([]byte(`{"test": "test"}`))
 		items := []*models.Alert{
 			{
@@ -273,7 +273,7 @@ func TestPausingAlerts(t *testing.T) {
 	Convey("Given an alert", t, func() {
 		InitTestDB(t)
 
-		testDash := insertTestDashboard("dashboard with alerts", 1, 0, false, "alert")
+		testDash := insertTestDashboard(t, "dashboard with alerts", 1, 0, false, "alert")
 		alert, _ := insertTestAlert("Alerting title", "Alerting message", testDash.OrgId, testDash.Id, simplejson.New())
 
 		stateDateBeforePause := alert.NewStateDate

--- a/pkg/services/sqlstore/dashboard_acl_test.go
+++ b/pkg/services/sqlstore/dashboard_acl_test.go
@@ -13,9 +13,9 @@ func TestDashboardAclDataAccess(t *testing.T) {
 	Convey("Testing DB", t, func() {
 		InitTestDB(t)
 		Convey("Given a dashboard folder and a user", func() {
-			currentUser := createUser("viewer", "Viewer", false)
-			savedFolder := insertTestDashboard("1 test dash folder", 1, 0, true, "prod", "webapp")
-			childDash := insertTestDashboard("2 test dash", 1, savedFolder.Id, false, "prod", "webapp")
+			currentUser := createUser(t, "viewer", "Viewer", false)
+			savedFolder := insertTestDashboard(t, "1 test dash folder", 1, 0, true, "prod", "webapp")
+			childDash := insertTestDashboard(t, "2 test dash", 1, savedFolder.Id, false, "prod", "webapp")
 
 			Convey("When adding dashboard permission with userId and teamId set to 0", func() {
 				err := testHelperUpdateDashboardAcl(savedFolder.Id, models.DashboardAcl{

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -16,12 +16,12 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 		InitTestDB(t)
 
 		Convey("Given one dashboard folder with two dashboards and one dashboard in the root folder", func() {
-			folder := insertTestDashboard("1 test dash folder", 1, 0, true, "prod", "webapp")
-			dashInRoot := insertTestDashboard("test dash 67", 1, 0, false, "prod", "webapp")
-			childDash := insertTestDashboard("test dash 23", 1, folder.Id, false, "prod", "webapp")
-			insertTestDashboard("test dash 45", 1, folder.Id, false, "prod")
+			folder := insertTestDashboard(t, "1 test dash folder", 1, 0, true, "prod", "webapp")
+			dashInRoot := insertTestDashboard(t, "test dash 67", 1, 0, false, "prod", "webapp")
+			childDash := insertTestDashboard(t, "test dash 23", 1, folder.Id, false, "prod", "webapp")
+			insertTestDashboard(t, "test dash 45", 1, folder.Id, false, "prod")
 
-			currentUser := createUser("viewer", "Viewer", false)
+			currentUser := createUser(t, "viewer", "Viewer", false)
 
 			Convey("and no acls are set", func() {
 				Convey("should return all dashboards", func() {
@@ -156,13 +156,13 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 		})
 
 		Convey("Given two dashboard folders with one dashboard each and one dashboard in the root folder", func() {
-			folder1 := insertTestDashboard("1 test dash folder", 1, 0, true, "prod")
-			folder2 := insertTestDashboard("2 test dash folder", 1, 0, true, "prod")
-			dashInRoot := insertTestDashboard("test dash 67", 1, 0, false, "prod")
-			childDash1 := insertTestDashboard("child dash 1", 1, folder1.Id, false, "prod")
-			childDash2 := insertTestDashboard("child dash 2", 1, folder2.Id, false, "prod")
+			folder1 := insertTestDashboard(t, "1 test dash folder", 1, 0, true, "prod")
+			folder2 := insertTestDashboard(t, "2 test dash folder", 1, 0, true, "prod")
+			dashInRoot := insertTestDashboard(t, "test dash 67", 1, 0, false, "prod")
+			childDash1 := insertTestDashboard(t, "child dash 1", 1, folder1.Id, false, "prod")
+			childDash2 := insertTestDashboard(t, "child dash 2", 1, folder2.Id, false, "prod")
 
-			currentUser := createUser("viewer", "Viewer", false)
+			currentUser := createUser(t, "viewer", "Viewer", false)
 			var rootFolderId int64 = 0
 
 			Convey("and one folder is expanded, the other collapsed", func() {
@@ -246,13 +246,13 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 		})
 
 		Convey("Given two dashboard folders", func() {
-			folder1 := insertTestDashboard("1 test dash folder", 1, 0, true, "prod")
-			folder2 := insertTestDashboard("2 test dash folder", 1, 0, true, "prod")
-			insertTestDashboard("folder in another org", 2, 0, true, "prod")
+			folder1 := insertTestDashboard(t, "1 test dash folder", 1, 0, true, "prod")
+			folder2 := insertTestDashboard(t, "2 test dash folder", 1, 0, true, "prod")
+			insertTestDashboard(t, "folder in another org", 2, 0, true, "prod")
 
-			adminUser := createUser("admin", "Admin", true)
-			editorUser := createUser("editor", "Editor", false)
-			viewerUser := createUser("viewer", "Viewer", false)
+			adminUser := createUser(t, "admin", "Admin", true)
+			editorUser := createUser(t, "editor", "Editor", false)
+			viewerUser := createUser(t, "viewer", "Viewer", false)
 
 			Convey("Admin users", func() {
 				Convey("Should have write access to all dashboard folders in their org", func() {

--- a/pkg/services/sqlstore/dashboard_version_test.go
+++ b/pkg/services/sqlstore/dashboard_version_test.go
@@ -31,7 +31,7 @@ func TestGetDashboardVersion(t *testing.T) {
 		InitTestDB(t)
 
 		Convey("Get a Dashboard ID and version ID", func() {
-			savedDash := insertTestDashboard("test dash 26", 1, 0, false, "diff")
+			savedDash := insertTestDashboard(t, "test dash 26", 1, 0, false, "diff")
 
 			query := models.GetDashboardVersionQuery{
 				DashboardId: savedDash.Id,
@@ -72,7 +72,7 @@ func TestGetDashboardVersion(t *testing.T) {
 func TestGetDashboardVersions(t *testing.T) {
 	Convey("Testing dashboard versions retrieval", t, func() {
 		InitTestDB(t)
-		savedDash := insertTestDashboard("test dash 43", 1, 0, false, "diff-all")
+		savedDash := insertTestDashboard(t, "test dash 43", 1, 0, false, "diff-all")
 
 		Convey("Get all versions for a given Dashboard ID", func() {
 			query := models.GetDashboardVersionsQuery{DashboardId: savedDash.Id, OrgId: 1}
@@ -112,7 +112,7 @@ func TestDeleteExpiredVersions(t *testing.T) {
 		versionsToWrite := 10
 		setting.DashboardVersionsToKeep = versionsToKeep
 
-		savedDash := insertTestDashboard("test dash 53", 1, 0, false, "diff-all")
+		savedDash := insertTestDashboard(t, "test dash 53", 1, 0, false, "diff-all")
 		for i := 0; i < versionsToWrite-1; i++ {
 			updateTestDashboard(savedDash, map[string]interface{}{
 				"tags": "different-tag",

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -284,8 +284,8 @@ func TestAccountDataAccess(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(len(query.Result), ShouldEqual, 3)
 
-					dash1 := insertTestDashboard("1 test dash", ac1.OrgId, 0, false, "prod", "webapp")
-					dash2 := insertTestDashboard("2 test dash", ac3.OrgId, 0, false, "prod", "webapp")
+					dash1 := insertTestDashboard(t, "1 test dash", ac1.OrgId, 0, false, "prod", "webapp")
+					dash2 := insertTestDashboard(t, "2 test dash", ac3.OrgId, 0, false, "prod", "webapp")
 
 					err = testHelperUpdateDashboardAcl(dash1.Id, models.DashboardAcl{DashboardId: dash1.Id, OrgId: ac1.OrgId, UserId: ac3.Id, Permission: models.PERMISSION_EDIT})
 					So(err, ShouldBeNil)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Rewrite two test helpers, `createUser` and `insertTestDashboard`, in the `sqlstore` package to not require a GoConvey context, to make rewriting GoConvey tests to stdlib and testify easier.

**Special notes for your reviewer**:

Part of #22844.

What do you think @aknuds1, @papagian?