### PR TITLE
Instrumentation: Add histograms for database queries 

### DIFF
--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/gchaincl/sqlhooks"
@@ -18,30 +19,23 @@ import (
 )
 
 var (
-	databaseQueryCounter   *prometheus.CounterVec
-	databaseQueryHistogram prometheus.Histogram
+	databaseQueryHistogram *prometheus.HistogramVec
 )
 
 func init() {
-	databaseQueryCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "grafana",
-		Name:      "database_queries_total",
-		Help:      "The total amount of Database queries",
-	}, []string{"status"})
-
-	databaseQueryHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+	databaseQueryHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "grafana",
 		Name:      "database_queries_duration_seconds",
 		Help:      "Database query histogram",
 		Buckets:   prometheus.ExponentialBuckets(0.0001, 4, 9),
-	})
+	}, []string{"status"})
 
-	prometheus.MustRegister(databaseQueryCounter, databaseQueryHistogram)
+	prometheus.MustRegister(databaseQueryHistogram)
 }
 
 // WrapDatabaseDriverWithHooks creates a fake database driver that
 // executes pre and post functions which we use to gather metrics about
-// database queries.
+// database queries. It also registers the metrics.
 func WrapDatabaseDriverWithHooks(dbType string) string {
 	drivers := map[string]driver.Driver{
 		migrator.SQLite:   &sqlite3.SQLiteDriver{},
@@ -56,7 +50,7 @@ func WrapDatabaseDriverWithHooks(dbType string) string {
 
 	driverWithHooks := dbType + "WithHooks"
 	sql.Register(driverWithHooks, sqlhooks.Wrap(d, &databaseQueryWrapper{log: log.New("sqlstore.metrics")}))
-	core.RegisterDriver(driverWithHooks, &databaseQueryWrapperParser{dbType: dbType})
+	core.RegisterDriver(driverWithHooks, &databaseQueryWrapperDriver{dbType: dbType})
 	return driverWithHooks
 }
 
@@ -78,8 +72,7 @@ func (h *databaseQueryWrapper) Before(ctx context.Context, query string, args ..
 func (h *databaseQueryWrapper) After(ctx context.Context, query string, args ...interface{}) (context.Context, error) {
 	begin := ctx.Value(databaseQueryWrapperKey{}).(time.Time)
 	elapsed := time.Since(begin)
-	databaseQueryCounter.WithLabelValues("success").Inc()
-	databaseQueryHistogram.Observe(elapsed.Seconds())
+	databaseQueryHistogram.WithLabelValues("success").Observe(elapsed.Seconds())
 	h.log.Debug("query finished", "status", "success", "elapsed time", elapsed, "sql", query)
 	return ctx, nil
 }
@@ -94,18 +87,20 @@ func (h *databaseQueryWrapper) OnError(ctx context.Context, err error, query str
 
 	begin := ctx.Value(databaseQueryWrapperKey{}).(time.Time)
 	elapsed := time.Since(begin)
-	databaseQueryCounter.WithLabelValues(status).Inc()
-	databaseQueryHistogram.Observe(elapsed.Seconds())
+	databaseQueryHistogram.WithLabelValues(status).Observe(elapsed.Seconds())
 	h.log.Debug("query finished", "status", status, "elapsed time", elapsed, "sql", query, "error", err)
 	return err
 }
 
-type databaseQueryWrapperParser struct {
+// databaseQueryWrapperDriver satisfies the xorm.io/core.Driver interface
+type databaseQueryWrapperDriver struct {
 	dbType string
 }
 
-func (hp *databaseQueryWrapperParser) Parse(string, string) (*core.Uri, error) {
-	return &core.Uri{
-		DbType: core.DbType(hp.dbType),
-	}, nil
+func (hp *databaseQueryWrapperDriver) Parse(driverName, dataSourceName string) (*core.Uri, error) {
+	driver := core.QueryDriver(hp.dbType)
+	if driver == nil {
+		return nil, fmt.Errorf("could not find driver with name %s", hp.dbType)
+	}
+	return driver.Parse(driverName, dataSourceName)
 }

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -240,6 +240,10 @@ func (ss *SQLStore) getEngine() (*xorm.Engine, error) {
 		return nil, err
 	}
 
+	if ss.Cfg.IsDatabaseMetricsEnabled() {
+		ss.dbCfg.Type = WrapDatabaseDriverWithHooks(ss.dbCfg.Type)
+	}
+
 	sqlog.Info("Connecting to DB", "dbtype", ss.dbCfg.Type)
 	if ss.dbCfg.Type == migrator.SQLite && strings.HasPrefix(connectionString, "file:") {
 		exists, err := fs.Exists(ss.dbCfg.Path)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -334,6 +334,11 @@ func (cfg Cfg) IsNgAlertEnabled() bool {
 	return cfg.FeatureToggles["ngalert"]
 }
 
+// IsDatabaseMetricsEnabled returns whether the database instrumentation feature is enabled.
+func (cfg Cfg) IsDatabaseMetricsEnabled() bool {
+	return cfg.FeatureToggles["database_metrics"]
+}
+
 // IsHTTPRequestHistogramEnabled returns whether the http_request_histogram feature is enabled.
 func (cfg Cfg) IsHTTPRequestHistogramEnabled() bool {
 	return cfg.FeatureToggles["http_request_histogram"]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR intends to re-enable a "hidden" feature we added in [this PR](https://github.com/grafana/grafana/pull/28236/files), plus fixing the bug that caused us to revoke it.

The changes in this original PR caused grafana to corrupt its database when using MySQL. We think this happened because we were not passing enough information into the URI constructor in the wrapped database's `Parse` method.

**Which issue(s) this PR fixes**:
This contributes to #29489 by adding metrics, but we still need to add traces.

**Special notes for your reviewer**:

The signifiant change from the original feature is to use the "unwrapped" driver's `Parse` function, instead of creating a new one.

Verifying the fix: In the original PR, we encountered a bug when starting a Grafana instance with an existing backend (a previously populated db). The Grafana migration script ran again and corrupted the existing data. Therefore we need to test that this new instance can start with a clean and existing database. Check this is possible for:
- [x] SQLite3
- [x] MySQL 
- [x] Postgres 

Snapshot of metrics when feature flag enabled:
```
# HELP grafana_database_queries_duration_seconds Database query histogram
# TYPE grafana_database_queries_duration_seconds histogram
grafana_database_queries_duration_seconds_bucket{le="0.0001"} 0
grafana_database_queries_duration_seconds_bucket{le="0.0004"} 0
grafana_database_queries_duration_seconds_bucket{le="0.0016"} 1026
grafana_database_queries_duration_seconds_bucket{le="0.0064"} 17491
grafana_database_queries_duration_seconds_bucket{le="0.0256"} 17751
grafana_database_queries_duration_seconds_bucket{le="0.1024"} 17752
grafana_database_queries_duration_seconds_bucket{le="0.4096"} 17752
grafana_database_queries_duration_seconds_bucket{le="1.6384"} 17752
grafana_database_queries_duration_seconds_bucket{le="6.5536"} 17752
grafana_database_queries_duration_seconds_bucket{le="+Inf"} 17752
grafana_database_queries_duration_seconds_sum 41.19716338399985
grafana_database_queries_duration_seconds_count 17752
# HELP grafana_database_queries_total The total amount of Database queries
# TYPE grafana_database_queries_total counter
grafana_database_queries_total{status="success"} 17752
```

Note: When flag is disabled, the metrics still get registered, but they are never incremented. @bergquist is this the desired behaviour? If not, could move it into `WrapDatabaseDriverWithHooks` I think.