### PR TITLE
Min/Max: move auto out of default apply overrides

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -24,7 +24,7 @@ import { ScopedVars } from '../types/ScopedVars';
 import { getTimeField } from '../dataframe/processDataFrame';
 import { getFieldMatcher } from '../transformations';
 import { FieldMatcherID } from '../transformations/matchers/ids';
-import { findNumericFieldMinMax } from './rangeUtils';
+import { FieldMinMaxInfo, findNumericFieldMinMax } from './scale';
 
 /**
  * Options for how to turn DataFrames into an array of display values
@@ -109,7 +109,7 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
     const scopedVars: ScopedVars = {};
     const defaultDisplayName = getTitleTemplate(calcs);
 
-    let range: GlobalMinMa | undefined = undefined;
+    let range: FieldMinMaxInfo | undefined = undefined;
 
     for (let s = 0; s < data.length && !hitLimit; s++) {
       const series = data[s]; // Name is already set

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -2,7 +2,6 @@ import {
   applyFieldOverrides,
   applyRawFieldOverrides,
   FieldOverrideEnv,
-  findNumericFieldMinMax,
   getLinksSupplier,
   setDynamicConfigValue,
   setFieldConfigDefaults,
@@ -73,68 +72,6 @@ locationUtil.initialize({
   buildParamsFromVariables: () => {},
   // @ts-ignore
   getTimeRangeForUrl: () => {},
-});
-
-describe('Global MinMax', () => {
-  it('find global min max', () => {
-    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
-      { title: 'AAA', value: 100, value2: 1234 },
-      { title: 'BBB', value: -20, value2: null },
-      { title: 'CCC', value: 200, value2: 1000 },
-    ]);
-
-    const minmax = findNumericFieldMinMax([f0]);
-    expect(minmax.min).toEqual(-20);
-    expect(minmax.max).toEqual(1234);
-  });
-
-  it('find global min max when all values are zero', () => {
-    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
-      { title: 'AAA', value: 0, value2: 0 },
-      { title: 'CCC', value: 0, value2: 0 },
-    ]);
-
-    const minmax = findNumericFieldMinMax([f0]);
-    expect(minmax.min).toEqual(0);
-    expect(minmax.max).toEqual(0);
-  });
-
-  describe('when value is null', () => {
-    it('then global min max should be null', () => {
-      const frame = toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [1] },
-          { name: 'Value', type: FieldType.number, values: [null] },
-        ],
-      });
-      const { min, max } = findNumericFieldMinMax([frame]);
-
-      expect(min).toBe(null);
-      expect(max).toBe(null);
-    });
-  });
-
-  describe('when value values are zeo', () => {
-    it('then global min max should be correct', () => {
-      const frame = toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [1, 2] },
-          { name: 'Value', type: FieldType.number, values: [1, 2] },
-        ],
-      });
-      const frame2 = toDataFrame({
-        fields: [
-          { name: 'Time', type: FieldType.time, values: [1, 2] },
-          { name: 'Value', type: FieldType.number, values: [0, 0] },
-        ],
-      });
-
-      const { min, max } = findNumericFieldMinMax([frame, frame2]);
-
-      expect(min).toBe(0);
-      expect(max).toBe(2);
-    });
-  });
 });
 
 describe('applyFieldOverrides', () => {
@@ -293,7 +230,6 @@ describe('applyFieldOverrides', () => {
       replaceVariables: (undefined as any) as InterpolateFunction,
       getDataSourceSettingsByUid: undefined as any,
       theme: getTestTheme(),
-      autoMinMax: true,
     })[0];
     const valueColumn = data.fields[1];
     const config = valueColumn.config;
@@ -317,7 +253,6 @@ describe('applyFieldOverrides', () => {
       }) as InterpolateFunction,
       getDataSourceSettingsByUid: undefined as any,
       theme: getTestTheme(),
-      autoMinMax: true,
       fieldConfigRegistry: customFieldRegistry,
     })[0];
 

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
@@ -32,7 +32,6 @@ describe('getFieldDisplayValuesProxy', () => {
     getDataSourceSettingsByUid: (val: string) => ({} as any),
     timeZone: 'utc',
     theme: getTestTheme(),
-    autoMinMax: true,
   })[0];
 
   it('should define all display functions', () => {

--- a/packages/grafana-data/src/field/scale.test.ts
+++ b/packages/grafana-data/src/field/scale.test.ts
@@ -1,8 +1,9 @@
 import { ThresholdsMode, Field, FieldType } from '../types';
 import { sortThresholds } from './thresholds';
 import { ArrayVector } from '../vector/ArrayVector';
-import { getScaleCalculator } from './scale';
+import { findNumericFieldMinMax, getScaleCalculator } from './scale';
 import { getTestTheme } from '../utils/testdata/testTheme';
+import { ArrayDataFrame, toDataFrame } from '../dataframe';
 
 describe('getScaleCalculator', () => {
   it('should return percent, threshold and color', () => {
@@ -24,6 +25,68 @@ describe('getScaleCalculator', () => {
       percent: 0.7,
       threshold: thresholds[1],
       color: '#EAB839',
+    });
+  });
+});
+
+describe('Global MinMax', () => {
+  it('find global min max', () => {
+    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
+      { title: 'AAA', value: 100, value2: 1234 },
+      { title: 'BBB', value: -20, value2: null },
+      { title: 'CCC', value: 200, value2: 1000 },
+    ]);
+
+    const minmax = findNumericFieldMinMax([f0]);
+    expect(minmax.min).toEqual(-20);
+    expect(minmax.max).toEqual(1234);
+  });
+
+  it('find global min max when all values are zero', () => {
+    const f0 = new ArrayDataFrame<{ title: string; value: number; value2: number | null }>([
+      { title: 'AAA', value: 0, value2: 0 },
+      { title: 'CCC', value: 0, value2: 0 },
+    ]);
+
+    const minmax = findNumericFieldMinMax([f0]);
+    expect(minmax.min).toEqual(0);
+    expect(minmax.max).toEqual(0);
+  });
+
+  describe('when value is null', () => {
+    it('then global min max should be null', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1] },
+          { name: 'Value', type: FieldType.number, values: [null] },
+        ],
+      });
+      const { min, max } = findNumericFieldMinMax([frame]);
+
+      expect(min).toBe(null);
+      expect(max).toBe(null);
+    });
+  });
+
+  describe('when value values are zeo', () => {
+    it('then global min max should be correct', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1, 2] },
+          { name: 'Value', type: FieldType.number, values: [1, 2] },
+        ],
+      });
+      const frame2 = toDataFrame({
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1, 2] },
+          { name: 'Value', type: FieldType.number, values: [0, 0] },
+        ],
+      });
+
+      const { min, max } = findNumericFieldMinMax([frame, frame2]);
+
+      expect(min).toBe(0);
+      expect(max).toBe(2);
     });
   });
 });

--- a/packages/grafana-data/src/field/scale.ts
+++ b/packages/grafana-data/src/field/scale.ts
@@ -34,7 +34,7 @@ export function getScaleCalculator(field: Field, theme: GrafanaTheme): ScaleCalc
   };
 }
 
-interface FieldMinMaxInfo {
+export interface FieldMinMaxInfo {
   min?: number | null;
   max?: number | null;
   delta: number;
@@ -71,12 +71,7 @@ function getMinMaxAndDelta(field: Field): FieldMinMaxInfo {
   };
 }
 
-interface GlobalMinMax {
-  min?: number | null;
-  max?: number | null;
-}
-
-export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
+export function findNumericFieldMinMax(data: DataFrame[]): FieldMinMaxInfo {
   let min: number | null = null;
   let max: number | null = null;
 
@@ -100,5 +95,5 @@ export function findNumericFieldMinMax(data: DataFrame[]): GlobalMinMax {
     }
   }
 
-  return { min, max };
+  return { min, max, delta: 0 };
 }

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -117,7 +117,6 @@ export interface ApplyFieldOverrideOptions {
   getDataSourceSettingsByUid: (uid: string) => DataSourceInstanceSettings | undefined;
   theme: GrafanaTheme;
   timeZone?: TimeZone;
-  autoMinMax?: boolean;
   fieldConfigRegistry?: FieldConfigOptionsRegistry;
 }
 

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -65,7 +65,7 @@ export const GraphNG: React.FC<GraphNGProps> = ({
   const hasLegend = useRef(legend && legend.displayMode !== LegendDisplayMode.Hidden);
   const alignedFrame = alignedFrameWithGapTest.frame;
   const compareFrames = useCallback(
-    (a: DataFrame, b: DataFrame) => compareDataFrameStructures(a, b, ['min', 'max']),
+    (a: DataFrame, b: DataFrame) => compareDataFrameStructures(a, b, []), //  ['min', 'max']),
     []
   );
   const configRev = useRevision(alignedFrame, compareFrames);

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -1,5 +1,5 @@
 import isNumber from 'lodash/isNumber';
-import { Scale } from 'uplot';
+import uPlot, { Scale, Range } from 'uplot';
 import { PlotConfigBuilder } from '../types';
 
 export interface ScaleProps {
@@ -12,7 +12,28 @@ export interface ScaleProps {
 export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
   getConfig() {
     const { isTime, scaleKey, min, max } = this.props;
-    const range = isNumber(min) && isNumber(max) ? [min, max] : undefined;
+
+    console.log('INIT SCALE', scaleKey);
+    let range: Range.Function | Range.MinMax | undefined = undefined;
+    if (isNumber(min)) {
+      if (isNumber(max)) {
+        range = [min!, max!];
+        console.log('MAX AND MIN');
+      } else {
+        range = (u: uPlot, initMin: number, initMax: number) => {
+          let [rmin, rmax] = uPlot.rangeNum(initMin, initMax, 0.05 as any, true);
+          console.log('ONLY MIN', { rmin, rmax, initMin, initMax });
+          return [min, rmax];
+        };
+      }
+    } else if (isNumber(max)) {
+      range = (u: uPlot, initMin: number, initMax: number) => {
+        let [rmin, rmax] = uPlot.rangeNum(initMin, initMax, 0.1 as any, true);
+        console.log('ONLY MAX', { rmin, rmax, initMin, initMax });
+        return [rmin, max];
+      };
+    }
+
     return {
       [scaleKey]: {
         time: !!isTime,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -10,7 +10,7 @@ export interface ScaleProps {
 
 export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
   getConfig() {
-    const { isTime, scaleKey, min, max } = this.props;
+    const { isTime, scaleKey } = this.props;
     if (isTime) {
       return {
         [scaleKey]: {
@@ -21,8 +21,9 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
     return {
       [scaleKey]: {
         range: (u: uPlot, initMin: number, initMax: number) => {
-          const [rmin, rmax] = uPlot.rangeNum(initMin, initMax, 0.05 as any, true);
-          return [min ?? rmin, max ?? rmax];
+          const { min, max } = this.props;
+          const [smin, smax] = uPlot.rangeNum(initMin, initMax, 0.05 as any, true);
+          return [min ?? smin, max ?? smax];
         },
       },
     };

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -1,5 +1,4 @@
-import isNumber from 'lodash/isNumber';
-import uPlot, { Scale, Range } from 'uplot';
+import uPlot, { Scale } from 'uplot';
 import { PlotConfigBuilder } from '../types';
 
 export interface ScaleProps {
@@ -12,32 +11,19 @@ export interface ScaleProps {
 export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
   getConfig() {
     const { isTime, scaleKey, min, max } = this.props;
-
-    console.log('INIT SCALE', scaleKey);
-    let range: Range.Function | Range.MinMax | undefined = undefined;
-    if (isNumber(min)) {
-      if (isNumber(max)) {
-        range = [min!, max!];
-        console.log('MAX AND MIN');
-      } else {
-        range = (u: uPlot, initMin: number, initMax: number) => {
-          let [rmin, rmax] = uPlot.rangeNum(initMin, initMax, 0.05 as any, true);
-          console.log('ONLY MIN', { rmin, rmax, initMin, initMax });
-          return [min, rmax];
-        };
-      }
-    } else if (isNumber(max)) {
-      range = (u: uPlot, initMin: number, initMax: number) => {
-        let [rmin, rmax] = uPlot.rangeNum(initMin, initMax, 0.1 as any, true);
-        console.log('ONLY MAX', { rmin, rmax, initMin, initMax });
-        return [rmin, max];
+    if (isTime) {
+      return {
+        [scaleKey]: {
+          time: true, // no explicit ranges for time?
+        },
       };
     }
-
     return {
       [scaleKey]: {
-        time: !!isTime,
-        range,
+        range: (u: uPlot, initMin: number, initMax: number) => {
+          const [rmin, rmax] = uPlot.rangeNum(initMin, initMax, 0.05 as any, true);
+          return [min ?? rmin, max ?? rmax];
+        },
       },
     };
   }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -20,9 +20,9 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
     }
     return {
       [scaleKey]: {
-        range: (u: uPlot, initMin: number, initMax: number) => {
+        range: (u: uPlot, dataMin: number, dataMax: number) => {
           const { min, max } = this.props;
-          const [smin, smax] = uPlot.rangeNum(initMin, initMax, 0.05 as any, true);
+          const [smin, smax] = uPlot.rangeNum(dataMin, dataMax, 0.05 as any, true);
           return [min ?? smin, max ?? smax];
         },
       },

--- a/public/app/features/dashboard/state/PanelQueryRunner.ts
+++ b/public/app/features/dashboard/state/PanelQueryRunner.ts
@@ -89,7 +89,6 @@ export class PanelQueryRunner {
               ...processedData,
               series: applyFieldOverrides({
                 timeZone: timeZone,
-                autoMinMax: true,
                 data: processedData.series,
                 ...fieldConfig,
               }),

--- a/public/app/features/dashboard/utils/loadSnapshotData.ts
+++ b/public/app/features/dashboard/utils/loadSnapshotData.ts
@@ -16,7 +16,6 @@ export function loadSnapshotData(panel: PanelModel, dashboard: DashboardModel): 
         defaults: {},
         overrides: [],
       },
-      autoMinMax: true,
       replaceVariables: panel.replaceVariables,
       getDataSourceSettingsByUid: getDatasourceSrv().getDataSourceSettingsByUid.bind(getDatasourceSrv()),
       fieldConfigRegistry: panel.plugin!.fieldConfigRegistry,

--- a/public/app/features/panel/panellinks/linkSuppliers.test.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.test.ts
@@ -93,7 +93,6 @@ describe('getFieldLinksSupplier', () => {
       getDataSourceSettingsByUid: (val: string) => ({} as any),
       timeZone: 'utc',
       theme: getTheme(),
-      autoMinMax: true,
     })[0];
 
     const rowIndex = 0;


### PR DESCRIPTION
I'm not sure about this one... :smirk:  it looks like calculating min/max was recently moved from fieldDisplay to fieldOverrides, this PR moves things back.  I suspect there was a good reason to move it, so this may be a bad idea.  My motivation for the change is because we want the auto min/max to be tied to unique units.  

I know understand why we needed the special handling to avoid updates on changes to min/max! 

Below are three series, two share share the same (default) units and a max 40, the third has its own units and auto range.  This was not possible when applying the min/max across all numeric fields

![image](https://user-images.githubusercontent.com/705951/100295489-9b9a7180-2f3e-11eb-9ff3-c2371f5c4211.png)

![image](https://user-images.githubusercontent.com/705951/100295500-a48b4300-2f3e-11eb-9be6-6d9910b8e664.png)


If we do need to keep auto min/max in `applyFieldOverrides` that should be modified so that it:
* is calculated per unit
* is not optional -- it seems weird to have an optional setting that is required in all execution paths
