### PR TITLE
@grafana/ui: Add bell-slash to available icons

### DIFF
--- a/packages/grafana-ui/src/types/icon.ts
+++ b/packages/grafana-ui/src/types/icon.ts
@@ -80,6 +80,7 @@ export type IconName =
   | 'compass'
   | 'sliders-v-alt'
   | 'bell'
+  | 'bell-slash'
   | 'database'
   | 'user'
   | 'camera'
@@ -198,6 +199,7 @@ export const getAvailableIcons = (): IconName[] => [
   'compass',
   'sliders-v-alt',
   'bell',
+  'bell-slash',
   'database',
   'user',
   'camera',


### PR DESCRIPTION
**What this PR does / why we need it**:

Used in [Alerting UI](https://github.com/grafana/alerting-ui-plugin) for alert silencing.