### PR TITLE
Drone: Fix publish-packages invocation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -524,14 +524,6 @@ steps:
   environment:
     GCP_GRAFANA_UPLOAD_KEY:
       from_secret: gcp_key
-    GPG_KEY_PASSWORD:
-      from_secret: gpg_key_password
-    GPG_PRIV_KEY:
-      from_secret: gpg_priv_key
-    GPG_PUB_KEY:
-      from_secret: gpg_pub_key
-    GRAFANA_COM_API_KEY:
-      from_secret: grafana_api_key
   depends_on:
   - package
   - end-to-end-tests
@@ -639,8 +631,17 @@ steps:
 - name: publish-packages
   image: grafana/grafana-ci-deploy:1.2.6
   commands:
-  - ./bin/grabpl publish-packages --edition oss --build-id ${DRONE_BUILD_NUMBER}
+  - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
+  - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json --build-id ${DRONE_BUILD_NUMBER}
   environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    GPG_KEY_PASSWORD:
+      from_secret: gpg_key_password
+    GPG_PRIV_KEY:
+      from_secret: gpg_priv_key
+    GPG_PUB_KEY:
+      from_secret: gpg_pub_key
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   depends_on:
@@ -926,14 +927,6 @@ steps:
   environment:
     GCP_GRAFANA_UPLOAD_KEY:
       from_secret: gcp_key
-    GPG_KEY_PASSWORD:
-      from_secret: gpg_key_password
-    GPG_PRIV_KEY:
-      from_secret: gpg_priv_key
-    GPG_PUB_KEY:
-      from_secret: gpg_pub_key
-    GRAFANA_COM_API_KEY:
-      from_secret: grafana_api_key
   depends_on:
   - package
   - end-to-end-tests
@@ -1284,14 +1277,6 @@ steps:
   environment:
     GCP_GRAFANA_UPLOAD_KEY:
       from_secret: gcp_key
-    GPG_KEY_PASSWORD:
-      from_secret: gpg_key_password
-    GPG_PRIV_KEY:
-      from_secret: gpg_priv_key
-    GPG_PUB_KEY:
-      from_secret: gpg_pub_key
-    GRAFANA_COM_API_KEY:
-      from_secret: grafana_api_key
   depends_on:
   - package
   - end-to-end-tests
@@ -1417,9 +1402,18 @@ steps:
 - name: publish-packages
   image: grafana/grafana-ci-deploy:1.2.6
   commands:
-  - ./bin/grabpl publish-packages --edition oss ${DRONE_TAG}
-  - ./bin/grabpl publish-packages --edition enterprise ${DRONE_TAG}
+  - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
+  - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl publish-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    GPG_KEY_PASSWORD:
+      from_secret: gpg_key_password
+    GPG_PRIV_KEY:
+      from_secret: gpg_priv_key
+    GPG_PUB_KEY:
+      from_secret: gpg_pub_key
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   depends_on:
@@ -1699,14 +1693,6 @@ steps:
   environment:
     GCP_GRAFANA_UPLOAD_KEY:
       from_secret: gcp_key
-    GPG_KEY_PASSWORD:
-      from_secret: gpg_key_password
-    GPG_PRIV_KEY:
-      from_secret: gpg_priv_key
-    GPG_PUB_KEY:
-      from_secret: gpg_pub_key
-    GRAFANA_COM_API_KEY:
-      from_secret: grafana_api_key
   depends_on:
   - package
   - end-to-end-tests
@@ -2047,14 +2033,6 @@ steps:
   environment:
     GCP_GRAFANA_UPLOAD_KEY:
       from_secret: gcp_key
-    GPG_KEY_PASSWORD:
-      from_secret: gpg_key_password
-    GPG_PRIV_KEY:
-      from_secret: gpg_priv_key
-    GPG_PUB_KEY:
-      from_secret: gpg_pub_key
-    GRAFANA_COM_API_KEY:
-      from_secret: grafana_api_key
   depends_on:
   - package
   - end-to-end-tests

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -799,18 +799,6 @@ def upload_packages_step(edition, ver_mode, is_downstream=False):
             'GCP_GRAFANA_UPLOAD_KEY': {
                 'from_secret': 'gcp_key',
             },
-            'GRAFANA_COM_API_KEY': {
-                'from_secret': 'grafana_api_key',
-            },
-            'GPG_PRIV_KEY': {
-                'from_secret': 'gpg_priv_key',
-            },
-            'GPG_PUB_KEY': {
-                'from_secret': 'gpg_pub_key',
-            },
-            'GPG_KEY_PASSWORD': {
-                'from_secret': 'gpg_key_password',
-            },
         },
         'commands': [cmd,],
     }
@@ -834,9 +822,24 @@ def publish_packages_step(edition, is_downstream):
             'GRAFANA_COM_API_KEY': {
                 'from_secret': 'grafana_api_key',
             },
+            'GCP_KEY': {
+                'from_secret': 'gcp_key',
+            },
+            'GPG_PRIV_KEY': {
+                'from_secret': 'gpg_priv_key',
+            },
+            'GPG_PUB_KEY': {
+                'from_secret': 'gpg_pub_key',
+            },
+            'GPG_KEY_PASSWORD': {
+                'from_secret': 'gpg_key_password',
+            },
         },
         'commands': [
-            './bin/grabpl publish-packages --edition {} --build-id {}'.format(edition, build_no),
+            'printenv GCP_KEY | base64 -d > /tmp/gcpkey.json',
+            './bin/grabpl publish-packages --edition {} --gcp-key /tmp/gcpkey.json --build-id {}'.format(
+                edition, build_no,
+            ),
         ],
     }
 

--- a/scripts/release.star
+++ b/scripts/release.star
@@ -26,7 +26,6 @@ load(
     'frontend_metrics_step',
     'publish_storybook_step',
     'upload_packages_step',
-    'publish_packages_step',
     'notify_pipeline',
     'integration_test_services',
 )
@@ -143,10 +142,23 @@ def release_pipelines(ver_mode='release', trigger=None):
                         'GRAFANA_COM_API_KEY': {
                             'from_secret': 'grafana_api_key',
                         },
+                        'GCP_KEY': {
+                            'from_secret': 'gcp_key',
+                        },
+                        'GPG_PRIV_KEY': {
+                            'from_secret': 'gpg_priv_key',
+                        },
+                        'GPG_PUB_KEY': {
+                            'from_secret': 'gpg_pub_key',
+                        },
+                        'GPG_KEY_PASSWORD': {
+                            'from_secret': 'gpg_key_password',
+                        },
                     },
                     'commands': [
-                        './bin/grabpl publish-packages --edition oss ${DRONE_TAG}',
-                        './bin/grabpl publish-packages --edition enterprise ${DRONE_TAG}',
+                        'printenv GCP_KEY | base64 -d > /tmp/gcpkey.json',
+                        './bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}',
+                        './bin/grabpl publish-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}',
                     ],
                 },
             ], depends_on=[p['name'] for p in oss_pipelines + enterprise_pipelines], install_deps=False,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix invocation of `grabpl publish-packages` during publishing of master and release artifacts.
