### PR TITLE
GraphNG: replace bizcharts with uPlot for sparklines

### DIFF
--- a/packages/grafana-data/src/dataframe/frameComparisons.ts
+++ b/packages/grafana-data/src/dataframe/frameComparisons.ts
@@ -6,7 +6,7 @@ import { DataFrame } from '../types/dataFrame';
  *
  * To compare multiple frames use:
  * ```
- * areArraysEqual(a, b, framesHaveSameStructure);
+ * compareArrayValues(a, b, framesHaveSameStructure);
  * ```
  * NOTE: this does a shallow check on the FieldConfig properties, when using the query
  * editor, this should be sufficient, however if applicaitons are mutating properties

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -2,7 +2,6 @@ import toString from 'lodash/toString';
 import isEmpty from 'lodash/isEmpty';
 
 import { getDisplayProcessor } from './displayProcessor';
-import { getFlotPairs } from '../utils/flotPairs';
 import {
   DataFrame,
   DisplayValue,
@@ -13,10 +12,10 @@ import {
   FieldType,
   InterpolateFunction,
   LinkModel,
+  TimeRange,
   TimeZone,
 } from '../types';
 import { DataFrameView } from '../dataframe/DataFrameView';
-import { GraphSeriesValue } from '../types/graph';
 import { GrafanaTheme } from '../types/theme';
 import { reduceField, ReducerID } from '../transformations/fieldReducer';
 import { ScopedVars } from '../types/ScopedVars';
@@ -56,11 +55,18 @@ function getTitleTemplate(stats: string[]): string {
   return parts.join(' ');
 }
 
+export interface FieldSparkline {
+  y: Field; // Y values
+  x?: Field; // if this does not exist, use the index
+  timeRange?: TimeRange; // Optionally force an absolute time
+  highlightIndex?: number;
+}
+
 export interface FieldDisplay {
   name: string; // The field name (title is in display)
   field: FieldConfig;
   display: DisplayValue;
-  sparkline?: GraphSeriesValue[][];
+  sparkline?: FieldSparkline;
 
   // Expose to the original values for delayed inspection (DataLinks etc)
   view?: DataFrameView;
@@ -185,15 +191,6 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
             field,
             reducers: calcs, // The stats to calculate
           });
-          let sparkline: GraphSeriesValue[][] | undefined = undefined;
-
-          // Single sparkline for every reducer
-          if (options.sparkline && timeField) {
-            sparkline = getFlotPairs({
-              xField: timeField,
-              yField: series.fields[i],
-            });
-          }
 
           for (const calc of calcs) {
             scopedVars[VAR_CALC] = { value: calc, text: calc };
@@ -202,6 +199,19 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
               ...field.state?.scopedVars, // series and field scoped vars
               ...scopedVars,
             });
+
+            let sparkline: FieldSparkline | undefined = undefined;
+            if (options.sparkline) {
+              sparkline = {
+                y: series.fields[i],
+                x: timeField,
+              };
+              if (calc === ReducerID.last) {
+                sparkline.highlightIndex = sparkline.y.values.length - 1;
+              } else if (calc === ReducerID.first) {
+                sparkline.highlightIndex = 0;
+              }
+            }
 
             values.push({
               name: calc,

--- a/packages/grafana-data/src/vector/IndexVector.ts
+++ b/packages/grafana-data/src/vector/IndexVector.ts
@@ -1,6 +1,11 @@
 import { Field, FieldType } from '../types';
 import { FunctionalVector } from './FunctionalVector';
 
+/**
+ * IndexVector is a simple vector implementation that returns the index value
+ * for each element in the vector.  It is functionally equivolant a vector backed
+ * by an array with values: `[0,1,2,...,length-1]`
+ */
 export class IndexVector extends FunctionalVector<number> {
   constructor(private len: number) {
     super();
@@ -14,6 +19,9 @@ export class IndexVector extends FunctionalVector<number> {
     return index;
   }
 
+  /**
+   * Returns a field representing the range [0 ... length-1]
+   */
   static newField(len: number): Field<number> {
     return {
       name: '',
@@ -21,7 +29,7 @@ export class IndexVector extends FunctionalVector<number> {
       type: FieldType.number,
       config: {
         min: 0,
-        max: len,
+        max: len - 1,
       },
     };
   }

--- a/packages/grafana-data/src/vector/IndexVector.ts
+++ b/packages/grafana-data/src/vector/IndexVector.ts
@@ -1,0 +1,28 @@
+import { Field, FieldType } from '../types';
+import { FunctionalVector } from './FunctionalVector';
+
+export class IndexVector extends FunctionalVector<number> {
+  constructor(private len: number) {
+    super();
+  }
+
+  get length() {
+    return this.len;
+  }
+
+  get(index: number): number {
+    return index;
+  }
+
+  static newField(len: number): Field<number> {
+    return {
+      name: '',
+      values: new IndexVector(len),
+      type: FieldType.number,
+      config: {
+        min: 0,
+        max: len,
+      },
+    };
+  }
+}

--- a/packages/grafana-data/src/vector/index.ts
+++ b/packages/grafana-data/src/vector/index.ts
@@ -5,5 +5,6 @@ export * from './ConstantVector';
 export * from './BinaryOperationVector';
 export * from './SortedVector';
 export * from './FormattedVector';
+export * from './IndexVector';
 
 export { vectorator } from './FunctionalVector';

--- a/packages/grafana-ui/.storybook/main.ts
+++ b/packages/grafana-ui/.storybook/main.ts
@@ -117,7 +117,7 @@ module.exports = {
       minimize: isProductionBuild,
       minimizer: isProductionBuild
         ? [
-            new TerserPlugin({ cache: false, parallel: false, sourceMap: false, exclude: /monaco|bizcharts/ }),
+            new TerserPlugin({ cache: false, parallel: false, sourceMap: false, exclude: /monaco/ }),
             new OptimizeCSSAssetsPlugin({}),
           ]
         : [],

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -41,7 +41,6 @@
     "@types/react-table": "7.0.12",
     "@types/slate": "0.47.1",
     "@types/slate-react": "0.22.5",
-    "bizcharts": "^3.5.8",
     "classnames": "2.2.6",
     "d3": "5.15.0",
     "emotion": "10.0.27",

--- a/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
@@ -4,6 +4,7 @@ import { BigValue, BigValueColorMode, BigValueGraphMode, BigValueJustifyMode, Bi
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import mdx from './BigValue.mdx';
 import { useTheme } from '../../themes';
+import { ArrayVector, FieldSparkline, FieldType } from '@grafana/data';
 
 const getKnobs = () => {
   return {
@@ -37,17 +38,13 @@ export default {
 export const Basic = () => {
   const { value, title, colorMode, graphMode, height, width, color, textMode, justifyMode } = getKnobs();
   const theme = useTheme();
-  const sparkline = {
-    xMin: 0,
-    xMax: 5,
-    data: [
-      [0, 10],
-      [1, 20],
-      [2, 15],
-      [3, 25],
-      [4, 5],
-      [5, 10],
-    ],
+  const sparkline: FieldSparkline = {
+    y: {
+      name: '',
+      values: new ArrayVector([1, 2, 3, 4, 3]),
+      type: FieldType.number,
+      config: {},
+    },
   };
 
   return (

--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -1,20 +1,11 @@
 // Library
 import React, { PureComponent } from 'react';
-import { DisplayValue, GraphSeriesValue, DisplayValueAlignmentFactors, TextDisplayOptions } from '@grafana/data';
+import { DisplayValue, DisplayValueAlignmentFactors, FieldSparkline, TextDisplayOptions } from '@grafana/data';
 
 // Types
 import { Themeable } from '../../types';
 import { buildLayout } from './BigValueLayout';
 import { FormattedValueDisplay } from '../FormattedValueDisplay/FormattedValueDisplay';
-
-export interface BigValueSparkline {
-  data: GraphSeriesValue[][];
-  xMin?: number | null;
-  xMax?: number | null;
-  yMin?: number | null;
-  yMax?: number | null;
-  highlightIndex?: number;
-}
 
 export enum BigValueColorMode {
   Value = 'value',
@@ -51,7 +42,7 @@ export interface Props extends Themeable {
   /** Value displayed as Big Value */
   value: DisplayValue;
   /** Sparkline values for showing a graph under/behind the value  */
-  sparkline?: BigValueSparkline;
+  sparkline?: FieldSparkline;
   /** onClick handler for the value */
   onClick?: React.MouseEventHandler<HTMLElement>;
   /** Custom styling */

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
@@ -1,6 +1,7 @@
 import { Props, BigValueColorMode, BigValueGraphMode } from './BigValue';
 import { buildLayout, StackedWithChartLayout, WideWithChartLayout } from './BigValueLayout';
 import { getTheme } from '../../themes';
+import { ArrayVector, FieldType } from '@grafana/data';
 
 function getProps(propOverrides?: Partial<Props>): Props {
   const props: Props = {
@@ -13,12 +14,12 @@ function getProps(propOverrides?: Partial<Props>): Props {
       numeric: 25,
     },
     sparkline: {
-      data: [
-        [10, 10],
-        [10, 10],
-      ],
-      xMin: 0,
-      xMax: 100,
+      y: {
+        name: '',
+        values: new ArrayVector([1, 2, 3, 4, 3]),
+        type: FieldType.number,
+        config: {},
+      },
     },
     theme: getTheme(),
   };

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -18,7 +18,7 @@ import { calculateFontSize } from '../../utils/measureText';
 import { BigValueColorMode, Props, BigValueJustifyMode, BigValueTextMode } from './BigValue';
 import { getTextColorForBackground } from '../../utils';
 import { GraphNG } from '../GraphNG/GraphNG';
-import { AxisPlacement, GraphFieldConfig } from '../uPlot/config';
+import { AxisPlacement } from '../uPlot/config';
 
 const LINE_HEIGHT = 1.2;
 const MAX_TITLE_SIZE = 30;

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -172,12 +172,8 @@ export abstract class BigValueLayout {
           .toRgbString();
     }
 
+    // The graph field configuration applied to Y values
     const config: FieldConfig<GraphFieldConfig> = {
-      // When the line/fill color is set, this should not be necessary
-      // color: {
-      //   mode: FieldColorModeId.Fixed,
-      //   fixedColor: this.valueColor,
-      // },
       custom: {
         drawStyle: DrawStyle.Line,
         lineWidth: 1,

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -10,7 +10,6 @@ import {
   IndexVector,
   DefaultTimeZone,
   DataFrame,
-  FieldConfig,
 } from '@grafana/data';
 import { calculateFontSize } from '../../utils/measureText';
 

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -11,7 +11,6 @@ import { BigValueColorMode, Props, BigValueJustifyMode, BigValueTextMode } from 
 import { getTextColorForBackground } from '../../utils';
 import { DrawStyle, GraphFieldConfig } from '../uPlot/config';
 import { Sparkline } from '../Sparkline/Sparkline';
-import { css } from 'emotion';
 
 const LINE_HEIGHT = 1.2;
 const MAX_TITLE_SIZE = 30;

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -11,6 +11,7 @@ import { BigValueColorMode, Props, BigValueJustifyMode, BigValueTextMode } from 
 import { getTextColorForBackground } from '../../utils';
 import { DrawStyle, GraphFieldConfig } from '../uPlot/config';
 import { Sparkline } from '../Sparkline/Sparkline';
+import { css } from 'emotion';
 
 const LINE_HEIGHT = 1.2;
 const MAX_TITLE_SIZE = 30;
@@ -187,16 +188,17 @@ export abstract class BigValueLayout {
     };
 
     return (
-      <Sparkline
-        height={this.chartHeight}
-        width={this.chartWidth}
-        sparkline={sparkline}
-        config={config}
-        theme={this.props.theme}
-      />
+      <div style={this.getChartStyles()}>
+        <Sparkline
+          height={this.chartHeight}
+          width={this.chartWidth}
+          sparkline={sparkline}
+          config={config}
+          theme={this.props.theme}
+        />
+      </div>
     );
   }
-
   getChartStyles(): CSSProperties {
     return {
       position: 'absolute',

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -1,15 +1,24 @@
 // Libraries
 import React, { CSSProperties } from 'react';
 import tinycolor from 'tinycolor2';
-import { Chart, Geom } from 'bizcharts';
 
 // Utils
-import { formattedValueToString, DisplayValue, getColorForTheme } from '@grafana/data';
+import {
+  formattedValueToString,
+  DisplayValue,
+  getColorForTheme,
+  IndexVector,
+  DefaultTimeZone,
+  DataFrame,
+  FieldConfig,
+} from '@grafana/data';
 import { calculateFontSize } from '../../utils/measureText';
 
 // Types
 import { BigValueColorMode, Props, BigValueJustifyMode, BigValueTextMode } from './BigValue';
 import { getTextColorForBackground } from '../../utils';
+import { GraphNG } from '../GraphNG/GraphNG';
+import { AxisPlacement, GraphFieldConfig } from '../uPlot/config';
 
 const LINE_HEIGHT = 1.2;
 const MAX_TITLE_SIZE = 30;
@@ -150,87 +159,32 @@ export abstract class BigValueLayout {
   renderChart(): JSX.Element | null {
     const { sparkline } = this.props;
 
-    if (!sparkline || sparkline.data.length === 0) {
+    if (!sparkline || !sparkline.y) {
       return null;
     }
 
-    const data = sparkline.data.map(values => {
-      return { time: values[0], value: values[1], name: 'A' };
-    });
+    const length = sparkline.y.values.length;
+    const x = { ...(sparkline.x ?? IndexVector.newField(length)) };
+    const y = { ...sparkline.y, config: { ...sparkline.y.config } };
+    if (!y.config.custom) {
+      y.config.custom = {};
+    }
+    y.config.custom = AxisPlacement.Hidden;
 
-    const scales = {
-      time: {
-        type: 'time',
-        min: sparkline.xMin,
-        max: sparkline.xMax,
-      },
-      value: {
-        min: sparkline.yMin,
-        max: sparkline.yMax,
-      },
+    const frame: DataFrame = {
+      refId: 'sparkline',
+      fields: [x, y],
+      length,
     };
 
-    if (sparkline.xMax && sparkline.xMin) {
-      // Having the last data point align with the edge of the panel looks good
-      // So if it's close adjust time.max to the last data point time
-      const timeDelta = sparkline.xMax - sparkline.xMin;
-      const lastDataPointTime = data[data.length - 1].time || 0;
-      const lastTimeDiffFromMax = Math.abs(sparkline.xMax - lastDataPointTime);
-
-      // if last data point is just 5% or lower from the edge adjust it
-      if (lastTimeDiffFromMax / timeDelta < 0.05) {
-        scales.time.max = lastDataPointTime;
-      }
-    }
-
     return (
-      <Chart
+      <GraphNG
+        data={[frame]}
         height={this.chartHeight}
         width={this.chartWidth}
-        data={data}
-        animate={false}
-        padding={[4, 0, 0, 0]}
-        scale={scales}
-        style={this.getChartStyles()}
-      >
-        {this.renderGeom()}
-      </Chart>
-    );
-  }
-
-  renderGeom(): JSX.Element {
-    const { colorMode } = this.props;
-
-    const lineStyle: any = {
-      opacity: 1,
-      fillOpacity: 1,
-      lineWidth: 2,
-    };
-
-    let fillColor: string;
-    let lineColor: string;
-
-    switch (colorMode) {
-      case BigValueColorMode.Value:
-        lineColor = this.valueColor;
-        fillColor = tinycolor(this.valueColor)
-          .setAlpha(0.2)
-          .toRgbString();
-        break;
-      case BigValueColorMode.Background:
-        fillColor = 'rgba(255,255,255,0.4)';
-        lineColor = tinycolor(this.valueColor)
-          .brighten(40)
-          .toRgbString();
-    }
-
-    lineStyle.stroke = lineColor;
-
-    return (
-      <>
-        <Geom type="area" position="time*value" size={0} color={fillColor} style={lineStyle} shape="smooth" />
-        <Geom type="line" position="time*value" size={1} color={lineColor} style={lineStyle} shape="smooth" />
-      </>
+        timeRange={sparkline.timeRange!}
+        timeZone={DefaultTimeZone}
+      />
     );
   }
 

--- a/packages/grafana-ui/src/components/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.ts
@@ -80,7 +80,7 @@ export function alignDataFrames(frames: DataFrame[], fields?: XYFieldMatchers): 
       }
       alignedData.push(values);
 
-      if (field.config.custom.spanNulls) {
+      if (field.config.custom?.spanNulls) {
         spanNulls = true;
       }
 

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -77,6 +77,11 @@ export class Sparkline extends PureComponent<Props, State> {
   prepareConfig = (data: DataFrame, props: Props) => {
     const { theme } = this.props;
     const builder = new UPlotConfigBuilder();
+    builder.setCursor({
+      show: true,
+      x: false, // no crosshairs
+      y: false,
+    });
 
     // X is the first field in the alligned frame
     const xField = data.fields[0];

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -43,10 +43,9 @@ export class Sparkline extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(oldProps: Props) {
-    const cfgChanged = oldProps.config !== this.props.config;
-    if (oldProps.sparkline !== this.props.sparkline || cfgChanged) {
+    if (oldProps.sparkline !== this.props.sparkline) {
       const data = this.perepareData(this.props);
-      if (cfgChanged || !compareDataFrameStructures(this.state.data, data)) {
+      if (!compareDataFrameStructures(this.state.data, data)) {
         const configBuilder = this.prepareConfig(data, this.props);
         this.setState({ data, configBuilder });
       } else {
@@ -78,6 +77,7 @@ export class Sparkline extends PureComponent<Props, State> {
   prepareConfig = (data: DataFrame, props: Props) => {
     const { theme } = this.props;
     const builder = new UPlotConfigBuilder();
+    debugger;
 
     // X is the first field in the alligned frame
     const xField = data.fields[0];
@@ -90,7 +90,6 @@ export class Sparkline extends PureComponent<Props, State> {
     //   theme,
     //   placement: AxisPlacement.Hidden,
     // });
-
     for (let i = 0; i < data.fields.length; i++) {
       const field = data.fields[i];
       const config = field.config as FieldConfig<GraphFieldConfig>;
@@ -114,22 +113,19 @@ export class Sparkline extends PureComponent<Props, State> {
       const colorMode = getFieldColorModeForField(field);
       const seriesColor = colorMode.getCalculator(field, theme)(0, 0);
       const pointsMode = customConfig.drawStyle === DrawStyle.Points ? PointMode.Always : customConfig.points;
-
       builder.addSeries({
         scaleKey,
         drawStyle: customConfig.drawStyle!,
-        lineColor: seriesColor,
+        lineColor: customConfig.lineColor ?? seriesColor,
         lineWidth: customConfig.lineWidth,
         lineInterpolation: customConfig.lineInterpolation,
         points: pointsMode,
         pointSize: customConfig.pointSize,
-        pointColor: seriesColor,
+        pointColor: customConfig.pointColor ?? seriesColor,
         fillOpacity: customConfig.fillOpacity,
-        fillColor: seriesColor,
+        fillColor: customConfig.fillColor ?? seriesColor,
       });
     }
-
-    console.log('BUILDER', builder);
 
     return builder;
   };

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -1,0 +1,155 @@
+import React, { PureComponent } from 'react';
+import {
+  compareDataFrameStructures,
+  DefaultTimeZone,
+  FieldSparkline,
+  IndexVector,
+  DataFrame,
+  FieldType,
+  getFieldColorModeForField,
+  FieldConfig,
+} from '@grafana/data';
+import { AxisPlacement, DrawStyle, GraphFieldConfig, PointMode } from '../uPlot/config';
+import { UPlotConfigBuilder } from '../uPlot/config/UPlotConfigBuilder';
+import { UPlotChart } from '../uPlot/Plot';
+import { Themeable } from '../../types';
+
+export interface Props extends Themeable {
+  width: number;
+  height: number;
+  config?: FieldConfig<GraphFieldConfig>;
+  sparkline: FieldSparkline;
+}
+
+interface State {
+  data: DataFrame;
+  configBuilder: UPlotConfigBuilder;
+}
+
+const defaultConfig: GraphFieldConfig = {
+  drawStyle: DrawStyle.Line,
+  points: PointMode.Auto,
+  axisPlacement: AxisPlacement.Hidden,
+};
+
+export class Sparkline extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    const data = this.perepareData(props);
+    this.state = {
+      data,
+      configBuilder: this.prepareConfig(data, props),
+    };
+  }
+
+  componentDidUpdate(oldProps: Props) {
+    const cfgChanged = oldProps.config !== this.props.config;
+    if (oldProps.sparkline !== this.props.sparkline || cfgChanged) {
+      const data = this.perepareData(this.props);
+      if (cfgChanged || !compareDataFrameStructures(this.state.data, data)) {
+        const configBuilder = this.prepareConfig(data, this.props);
+        this.setState({ data, configBuilder });
+      } else {
+        this.setState({ data });
+      }
+    }
+  }
+
+  perepareData = (props: Props): DataFrame => {
+    const { sparkline } = this.props;
+    const length = sparkline.y.values.length;
+    const yFieldConfig = {
+      ...sparkline.y.config,
+      ...this.props.config,
+    };
+    return {
+      refId: 'sparkline',
+      fields: [
+        sparkline.x ?? IndexVector.newField(length),
+        {
+          ...sparkline.y,
+          config: yFieldConfig,
+        },
+      ],
+      length,
+    };
+  };
+
+  prepareConfig = (data: DataFrame, props: Props) => {
+    const { theme } = this.props;
+    const builder = new UPlotConfigBuilder();
+
+    // X is the first field in the alligned frame
+    const xField = data.fields[0];
+    builder.addScale({
+      scaleKey: 'x',
+      isTime: xField.type === FieldType.time,
+    });
+    // builder.addAxis({
+    //   scaleKey: 'x',
+    //   theme,
+    //   placement: AxisPlacement.Hidden,
+    // });
+
+    for (let i = 0; i < data.fields.length; i++) {
+      const field = data.fields[i];
+      const config = field.config as FieldConfig<GraphFieldConfig>;
+      const customConfig: GraphFieldConfig = {
+        ...defaultConfig,
+        ...config.custom,
+      };
+
+      if (field === xField || field.type !== FieldType.number) {
+        continue;
+      }
+
+      const scaleKey = config.unit || '__fixed';
+      builder.addScale({ scaleKey, min: field.config.min, max: field.config.max });
+      // builder.addAxis({
+      //   scaleKey,
+      //   theme,
+      //   placement: AxisPlacement.Hidden,
+      // });
+
+      const colorMode = getFieldColorModeForField(field);
+      const seriesColor = colorMode.getCalculator(field, theme)(0, 0);
+      const pointsMode = customConfig.drawStyle === DrawStyle.Points ? PointMode.Always : customConfig.points;
+
+      builder.addSeries({
+        scaleKey,
+        drawStyle: customConfig.drawStyle!,
+        lineColor: seriesColor,
+        lineWidth: customConfig.lineWidth,
+        lineInterpolation: customConfig.lineInterpolation,
+        points: pointsMode,
+        pointSize: customConfig.pointSize,
+        pointColor: seriesColor,
+        fillOpacity: customConfig.fillOpacity,
+        fillColor: seriesColor,
+      });
+    }
+
+    console.log('BUILDER', builder);
+
+    return builder;
+  };
+
+  render() {
+    const { data, configBuilder } = this.state;
+    const { width, height, sparkline } = this.props;
+
+    return (
+      <UPlotChart
+        data={{
+          frame: data,
+          isGap: () => true,
+        }}
+        config={configBuilder}
+        width={width}
+        height={height}
+        timeRange={sparkline.timeRange!}
+        timeZone={DefaultTimeZone}
+      />
+    );
+  }
+}

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -77,7 +77,6 @@ export class Sparkline extends PureComponent<Props, State> {
   prepareConfig = (data: DataFrame, props: Props) => {
     const { theme } = this.props;
     const builder = new UPlotConfigBuilder();
-    debugger;
 
     // X is the first field in the alligned frame
     const xField = data.fields[0];

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -9,7 +9,7 @@ import {
   getFieldColorModeForField,
   FieldConfig,
 } from '@grafana/data';
-import { AxisPlacement, DrawStyle, GraphFieldConfig, PointMode } from '../uPlot/config';
+import { AxisPlacement, DrawStyle, GraphFieldConfig, PointVisibility } from '../uPlot/config';
 import { UPlotConfigBuilder } from '../uPlot/config/UPlotConfigBuilder';
 import { UPlotChart } from '../uPlot/Plot';
 import { Themeable } from '../../types';
@@ -28,7 +28,7 @@ interface State {
 
 const defaultConfig: GraphFieldConfig = {
   drawStyle: DrawStyle.Line,
-  points: PointMode.Auto,
+  showPoints: PointVisibility.Auto,
   axisPlacement: AxisPlacement.Hidden,
 };
 
@@ -111,14 +111,14 @@ export class Sparkline extends PureComponent<Props, State> {
 
       const colorMode = getFieldColorModeForField(field);
       const seriesColor = colorMode.getCalculator(field, theme)(0, 0);
-      const pointsMode = customConfig.drawStyle === DrawStyle.Points ? PointMode.Always : customConfig.points;
+      const pointsMode = customConfig.drawStyle === DrawStyle.Points ? PointVisibility.Always : customConfig.showPoints;
       builder.addSeries({
         scaleKey,
         drawStyle: customConfig.drawStyle!,
         lineColor: customConfig.lineColor ?? seriesColor,
         lineWidth: customConfig.lineWidth,
         lineInterpolation: customConfig.lineInterpolation,
-        points: pointsMode,
+        showPoints: pointsMode,
         pointSize: customConfig.pointSize,
         pointColor: customConfig.pointColor ?? seriesColor,
         fillOpacity: customConfig.fillOpacity,
@@ -137,7 +137,7 @@ export class Sparkline extends PureComponent<Props, State> {
       <UPlotChart
         data={{
           frame: data,
-          isGap: () => true,
+          isGap: () => true, // any null is a gap
         }}
         config={configBuilder}
         width={width}

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -35,7 +35,8 @@ const defaultConfig: GraphFieldConfig = {
 export class Sparkline extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
-    const data = this.perepareData(props);
+
+    const data = this.prepareData(props);
     this.state = {
       data,
       configBuilder: this.prepareConfig(data, props),
@@ -44,7 +45,7 @@ export class Sparkline extends PureComponent<Props, State> {
 
   componentDidUpdate(oldProps: Props) {
     if (oldProps.sparkline !== this.props.sparkline) {
-      const data = this.perepareData(this.props);
+      const data = this.prepareData(this.props);
       if (!compareDataFrameStructures(this.state.data, data)) {
         const configBuilder = this.prepareConfig(data, this.props);
         this.setState({ data, configBuilder });
@@ -54,13 +55,14 @@ export class Sparkline extends PureComponent<Props, State> {
     }
   }
 
-  perepareData = (props: Props): DataFrame => {
-    const { sparkline } = this.props;
+  prepareData(props: Props): DataFrame {
+    const { sparkline } = props;
     const length = sparkline.y.values.length;
     const yFieldConfig = {
       ...sparkline.y.config,
       ...this.props.config,
     };
+
     return {
       refId: 'sparkline',
       fields: [
@@ -72,11 +74,12 @@ export class Sparkline extends PureComponent<Props, State> {
       ],
       length,
     };
-  };
+  }
 
-  prepareConfig = (data: DataFrame, props: Props) => {
+  prepareConfig(data: DataFrame, props: Props) {
     const { theme } = this.props;
     const builder = new UPlotConfigBuilder();
+
     builder.setCursor({
       show: true,
       x: false, // no crosshairs
@@ -100,11 +103,13 @@ export class Sparkline extends PureComponent<Props, State> {
         return [0, sparkline.y.values.length - 1];
       },
     });
+
     builder.addAxis({
       scaleKey: 'x',
       theme,
       placement: AxisPlacement.Hidden,
     });
+
     for (let i = 0; i < data.fields.length; i++) {
       const field = data.fields[i];
       const config = field.config as FieldConfig<GraphFieldConfig>;
@@ -143,7 +148,7 @@ export class Sparkline extends PureComponent<Props, State> {
     }
 
     return builder;
-  };
+  }
 
   render() {
     const { data, configBuilder } = this.state;

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -82,13 +82,24 @@ export class Sparkline extends PureComponent<Props, State> {
     const xField = data.fields[0];
     builder.addScale({
       scaleKey: 'x',
-      isTime: xField.type === FieldType.time,
+      isTime: false, //xField.type === FieldType.time,
+      range: () => {
+        const { sparkline } = this.props;
+        if (sparkline.x) {
+          if (sparkline.timeRange && sparkline.x.type === FieldType.time) {
+            return [sparkline.timeRange.from.valueOf(), sparkline.timeRange.to.valueOf()];
+          }
+          const vals = sparkline.x.values;
+          return [vals.get(0), vals.get(vals.length - 1)];
+        }
+        return [0, sparkline.y.values.length - 1];
+      },
     });
-    // builder.addAxis({
-    //   scaleKey: 'x',
-    //   theme,
-    //   placement: AxisPlacement.Hidden,
-    // });
+    builder.addAxis({
+      scaleKey: 'x',
+      theme,
+      placement: AxisPlacement.Hidden,
+    });
     for (let i = 0; i < data.fields.length; i++) {
       const field = data.fields[i];
       const config = field.config as FieldConfig<GraphFieldConfig>;
@@ -103,11 +114,11 @@ export class Sparkline extends PureComponent<Props, State> {
 
       const scaleKey = config.unit || '__fixed';
       builder.addScale({ scaleKey, min: field.config.min, max: field.config.max });
-      // builder.addAxis({
-      //   scaleKey,
-      //   theme,
-      //   placement: AxisPlacement.Hidden,
-      // });
+      builder.addAxis({
+        scaleKey,
+        theme,
+        placement: AxisPlacement.Hidden,
+      });
 
       const colorMode = getFieldColorModeForField(field);
       const seriesColor = colorMode.getCalculator(field, theme)(0, 0);

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -63,7 +63,6 @@ export { Counter } from './Tabs/Counter';
 export {
   BigValue,
   BigValueColorMode,
-  BigValueSparkline,
   BigValueGraphMode,
   BigValueJustifyMode,
   BigValueTextMode,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -3,11 +3,13 @@ import { ScaleProps, UPlotScaleBuilder } from './UPlotScaleBuilder';
 import { SeriesProps, UPlotSeriesBuilder } from './UPlotSeriesBuilder';
 import { AxisProps, UPlotAxisBuilder } from './UPlotAxisBuilder';
 import { AxisPlacement } from '../config';
+import { Cursor } from 'uplot';
 
 export class UPlotConfigBuilder {
   private series: UPlotSeriesBuilder[] = [];
   private axes: Record<string, UPlotAxisBuilder> = {};
   private scales: UPlotScaleBuilder[] = [];
+  private cursor: Cursor | undefined;
 
   hasLeftAxis = false;
 
@@ -41,6 +43,10 @@ export class UPlotConfigBuilder {
     return axis?.props.placement! ?? AxisPlacement.Left;
   }
 
+  setCursor(cursor?: Cursor) {
+    this.cursor = cursor;
+  }
+
   addSeries(props: SeriesProps) {
     this.series.push(new UPlotSeriesBuilder(props));
   }
@@ -62,6 +68,7 @@ export class UPlotConfigBuilder {
     config.scales = this.scales.reduce((acc, s) => {
       return { ...acc, ...s.getConfig() };
     }, {});
+    config.cursor = this.cursor;
     return config;
   }
 }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -28,6 +28,11 @@ export class UPlotConfigBuilder {
       this.hasLeftAxis = true;
     }
 
+    if (props.placement === AxisPlacement.Hidden) {
+      props.show = false;
+      props.size = 0;
+    }
+
     this.axes[props.scaleKey] = new UPlotAxisBuilder(props);
   }
 
@@ -57,7 +62,6 @@ export class UPlotConfigBuilder {
     config.scales = this.scales.reduce((acc, s) => {
       return { ...acc, ...s.getConfig() };
     }, {});
-
     return config;
   }
 }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -68,7 +68,9 @@ export class UPlotConfigBuilder {
     config.scales = this.scales.reduce((acc, s) => {
       return { ...acc, ...s.getConfig() };
     }, {});
-    config.cursor = this.cursor;
+    if (this.cursor) {
+      config.cursor = this.cursor;
+    }
     return config;
   }
 }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -77,21 +77,23 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
       pointsConfig.points!.show = true;
     }
 
-    const areaConfig =
-      fillOpacity !== undefined
-        ? {
-            fill: tinycolor(fillColor)
+    let fillConfig: any | undefined;
+    if (fillColor && fillOpacity !== 0) {
+      fillConfig = {
+        fill: fillOpacity
+          ? tinycolor(fillColor)
               .setAlpha(fillOpacity)
-              .toRgbString(),
-          }
-        : { fill: undefined };
+              .toRgbString()
+          : fillColor,
+      };
+    }
 
     return {
       scale: scaleKey,
       spanGaps: spanNulls,
       ...lineConfig,
       ...pointsConfig,
-      ...areaConfig,
+      ...fillConfig,
     };
   }
 }

--- a/packages/grafana-ui/src/components/uPlot/types.ts
+++ b/packages/grafana-ui/src/components/uPlot/types.ts
@@ -3,7 +3,7 @@ import uPlot, { Options, Series, Hooks } from 'uplot';
 import { DataFrame, TimeRange, TimeZone } from '@grafana/data';
 import { UPlotConfigBuilder } from './config/UPlotConfigBuilder';
 
-export type PlotSeriesConfig = Pick<Options, 'series' | 'scales' | 'axes'>;
+export type PlotSeriesConfig = Pick<Options, 'series' | 'scales' | 'axes' | 'cursor'>;
 export type PlotPlugin = {
   id: string;
   /** can mutate provided opts as necessary */

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import {
   BigValue,
   BigValueGraphMode,
-  BigValueSparkline,
   DataLinksContextMenu,
   VizRepeater,
   VizRepeaterRenderValueProps,
@@ -14,7 +13,6 @@ import {
   getDisplayValueAlignmentFactors,
   getFieldDisplayValues,
   PanelProps,
-  ReducerID,
 } from '@grafana/data';
 
 import { config } from 'app/core/config';
@@ -29,21 +27,9 @@ export class StatPanel extends PureComponent<PanelProps<StatPanelOptions>> {
     const { timeRange, options } = this.props;
     const { value, alignmentFactors, width, height, count } = valueProps;
     const { openMenu, targetClassName } = menuProps;
-    let sparkline: BigValueSparkline | undefined;
-
-    if (value.sparkline) {
-      sparkline = {
-        data: value.sparkline,
-        xMin: timeRange.from.valueOf(),
-        xMax: timeRange.to.valueOf(),
-        yMin: value.field.min,
-        yMax: value.field.max,
-      };
-
-      const calc = options.reduceOptions.calcs[0];
-      if (calc === ReducerID.last) {
-        sparkline.highlightIndex = sparkline.data.length - 1;
-      }
+    let sparkline = value.sparkline;
+    if (sparkline) {
+      sparkline.timeRange = timeRange;
     }
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,84 +2,6 @@
 # yarn lockfile v1
 
 
-"@antv/adjust@~0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@antv/adjust/-/adjust-0.1.1.tgz#e263ab0e1a1941a648842fc086cf65a7e3b75e98"
-  integrity sha512-9FaMOyBlM4AgoRL0b5o0VhEKAYkexBNUrxV8XmpHU/9NBPJONBOB/NZUlQDqxtLItrt91tCfbAuMQmF529UX2Q==
-  dependencies:
-    "@antv/util" "~1.3.1"
-
-"@antv/attr@~0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@antv/attr/-/attr-0.1.2.tgz#2eeb122fcaaf851a2d8749abc7c60519d3f77e37"
-  integrity sha512-QXjP+T2I+pJQcwZx1oCA4tipG43vgeCeKcGGKahlcxb71OBAzjJZm1QbF4frKXcnOqRkxVXtCr70X9TRair3Ew==
-  dependencies:
-    "@antv/util" "~1.3.1"
-
-"@antv/component@~0.3.3":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@antv/component/-/component-0.3.8.tgz#677ecd3b5026907d4cb70d9082951d7c3c2b5434"
-  integrity sha512-1WN3FzeRyJ1jraS/2og5gnm2ragnwtRMVQMiLolztWaUgC++F/B1CcSrPYfV1WvYrfuwbpX/QQxo3HL9aS+YJA==
-  dependencies:
-    "@antv/attr" "~0.1.2"
-    "@antv/g" "~3.3.5"
-    "@antv/util" "~1.3.1"
-    wolfy87-eventemitter "~5.1.0"
-
-"@antv/coord@~0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@antv/coord/-/coord-0.1.0.tgz#48a80ae36d07552f96657e7f8095227c63f0c0a9"
-  integrity sha512-W1R8h3Jfb3AfMBVfCreFPMVetgEYuwHBIGn0+d3EgYXe2ckOF8XWjkpGF1fZhOMHREMr+Gt27NGiQh8yBdLUgg==
-  dependencies:
-    "@antv/util" "~1.3.1"
-
-"@antv/g2@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@antv/g2/-/g2-3.5.13.tgz#2b0365406e89855e6af34cd374bcb307a0edad42"
-  integrity sha512-Ok1hA4GyXWrYEAfDo54um4XCz2QNgwe4i45xNsVKHx+HXY0lwzkLp+LLa0QoFVW3gcxrBCrsGww3rp6GafEJGg==
-  dependencies:
-    "@antv/adjust" "~0.1.0"
-    "@antv/attr" "~0.1.2"
-    "@antv/component" "~0.3.3"
-    "@antv/coord" "~0.1.0"
-    "@antv/g" "~3.3.6"
-    "@antv/scale" "~0.1.1"
-    "@antv/util" "~1.3.1"
-    venn.js "~0.2.20"
-    wolfy87-eventemitter "~5.1.0"
-
-"@antv/g@~3.3.5", "@antv/g@~3.3.6":
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/@antv/g/-/g-3.3.6.tgz#11fed9ddc9ed4e5a2aa244b7c8abb982a003f201"
-  integrity sha512-2GtyTz++s0BbN6s0ZL2/nrqGYCkd52pVoNH92YkrTdTOvpO6Z4DNoo6jGVgZdPX6Nzwli6yduC8MinVAhE8X6g==
-  dependencies:
-    "@antv/gl-matrix" "~2.7.1"
-    "@antv/util" "~1.3.1"
-    d3-ease "~1.0.3"
-    d3-interpolate "~1.1.5"
-    d3-timer "~1.0.6"
-    wolfy87-eventemitter "~5.1.0"
-
-"@antv/gl-matrix@^2.7.1", "@antv/gl-matrix@~2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@antv/gl-matrix/-/gl-matrix-2.7.1.tgz#acb8e37f7ab3df01345aba4372d7942be42eba14"
-  integrity sha512-oOWcVNlpELIKi9x+Mm1Vwbz8pXfkbJKykoCIOJ/dNK79hSIANbpXJ5d3Rra9/wZqK6MC961B7sybFhPlLraT3Q==
-
-"@antv/scale@~0.1.1":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@antv/scale/-/scale-0.1.3.tgz#4876e6140cb7dcda190e7fe2e780882dcac6b09d"
-  integrity sha512-oknlOg4OUqIh8LygrfQttx+OAnNJm2fQ81si4g8aby1WJJwj/TU1gCr+J3loIpKBtBK4VpP/OzTTqg1Ym67SOQ==
-  dependencies:
-    "@antv/util" "~1.3.1"
-    fecha "~2.3.3"
-
-"@antv/util@~1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@antv/util/-/util-1.3.1.tgz#30a34b201ff9126ec0d58c72c8166a9c3e644ccd"
-  integrity sha512-cbUta0hIJrKEaW3eKoGarz3Ita+9qUPF2YzTj8A6wds/nNiy20G26ztIWHU+5ThLc13B1n5Ik52LbaCaeg9enA==
-  dependencies:
-    "@antv/gl-matrix" "^2.7.1"
-
 "@babel/code-frame@7.8.3", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -7885,24 +7807,10 @@ ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-align-text@^0.1.1, align-text@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
-  integrity sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=
-  dependencies:
-    kind-of "^3.0.2"
-    longest "^1.0.1"
-    repeat-string "^1.5.2"
-
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
-
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
 angular-bindonce@0.3.1:
   version "0.3.1"
@@ -8973,19 +8881,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bizcharts@^3.5.8:
-  version "3.5.8"
-  resolved "https://registry.yarnpkg.com/bizcharts/-/bizcharts-3.5.8.tgz#50abcb4960891aada6ca35318af791dd68d85825"
-  integrity sha512-s/Nt66HLQXD8oyN8yE26inh5ZGkoIr1eFE+/2TBln6lpyATm51LrqCXJPOTgOSyEp3dSNVZ7rOFCKFMMVcdOwA==
-  dependencies:
-    "@antv/g2" "3.5.13"
-    "@babel/runtime" "^7.7.6"
-    invariant "^2.2.2"
-    lodash.debounce "^4.0.8"
-    prop-types "^15.6.0"
-    resize-observer-polyfill "^1.5.1"
-    warning "^3.0.0"
-
 blink-diff@1.0.13:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/blink-diff/-/blink-diff-1.0.13.tgz#80e3df69de804b30d40c70f041e983841ecda899"
@@ -9488,11 +9383,6 @@ camelcase-keys@^4.0.0:
     map-obj "^2.0.0"
     quick-lru "^1.0.0"
 
-camelcase@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
-
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
@@ -9564,14 +9454,6 @@ ccount@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
-
-center-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  integrity sha1-qg0yYptu6XIgBBHL1EYckHvCt60=
-  dependencies:
-    align-text "^0.1.3"
-    lazy-cache "^1.0.3"
 
 centrifuge@^2.6.4:
   version "2.6.4"
@@ -9916,15 +9798,6 @@ clipboard@2.0.4, clipboard@^2.0.0:
     good-listener "^1.2.2"
     select "^1.1.2"
     tiny-emitter "^2.0.0"
-
-cliui@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
-  integrity sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=
-  dependencies:
-    center-align "^0.1.1"
-    right-align "^0.1.1"
-    wordwrap "0.0.2"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -10322,11 +10195,6 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
-contour_plot@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/contour_plot/-/contour_plot-0.0.1.tgz#475870f032b8e338412aa5fc507880f0bf495c77"
-  integrity sha1-R1hw8DK44zhBKqX8UHiA8L9JXHc=
 
 conventional-changelog-angular@^5.0.3:
   version "5.0.5"
@@ -11128,7 +10996,7 @@ d3-dsv@1:
     iconv-lite "0.4"
     rw "1"
 
-d3-ease@1, d3-ease@~1.0.3:
+d3-ease@1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.5.tgz#8ce59276d81241b1b72042d6af2d40e76d936ffb"
   integrity sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ==
@@ -11174,13 +11042,6 @@ d3-interpolate@1:
   dependencies:
     d3-color "1"
 
-d3-interpolate@~1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.6.tgz#2cf395ae2381804df08aa1bf766b7f97b5f68fb6"
-  integrity sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==
-  dependencies:
-    d3-color "1"
-
 d3-path@1:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.8.tgz#4a0606a794d104513ec4a8af43525f374b278719"
@@ -11221,7 +11082,7 @@ d3-scale@2:
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@1, d3-selection@^1.0.2, d3-selection@^1.1.0:
+d3-selection@1, d3-selection@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.0.tgz#ab9ac1e664cf967ebf1b479cc07e28ce9908c474"
   integrity sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg==
@@ -11245,12 +11106,12 @@ d3-time@1:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
-d3-timer@1, d3-timer@~1.0.6:
+d3-timer@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.9.tgz#f7bb8c0d597d792ff7131e1c24a36dd471a471ba"
   integrity sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg==
 
-d3-transition@1, d3-transition@^1.0.1:
+d3-transition@1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.2.0.tgz#f538c0e21b2aa1f05f3e965f8567e81284b3b2b8"
   integrity sha512-VJ7cmX/FPIPJYuaL2r1o1EMHLttvoIuZhhuAlRoOxDzogV8iQS6jYulDm3xEU3TqL80IZIhI551/ebmCMrkvhw==
@@ -11426,7 +11287,7 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -11462,11 +11323,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-equal@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 deep-extend@^0.6.0, deep-extend@~0.6.0:
   version "0.6.0"
@@ -11536,11 +11392,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-defined@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
-  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
 del@^4.1.1:
   version "4.1.1"
@@ -12312,7 +12163,7 @@ es-abstract@1.18.0-next.1, es-abstract@^1.18.0-next.0, es-abstract@^1.18.0-next.
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
-es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.5.0, es-abstract@^1.5.1:
+es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.5.1:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.0.tgz#d3a26dc9c3283ac9750dca569586e976d9dcc06d"
   integrity sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==
@@ -13355,11 +13206,6 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
-fecha@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
-  integrity sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==
-
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -13615,17 +13461,6 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-fmin@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/fmin/-/fmin-0.0.2.tgz#59bbb40d43ffdc1c94cd00a568c41f95f1973017"
-  integrity sha1-Wbu0DUP/3ByUzQClaMQflfGXMBc=
-  dependencies:
-    contour_plot "^0.0.1"
-    json2module "^0.0.3"
-    rollup "^0.25.8"
-    tape "^4.5.1"
-    uglify-js "^2.6.2"
-
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -13637,13 +13472,6 @@ follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
-
-for-each@~0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
-  dependencies:
-    is-callable "^1.1.3"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -13866,7 +13694,7 @@ fsevents@~2.1.1, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
 
-function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
@@ -14194,7 +14022,7 @@ glob@7.1.6, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1, glob@~7.1.4:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -14561,7 +14389,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.0, has@^1.0.1, has@^1.0.3, has@~1.0.3:
+has@^1.0.0, has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
@@ -15186,7 +15014,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -15459,7 +15287,7 @@ is-buffer@~2.0.3:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.3, is-callable@^1.1.4:
+is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
@@ -16849,13 +16677,6 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json2module@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/json2module/-/json2module-0.0.3.tgz#00fb5f4a9b7adfc3f0647c29cb17bcd1979be9b2"
-  integrity sha1-APtfSpt638PwZHwpyxe80Zeb6bI=
-  dependencies:
-    rw "^1.3.2"
-
 json3@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
@@ -17042,11 +16863,6 @@ lazy-ass@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
-
-lazy-cache@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-  integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
 
 lazy-universal-dotenv@^3.0.1:
   version "3.0.1"
@@ -17349,11 +17165,6 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -17536,11 +17347,6 @@ long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
-longest@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
-  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -18107,7 +17913,7 @@ minimist@1.1.x:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
   integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -18905,7 +18711,7 @@ object-hash@^1.1.8:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
-object-inspect@^1.6.0, object-inspect@~1.6.0:
+object-inspect@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
   integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
@@ -22546,7 +22352,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -22803,13 +22609,6 @@ resolve@^1.14.2:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@~1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
-  dependencies:
-    path-parse "^1.0.6"
-
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -22844,13 +22643,6 @@ restructured@0.0.11:
     power-assert "^1.2.0"
     unist-util-map "^1.0.2"
 
-resumer@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
-  integrity sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=
-  dependencies:
-    through "~2.3.4"
-
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -22880,13 +22672,6 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
-
-right-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
-  integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
-  dependencies:
-    align-text "^0.1.1"
 
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
@@ -23044,15 +22829,6 @@ rollup@2.33.3:
   optionalDependencies:
     fsevents "~2.1.2"
 
-rollup@^0.25.8:
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.25.8.tgz#bf6ce83b87510d163446eeaa577ed6a6fc5835e0"
-  integrity sha1-v2zoO4dRDRY0Ru6qV37WpvxYNeA=
-  dependencies:
-    chalk "^1.1.1"
-    minimist "^1.2.0"
-    source-map-support "^0.3.2"
-
 rollup@^0.63.4:
   version "0.63.5"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.63.5.tgz#5543eecac9a1b83b7e1be598b5be84c9c0a089db"
@@ -23118,7 +22894,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rw@1, rw@^1.3.2:
+rw@1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
@@ -23844,13 +23620,6 @@ source-map-resolve@^0.6.0:
     atob "^2.1.2"
     decode-uri-component "^0.2.0"
 
-source-map-support@^0.3.2:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.3.3.tgz#34900977d5ba3f07c7757ee72e73bb1a9b53754f"
-  integrity sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=
-  dependencies:
-    source-map "0.1.32"
-
 source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
@@ -23872,19 +23641,12 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@0.1.32:
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
-  integrity sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=
-  dependencies:
-    amdefine ">=0.0.4"
-
 source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
   integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -24266,15 +24028,6 @@ string.prototype.trim@^1.2.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
 
-string.prototype.trim@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
-  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.0"
-    function-bind "^1.0.2"
-
 string.prototype.trimend@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz#6ddd9a8796bc714b489a3ae22246a208f37bfa46"
@@ -24640,25 +24393,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tape@^4.5.1:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.11.0.tgz#63d41accd95e45a23a874473051c57fdbc58edc1"
-  integrity sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==
-  dependencies:
-    deep-equal "~1.0.1"
-    defined "~1.0.0"
-    for-each "~0.3.3"
-    function-bind "~1.1.1"
-    glob "~7.1.4"
-    has "~1.0.3"
-    inherits "~2.0.4"
-    minimist "~1.2.0"
-    object-inspect "~1.6.0"
-    resolve "~1.11.1"
-    resumer "~0.0.0"
-    string.prototype.trim "~1.1.2"
-    through "~2.3.8"
-
 tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
@@ -24922,7 +24656,7 @@ through2@^3.0.0:
   dependencies:
     readable-stream "2 || 3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.4, through@~2.3.6, through@~2.3.8:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -25391,25 +25125,10 @@ uglify-js@3.4.x:
     commander "~2.19.0"
     source-map "~0.6.1"
 
-uglify-js@^2.6.2:
-  version "2.8.29"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
-  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
-  dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
-
 uglify-js@^3.1.4:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.1.tgz#32d274fea8aac333293044afd7f81409d5040d38"
   integrity sha512-OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g==
-
-uglify-to-browserify@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
-  integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -25881,15 +25600,6 @@ vendors@^1.0.0:
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.3.tgz#a6467781abd366217c050f8202e7e50cc9eef8c0"
   integrity sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==
 
-venn.js@~0.2.20:
-  version "0.2.20"
-  resolved "https://registry.yarnpkg.com/venn.js/-/venn.js-0.2.20.tgz#3f0e50cc75cba1f58692a8a32f67bd7aaf1aa6fa"
-  integrity sha512-bb5SYq/wamY9fvcuErb9a0FJkgIFHJjkLZWonQ+DoKKuDX3WPH2B4ouI1ce4K2iejBklQy6r1ly8nOGIyOCO6w==
-  dependencies:
-    d3-selection "^1.0.2"
-    d3-transition "^1.0.1"
-    fmin "0.0.2"
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -25976,13 +25686,6 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
-  dependencies:
-    loose-envify "^1.0.0"
 
 warning@^4.0.1, warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
@@ -26359,11 +26062,6 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
-window-size@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-  integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
-
 windows-release@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.2.0.tgz#8122dad5afc303d833422380680a79cdfa91785f"
@@ -26371,20 +26069,10 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-wolfy87-eventemitter@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wolfy87-eventemitter/-/wolfy87-eventemitter-5.1.0.tgz#35c1ac0dd1ac0c15e35d981508fc22084a13a011"
-  integrity sha1-NcGsDdGsDBXjXZgVCPwiCEoToBE=
-
 word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
-wordwrap@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-  integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
 wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"
@@ -26792,16 +26480,6 @@ yargs@^16.0.3:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  integrity sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
 
 yauzl@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
This sketches out how we may like to support sparklines more generally

![image](https://user-images.githubusercontent.com/705951/101416567-fe74fc80-389e-11eb-92c2-e13ffde4c41c.png)
![image](https://user-images.githubusercontent.com/705951/101416590-0896fb00-389f-11eb-8348-96fe02d0f84c.png)
![image](https://user-images.githubusercontent.com/705951/101416618-164c8080-389f-11eb-9644-34efb2bd31b9.png)


This adds a simple `<Sparkline .../>` component that takes two fields -- this is a breaking API change as it gets rid of `GraphSeriesValue[][];` but I think that is OK.

TODO:

- [x] fix layout issues