### PR TITLE
GraphNG: Restore focus option

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/hooks.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/hooks.test.ts
@@ -10,7 +10,7 @@ describe('usePlotConfig', () => {
         "axes": Array [],
         "cursor": Object {
           "focus": Object {
-            "prox": -1,
+            "prox": 30,
           },
         },
         "focus": Object {
@@ -52,7 +52,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -101,7 +101,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -148,7 +148,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -196,7 +196,7 @@ describe('usePlotConfig', () => {
           ],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -246,7 +246,7 @@ describe('usePlotConfig', () => {
           ],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -290,7 +290,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -334,7 +334,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -384,7 +384,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -432,7 +432,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -477,7 +477,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {
@@ -531,7 +531,7 @@ describe('usePlotConfig', () => {
           "axes": Array [],
           "cursor": Object {
             "focus": Object {
-              "prox": -1,
+              "prox": 30,
             },
           },
           "focus": Object {

--- a/packages/grafana-ui/src/components/uPlot/hooks.ts
+++ b/packages/grafana-ui/src/components/uPlot/hooks.ts
@@ -88,7 +88,7 @@ export const DEFAULT_PLOT_CONFIG = {
   },
   cursor: {
     focus: {
-      prox: -1,
+      prox: 30,
     },
   },
   legend: {


### PR DESCRIPTION
I set focus proximity to -1 as we did not use the focus highlight, did not know it would impact the tooltip. 

The reason I turned this off was that having this on triggers axis re-rendering while hovering and the axis formats function is called while hovering: 
https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/components/uPlot/geometries/Axis.tsx#L116

Is this really needed for the focus feature @leeoniya ? 