### PR TITLE
LogsPanel: Don't show scroll bars when not needed

### DIFF
--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -62,7 +62,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
     `,
     logsRowsHorizontalScroll: css`
       label: logs-rows__horizontal-scroll;
-      overflow: scroll;
+      overflow: auto;
     `,
     context: context,
     logsRow: css`


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/25571

With overflow: scroll the scroll bars were always visible which seem weird when there is nothing to scroll especially if you only have the background without actual scroll bars.