### PR TITLE
Elasticseach: Add support for histogram fields

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -618,6 +618,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
           text: 'string',
           scaled_float: 'number',
           nested: 'nested',
+          histogram: 'number',
         };
 
         const shouldAddField = (obj: any, key: string) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR closes #29078 by adding the `histogram` type to the list of fields identified as `number` fields. This will allow users to visualize the `histogram` fields with Grafana and should not impact distributions without support.

![image](https://user-images.githubusercontent.com/41702/98989133-e69b9a00-24e5-11eb-8b67-27d8aebfe766.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #29078

**Special notes for your reviewer**:

