### PR TITLE
Graph: Nonnull tooltip hover mode

### DIFF
--- a/dashboard-schemas/panels/Graph.cue
+++ b/dashboard-schemas/panels/Graph.cue
@@ -120,10 +120,12 @@ package panels
 	timeShift: string
 	// Tooltip settings.
 	tooltip: {
-		// * true - The hover tooltip shows all series in the graph.  Grafana
+		// * 1 - The hover tooltip shows all series in the graph.  Grafana
 		// highlights the series that you are hovering over in bold in the series
 		// list in the tooltip.
-		// * false - The hover tooltip shows only a single series, the one that you
+		// * 2 - The hover tooltip shows all series in the graph but filters out
+		// null values.
+		// * 0 - The hover tooltip shows only a single series, the one that you
 		// are hovering over on the graph.
 		shared: bool | *true
 		// * 0 (none) - The order of the series in the tooltip is determined by the

--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -50,6 +50,7 @@ Use these settings to change the appearance of the tooltip that appears when you
 - **Mode**
   - **All series -** The hover tooltip shows all series in the graph. Grafana highlights the series that you are hovering over in bold in the series list in the tooltip.
   - **Single -** The hover tooltip shows only a single series, the one that you are hovering over on the graph.
+  - **Nonnull -** The hover tooltip shows all series in the graph but filters out null values from the hovered region.
 - **Sort order -** Sorts the order of series in the hover tooltip if you have selected **All series** mode. When you hover your cursor on a graph, Grafana displays the values associated with the lines. Generally users are most interested in the highest or lowest values. Sorting these values can make it much easier to find the data of interest.
   - **None -** The order of the series in the tooltip is determined by the sort order in your query. For example, they could be alphabetically sorted by series name.
   - **Increasing -** The series in the hover tooltip are sorted by value and in increasing order, with the lowest value at the top of the list.

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -107,7 +107,7 @@ export class DataProcessor {
         this.panel.lines = true;
         this.panel.points = false;
         this.panel.legend.show = true;
-        this.panel.tooltip.shared = true;
+        this.panel.tooltip.shared = 1;
         this.panel.xaxis.values = [];
         break;
       }
@@ -117,7 +117,7 @@ export class DataProcessor {
         this.panel.points = false;
         this.panel.stack = false;
         this.panel.legend.show = false;
-        this.panel.tooltip.shared = false;
+        this.panel.tooltip.shared = 0;
         this.panel.xaxis.values = ['total'];
         break;
       }
@@ -127,7 +127,7 @@ export class DataProcessor {
         this.panel.points = false;
         this.panel.stack = false;
         this.panel.legend.show = false;
-        this.panel.tooltip.shared = false;
+        this.panel.tooltip.shared = 0;
         break;
       }
     }

--- a/public/app/plugins/panel/graph/tab_display.html
+++ b/public/app/plugins/panel/graph/tab_display.html
@@ -130,7 +130,7 @@
       <select
         class="gf-form-input"
         ng-model="ctrl.panel.tooltip.shared"
-        ng-options="f.value as f.text for f in [{text: 'All series', value: true}, {text: 'Single', value: false}]"
+        ng-options="f.value as f.text for f in [{text: 'All series', value: 1}, {text: 'Single', value: 0}, {text: 'Nonnull', value: 2}]"
         ng-change="ctrl.render()"
       ></select>
     </div>


### PR DESCRIPTION
## Add a Nonnull tooltip hover mode

This adds a Nonnull option to hover tooltip modes.
Nonnull hides series in a tooltip when they would be displayed as null.
This is useful when you have sparsely reported series and only care which values were reported at a given time column.

All tests pass.


**What this PR does / why we need it**:
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/3454741/100298024-e1f2cf00-2f44-11eb-99e4-33de6ebfdd52.png">

This new option hides series with null value at the currently hovered time column from the data tooltip in graph panels.

When a time series has sparse data - e.g., reporting infrequent errors by `device_id`, and potentially _many_ distinct series across a dashboard's time range - e.g., a `device_id`, a tooltip becomes quickly unreadable if you don't sort by value descending, or unresponsive if you sort 10,000 mostly-null series by value descending for every pixel the mouse moves.

This gives dashboard authors the ability to choose whether null valued series show up in a hover tooltip.


**Which issue(s) this PR fixes**:
There are many "closed" issues from people who appear to be asking for this but they are either misunderstood or fall into the trap of also mentioning the existing feature of "hide a series from the tooltip when ALL of its values happen to be 0 or null" which is different from this PR which focuses on sparse data.

Relates to:
https://github.com/grafana/grafana/issues/3094
https://github.com/grafana/grafana/issues/1381
https://github.com/grafana/grafana/issues/4623

This PR does not include a "Nonzero" option and it does not affect what is in the legend, so it does not seem to satisfy every aspect of each of these (and myriad other loosely related) issues.