### PR TITLE
Tracing: Add setting for sampling server

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -706,7 +706,7 @@ sampler_type = const
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
 sampler_param = 1
-# sampling_server_url is the URL of a sampling manager providing a sampling strategy to this service.
+# sampling_server_url is the URL of a sampling manager providing a sampling strategy.
 sampling_server_url =
 # Whether or not to use Zipkin span propagation (x-b3- HTTP headers).
 zipkin_propagation = false

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -706,7 +706,7 @@ sampler_type = const
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
 sampler_param = 1
-# sampling_server_url is the URL of sampling manager that can provide sampling strategy to this service.
+# sampling_server_url is the URL of a sampling manager providing a sampling strategy to this service.
 sampling_server_url =
 # Whether or not to use Zipkin span propagation (x-b3- HTTP headers).
 zipkin_propagation = false

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -706,6 +706,8 @@ sampler_type = const
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
 sampler_param = 1
+# sampling_server_url is the URL of sampling manager that can provide sampling strategy to this service.
+sampling_server_url =
 # Whether or not to use Zipkin span propagation (x-b3- HTTP headers).
 zipkin_propagation = false
 # Setting this to true disables shared RPC spans.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -698,7 +698,7 @@
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
 ;sampler_param = 1
-# sampling_server_url is the URL of a sampling manager providing a sampling strategy to this service.
+# sampling_server_url is the URL of a sampling manager providing a sampling strategy.
 ;sampling_server_url =
 # Whether or not to use Zipkin propagation (x-b3- HTTP headers).
 ;zipkin_propagation = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -698,7 +698,7 @@
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
 ;sampler_param = 1
-# sampling_server_url is the URL of sampling manager that can provide sampling strategy to this service.
+# sampling_server_url is the URL of a sampling manager providing a sampling strategy to this service.
 ;sampling_server_url =
 # Whether or not to use Zipkin propagation (x-b3- HTTP headers).
 ;zipkin_propagation = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -698,6 +698,8 @@
 # and indicates the initial sampling rate before the actual one
 # is received from the mothership
 ;sampler_param = 1
+# sampling_server_url is the URL of sampling manager that can provide sampling strategy to this service.
+;sampling_server_url =
 # Whether or not to use Zipkin propagation (x-b3- HTTP headers).
 ;zipkin_propagation = false
 # Setting this to true disables shared RPC spans.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1156,7 +1156,7 @@ May be set with the environment variable `JAEGER_SAMPLER_PARAM`.
 
 ### sampling_server_url
 
-sampling_server_url is the URL of sampling manager that can provide sampling strategy to this service.
+sampling_server_url is the URL of a sampling manager that providing a sampling strategy to this service.
 
 ### zipkin_propagation
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1156,7 +1156,7 @@ May be set with the environment variable `JAEGER_SAMPLER_PARAM`.
 
 ### sampling_server_url
 
-sampling_server_url is the URL of a sampling manager that providing a sampling strategy to this service.
+sampling_server_url is the URL of a sampling manager that providing a sampling strategy.
 
 ### zipkin_propagation
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1156,7 +1156,7 @@ May be set with the environment variable `JAEGER_SAMPLER_PARAM`.
 
 ### sampling_server_url
 
-sampling_server_url is the URL of a sampling manager that providing a sampling strategy.
+sampling_server_url is the URL of a sampling manager providing a sampling strategy.
 
 ### zipkin_propagation
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1154,6 +1154,10 @@ This is the sampler configuration parameter. Depending on the value of `sampler_
 
 May be set with the environment variable `JAEGER_SAMPLER_PARAM`.
 
+### sampling_server_url
+
+sampling_server_url is the URL of sampling manager that can provide sampling strategy to this service.
+
 ### zipkin_propagation
 
 Default value is `false`.

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -25,6 +25,7 @@ type TracingService struct {
 	customTags               map[string]string
 	samplerType              string
 	samplerParam             float64
+	samplingServerURL        string
 	log                      log.Logger
 	closer                   io.Closer
 	zipkinPropagation        bool
@@ -60,6 +61,7 @@ func (ts *TracingService) parseSettings() {
 	ts.samplerParam = section.Key("sampler_param").MustFloat64(1)
 	ts.zipkinPropagation = section.Key("zipkin_propagation").MustBool(false)
 	ts.disableSharedZipkinSpans = section.Key("disable_shared_zipkin_spans").MustBool(false)
+	ts.samplingServerURL = section.Key("sampling_server_url").MustString("")
 }
 
 func (ts *TracingService) initJaegerCfg() (jaegercfg.Configuration, error) {
@@ -67,8 +69,9 @@ func (ts *TracingService) initJaegerCfg() (jaegercfg.Configuration, error) {
 		ServiceName: "grafana",
 		Disabled:    !ts.enabled,
 		Sampler: &jaegercfg.SamplerConfig{
-			Type:  ts.samplerType,
-			Param: ts.samplerParam,
+			Type:              ts.samplerType,
+			Param:             ts.samplerParam,
+			SamplingServerURL: ts.samplingServerURL,
 		},
 		Reporter: &jaegercfg.ReporterConfig{
 			LogSpans:           false,


### PR DESCRIPTION
We use a sampling service internally and I would like to configure it using grafana.ini rather than env vars. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>

