### PR TITLE
Cloudwatch: session cache should use UTC consistently

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -153,7 +153,7 @@ func (e *cloudWatchExecutor) newSession(region string) (*session.Session, error)
 	}
 
 	duration := stscreds.DefaultDuration
-	expiration := time.Now().Add(duration)
+	expiration := time.Now().UTC().Add(duration)
 	if dsInfo.AssumeRoleARN != "" {
 		// We should assume a role in AWS
 		plog.Debug("Trying to assume role in AWS", "arn", dsInfo.AssumeRoleARN)


### PR DESCRIPTION
Duplicate of https://github.com/grafana/grafana-aws-sdk/pull/2

the expiration time is currently saved in local time but compared to UTC when loaded from cache.
Local time: https://github.com/grafana/grafana-aws-sdk/blob/main/pkg/awsds/sessions.go#L120
UTC time:  https://github.com/grafana/grafana-aws-sdk/blob/main/pkg/awsds/sessions.go#L74

Ideally we will just have to fix once for core and all plugins after:  https://github.com/grafana/grafana/pull/29550