### PR TITLE
Docs: Fix prometheus docs related to query variables

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -86,11 +86,11 @@ provides the following functions you can use in the `Query` input field.
 
 | Name                             | Description                                                             |
 | -------------------------------- | ----------------------------------------------------------------------- |
-| `label_\__names()`               | Returns a list of label names.                                          |
-| `label_\__values(label)`         | Returns a list of label values for the `label` in every metric.         |
-| `label_\__values(metric, label)` | Returns a list of label values for the `label` in the specified metric. |
-| `metrics(metric)`                | Returns a list of metrics matching the specified `metric` regex.        |
-| `query_\__result(query)`         | Returns a list of Prometheus query result for the `query`.              |
+| `label_names()`                  | Returns a list of label names.                                          |
+| `label_values(label)`            | Returns a list of label values for the `label` in every metric.         |
+| `label_values(metric, label)`    | Returns a list of label values for the `label` in the specified metric.  |
+| `metrics(metric)`                | Returns a list of metrics matching the specified `metric` regex.         |
+| `query_result(query)`            | Returns a list of Prometheus query result for the `query`.              |
 
 For details of what _metric names_, _label names_ and _label values_ are please refer to the [Prometheus documentation](http://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).
 


### PR DESCRIPTION
**What this PR does / why we need it**:
These are not correct - https://grafana.com/docs/grafana/latest/datasources/prometheus/#query-variable
![image](https://user-images.githubusercontent.com/30407135/98814304-c60c0b00-2425-11eb-95ed-c1d0a624e293.png)


Should be:
`label_names()`
`label_values(label)`
`label_values(metric, label)`
`metrics(metric)`
`query_result(query)`  

