### PR TITLE
Logging: respect fronted-logging.enabled flag

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -206,13 +206,15 @@ export class GrafanaApp {
     });
 
     registerEchoBackend(new PerformanceBackend({}));
-    registerEchoBackend(
-      new SentryEchoBackend({
-        ...config.sentry,
-        user: config.bootData.user,
-        buildInfo: config.buildInfo,
-      })
-    );
+    if (config.sentry.enabled) {
+      registerEchoBackend(
+        new SentryEchoBackend({
+          ...config.sentry,
+          user: config.bootData.user,
+          buildInfo: config.buildInfo,
+        })
+      );
+    }
 
     window.addEventListener('DOMContentLoaded', () => {
       reportPerformance('dcl', Math.round(performance.now()));


### PR DESCRIPTION
**What this PR does / why we need it**:

Respect `sentry.enabled` flag and do not initialize `SentryEchoBackend` if it is not set.
Seems this got lost during refactoring of PR introducing Sentry :( 
