### PR TITLE
Docs: Update broken aliases

### DIFF
--- a/docs/sources/developers/_index.md
+++ b/docs/sources/developers/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Developers"
-aliases = ["/docs/plugins/developing/"]
+aliases = ["/docs/grafana/latest/plugins/developing/"]
 weight = 190
 +++
 

--- a/docs/sources/plugins/installation.md
+++ b/docs/sources/plugins/installation.md
@@ -1,6 +1,6 @@
 +++
 title = "Install plugins"
-aliases = ["/docs/plugins/installation/"]
+aliases = ["/docs/grafana/latest/plugins/installation/"]
 weight = 1
 +++
 

--- a/docs/sources/plugins/plugin-signatures.md
+++ b/docs/sources/plugins/plugin-signatures.md
@@ -1,7 +1,7 @@
 +++
 title = "Plugin signatures"
 type = "docs"
-aliases = ["/docs/plugins/plugin-signature-verification"]
+aliases = ["/docs/grafana/latest/plugins/plugin-signature-verification"]
 +++
 
 # Plugin signatures


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a few broken aliases in docs.

These are the ones I found using the following regex (occurrences of `/docs/` that's not followed by a `g`).

```
ag "\"/docs/[^g]"
```