### PR TITLE
Chore: remove compress:release grunt task

### DIFF
--- a/scripts/grunt/release_task.js
+++ b/scripts/grunt/release_task.js
@@ -4,10 +4,10 @@ module.exports = function(grunt) {
   'use strict';
 
   // build then zip
-  grunt.registerTask('release', ['build', 'build-post-process', 'compress:release']);
+  grunt.registerTask('release', ['build', 'build-post-process']);
 
   // package into archives
-  grunt.registerTask('package', ['clean:temp', 'build-post-process', 'compress:release']);
+  grunt.registerTask('package', ['clean:temp', 'build-post-process']);
 
   grunt.registerTask('build-post-process', function() {
     grunt.config('copy.public_to_temp', {


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/28624 is merged it turned out that `grunt-contrib-compress` was used. This pr removes it's usage.
