### PR TITLE
Devenv: update mysql_tests and postgres_tests blocks for allowing dynamically change of underlying docker image

### DIFF
--- a/devenv/docker/blocks/mysql_tests/.env
+++ b/devenv/docker/blocks/mysql_tests/.env
@@ -1,0 +1,1 @@
+mysql_version=5.6

--- a/devenv/docker/blocks/mysql_tests/Dockerfile
+++ b/devenv/docker/blocks/mysql_tests/Dockerfile
@@ -1,3 +1,4 @@
-FROM mysql:5.6
+ARG mysql_version=5.6
+FROM mysql:${mysql_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 CMD ["mysqld"]

--- a/devenv/docker/blocks/mysql_tests/docker-compose.yaml
+++ b/devenv/docker/blocks/mysql_tests/docker-compose.yaml
@@ -1,6 +1,8 @@
   mysqltests:
     build:
       context: docker/blocks/mysql_tests
+      args:
+        - mysql_version=${mysql_version}
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: grafana_tests

--- a/devenv/docker/blocks/postgres_tests/.env
+++ b/devenv/docker/blocks/postgres_tests/.env
@@ -1,0 +1,1 @@
+postgres_version=9.3

--- a/devenv/docker/blocks/postgres_tests/Dockerfile
+++ b/devenv/docker/blocks/postgres_tests/Dockerfile
@@ -1,3 +1,4 @@
-FROM postgres:9.3
+ARG postgres_version=9.3
+FROM postgres:${postgres_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 CMD ["postgres"]

--- a/devenv/docker/blocks/postgres_tests/docker-compose.yaml
+++ b/devenv/docker/blocks/postgres_tests/docker-compose.yaml
@@ -1,6 +1,8 @@
   postgrestest:
     build:
       context: docker/blocks/postgres_tests
+      args:
+        - postgres_version=${postgres_version}
     environment:
       POSTGRES_USER: grafanatest
       POSTGRES_PASSWORD: grafanatest


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
With this fix we can run the grafana tests against different MySQL and PostgreSQL server versions.
This is similar to the work done in #18112 for the `mysql` and `postgres` blocks

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Example command for building mysql_tests based on mysql:5.7 docker image (overriding the default 5.6):
```
# make devenv sources=mysql_tests mysql_version=5.7 
Removing network devenv_default
Deleting docker-compose.yaml
Deleting .env
Adding Compose header to docker-compose.yaml
Adding docker/blocks/mysql_tests/docker-compose.yaml to docker-compose.yaml
Adding docker/blocks/mysql_tests/.env to .env
Creating network "devenv_default" with the default driver
Building mysqltests
Step 1/4 : ARG mysql_version=5.6
Step 2/4 : FROM mysql:${mysql_version}
5.7: Pulling from library/mysql
852e50cd189d: Pull complete
29969ddb0ffb: Pull complete
a43f41a44c48: Pull complete
5cdd802543a3: Pull complete
b79b040de953: Pull complete
938c64119969: Pull complete
7689ec51a0d9: Pull complete
36bd6224d58f: Pull complete
cab9d3fa4c8c: Pull complete
1b741e1c47de: Pull complete
aac9d11987ac: Pull complete
Digest: sha256:8e2004f9fe43df06c3030090f593021a5f283d028b5ed5765cc24236c2c4d88e
Status: Downloaded newer image for mysql:5.7
 ---> ae0658fdbad5
Step 3/4 : ADD setup.sql /docker-entrypoint-initdb.d
 ---> 28d35fabcf6c
Step 4/4 : CMD ["mysqld"]
 ---> Running in 0ae1a88cb53d
Removing intermediate container 0ae1a88cb53d
 ---> f4d85db01ddf

Successfully built f4d85db01ddf
Successfully tagged devenv_mysqltests:latest
Creating devenv_mysqltests_1 ... done
```

Example command for building postgres_tests based on postgres:9.5 docker image(overriding the default 9.3):
```
make devenv sources=postgres_tests postgres_version=9.5
Stopping devenv_mysqltests_1 ... done
Removing devenv_mysqltests_1 ... done
Removing network devenv_default
Deleting docker-compose.yaml
Deleting .env
Adding Compose header to docker-compose.yaml
Adding docker/blocks/postgres_tests/docker-compose.yaml to docker-compose.yaml
Adding docker/blocks/postgres_tests/.env to .env
Creating network "devenv_default" with the default driver
Building postgrestest
Step 1/4 : ARG postgres_version=9.3
Step 2/4 : FROM postgres:${postgres_version}
9.5: Pulling from library/postgres
4297e0229558: Already exists
bbb46d73f55c: Pull complete
53d469d8e1fd: Pull complete
7f39a73e3de8: Pull complete
3d76e68bd184: Pull complete
dab98e943539: Pull complete
373b1009766f: Pull complete
644c45c53969: Pull complete
40c24590d9d6: Pull complete
e79eb42a921b: Pull complete
95d5cf8ad973: Pull complete
43e41167e9d4: Pull complete
8d8e842f8733: Pull complete
82e538444abf: Pull complete
Digest: sha256:9c6f2e1b28a4ed3953824876ae654a67c5e064cbf7201cf4ee5860ebc573e85a
Status: Downloaded newer image for postgres:9.5
 ---> 693ab34b0689
Step 3/4 : ADD setup.sql /docker-entrypoint-initdb.d
 ---> c9fba724321d
Step 4/4 : CMD ["postgres"]
 ---> Running in 72ba1606277c
Removing intermediate container 72ba1606277c
 ---> 07b7e2eca142

Successfully built 07b7e2eca142
Successfully tagged devenv_postgrestest:latest
Creating devenv_postgrestest_1 ... done
```
