### PR TITLE
Drone: Fix Drone config verification for enterprise on Windows

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1342,7 +1342,6 @@ steps:
   commands:
   - $$ProgressPreference = "SilentlyContinue"
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
-  - .\grabpl.exe verify-drone
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout ${DRONE_TAG}
@@ -1359,6 +1358,7 @@ steps:
   - rm -force grabpl.exe
   - C:\App\grabpl.exe init-enterprise C:\App\grafana-enterprise
   - cp C:\App\grabpl.exe grabpl.exe
+  - .\grabpl.exe verify-drone
   depends_on:
   - clone
 
@@ -2105,7 +2105,6 @@ steps:
   commands:
   - $$ProgressPreference = "SilentlyContinue"
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
-  - .\grabpl.exe verify-drone
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout master
@@ -2122,6 +2121,7 @@ steps:
   - rm -force grabpl.exe
   - C:\App\grabpl.exe init-enterprise C:\App\grafana-enterprise
   - cp C:\App\grabpl.exe grabpl.exe
+  - .\grabpl.exe verify-drone
   depends_on:
   - clone
 
@@ -2812,7 +2812,6 @@ steps:
   commands:
   - $$ProgressPreference = "SilentlyContinue"
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
-  - .\grabpl.exe verify-drone
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout $$env:DRONE_BRANCH
@@ -2829,6 +2828,7 @@ steps:
   - rm -force grabpl.exe
   - C:\App\grabpl.exe init-enterprise C:\App\grafana-enterprise
   - cp C:\App\grabpl.exe grabpl.exe
+  - .\grabpl.exe verify-drone
   depends_on:
   - clone
 

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -930,7 +930,6 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
             'Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/windows/grabpl.exe -OutFile grabpl.exe'.format(grabpl_version),
         ]
         clone_cmds = [
-            '.\\grabpl.exe verify-drone',
             'git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"',
         ]
         if not is_downstream:
@@ -959,6 +958,7 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
             'rm -force grabpl.exe',
             'C:\\App\\grabpl.exe init-enterprise C:\\App\\grafana-enterprise{}'.format(source_commit),
             'cp C:\\App\\grabpl.exe grabpl.exe',
+            '.\\grabpl.exe verify-drone',
         ])
 
     return steps


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Drone configuration verification for enterprise builds on Windows, by moving the call to `.\grabpl.exe verify-drone` until after the repo is initialized.