### PR TITLE
Drone: Publish NPM packages after Storybook to avoid race condition

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -434,6 +434,7 @@ steps:
       from_secret: gcp_key
   depends_on:
   - build-storybook
+  - end-to-end-tests
 
 - name: build-frontend-docs
   image: grafana/build-container:1.2.29
@@ -933,18 +934,6 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
 
-- name: release-npm-packages
-  image: grafana/build-container:1.2.29
-  commands:
-  - ./node_modules/.bin/lerna bootstrap
-  - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
-  - ./scripts/build/release-packages.sh ${DRONE_TAG}
-  environment:
-    NPM_TOKEN:
-      from_secret: npm_token
-  depends_on:
-  - end-to-end-tests
-
 - name: publish-storybook
   image: grafana/grafana-ci-deploy:1.2.7
   commands:
@@ -957,6 +946,19 @@ steps:
       from_secret: gcp_key
   depends_on:
   - build-storybook
+  - end-to-end-tests
+
+- name: release-npm-packages
+  image: grafana/build-container:1.2.29
+  commands:
+  - ./node_modules/.bin/lerna bootstrap
+  - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
+  - ./scripts/build/release-packages.sh ${DRONE_TAG}
+  environment:
+    NPM_TOKEN:
+      from_secret: npm_token
+  depends_on:
+  - publish-storybook
 
 services:
 - name: postgres
@@ -1699,17 +1701,6 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
 
-- name: release-npm-packages
-  image: grafana/build-container:1.2.29
-  commands:
-  - ./node_modules/.bin/lerna bootstrap
-  - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
-  environment:
-    NPM_TOKEN:
-      from_secret: npm_token
-  depends_on:
-  - end-to-end-tests
-
 - name: publish-storybook
   image: grafana/grafana-ci-deploy:1.2.7
   commands:
@@ -1719,6 +1710,18 @@ steps:
       from_secret: gcp_key
   depends_on:
   - build-storybook
+  - end-to-end-tests
+
+- name: release-npm-packages
+  image: grafana/build-container:1.2.29
+  commands:
+  - ./node_modules/.bin/lerna bootstrap
+  - echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" >> ~/.npmrc
+  environment:
+    NPM_TOKEN:
+      from_secret: npm_token
+  depends_on:
+  - publish-storybook
 
 services:
 - name: postgres

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -301,6 +301,7 @@ def publish_storybook_step(edition, ver_mode):
         'image': publish_image,
         'depends_on': [
             'build-storybook',
+            'end-to-end-tests',
         ],
         'environment': {
             'GCP_KEY': {

--- a/scripts/release.star
+++ b/scripts/release.star
@@ -45,7 +45,8 @@ def release_npm_packages_step(edition, ver_mode):
         'name': 'release-npm-packages',
         'image': build_image,
         'depends_on': [
-            'end-to-end-tests',
+            # Has to run after publish-storybook since this step cleans the files publish-storybook depends on
+            'publish-storybook',
         ],
         'environment': {
             'NPM_TOKEN': {
@@ -78,8 +79,8 @@ def get_steps(edition, ver_mode, publish):
     if publish:
         steps.extend([
             upload_packages_step(edition=edition, ver_mode=ver_mode),
-            release_npm_packages_step(edition=edition, ver_mode=ver_mode),
             publish_storybook_step(edition=edition, ver_mode=ver_mode),
+            release_npm_packages_step(edition=edition, ver_mode=ver_mode),
         ])
     windows_steps = get_windows_steps(edition=edition, ver_mode=ver_mode)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Drone: Publish NPM packages only after Storybook, to avoid race condition, since the former cleans up files the latter depends on.
