### PR TITLE
docker: use yarn to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY scripts scripts
 COPY emails emails
 
 ENV NODE_ENV production
-RUN ./node_modules/.bin/grunt build
+RUN yarn build
 
 FROM golang:1.15.1-alpine3.12 as go-builder
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -14,7 +14,7 @@ COPY scripts scripts
 COPY emails emails
 
 ENV NODE_ENV production
-RUN ./node_modules/.bin/grunt build
+RUN yarn build
 
 FROM golang:1.15.1 AS go-builder
 


### PR DESCRIPTION

**What this PR does / why we need it**:
This fixes the docker builds after the transition away from Grunt (https://github.com/grafana/grafana/pull/29461)

**Special notes for your reviewer**:
Sorry @aknuds1, I thought I had committed these two lines as well in: https://github.com/grafana/grafana/pull/29515

