### PR TITLE
Provisioning: Build paths in an os independent way

### DIFF
--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -2,7 +2,7 @@ package provisioning
 
 import (
 	"context"
-	"path"
+	"path/filepath"
 	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -115,25 +115,25 @@ func (ps *provisioningServiceImpl) Run(ctx context.Context) error {
 }
 
 func (ps *provisioningServiceImpl) ProvisionDatasources() error {
-	datasourcePath := path.Join(ps.Cfg.ProvisioningPath, "datasources")
+	datasourcePath := filepath.Join(ps.Cfg.ProvisioningPath, "datasources")
 	err := ps.provisionDatasources(datasourcePath)
 	return errutil.Wrap("Datasource provisioning error", err)
 }
 
 func (ps *provisioningServiceImpl) ProvisionPlugins() error {
-	appPath := path.Join(ps.Cfg.ProvisioningPath, "plugins")
+	appPath := filepath.Join(ps.Cfg.ProvisioningPath, "plugins")
 	err := ps.provisionPlugins(appPath)
 	return errutil.Wrap("app provisioning error", err)
 }
 
 func (ps *provisioningServiceImpl) ProvisionNotifications() error {
-	alertNotificationsPath := path.Join(ps.Cfg.ProvisioningPath, "notifiers")
+	alertNotificationsPath := filepath.Join(ps.Cfg.ProvisioningPath, "notifiers")
 	err := ps.provisionNotifiers(alertNotificationsPath)
 	return errutil.Wrap("Alert notification provisioning error", err)
 }
 
 func (ps *provisioningServiceImpl) ProvisionDashboards() error {
-	dashboardPath := path.Join(ps.Cfg.ProvisioningPath, "dashboards")
+	dashboardPath := filepath.Join(ps.Cfg.ProvisioningPath, "dashboards")
 	dashProvisioner, err := ps.newDashboardProvisioner(dashboardPath)
 	if err != nil {
 		return errutil.Wrap("Failed to create provisioner", err)


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR builds provisioning paths in an os independent way.   It is required to use provisioning on windows OS.

The patch implements filepath instead of path to manipulate filename paths in a way compatible with the target operating system-defined file paths.

**Which issue(s) this PR fixes**:
Fixes #29137

**Special notes for your reviewer**:
None.
