### PR TITLE
Drone: Upgrade build pipeline tool and build image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,10 +14,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -28,7 +28,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -42,7 +42,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -50,7 +50,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -65,7 +65,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -75,7 +75,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -84,7 +84,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
   depends_on:
@@ -93,7 +93,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -101,7 +101,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
@@ -109,7 +109,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
   depends_on:
@@ -122,7 +122,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -140,7 +140,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -150,7 +150,7 @@ steps:
   - package
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
@@ -167,7 +167,7 @@ steps:
   - build-frontend-docs
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -183,7 +183,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -200,7 +200,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -251,10 +251,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -277,7 +277,7 @@ steps:
       from_secret: drone_token
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -291,7 +291,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -299,7 +299,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -314,7 +314,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -324,7 +324,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -333,7 +333,7 @@ steps:
   - initialize
 
 - name: publish-frontend-metrics
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
   environment:
@@ -344,7 +344,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -353,7 +353,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -361,7 +361,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -372,7 +372,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -396,7 +396,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -414,7 +414,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -436,14 +436,14 @@ steps:
   - build-storybook
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -473,7 +473,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -490,7 +490,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -506,7 +506,7 @@ steps:
   - test-frontend
 
 - name: release-next-npm-packages
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./node_modules/.bin/lerna bootstrap
   - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
@@ -580,7 +580,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/windows/grabpl.exe -OutFile grabpl.exe
   - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
@@ -627,10 +627,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   environment:
@@ -703,10 +703,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version ${DRONE_TAG}
@@ -718,7 +718,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -732,7 +732,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -740,7 +740,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -755,7 +755,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -765,7 +765,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -774,7 +774,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -786,7 +786,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise ${DRONE_TAG}
   depends_on:
@@ -794,7 +794,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -805,7 +805,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -829,7 +829,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -847,7 +847,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -857,7 +857,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -887,7 +887,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -904,7 +904,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -941,7 +941,7 @@ steps:
   - postgres-integration-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./node_modules/.bin/lerna bootstrap
   - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
@@ -1005,7 +1005,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/windows/grabpl.exe -OutFile grabpl.exe
   - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
@@ -1053,10 +1053,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -1066,7 +1066,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -1086,7 +1086,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -1100,7 +1100,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1108,7 +1108,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -1123,7 +1123,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -1133,7 +1133,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1142,7 +1142,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -1154,7 +1154,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise ${DRONE_TAG}
   depends_on:
@@ -1162,7 +1162,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -1173,7 +1173,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -1197,7 +1197,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -1215,7 +1215,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -1245,7 +1245,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1262,7 +1262,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1341,7 +1341,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/windows/grabpl.exe -OutFile grabpl.exe
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout ${DRONE_TAG}
@@ -1404,10 +1404,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version ${DRONE_TAG}
@@ -1482,10 +1482,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version v7.3.0-test
@@ -1497,7 +1497,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -1511,7 +1511,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1519,7 +1519,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -1534,7 +1534,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -1544,7 +1544,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1553,7 +1553,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -1565,7 +1565,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise v7.3.0-test
   depends_on:
@@ -1573,7 +1573,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -1584,7 +1584,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -1608,7 +1608,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -1626,7 +1626,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1636,7 +1636,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -1660,7 +1660,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1677,7 +1677,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1714,7 +1714,7 @@ steps:
   - postgres-integration-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./node_modules/.bin/lerna bootstrap
   - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
@@ -1774,7 +1774,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/windows/grabpl.exe -OutFile grabpl.exe
   - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
@@ -1822,10 +1822,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -1835,7 +1835,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -1855,7 +1855,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -1869,7 +1869,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1877,7 +1877,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -1892,7 +1892,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -1902,7 +1902,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1911,7 +1911,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -1923,7 +1923,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise v7.3.0-test
   depends_on:
@@ -1931,7 +1931,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -1942,7 +1942,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -1966,7 +1966,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -1984,7 +1984,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -2008,7 +2008,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2025,7 +2025,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2104,7 +2104,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/windows/grabpl.exe -OutFile grabpl.exe
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout master
@@ -2167,10 +2167,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version v7.3.0-test
@@ -2254,10 +2254,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
@@ -2268,7 +2268,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -2282,7 +2282,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2290,7 +2290,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -2305,7 +2305,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -2315,7 +2315,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2324,7 +2324,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2333,7 +2333,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2341,7 +2341,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -2352,7 +2352,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -2376,7 +2376,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -2394,7 +2394,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -2404,7 +2404,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -2428,7 +2428,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2445,7 +2445,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2500,7 +2500,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/windows/grabpl.exe -OutFile grabpl.exe
   - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
@@ -2544,10 +2544,10 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/grabpl
   - chmod +x bin/grabpl
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -2557,7 +2557,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -2576,7 +2576,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - golangci-lint run --config scripts/go/configs/.golangci.toml ./pkg/...
   - revive -formatter stylish -config scripts/go/configs/revive.toml ./pkg/...
@@ -2590,7 +2590,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2598,7 +2598,7 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - curl -fLO http://storage.googleapis.com/grafana-downloads/ci-dependencies/shellcheck-v$${VERSION}.linux.x86_64.tar.xz
   - echo $$CHKSUM shellcheck-v$${VERSION}.linux.x86_64.tar.xz | sha512sum --check --strict --status
@@ -2613,7 +2613,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -2623,7 +2623,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2632,7 +2632,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2641,7 +2641,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2649,7 +2649,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -2660,7 +2660,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -2684,7 +2684,7 @@ steps:
   - shellcheck
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   detach: true
   commands:
   - ./e2e/start-server
@@ -2702,7 +2702,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -2712,7 +2712,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -2736,7 +2736,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2753,7 +2753,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.2.28
+  image: grafana/build-container:1.2.29
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2811,7 +2811,7 @@ steps:
   image: grafana/ci-wix:0.1.1
   commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.26/windows/grabpl.exe -OutFile grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.27/windows/grabpl.exe -OutFile grabpl.exe
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
   - git checkout $$env:DRONE_BRANCH

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,5 +1,5 @@
-grabpl_version = '0.5.26'
-build_image = 'grafana/build-container:1.2.28'
+grabpl_version = '0.5.27'
+build_image = 'grafana/build-container:1.2.29'
 publish_image = 'grafana/grafana-ci-deploy:1.2.6'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 alpine_image = 'alpine:3.12'


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade to latest build pipeline tool and build Docker image.

This will fix retrying of failed Docker manifest pushes in release builds, and also move uploading of RPMs and Debs in release builds to the publishing stage. Basically release builds will be more robust, and retry-friendly.