### PR TITLE
Test Datasource/Bug: Fixes division by zero in csv metric values scenario

### DIFF
--- a/pkg/tsdb/testdatasource/scenarios.go
+++ b/pkg/tsdb/testdatasource/scenarios.go
@@ -237,7 +237,10 @@ func init() {
 			series := newSeriesForQuery(query, 0)
 			startTime := context.TimeRange.GetFromAsMsEpoch()
 			endTime := context.TimeRange.GetToAsMsEpoch()
-			step := (endTime - startTime) / int64(len(values)-1)
+			var step int64 = 0
+			if len(values) > 1 {
+				step = (endTime - startTime) / int64(len(values)-1)
+			}
 
 			for _, val := range values {
 				series.Points = append(series.Points, tsdb.TimePoint{val, null.FloatFrom(float64(startTime))})


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents a division by zero error when the list of csv metric values contains only one value.

**Which issue(s) this PR fixes**:
Closes #8705
