### PR TITLE
StatPanel: Fixed center of values in edge case scenarios

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -67,6 +67,10 @@ export abstract class BigValueLayout {
       zIndex: 1,
     };
 
+    if (this.justifyCenter) {
+      styles.textAlign = 'center';
+    }
+
     switch (this.props.colorMode) {
       case BigValueColorMode.Value:
         styles.color = this.valueColor;

--- a/packages/grafana-ui/src/components/BigValue/__snapshots__/BigValue.test.tsx.snap
+++ b/packages/grafana-ui/src/components/BigValue/__snapshots__/BigValue.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`BigValue Render with basic options should render 1`] = `
           "fontWeight": 500,
           "lineHeight": 1.2,
           "position": "relative",
+          "textAlign": "center",
           "zIndex": 1,
         }
       }


### PR DESCRIPTION
In some edge cases when string contains many `-` for some reason the text measurement is off by 2 pixels so the text will wrap. Not sure how to fix that but this at least makes the wrapped text centered.


Fixes #28894
