### PR TITLE
Security: Prefer server cipher suites for http2

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -249,7 +249,7 @@ func (hs *HTTPServer) configureHttp2() error {
 
 	tlsCfg := &tls.Config{
 		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: false,
+		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
 			tls.TLS_CHACHA20_POLY1305_SHA256,
 			tls.TLS_AES_128_GCM_SHA256,


### PR DESCRIPTION
G402 (CWE-295):  TLS PreferServerCipherSuites set false.

Signed-off-by: bergquist <carl.bergquist@gmail.com>


