### PR TITLE
Admin API: Add admin API for managing auth keys

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -232,7 +232,7 @@ func (hs *HTTPServer) registerRoutes() {
 		// auth api keys
 		apiRoute.Group("/auth/keys", func(keysRoute routing.RouteRegister) {
 			keysRoute.Get("/", Wrap(GetAPIKeys))
-			keysRoute.Post("/", quota("api_key"), bind(models.AddApiKeyCommand{}), Wrap(hs.AddAPIKey))
+			keysRoute.Post("/", quota("api_key"), bind(dtos.AddApiKeyCommand{}), Wrap(hs.AddAPIKey))
 			keysRoute.Delete("/:id", Wrap(DeleteAPIKey))
 		}, reqOrgAdmin)
 
@@ -420,6 +420,13 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/ldap/sync/:id", Wrap(hs.PostSyncUserWithLDAP))
 		adminRoute.Get("/ldap/:username", Wrap(hs.GetUserFromLDAP))
 		adminRoute.Get("/ldap/status", Wrap(hs.GetLDAPStatus))
+
+		// auth api keys
+		adminRoute.Group("/auth/keys", func(keysRoute routing.RouteRegister) {
+			// TODO: GET // keysRoute.Get("/:orgId", Wrap(GetAPIKeysForOrg))
+			keysRoute.Post("/", bind(dtos.AddApiKeyForOrgCommand{}), Wrap(hs.AddAPIKeyForOrg))
+			// TODO: DELETE // keysRoute.Delete("/:orgId/:id", Wrap(DeleteAPIKeyForOrg))
+		})
 	}, reqGrafanaAdmin)
 
 	// rendering

--- a/pkg/api/dtos/apikey.go
+++ b/pkg/api/dtos/apikey.go
@@ -1,5 +1,20 @@
 package dtos
 
+import "github.com/grafana/grafana/pkg/models"
+
+type AddApiKeyCommand struct {
+	Name          string          `json:"name" binding:"Required"`
+	Role          models.RoleType `json:"role" binding:"Required"`
+	SecondsToLive int64           `json:"secondsToLive"`
+}
+
+type AddApiKeyForOrgCommand struct {
+	Name          string          `json:"name" binding:"Required"`
+	Role          models.RoleType `json:"role" binding:"Required"`
+	OrgId         int64           `json:"orgId" binding:"Required"`
+	SecondsToLive int64           `json:"secondsToLive"`
+}
+
 type NewApiKeyResult struct {
 	ID   int64  `json:"id"`
 	Name string `json:"name"`

--- a/pkg/models/apikey.go
+++ b/pkg/models/apikey.go
@@ -20,16 +20,21 @@ type ApiKey struct {
 	Expires *int64
 }
 
+type ApiKeyClientSecret struct {
+	Id   int64
+	Name string
+	Key  string
+}
+
 // ---------------------
 // COMMANDS
 type AddApiKeyCommand struct {
-	Name          string   `json:"name" binding:"Required"`
-	Role          RoleType `json:"role" binding:"Required"`
-	OrgId         int64    `json:"-"`
-	Key           string   `json:"-"`
-	SecondsToLive int64    `json:"secondsToLive"`
+	Name          string
+	Role          RoleType
+	OrgId         int64
+	SecondsToLive int64
 
-	Result *ApiKey `json:"-"`
+	Result *ApiKeyClientSecret
 }
 
 type DeleteApiKeyCommand struct {

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -18,7 +18,7 @@ func TestApiKeyDataAccess(t *testing.T) {
 		InitTestDB(t)
 
 		t.Run("Given saved api key", func(t *testing.T) {
-			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "hello", Key: "asd"}
+			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "hello"}
 			err := AddApiKey(&cmd)
 			assert.Nil(t, err)
 
@@ -32,7 +32,7 @@ func TestApiKeyDataAccess(t *testing.T) {
 		})
 
 		t.Run("Add non expiring key", func(t *testing.T) {
-			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "non-expiring", Key: "asd1", SecondsToLive: 0}
+			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "non-expiring", SecondsToLive: 0}
 			err := AddApiKey(&cmd)
 			assert.Nil(t, err)
 
@@ -45,7 +45,7 @@ func TestApiKeyDataAccess(t *testing.T) {
 
 		t.Run("Add an expiring key", func(t *testing.T) {
 			// expires in one hour
-			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "expiring-in-an-hour", Key: "asd2", SecondsToLive: 3600}
+			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "expiring-in-an-hour", SecondsToLive: 3600}
 			err := AddApiKey(&cmd)
 			assert.Nil(t, err)
 
@@ -65,7 +65,7 @@ func TestApiKeyDataAccess(t *testing.T) {
 
 		t.Run("Add a key with negative lifespan", func(t *testing.T) {
 			// expires in one day
-			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "key-with-negative-lifespan", Key: "asd3", SecondsToLive: -3600}
+			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "key-with-negative-lifespan", SecondsToLive: -3600}
 			err := AddApiKey(&cmd)
 			assert.EqualError(t, err, models.ErrInvalidApiKeyExpiration.Error())
 
@@ -76,17 +76,17 @@ func TestApiKeyDataAccess(t *testing.T) {
 
 		t.Run("Add keys", func(t *testing.T) {
 			// never expires
-			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "key1", Key: "key1", SecondsToLive: 0}
+			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "key1", SecondsToLive: 0}
 			err := AddApiKey(&cmd)
 			assert.Nil(t, err)
 
 			// expires in 1s
-			cmd = models.AddApiKeyCommand{OrgId: 1, Name: "key2", Key: "key2", SecondsToLive: 1}
+			cmd = models.AddApiKeyCommand{OrgId: 1, Name: "key2", SecondsToLive: 1}
 			err = AddApiKey(&cmd)
 			assert.Nil(t, err)
 
 			// expires in one hour
-			cmd = models.AddApiKeyCommand{OrgId: 1, Name: "key3", Key: "key3", SecondsToLive: 3600}
+			cmd = models.AddApiKeyCommand{OrgId: 1, Name: "key3", SecondsToLive: 3600}
 			err = AddApiKey(&cmd)
 			assert.Nil(t, err)
 
@@ -125,12 +125,12 @@ func TestApiKeyErrors(t *testing.T) {
 	t.Run("Testing API Duplicate Key Errors", func(t *testing.T) {
 		InitTestDB(t)
 		t.Run("Given saved api key", func(t *testing.T) {
-			cmd := models.AddApiKeyCommand{OrgId: 0, Name: "duplicate", Key: "asd"}
+			cmd := models.AddApiKeyCommand{OrgId: 0, Name: "duplicate"}
 			err := AddApiKey(&cmd)
 			assert.Nil(t, err)
 
 			t.Run("Add API Key with existing Org ID and Name", func(t *testing.T) {
-				cmd := models.AddApiKeyCommand{OrgId: 0, Name: "duplicate", Key: "asd"}
+				cmd := models.AddApiKeyCommand{OrgId: 0, Name: "duplicate"}
 				err = AddApiKey(&cmd)
 				assert.EqualError(t, err, models.ErrDuplicateApiKey.Error())
 			})

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -18,7 +18,7 @@ func TestTransaction(t *testing.T) {
 	ss := InitTestDB(t)
 
 	Convey("InTransaction", t, func() {
-		cmd := &models.AddApiKeyCommand{Key: "secret-key", Name: "key", OrgId: 1}
+		cmd := &models.AddApiKeyCommand{Name: "key", OrgId: 1}
 
 		err := AddApiKey(cmd)
 		So(err, ShouldBeNil)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #29435

**Special notes for your reviewer**:

This API allows Grafana admins to create auth keys for any org without switching the org context.

So far I've only implemented `POST /api/admin/auth/keys` endpoint. I can implement the rest of this API (GET, DELETE) and add tests/docs if this feature gets accepted.