### PR TITLE
Auth: Enable more complete credential chain for SigV4 default SDK auth option

### DIFF
--- a/pkg/models/sigv4.go
+++ b/pkg/models/sigv4.go
@@ -107,6 +107,11 @@ func (m *SigV4Middleware) signer() (*v4.Signer, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if m.Config.AssumeRoleARN != "" {
+			return v4.NewSigner(stscreds.NewCredentials(s, m.Config.AssumeRoleARN)), nil
+		}
+
 		return v4.NewSigner(s.Config.Credentials), nil
 	}
 

--- a/pkg/models/sigv4.go
+++ b/pkg/models/sigv4.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
@@ -90,9 +89,28 @@ func (m *SigV4Middleware) signRequest(req *http.Request) (http.Header, error) {
 }
 
 func (m *SigV4Middleware) signer() (*v4.Signer, error) {
-	c, err := m.credentials()
-	if err != nil {
-		return nil, err
+	authType := AuthType(m.Config.AuthType)
+
+	var c *credentials.Credentials
+	switch authType {
+	case Default:
+		c = nil
+	case Keys:
+		c = credentials.NewStaticCredentials(m.Config.AccessKey, m.Config.SecretKey, "")
+	case Credentials:
+		c = credentials.NewSharedCredentials("", m.Config.Profile)
+	}
+
+	// passing nil credentials will force AWS to allow more complete credential chain vs the explicit default
+	if c == nil {
+		s, err := session.NewSession(&aws.Config{
+			Region:      aws.String(m.Config.Region),
+			Credentials: nil},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return v4.NewSigner(s.Config.Credentials), nil
 	}
 
 	if m.Config.AssumeRoleARN != "" {
@@ -107,21 +125,6 @@ func (m *SigV4Middleware) signer() (*v4.Signer, error) {
 	}
 
 	return v4.NewSigner(c), nil
-}
-
-func (m *SigV4Middleware) credentials() (*credentials.Credentials, error) {
-	authType := AuthType(m.Config.AuthType)
-
-	switch authType {
-	case Default:
-		return defaults.CredChain(defaults.Config(), defaults.Handlers()), nil
-	case Keys:
-		return credentials.NewStaticCredentials(m.Config.AccessKey, m.Config.SecretKey, ""), nil
-	case Credentials:
-		return credentials.NewSharedCredentials("", m.Config.Profile), nil
-	}
-
-	return nil, fmt.Errorf("unrecognized authType: %s", authType)
 }
 
 func replaceBody(req *http.Request) ([]byte, error) {

--- a/pkg/models/sigv4.go
+++ b/pkg/models/sigv4.go
@@ -93,20 +93,17 @@ func (m *SigV4Middleware) signer() (*v4.Signer, error) {
 
 	var c *credentials.Credentials
 	switch authType {
-	case Default:
-		c = nil
 	case Keys:
 		c = credentials.NewStaticCredentials(m.Config.AccessKey, m.Config.SecretKey, "")
 	case Credentials:
 		c = credentials.NewSharedCredentials("", m.Config.Profile)
 	}
 
-	// passing nil credentials will force AWS to allow more complete credential chain vs the explicit default
+	// passing nil credentials will force AWS to allow a more complete credential chain vs the explicit default
 	if c == nil {
 		s, err := session.NewSession(&aws.Config{
-			Region:      aws.String(m.Config.Region),
-			Credentials: nil},
-		)
+			Region: aws.String(m.Config.Region),
+		})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #28931


**Special notes:** 
`defaults.CredChain` doesn't include the IAM roles for Service Accounts credential provider but the default cred chain in `session.NewSession()` does. See here: https://github.com/aws/aws-sdk-go/blob/d6d63adc1c143626733f1ab3d575b6f777357d04/aws/session/credentials.go#L18