### PR TITLE
Plugins: Add support for includes' icon

### DIFF
--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -68,6 +68,7 @@ Plugin dependencies.
 | `name`       | string  | No       |             |
 | `role`       | string  | No       |             |
 | `type`       | string  | No       |             |
+| `icon`       | string  | No       |             |
 
 ## info
 

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -104,6 +104,7 @@ func getAppLinks(c *models.ReqContext) ([]*dtos.NavLink, error) {
 						Text: include.Name,
 					}
 				}
+				link.Icon = include.Icon
 				appLink.Children = append(appLink.Children, link)
 			}
 

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -133,6 +133,7 @@ type PluginInclude struct {
 	AddToNav   bool            `json:"addToNav"`
 	DefaultNav bool            `json:"defaultNav"`
 	Slug       string          `json:"slug"`
+	Icon       string          `json:"icon"`
 
 	Id string `json:"-"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I was developing a Grafana application plugin when I realized that there's no support for includes' icon.

However, the [`PluginInclude`](https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/plugin.ts#L91) type already has the `icon` attribute and the [`DropDownChild`](https://github.com/grafana/grafana/blob/master/public/app/core/components/sidemenu/DropDownChild.tsx) component already has support for displaying an icon. See on the image below that `NavLink`s other than plugin includes are already drawing the icons.

![screenshot1](https://user-images.githubusercontent.com/5459617/100369899-cef40380-3005-11eb-80c1-a6db36f25885.png) 

So, I introduced the minor changes needed to add support for includes' icon.

**Special notes for your reviewer**:

Note that I only added support for `page` includes, but it could make sense to add it for other types of includes.
Also, I added the `icon` field into the [`plugin.json`](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/#includes) reference, but more changes might be required.

Thanks!!