### PR TITLE
Docs: fixing link issues in auto generated frontend docs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-react": "7.8.3",
     "@babel/preset-typescript": "7.8.3",
     "@emotion/core": "10.0.27",
-    "@grafana/api-documenter": "0.9.3",
+    "@grafana/api-documenter": "7.11.1",
     "@grafana/api-extractor": "7.10.1",
     "@grafana/eslint-config": "2.0.6",
     "@rtsao/plugin-proposal-class-properties": "7.0.1-patch.1",

--- a/packages/grafana-data/src/transformations/matchers.ts
+++ b/packages/grafana-data/src/transformations/matchers.ts
@@ -38,7 +38,7 @@ export const frameMatchers = new Registry<FrameMatcherInfo>(() => {
 
 /**
  * Resolves a field matcher from the registry for given config.
- * If no matcher can be found an error will be thrown.
+ * Will throw an error if matcher can not be resolved.
  * @public
  */
 export function getFieldMatcher(config: MatcherConfig): FieldMatcher {
@@ -51,7 +51,7 @@ export function getFieldMatcher(config: MatcherConfig): FieldMatcher {
 
 /**
  * Resolves a frame matcher from the registry for given config.
- * If no matcher can be found an error will be thrown.
+ * Will throw an error if matcher can not be resolved.
  * @public
  */
 export function getFrameMatchers(config: MatcherConfig): FrameMatcher {

--- a/packages/grafana-data/src/transformations/matchers.ts
+++ b/packages/grafana-data/src/transformations/matchers.ts
@@ -12,6 +12,10 @@ import {
 } from '../types/transformations';
 import { Registry } from '../utils/Registry';
 
+/**
+ * Registry that contains all of the built in field matchers.
+ * @public
+ */
 export const fieldMatchers = new Registry<FieldMatcherInfo>(() => {
   return [
     ...getFieldPredicateMatchers(), // Predicates
@@ -20,6 +24,10 @@ export const fieldMatchers = new Registry<FieldMatcherInfo>(() => {
   ];
 });
 
+/**
+ * Registry that contains all of the built in frame matchers.
+ * @public
+ */
 export const frameMatchers = new Registry<FrameMatcherInfo>(() => {
   return [
     ...getFramePredicateMatchers(), // Predicates
@@ -28,6 +36,11 @@ export const frameMatchers = new Registry<FrameMatcherInfo>(() => {
   ];
 });
 
+/**
+ * Resolves a field matcher from the registry for given config.
+ * If no matcher can be found an error will be thrown.
+ * @public
+ */
 export function getFieldMatcher(config: MatcherConfig): FieldMatcher {
   const info = fieldMatchers.get(config.id);
   if (!info) {
@@ -36,6 +49,11 @@ export function getFieldMatcher(config: MatcherConfig): FieldMatcher {
   return info.get(config.options);
 }
 
+/**
+ * Resolves a frame matcher from the registry for given config.
+ * If no matcher can be found an error will be thrown.
+ * @public
+ */
 export function getFrameMatchers(config: MatcherConfig): FrameMatcher {
   const info = frameMatchers.get(config.id);
   if (!info) {

--- a/packages/grafana-runtime/src/types/analytics.ts
+++ b/packages/grafana-runtime/src/types/analytics.ts
@@ -64,7 +64,7 @@ export interface DataRequestEventPayload extends DataRequestInfo {
 export type MetaAnalyticsEventPayload = DashboardViewEventPayload | DataRequestEventPayload;
 
 /**
- * Describes meta analytics event with predefined {@link EchoEventType.MetaAnalytics} type.
+ * Describes meta analytics event with predefined {@link EchoEventType.EchoEventType} type.
  *
  * @public
  */

--- a/scripts/ci-reference-docs-lint.sh
+++ b/scripts/ci-reference-docs-lint.sh
@@ -29,7 +29,7 @@ if [ ! -d "$REPORT_PATH" ]; then
 fi
 
 WARNINGS_COUNT="$(find "$REPORT_PATH" -type f -name \*.log -print0 | xargs -0 grep -o "Warning: " | wc -l | xargs)"
-WARNINGS_COUNT_LIMIT=1058
+WARNINGS_COUNT_LIMIT=1055
 
 if [ "$WARNINGS_COUNT" -gt $WARNINGS_COUNT_LIMIT ]; then
   echo -e "API Extractor warnings/errors $WARNINGS_COUNT exceeded $WARNINGS_COUNT_LIMIT so failing build.\n"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3339,18 +3339,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@grafana/api-documenter@0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@grafana/api-documenter/-/api-documenter-0.9.3.tgz#543d0a973157541dd8870d67fb29c3209c52292b"
-  integrity sha512-irYVzjmBQnJ8WEM7WECFhnaAy9b3jzfFbLbiWkTqpxNT1l4RzMycJyjBGdUVUhQjIvg/HbpF8Vqf1utNkrJdxA==
+"@grafana/api-documenter@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@grafana/api-documenter/-/api-documenter-7.11.1.tgz#5980016ae28aceca16bbeca112913aca5ccda405"
+  integrity sha512-4AJ5m4ychpRA1bFMOm5lP3pMAdR9ZuiSlRuQIdeBrTZh+sFA+C9SiburYdAfr7gQuetlT8LM4+CzJdxQNw7Lbw==
   dependencies:
-    "@microsoft/api-extractor-model" "7.7.7"
-    "@microsoft/node-core-library" "3.19.3"
-    "@microsoft/ts-command-line" "4.3.10"
-    "@microsoft/tsdoc" "0.12.14"
+    "@microsoft/api-extractor-model" "workspace:*"
+    "@microsoft/tsdoc" "0.12.19"
+    "@rushstack/node-core-library" "workspace:*"
+    "@rushstack/ts-command-line" "workspace:*"
     colors "~1.2.1"
     js-yaml "~3.13.1"
-    resolve "1.8.1"
+    resolve "~1.17.0"
 
 "@grafana/api-extractor@7.10.1":
   version "7.10.1"
@@ -4866,14 +4866,6 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.5.5.tgz#6f88bcb847ebd0117fc81bcd26b83220062fd881"
   integrity sha512-IudQkyZuM8T1CrSX9r0ShPXCABjtEtyrV4lxQqhKAwFqw1aYpy/5LOZhitMLoJTybZPVdPotuh+zjqYy9ZOSbA==
 
-"@microsoft/api-extractor-model@7.7.7":
-  version "7.7.7"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.7.7.tgz#1d15eae7a19b72abbfca9053f200fe79b6f9d755"
-  integrity sha512-822kyHMEx2sl+KnBioEiFoTIXuz/4pYBo94nQ4AMqb9BFvY9I1AZUPtC4HFh2zcXQqpFLpKKC55s/o8UOze2wQ==
-  dependencies:
-    "@microsoft/node-core-library" "3.19.3"
-    "@microsoft/tsdoc" "0.12.14"
-
 "@microsoft/api-extractor-model@workspace:*":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.10.3.tgz#f687f324e940bd71e3e73b5b262a54594b0ea61c"
@@ -4881,33 +4873,6 @@
   dependencies:
     "@microsoft/tsdoc" "0.12.19"
     "@rushstack/node-core-library" "3.34.3"
-
-"@microsoft/node-core-library@3.19.3":
-  version "3.19.3"
-  resolved "https://registry.yarnpkg.com/@microsoft/node-core-library/-/node-core-library-3.19.3.tgz#cf09ddb2905a29b32956d4a88f9d035a00637be9"
-  integrity sha512-rJ+hT6+XK5AESbhn31YBnHKpZSFKCmqHCRZyK9+jyWwav1HXv0qzuXnFvnyrO0MZyJ6rH0seWOZVWbU5KGv1tg==
-  dependencies:
-    "@types/node" "10.17.13"
-    colors "~1.2.1"
-    fs-extra "~7.0.1"
-    jju "~1.4.0"
-    semver "~5.3.0"
-    timsort "~0.3.0"
-    z-schema "~3.18.3"
-
-"@microsoft/ts-command-line@4.3.10":
-  version "4.3.10"
-  resolved "https://registry.yarnpkg.com/@microsoft/ts-command-line/-/ts-command-line-4.3.10.tgz#fcb4f5ea43c93d17db6cc810bbee39ea32b2a86d"
-  integrity sha512-AgxArGqPt0H5WTo3fxNFP3Blm3obkCCopVG9kwIo+/mMdXaj6qMDn6+8Bv8+5Nke3CvvXpKAZtu3IaGY5cV1Hg==
-  dependencies:
-    "@types/argparse" "1.0.33"
-    argparse "~1.0.9"
-    colors "~1.2.1"
-
-"@microsoft/tsdoc@0.12.14":
-  version "0.12.14"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.14.tgz#0e0810a0a174e50e22dfe8edb30599840712f22d"
-  integrity sha512-518yewjSga1jLdiLrcmpMFlaba5P+50b0TWNFUpC+SL9Yzf0kMi57qw+bMl+rQ08cGqH1vLx4eg9YFUbZXgZ0Q==
 
 "@microsoft/tsdoc@0.12.19":
   version "0.12.19"
@@ -5955,11 +5920,6 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
-
-"@types/argparse@1.0.33":
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.33.tgz#2728669427cdd74a99e53c9f457ca2866a37c52d"
-  integrity sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==
 
 "@types/argparse@1.0.38":
   version "1.0.38"
@@ -20443,7 +20403,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.5, path-parse@^1.0.6:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
@@ -23889,13 +23849,6 @@ resolve@1.15.1, resolve@^1.1.7:
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
-
-resolve@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
-  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
-  dependencies:
-    path-parse "^1.0.5"
 
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2:
   version "1.12.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will resolve wrongly generated documentation links when we reference other classes, interfaces, enum etc. in code comments by using the `@link` tag.

It also adds the `disable_edit_link = true` so we don't link users to the github edit page since this documentation is autogenerated and needs to be updated in the code.

We are also changing the link type from regular anchor tags to `relref` so we will get Hugo warnings when the link can't be resolved (https://gohugo.io/content-management/cross-references/#use-ref-and-relref).

**Which issue(s) this PR fixes**:
Fixes #26459
Fixes #26487
Fixes #26260
