### PR TITLE
Logs Panel: Fix inconsistent highlighting

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -94,7 +94,6 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
       ? cx([style.logsRowMatchHighLight, style.logsRowMatchHighLightPreview])
       : cx([style.logsRowMatchHighLight]);
     const styles = getStyles(theme);
-    console.log('highlighterExpressions', highlighterExpressions);
 
     return (
       <td className={style.logsRowMessage}>

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -86,7 +86,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
     const style = getLogRowStyles(theme, row.logLevel);
     const { entry, hasAnsi, raw } = row;
 
-    const previewHighlights = highlighterExpressions && !_.isEqual(highlighterExpressions, row.searchWords);
+    const previewHighlights = highlighterExpressions?.length && !_.isEqual(highlighterExpressions, row.searchWords);
     const highlights = previewHighlights ? highlighterExpressions : row.searchWords;
     const needsHighlighter =
       highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0 && entry.length < MAX_CHARACTERS;
@@ -94,6 +94,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
       ? cx([style.logsRowMatchHighLight, style.logsRowMatchHighLightPreview])
       : cx([style.logsRowMatchHighLight]);
     const styles = getStyles(theme);
+    console.log('highlighterExpressions', highlighterExpressions);
 
     return (
       <td className={style.logsRowMessage}>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that when `highlighterExpressions` is empty array, we highlight `row.searchWords`, if there are any. Before this, we have used empty array of highlighterExpressions (truthy) instead of  `row.searchWords`. 

Before: 
![Kapture 2020-11-10 at 12 55 27](https://user-images.githubusercontent.com/30407135/98671147-19ae2400-2354-11eb-9e0d-b136e41ef85c.gif)

After this fix: 
![Kapture 2020-11-10 at 12 57 06](https://user-images.githubusercontent.com/30407135/98671255-45310e80-2354-11eb-8486-39c70f23d61f.gif)

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/22190


