### PR TITLE
Docs: Fix broken link for plugins

### DIFF
--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -1,5 +1,6 @@
 +++
-title = "Build a plugin."
+title = "Build a plugin"
+aliases = ["/docs/grafana/latest/plugins/developing/"]
 +++
 
 # Build a plugin


### PR DESCRIPTION
This fixes a broken link reported in [this issue](https://github.com/grafana/grafana-plugin-repository/issues/793).