### PR TITLE
Add PPL support configuration setting

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
@@ -25,8 +25,9 @@ describe('ConfigEditor', () => {
     //@ts-ignore
     delete options.jsonData.timeField;
     delete options.jsonData.maxConcurrentShardRequests;
+    delete options.jsonData.pplSupportEnabled;
 
-    expect.assertions(3);
+    expect.assertions(4);
 
     mount(
       <ConfigEditor
@@ -34,6 +35,7 @@ describe('ConfigEditor', () => {
           expect(options.jsonData.esVersion).toBe(5);
           expect(options.jsonData.timeField).toBe('@timestamp');
           expect(options.jsonData.maxConcurrentShardRequests).toBe(256);
+          expect(options.jsonData.pplSupportEnabled).toBe(false);
         }}
         options={options}
       />
@@ -41,7 +43,7 @@ describe('ConfigEditor', () => {
   });
 
   it('should not apply default if values are set', () => {
-    expect.assertions(3);
+    expect.assertions(4);
 
     mount(
       <ConfigEditor
@@ -49,6 +51,7 @@ describe('ConfigEditor', () => {
           expect(options.jsonData.esVersion).toBe(70);
           expect(options.jsonData.timeField).toBe('@time');
           expect(options.jsonData.maxConcurrentShardRequests).toBe(300);
+          expect(options.jsonData.pplSupportEnabled).toBe(true);
         }}
         options={createDefaultConfigOptions()}
       />

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -22,6 +22,7 @@ export const ConfigEditor = (props: Props) => {
         esVersion,
         maxConcurrentShardRequests:
           options.jsonData.maxConcurrentShardRequests || defaultMaxConcurrentShardRequests(esVersion),
+        pplSupportEnabled: options.jsonData.pplSupportEnabled || false,
         logMessageField: options.jsonData.logMessageField || '',
         logLevelField: options.jsonData.logLevelField || '',
       },

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.test.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import { ElasticDetails } from './ElasticDetails';
 import { createDefaultConfigOptions } from './mocks';
 import { LegacyForms } from '@grafana/ui';
-const { Select } = LegacyForms;
+const { Select, Switch } = LegacyForms;
 
 describe('ElasticDetails', () => {
   it('should render without error', () => {
@@ -84,6 +84,37 @@ describe('ElasticDetails', () => {
           tc.expectedMaxConcurrentShardRequests
         );
       });
+    });
+  });
+
+  describe('PPL support', () => {
+    it('should render switch if version high enough', () => {
+      const options = createDefaultConfigOptions();
+      options.jsonData.esVersion = 70;
+      const wrapper = mount(<ElasticDetails onChange={() => {}} value={options} />);
+      expect(wrapper.find({ label: 'PPL support' }).length).toBe(1);
+    });
+
+    it('should not render switch if version is low', () => {
+      const options = createDefaultConfigOptions();
+      options.jsonData.esVersion = 60;
+      const wrapper = mount(<ElasticDetails onChange={() => {}} value={options} />);
+      expect(wrapper.find({ label: 'PPL support' }).length).toBe(0);
+    });
+
+    it('should set pplSupportEnabled', () => {
+      const onChangeMock = jest.fn();
+      const options = createDefaultConfigOptions();
+      options.jsonData.pplSupportEnabled = false;
+      const wrapper = mount(<ElasticDetails onChange={onChangeMock} value={options} />);
+
+      const switchEl = wrapper.find({ label: 'PPL support' }).find(Switch);
+      const event = {
+        currentTarget: { checked: true },
+      } as React.ChangeEvent<HTMLInputElement>;
+      switchEl.props().onChange(event);
+
+      expect(onChangeMock.mock.calls[0][0].jsonData.pplSupportEnabled).toBe(true);
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EventsWithValidation, regexValidation, LegacyForms } from '@grafana/ui';
-const { Select, Input, FormField } = LegacyForms;
+const { Select, Input, FormField, Switch } = LegacyForms;
 import { ElasticsearchOptions } from '../types';
 import { DataSourceSettings, SelectableValue } from '@grafana/data';
 
@@ -144,6 +144,17 @@ export const ElasticDetails = (props: Props) => {
             />
           </div>
         </div>
+        {value.jsonData.esVersion >= 70 && (
+          <div className="gf-form">
+            <Switch
+              label="PPL support"
+              labelClass="width-10"
+              tooltip="Allow Piped Processing Language as an alternative query syntax in the Elasticsearch query editor."
+              checked={value.jsonData.pplSupportEnabled || false}
+              onChange={jsonDataSwitchChangeHandler('pplSupportEnabled', value, onChange)}
+            />
+          </div>
+        )}
       </div>
     </>
   );
@@ -168,6 +179,20 @@ const jsonDataChangeHandler = (key: keyof ElasticsearchOptions, value: Props['va
     jsonData: {
       ...value.jsonData,
       [key]: event.currentTarget.value,
+    },
+  });
+};
+
+const jsonDataSwitchChangeHandler = (
+  key: keyof ElasticsearchOptions,
+  value: Props['value'],
+  onChange: Props['onChange']
+) => (event: React.SyntheticEvent<HTMLInputElement>) => {
+  onChange({
+    ...value,
+    jsonData: {
+      ...value.jsonData,
+      [key]: event.currentTarget.checked,
     },
   });
 };

--- a/public/app/plugins/datasource/elasticsearch/configuration/mocks.ts
+++ b/public/app/plugins/datasource/elasticsearch/configuration/mocks.ts
@@ -11,5 +11,6 @@ export function createDefaultConfigOptions(): DataSourceSettings<ElasticsearchOp
     maxConcurrentShardRequests: 300,
     logMessageField: 'test.message',
     logLevelField: 'test.level',
+    pplSupportEnabled: true,
   });
 }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -52,6 +52,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   logLevelField?: string;
   dataLinks: DataLinkConfig[];
   languageProvider: LanguageProvider;
+  pplSupportEnabled?: boolean;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>,
@@ -87,6 +88,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       this.logLevelField = undefined;
     }
     this.languageProvider = new LanguageProvider(this);
+    this.pplSupportEnabled = settingsData.pplSupportEnabled;
   }
 
   private request(method: string, url: string, data?: undefined) {

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -9,6 +9,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  pplSupportEnabled?: boolean;
 }
 
 export interface ElasticsearchAggregation {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the `elasticsearch-ppl-support` branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the `elasticsearch-ppl-support-frontend` branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR adds the option to enable PPL support under the Elasticsearch Details section of the Elasticsearch data source configuration menu.

![image](https://user-images.githubusercontent.com/25109478/99728590-87520280-2a6e-11eb-9438-7eb1ff2b1256.png)

This setting is only available when the Elasticsearch version is set 7.0+ as PPL is only available in the opendistro_sql plugin version that goes with Elasticsearch version 7.9.1+ (see [plugin compatibility](https://opendistro.github.io/for-elasticsearch-docs/docs/install/plugins/#plugin-compatibility) for details). This setting is then made available to the `ElasticDatasource` class, which can then be used to control whether the user has the option of writing PPL queries.


**Which issue(s) this PR fixes**:

Partially resolves #28674

cc: @alolita