### PR TITLE
prometheus: Improve IsAPIError's documentation

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -218,9 +218,9 @@ func parseResponse(value model.Value, query *PrometheusQuery) (*tsdb.QueryResult
 	return queryRes, nil
 }
 
+// IsAPIError returns whether err is or wraps a Prometheus error.
 func IsAPIError(err error) bool {
-	// Have to use errors.As to compare Prometheus errors, since errors.Is won't work due to Prometheus
-	// errors being pointers and errors.Is ends up comparing them by pointer address
+	// Check if the right error type is in err's chain.
 	var e *apiv1.Error
 	return errors.As(err, &e)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve `prometheus.IsAPIError`s documentation, since we realized that `errors.As` is the correct function to use.


