### PR TITLE
Drone: Execute artifact publishing for both editions in parallel during release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1401,11 +1401,29 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
-- name: publish-packages
+- name: publish-packages-oss
   image: grafana/grafana-ci-deploy:1.2.7
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    GPG_KEY_PASSWORD:
+      from_secret: gpg_key_password
+    GPG_PRIV_KEY:
+      from_secret: gpg_priv_key
+    GPG_PUB_KEY:
+      from_secret: gpg_pub_key
+    GRAFANA_COM_API_KEY:
+      from_secret: grafana_api_key
+  depends_on:
+  - initialize
+
+- name: publish-packages-enterprise
+  image: grafana/grafana-ci-deploy:1.2.7
+  commands:
+  - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   environment:
     GCP_KEY:


### PR DESCRIPTION
**What this PR does / why we need it**:
In Drone, execute artifact publishing for OSS and enterprise editions in parallel, so that if one fails, the other can still continue. I learnt that this is necessary during the last release, where OSS publishing failed due to a GCS issue and enterprise could've succeeded. Manual publishing is currently a huge pain since syncing RPM and Deb repos requires downloading and uploading great amounts of data.
