### PR TITLE
Annotations: Remove annotation_tag entries as part of annotations cleanup

### DIFF
--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -16,7 +16,7 @@ type Repository interface {
 
 // AnnotationCleaner is responsible for cleaning up old annotations
 type AnnotationCleaner interface {
-	CleanAnnotations(ctx context.Context, cfg *setting.Cfg) error
+	CleanAnnotations(ctx context.Context, cfg *setting.Cfg) (int64, int64, error)
 }
 
 type ItemQuery struct {

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -65,9 +65,11 @@ func (srv *CleanUpService) Run(ctx context.Context) error {
 
 func (srv *CleanUpService) cleanUpOldAnnotations(ctx context.Context) {
 	cleaner := annotations.GetAnnotationCleaner()
-	err := cleaner.CleanAnnotations(ctx, srv.Cfg)
+	affected, affectedTags, err := cleaner.CleanAnnotations(ctx, srv.Cfg)
 	if err != nil {
 		srv.log.Error("failed to clean up old annotations", "error", err)
+	} else {
+		srv.log.Debug("Deleted excess annotations", "annotations affected", affected, "annotation tags affected", affectedTags)
 	}
 }
 

--- a/pkg/services/sqlstore/annotation_cleanup.go
+++ b/pkg/services/sqlstore/annotation_cleanup.go
@@ -43,6 +43,8 @@ func (acs *AnnotationCleanupService) CleanAnnotations(ctx context.Context, cfg *
 		return totalCleanedAnnotations, 0, err
 	}
 
+	acs.log.Debug("Finished cleaning annotations. Now cleaning orphaned records from annotation_tag")
+
 	affected, err = acs.cleanOrphanedAnnotationTags(ctx)
 	return totalCleanedAnnotations, affected, err
 }
@@ -98,7 +100,7 @@ func (acs *AnnotationCleanupService) executeUntilDoneOrCancelled(ctx context.Con
 				return err
 			})
 			if err != nil {
-				return 0, err
+				return totalAffected, err
 			}
 
 			if affected == 0 {

--- a/pkg/services/sqlstore/annotation_cleanup.go
+++ b/pkg/services/sqlstore/annotation_cleanup.go
@@ -21,8 +21,11 @@ const (
 	apiAnnotationType       = "alert_id = 0 AND dashboard_id = 0"
 )
 
-// CleanAnnotations deletes old annotations created by
-// alert rules, API requests and human made in the UI.
+// CleanAnnotations deletes old annotations created by alert rules, API
+// requests and human made in the UI. It subsequently deletes orphaned rows
+// from the annotation_tag table.
+// Returns the number of annotation and annotation_tag rows deleted. If an
+// error occurs, it returns the number of rows affected so far.
 func (acs *AnnotationCleanupService) CleanAnnotations(ctx context.Context, cfg *setting.Cfg) (int64, int64, error) {
 	var totalCleanedAnnotations int64
 	affected, err := acs.cleanAnnotations(ctx, cfg.AlertingAnnotationCleanupSetting, alertAnnotationType)

--- a/pkg/services/sqlstore/annotation_cleanup.go
+++ b/pkg/services/sqlstore/annotation_cleanup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-// AnnotationCleanupService is responseible for cleaning old annotations.
+// AnnotationCleanupService is responsible for cleaning old annotations.
 type AnnotationCleanupService struct {
 	batchSize int64
 	log       log.Logger
@@ -23,7 +23,9 @@ const (
 
 // CleanAnnotations deletes old annotations created by alert rules, API
 // requests and human made in the UI. It subsequently deletes orphaned rows
-// from the annotation_tag table.
+// from the annotation_tag table. Cleanup actions are performed in batches
+// so that no query takes too long to complete.
+//
 // Returns the number of annotation and annotation_tag rows deleted. If an
 // error occurs, it returns the number of rows affected so far.
 func (acs *AnnotationCleanupService) CleanAnnotations(ctx context.Context, cfg *setting.Cfg) (int64, int64, error) {
@@ -45,8 +47,6 @@ func (acs *AnnotationCleanupService) CleanAnnotations(ctx context.Context, cfg *
 	if err != nil {
 		return totalCleanedAnnotations, 0, err
 	}
-
-	acs.log.Debug("Finished cleaning annotations. Now cleaning orphaned records from annotation_tag")
 
 	affected, err = acs.cleanOrphanedAnnotationTags(ctx)
 	return totalCleanedAnnotations, affected, err

--- a/pkg/services/sqlstore/annotation_cleanup.go
+++ b/pkg/services/sqlstore/annotation_cleanup.go
@@ -64,7 +64,8 @@ func (acs *AnnotationCleanupService) cleanAnnotations(ctx context.Context, cfg s
 }
 
 func (acs *AnnotationCleanupService) cleanOrphanedAnnotationTags(ctx context.Context) error {
-	sql := "DELETE FROM annotation_tag WHERE NOT EXISTS (SELECT null FROM annotation WHERE annotation_tag.annotation_id = annotation.id)"
+	deleteQuery := `DELETE FROM annotation_tag WHERE id IN ( SELECT id FROM (SELECT id FROM annotation_tag WHERE NOT EXISTS (SELECT 1 FROM annotation a WHERE annotation_id = a.id) %s) a)`
+	sql := fmt.Sprintf(deleteQuery, dialect.Limit(acs.batchSize))
 	return acs.executeUntilDoneOrCancelled(ctx, sql)
 }
 

--- a/pkg/services/sqlstore/annotation_cleanup.go
+++ b/pkg/services/sqlstore/annotation_cleanup.go
@@ -23,57 +23,67 @@ const (
 
 // CleanAnnotations deletes old annotations created by
 // alert rules, API requests and human made in the UI.
-func (acs *AnnotationCleanupService) CleanAnnotations(ctx context.Context, cfg *setting.Cfg) error {
-	err := acs.cleanAnnotations(ctx, cfg.AlertingAnnotationCleanupSetting, alertAnnotationType)
+func (acs *AnnotationCleanupService) CleanAnnotations(ctx context.Context, cfg *setting.Cfg) (int64, int64, error) {
+	var totalCleanedAnnotations int64
+	affected, err := acs.cleanAnnotations(ctx, cfg.AlertingAnnotationCleanupSetting, alertAnnotationType)
+	totalCleanedAnnotations += affected
 	if err != nil {
-		return err
+		return totalCleanedAnnotations, 0, err
 	}
 
-	err = acs.cleanAnnotations(ctx, cfg.APIAnnotationCleanupSettings, apiAnnotationType)
+	affected, err = acs.cleanAnnotations(ctx, cfg.APIAnnotationCleanupSettings, apiAnnotationType)
+	totalCleanedAnnotations += affected
 	if err != nil {
-		return err
+		return totalCleanedAnnotations, 0, err
 	}
 
-	err = acs.cleanAnnotations(ctx, cfg.DashboardAnnotationCleanupSettings, dashboardAnnotationType)
+	affected, err = acs.cleanAnnotations(ctx, cfg.DashboardAnnotationCleanupSettings, dashboardAnnotationType)
+	totalCleanedAnnotations += affected
 	if err != nil {
-		return err
+		return totalCleanedAnnotations, 0, err
 	}
 
-	return acs.cleanOrphanedAnnotationTags(ctx)
+	affected, err = acs.cleanOrphanedAnnotationTags(ctx)
+	return totalCleanedAnnotations, affected, err
 }
 
-func (acs *AnnotationCleanupService) cleanAnnotations(ctx context.Context, cfg setting.AnnotationCleanupSettings, annotationType string) error {
+func (acs *AnnotationCleanupService) cleanAnnotations(ctx context.Context, cfg setting.AnnotationCleanupSettings, annotationType string) (int64, error) {
+	var totalAffected int64
 	if cfg.MaxAge > 0 {
 		cutoffDate := time.Now().Add(-cfg.MaxAge).UnixNano() / int64(time.Millisecond)
 		deleteQuery := `DELETE FROM annotation WHERE id IN (SELECT id FROM (SELECT id FROM annotation WHERE %s AND created < %v ORDER BY id DESC %s) a)`
 		sql := fmt.Sprintf(deleteQuery, annotationType, cutoffDate, dialect.Limit(acs.batchSize))
 
-		err := acs.executeUntilDoneOrCancelled(ctx, sql)
+		affected, err := acs.executeUntilDoneOrCancelled(ctx, sql)
+		totalAffected += affected
 		if err != nil {
-			return err
+			return totalAffected, err
 		}
 	}
 
 	if cfg.MaxCount > 0 {
 		deleteQuery := `DELETE FROM annotation WHERE id IN (SELECT id FROM (SELECT id FROM annotation WHERE %s ORDER BY id DESC %s) a)`
 		sql := fmt.Sprintf(deleteQuery, annotationType, dialect.LimitOffset(acs.batchSize, cfg.MaxCount))
-		return acs.executeUntilDoneOrCancelled(ctx, sql)
+		affected, err := acs.executeUntilDoneOrCancelled(ctx, sql)
+		totalAffected += affected
+		return totalAffected, err
 	}
 
-	return nil
+	return totalAffected, nil
 }
 
-func (acs *AnnotationCleanupService) cleanOrphanedAnnotationTags(ctx context.Context) error {
+func (acs *AnnotationCleanupService) cleanOrphanedAnnotationTags(ctx context.Context) (int64, error) {
 	deleteQuery := `DELETE FROM annotation_tag WHERE id IN ( SELECT id FROM (SELECT id FROM annotation_tag WHERE NOT EXISTS (SELECT 1 FROM annotation a WHERE annotation_id = a.id) %s) a)`
 	sql := fmt.Sprintf(deleteQuery, dialect.Limit(acs.batchSize))
 	return acs.executeUntilDoneOrCancelled(ctx, sql)
 }
 
-func (acs *AnnotationCleanupService) executeUntilDoneOrCancelled(ctx context.Context, sql string) error {
+func (acs *AnnotationCleanupService) executeUntilDoneOrCancelled(ctx context.Context, sql string) (int64, error) {
+	var totalAffected int64
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return totalAffected, ctx.Err()
 		default:
 			var affected int64
 			err := withDbSession(ctx, func(session *DBSession) error {
@@ -83,15 +93,16 @@ func (acs *AnnotationCleanupService) executeUntilDoneOrCancelled(ctx context.Con
 				}
 
 				affected, err = res.RowsAffected()
+				totalAffected += affected
 
 				return err
 			})
 			if err != nil {
-				return err
+				return 0, err
 			}
 
 			if affected == 0 {
-				return nil
+				return totalAffected, nil
 			}
 		}
 	}

--- a/pkg/services/sqlstore/annotation_cleanup_test.go
+++ b/pkg/services/sqlstore/annotation_cleanup_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package sqlstore
 
 import (
@@ -25,6 +27,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 
 	createTestAnnotations(t, fakeSQL, 21, 6)
 	assertAnnotationCount(t, fakeSQL, "", 21)
+	assertAnnotationTagCount(t, fakeSQL, 42)
 
 	tests := []struct {
 		name                     string
@@ -32,6 +35,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 		alertAnnotationCount     int64
 		dashboardAnnotationCount int64
 		APIAnnotationCount       int64
+		annotationTagCount       int64
 	}{
 		{
 			name: "default settings should not delete any annotations",
@@ -43,6 +47,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     7,
 			dashboardAnnotationCount: 7,
 			APIAnnotationCount:       7,
+			annotationTagCount:       42,
 		},
 		{
 			name: "should remove annotations created before cut off point",
@@ -54,6 +59,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     5,
 			dashboardAnnotationCount: 5,
 			APIAnnotationCount:       5,
+			annotationTagCount:       30,
 		},
 		{
 			name: "should only keep three annotations",
@@ -65,6 +71,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     3,
 			dashboardAnnotationCount: 3,
 			APIAnnotationCount:       3,
+			annotationTagCount:       18,
 		},
 		{
 			name: "running the max count delete again should not remove any annotations",
@@ -76,6 +83,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     3,
 			dashboardAnnotationCount: 3,
 			APIAnnotationCount:       3,
+			annotationTagCount:       18,
 		},
 	}
 
@@ -88,6 +96,7 @@ func TestAnnotationCleanUp(t *testing.T) {
 			assertAnnotationCount(t, fakeSQL, alertAnnotationType, test.alertAnnotationCount)
 			assertAnnotationCount(t, fakeSQL, dashboardAnnotationType, test.dashboardAnnotationCount)
 			assertAnnotationCount(t, fakeSQL, apiAnnotationType, test.APIAnnotationCount)
+			assertAnnotationTagCount(t, fakeSQL, test.annotationTagCount)
 		})
 	}
 }
@@ -151,6 +160,17 @@ func assertAnnotationCount(t *testing.T, fakeSQL *SQLStore, sql string, expected
 	require.Equal(t, expectedCount, count)
 }
 
+func assertAnnotationTagCount(t *testing.T, fakeSQL *SQLStore, expectedCount int64) {
+	t.Helper()
+
+	session := fakeSQL.NewSession()
+	defer session.Close()
+
+	count, err := session.SQL("select count(*) from annotation_tag").Count()
+	require.NoError(t, err)
+	require.Equal(t, expectedCount, count)
+}
+
 func createTestAnnotations(t *testing.T, sqlstore *SQLStore, expectedCount int, oldAnnotations int) {
 	t.Helper()
 
@@ -187,6 +207,14 @@ func createTestAnnotations(t *testing.T, sqlstore *SQLStore, expectedCount int, 
 
 		_, err := sqlstore.NewSession().Insert(a)
 		require.NoError(t, err, "should be able to save annotation", err)
+
+		// mimick the SQL annotation Save logic by writing records to the annotation_tag table
+		// we need to ensure they get deleted when we clean up annotations
+		sess := sqlstore.NewSession()
+		for tagID := range []int{1, 2} {
+			_, err = sess.Exec("INSERT INTO annotation_tag (annotation_id, tag_id) VALUES(?,?)", a.Id, tagID)
+			require.NoError(t, err, "should be able to save annotation tag ID", err)
+		}
 	}
 }
 

--- a/pkg/services/sqlstore/annotation_cleanup_test.go
+++ b/pkg/services/sqlstore/annotation_cleanup_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/annotation_cleanup_test.go
+++ b/pkg/services/sqlstore/annotation_cleanup_test.go
@@ -35,7 +35,6 @@ func TestAnnotationCleanUp(t *testing.T) {
 		alertAnnotationCount     int64
 		dashboardAnnotationCount int64
 		APIAnnotationCount       int64
-		annotationTagCount       int64
 	}{
 		{
 			name: "default settings should not delete any annotations",
@@ -47,7 +46,6 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     7,
 			dashboardAnnotationCount: 7,
 			APIAnnotationCount:       7,
-			annotationTagCount:       42,
 		},
 		{
 			name: "should remove annotations created before cut off point",
@@ -59,7 +57,6 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     5,
 			dashboardAnnotationCount: 5,
 			APIAnnotationCount:       5,
-			annotationTagCount:       30,
 		},
 		{
 			name: "should only keep three annotations",
@@ -71,7 +68,6 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     3,
 			dashboardAnnotationCount: 3,
 			APIAnnotationCount:       3,
-			annotationTagCount:       18,
 		},
 		{
 			name: "running the max count delete again should not remove any annotations",
@@ -83,7 +79,6 @@ func TestAnnotationCleanUp(t *testing.T) {
 			alertAnnotationCount:     3,
 			dashboardAnnotationCount: 3,
 			APIAnnotationCount:       3,
-			annotationTagCount:       18,
 		},
 	}
 
@@ -96,7 +91,12 @@ func TestAnnotationCleanUp(t *testing.T) {
 			assertAnnotationCount(t, fakeSQL, alertAnnotationType, test.alertAnnotationCount)
 			assertAnnotationCount(t, fakeSQL, dashboardAnnotationType, test.dashboardAnnotationCount)
 			assertAnnotationCount(t, fakeSQL, apiAnnotationType, test.APIAnnotationCount)
-			assertAnnotationTagCount(t, fakeSQL, test.annotationTagCount)
+
+			// we create two records in annotation_tag for each sample annotation
+			expectedAnnotationTagCount := (test.alertAnnotationCount +
+				test.dashboardAnnotationCount +
+				test.APIAnnotationCount) * 2
+			assertAnnotationTagCount(t, fakeSQL, expectedAnnotationTagCount)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
We have an annotation cleanup job which deletes annotations based on age or max count. When we write annotations, we also might create a tag and we definitely create a record in the `annotation_tag` table. Therefore when we delete annotations, we also need to delete the records associated with that annotation from the `annotation_tag` table.

We need this because we have run into issues with a customer who uses annotations very heavily. The size of `annotation_tag` grows so large that the queries to insert and read annotations are very slow. 


**Which issue(s) this PR fixes**:
#29484 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #29484 

**Special notes for your reviewer**:
- I've not used xorm before. If there is a better way to perform the count query, I'd be happy to use it. I'm not use how the struct->table mapping for annotation_tag would work, there are no examples of it in the codebase.
- I've opted for cleaning up orphaned records from `annotation_tag` as a separate query, executed after the original cleanup queries. I felt this was cleaner that something where we extract the ID of the annotation we're deleting and delete records from `annotation_tag` which have that id in the `annotation_id` column
- The tests validate purely with counts, rather than checking specific records have been deleted. This is consistent with what is already there.
- I've only tested this against SQLite3 manually. Are other databases tested as part of the tests or do I need to verify those manually?