### PR TITLE
Chore: Upgrade grafana/build-ci-deploy image to latest Go (#29171)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -416,7 +416,7 @@ steps:
   - package
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
@@ -510,7 +510,7 @@ steps:
   - end-to-end-tests
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -629,7 +629,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl publish-packages --edition oss --build-id ${DRONE_BUILD_NUMBER}
   environment:
@@ -845,7 +845,7 @@ steps:
   - package
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
@@ -933,7 +933,7 @@ steps:
   - end-to-end-tests
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -1265,7 +1265,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl upload-packages --edition enterprise
   environment:
@@ -1402,7 +1402,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl publish-packages --edition oss ${DRONE_TAG}
   - ./bin/grabpl publish-packages --edition enterprise ${DRONE_TAG}
@@ -1619,7 +1619,7 @@ steps:
   - package
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - echo Testing release
   environment:
@@ -1697,7 +1697,7 @@ steps:
   - end-to-end-tests
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl upload-packages --edition oss --deb-db-bucket grafana-testing-aptly-db --deb-repo-bucket grafana-testing-repo --packages-bucket grafana-downloads-test --rpm-repo-bucket grafana-testing-repo
   environment:
@@ -2023,7 +2023,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl upload-packages --edition enterprise --deb-db-bucket grafana-testing-aptly-db --deb-repo-bucket grafana-testing-repo --packages-bucket grafana-downloads-test --rpm-repo-bucket grafana-testing-repo
   environment:
@@ -2160,7 +2160,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages-oss
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl publish-packages --edition oss --dry-run v7.3.0-test
   environment:
@@ -2170,7 +2170,7 @@ steps:
   - initialize
 
 - name: publish-packages-enterprise
-  image: grafana/grafana-ci-deploy:1.2.6
+  image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - ./bin/grabpl publish-packages --edition enterprise --dry-run v7.3.0-test
   environment:

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -10,10 +10,10 @@ FROM circleci/python:2.7-stretch-node
 
 USER root
 
-ARG GOOGLE_SDK_VERSION=308.0.0
-ARG GOOGLE_SDK_CHECKSUM=9e8e31d9503340fc912374311ac1fffbfc5b59748d20b681f9aca3de2b68deb5
+ARG GOOGLE_SDK_VERSION=319.0.0
+ARG GOOGLE_SDK_CHECKSUM=28048af8fe83a1c80a37258d4e6c00edf22bc93edf570fb9bb6a42cca726d4c5
 
-RUN pip install -U awscli crcmod && \
+RUN apt-get install -yq python3-pip && pip3 install -U awscli crcmod && \
     curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     echo "${GOOGLE_SDK_CHECKSUM} google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
     tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.6"
+_version="1.2.7"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,6 +1,6 @@
 grabpl_version = '0.5.27'
 build_image = 'grafana/build-container:1.2.29'
-publish_image = 'grafana/grafana-ci-deploy:1.2.6'
+publish_image = 'grafana/grafana-ci-deploy:1.2.7'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 alpine_image = 'alpine:3.12'
 windows_image = 'mcr.microsoft.com/windows:1809'


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport #29171.

