### PR TITLE
Elasticsearch: Deprecate browser access mode

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -35,6 +35,8 @@ All requests will be made from the browser to Grafana backend/server which in tu
 
 ### Browser (Direct) access
 
+> **Warning:** Browser (Direct) access is deprecated and will be removed in a future release.
+
 All requests will be made from the browser directly to the data source and may be subject to Cross-Origin Resource Sharing (CORS) requirements. The URL needs to be accessible from the browser if you select this access mode.
 
 If you select Browser access you must update your Elasticsearch configuration to allow other domains to access

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { DataSourceHttpSettings } from '@grafana/ui';
+import { Alert, DataSourceHttpSettings } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { ElasticsearchOptions } from '../types';
 import { defaultMaxConcurrentShardRequests, ElasticDetails } from './ElasticDetails';
@@ -30,6 +30,12 @@ export const ConfigEditor = (props: Props) => {
 
   return (
     <>
+      {options.access === 'direct' && (
+        <Alert title="Deprecation Notice" severity="warning">
+          Browser access mode in the Elasticsearch datasource is deprecated and will be removed in a future release.
+        </Alert>
+      )}
+
       <DataSourceHttpSettings
         defaultUrl={'http://localhost:9200'}
         dataSourceConfig={options}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
There is a lot of code duplication in the frontend and backend to manage both browser and server access mode. As we plan to remove Browser access mode for Elasticsearch in a future release, this PR displays a deprecation notice when selecting Browser Access mode in datasource configuration as well a warning in the related documentation section.

![Screenshot 2020-12-07 at 10 55 08](https://user-images.githubusercontent.com/1170767/101343472-f5266880-387b-11eb-8428-a51ae75bf68e.png)


