### PR TITLE
Docs: Alerts - Changed image links

### DIFF
--- a/docs/sources/alerting/create-alerts.md
+++ b/docs/sources/alerting/create-alerts.md
@@ -9,7 +9,7 @@ weight = 200
 
 Grafana alerting allows you to attach rules to your dashboard panels. When you save the dashboard, Grafana extracts the alert rules into a separate alert rule storage and schedules them for evaluation.
 
-{{< imgbox max-width="1000px" img="/img/docs/alerting/drag_handles_gif.gif" caption="Alerting overview" >}}
+![Alerting overview](/img/docs/alerting/drag_handles_gif.gif)
 
 In the Alert tab of the graph panel you can configure how often the alert rule should be evaluated and the conditions that need to be met for the alert to change state and trigger its [notifications]({{< relref "notifications.md" >}}).
 

--- a/docs/sources/alerting/troubleshoot-alerts.md
+++ b/docs/sources/alerting/troubleshoot-alerts.md
@@ -9,7 +9,7 @@ weight = 500
 
 If alerts are not behaving as you expect, here are some steps you can take to troubleshoot and figure out what is going wrong.
 
-{{< imgbox max-width="1000px" img="/img/docs/v4/alert_test_rule.png" caption="Test Rule" >}}
+![Test Rule](/img/docs/v4/alert_test_rule.png)
 
 The first level of troubleshooting you can do is click **Test Rule**. You will get result back that you can expand to the point where you can see the raw data that was returned from your query.
 


### PR DESCRIPTION
Changed image links from shortcodes to generic markdown because the word wrapping looked awful