### PR TITLE
Chore: Require OrgId to be specified in delete playlist command

### DIFF
--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -108,7 +108,7 @@ func GetPlaylist(query *models.GetPlaylistByIdQuery) error {
 }
 
 func DeletePlaylist(cmd *models.DeletePlaylistCommand) error {
-	if cmd.Id == 0 {
+	if cmd.Id == 0 || cmd.OrgId == 0 {
 		return models.ErrCommandValidationFailed
 	}
 

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -3,6 +3,7 @@
 package sqlstore
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -32,9 +33,36 @@ func TestPlaylistDataAccess(t *testing.T) {
 		})
 
 		t.Run("Can remove playlist", func(t *testing.T) {
-			query := models.DeletePlaylistCommand{Id: 1}
-			err = DeletePlaylist(&query)
+			deleteQuery := models.DeletePlaylistCommand{Id: 1, OrgId: 1}
+			err = DeletePlaylist(&deleteQuery)
 			require.NoError(t, err)
+
+			getQuery := models.GetPlaylistByIdQuery{Id: 1}
+			err = GetPlaylist(&getQuery)
+			require.NoError(t, err)
+			require.Equal(t, int64(0), getQuery.Result.Id, "playlist should've been removed")
 		})
+	})
+
+	t.Run("Delete playlist that doesn't exist", func(t *testing.T) {
+		deleteQuery := models.DeletePlaylistCommand{Id: 1, OrgId: 1}
+		err := DeletePlaylist(&deleteQuery)
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete playlist with invalid command yields error", func(t *testing.T) {
+		testCases := []struct {
+			desc string
+			cmd  models.DeletePlaylistCommand
+		}{
+			{desc: "none", cmd: models.DeletePlaylistCommand{}},
+			{desc: "no OrgId", cmd: models.DeletePlaylistCommand{Id: 1}},
+			{desc: "no Id", cmd: models.DeletePlaylistCommand{OrgId: 1}},
+		}
+
+		for _, tc := range testCases {
+			err := DeletePlaylist(&tc.cmd)
+			require.EqualError(t, err, models.ErrCommandValidationFailed.Error(), fmt.Sprintf("expected command validation error for %q", tc.desc))
+		}
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Require `OrgId` to be specified in delete playlist command to ensure that the interface for deleting playlists reflects implementation.

**Special notes for your reviewer**:

A follow-up to https://github.com/grafana/grafana/pull/28918, where I noticed that the "Can remove playlist" subtest didn't specify `OrgId`. If `OrgId` isn't specified, then the playlist isn't deleted per https://github.com/grafana/grafana/blob/fbf0d2c0869bb40acbdc3175f287d4c92f3e095a/pkg/services/sqlstore/playlist.go#L116-L117

Require `OrgId` to be specified and add associated tests for it.
Update the "Can remove playlist" subtest to check that the playlist was deleted.

Also add a test for deleting a playlist that doesn't exist while here.