### PR TITLE
[v7.3.x]: Backport Snapshots: Fixes so that dashboard snapshots show data when using Stat, Gauge, BarGauge or Table panels 

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -9,7 +9,6 @@ import { ErrorBoundary } from '@grafana/ui';
 import { getTimeSrv, TimeSrv } from '../services/TimeSrv';
 import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { profiler } from 'app/core/profiler';
-import { getProcessedDataFrames } from '../state/runRequest';
 import config from 'app/core/config';
 import { updateLocation } from 'app/core/actions';
 // Types
@@ -28,6 +27,7 @@ import {
   PanelPluginMeta,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { loadSnapshotData } from '../utils/loadSnapshotData';
 
 const DEFAULT_PLUGIN_ERROR = 'Error in plugin';
 
@@ -81,11 +81,7 @@ export class PanelChrome extends PureComponent<Props, State> {
     // Move snapshot data into the query response
     if (this.hasPanelSnapshot) {
       this.setState({
-        data: {
-          ...this.state.data,
-          state: LoadingState.Done,
-          series: getProcessedDataFrames(panel.snapshotData),
-        },
+        data: loadSnapshotData(panel, dashboard),
         isFirstLoad: false,
       });
       return;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -10,7 +10,6 @@ import {
   DataConfigSource,
   DataLink,
   DataQuery,
-  DataQueryResponseData,
   DataTransformerConfig,
   eventFactory,
   FieldConfigSource,
@@ -19,6 +18,7 @@ import {
   ScopedVars,
   ThresholdsConfig,
   ThresholdsMode,
+  DataFrameDTO,
 } from '@grafana/data';
 import { EDIT_PANEL_ID } from 'app/core/constants';
 import config from 'app/core/config';
@@ -124,7 +124,7 @@ export class PanelModel implements DataConfigSource {
   thresholds?: any;
   pluginVersion?: string;
 
-  snapshotData?: DataQueryResponseData[];
+  snapshotData?: DataFrameDTO[];
   timeFrom?: any;
   timeShift?: any;
   hideTimeOverride?: any;

--- a/public/app/features/dashboard/utils/loadSnapshotData.ts
+++ b/public/app/features/dashboard/utils/loadSnapshotData.ts
@@ -1,0 +1,27 @@
+import { applyFieldOverrides, DefaultTimeRange, LoadingState, PanelData } from '@grafana/data';
+import { config } from 'app/core/config';
+import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
+import { DashboardModel, PanelModel } from '../state';
+import { getProcessedDataFrames } from '../state/runRequest';
+
+export function loadSnapshotData(panel: PanelModel, dashboard: DashboardModel): PanelData {
+  const data = getProcessedDataFrames(panel.snapshotData);
+
+  return {
+    timeRange: DefaultTimeRange,
+    state: LoadingState.Done,
+    series: applyFieldOverrides({
+      data,
+      fieldConfig: {
+        defaults: {},
+        overrides: [],
+      },
+      autoMinMax: true,
+      replaceVariables: panel.replaceVariables,
+      getDataSourceSettingsByUid: getDatasourceSrv().getDataSourceSettingsByUid.bind(getDatasourceSrv()),
+      fieldConfigRegistry: panel.plugin!.fieldConfigRegistry,
+      theme: config.theme,
+      timeZone: dashboard.getTimezone(),
+    }),
+  };
+}


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/29031