### PR TITLE
Graph: Fixes stacking issues like floating bars when data is not aligned 

### DIFF
--- a/public/app/plugins/panel/graph/graph_tooltip.ts
+++ b/public/app/plugins/panel/graph/graph_tooltip.ts
@@ -102,17 +102,11 @@ export default function GraphTooltip(this: any, elem: any, dashboard: any, scope
         minTime = pointTime;
       }
 
-      if (series.stack) {
-        if (panel.tooltip.value_type === 'individual') {
-          value = series.data[hoverIndex][1];
-        } else if (!series.stack) {
-          value = series.data[hoverIndex][1];
-        } else {
-          lastValue += series.data[hoverIndex][1];
-          value = lastValue;
-        }
-      } else {
-        value = series.data[hoverIndex][1];
+      value = series.data[hoverIndex][1];
+
+      if (series.stack && value !== null && panel.tooltip.value_type !== 'individual') {
+        lastValue += value;
+        value = lastValue;
       }
 
       // Highlighting multiple Points depending on the plot type

--- a/public/vendor/flot/jquery.flot.stack.js
+++ b/public/vendor/flot/jquery.flot.stack.js
@@ -134,7 +134,7 @@ charts or filled areas).
                         // we got past point below, might need to
                         // insert interpolated extra point
                         if (i > 0 && points[i - ps] != null) {
-                            intery = py + (points[i - ps + accumulateOffset] - py) * (qx - px) / (points[i - ps + keyOffset] - px);
+                            intery = 0;
                             newpoints.push(qx);
                             newpoints.push(intery + qy);
                             for (m = 2; m < ps; ++m)
@@ -151,7 +151,7 @@ charts or filled areas).
                         // we might be able to interpolate a point below,
                         // this can give us a better y
                         if (j > 0 && otherpoints[j - otherps] != null)
-                            bottom = qy + (otherpoints[j - otherps + accumulateOffset] - qy) * (px - qx) / (otherpoints[j - otherps + keyOffset] - qx);
+                            bottom = 0;
 
                         newpoints[l + accumulateOffset] += bottom;
 


### PR DESCRIPTION
Fixes #27033
Fixes #9294

Many are encountering strange stacking issues for years. This removes the interpolation logic that existed for data points that does not align (or missing).

Before:
![Screenshot from 2020-11-12 09-21-50](https://user-images.githubusercontent.com/10999/98914110-8e09d400-24c8-11eb-853b-26e004326dd8.png)

After:
![Screenshot from 2020-11-12 09-21-17](https://user-images.githubusercontent.com/10999/98914128-9104c480-24c8-11eb-8081-b2bb177ddf5d.png)

Might be some scenarios that now get worse when data points are close but not perfectly aligned, they will now not stack together 