### PR TITLE
Arrow: cast timestamps to Number

### DIFF
--- a/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/ArrowDataFrame.ts
@@ -68,6 +68,7 @@ export function arrowTableToDataFrame(table: Table): ArrowDataFrame {
         }
         case ArrowType.Timestamp: {
           type = FieldType.time;
+          values = new NumberColumn(col); // Cast to number
           break;
         }
         case ArrowType.Utf8: {

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -6,7 +6,6 @@ import {
   Field,
   DataFrame,
   getTimeField,
-  dateTime,
   getFieldDisplayName,
   getColorForTheme,
 } from '@grafana/data';
@@ -47,7 +46,7 @@ export class DataProcessor {
         const datapoints = [];
 
         for (let r = 0; r < series.length; r++) {
-          datapoints.push([field.values.get(r), dateTime(timeField.values.get(r)).valueOf()]);
+          datapoints.push([field.values.get(r), timeField.values.get(r)]);
         }
 
         list.push(this.toTimeSeries(field, name, i, j, datapoints, list.length, range));


### PR DESCRIPTION
This PR wraps timestamp values as Number so they be used simply in JS functions.  This lets us simplify time parsing in the graph panels