### PR TITLE
Alerting: adjusted time ranges for alert probe query

### DIFF
--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -8,7 +8,7 @@ const alertQueryDef = new QueryPartDef({
     {
       name: 'from',
       type: 'string',
-      options: ['10s', '1m', '5m', '10m', '15m', '1h', '24h', '48h'],
+      options: ['10s', '1m', '5m', '10m', '15m', '1h', '2h', '6h', '12h', '24h', '48h'],
     },
     { name: 'to', type: 'string', options: ['now', 'now-1m', 'now-5m', 'now-10m', 'now-1h'] },
   ],


### PR DESCRIPTION
**What this PR does / why we need it**:
Fills the alert probe query time range gap between 1h and 24h with some other values like 6h. Current gap is too big and it makes it difficult to create some useful alerts.

**Which issue(s) this PR fixes**: 7777
Fixes #7777.

**Special notes for your reviewer**: please change the ranges if you prefer others, but the gap between 1h and 24h is just troublesome. Thank you.
