### PR TITLE
Grafana headline format style update

### DIFF
--- a/docs/sources/administration/change-home-dashboard.md
+++ b/docs/sources/administration/change-home-dashboard.md
@@ -13,10 +13,10 @@ You can change the default dashboard on the organization, team and user level. T
 
 ### Set the default dashboard through preferences
 
-1. Navigate to the dashboard you want to set as the home dashboard.
-1. Star this dashboard by clicking on the star next to the dashboard title.
-1. On the left menu, hover your cursor over the **Configuration** (gear) icon and then click **Preferences**.
-1. In the **Home Dashboard** field, select the dashboard you want to use for your home dashboard. Options include all starred dashboards.
+Step 1. Navigate to the dashboard you want to set as the home dashboard.
+Step 2. Star this dashboard by clicking on the star next to the dashboard title.
+Step 3. On the left menu, hover your cursor over the **Configuration** (gear) icon and then click **Preferences**.
+Step 4. In the **Home Dashboard** field, select the dashboard you want to use for your home dashboard. Options include all starred dashboards.
 
 ### Set the default dashboard through configuration
 
@@ -24,13 +24,13 @@ If preferences are set as described above, then they override this value.
 You can provide your own JSON file to change the home dashboard. No user will be able to update this dashboard in Grafana.
 
 #### [Optional] Convert an existing dashboard into a JSON file
-1. Navigate to your dashboard page.
-1. Click the **Share dashboard** icon next to the dashboard title.
-1. In the **Export** tab, click on **Save to file**.
+Step 1. Navigate to your dashboard page.
+Step 2. Click the **Share dashboard** icon next to the dashboard title.
+Step 3. In the **Export** tab, click on **Save to file**.
 
 #### Use a JSON file as the home dashboard
-1. Save your JSON file somewhere that Grafana can access it, for example, in the Grafana `data` folder of Grafana.
-1. Update your configuration file to set the path to the JSON file. Read how to update this file in the [configuration]({{< relref "./configuration.md">}}) documentation.
+Step 1. Save your JSON file somewhere that Grafana can access it, for example, in the Grafana `data` folder of Grafana.
+Step 2. Update your configuration file to set the path to the JSON file. Read how to update this file in the [configuration]({{< relref "./configuration.md">}}) documentation.
 ```ini
 [dashboards]
 # Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
@@ -39,15 +39,15 @@ default_home_dashboard_path = data/main-dashboard.json
 
 ## Set home dashboard for your team
 
-1. Navigate to the dashboard you want to set as the home dashboard.
-1. Star this dashboard by clicking on the star next to the dashboard title.
-1. On the left menu, hover your cursor over the **Configuration** (gear) icon and then click **Teams**.
-1. Click on the team you want to change the home dashboard for and then navigate to the **Settings** tab.
-1. In the **Home Dashboard** field, select the dashboard you want to use for your home dashboard. Options include all starred dashboards.
+Step 1. Navigate to the dashboard you want to set as the home dashboard.
+Step 2. Star this dashboard by clicking on the star next to the dashboard title.
+Step 3. On the left menu, hover your cursor over the **Configuration** (gear) icon and then click **Teams**.
+Step 4. Click on the team you want to change the home dashboard for and then navigate to the **Settings** tab.
+Step 5. In the **Home Dashboard** field, select the dashboard you want to use for your home dashboard. Options include all starred dashboards.
 
 ## Set your personal home dashboard
 
-1. Navigate to the dashboard you want to set as the home dashboard.
-1. Star this dashboard by clicking on the star next to the dashboard title.
-1. On the left menu, hover your cursor over your avatar and then click **Preferences**.
-1. In the **Home Dashboard** field, select the dashboard you want to use for your home dashboard. Options include all starred dashboards.
+Step 1. Navigate to the dashboard you want to set as the home dashboard.
+Step 2. Star this dashboard by clicking on the star next to the dashboard title.
+Step 3. On the left menu, hover your cursor over your avatar and then click **Preferences**.
+Step 4. In the **Home Dashboard** field, select the dashboard you want to use for your home dashboard. Options include all starred dashboards.

--- a/docs/sources/administration/change-your-password.md
+++ b/docs/sources/administration/change-your-password.md
@@ -13,11 +13,11 @@ You can change your password in the Change Password tab.
 
 ## Change your password
 
-1. Hover your mouse over your user icon in the lower left corner of the screen.
-1. Click **Change Password**. Grafana opens the Change Password tab.
-1. Enter your **Old password** to authorize the change.
-1. Enter your **New password** and then **Confirm password**.
-1. Click **Change Password**.
+Step 1. Hover your mouse over your user icon in the lower left corner of the screen.
+Step 2. Click **Change Password**. Grafana opens the Change Password tab.
+Step 3. Enter your **Old password** to authorize the change.
+Step 4. Enter your **New password** and then **Confirm password**.
+Step 5. Click **Change Password**.
 
 ## Admin user management resources
 

--- a/docs/sources/administration/image_rendering.md
+++ b/docs/sources/administration/image_rendering.md
@@ -79,21 +79,21 @@ docker-compose up
 
 The following example describes how to build and run the remote HTTP rendering service as a standalone Node.js application and configure Grafana appropriately.
 
-1. Clone the [Grafana image renderer plugin](https://grafana.com/grafana/plugins/grafana-image-renderer) Git repository.
-1. Install dependencies and build:
+Step 1. Clone the [Grafana image renderer plugin](https://grafana.com/grafana/plugins/grafana-image-renderer) Git repository.
+Step 2. Install dependencies and build:
 
     ```bash
     yarn install --pure-lockfile
     yarn run build
     ```
 
-1. Run the server:
+Step 3. Run the server:
 
     ```bash
     node build/app.js server --port=8081
     ```
 
-1. Update Grafana configuration:
+Step 4. Update Grafana configuration:
 
     ```
     [rendering]
@@ -101,7 +101,7 @@ The following example describes how to build and run the remote HTTP rendering s
     callback_url = http://localhost:3000/
     ```
 
-1. Restart Grafana.
+Step 5. Restart Grafana.
 
 ## PhantomJS
 

--- a/docs/sources/administration/metrics.md
+++ b/docs/sources/administration/metrics.md
@@ -26,7 +26,7 @@ When enabled, Grafana exposes a number of metrics, including:
 
 These instructions assume you have already added Prometheus as a data source in Grafana.
 
-1. Enable Prometheus to scrape metrics from Grafana. In your configuration file (`grafana.ini` or `custom.ini` depending on your operating system) remove the semicolon to enable the following configuration options:
+Step 1. Enable Prometheus to scrape metrics from Grafana. In your configuration file (`grafana.ini` or `custom.ini` depending on your operating system) remove the semicolon to enable the following configuration options:
 
    ```
    # Metrics available at HTTP API Url /metrics
@@ -38,15 +38,15 @@ These instructions assume you have already added Prometheus as a data source in 
    disable_total_stats = false
    ```
 
-1. (optional) If you want to require authorization to view the metrics endpoint, then uncomment and set the following options:
+Step 2. (optional) If you want to require authorization to view the metrics endpoint, then uncomment and set the following options:
 
    ```
    basic_auth_username =
    basic_auth_password =
    ```
 
-1. Restart Grafana. Grafana now exposes metrics at http://localhost:3000/metrics.
-1. Add the job to your prometheus.yml file.
+Step 3. Restart Grafana. Grafana now exposes metrics at http://localhost:3000/metrics.
+Step 4. Add the job to your prometheus.yml file.
    Example:
 
    ```
@@ -58,16 +58,16 @@ These instructions assume you have already added Prometheus as a data source in 
       static_configs:
         - targets: ['localhost:3000']
    ```
-1. Restart Prometheus. Your new job should appear on the Targets tab.
-1. In Grafana, hover your mouse over the **Configuration** (gear) icon on the left sidebar and then click **Data Sources**.
-1. Select the **Prometheus** data source.
-1. On the Dashboards tab, **Import** the Grafana metrics dashboard. All scraped Grafana metrics are available in the dashboard.
+Step 1. Restart Prometheus. Your new job should appear on the Targets tab.
+Step 2. In Grafana, hover your mouse over the **Configuration** (gear) icon on the left sidebar and then click **Data Sources**.
+Step 3. Select the **Prometheus** data source.
+Step 4. On the Dashboards tab, **Import** the Grafana metrics dashboard. All scraped Grafana metrics are available in the dashboard.
 
 ## View Grafana metrics in Graphite
 
 These instructions assume you have already added Graphite as a data source in Grafana.
 
-1. Enable sending metrics to Graphite. In your configuration file (`grafana.ini` or `custom.ini` depending on your operating system) remove the semicolon to enable the following configuration options:
+Step 1. Enable sending metrics to Graphite. In your configuration file (`grafana.ini` or `custom.ini` depending on your operating system) remove the semicolon to enable the following configuration options:
 
    ```
    # Metrics available at HTTP API Url /metrics
@@ -79,7 +79,7 @@ These instructions assume you have already added Graphite as a data source in Gr
    disable_total_stats = false
    ```
 
-1. Enable [metrics.graphite] options:
+Step 2. Enable [metrics.graphite] options:
    ```
    # Send internal metrics to Graphite
    [metrics.graphite]
@@ -88,4 +88,4 @@ These instructions assume you have already added Graphite as a data source in Gr
    prefix = prod.grafana.%(instance_name)s.
    ```
 
-1. Restart Grafana. Grafana now exposes metrics at http://localhost:3000/metrics and sends them to the Graphite location you specified.
+Step 3. Restart Grafana. Grafana now exposes metrics at http://localhost:3000/metrics and sends them to the Graphite location you specified.

--- a/docs/sources/administration/preferences.md
+++ b/docs/sources/administration/preferences.md
@@ -13,12 +13,12 @@ You can perform several tasks in the Preferences tab. You can edit your profile,
 
 Your profile includes your name, user name, and email address.
 
-1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
-1. In the Edit Profile section, you can edit any of the following:
+Step 1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
+Step 2. In the Edit Profile section, you can edit any of the following:
    - **Name -** Edit this field to change the display name associated with your profile.
    - **Email -** Edit this field to change the email address associated with your profile.
    - **Username -** Edit this field to change your user name.
-1. Click **Save**.
+Step 3. Click **Save**.
 
 ## Edit your Grafana preferences
 
@@ -26,29 +26,29 @@ Your Grafana preferences include whether uses the dark or light theme, your home
 
 > **Note:** Settings on your personal instance override settings made by your administrator at the instance or team level.
 
-1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
-1. In the Preferences section, you can edit any of the following:
+Step 1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
+Step 2. In the Preferences section, you can edit any of the following:
    - **UI Theme -** Click to set the **Dark** or **Light** to select a theme. **Default** is either the dark theme or the theme selected by your Grafana administrator.
    - **Home Dashboard -** Refer to [Set your personal home dashboard]({{< relref "change-home-dashboard.md#set-your-personal-home-dashboard" >}}) for more information.
    - **Timezone -** Click to select an option in the **Timezone** list. **Default** is either the browser local timezone or the timezone selected by your Grafana administrator. Refer to [Time range controls]({{< relref "../dashboards/time-range-controls.md" >}}) for more information about Grafana time settings.
-1. Click **Save**.
+Step 3. Click **Save**.
 
-## View your assigned organizations
+### View your assigned organizations
 
 Every user is a member of at least one organization. You can have different roles in every organization that you are a member of.
 
-1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
-1. Scroll down to the Organizations section.
+Step 1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
+Step 2. Scroll down to the Organizations section.
    - **Name -** The name of the organizations you are a member of in that Grafana instance.
    - **Role -** The role you are assigned in the organization. Refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}) about permissions assigned to each role.
    - **Current -** Grafana tags the organization that you are currently signed in to as _Current_.
 
-## View your Grafana sessions
+### View your Grafana sessions
 
 Grafana logs your sessions in each Grafana instance. You can review this section if you suspect someone has misused your Grafana credentials.
 
-1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
-1. Scroll down to the Sessions section. Grafana displays the following:
+Step 1. Navigate to the Preferences tab. Hover your cursor over your user icon in the lower left corner of the screen, and then click **Preferences.**
+Step 2. Scroll down to the Sessions section. Grafana displays the following:
    - **Last seen -** How long ago you logged on.
    - **Logged on -** The date you logged on to the current Grafana instance.
    - **IP address -** The IP address that you logged on from.

--- a/docs/sources/administration/view-server-settings.md
+++ b/docs/sources/administration/view-server-settings.md
@@ -13,8 +13,8 @@ If you are a Grafana server admin, then you can use the Settings tab to view the
 
 ## View server settings
 
-1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
-1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click the **Settings** tab.
+Step 1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
+Step 2. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click the **Settings** tab.
 
 ## Available settings
 

--- a/docs/sources/administration/view-server-stats.md
+++ b/docs/sources/administration/view-server-stats.md
@@ -12,8 +12,8 @@ If you are a Grafana server admin, then you can view useful statistics about you
 
 ## View server stats
 
-1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
-1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click the **Stats** tab.
+Step 1. Log in to your Grafana server with an account that has the Grafana Admin flag set.
+Step 2. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click the **Stats** tab.
 
 ## Available stats
 

--- a/docs/sources/alerting/create-alerts.md
+++ b/docs/sources/alerting/create-alerts.md
@@ -17,11 +17,11 @@ Currently only the graph panel supports alert rules.
 
 ## Add or edit an alert rule
 
-1. Navigate to the panel you want to add or edit an alert rule for, click the title, and then click **Edit**.
-1. On the Alert tab, click **Create Alert**. If an alert already exists for this panel, then you can just edit the fields on the Alert tab.
-1. Fill out the fields. Descriptions are listed below in [Alert rule fields](#alert-rule-fields).
-1. When you have finished writing your rule, click **Save** in the upper right corner to save alert rule and the dashboard.
-1. (Optional but recommended) Click **Test rule** to make sure the rule returns the results you expect.
+Step 1. Navigate to the panel you want to add or edit an alert rule for, click the title, and then click **Edit**.
+Step 2. On the Alert tab, click **Create Alert**. If an alert already exists for this panel, then you can just edit the fields on the Alert tab.
+Step 3. Fill out the fields. Descriptions are listed below in [Alert rule fields](#alert-rule-fields).
+Step 4. When you have finished writing your rule, click **Save** in the upper right corner to save alert rule and the dashboard.
+Step 5. (Optional but recommended) Click **Test rule** to make sure the rule returns the results you expect.
 
 ## Delete an alert
 
@@ -55,7 +55,7 @@ Below you can see an example timeline of an alert using the `For` setting. At ~1
 Currently the only condition type that exists is a `Query` condition that allows you to
 specify a query letter, time range and an aggregation function.
 
-#### Query condition example
+### Query condition example
 
 ```sql
 avg() OF query(A, 15m, now) IS BELOW 14

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -17,9 +17,9 @@ This is done from the Notification channels page.
 
 ## Add a notification channel
 
-1. In the Grafana side bar, hover your cursor over the **Alerting** (bell) icon and then click **Notification channels**.
-1. Click **Add channel**.
-1. Fill out the fields or select options described below.
+Step 1. In the Grafana side bar, hover your cursor over the **Alerting** (bell) icon and then click **Notification channels**.
+Step 2. Click **Add channel**.
+Step 3. Fill out the fields or select options described below.
 
 ## New notification channel fields
 
@@ -170,17 +170,17 @@ Example json body:
 
 In DingTalk PC Client:
 
-1. Click "more" icon on upper right of the panel.
+Step 1. Click "more" icon on upper right of the panel.
 
-1. Click "Robot Manage" item in the pop menu, there will be a new panel call "Robot Manage".
+Step 2. Click "Robot Manage" item in the pop menu, there will be a new panel call "Robot Manage".
 
-1. In the  "Robot Manage" panel, select "customized: customized robot with Webhook".
+Step 3. In the  "Robot Manage" panel, select "customized: customized robot with Webhook".
 
-1. In the next new panel named "robot detail", click "Add" button.
+Step 4. In the next new panel named "robot detail", click "Add" button.
 
-1. In "Add Robot" panel, input a nickname for the robot and select a "message group" which the robot will join in. click "next".
+Step 5. In "Add Robot" panel, input a nickname for the robot and select a "message group" which the robot will join in. click "next".
 
-1. There will be a Webhook URL in the panel, looks like this: https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx. Copy this URL to the Grafana DingTalk setting page and then click "finish".
+Step 6. There will be a Webhook URL in the panel, looks like this: https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx. Copy this URL to the Grafana DingTalk setting page and then click "finish".
 
 DingTalk supports the following "message type": `text`, `link` and `markdown`. Only the `link` message type is supported.
 
@@ -191,7 +191,7 @@ There are a couple of configuration options which need to be set up in Grafana U
 
 1. Kafka REST Proxy endpoint.
 
-1. Kafka Topic.
+2. Kafka Topic.
 
 Once these two properties are set, you can send the alerts to Kafka for further processing or throttling.
 

--- a/docs/sources/alerting/pause-an-alert-rule.md
+++ b/docs/sources/alerting/pause-an-alert-rule.md
@@ -9,6 +9,6 @@ weight = 400
 
 Pausing the evaluation of an alert rule can sometimes be useful. For example, during a maintenance window, pausing alert rules can avoid triggering a flood of alerts.
 
-1. In the Grafana side bar, hover your cursor over the Alerting (bell) icon and then click **Alert Rules**. All configured alert rules are listed, along with their current state.
-1. Find your alert in the list, and click the **Pause** icon on the right. The **Pause** icon turns into a **Play** icon.
-1. Click the **Play** icon to resume evaluation of your alert.
+Step 1. In the Grafana side bar, hover your cursor over the Alerting (bell) icon and then click **Alert Rules**. All configured alert rules are listed, along with their current state.
+Step 2. Find your alert in the list, and click the **Pause** icon on the right. The **Pause** icon turns into a **Play** icon.
+Step 3. Click the **Play** icon to resume evaluation of your alert.


### PR DESCRIPTION

Update of headline format guide #29355 

1. This PR updates step-by-step and headline formatting according to the Grafana format guide 

2. Few headings like "Graphite" are left in Title case instead of sentence case because of Grafana terms. 



**Step-by-step-headline format guide**:

**Which issue(s) this PR fixes**:
#29355 

There are more documentation remaining that I'm working on on this issue. 


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: This update follows the Grafana style guide for headline and step-by-step instructions making documentations better and uniform. There are more documentations remaining in this list. 

