### PR TITLE
Tracing: log traceID in request logger

### DIFF
--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -16,12 +16,15 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/uber/jaeger-client-go"
 	"gopkg.in/macaron.v1"
 )
 
@@ -49,13 +52,40 @@ func Logger() macaron.Handler {
 
 		if ctx, ok := c.Data["ctx"]; ok {
 			ctxTyped := ctx.(*models.ReqContext)
+
+			logParams := []interface{}{
+				"method", req.Method,
+				"path", req.URL.Path,
+				"status", status,
+				"remote_addr", c.RemoteAddr(),
+				"time_ms", int64(timeTaken),
+				"size", rw.Size(),
+				"referer", req.Referer(),
+			}
+
+			traceID, exist := extractTraceID(ctxTyped.Req.Request.Context())
+			if exist {
+				logParams = append(logParams, "traceID", traceID)
+			}
+
 			if status == 500 {
-				ctxTyped.Logger.Error("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status,
-					"remote_addr", c.RemoteAddr(), "time_ms", int64(timeTaken), "size", rw.Size(), "referer", req.Referer())
+				ctxTyped.Logger.Error("Request Completed", logParams...)
 			} else {
-				ctxTyped.Logger.Info("Request Completed", "method", req.Method, "path", req.URL.Path, "status", status,
-					"remote_addr", c.RemoteAddr(), "time_ms", int64(timeTaken), "size", rw.Size(), "referer", req.Referer())
+				ctxTyped.Logger.Info("Request Completed", logParams...)
 			}
 		}
 	}
+}
+
+func extractTraceID(ctx context.Context) (string, bool) {
+	sp := opentracing.SpanFromContext(ctx)
+	if sp == nil {
+		return "", false
+	}
+	sctx, ok := sp.Context().(jaeger.SpanContext)
+	if !ok {
+		return "", false
+	}
+
+	return sctx.TraceID().String(), true
 }

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -68,7 +68,7 @@ func Logger() macaron.Handler {
 				logParams = append(logParams, "traceID", traceID)
 			}
 
-			if status == 500 {
+			if status >= 500 {
 				ctxTyped.Logger.Error("Request Completed", logParams...)
 			} else {
 				ctxTyped.Logger.Info("Request Completed", logParams...)


### PR DESCRIPTION
This will make it possible to lookup traces in tempo using `traceID` 

I've been trying to verify this locally but I can't get Grafana to write traces to jaeger in devenv.. I know it worked 3 years ago when I added it. Not sure what happened between that and now :/

closes https://github.com/grafana/grafana/issues/27549

Signed-off-by: bergquist <carl.bergquist@gmail.com>

