### PR TITLE
Expr: fix time unit typo in ds queries

### DIFF
--- a/pkg/expr/transform.go
+++ b/pkg/expr/transform.go
@@ -154,7 +154,7 @@ func QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.Que
 		}
 		queries[i] = &tsdb.Query{
 			RefId:         query.RefID,
-			IntervalMs:    query.Interval.Microseconds(),
+			IntervalMs:    query.Interval.Milliseconds(),
 			MaxDataPoints: query.MaxDataPoints,
 			QueryType:     query.QueryType,
 			DataSource:    getDsInfo.Result,


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses the correct time unit, milliseconds and not microseconds. We need it because either autocomplete failed me, or I failed it.


