### PR TITLE
Plugins: Changed alertlist alert url to view instead of edit

### DIFF
--- a/public/app/plugins/panel/alertlist/module.html
+++ b/public/app/plugins/panel/alertlist/module.html
@@ -12,7 +12,7 @@
         <div class="alert-rule-item__body">
           <div class="alert-rule-item__header">
             <p class="alert-rule-item__name">
-              <a href="{{alert.url}}?editPanel={{alert.panelId}}&tab=alert">
+              <a href="{{alert.url}}?viewPanel={{alert.panelId}}&tab=alert">
                 {{alert.name}}
               </a>
             </p>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR changed the URL in alertlist panel to `viewPanel` instead of `editPanel`

This is my alertlist panel in Home
![Screenshot from 2020-11-10 10-58-26](https://user-images.githubusercontent.com/1005824/98626991-0ac47300-234e-11eb-939b-6c087ebeaab8.png)

As a user with view permission, I want to view the triggered alert. Clicking the the first alert will result as below
![Screenshot from 2020-11-10 11-04-50](https://user-images.githubusercontent.com/1005824/98627084-5119d200-234e-11eb-8f48-b3475cc3b3c4.png)

This behaviour (clicked alert open viewPanel) also same when we get a notification from grafana (msteam, email etc)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

