### PR TITLE
Live: publish all dashboard changes to a single channel

### DIFF
--- a/pkg/services/live/features/dashboard.go
+++ b/pkg/services/live/features/dashboard.go
@@ -48,7 +48,11 @@ func (h *DashboardHandler) publish(event dashboardEvent) error {
 	if err != nil {
 		return err
 	}
-	return h.Publisher("grafana/dashboard/"+event.UID, msg)
+	err = h.Publisher("grafana/dashboard/uid/"+event.UID, msg)
+	if err != nil {
+		return err
+	}
+	return h.Publisher("grafana/dashboard/changes", msg)
 }
 
 // DashboardSaved will broadcast to all connected dashboards

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -61,13 +61,11 @@ class DashboardWatcher {
       this.channel = live.getChannel({
         scope: LiveChannelScope.Grafana,
         namespace: 'dashboard',
-        path: uid,
+        path: `uid/${uid}`,
       });
       this.channel.getStream().subscribe(this.observer);
       this.uid = uid;
     }
-
-    console.log('Watch', uid);
   }
 
   leave() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the broadcast logic to publish both an scoped event for the single dashboard, and a channel that collects all changes

**Special notes for your reviewer**:

This request came from @malcolmholmes work on https://github.com/grafana/grizzly
