### PR TITLE
Logs Panel: Fixes problem dragging scrollbar inside logs panel 

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -117,7 +117,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
 
     // For horizontal scrolling we can't use CustomScrollbar as it causes the problem with logs context - it is not visible
     // for top log rows. Therefore we use CustomScrollbar only in LogsPanel and for Explore, we use custom css styling.
-    const horizontalScrollWindow = wrapLogMessage && !disableCustomHorizontalScroll ? '' : logsRowsHorizontalScroll;
+    const horizontalScrollWindow = wrapLogMessage || disableCustomHorizontalScroll ? '' : logsRowsHorizontalScroll;
 
     // Staged rendering
     const processedRows = dedupedRows ? dedupedRows : [];


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/28723

The scroll bars we use in dashboards come from panel chrome and are custom, in explore though we use native scrollbars. There was a condition to disable the native ones when in dashboards but that seemed to be wrong and in result both native and custom scrollbars interacted weirdly and prevented scrolling in dashboards.