### PR TITLE
use pre-defined output array length in vectorToArray()

### DIFF
--- a/packages/grafana-data/src/vector/vectorToArray.ts
+++ b/packages/grafana-data/src/vector/vectorToArray.ts
@@ -1,7 +1,7 @@
 import { Vector } from '../types/vector';
 
 export function vectorToArray<T>(v: Vector<T>): T[] {
-  const arr: T[] = [];
+  const arr: T[] = Array(v.length);
   for (let i = 0; i < v.length; i++) {
     arr[i] = v.get(i);
   }


### PR DESCRIPTION
this improves performance by 25%

![image](https://user-images.githubusercontent.com/43234/100806514-35a66200-33f6-11eb-9ca7-f4d706506bdd.png)
