### PR TITLE
Devenv: Add default db for influxdb

### DIFF
--- a/devenv/docker/blocks/influxdb/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb/docker-compose.yaml
@@ -8,6 +8,7 @@
     environment:
       INFLUXDB_ADMIN_USER: grafana
       INFLUXDB_ADMIN_PASSWORD: grafana
+      INFLUXDB_DB: site
     volumes:
       - ./docker/blocks/influxdb/influxdb.conf:/etc/influxdb/influxdb.conf
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When starting a new influxdb instance, Grafana is not able to connect to influxdb datasource  with `InfluxDB Error: database not found: site` error.

**Special notes for your reviewer**:
Related to the recent fix #29344  - after all the changes, including this PR, I'm finally able to connect to the datasource.
