### PR TITLE
Docs: fixing frontend docs issue where enums ending up in wrong folder level.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-react": "7.8.3",
     "@babel/preset-typescript": "7.8.3",
     "@emotion/core": "10.0.27",
-    "@grafana/api-documenter": "7.11.1",
+    "@grafana/api-documenter": "7.11.2",
     "@grafana/api-extractor": "7.10.1",
     "@grafana/eslint-config": "2.0.6",
     "@rtsao/plugin-proposal-class-properties": "7.0.1-patch.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3536,10 +3536,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@grafana/api-documenter@7.11.1":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@grafana/api-documenter/-/api-documenter-7.11.1.tgz#5980016ae28aceca16bbeca112913aca5ccda405"
-  integrity sha512-4AJ5m4ychpRA1bFMOm5lP3pMAdR9ZuiSlRuQIdeBrTZh+sFA+C9SiburYdAfr7gQuetlT8LM4+CzJdxQNw7Lbw==
+"@grafana/api-documenter@7.11.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@grafana/api-documenter/-/api-documenter-7.11.2.tgz#c08372e51426e3d67d2406834ddbe59f1585b297"
+  integrity sha512-03PvAj6fiN5EY+BsdHN61kGpUGdAhRBPTUtnzdMGPYuWlCQthMys0jB5XcrtRWJiOVHkxp597LG+7ZFjI+jaUw==
   dependencies:
     "@microsoft/api-extractor-model" "workspace:*"
     "@microsoft/tsdoc" "0.12.19"


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes the following issue:

<img width="333" alt="Skärmavbild 2020-11-27 kl  09 24 14" src="https://user-images.githubusercontent.com/172951/100427156-525b3680-3092-11eb-8e9d-422b35061ba0.png">


