### PR TITLE
Elasticsearch: Add PPL support to ElasticDatasource

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -257,8 +257,8 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if proxy.ctx.Req.Request.Method == "PUT" {
 			return errors.New("puts not allowed on proxied Elasticsearch datasource")
 		}
-		if proxy.ctx.Req.Request.Method == "POST" && proxy.proxyPath != "_msearch" {
-			return errors.New("posts not allowed on proxied Elasticsearch datasource except on /_msearch")
+		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "_msearch" || proxy.proxyPath == "_opendistro/_ppl") {
+			return errors.New("posts not allowed on proxied Elasticsearch datasource except on /_msearch or /_opendistro/_ppl")
 		}
 	}
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -494,15 +494,15 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       subQueries.push(
         from(this.post(this.getPPLUrl(), payload)).pipe(
           map((res: any) => {
-            const er = new ElasticResponse(targets, res, ElasticsearchQueryType.PPL);
+            const er = new ElasticResponse(target, res, ElasticsearchQueryType.PPL);
 
-            if (targets.some(target => target.isLogsQuery)) {
+            if (target.isLogsQuery) {
               const response = er.getLogs(this.logMessageField, this.logLevelField);
               for (const dataFrame of response.data) {
                 enhanceDataFrame(dataFrame, this.dataLinks);
               }
               return response;
-            } else if (targets.some(target => target.format === 'table')) {
+            } else if (target.format === 'table') {
               return er.getTable();
             }
             return er.getTimeSeries();

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1,15 +1,19 @@
 import angular from 'angular';
 import _ from 'lodash';
+import { from, merge, of, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import {
   DataSourceApi,
   DataSourceInstanceSettings,
   DataQueryRequest,
   DataQueryResponse,
   DataFrame,
+  LoadingState,
   ScopedVars,
   DataLink,
   PluginMeta,
   DataQuery,
+  dateTime,
 } from '@grafana/data';
 import LanguageProvider from './language_provider';
 import { ElasticResponse } from './elastic_response';
@@ -20,7 +24,7 @@ import * as queryDef from './query_def';
 import { getBackendSrv } from '@grafana/runtime';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
-import { DataLinkConfig, ElasticsearchOptions, ElasticsearchQuery } from './types';
+import { DataLinkConfig, ElasticsearchOptions, ElasticsearchQuery, ElasticsearchQueryType } from './types';
 
 // Those are metadata fields as defined in https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html#_identity_metadata_fields.
 // custom fields can start with underscores, therefore is not safe to exclude anything that starts with one.
@@ -52,6 +56,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   logLevelField?: string;
   dataLinks: DataLinkConfig[];
   languageProvider: LanguageProvider;
+  pplSupportEnabled?: boolean;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>,
@@ -78,7 +83,6 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     this.logMessageField = settingsData.logMessageField || '';
     this.logLevelField = settingsData.logLevelField || '';
     this.dataLinks = settingsData.dataLinks || [];
-
     if (this.logMessageField === '') {
       this.logMessageField = undefined;
     }
@@ -309,18 +313,28 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   }
 
   private interpolateLuceneQuery(queryString: string, scopedVars: ScopedVars) {
-    // Elasticsearch queryString should always be '*' if empty string
+    // Elasticsearch Lucene queryString should always be '*' if empty string
     return this.templateSrv.replace(queryString, scopedVars, 'lucene') || '*';
+  }
+
+  private interpolatePPLQuery(queryString: string, scopedVars: ScopedVars) {
+    return this.templateSrv.replace(queryString, scopedVars, 'pipe');
   }
 
   interpolateVariablesInQueries(queries: ElasticsearchQuery[], scopedVars: ScopedVars): ElasticsearchQuery[] {
     let expandedQueries = queries;
     if (queries && queries.length > 0) {
       expandedQueries = queries.map(query => {
+        let interpolatedQuery;
+        if (query.queryType === ElasticsearchQueryType.PPL) {
+          interpolatedQuery = this.interpolatePPLQuery(query.query || '', scopedVars);
+        } else {
+          interpolatedQuery = this.interpolateLuceneQuery(query.query || '', scopedVars);
+        }
         const expandedQuery = {
           ...query,
           datasource: this.name,
-          query: this.interpolateLuceneQuery(query.query || '', scopedVars),
+          query: interpolatedQuery,
         };
 
         for (let bucketAgg of query.bucketAggs || []) {
@@ -374,47 +388,60 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     return angular.toJson(queryHeader);
   }
 
-  query(options: DataQueryRequest<ElasticsearchQuery>): Promise<DataQueryResponse> {
-    let payload = '';
+  query(options: DataQueryRequest<ElasticsearchQuery>): Observable<DataQueryResponse> {
     const targets = this.interpolateVariablesInQueries(_.cloneDeep(options.targets), options.scopedVars);
-    const sentTargets: ElasticsearchQuery[] = [];
 
-    // add global adhoc filters to timeFilter
-    const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
+    const luceneTargets: ElasticsearchQuery[] = [];
+    const pplTargets: ElasticsearchQuery[] = [];
 
     for (const target of targets) {
       if (target.hide) {
         continue;
       }
 
-      let queryObj;
-      if (target.isLogsQuery || queryDef.hasMetricOfType(target, 'logs')) {
-        target.bucketAggs = [queryDef.defaultBucketAgg()];
-        target.metrics = [];
-        // Setting this for metrics queries that are typed as logs
-        target.isLogsQuery = true;
-        queryObj = this.queryBuilder.getLogsQuery(target, adhocFilters, target.query);
-      } else {
-        if (target.alias) {
-          target.alias = this.templateSrv.replace(target.alias, options.scopedVars, 'lucene');
-        }
-
-        queryObj = this.queryBuilder.build(target, adhocFilters, target.query);
+      switch (target.queryType) {
+        case ElasticsearchQueryType.PPL:
+          pplTargets.push(target);
+          break;
+        case ElasticsearchQueryType.Lucene:
+        default:
+          luceneTargets.push(target);
       }
-
-      const esQuery = angular.toJson(queryObj);
-
-      const searchType = queryObj.size === 0 && this.esVersion < 5 ? 'count' : 'query_then_fetch';
-      const header = this.getQueryHeader(searchType, options.range.from, options.range.to);
-      payload += header + '\n';
-
-      payload += esQuery + '\n';
-
-      sentTargets.push(target);
     }
 
-    if (sentTargets.length === 0) {
-      return Promise.resolve({ data: [] });
+    const subQueries: Array<Observable<DataQueryResponse>> = [];
+    const luceneResponses = this.executeLuceneQueries(luceneTargets, options);
+    const pplResponses = this.executePPLQueries(pplTargets, options);
+    if (luceneResponses) {
+      subQueries.push(luceneResponses);
+    }
+    if (pplResponses) {
+      subQueries.push(pplResponses);
+    }
+    if (subQueries.length === 0) {
+      return of({
+        data: [],
+        state: LoadingState.Done,
+      });
+    }
+    return merge(...subQueries);
+  }
+
+  /**
+   * Execute all Lucene queries. Returns an Observable to be merged.
+   */
+  private executeLuceneQueries(
+    targets: ElasticsearchQuery[],
+    options: DataQueryRequest<ElasticsearchQuery>
+  ): Observable<DataQueryResponse> | undefined {
+    if (targets.length === 0) {
+      return;
+    }
+
+    let payload = '';
+
+    for (const target of targets) {
+      payload += this.createLuceneQuery(target, options);
     }
 
     // We replace the range here for actual values. We need to replace it together with enclosing "" so that we replace
@@ -425,21 +452,115 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     payload = payload.replace(/"\$timeTo"/g, options.range.to.valueOf().toString());
     payload = this.templateSrv.replace(payload, options.scopedVars);
 
-    const url = this.getMultiSearchUrl();
+    return from(this.post(this.getMultiSearchUrl(), payload)).pipe(
+      map((res: any) => {
+        const er = new ElasticResponse(targets, res);
 
-    return this.post(url, payload).then((res: any) => {
-      const er = new ElasticResponse(sentTargets, res);
-
-      if (sentTargets.some(target => target.isLogsQuery)) {
-        const response = er.getLogs(this.logMessageField, this.logLevelField);
-        for (const dataFrame of response.data) {
-          enhanceDataFrame(dataFrame, this.dataLinks);
+        if (targets.some(target => target.isLogsQuery)) {
+          const response = er.getLogs(this.logMessageField, this.logLevelField);
+          for (const dataFrame of response.data) {
+            enhanceDataFrame(dataFrame, this.dataLinks);
+          }
+          return response;
         }
-        return response;
-      }
 
-      return er.getTimeSeries();
-    });
+        return er.getTimeSeries();
+      })
+    );
+  }
+
+  /**
+   * Execute all PPL queries. Returns an Observable to be merged.
+   */
+  private executePPLQueries(
+    targets: ElasticsearchQuery[],
+    options: DataQueryRequest<ElasticsearchQuery>
+  ): Observable<DataQueryResponse> | undefined {
+    if (targets.length === 0) {
+      return;
+    }
+
+    const subQueries: Array<Observable<DataQueryResponse>> = [];
+
+    for (const target of targets) {
+      let payload = this.createPPLQuery(target, options);
+
+      const rangeFrom = dateTime(options.range.from.valueOf()).format('YYYY-MM-DD HH:mm:ss');
+      const rangeTo = dateTime(options.range.to.valueOf()).format('YYYY-MM-DD HH:mm:ss');
+      // Replace the range here for actual values.
+      payload = payload.replace(/\$timeTo/g, rangeTo);
+      payload = payload.replace(/\$timeFrom/g, rangeFrom);
+      payload = payload.replace(/\$timestamp/g, `\`${this.timeField}\``);
+      subQueries.push(
+        from(this.post(this.getPPLUrl(), payload)).pipe(
+          map((res: any) => {
+            const er = new ElasticResponse(targets, res, ElasticsearchQueryType.PPL);
+
+            if (targets.some(target => target.isLogsQuery)) {
+              const response = er.getLogs(this.logMessageField, this.logLevelField);
+              for (const dataFrame of response.data) {
+                enhanceDataFrame(dataFrame, this.dataLinks);
+              }
+              return response;
+            } else if (targets.some(target => target.format === 'table')) {
+              return er.getTable();
+            }
+            return er.getTimeSeries();
+          })
+        )
+      );
+    }
+    return merge(...subQueries);
+  }
+
+  /**
+   * Creates the payload string for a Lucene query
+   */
+  private createLuceneQuery(target: ElasticsearchQuery, options: DataQueryRequest<ElasticsearchQuery>): string {
+    let queryString = this.templateSrv.replace(target.query, options.scopedVars, 'lucene');
+    // add global adhoc filters to timeFilter
+    const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
+    // Elasticsearch queryString should always be '*' if empty string
+    if (!queryString || queryString === '') {
+      queryString = '*';
+    }
+
+    let queryObj;
+    if (target.isLogsQuery || queryDef.hasMetricOfType(target, 'logs')) {
+      target.bucketAggs = [queryDef.defaultBucketAgg()];
+      target.metrics = [];
+      // Setting this for metrics queries that are typed as logs
+      target.isLogsQuery = true;
+      queryObj = this.queryBuilder.getLogsQuery(target, adhocFilters, queryString);
+    } else {
+      if (target.alias) {
+        target.alias = this.templateSrv.replace(target.alias, options.scopedVars, 'lucene');
+      }
+      queryObj = this.queryBuilder.build(target, adhocFilters, queryString);
+    }
+
+    const esQuery = angular.toJson(queryObj);
+    const searchType = queryObj.size === 0 && this.esVersion < 5 ? 'count' : 'query_then_fetch';
+    const header = this.getQueryHeader(searchType, options.range.from, options.range.to);
+    return header + '\n' + esQuery + '\n';
+  }
+
+  /**
+   * Creates the payload string for a PPL query
+   */
+  private createPPLQuery(target: ElasticsearchQuery, options: DataQueryRequest<ElasticsearchQuery>): string {
+    let queryString = this.templateSrv.replace(target.query, options.scopedVars, 'pipe');
+    let queryObj;
+
+    const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
+
+    // Elasticsearch PPL queryString should always be 'source=indexName' if empty string
+    if (!queryString) {
+      queryString = `source=\`${this.indexPattern.getPPLIndexPattern()}\``;
+    }
+
+    queryObj = this.queryBuilder.buildPPLQuery(target, adhocFilters, queryString);
+    return angular.toJson(queryObj);
   }
 
   isMetadataField(fieldName: string) {
@@ -563,9 +684,13 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   getMultiSearchUrl() {
     if (this.esVersion >= 70 && this.maxConcurrentShardRequests) {
       return `_msearch?max_concurrent_shard_requests=${this.maxConcurrentShardRequests}`;
+    } else {
+      return '_msearch';
     }
+  }
 
-    return '_msearch';
+  getPPLUrl() {
+    return '_opendistro/_ppl';
   }
 
   metricFindQuery(query: any) {

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -10,12 +10,17 @@ import {
   MutableDataFrame,
   PreferredVisualisationType,
 } from '@grafana/data';
-import { ElasticsearchAggregation } from './types';
+import { ElasticsearchAggregation, ElasticsearchQueryType } from './types';
 
 export class ElasticResponse {
-  constructor(private targets: any, private response: any) {
+  constructor(
+    private targets: any,
+    private response: any,
+    private targetType: ElasticsearchQueryType = ElasticsearchQueryType.Lucene
+  ) {
     this.targets = targets;
     this.response = response;
+    this.targetType = targetType;
   }
 
   processMetrics(esAgg: any, target: any, seriesList: any, props: any) {
@@ -395,14 +400,23 @@ export class ElasticResponse {
   }
 
   getTimeSeries() {
-    if (this.targets.some((target: any) => target.metrics.some((metric: any) => metric.type === 'raw_data'))) {
+    if (this.targetType === ElasticsearchQueryType.PPL) {
+      return { data: [] };
+    } else if (this.targets.some((target: any) => target.metrics.some((metric: any) => metric.type === 'raw_data'))) {
       return this.processResponseToDataFrames(false);
     }
     return this.processResponseToSeries();
   }
 
   getLogs(logMessageField?: string, logLevelField?: string): DataQueryResponse {
+    if (this.targetType === ElasticsearchQueryType.PPL) {
+      return { data: [] };
+    }
     return this.processResponseToDataFrames(true, logMessageField, logLevelField);
+  }
+
+  getTable(): DataQueryResponse {
+    return { data: [] };
   }
 
   processResponseToDataFrames(

--- a/public/app/plugins/datasource/elasticsearch/index_pattern.ts
+++ b/public/app/plugins/datasource/elasticsearch/index_pattern.ts
@@ -45,4 +45,16 @@ export class IndexPattern {
 
     return indexList;
   }
+
+  getPPLIndexPattern() {
+    // PPL currently does not support multi-indexing through lists, so a wildcard
+    // pattern is used to match all patterns and relies on the time range filter
+    // to filter out the incorrect indexes.
+    if (!this.interval) {
+      return this.pattern;
+    }
+
+    const indexPattern = this.pattern.match(/\[(.*)\]/)[1] + '*';
+    return indexPattern;
+  }
 }

--- a/public/app/plugins/datasource/elasticsearch/index_pattern.ts
+++ b/public/app/plugins/datasource/elasticsearch/index_pattern.ts
@@ -54,7 +54,13 @@ export class IndexPattern {
       return this.pattern;
     }
 
-    const indexPattern = this.pattern.match(/\[(.*)\]/)[1] + '*';
+    let indexPattern = this.pattern.match(/\[(.*?)\]/)[1];
+
+    if (this.pattern.startsWith('[')) {
+      indexPattern = indexPattern + '*';
+    } else if (this.pattern.endsWith(']')) {
+      indexPattern = '*' + indexPattern;
+    }
     return indexPattern;
   }
 }

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -419,4 +419,8 @@ export class ElasticQueryBuilder {
       aggs: this.build(target, null, querystring).aggs,
     };
   }
+
+  buildPPLQuery(target: any, adhocFilters?: any, queryString?: string) {
+    return { query: queryString };
+  }
 }

--- a/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
@@ -60,4 +60,20 @@ describe('IndexPattern', () => {
       });
     });
   });
+
+  describe('getPPLIndexPattern', () => {
+    describe('no interval', () => {
+      test('should return correct index', () => {
+        const pattern = new IndexPattern('my-metrics');
+        expect(pattern.getPPLIndexPattern()).toEqual('my-metrics');
+      });
+    });
+
+    describe('daily', () => {
+      test('should return correct index pattern', () => {
+        const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
+        expect(pattern.getPPLIndexPattern()).toEqual('asd-*');
+      });
+    });
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
@@ -69,8 +69,15 @@ describe('IndexPattern', () => {
       });
     });
 
-    describe('daily', () => {
+    describe('daily interval pattern prefix', () => {
       test('should return correct index pattern', () => {
+        const pattern = new IndexPattern('YYYY.MM.DD[-asd]', 'Daily');
+        expect(pattern.getPPLIndexPattern()).toEqual('*-asd');
+      });
+    });
+
+    describe('daily interval pattern suffix', () => {
+      test('should return correct index with time pattern suffix', () => {
         const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
         expect(pattern.getPPLIndexPattern()).toEqual('asd-*');
       });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -9,6 +9,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  pplSupportEnabled?: boolean;
 }
 
 export interface ElasticsearchAggregation {
@@ -23,8 +24,10 @@ export interface ElasticsearchQuery extends DataQuery {
   isLogsQuery: boolean;
   alias?: string;
   query?: string;
+  queryType?: ElasticsearchQueryType;
   bucketAggs?: ElasticsearchAggregation[];
   metrics?: ElasticsearchAggregation[];
+  format?: string;
 }
 
 export type DataLinkConfig = {
@@ -32,3 +35,8 @@ export type DataLinkConfig = {
   url: string;
   datasourceUid?: string;
 };
+
+export enum ElasticsearchQueryType {
+  Lucene = 'lucene',
+  PPL = 'PPL',
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the `elasticsearch-ppl-support` branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the `elasticsearch-ppl-support-frontend` branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR updates the `ElasticDatasource` class to handle PPL queries. The implementation for building PPL queries and parsing the response will be in other PRs. The main purpose of this PR is to send Lucene queries and PPL queries to their respective data paths. Changes to existing Lucene query handling should be purely structural. Finally, the `query` method returns an `Observable` instead of a `Promise` since now not all queries can fit in a single request.

**Which issue(s) this PR fixes**:

Partially resolves #28674

cc: @alolita