### PR TITLE
put the default template for AWS EC2 target region us-east-2

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/dashboards/ec2.json
+++ b/public/app/plugins/datasource/cloudwatch/dashboards/ec2.json
@@ -1524,7 +1524,10 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "text": "us-east-2",
+          "value": "us-east-2"
+        },
         "datasource": "$datasource",
         "definition": "regions()",
         "hide": 0,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: today the template EC2 for cloudwatch doesn't have a default setting for region us-east-2, the PR is to set the region for template

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

