### PR TITLE
Installing Grafana on IBM Cloud

### DIFF
--- a/docs/sources/installation/IBM Installation
+++ b/docs/sources/installation/IBM Installation
@@ -1,0 +1,120 @@
+
+Step 1 provision Kubernetes Cluster
+
+•	Click the Catalog button on the top
+•	Select Service from the catalog
+•	Search for Kubernetes Service and click on it
+ 
+
+•	You are now at the Kubernetes deployment page, you need to specify some details about the cluster
+•	Choose a plan standard or free, the free plan only has one worker node and no subnet, to provision a standard cluster, you will need to upgrade you account to Pay-As-You-Go
+•	To upgrade to a Pay-As-You-Go account, complete the following steps:
+•	In the console, go to Manage > Account.
+•	Select Account settings, and click Add credit card.
+•	Enter your payment information, click Next, and submit your information
+•	Choose classic or VPC, read the docs and choose the most suitable type for yourself
+
+ 
+•	Now choose your location settings, for more information please visit Locations
+•	Choose Geography (continent)
+ 
+•	Choose Single or Multizone, in single zone your data is only kept in on datacenter, on the other hand with Multizone it is distributed to multiple zones, thus safer in an unforseen zone failure
+ 
+•	If you wish to use Multizone please set up your account with VRF or enable Vlan spanning
+•	If at your current location selection, there is no available Virtual LAN, a new Vlan will be created for you
+•	Choose a Worker node setup or use the preselected one, set Worker node amount per zone
+ 
+•	Choose Master Service Endpoint, In VRF-enabled accounts, you can choose private-only to make your master accessible on the private network or via VPN tunnel. Choose public-only to make your master publicly accessible. When you have a VRF-enabled account, your cluster is set up by default to use both private and public endpoints. For more information visit endpoints.
+ 
+•	Give cluster a name
+ 
+•	Give desired tags to your cluster, for more information visit tags
+ 
+•	Click create
+ 
+•	Wait for you cluster to be provisioned
+ 
+•	Your cluster is ready for usage
+ 
+Step 2 deploy IBM Cloud Block Storage plug-in
+
+The Block Storage plug-in is a persistent, high-performance iSCSI storage that you can add to your apps by using Kubernetes Persistent Volumes (PVs).
+•	Click the Catalog button on the top
+•	Select Software from the catalog
+•	Search for IBM Cloud Block Storage plug-in and click on it
+ 
+•	On the application page Click in the dot next to the cluster, you wish to use
+•	Click on Enter or Select Namespace and choose the default Namespace or use a custom one (if you get error please wait 30 minutes for the cluster to finalize)
+ 
+•	Give a name to this workspace
+•	Click install and wait for the deployment
+ 
+
+
+Step 3 deploy Grafana
+
+We will deploy MySQL on our cluster
+•	Click the Catalog button on the top
+•	Select Software from the catalog
+•	Search for Grafana and click on it
+
+ 
+
+•	Please select IBM Kubernetes Service
+ 
+•	On the application page Click in the dot next to the cluster, you wish to use
+ 
+
+•	Click on Enter or Select Namespace and choose the default Namespace or use a custom one
+ 
+•	Give a unique name to workspace, which you can easily recognize
+ 
+•	Select which resource group you want to use, it's for access control and billing purposes. For more information please visit resource groups
+ 
+
+•	Give tags to your Grafana, for more information visit tags
+ 
+
+•	Click on Parameters with default values, You can set deployment values or use the default ones
+
+ 
+
+•	Please set the Grafana root password in the parameters
+ 
+•	Please change the service.type from ClusterIP to LoadBalancer in the parameters
+ 
+•	After finishing everything, tick the box next to the agreements and click install
+ 
+•	The Grafana workspace will start installing, wait a couple of minutes
+•	Your Grafana workspace has been successfully deployed
+ 
+
+Verify Grafana installation
+•	Go to Resources in your browser
+•	Click on Clusters
+•	Click on your Cluster
+
+ 
+
+•	Now you are at you clusters overview, here Click on Actions and Web terminal from the dropdown menu
+ 
+•	Click install - wait couple of minutes
+ 
+
+•	Click on Actions
+•	Click Web terminal --> a terminal will open up
+•	Type in the terminal, please change NAMESPACE to the namespace you choose at the deployment setup:
+$ kubectl get ns
+ 
+
+$ kubectl get pod -n NAMESPACE -o wide 
+ 
+
+$ kubectl get service -n NAMESPACE
+ 
+•	Running Grafana service will be visible
+•	Copy the External IP and Port number, you can access the website on this IP
+•	Paste it into your browser
+•	Grafana welcome message will be visible
+ 
+


### PR DESCRIPTION

Add to documentation page 
how to install Grafana on ibm cloud

Step 1 provision Kubernetes Cluster
•	Click the Catalog button on the top
•	Select Service from the catalog
•	Search for Kubernetes Service and click on it
 

•	You are now at the Kubernetes deployment page, you need to specify some details about the cluster
•	Choose a plan standard or free, the free plan only has one worker node and no subnet, to provision a standard cluster, you will need to upgrade you account to Pay-As-You-Go
•	To upgrade to a Pay-As-You-Go account, complete the following steps:
•	In the console, go to Manage > Account.
•	Select Account settings, and click Add credit card.
•	Enter your payment information, click Next, and submit your information
•	Choose classic or VPC, read the docs and choose the most suitable type for yourself

 
•	Now choose your location settings, for more information please visit Locations
•	Choose Geography (continent)
 
•	Choose Single or Multizone, in single zone your data is only kept in on datacenter, on the other hand with Multizone it is distributed to multiple zones, thus safer in an unforseen zone failure
 
•	If you wish to use Multizone please set up your account with VRF or enable Vlan spanning
•	If at your current location selection, there is no available Virtual LAN, a new Vlan will be created for you
•	Choose a Worker node setup or use the preselected one, set Worker node amount per zone
 
•	Choose Master Service Endpoint, In VRF-enabled accounts, you can choose private-only to make your master accessible on the private network or via VPN tunnel. Choose public-only to make your master publicly accessible. When you have a VRF-enabled account, your cluster is set up by default to use both private and public endpoints. For more information visit endpoints.
 
•	Give cluster a name
 
•	Give desired tags to your cluster, for more information visit tags
 
•	Click create
 
•	Wait for you cluster to be provisioned
 
•	Your cluster is ready for usage
 
Step 2 deploy IBM Cloud Block Storage plug-in
The Block Storage plug-in is a persistent, high-performance iSCSI storage that you can add to your apps by using Kubernetes Persistent Volumes (PVs).
•	Click the Catalog button on the top
•	Select Software from the catalog
•	Search for IBM Cloud Block Storage plug-in and click on it
 
•	On the application page Click in the dot next to the cluster, you wish to use
•	Click on Enter or Select Namespace and choose the default Namespace or use a custom one (if you get error please wait 30 minutes for the cluster to finalize)
 
•	Give a name to this workspace
•	Click install and wait for the deployment
 


Step 3 deploy Grafana

We will deploy MySQL on our cluster
•	Click the Catalog button on the top
•	Select Software from the catalog
•	Search for Grafana and click on it

 

•	Please select IBM Kubernetes Service
 
•	On the application page Click in the dot next to the cluster, you wish to use
 

•	Click on Enter or Select Namespace and choose the default Namespace or use a custom one
 
•	Give a unique name to workspace, which you can easily recognize
 
•	Select which resource group you want to use, it's for access control and billing purposes. For more information please visit resource groups
 

•	Give tags to your Grafana, for more information visit tags
 

•	Click on Parameters with default values, You can set deployment values or use the default ones

 

•	Please set the Grafana root password in the parameters
 
•	Please change the service.type from ClusterIP to LoadBalancer in the parameters
 
•	After finishing everything, tick the box next to the agreements and click install
 
•	The Grafana workspace will start installing, wait a couple of minutes
•	Your Grafana workspace has been successfully deployed
 

Verify Grafana installation
•	Go to Resources in your browser
•	Click on Clusters
•	Click on your Cluster

 

•	Now you are at you clusters overview, here Click on Actions and Web terminal from the dropdown menu
 
•	Click install - wait couple of minutes
 

•	Click on Actions
•	Click Web terminal --> a terminal will open up
•	Type in the terminal, please change NAMESPACE to the namespace you choose at the deployment setup:
$ kubectl get ns
 

$ kubectl get pod -n NAMESPACE -o wide 
 

$ kubectl get service -n NAMESPACE
 
•	Running Grafana service will be visible
•	Copy the External IP and Port number, you can access the website on this IP
•	Paste it into your browser
•	Grafana welcome message will be visible
 




[Grafana.docx](https://github.com/grafana/grafana/files/5610562/Grafana.docx)
