### PR TITLE
Datasources: fixed long error message overflowing container

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -13,6 +13,7 @@ export const Pages = {
     name: 'Data source settings page name input field',
     delete: 'Data source settings page Delete button',
     saveAndTest: 'Data source settings page Save and Test button',
+    alert: 'Data source settings page Alert',
   },
   DataSources: {
     url: '/datasources',

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -13,8 +13,6 @@ export const Pages = {
     name: 'Data source settings page name input field',
     delete: 'Data source settings page Delete button',
     saveAndTest: 'Data source settings page Save and Test button',
-    alert: 'Data source settings page Alert',
-    alertMessage: 'Data source settings page Alert message',
   },
   DataSources: {
     url: '/datasources',

--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -85,8 +85,9 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
   form();
 
   e2e.pages.DataSource.saveAndTest().click();
-  e2e.pages.DataSource.alert().should('exist');
-  e2e.pages.DataSource.alertMessage().contains(expectedAlertMessage); // assertion
+  e2e.components.Alert.alert().should('exist');
+  e2e.components.Alert.alert().contains(expectedAlertMessage); // assertion
+
   e2e().logToConsole('Added data source with name:', name);
 
   return e2e()

--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -85,8 +85,9 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
   form();
 
   e2e.pages.DataSource.saveAndTest().click();
-  e2e.components.Alert.alert().should('exist');
-  e2e.components.Alert.alert().contains(expectedAlertMessage); // assertion
+  e2e.pages.DataSource.alert()
+    .should('exist')
+    .contains(expectedAlertMessage); // assertion
 
   e2e().logToConsole('Added data source with name:', name);
 

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC, HTMLAttributes, ReactNode } from 'react';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -9,7 +9,7 @@ import { getColorsFromSeverity } from '../../utils/colors';
 
 export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
 
-export interface Props {
+export interface Props extends HTMLAttributes<HTMLElement> {
   title: string;
   /** On click handler for alert button, mostly used for dismissing the alert */
   onRemove?: (event: React.MouseEvent) => void;
@@ -39,40 +39,34 @@ function getIconFromSeverity(severity: AlertVariant): string {
   }
 }
 
-export const Alert: FC<Props> = ({
-  title,
-  buttonText,
-  onButtonClick,
-  onRemove,
-  children,
-  buttonContent,
-  severity = 'error',
-}) => {
-  const theme = useTheme();
-  const styles = getStyles(theme, severity, !!buttonContent);
+export const Alert: FC<Props> = React.forwardRef<HTMLElement, Props>(
+  ({ title, buttonText, onButtonClick, onRemove, children, buttonContent, severity = 'error', ...restProps }) => {
+    const theme = useTheme();
+    const styles = getStyles(theme, severity, !!buttonContent);
 
-  return (
-    <div className={styles.alert} aria-label={selectors.components.Alert.alert(severity)}>
-      <div className={styles.icon}>
-        <Icon size="xl" name={getIconFromSeverity(severity) as IconName} />
+    return (
+      <div className={styles.alert} aria-label={selectors.components.Alert.alert(severity)} {...restProps}>
+        <div className={styles.icon}>
+          <Icon size="xl" name={getIconFromSeverity(severity) as IconName} />
+        </div>
+        <div className={styles.body}>
+          <div className={styles.title}>{title}</div>
+          {children && <div>{children}</div>}
+        </div>
+        {/* If onRemove is specified, giving preference to onRemove */}
+        {onRemove ? (
+          <button type="button" className={styles.close} onClick={onRemove}>
+            {buttonContent || <Icon name="times" size="lg" />}
+          </button>
+        ) : onButtonClick ? (
+          <button type="button" className="btn btn-outline-danger" onClick={onButtonClick}>
+            {buttonText}
+          </button>
+        ) : null}
       </div>
-      <div className={styles.body}>
-        <div className={styles.title}>{title}</div>
-        {children && <div>{children}</div>}
-      </div>
-      {/* If onRemove is specified, giving preference to onRemove */}
-      {onRemove ? (
-        <button type="button" className={styles.close} onClick={onRemove}>
-          {buttonContent || <Icon name="times" size="lg" />}
-        </button>
-      ) : onButtonClick ? (
-        <button type="button" className="btn btn-outline-danger" onClick={onButtonClick}>
-          {buttonText}
-        </button>
-      ) : null}
-    </div>
-  );
-};
+    );
+  }
+);
 
 const getStyles = (theme: GrafanaTheme, severity: AlertVariant, outline: boolean) => {
   const { white } = theme.palette;

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -107,6 +107,8 @@ const getStyles = (theme: GrafanaTheme, severity: AlertVariant, outline: boolean
     body: css`
       flex-grow: 1;
       margin: 0 ${theme.spacing.md} 0 0;
+      overflow-wrap: break-word;
+      word-break: break-word;
 
       a {
         color: ${white};

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -68,6 +68,8 @@ export const Alert: FC<Props> = React.forwardRef<HTMLElement, Props>(
   }
 );
 
+Alert.displayName = 'Alert';
+
 const getStyles = (theme: GrafanaTheme, severity: AlertVariant, outline: boolean) => {
   const { white } = theme.palette;
   const severityColors = getColorsFromSeverity(severity, theme);

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -2,7 +2,6 @@
 import React, { PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
 import isString from 'lodash/isString';
-import { selectors } from '@grafana/e2e-selectors';
 // Components
 import Page from 'app/core/components/Page/Page';
 import { GenericDataSourcePlugin, PluginSettings } from './PluginSettings';
@@ -204,11 +203,7 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
 
         <div className="gf-form-group">
           {testingStatus && testingStatus.message && (
-            <Alert
-              severity={testingStatus.status === 'error' ? 'error' : 'success'}
-              title={testingStatus.message}
-              aria-label={selectors.pages.DataSource.alert}
-            />
+            <Alert severity={testingStatus.status === 'error' ? 'error' : 'success'} title={testingStatus.message} />
           )}
         </div>
 

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -28,6 +28,7 @@ import { getDataSourceLoadingNav } from '../state/navModel';
 import PluginStateinfo from 'app/features/plugins/PluginStateInfo';
 import { dataSourceLoaded, setDataSourceName, setIsDefault } from '../state/reducers';
 import { connectWithCleanUp } from 'app/core/components/connectWithCleanUp';
+import { selectors } from '@grafana/e2e-selectors';
 
 export interface Props {
   navModel: NavModel;
@@ -203,7 +204,11 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
 
         <div className="gf-form-group">
           {testingStatus && testingStatus.message && (
-            <Alert severity={testingStatus.status === 'error' ? 'error' : 'success'} title={testingStatus.message} />
+            <Alert
+              severity={testingStatus.status === 'error' ? 'error' : 'success'}
+              title={testingStatus.message}
+              aria-label={selectors.pages.DataSource.alert}
+            />
           )}
         </div>
 

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -2,7 +2,6 @@
 import React, { PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
 import isString from 'lodash/isString';
-import { Icon } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 // Components
 import Page from 'app/core/components/Page/Page';
@@ -25,6 +24,7 @@ import { getRouteParamsId } from 'app/core/selectors/location';
 // Types
 import { CoreEvents, StoreState } from 'app/types/';
 import { DataSourcePluginMeta, DataSourceSettings, NavModel, UrlQueryMap } from '@grafana/data';
+import { Alert } from '@grafana/ui';
 import { getDataSourceLoadingNav } from '../state/navModel';
 import PluginStateinfo from 'app/features/plugins/PluginStateInfo';
 import { dataSourceLoaded, setDataSourceName, setIsDefault } from '../state/reducers';
@@ -172,7 +172,7 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
   }
 
   renderSettings() {
-    const { dataSourceMeta, setDataSourceName, setIsDefault, dataSource, testingStatus, plugin } = this.props;
+    const { dataSourceMeta, setDataSourceName, setIsDefault, dataSource, plugin, testingStatus } = this.props;
 
     return (
       <form onSubmit={this.onSubmit}>
@@ -204,16 +204,11 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
 
         <div className="gf-form-group">
           {testingStatus && testingStatus.message && (
-            <div className={`alert-${testingStatus.status} alert`} aria-label={selectors.pages.DataSource.alert}>
-              <div className="alert-icon">
-                {testingStatus.status === 'error' ? <Icon name="exclamation-triangle" /> : <Icon name="check" />}
-              </div>
-              <div className="alert-body">
-                <div className="alert-title" aria-label={selectors.pages.DataSource.alertMessage}>
-                  {testingStatus.message}
-                </div>
-              </div>
-            </div>
+            <Alert
+              severity={testingStatus.status === 'error' ? 'error' : 'success'}
+              title={testingStatus.message}
+              aria-label={selectors.pages.DataSource.alert}
+            />
           )}
         </div>
 

--- a/public/sass/components/_alerts.scss
+++ b/public/sass/components/_alerts.scss
@@ -17,7 +17,6 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  overflow-wrap: break-word;
 }
 
 // Alternate styles
@@ -78,8 +77,9 @@
 }
 
 .alert-body {
+  overflow-wrap: break-word;
+  word-break: break-word;
   flex-grow: 1;
-  min-width: 0;
 }
 
 .alert-icon-on-top {

--- a/public/sass/components/_alerts.scss
+++ b/public/sass/components/_alerts.scss
@@ -79,7 +79,7 @@
 
 .alert-body {
   flex-grow: 1;
-  width: 50%;
+  min-width: 0;
 }
 
 .alert-icon-on-top {

--- a/public/sass/components/_alerts.scss
+++ b/public/sass/components/_alerts.scss
@@ -17,6 +17,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  overflow-wrap: break-word;
 }
 
 // Alternate styles
@@ -78,6 +79,7 @@
 
 .alert-body {
   flex-grow: 1;
+  width: 50%;
 }
 
 .alert-icon-on-top {


### PR DESCRIPTION
Signed-off-by: Uchechukwu Obasi <obasiuche62@gmail.com>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes long error messages overflowing its container. 
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #29196 

**Special notes for your reviewer**:
Long error messages now fit into its parent container
<img width="1792" alt="Screenshot 2020-11-27 at 17 00 55" src="https://user-images.githubusercontent.com/29557702/100470754-21eabb00-30d9-11eb-8302-2997f925a32d.png">

