### PR TITLE
Elasticsearch: Add PPL response parser for time series format

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -539,7 +539,8 @@ export class ElasticResponse {
   };
 
   processPPLResponseToSeries = () => {
-    const target = this.targets[0];
+    // Each target is inputted separately from Elasticdatasource for PPL
+    const target = this.targets;
     const response = this.response;
     // Get the data points and target that will be inputted to newSeries
     const { datapoints, targetVal, invalidTS } = getPPLDatapoints(response);
@@ -556,7 +557,7 @@ export class ElasticResponse {
       target: targetVal,
     };
 
-    return { data: [newSeries], key: this.targets[0]?.refId };
+    return { data: [newSeries], key: target.refId };
   };
 }
 

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -619,7 +619,11 @@ const getPPLDatapoints = (response: any): { datapoints: any; targetVal: any; inv
   const valueIndex = timeFieldIndex === 0 ? 1 : 0;
 
   //time series response should include a value field and timestamp
-  if (timeFieldIndex === -1 || response.datarows[0].length !== 2 || isNaN(response.datarows[0][valueIndex])) {
+  if (
+    timeFieldIndex === -1 ||
+    response.datarows[0].length !== 2 ||
+    typeof response.datarows[0][valueIndex] !== 'number'
+  ) {
     invalidTS = true;
   }
 

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -1,5 +1,10 @@
 import _ from 'lodash';
-import { ElasticsearchAggregation, ElasticsearchQuery } from './types';
+import { ElasticsearchAggregation, ElasticsearchQuery, ElasticsearchQueryType } from './types';
+
+export const queryTypes = [
+  { text: 'Lucene', value: ElasticsearchQueryType.Lucene },
+  { text: 'PPL', value: ElasticsearchQueryType.PPL },
+];
 
 export const metricAggTypes = [
   { text: 'Count', value: 'count', requiresField: false },
@@ -182,6 +187,18 @@ export const movingAvgModelSettings: any = {
   ],
 };
 
+export const pplFormatTypes = [
+  { text: 'Table', value: 'table' },
+  { text: 'Logs', value: 'logs' },
+  { text: 'Time series', value: 'time_series' },
+];
+
+export function getQueryTypes(supportedTypes: ElasticsearchQueryType[]) {
+  return _.filter(queryTypes, queryType => {
+    return supportedTypes.includes(queryType.value);
+  });
+}
+
 export function getMetricAggTypes(esVersion: any) {
   return _.filter(metricAggTypes, f => {
     if (f.minVersion || f.maxVersion) {
@@ -297,6 +314,10 @@ export function defaultMetricAgg() {
 
 export function defaultBucketAgg() {
   return { type: 'date_histogram', id: '2', settings: { interval: 'auto' } };
+}
+
+export function defaultPPLFormat() {
+  return 'table';
 }
 
 export const findMetricById = (metrics: any[], id: any) => {

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1329,14 +1329,14 @@ describe('ElasticResponse', () => {
         context: 'explore',
         interval: '10s',
         isLogsQuery: true,
-        key: 'Q-89d91614-009c-47b5-9945-39dd66ebcbf2-0',
-        liveStreaming: false,
         query: 'source=sample_data | stats count(test) by timestamp',
         queryType: ElasticsearchQueryType.PPL,
         timeField: 'timestamp',
         format: 'time_series',
       },
     ];
+    const targetType = ElasticsearchQueryType.PPL;
+
     const response = {
       datarows: [
         [5, '2020-11-01 00:39:02.912Z'],
@@ -1344,17 +1344,35 @@ describe('ElasticResponse', () => {
         [4, '2020-11-01 03:34:43.399Z'],
       ],
       schema: [
-        { name: 'test', type: 'string' },
-        { name: 'timeName', type: 'date' },
+        { name: 'test', type: 'int' },
+        { name: 'timeName', type: 'timestamp' },
       ],
     };
-    const targetType = ElasticsearchQueryType.PPL;
     it('should return series', () => {
       const result = new ElasticResponse(targets, response, targetType).getTimeSeries();
       expect(result.data.length).toBe(1);
       expect(result.data[0].datapoints.length).toBe(3);
       expect(result.data[0].datapoints[0][0]).toBe(5);
       expect(result.data[0].datapoints[0][1]).toBe(1604191142000);
+    });
+
+    const response2 = {
+      datarows: [
+        ['2020-11-01', 5],
+        ['2020-11-02', 1],
+        ['2020-11-03', 4],
+      ],
+      schema: [
+        { name: 'timeName', type: 'date' },
+        { name: 'test', type: 'int' },
+      ],
+    };
+    it('should return series', () => {
+      const result = new ElasticResponse(targets, response2, targetType).getTimeSeries();
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].datapoints.length).toBe(3);
+      expect(result.data[0].datapoints[0][0]).toBe(5);
+      expect(result.data[0].datapoints[0][1]).toBe(1604206800000);
     });
   });
 
@@ -1363,13 +1381,14 @@ describe('ElasticResponse', () => {
       {
         refId: 'A',
         isLogsQuery: true,
-        liveStreaming: false,
         query: 'source=sample_data | stats count(test) by data',
         queryType: ElasticsearchQueryType.PPL,
         timeField: 'timestamp',
         format: 'time_series',
       },
     ];
+    const targetType = ElasticsearchQueryType.PPL;
+
     const response1 = {
       datarows: [
         [5, '5000'],
@@ -1377,28 +1396,28 @@ describe('ElasticResponse', () => {
         [4, '4000'],
       ],
       schema: [
-        { name: 'test', type: 'string' },
+        { name: 'test', type: 'int' },
         { name: 'data', type: 'string' },
       ],
     };
+    it('should return invalid query error due to no timestamp', () => {
+      expect(() => new ElasticResponse(targets, response1, targetType).getTimeSeries()).toThrowError(
+        'Invalid time series query'
+      );
+    });
+
     const response2 = {
       datarows: [
-        ['data1', '2020-11-01 00:39:02.912Z'],
-        ['data2', '2020-11-01 03:26:21.326Z'],
-        ['data3', '2020-11-01 03:34:43.399Z'],
+        ['1', '2020-11-01 00:39:02.912Z'],
+        ['2', '2020-11-01 03:26:21.326Z'],
+        ['3', '2020-11-01 03:34:43.399Z'],
       ],
       schema: [
         { name: 'data', type: 'string' },
         { name: 'time', type: 'timestamp' },
       ],
     };
-    const targetType = ElasticsearchQueryType.PPL;
-    it('should return invalid query error', () => {
-      expect(() => new ElasticResponse(targets, response1, targetType).getTimeSeries()).toThrowError(
-        'Invalid time series query'
-      );
-    });
-    it('should return invalid query error', () => {
+    it('should return invalid query error due to no numerical column', () => {
       expect(() => new ElasticResponse(targets, response2, targetType).getTimeSeries()).toThrowError(
         'Invalid time series query'
       );

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1,6 +1,7 @@
 import { DataFrameView, FieldCache, KeyValue, MutableDataFrame } from '@grafana/data';
 import { ElasticResponse } from '../elastic_response';
 import flatten from 'app/core/utils/flatten';
+import { ElasticsearchQueryType } from '../types';
 
 describe('ElasticResponse', () => {
   let targets: any;
@@ -1318,6 +1319,89 @@ describe('ElasticResponse', () => {
       const fieldCache = new FieldCache(result.data[0]);
       const field = fieldCache.getFieldByName('level');
       expect(field?.values.toArray()).toEqual(['debug', 'info']);
+    });
+  });
+
+  describe('PPL time series query response', () => {
+    const targets: any = [
+      {
+        refId: 'A',
+        context: 'explore',
+        interval: '10s',
+        isLogsQuery: true,
+        key: 'Q-89d91614-009c-47b5-9945-39dd66ebcbf2-0',
+        liveStreaming: false,
+        query: 'source=sample_data | stats count(test) by timestamp',
+        queryType: ElasticsearchQueryType.PPL,
+        timeField: 'timestamp',
+        format: 'time_series',
+      },
+    ];
+    const response = {
+      datarows: [
+        [5, '2020-11-01 00:39:02.912Z'],
+        [1, '2020-11-01 03:26:21.326Z'],
+        [4, '2020-11-01 03:34:43.399Z'],
+      ],
+      schema: [
+        { name: 'test', type: 'string' },
+        { name: 'timeName', type: 'date' },
+      ],
+    };
+    const targetType = ElasticsearchQueryType.PPL;
+    it('should return series', () => {
+      const result = new ElasticResponse(targets, response, targetType).getTimeSeries();
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].datapoints.length).toBe(3);
+      expect(result.data[0].datapoints[0][0]).toBe(5);
+      expect(result.data[0].datapoints[0][1]).toBe(1604191142000);
+    });
+  });
+
+  describe('Invalid PPL time series query response', () => {
+    const targets: any = [
+      {
+        refId: 'A',
+        isLogsQuery: true,
+        liveStreaming: false,
+        query: 'source=sample_data | stats count(test) by data',
+        queryType: ElasticsearchQueryType.PPL,
+        timeField: 'timestamp',
+        format: 'time_series',
+      },
+    ];
+    const response1 = {
+      datarows: [
+        [5, '5000'],
+        [1, '1000'],
+        [4, '4000'],
+      ],
+      schema: [
+        { name: 'test', type: 'string' },
+        { name: 'data', type: 'string' },
+      ],
+    };
+    const response2 = {
+      datarows: [
+        ['data1', '2020-11-01 00:39:02.912Z'],
+        ['data2', '2020-11-01 03:26:21.326Z'],
+        ['data3', '2020-11-01 03:34:43.399Z'],
+      ],
+      schema: [
+        { name: 'data', type: 'string' },
+        { name: 'time', type: 'timestamp' },
+      ],
+    };
+    const targetType = ElasticsearchQueryType.PPL;
+    it('should return invalid query error', () => {
+      expect(() => new ElasticResponse(targets, response1, targetType).getTimeSeries()).toThrowError(
+        'Invalid time series query'
+      );
+    });
+    it('should return invalid query error', () => {
+      expect(() => new ElasticResponse(targets, response2, targetType).getTimeSeries()).toThrowError(
+        'Invalid time series query'
+      );
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -9,6 +9,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  pplSupportEnabled?: boolean;
 }
 
 export interface ElasticsearchAggregation {
@@ -23,8 +24,10 @@ export interface ElasticsearchQuery extends DataQuery {
   isLogsQuery: boolean;
   alias?: string;
   query?: string;
+  queryType?: ElasticsearchQueryType;
   bucketAggs?: ElasticsearchAggregation[];
   metrics?: ElasticsearchAggregation[];
+  format?: string;
 }
 
 export type DataLinkConfig = {
@@ -32,3 +35,8 @@ export type DataLinkConfig = {
   url: string;
   datasourceUid?: string;
 };
+
+export enum ElasticsearchQueryType {
+  Lucene = 'lucene',
+  PPL = 'PPL',
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the `elasticsearch-ppl-support` branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the `elasticsearch-ppl-support` branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR adds the PPL response parser for time series visualization in Grafana. In order for users to create time series queries with PPL, there are a few requirements for how the inputted query should be formatted. 
In order to visualize time series, the PPL query must return a column with a date type that is supported by PPL, which are `timestamp`, `datetime`, `date`. This time field can be named anything the user specifies, as long as it is of the correct date type. It must also return another column with numeric datatype as values. No additional columns should be returned other than the two.

<img width="715" alt="image" src="https://user-images.githubusercontent.com/43913498/99862187-a1aedd80-2b4d-11eb-8998-b5b96b889ba7.png">

If any of these requirements are not met, users will be outputted with an error.

<img width="431" alt="image" src="https://user-images.githubusercontent.com/43913498/99862127-7b893d80-2b4d-11eb-8078-9d31bc23f206.png">

Similar to MySQL, a `Show Help` dropdown is included to notify users of these requirements. Please note that the `Show Help` dropdown and the UI to choose time series format is implemented in PR 3.

**Which issue(s) this PR fixes**:

Partially resolves #28674 

cc: @alolita
