### PR TITLE
AzureMonitor: Fix unit translation for MilliSeconds

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -421,7 +421,7 @@ func toGrafanaUnit(unit string) string {
 		return "cps"
 	case "Percent":
 		return "percent"
-	case "Milliseconds":
+	case "MilliSeconds":
 		return "ms"
 	case "Seconds":
 		return "s"


### PR DESCRIPTION
**What this PR does / why we need it**: This fixes the unit translations of Azure Monitor queries to Grafana units. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

#### Dataframe
Before: 
```json
[
  {
    "length": 360,
    "refId": "A",
    "fields": [
      {
        "name": "",
        "type": "time",
        "config": {}
      },
      {
        "name": "Routing Delivery Latency (preview)",
        "type": "number",
        "config": {
          "displayName": "Iot Hub routing latency",
          "unit": "MilliSeconds",
          "min": 500.75183075671276,
          "max": 4354.597701149425
        }
      }
    ]
  }
]
```
After: 
```json
[
  {
    "length": 360,
    "refId": "A",
    "fields": [
      {
        "name": "",
        "type": "time",
        "config": {}
      },
      {
        "name": "Routing Delivery Latency (preview)",
        "type": "number",
        "config": {
          "displayName": "Iot Hub routing latency",
          "unit": "ms",
          "min": 500.75183075671276,
          "max": 4354.597701149425
        }
      }
    ]
  }
]
```
This leads to that metrics with `MilliSeconds` as unit are correctly displayed. 
![image](https://user-images.githubusercontent.com/17493763/100274856-68b4a580-2f5f-11eb-8d21-4ac79ee35e69.png)
