### PR TITLE
Fix: Correct panel edit uistate migration

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/reducers.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/reducers.ts
@@ -41,8 +41,8 @@ export const initialState = (): PanelEditorState => {
 
   let migratedState = { ...storedUiState };
 
-  if (typeof storedUiState.rightPaneSize === 'string') {
-    migratedState = { ...storedUiState, rightPaneSize: parseFloat(storedUiState.rightPaneSize) / 100 };
+  if (typeof storedUiState.topPaneSize === 'string') {
+    migratedState = { ...storedUiState, topPaneSize: parseFloat(storedUiState.topPaneSize) / 100 };
   }
 
   return {


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects https://github.com/grafana/grafana/pull/29412. It is the topPaneSize that can be a percentage string.

**Which issue(s) this PR fixes**:
Fixes #29388

**Special notes for your reviewer**:

