### PR TITLE
GraphNG: use uPlot timestamp config format & pre-compile templates

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -84,7 +84,6 @@ export const GraphNG: React.FC<GraphNGProps> = ({
         scaleKey: 'x',
         isTime: true,
         placement: AxisPlacement.Bottom,
-        timeZone,
         theme,
       });
     } else {


### PR DESCRIPTION
this is a proposal to use uPlot's datetime config format & pre-compiler. it also simplifies not having to have timezone knowledge at the axis level since this is a global setting in uPlot that handles `time: true` scales (and linked axes).