### PR TITLE
Chore: Disable gosec on certain line

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -177,6 +177,7 @@ func (hs *HTTPServer) getListener() (net.Listener, error) {
 		}
 
 		// Make socket writable by group
+		// nolint:gosec
 		if err := os.Chmod(setting.SocketPath, 0660); err != nil {
 			return nil, errutil.Wrapf(err, "failed to change socket permissions")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable gosec linter on a certain line, that I think produces the correct file permissions although I don't remember the context any more.
