### PR TITLE
DashboardSchema: Compatible with Cue 3.0.0-alpha5

### DIFF
--- a/dashboard-schemas/panels/Gauge.cue
+++ b/dashboard-schemas/panels/Gauge.cue
@@ -2,7 +2,7 @@ package panels
 
 // Gauge is a single value panel that can repeat a gauge for every series,
 // column or row.
-#Gauge: panel & {
+#Gauge: _panel & {
 	// Field config.
 	fieldConfig: {
 		// Defaults.
@@ -22,14 +22,14 @@ package panels
 			// What to show when there is no value.
 			noValue: string
 			// Threshold config.
-			thresholds: thresholds
+			thresholds: _thresholds
 			// Mappings.
-			mappings: [...mapping]
+			mappings: [..._mapping]
 			// Data Links.
-			links: [...dataLink]
+			links: [..._dataLink]
 		}
 		// Overrides.
-		overrides: [...override]
+		overrides: [..._override]
 	}
 	// Options.
 	options: {

--- a/dashboard-schemas/panels/Graph.cue
+++ b/dashboard-schemas/panels/Graph.cue
@@ -1,6 +1,6 @@
 package panels
 
-#Graph: panel & {
+#Graph: _panel & {
 	// Display values as a bar chart.
 	bars: bool | *false
 	// Dashed line length.
@@ -17,7 +17,7 @@ package panels
 		// Defaults.
 		defaults: custom: {}
 		// Overrides.
-		overrides: [...override]
+		overrides: [..._override]
 	}
 	// Amount of color fill for a series. Expects a value between 0 and 1.
 	fill: number & >=0 & <=1 | *1
@@ -66,7 +66,7 @@ package panels
 	// Options.
 	options: {
 		// Data links.
-		dataLinks: [...dataLink]
+		dataLinks: [..._dataLink]
 	}
 	// Available when `stack` is true. Each series is drawn as a percentage of the
 	// total of all series.
@@ -111,7 +111,7 @@ package panels
 	// Draws adjacent points as staircase.
 	steppedLine: bool | *false
 	// Threshold config.
-	thresholds: thresholds
+	thresholds: _thresholds
 	// Time from.
 	timeFrom: string
 	// Time regions.

--- a/dashboard-schemas/panels/Row.cue
+++ b/dashboard-schemas/panels/Row.cue
@@ -8,7 +8,7 @@ package panels
 	// Name of default data source.
 	datasource?: string
 	// Grid position.
-	gridPos?: gridPos
+	gridPos?: _gridPos
 	// Dashboard panels.
 	panels?: [...{}]
 	// Name of template variable to repeat for.

--- a/dashboard-schemas/panels/gridPos.cue
+++ b/dashboard-schemas/panels/gridPos.cue
@@ -1,6 +1,6 @@
 package panels
 
-gridPos: {
+_gridPos: {
 	// Panel height.
 	h: int & >0 | *9
 	// Panel width.

--- a/dashboard-schemas/panels/link.cue
+++ b/dashboard-schemas/panels/link.cue
@@ -9,6 +9,6 @@ _link: {
 	url: string
 }
 
-panelLink: _link
+_panelLink: _link
 
-dataLink: _link
+_dataLink: _link

--- a/dashboard-schemas/panels/mapping.cue
+++ b/dashboard-schemas/panels/mapping.cue
@@ -1,6 +1,6 @@
 package panels
 
-mapping: {
+_mapping: {
 	id:       int
 	from:     string
 	operator: string

--- a/dashboard-schemas/panels/override.cue
+++ b/dashboard-schemas/panels/override.cue
@@ -1,6 +1,6 @@
 package panels
 
-override: {
+_override: {
 	matcher: {
 		id:      string
 		options: string

--- a/dashboard-schemas/panels/panel.cue
+++ b/dashboard-schemas/panels/panel.cue
@@ -1,6 +1,6 @@
 package panels
 
-panel: {
+_panel: {
 	// Panel title.
 	title?: string
 	// Description.
@@ -10,9 +10,9 @@ panel: {
 	// Name of default datasource.
 	datasource?: string
 	// Grid position.
-	gridPos?: gridPos
+	gridPos?: _gridPos
 	// Panel links.
-	links?: [...panelLink]
+	links?: [..._panelLink]
 	// Name of template variable to repeat for.
 	repeat?: string
 	// Direction to repeat in if 'repeat' is set.

--- a/dashboard-schemas/panels/thresholds.cue
+++ b/dashboard-schemas/panels/thresholds.cue
@@ -1,6 +1,6 @@
 package panels
 
-thresholds: {
+_thresholds: {
 	// Threshold mode.
 	mode: string | *"absolute"
 	// Threshold steps.

--- a/dashboard-schemas/variables/Custom.cue
+++ b/dashboard-schemas/variables/Custom.cue
@@ -1,7 +1,7 @@
 package variables
 
 // Custom variables are for values that do not change.
-#Custom: variable & {
+#Custom: _variable & {
 	// Options as comma separated values.
 	query: string
 	// Variable type.

--- a/dashboard-schemas/variables/Datasource.cue
+++ b/dashboard-schemas/variables/Datasource.cue
@@ -2,7 +2,7 @@ package variables
 
 // Data source variables allow you to quickly change the data source for an
 // entire dashboard.
-#Datasource: variable & {
+#Datasource: _variable & {
 	// Data source type.
 	query: string
 	// Query value.

--- a/dashboard-schemas/variables/Query.cue
+++ b/dashboard-schemas/variables/Query.cue
@@ -2,7 +2,7 @@ package variables
 
 // Query variables allow you to write a data source query that can return a
 // list of metric names, tag values, or keys.
-#Query: variable & {
+#Query: _variable & {
 	// Data source to use.
 	datasource: string
 	// Definition.

--- a/dashboard-schemas/variables/variable.cue
+++ b/dashboard-schemas/variables/variable.cue
@@ -1,6 +1,6 @@
 package variables
 
-variable: {
+_variable: {
 	// Currently selected value.
 	current: {
 		selected: bool | *false


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Lead all top-level properties that we do not intend to export with an underscore.

In 2.2.0, only definitions starting with a capital letter were exported. As well, properties with a leading underscore were not visible to an entire package - just within the same file. 3.0.0 still considers them hidden, however, they are now visible to an entire package.

**Which issue(s) this PR fixes**:

Unblocks https://github.com/grafana/grafana/pull/29334#issuecomment-732805078.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

I had hoped to also rename files of hidden properties with a leading underscore, but `cue export` ignores them. Instead just the properties themselves are renamed. My POC in [grafana/dashboard-spec](https://github.com/grafana/dashboard-spec/tree/0a756ea8a6aa4c76b24add2057beb70c37d6c65a/specs/7.0/panels) used a leading underscore naming convention which I think helped distinguish files with hidden properties. Not a big deal, but I wanted to mention I made the attempt.