### PR TITLE
Chore: Update dev guide node version for Mac

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -20,7 +20,7 @@ We recommend using [Homebrew](https://brew.sh/) for installing any missing depen
 ```
 brew install git
 brew install go
-brew install node@12
+brew install node@14
 
 npm install -g yarn
 ```


### PR DESCRIPTION
to match the new min version specified for node in packages.json as of https://github.com/grafana/grafana/commit/00d59ec1fc50d8be386188bad6dbe50979e4823f
