### PR TITLE
Backend: Remove unused function GetAllDataSources

### DIFF
--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -206,10 +206,6 @@ type GetDataSourcesQuery struct {
 	Result []*DataSource
 }
 
-type GetAllDataSourcesQuery struct {
-	Result []*DataSource
-}
-
 type GetDataSourceByIdQuery struct {
 	Id     int64
 	OrgId  int64

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -35,7 +35,6 @@ func TestDatasourceAsConfig(t *testing.T) {
 		bus.AddHandler("test", mockInsert)
 		bus.AddHandler("test", mockUpdate)
 		bus.AddHandler("test", mockGet)
-		bus.AddHandler("test", mockGetAll)
 		bus.AddHandler("test", mockGetOrg)
 
 		Convey("apply default values when missing", func() {
@@ -279,11 +278,6 @@ func mockUpdate(cmd *models.UpdateDataSourceCommand) error {
 
 func mockInsert(cmd *models.AddDataSourceCommand) error {
 	fakeRepo.inserted = append(fakeRepo.inserted, cmd)
-	return nil
-}
-
-func mockGetAll(cmd *models.GetAllDataSourcesQuery) error {
-	cmd.Result = fakeRepo.loadAll
 	return nil
 }
 

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -18,7 +18,6 @@ import (
 
 func init() {
 	bus.AddHandler("sql", GetDataSources)
-	bus.AddHandler("sql", GetAllDataSources)
 	bus.AddHandler("sql", AddDataSource)
 	bus.AddHandler("sql", DeleteDataSourceById)
 	bus.AddHandler("sql", DeleteDataSourceByName)
@@ -69,13 +68,6 @@ func GetDataSourceByName(query *models.GetDataSourceByNameQuery) error {
 
 func GetDataSources(query *models.GetDataSourcesQuery) error {
 	sess := x.Limit(5000, 0).Where("org_id=?", query.OrgId).Asc("name")
-
-	query.Result = make([]*models.DataSource, 0)
-	return sess.Find(&query.Result)
-}
-
-func GetAllDataSources(query *models.GetAllDataSourcesQuery) error {
-	sess := x.Limit(5000, 0).Asc("name")
 
 	query.Result = make([]*models.DataSource, 0)
 	return sess.Find(&query.Result)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove unused Go function sqlstore.GetAllDataSources. I checked also with Grafana enterprise, not in use there either AFAICT.