### PR TITLE
Expr: fix failure to execute due to OrgID

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -137,7 +137,7 @@ func (dn *DSNode) NodeType() NodeType {
 	return TypeDatasourceNode
 }
 
-func buildDSNode(dp *simple.DirectedGraph, rn *rawNode) (*DSNode, error) {
+func buildDSNode(dp *simple.DirectedGraph, rn *rawNode, orgID int64) (*DSNode, error) {
 	encodedQuery, err := json.Marshal(rn.Query)
 	if err != nil {
 		return nil, err
@@ -148,6 +148,7 @@ func buildDSNode(dp *simple.DirectedGraph, rn *rawNode) (*DSNode, error) {
 			id:    dp.NewNode().ID(),
 			refID: rn.RefID,
 		},
+		orgID:      orgID,
 		query:      json.RawMessage(encodedQuery),
 		queryType:  rn.QueryType,
 		intervalMS: defaultIntervalMS,
@@ -164,16 +165,6 @@ func buildDSNode(dp *simple.DirectedGraph, rn *rawNode) (*DSNode, error) {
 		return nil, fmt.Errorf("expected datasourceId to be a float64, got type %T for refId %v", rawDsID, rn.RefID)
 	}
 	dsNode.datasourceID = int64(floatDsID)
-
-	rawOrgID, ok := rn.Query["orgId"]
-	if !ok {
-		return nil, fmt.Errorf("no orgId in expression data source request command for refId %v", rn.RefID)
-	}
-	floatOrgID, ok := rawOrgID.(float64)
-	if !ok {
-		return nil, fmt.Errorf("expected orgId to be a float64, got type %T for refId %v", rawOrgID, rn.RefID)
-	}
-	dsNode.orgID = int64(floatOrgID)
 
 	var floatIntervalMS float64
 	if rawIntervalMS := rn.Query["intervalMs"]; ok {

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -19,8 +19,8 @@ type Service struct {
 }
 
 // BuildPipeline builds a pipeline from a request.
-func (s *Service) BuildPipeline(queries []backend.DataQuery) (DataPipeline, error) {
-	return buildPipeline(queries)
+func (s *Service) BuildPipeline(req *backend.QueryDataRequest) (DataPipeline, error) {
+	return buildPipeline(req)
 }
 
 // ExecutePipeline executes an expression pipeline and returns all the results.

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -36,7 +36,9 @@ func TestService(t *testing.T) {
 		},
 	}
 
-	pl, err := s.BuildPipeline(queries)
+	req := &backend.QueryDataRequest{Queries: queries}
+
+	pl, err := s.BuildPipeline(req)
 	require.NoError(t, err)
 
 	res, err := s.ExecutePipeline(context.Background(), pl)

--- a/pkg/expr/transform.go
+++ b/pkg/expr/transform.go
@@ -73,7 +73,7 @@ func TransformData(ctx context.Context, req *backend.QueryDataRequest) (*backend
 	svc := Service{}
 	// Build the pipeline from the request, checking for ordering issues (e.g. loops)
 	// and parsing graph nodes from the queries.
-	pipeline, err := svc.BuildPipeline(req.Queries)
+	pipeline, err := svc.BuildPipeline(req)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/services/ngalert/alert_definition.go
+++ b/pkg/services/ngalert/alert_definition.go
@@ -5,7 +5,7 @@ import "fmt"
 // preSave sets datasource and loads the updated model for each alert query.
 func (alertDefinition *AlertDefinition) preSave() error {
 	for i, q := range alertDefinition.Data {
-		err := q.PreSave(alertDefinition.OrgId)
+		err := q.PreSave()
 		if err != nil {
 			return fmt.Errorf("invalid alert query %s: %w", q.RefID, err)
 		}

--- a/pkg/services/ngalert/eval/alert_query.go
+++ b/pkg/services/ngalert/eval/alert_query.go
@@ -237,18 +237,6 @@ func (aq *AlertQuery) getModel() ([]byte, error) {
 	return model, nil
 }
 
-func (aq *AlertQuery) setOrgID(orgID int64) error {
-	if aq.modelProps == nil {
-		err := aq.setModelProps()
-		if err != nil {
-			return err
-		}
-	}
-
-	aq.modelProps["orgId"] = orgID
-	return nil
-}
-
 func (aq *AlertQuery) setQueryType() error {
 	if aq.modelProps == nil {
 		err := aq.setModelProps()
@@ -272,12 +260,7 @@ func (aq *AlertQuery) setQueryType() error {
 
 // PreSave sets query's properties.
 // It should be called before being saved.
-func (aq *AlertQuery) PreSave(orgID int64) error {
-	err := aq.setOrgID(orgID)
-	if err != nil {
-		return fmt.Errorf("failed to set orgId to query model: %w", err)
-	}
-
+func (aq *AlertQuery) PreSave() error {
 	if err := aq.setDatasource(); err != nil {
 		return fmt.Errorf("failed to set datasource to query model: %w", err)
 	}

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -96,11 +96,12 @@ func (c *Condition) Execute(ctx AlertExecCtx, fromStr, toStr string) (*Execution
 	result := ExecutionResults{}
 	if !c.IsValid() {
 		return nil, fmt.Errorf("invalid conditions")
+		// TODO: Things probably
 	}
 
 	queryDataReq := &backend.QueryDataRequest{
 		PluginContext: backend.PluginContext{
-			// TODO: Things probably
+			OrgID: ctx.SignedInUser.OrgId,
 		},
 		Queries: []backend.DataQuery{},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
For server side expressions, gets orgID from the plugin context instead of json body of query, which makes more sense anyways.

Needed to makes expressions work again after https://github.com/grafana/grafana/pull/29449 changes.

