### PR TITLE
Alerting: Add Rundeck Alert Notifier

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -63,6 +63,7 @@ OpsGenie | `opsgenie` | yes, external only | yes
 [Pagerduty](#pagerduty) | `pagerduty` | yes, external only | yes
 Prometheus Alertmanager | `prometheus-alertmanager` | yes, external only | yes
 Pushover | `pushover` | yes | no
+[Rundeck](#rundeck) | `rundeck` | no | no
 Sensu | `sensu` | yes, external only | no
 [Sensu Go](#sensu-go) | `sensugo` | yes, external only | no
 [Slack](#slack) | `slack` | yes | no
@@ -216,6 +217,9 @@ Alertmanager handles alerts sent by client applications such as Prometheus serve
 ### Sensu Go
 
 [Sensu](https://sensu.io) is a complete solution for monitoring and observability at scale. Sensu Go is designed to give you visibility into everything you care about: traditional server closets, containers, applications, the cloud, and more. Grafana notifications can be sent to Sensu Go as events via the API. This operation requires an API Key. Refer to the [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication) for information on creating this key.
+
+### Rundeck
+[Rundeck](https://rundeck.com) is runbook automation. Alert notifications can be used to trigger Rundeck job executions.
 
 ## Enable images in notifications {#external-image-store}
 

--- a/pkg/services/alerting/notifiers/rundeck.go
+++ b/pkg/services/alerting/notifiers/rundeck.go
@@ -1,0 +1,94 @@
+package notifiers
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+func init() {
+	alerting.RegisterNotifier(&alerting.NotifierPlugin{
+		Type:        "rundeck",
+		Name:        "Rundeck",
+		Description: "Triggers a Rundeck Job on Alert",
+		Heading:     "Rundeck Settings",
+		Factory:     NewRundeckNotifier,
+		Options: []alerting.NotifierOption{
+			{
+				Label:        "URL",
+				Element:      alerting.ElementTypeInput,
+				InputType:    alerting.InputTypeText,
+				PropertyName: "url",
+				Required:     true,
+			},
+			{
+				Label:        "Auth Token",
+				Element:      alerting.ElementTypeInput,
+				InputType:    alerting.InputTypeText,
+				PropertyName: "authtoken",
+				Required:     true,
+			},
+			{
+				Label:        "Job ID",
+				Element:      alerting.ElementTypeInput,
+				InputType:    alerting.InputTypeText,
+				PropertyName: "jobid",
+				Required:     true,
+			},
+		},
+	})
+}
+
+// NewRundeckNotifier is the constructor for the rundeck notifier.
+func NewRundeckNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+	url := model.Settings.Get("url").MustString()
+	if url == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find url property in settings"}
+	}
+	authToken := model.Settings.Get("authtoken").MustString()
+	if authToken == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find auth token property in settings"}
+	}
+	jobID := model.Settings.Get("jobid").MustString()
+	if jobID == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find job id property in settings"}
+	}
+
+	return &RundeckNotifier{
+		NotifierBase: NewNotifierBase(model),
+		URL:          fmt.Sprintf("%s/api/12/job/%s/executions", url, jobID),
+		AuthToken:    authToken,
+		log:          log.New("alerting.notifier.rundeck"),
+	}, nil
+}
+
+// RundeckNotifier is responsible for invoking Rundeck jobs on Alerts
+type RundeckNotifier struct {
+	NotifierBase
+	URL       string
+	AuthToken string
+	log       log.Logger
+}
+
+// Notify send alert notifications as rundeck as http requests.
+func (rn *RundeckNotifier) Notify(evalContext *alerting.EvalContext) error {
+	if evalContext.Rule.State == models.AlertStateAlerting {
+		rn.log.Info("Sending rundeck")
+		cmd := &models.SendWebhookSync{
+			Url:        rn.URL,
+			HttpMethod: "POST",
+			HttpHeader: map[string]string{
+				"X-Rundeck-Auth-Token": rn.AuthToken,
+			},
+		}
+
+		if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
+			rn.log.Error("Failed to send Rundeck", "error", err, "rundeck", rn.Name)
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/services/alerting/notifiers/rundeck_test.go
+++ b/pkg/services/alerting/notifiers/rundeck_test.go
@@ -1,0 +1,54 @@
+package notifiers
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRundeckNotifier(t *testing.T) {
+	Convey("Rundeck notifier tests", t, func() {
+		Convey("Parsing alert notification from settings", func() {
+			Convey("empty settings should return error", func() {
+				json := `{ }`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "Rundeck",
+					Type:     "rundeck",
+					Settings: settingsJSON,
+				}
+
+				_, err := NewRundeckNotifier(model)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("from settings", func() {
+				json := `
+				{
+					"url": "http://rundeck.example.com",
+					"authtoken": "123456789",
+					"jobid": "d203cc76-9bca-49e6-a3cf-1149dab45cf9"
+				}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "Rundeck",
+					Type:     "rundeck",
+					Settings: settingsJSON,
+				}
+
+				not, err := NewRundeckNotifier(model)
+				RundeckNotifier := not.(*RundeckNotifier)
+
+				So(err, ShouldBeNil)
+				So(RundeckNotifier.Name, ShouldEqual, "Rundeck")
+				So(RundeckNotifier.Type, ShouldEqual, "rundeck")
+				So(RundeckNotifier.URL, ShouldEqual, "http://rundeck.example.com/api/12/job/d203cc76-9bca-49e6-a3cf-1149dab45cf9/executions")
+				So(RundeckNotifier.AuthToken, ShouldEqual, "123456789")
+			})
+		})
+	})
+}


### PR DESCRIPTION
This PR adds a new notifier type that makes an API request to [Rundeck](https://www.rundeck.com/) to trigger the execution of a Rundeck job on an alert.

While this satisfies the needs I have, I figured I'd make a draft PR to get feedback to see what you all would like to see from it, in order to get it merged.

Right now it only triggers the API call on Alert, which was intentional as to not over complicate it. However, I could see a case being made to allow for jobs to be specified for each state change.