### PR TITLE
StatPanel: Fixes hanging issue when all values are zero

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -88,6 +88,17 @@ describe('Global MinMax', () => {
     expect(minmax.max).toEqual(1234);
   });
 
+  it('find global min max when all values are zero', () => {
+    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
+      { title: 'AAA', value: 0, value2: 0 },
+      { title: 'CCC', value: 0, value2: 0 },
+    ]);
+
+    const minmax = findNumericFieldMinMax([f0]);
+    expect(minmax.min).toEqual(0);
+    expect(minmax.max).toEqual(0);
+  });
+
   describe('when value is null', () => {
     it('then global min max should be null', () => {
       const frame = toDataFrame({
@@ -98,8 +109,8 @@ describe('Global MinMax', () => {
       });
       const { min, max } = findNumericFieldMinMax([frame]);
 
-      expect(min).toBe(Number.MIN_VALUE);
-      expect(max).toBe(Number.MAX_VALUE);
+      expect(min).toBe(null);
+      expect(max).toBe(null);
     });
   });
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -41,13 +41,13 @@ interface OverrideProps {
 }
 
 interface GlobalMinMax {
-  min: number;
-  max: number;
+  min?: number | null;
+  max?: number | null;
 }
 
 export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
-  let min = Number.MAX_VALUE;
-  let max = Number.MIN_VALUE;
+  let min: number | null | undefined = null;
+  let max: number | null | undefined = null;
 
   const reducers = [ReducerID.min, ReducerID.max];
 
@@ -58,23 +58,15 @@ export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
         const statsMin = stats[ReducerID.min];
         const statsMax = stats[ReducerID.max];
 
-        if (statsMin !== undefined && statsMin !== null && statsMin < min) {
+        if (min === null || statsMin < min) {
           min = statsMin;
         }
 
-        if (statsMax !== undefined && statsMax !== null && statsMax > max) {
+        if (max === null || statsMax > max) {
           max = statsMax;
         }
       }
     }
-  }
-
-  if (min === Number.MAX_VALUE) {
-    min = Number.MIN_VALUE;
-  }
-
-  if (max === Number.MIN_VALUE) {
-    max = Number.MAX_VALUE;
   }
 
   return { min, max };

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -46,8 +46,8 @@ interface GlobalMinMax {
 }
 
 export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
-  let min: number | null | undefined = null;
-  let max: number | null | undefined = null;
+  let min: number | null = null;
+  let max: number | null = null;
 
   const reducers = [ReducerID.min, ReducerID.max];
 


### PR DESCRIPTION
Fixes #29073

Apperently Number.MIN_VALUE is not what I thought. Stupid rookie mistake :(

This PR https://github.com/grafana/grafana/pull/28982/ that fixed min max calculations when one series had zero made it so that max became Number.MIN_VALUE when all values are zero as zero is actually smaller than Number.MIN_VALUE. This max value made bizcharts change the browser.

This changes the logic so min & max remain null if all values are null. 