### PR TITLE
Plugin proxy: Handle URL parsing errors

### DIFF
--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -57,7 +57,12 @@ func AppPluginRoute(route *plugins.AppPluginRoute, appID string, hs *HTTPServer)
 	return func(c *models.ReqContext) {
 		path := c.Params("*")
 
-		proxy := pluginproxy.NewApiPluginProxy(c, path, route, appID, hs.Cfg)
+		proxy, err := pluginproxy.NewApiPluginProxy(c, path, route, appID, hs.Cfg)
+		if err != nil {
+			c.JsonApiErr(500, "Failed to create API plugin proxy", err)
+			return
+		}
+
 		proxy.Transport = pluginProxyTransport
 		proxy.ServeHTTP(c.Resp, c.Req.Request)
 	}

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -56,8 +56,12 @@ func updateURL(route *plugins.AppPluginRoute, orgId int64, appID string) (string
 }
 
 // NewApiPluginProxy create a plugin proxy
-func NewApiPluginProxy(ctx *models.ReqContext, proxyPath string, route *plugins.AppPluginRoute, appID string, cfg *setting.Cfg) *httputil.ReverseProxy {
-	targetURL, _ := url.Parse(route.URL)
+func NewApiPluginProxy(ctx *models.ReqContext, proxyPath string, route *plugins.AppPluginRoute, appID string,
+	cfg *setting.Cfg) (*httputil.ReverseProxy, error) {
+	targetURL, err := url.Parse(route.URL)
+	if err != nil {
+		return nil, err
+	}
 
 	director := func(req *http.Request) {
 		req.URL.Scheme = targetURL.Scheme
@@ -115,5 +119,5 @@ func NewApiPluginProxy(ctx *models.ReqContext, proxyPath string, route *plugins.
 		// log.Tracef("Proxying plugin request: %s", string(reqBytes))
 	}
 
-	return &httputil.ReverseProxy{Director: director}
+	return &httputil.ReverseProxy{Director: director}, nil
 }

--- a/pkg/api/pluginproxy/pluginproxy_test.go
+++ b/pkg/api/pluginproxy/pluginproxy_test.go
@@ -140,7 +140,8 @@ func getPluginProxiedRequest(ctx *models.ReqContext, cfg *setting.Cfg, route *pl
 			ReqRole: models.ROLE_EDITOR,
 		}
 	}
-	proxy := NewApiPluginProxy(ctx, "", route, "", cfg)
+	proxy, err := NewApiPluginProxy(ctx, "", route, "", cfg)
+	So(err, ShouldBeNil)
 
 	req, err := http.NewRequest(http.MethodGet, route.URL, nil)
 	So(err, ShouldBeNil)


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement URL parsing error handling in plugin proxy.