### PR TITLE
Chore: Allow reducerTester to work with every data type & payload-less actions

### DIFF
--- a/public/test/core/redux/reducerTester.ts
+++ b/public/test/core/redux/reducerTester.ts
@@ -1,9 +1,10 @@
 import { Reducer } from 'redux';
-import { PayloadAction } from '@reduxjs/toolkit';
+import { PayloadAction, Action } from '@reduxjs/toolkit';
+import { cloneDeep } from 'lodash';
 
 export interface Given<State> {
   givenReducer: (
-    reducer: Reducer<State, PayloadAction<any>>,
+    reducer: Reducer<State, PayloadAction<any> | Action<any>>,
     state: State,
     showDebugOutput?: boolean,
     disableDeepFreeze?: boolean
@@ -11,7 +12,7 @@ export interface Given<State> {
 }
 
 export interface When<State> {
-  whenActionIsDispatched: (action: PayloadAction<any>) => Then<State>;
+  whenActionIsDispatched: (action: PayloadAction<any> | Action<any>) => Then<State>;
 }
 
 export interface Then<State> {
@@ -66,9 +67,9 @@ export const reducerTester = <State>(): Given<State> => {
     disableDeepFreeze = false
   ): When<State> => {
     reducerUnderTest = reducer;
-    initialState = { ...state };
-    if (!disableDeepFreeze) {
-      initialState = deepFreeze(initialState);
+    initialState = cloneDeep(state);
+    if (!disableDeepFreeze && (typeof state === 'object' || typeof state === 'function')) {
+      deepFreeze(initialState);
     }
     showDebugOutput = debug;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

currently `reducerTester` doesn't work with any other data structure than objects and `whenActionIsDispatched` only works with actions containing a payload. This PR allows `reducerTester` to be used on any data structure and `whenActionIsDispatched` to accept payload-less actions.

