### PR TITLE
Elasticsearch: Add PPL support to ElasticDatasource

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -257,8 +257,8 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if proxy.ctx.Req.Request.Method == "PUT" {
 			return errors.New("puts not allowed on proxied Elasticsearch datasource")
 		}
-		if proxy.ctx.Req.Request.Method == "POST" && proxy.proxyPath != "_msearch" {
-			return errors.New("posts not allowed on proxied Elasticsearch datasource except on /_msearch")
+		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "_msearch" || proxy.proxyPath == "_opendistro/_ppl") {
+			return errors.New("Posts not allowed on proxied Elasticsearch datasource except on /_msearch or /_opendistro/_ppl")
 		}
 	}
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1,8 +1,10 @@
 import angular from 'angular';
+import { first } from 'rxjs/operators';
 import {
   ArrayVector,
   CoreApp,
   DataQueryRequest,
+  DataQueryResponse,
   DataSourceInstanceSettings,
   dateMath,
   dateTime,
@@ -15,7 +17,7 @@ import { ElasticDatasource, enhanceDataFrame } from './datasource';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { ElasticsearchOptions, ElasticsearchQuery } from './types';
+import { ElasticsearchOptions, ElasticsearchQuery, ElasticsearchQueryType } from './types';
 
 const ELASTICSEARCH_MOCK_URL = 'http://elasticsearch.local';
 
@@ -154,7 +156,10 @@ describe('ElasticDatasource', function(this: any) {
         ],
       };
 
-      result = await ctx.ds.query(query);
+      result = await ctx.ds
+        .query(query)
+        .pipe(first())
+        .toPromise();
 
       parts = requestOptions.data.split('\n');
       header = angular.fromJson(parts[0]);
@@ -215,7 +220,10 @@ describe('ElasticDatasource', function(this: any) {
       };
 
       const queryBuilderSpy = jest.spyOn(ctx.ds.queryBuilder, 'getLogsQuery');
-      const response = await ctx.ds.query(query);
+      const response = await ctx.ds
+        .query(query)
+        .pipe(first())
+        .toPromise();
       return { queryBuilderSpy, response };
     }
 
@@ -842,6 +850,102 @@ describe('ElasticDatasource', function(this: any) {
     });
   });
 
+  describe('When issuing PPL query', () => {
+    async function setupDataSource(targets: ElasticsearchQuery[]) {
+      let payloads: any[] = [];
+
+      createDatasource({
+        url: ELASTICSEARCH_MOCK_URL,
+        database: 'test',
+        jsonData: { esVersion: 70, pplSupportEnabled: true } as ElasticsearchOptions,
+      } as DataSourceInstanceSettings<ElasticsearchOptions>);
+
+      datasourceRequestMock.mockImplementation(options => {
+        const requestOptions = options;
+        const parts = requestOptions.data.split('\n');
+        const payload = angular.fromJson(parts[0]);
+        payloads.push(payload);
+        return Promise.resolve({ data: { responses: [] } });
+      });
+
+      const query = {
+        range: {
+          from: dateTime([2015, 4, 30, 10]),
+          to: dateTime([2015, 5, 1, 10]),
+        },
+        targets,
+      };
+
+      const queryBuilderSpy = jest.spyOn(ctx.ds.queryBuilder, 'buildPPLQuery');
+      await ctx.ds.query(query);
+      return { queryBuilderSpy, payloads };
+    }
+
+    it('should change empty PPL query to query configured index', async () => {
+      const targets = [
+        {
+          queryType: ElasticsearchQueryType.PPL,
+          query: '',
+          refId: '',
+          isLogsQuery: false,
+        },
+      ];
+      const { payloads } = await setupDataSource(targets);
+      expect(payloads[0].query.startsWith('source=`test`')).toBe(true);
+    });
+
+    it('should call buildPPLQuery()', async () => {
+      const targets = [
+        {
+          queryType: ElasticsearchQueryType.PPL,
+          query: '',
+          refId: '',
+          isLogsQuery: false,
+        },
+      ];
+      const { queryBuilderSpy } = await setupDataSource(targets);
+      expect(queryBuilderSpy).toHaveBeenCalled();
+    });
+
+    it('should handle multiple PPL queries', async () => {
+      const targets = [
+        {
+          queryType: ElasticsearchQueryType.PPL,
+          query: '',
+          refId: 'A',
+          isLogsQuery: false,
+        },
+        {
+          queryType: ElasticsearchQueryType.PPL,
+          query: '',
+          refId: 'B',
+          isLogsQuery: false,
+        },
+      ];
+      await setupDataSource(targets);
+      expect(datasourceRequestMock).toBeCalledTimes(2);
+    });
+
+    it('should handle both Lucene and PPL queries together', async () => {
+      const targets = [
+        {
+          queryType: ElasticsearchQueryType.PPL,
+          query: '',
+          refId: 'A',
+          isLogsQuery: false,
+        },
+        {
+          queryType: ElasticsearchQueryType.Lucene,
+          query: '*',
+          refId: 'B',
+          isLogsQuery: false,
+        },
+      ];
+      await setupDataSource(targets);
+      expect(datasourceRequestMock).toBeCalledTimes(2);
+    });
+  });
+
   describe('query', () => {
     it('should replace range as integer not string', () => {
       const dataSource = new ElasticDatasource(
@@ -865,32 +969,45 @@ describe('ElasticDatasource', function(this: any) {
     });
   });
 
-  it('should correctly interpolate variables in query', () => {
-    const query = {
-      alias: '',
-      bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '$var', label: '' }] }, id: '1' }],
-      metrics: [{ type: 'count', id: '1' }],
-      query: '$var',
-    };
+  describe('interpolateVariablesInQueries', () => {
+    it('should correctly interpolate variables in query', () => {
+      const query = {
+        alias: '',
+        bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '$var', label: '' }] }, id: '1' }],
+        metrics: [{ type: 'count', id: '1' }],
+        query: '$var',
+      };
 
-    const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
+      const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
 
-    expect(interpolatedQuery.query).toBe('resolvedVariable');
-    expect(interpolatedQuery.bucketAggs[0].settings.filters[0].query).toBe('resolvedVariable');
-  });
+      expect(interpolatedQuery.query).toBe('resolvedVariable');
+      expect(interpolatedQuery.bucketAggs[0].settings.filters[0].query).toBe('resolvedVariable');
+    });
 
-  it('should correctly handle empty query strings', () => {
-    const query = {
-      alias: '',
-      bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '', label: '' }] }, id: '1' }],
-      metrics: [{ type: 'count', id: '1' }],
-      query: '',
-    };
+    it('should correctly handle empty Lucene query strings', () => {
+      const query = {
+        alias: '',
+        bucketAggs: [{ type: 'filters', settings: { filters: [{ query: '', label: '' }] }, id: '1' }],
+        metrics: [{ type: 'count', id: '1' }],
+        query: '',
+      };
 
-    const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
+      const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
 
-    expect(interpolatedQuery.query).toBe('*');
-    expect(interpolatedQuery.bucketAggs[0].settings.filters[0].query).toBe('*');
+      expect(interpolatedQuery.query).toBe('*');
+      expect(interpolatedQuery.bucketAggs[0].settings.filters[0].query).toBe('*');
+    });
+
+    it('should correctly handle empty PPL query strings', () => {
+      const query = {
+        queryType: ElasticsearchQueryType.PPL,
+        query: '',
+      };
+
+      const interpolatedQuery = ctx.ds.interpolateVariablesInQueries([query], {})[0];
+
+      expect(interpolatedQuery.query).toBe('');
+    });
   });
 });
 

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -10,12 +10,17 @@ import {
   MutableDataFrame,
   PreferredVisualisationType,
 } from '@grafana/data';
-import { ElasticsearchAggregation } from './types';
+import { ElasticsearchAggregation, ElasticsearchQueryType } from './types';
 
 export class ElasticResponse {
-  constructor(private targets: any, private response: any) {
+  constructor(
+    private targets: any,
+    private response: any,
+    private targetType: ElasticsearchQueryType = ElasticsearchQueryType.Lucene
+  ) {
     this.targets = targets;
     this.response = response;
+    this.targetType = targetType;
   }
 
   processMetrics(esAgg: any, target: any, seriesList: any, props: any) {
@@ -395,14 +400,23 @@ export class ElasticResponse {
   }
 
   getTimeSeries() {
-    if (this.targets.some((target: any) => target.metrics.some((metric: any) => metric.type === 'raw_data'))) {
+    if (this.targetType === ElasticsearchQueryType.PPL) {
+      return { data: [] };
+    } else if (this.targets.some((target: any) => target.metrics.some((metric: any) => metric.type === 'raw_data'))) {
       return this.processResponseToDataFrames(false);
     }
     return this.processResponseToSeries();
   }
 
   getLogs(logMessageField?: string, logLevelField?: string): DataQueryResponse {
+    if (this.targetType === ElasticsearchQueryType.PPL) {
+      return { data: [] };
+    }
     return this.processResponseToDataFrames(true, logMessageField, logLevelField);
+  }
+
+  getTable(): DataQueryResponse {
+    return { data: [] };
   }
 
   processResponseToDataFrames(

--- a/public/app/plugins/datasource/elasticsearch/index_pattern.ts
+++ b/public/app/plugins/datasource/elasticsearch/index_pattern.ts
@@ -45,4 +45,16 @@ export class IndexPattern {
 
     return indexList;
   }
+
+  getPPLIndexPattern() {
+    // PPL currently does not support multi-indexing through lists, so a wildcard
+    // pattern is used to match all patterns and relies on the time range filter
+    // to filter out the incorrect indexes.
+    if (!this.interval) {
+      return this.pattern;
+    }
+
+    const indexPattern = this.pattern.match(/\[(.*)\]/)[1] + '*';
+    return indexPattern;
+  }
 }

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -419,4 +419,8 @@ export class ElasticQueryBuilder {
       aggs: this.build(target, null, querystring).aggs,
     };
   }
+
+  buildPPLQuery(target: any, adhocFilters?: any, queryString?: string) {
+    return { query: queryString };
+  }
 }

--- a/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
@@ -60,4 +60,20 @@ describe('IndexPattern', () => {
       });
     });
   });
+
+  describe('getPPLIndexPattern', () => {
+    describe('no interval', () => {
+      test('should return correct index', () => {
+        const pattern = new IndexPattern('my-metrics');
+        expect(pattern.getPPLIndexPattern()).toEqual('my-metrics');
+      });
+    });
+
+    describe('daily', () => {
+      test('should return correct index pattern', () => {
+        const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
+        expect(pattern.getPPLIndexPattern()).toEqual('asd-*');
+      });
+    });
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -9,6 +9,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  pplSupportEnabled?: boolean;
 }
 
 export interface ElasticsearchAggregation {
@@ -23,8 +24,10 @@ export interface ElasticsearchQuery extends DataQuery {
   isLogsQuery: boolean;
   alias?: string;
   query?: string;
+  queryType?: ElasticsearchQueryType;
   bucketAggs?: ElasticsearchAggregation[];
   metrics?: ElasticsearchAggregation[];
+  format?: string;
 }
 
 export type DataLinkConfig = {
@@ -32,3 +35,8 @@ export type DataLinkConfig = {
   url: string;
   datasourceUid?: string;
 };
+
+export enum ElasticsearchQueryType {
+  Lucene = 'lucene',
+  PPL = 'PPL',
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the `elasticsearch-ppl-support-frontend` branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the `elasticsearch-ppl-support-frontend` branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR updates the `ElasticDatasource` class to handle PPL queries. The implementation for building PPL queries and parsing the response will be in other PRs. The main purpose of this PR is to send Lucene queries and PPL queries to their respective data paths. Changes to existing Lucene query handling should be purely structural. Finally, the `query` method returns an `Observable` instead of a `Promise` since now not all queries can fit in a single request.

**Which issue(s) this PR fixes:**

Partially resolves Grafana issue 28674

**Special notes for your reviewer:**

The relevant issue is not linked to avoid having this PR referenced in the issue conversation upstream.

cc: @alolita @robbierolin