### PR TITLE
fix panel header description inline code wrapping

### DIFF
--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -179,6 +179,12 @@ $panel-header-no-title-zindex: 1;
     }
   }
 
+  code {
+    white-space: normal;
+    display: block;
+    word-wrap: break-word;
+  }
+
   .panel-info-corner-links {
     list-style: none;
     padding-left: 0;


### PR DESCRIPTION


**What this PR does / why we need it**:
Resolves:https://github.com/grafana/grafana/issues/29239
 fixes panel header description inline code wrapping

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/29239


After:
Inline code in description properly wraps into next line.
![image](https://user-images.githubusercontent.com/3505601/101219805-db6f0080-3684-11eb-9741-d96d1c9731a6.png)

