### PR TITLE
StatPanels: Fixes auto min max when latest value is zero

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -98,8 +98,30 @@ describe('Global MinMax', () => {
       });
       const { min, max } = findNumericFieldMinMax([frame]);
 
-      expect(min).toBeNull();
-      expect(max).toBeNull();
+      expect(min).toBe(Number.MIN_VALUE);
+      expect(max).toBe(Number.MAX_VALUE);
+    });
+  });
+
+  describe('when value values are zeo', () => {
+    it('then global min max should be correct', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1, 2] },
+          { name: 'Value', type: FieldType.number, values: [1, 2] },
+        ],
+      });
+      const frame2 = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1, 2] },
+          { name: 'Value', type: FieldType.number, values: [0, 0] },
+        ],
+      });
+
+      const { min, max } = findNumericFieldMinMax([frame, frame2]);
+
+      expect(min).toBe(0);
+      expect(max).toBe(2);
     });
   });
 });

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -58,23 +58,23 @@ export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
         const statsMin = stats[ReducerID.min];
         const statsMax = stats[ReducerID.max];
 
-        if (!statsMin) {
+        if (statsMin !== undefined && statsMin !== null && statsMin < min) {
           min = statsMin;
         }
 
-        if (!statsMax) {
-          max = statsMax;
-        }
-
-        if (statsMin && statsMin < min) {
-          min = statsMin;
-        }
-
-        if (statsMax && statsMax > max) {
+        if (statsMax !== undefined && statsMax !== null && statsMax > max) {
           max = statsMax;
         }
       }
     }
+  }
+
+  if (min === Number.MAX_VALUE) {
+    min = Number.MIN_VALUE;
+  }
+
+  if (max === Number.MIN_VALUE) {
+    max = Number.MAX_VALUE;
   }
 
   return { min, max };


### PR DESCRIPTION
Fixes #28883

This changes to so that min & max are not null when all values are null but number.MIN_VALUE and number.MAX_VALUE respectively. The fix is not dependent on that change however, just made the code more simple and typings more correct