### PR TITLE
Add changelog to docs style guide

### DIFF
--- a/contribute/style-guides/documentation-style-guide.md
+++ b/contribute/style-guides/documentation-style-guide.md
@@ -207,6 +207,14 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 Grafana products has some words, abbreviations, and terms particular to the Grafana discourse community.
 
+#### changelog
+
+One word, not two.
+
+**Example**
+
+- Read the full changelog.
+
 #### checkout, check out
 
 Two words if used as a verb, one word if used as a noun.

--- a/contribute/style-guides/documentation-style-guide.md
+++ b/contribute/style-guides/documentation-style-guide.md
@@ -215,6 +215,10 @@ One word, not two.
 
 - Read the full changelog.
 
+**Exception:**
+
+- When referring to the file containing the official changelog, use the filename: `CHANGELOG.md`.
+
 #### checkout, check out
 
 Two words if used as a verb, one word if used as a noun.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds "changelog" to the docs style guide. 

With a few exception we're already using "changelog" rather than "change log". This makes it clearer.