### PR TITLE
annotations: fetch all grafana annotations when no tags or dashboard ID is specified

### DIFF
--- a/public/app/plugins/datasource/grafana/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana/datasource.test.ts
@@ -71,7 +71,52 @@ describe('grafana data source', () => {
         return ds.annotationQuery(options);
       });
 
+      it('should query by dashboard ID', () => {
+        expect(calledBackendSrvParams.dashboardId).toBe(1);
+      });
       it('should remove tags from query options', () => {
+        expect(calledBackendSrvParams.tags).toBe(undefined);
+      });
+    });
+
+    describe('with type tags and tags', () => {
+      const options = setupAnnotationQueryOptions(
+        {
+          type: GrafanaAnnotationType.Tags,
+          tags: ['tag1', 'tag2'],
+        },
+        { id: 1 }
+      );
+
+      beforeEach(() => {
+        return ds.annotationQuery(options);
+      });
+
+      it('should not set dashboard ID in query options', () => {
+        expect(calledBackendSrvParams.dashboardId).toBe(undefined);
+      });
+      it('should set tags in query options', () => {
+        expect(calledBackendSrvParams.tags).toStrictEqual(['tag1', 'tag2']);
+      });
+    });
+
+    describe('with type tags and no tags', () => {
+      const options = setupAnnotationQueryOptions(
+        {
+          type: GrafanaAnnotationType.Tags,
+          tags: [],
+        },
+        { id: 1 }
+      );
+
+      beforeEach(() => {
+        return ds.annotationQuery(options);
+      });
+
+      it('should not set dashboard ID in query options', () => {
+        expect(calledBackendSrvParams.dashboardId).toBe(undefined);
+      });
+      it('should set not tags in query options', () => {
         expect(calledBackendSrvParams.tags).toBe(undefined);
       });
     });

--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -81,11 +81,7 @@ export class GrafanaDatasource extends DataSourceApi<GrafanaQuery> {
       params.dashboardId = options.dashboard.id;
       // remove tags filter if any
       delete params.tags;
-    } else {
-      // require at least one tag
-      if (!Array.isArray(annotation.tags) || annotation.tags.length === 0) {
-        return Promise.resolve([]);
-      }
+    } else if (Array.isArray(annotation.tags) && annotation.tags.length > 0) {
       const delimiter = '__delimiter__';
       const tags = [];
       for (const t of params.tags) {
@@ -101,6 +97,9 @@ export class GrafanaDatasource extends DataSourceApi<GrafanaQuery> {
         }
       }
       params.tags = tags;
+    } else {
+      // If neither tags nor dashboard are specified, fetch all annotations.
+      delete params.tags;
     }
 
     return getBackendSrv().get(


### PR DESCRIPTION
**What this PR does / why we need it**:

There's currently no way to have a dashboard/panel display all Grafana-stored annotations -- you can either show them just on the panel where they were created, or by tag. This changes the behavior of the Tags type with no tags specified: it now fetches all annotations, instead of none. This enables showing all annotations, instead of an otherwise unuseful behavior. 

**Special notes for your reviewer**:

I ran the go and jest tests and they pass.