### PR TITLE
Typescript: Raise strict error limit for enterprise

### DIFF
--- a/scripts/ci-check-strict.sh
+++ b/scripts/ci-check-strict.sh
@@ -3,7 +3,7 @@ set -e
 
 echo -e "Collecting code stats (typescript errors & more)"
 
-ERROR_COUNT_LIMIT=579
+ERROR_COUNT_LIMIT=592
 ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --strict true | grep -oP 'Found \K(\d+)')"
 
 if [ "$ERROR_COUNT" -gt $ERROR_COUNT_LIMIT ]; then


### PR DESCRIPTION
Enterprise has more errors so need to raise this limit
