### PR TITLE
Explore: Make URL parsing backwards compatible with previous 7.x releases

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -59,6 +59,20 @@ describe('state functions', () => {
       });
     });
 
+    it('should not return a query for mode in the url', () => {
+      // Previous versions of Grafana included "Explore mode" in the URL; this should not be treated as a query.
+      const paramValue =
+        '["now-1h","now","x-ray-datasource",{"queryType":"getTraceSummaries"},{"mode":"Metrics"},{"ui":[true,true,true,"none"]}]';
+      expect(parseUrlState(paramValue)).toMatchObject({
+        datasource: 'x-ray-datasource',
+        queries: [{ queryType: 'getTraceSummaries' }],
+        range: {
+          from: 'now-1h',
+          to: 'now',
+        },
+      });
+    });
+
     it('should return queries if queryType is present in the url', () => {
       const paramValue =
         '["now-1h","now","x-ray-datasource",{"queryType":"getTraceSummaries"},{"ui":[true,true,true,"none"]}]';

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -243,7 +243,7 @@ export function parseUrlState(initial: string | undefined): ExploreUrlState {
   };
   const datasource = parsed[ParseUrlStateIndex.Datasource];
   const parsedSegments = parsed.slice(ParseUrlStateIndex.SegmentsStart);
-  const queries = parsedSegments.filter(segment => !isSegment(segment, 'ui', 'originPanelId'));
+  const queries = parsedSegments.filter(segment => !isSegment(segment, 'ui', 'originPanelId', 'mode'));
 
   const originPanelId = parsedSegments.filter(segment => isSegment(segment, 'originPanelId'))[0];
   return { datasource, queries, range, originPanelId };


### PR DESCRIPTION
**What this PR does / why we need it**: This change makes Explore URL parsing not treat the `mode` query parameter as a query to be instantiated. Previous versions of Grafana 7 used this field to indicate "Explore mode" (logs/metrics), but when these URLs are opened in subsequent versions >=7.1.1 it results in an extra (empty) query being added.

I realize there's no backwards compatibility guarantee for Explore URLs, but since this is a minor change it seems desirable to be backwards compatible where possible across minor version releases.

**Which issue(s) this PR fixes**: #29172

Fixes #29172

**Special notes for your reviewer**: Added a unit test and also verified behavior manually in dev environment

