### PR TITLE
Dashboard: Fixes kiosk state after being redirected to login page and back

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -53,15 +54,11 @@ func notAuthorized(c *models.ReqContext) {
 		redirectTo = setting.AppSubUrl + c.Req.RequestURI
 	}
 
-	// remove forceLogin query param if it exists
-	if parsed, err := url.ParseRequestURI(redirectTo); err == nil {
-		params := parsed.Query()
-		params.Del("forceLogin")
-		parsed.RawQuery = params.Encode()
-		WriteCookie(c.Resp, "redirect_to", url.QueryEscape(parsed.String()), 0, newCookieOptions)
-	} else {
-		c.Logger.Debug("Failed parsing request URI; redirect cookie will not be set", "redirectTo", redirectTo, "error", err)
-	}
+	// remove any forceLogin=true params
+	re := regexp.MustCompile(`&?forceLogin=true`)
+	redirectTo = re.ReplaceAllString(redirectTo, "")
+
+	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, newCookieOptions)
 	c.Redirect(setting.AppSubUrl + "/login")
 }
 

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -55,11 +55,16 @@ func notAuthorized(c *models.ReqContext) {
 	}
 
 	// remove any forceLogin=true params
-	re := regexp.MustCompile(`&?forceLogin=true`)
-	redirectTo = re.ReplaceAllString(redirectTo, "")
+	redirectTo = removeForceLoginParams(redirectTo)
 
 	WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, newCookieOptions)
 	c.Redirect(setting.AppSubUrl + "/login")
+}
+
+var forceLoginParamsRegexp = regexp.MustCompile(`&?forceLogin=true`)
+
+func removeForceLoginParams(str string) string {
+	return forceLoginParamsRegexp.ReplaceAllString(str, "")
 }
 
 func EnsureEditorOrViewerCanEdit(c *models.ReqContext) {

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -103,4 +105,21 @@ func TestMiddlewareAuth(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestRemoveForceLoginparams(t *testing.T) {
+	tcs := []struct {
+		inp string
+		exp string
+	}{
+		{inp: "http://localhost_3000/?forceLogin=true", exp: "http://localhost_3000/?"},
+		{inp: "http://localhost_3000/d/dash/dash-title?ordId=1&forceLogin=true", exp: "http://localhost_3000/d/dash/dash-title?ordId=1"},
+		{inp: "http://localhost_3000/?kiosk&forceLogin=true", exp: "http://localhost_3000/?kiosk"},
+		{inp: "http://localhost_3000/d/dash/dash-title?ordId=1&kiosk&forceLogin=true", exp: "http://localhost_3000/d/dash/dash-title?ordId=1&kiosk"},
+	}
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
+			require.Equal(t, tc.exp, removeForceLoginParams(tc.inp))
+		})
+	}
 }

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -116,6 +116,8 @@ func TestRemoveForceLoginparams(t *testing.T) {
 		{inp: "/d/dash/dash-title?ordId=1&forceLogin=true", exp: "/d/dash/dash-title?ordId=1"},
 		{inp: "/?kiosk&forceLogin=true", exp: "/?kiosk"},
 		{inp: "/d/dash/dash-title?ordId=1&kiosk&forceLogin=true", exp: "/d/dash/dash-title?ordId=1&kiosk"},
+				{inp: "/d/dash/dash-title?ordId=1&forceLogin=true&kiosk", exp: "/d/dash/dash-title?ordId=1&kiosk"},
+		{inp: "/d/dash/dash-title?forceLogin=true&kiosk", exp: "/d/dash/dash-title?&kiosk"},
 	}
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -116,7 +116,7 @@ func TestRemoveForceLoginparams(t *testing.T) {
 		{inp: "/d/dash/dash-title?ordId=1&forceLogin=true", exp: "/d/dash/dash-title?ordId=1"},
 		{inp: "/?kiosk&forceLogin=true", exp: "/?kiosk"},
 		{inp: "/d/dash/dash-title?ordId=1&kiosk&forceLogin=true", exp: "/d/dash/dash-title?ordId=1&kiosk"},
-				{inp: "/d/dash/dash-title?ordId=1&forceLogin=true&kiosk", exp: "/d/dash/dash-title?ordId=1&kiosk"},
+		{inp: "/d/dash/dash-title?ordId=1&forceLogin=true&kiosk", exp: "/d/dash/dash-title?ordId=1&kiosk"},
 		{inp: "/d/dash/dash-title?forceLogin=true&kiosk", exp: "/d/dash/dash-title?&kiosk"},
 	}
 	for i, tc := range tcs {

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -112,10 +112,10 @@ func TestRemoveForceLoginparams(t *testing.T) {
 		inp string
 		exp string
 	}{
-		{inp: "http://localhost_3000/?forceLogin=true", exp: "http://localhost_3000/?"},
-		{inp: "http://localhost_3000/d/dash/dash-title?ordId=1&forceLogin=true", exp: "http://localhost_3000/d/dash/dash-title?ordId=1"},
-		{inp: "http://localhost_3000/?kiosk&forceLogin=true", exp: "http://localhost_3000/?kiosk"},
-		{inp: "http://localhost_3000/d/dash/dash-title?ordId=1&kiosk&forceLogin=true", exp: "http://localhost_3000/d/dash/dash-title?ordId=1&kiosk"},
+		{inp: "/?forceLogin=true", exp: "/?"},
+		{inp: "/d/dash/dash-title?ordId=1&forceLogin=true", exp: "/d/dash/dash-title?ordId=1"},
+		{inp: "/?kiosk&forceLogin=true", exp: "/?kiosk"},
+		{inp: "/d/dash/dash-title?ordId=1&kiosk&forceLogin=true", exp: "/d/dash/dash-title?ordId=1&kiosk"},
 	}
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {


### PR DESCRIPTION
Fixes #26899

This fixes a bug in the golang query Values Encode function where it write "=" even for keys that have no value. A query parameter "&kiosk" is treated as a boolean true in the frontend but "&kiosk=" is treated as an empty string by the frontend.

A big hacky fix but since the bug is in the golang standard lib not sure what is best here.
