### PR TITLE
Panel: making sure we support all versions of chrome when detecting position of click event.

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -1,6 +1,14 @@
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import { DataLink, LoadingState, PanelData, PanelMenuItem, QueryResultMetaNotice, ScopedVars } from '@grafana/data';
+import {
+  DataLink,
+  LoadingState,
+  numberUtil,
+  PanelData,
+  PanelMenuItem,
+  QueryResultMetaNotice,
+  ScopedVars,
+} from '@grafana/data';
 import { AngularComponent, config, getTemplateSrv } from '@grafana/runtime';
 import { ClickOutsideWrapper, Icon, IconName, Tooltip, stylesFactory } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
@@ -51,17 +59,10 @@ export class PanelHeader extends PureComponent<Props, State> {
 
   eventToClickCoordinates = (event: React.MouseEvent<HTMLDivElement>) => {
     return {
-      x: this.truncate(event.clientX, 0),
-      y: this.truncate(event.clientY, 0),
+      x: Math.floor(event.clientX),
+      y: Math.floor(event.clientY),
     };
   };
-
-  truncate(input: number, digits: number): number {
-    const step = Math.pow(10, digits || 0);
-    const temp = Math.trunc(step * input);
-
-    return temp / step;
-  }
 
   onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     this.clickCoordinates = this.eventToClickCoordinates(event);

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import { isEqual } from 'lodash';
 import { DataLink, LoadingState, PanelData, PanelMenuItem, QueryResultMetaNotice, ScopedVars } from '@grafana/data';
 import { AngularComponent, config, getTemplateSrv } from '@grafana/runtime';
 import { ClickOutsideWrapper, Icon, IconName, Tooltip, stylesFactory } from '@grafana/ui';
@@ -15,6 +14,7 @@ import { getPanelLinksSupplier } from 'app/features/panel/panellinks/linkSupplie
 import { getPanelMenu } from 'app/features/dashboard/utils/getPanelMenu';
 import { updateLocation } from 'app/core/actions';
 import { css } from 'emotion';
+import { truncateNumber } from '../../utils/truncator';
 
 export interface Props {
   panel: PanelModel;
@@ -52,17 +52,24 @@ export class PanelHeader extends PureComponent<Props, State> {
 
   eventToClickCoordinates = (event: React.MouseEvent<HTMLDivElement>) => {
     return {
-      x: event.clientX,
-      y: event.clientY,
+      x: this.truncate(event.clientX, 0),
+      y: this.truncate(event.clientY, 0),
     };
   };
+
+  truncate(input: number, digits: number): number {
+    const step = Math.pow(10, digits || 0);
+    const temp = Math.trunc(step * input);
+
+    return temp / step;
+  }
 
   onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     this.clickCoordinates = this.eventToClickCoordinates(event);
   };
 
   isClick = (clickCoordinates: ClickCoordinates) => {
-    return isEqual(clickCoordinates, this.clickCoordinates);
+    return clickCoordinates.x === this.clickCoordinates.x && clickCoordinates.y === this.clickCoordinates.y;
   };
 
   onMenuToggle = (event: React.MouseEvent<HTMLDivElement>) => {

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -1,14 +1,6 @@
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import {
-  DataLink,
-  LoadingState,
-  numberUtil,
-  PanelData,
-  PanelMenuItem,
-  QueryResultMetaNotice,
-  ScopedVars,
-} from '@grafana/data';
+import { DataLink, LoadingState, PanelData, PanelMenuItem, QueryResultMetaNotice, ScopedVars } from '@grafana/data';
 import { AngularComponent, config, getTemplateSrv } from '@grafana/runtime';
 import { ClickOutsideWrapper, Icon, IconName, Tooltip, stylesFactory } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -14,7 +14,6 @@ import { getPanelLinksSupplier } from 'app/features/panel/panellinks/linkSupplie
 import { getPanelMenu } from 'app/features/dashboard/utils/getPanelMenu';
 import { updateLocation } from 'app/core/actions';
 import { css } from 'emotion';
-import { truncateNumber } from '../../utils/truncator';
 
 export interface Props {
   panel: PanelModel;


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like some version of chrome starts to emit events where coordinates contains float values instead of integer values. This change make sure we are always using integer values.

**Which issue(s) this PR fixes**:
Fixes #25018
Fixes https://github.com/grafana/grafana/issues/29138
