### PR TITLE
Docs: Accurately reflecting available variables

### DIFF
--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -27,13 +27,13 @@ These variables allow you to include the current time range in the data link URL
 Series specific variables are available under ``__series`` namespace:
 
 - ``__series.name`` - series name to the URL
-- ``__series.labels.<LABEL>`` - label's value to the URL. If your label contains dots, then use ``__series.labels["<LABEL>"]`` syntax.
 
 ## Field variables
 
 Field-specific variables are available under ``__field`` namespace:
 
 - ``__field.name`` - the name of the field
+- ``__field.labels.<LABEL>`` - label's value to the URL. If your label contains dots, then use ``__field.labels["<LABEL>"]`` syntax.
 
 ## Value variables
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Labels are only available at the field level, and not the series level
