### PR TITLE
Add missing color type

### DIFF
--- a/packages/grafana-data/src/types/theme.ts
+++ b/packages/grafana-data/src/types/theme.ts
@@ -136,6 +136,7 @@ export interface GrafanaTheme extends GrafanaThemeCommons {
 
     // New greys palette used by next-gen form elements
     gray98: string;
+    gray97: string;
     gray95: string;
     gray90: string;
     gray85: string;


### PR DESCRIPTION
Noticed that type for [`gray97`](https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/themes/default.ts#L6)  was missing while using within plugin development.

