### PR TITLE
Explore: Fix a bug where Typeahead crashes when a large amount of ite…

### DIFF
--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.test.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import { Typeahead, State } from './Typeahead';
 import { TypeaheadItem } from './TypeaheadItem';
-import { CompletionItemKind } from '../../types';
+import {CompletionItemGroup, CompletionItemKind} from '../../types';
 
 describe('Typeahead', () => {
   const completionItemGroups = [{ label: 'my group', items: [{ label: 'first item' }] }];
@@ -42,5 +42,15 @@ describe('Typeahead', () => {
     items = component.find(TypeaheadItem);
     expect(items.get(0).props.isSelected).toBeFalsy();
     expect(items.get(1).props.isSelected).toBeTruthy();
+  });
+  it('can be rendered properly even if the size of items is large', () => {
+    const completionItemGroups: CompletionItemGroup[] = [{ label: 'my group', items: [] }];
+    const itemsSize = 1000000;
+    for (let i = 0; i < itemsSize; i++) {
+      completionItemGroups[0].items.push({ label: 'item' + i });
+    }
+
+    const component = mount(<Typeahead origin="test" groupedItems={completionItemGroups} isOpen />);
+    expect(component.find('.typeahead')).toHaveLength(1);
   });
 });

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.test.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import { Typeahead, State } from './Typeahead';
 import { TypeaheadItem } from './TypeaheadItem';
-import {CompletionItemGroup, CompletionItemKind} from '../../types';
+import { CompletionItemGroup, CompletionItemKind } from '../../types';
 
 describe('Typeahead', () => {
   const completionItemGroups = [{ label: 'my group', items: [{ label: 'first item' }] }];

--- a/packages/grafana-ui/src/utils/typeahead.ts
+++ b/packages/grafana-ui/src/utils/typeahead.ts
@@ -8,8 +8,7 @@ export const flattenGroupItems = (groupedItems: CompletionItemGroup[]): Completi
       label,
       kind: CompletionItemKind.GroupTitle,
     };
-    all.push(titleItem, ...items);
-    return all;
+    return all.concat(titleItem, items);
   }, []);
 };
 

--- a/packages/grafana-ui/src/utils/typeahead.ts
+++ b/packages/grafana-ui/src/utils/typeahead.ts
@@ -4,11 +4,14 @@ import { GrafanaTheme } from '@grafana/data';
 
 export const flattenGroupItems = (groupedItems: CompletionItemGroup[]): CompletionItem[] => {
   return groupedItems.reduce((all: CompletionItem[], { items, label }) => {
-    const titleItem: CompletionItem = {
+    all.push({
       label,
       kind: CompletionItemKind.GroupTitle,
-    };
-    return all.concat(titleItem, items);
+    });
+    return items.reduce((all, item) => {
+      all.push(item);
+      return all;
+    }, all);
   }, []);
 };
 


### PR DESCRIPTION
**What this PR does / why we need it:**
Because calling push API with array spreading will push all arguments to the stack,  it could cause a stack overflow if the input size is too large.
Reference: 
https://github.com/nodejs/node/issues/27732
`Array.prototype.push is not supposed to be called with a large number of arguments.`

This PR changes to use concat API instead of push API  in order to handle a large number of items.

This will resolve #27631

**Which issue(s) this PR fixes:**
#27631

Before fix
![before](https://user-images.githubusercontent.com/8587613/101271829-bfc14280-37c9-11eb-8412-d37992fc4799.gif)
After
![after](https://user-images.githubusercontent.com/8587613/101271837-df586b00-37c9-11eb-96d0-9f37b6b7bc81.gif)

