### PR TITLE
Rendering: Allow overriding callback URL for direct image rendering

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -217,7 +217,7 @@ func (rs *RenderingService) getFilePathForNewImage() (string, error) {
 }
 
 func (rs *RenderingService) getURL(path string) string {
-	if rs.Cfg.RendererUrl != "" {
+	if rs.Cfg.RendererCallbackUrl != "" {
 		// The backend rendering service can potentially be remote.
 		// So we need to use the root_url to ensure the rendering service
 		// can reach this Grafana instance.


### PR DESCRIPTION
**What this PR does / why we need it**:

This is necessary for direct image rendering to work when Grafana is configured to use UNIX socket protocol. A workaround suggested in https://github.com/grafana/grafana/issues/20725#issuecomment-614059117 was to use `[rendering].callback_url`, but it would not actually work because `callback_url` is ignored for direct image rendering.

**Which issue(s) this PR fixes**:

Fixes #20725 (by making a workaround possible).