### PR TITLE
docker: fix Dockerfile after Gruntfile.js removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY packages packages
 
 RUN yarn install --pure-lockfile --no-progress
 
-COPY Gruntfile.js tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js ./
+COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js ./
 COPY public public
 COPY tools tools
 COPY scripts scripts

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -7,7 +7,7 @@ COPY packages packages
 
 RUN yarn install --pure-lockfile
 
-COPY Gruntfile.js tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js ./
+COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js ./
 COPY public public
 COPY tools tools
 COPY scripts scripts


### PR DESCRIPTION

**What this PR does / why we need it**:

Fixes the Dockerfiles after the Gruntfile.js file was removed here: https://github.com/grafana/grafana/pull/29461
