### PR TITLE
Login: Fixes redirect url encoding issues of # %23 being unencoded after login

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -121,7 +121,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 			}
 		}
 
-		if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
+		if redirectTo := c.GetCookie("redirect_to"); len(redirectTo) > 0 {
 			if err := hs.ValidateRedirectTo(redirectTo); err != nil {
 				// the user is already logged so instead of rendering the login page with error
 				// it should be redirected to the home page.
@@ -229,7 +229,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) Res
 		"message": "Logged in",
 	}
 
-	if redirectTo, _ := url.QueryUnescape(c.GetCookie("redirect_to")); len(redirectTo) > 0 {
+	if redirectTo := c.GetCookie("redirect_to"); len(redirectTo) > 0 {
 		if err := hs.ValidateRedirectTo(redirectTo); err == nil {
 			result["redirectUrl"] = redirectTo
 		} else {


### PR DESCRIPTION
Fixes #29237

This was also a backend issue caused by double url decoding the cookie value. The maracon function c.GetCookie does Url decoding internally so we double decoded the value
