### PR TITLE
Overrides: show category for override properties

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/DynamicConfigValueEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/DynamicConfigValueEditor.tsx
@@ -33,7 +33,7 @@ export const DynamicConfigValueEditor: React.FC<DynamicConfigValueEditorProps> =
   // eslint-disable-next-line react/display-name
   const renderLabel = (includeDescription = true, includeCounter = false) => (isExpanded = false) => (
     <HorizontalGroup justify="space-between">
-      <Label description={includeDescription ? item.description : undefined}>
+      <Label category={item.category?.splice(1)} description={includeDescription ? item.description : undefined}>
         {item.name}
         {!isExpanded && includeCounter && item.getItemsCount && <Counter value={item.getItemsCount(property.value)} />}
       </Label>

--- a/public/app/features/dashboard/components/PanelEditor/OverrideEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OverrideEditor.tsx
@@ -98,8 +98,12 @@ export const OverrideEditor: React.FC<OverrideEditorProps> = ({
   );
 
   let configPropertiesOptions = registry.list().map(item => {
+    let label = item.name;
+    if (item.category && item.category.length > 1) {
+      label = [...item.category!.slice(1), item.name].join(' > ');
+    }
     return {
-      label: item.name,
+      label,
       value: item.id,
       description: item.description,
     };


### PR DESCRIPTION
The current UI does not show overides category -- that makes picking things under "Axis" awkward

| before | after |
|---|---|
| ![image](https://user-images.githubusercontent.com/705951/100955374-496fc800-34cb-11eb-8525-6d8451fb52ae.png) | ![image](https://user-images.githubusercontent.com/705951/100955254-09104a00-34cb-11eb-8c88-dc117f954c80.png) |

