### PR TITLE
PanelEdit: making sure the correct datasource query editor is being rendered.

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -88,12 +88,13 @@ export class QueryEditorRow extends PureComponent<Props, State> {
   }
 
   async loadDatasource() {
-    const { query, panel } = this.props;
+    const { query, panel, dataSourceValue } = this.props;
     const dataSourceSrv = getDatasourceSrv();
     let datasource;
 
     try {
-      datasource = await dataSourceSrv.get(query.datasource || panel.datasource);
+      const datasourceName = dataSourceValue ?? query.datasource ?? panel.datasource;
+      datasource = await dataSourceSrv.get(datasourceName);
     } catch (error) {
       datasource = await dataSourceSrv.get();
     }

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -93,7 +93,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     let datasource;
 
     try {
-      const datasourceName = dataSourceValue ?? query.datasource ?? panel.datasource;
+      const datasourceName = dataSourceValue || query.datasource || panel.datasource;
       datasource = await dataSourceSrv.get(datasourceName);
     } catch (error) {
       datasource = await dataSourceSrv.get();


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating a new dashboard and you have a datasource that doesn't have query editor support you will get the "Data source plugin does not export any Query Editor component" message. It is a bit confusing since the one selected in the datasource select dropdown supports query editors.

This PR fixes that by making sure we try to use the same dataSourceValue in both the QueryRows as in the datasource selector.

**Which issue(s) this PR fixes**:
Fixes #15049

**Special notes for your reviewer**:

