### PR TITLE
Add PPL query editor

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/partials/query.editor.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/query.editor.html
@@ -3,15 +3,24 @@
 	<div class="gf-form-inline">
 		<div class="gf-form gf-form--grow">
 			<label class="gf-form-label query-keyword width-7">Query</label>
-			<input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck='false' placeholder="Lucene query" ng-blur="ctrl.refresh()">
+			<gf-form-dropdown
+				model="ctrl.target.queryType"
+				lookup-text="true"
+				get-options="ctrl.getQueryTypes()"
+				on-change="ctrl.refresh()"
+				allow-custom="false"
+				label-mode="true"
+			>
+			</gf-form-dropdown>
+			<input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck='false' placeholder="{{ctrl.getQueryInputPlaceholder()}}" ng-blur="ctrl.refresh()">
 		</div>
-		<div class="gf-form max-width-15">
+		<div ng-if="ctrl.target.queryType === ctrl.esQueryType.Lucene" class="gf-form max-width-15">
 			<label class="gf-form-label query-keyword">Alias</label>
 			<input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="alias patterns" ng-blur="ctrl.refresh()" pattern='[^<>&\\"]+'>
 		</div>
 	</div>
 
-	<div ng-repeat="agg in ctrl.target.metrics">
+	<div ng-if="ctrl.target.queryType === ctrl.esQueryType.Lucene" ng-repeat="agg in ctrl.target.metrics">
 		<elastic-metric-agg
 			target="ctrl.target" index="$index"
 			get-fields="ctrl.getFields($fieldType)"
@@ -20,7 +29,7 @@
 		</elastic-metric-agg>
 	</div>
 
-	<div ng-repeat="agg in ctrl.target.bucketAggs">
+	<div ng-if="ctrl.target.queryType === ctrl.esQueryType.Lucene" ng-repeat="agg in ctrl.target.bucketAggs">
 		<elastic-bucket-agg
 			target="ctrl.target" index="$index"
 			get-fields="ctrl.getFields($fieldType)"
@@ -28,4 +37,43 @@
 		</elastic-bucket-agg>
 	</div>
 
+	<div ng-if="ctrl.target.queryType === ctrl.esQueryType.PPL" class="gf-form-inline">
+		<div class="gf-form" style="margin-right: 4px;">
+			<label class="gf-form-label query-keyword width-7">Format as</label>
+			<gf-form-dropdown
+				model="ctrl.target.format"
+				lookup-text="true"
+				get-options="ctrl.getPPLFormatTypes()"
+				on-change="ctrl.refresh()"
+				allow-custom="false"
+				label-mode="true"
+			>
+			</gf-form-dropdown>
+		</div>
+		<div class="gf-form">
+			<label class="gf-form-label query-keyword pointer" ng-click="ctrl.showHelp = !ctrl.showHelp">
+				Show Help
+				<icon name="'angle-down'" ng-show="ctrl.showHelp" style="margin-top: 3px;"></icon>
+				<icon name="'angle-right'" ng-hide="ctrl.showHelp" style="margin-top: 3px;"></icon>
+			</label>
+		</div>
+	</div>
+
+	<div class="gf-form"	ng-show="ctrl.showHelp">
+		<pre class="gf-form-pre alert alert-info">Table:
+- return any set of columns
+
+Logs:
+- return any set of columns
+
+Time series:
+- return column as date, time, datetime, or timestamp
+- return column with numeric datatype as values
+
+Resultsets of time series queries need to be sorted by time.
+
+Example PPL query for time series:
+source=&lt;index&gt; | eval dateValue=time(timestamp) | stats count(response) by dateValue
+		</pre>
+	</div>
 </query-editor-row>

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -1,5 +1,10 @@
 import _ from 'lodash';
-import { ElasticsearchAggregation, ElasticsearchQuery } from './types';
+import { ElasticsearchAggregation, ElasticsearchQuery, ElasticsearchQueryType } from './types';
+
+export const queryTypes = [
+  { text: 'Lucene', value: ElasticsearchQueryType.Lucene },
+  { text: 'PPL', value: ElasticsearchQueryType.PPL },
+];
 
 export const metricAggTypes = [
   { text: 'Count', value: 'count', requiresField: false },
@@ -182,6 +187,18 @@ export const movingAvgModelSettings: any = {
   ],
 };
 
+export const pplFormatTypes = [
+  { text: 'Table', value: 'table' },
+  { text: 'Logs', value: 'logs' },
+  { text: 'Time series', value: 'time_series' },
+];
+
+export function getQueryTypes(supportedTypes: ElasticsearchQueryType[]) {
+  return _.filter(queryTypes, queryType => {
+    return supportedTypes.includes(queryType.value);
+  });
+}
+
 export function getMetricAggTypes(esVersion: any) {
   return _.filter(metricAggTypes, f => {
     if (f.minVersion || f.maxVersion) {
@@ -297,6 +314,10 @@ export function defaultMetricAgg() {
 
 export function defaultBucketAgg() {
   return { type: 'date_histogram', id: '2', settings: { interval: 'auto' } };
+}
+
+export function defaultPPLFormat() {
+  return 'table';
 }
 
 export const findMetricById = (metrics: any[], id: any) => {

--- a/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_def.test.ts
@@ -1,4 +1,5 @@
 import * as queryDef from '../query_def';
+import { ElasticsearchQueryType } from '../types';
 
 describe('ElasticQueryDef', () => {
   describe('getAncestors', () => {
@@ -177,6 +178,22 @@ describe('ElasticQueryDef', () => {
       });
       test('should get pipeline aggs without moving average', () => {
         expect(metricAggTypes.some(m => m.value === 'moving_avg')).toBeFalsy();
+      });
+    });
+  });
+
+  describe('query types depending on types included', () => {
+    describe('without any supported types', () => {
+      const queryTypes = queryDef.getQueryTypes([]);
+      test('should return no query types', () => {
+        expect(queryTypes.length).toBe(0);
+      });
+    });
+    describe('with Lucene type included', () => {
+      const queryTypes = queryDef.getQueryTypes([ElasticsearchQueryType.Lucene]);
+      test('should get lucene and PPL query type', () => {
+        expect(queryTypes.length).toBe(1);
+        expect(queryTypes.some(t => t.value === ElasticsearchQueryType.Lucene)).toBe(true);
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -9,6 +9,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  pplSupportEnabled?: boolean;
 }
 
 export interface ElasticsearchAggregation {
@@ -23,8 +24,10 @@ export interface ElasticsearchQuery extends DataQuery {
   isLogsQuery: boolean;
   alias?: string;
   query?: string;
+  queryType?: ElasticsearchQueryType;
   bucketAggs?: ElasticsearchAggregation[];
   metrics?: ElasticsearchAggregation[];
+  format?: string;
 }
 
 export type DataLinkConfig = {
@@ -32,3 +35,8 @@ export type DataLinkConfig = {
   url: string;
   datasourceUid?: string;
 };
+
+export enum ElasticsearchQueryType {
+  Lucene = 'lucene',
+  PPL = 'PPL',
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the `elasticsearch-ppl-support` branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the `elasticsearch-ppl-support-frontend` branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR adds the option to display a different query editor depending on the user's choice of query syntax. A dropdown next to the main query input field will allow users to choose either Lucene or PPL if PPL support is enabled for the datasource (this setting will be handled in another PR). Lucene is the selected query syntax by default. Except for the query syntax dropdown, the Lucene query editor will look and function the same as before. 

![image](https://user-images.githubusercontent.com/25109478/99478432-3aa0e700-2909-11eb-98aa-e50384076b61.png)

The PPL query editor contains a main query input field and an additional dropdown that will be used to determine the visualization format.

![image](https://user-images.githubusercontent.com/25109478/99478513-5e642d00-2909-11eb-96b6-c1d6fe5707c3.png)

**Which issue(s) this PR fixes**:

Partially resolves #28674

cc: @alolita