### PR TITLE
Graph NG: Invalidate uPlot config on timezone changes

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -160,7 +160,7 @@ export const GraphNG: React.FC<GraphNGProps> = ({
 
     legendItemsRef.current = legendItems;
     return builder;
-  }, [configRev]);
+  }, [configRev, timeZone]);
 
   if (alignedFrameWithGapTest == null) {
     return (

--- a/packages/grafana-ui/src/components/uPlot/hooks.ts
+++ b/packages/grafana-ui/src/components/uPlot/hooks.ts
@@ -105,7 +105,6 @@ export const DEFAULT_PLOT_CONFIG = {
   hooks: {},
 };
 
-//pass plain confsig object,memoize!
 export const usePlotConfig = (width: number, height: number, timeZone: TimeZone, configBuilder: UPlotConfigBuilder) => {
   const { arePluginsReady, plugins, registerPlugin } = usePlotPlugins();
   const [isConfigReady, setIsConfigReady] = useState(false);


### PR DESCRIPTION
Since the config builder was only invalidated on data frame structure changes, the time zone change did not have any effect on the axis config being returned from the builder. This PR brings back the timezone being respected on the time axis when the user changes it.