### PR TITLE
Variables: Fixes upgrade of legacy Prometheus queries

### DIFF
--- a/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
@@ -30,8 +30,8 @@ interface DispatchProps {
 type Props = OwnProps & ConnectedProps & DispatchProps;
 
 export class DataSourceVariableEditorUnConnected extends PureComponent<Props> {
-  async componentDidMount() {
-    await this.props.initDataSourceVariableEditor();
+  componentDidMount() {
+    this.props.initDataSourceVariableEditor();
   }
 
   onRegExChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/public/app/features/variables/datasource/actions.test.ts
+++ b/public/app/features/variables/datasource/actions.test.ts
@@ -143,15 +143,9 @@ describe('data source actions', () => {
   describe('when initDataSourceVariableEditor is dispatched', () => {
     it('then the correct actions are dispatched', async () => {
       const meta = getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' });
-      const mixedMeta = getMockPlugin(({
-        name: 'mixed-data-name',
-        id: 'mixed-data-id',
-        mixed: true,
-      } as unknown) as DataSourcePluginMeta);
       const sources: DataSourceInstanceSettings[] = [
         getDataSourceInstanceSetting('first-name', meta),
         getDataSourceInstanceSetting('second-name', meta),
-        getDataSourceInstanceSetting('mixed-name', mixedMeta),
       ];
 
       const { dependencies, getListMock, getDatasourceSrvMock } = getTestContext({ sources });

--- a/public/app/features/variables/datasource/actions.test.ts
+++ b/public/app/features/variables/datasource/actions.test.ts
@@ -9,12 +9,31 @@ import {
   initDataSourceVariableEditor,
   updateDataSourceVariableOptions,
 } from './actions';
-import { DataSourcePluginMeta, DataSourceSelectItem } from '@grafana/data';
+import { DataSourceInstanceSettings, DataSourceJsonData, DataSourcePluginMeta } from '@grafana/data';
 import { getMockPlugin } from '../../plugins/__mocks__/pluginMocks';
 import { createDataSourceOptions } from './reducer';
-import { setCurrentVariableValue, addVariable } from '../state/sharedReducer';
+import { addVariable, setCurrentVariableValue } from '../state/sharedReducer';
 import { changeVariableEditorExtended } from '../editor/reducer';
 import { datasourceBuilder } from '../shared/testing/builders';
+
+interface Args {
+  sources?: DataSourceInstanceSettings[];
+  query?: string;
+  regex?: string;
+}
+
+function getTestContext({ sources = [], query, regex }: Args = {}) {
+  const getListMock = jest.fn().mockReturnValue(sources);
+  const getDatasourceSrvMock = jest.fn().mockReturnValue({ getList: getListMock });
+  const dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrvMock };
+  const datasource = datasourceBuilder()
+    .withId('0')
+    .withQuery(query)
+    .withRegEx(regex)
+    .build();
+
+  return { getListMock, getDatasourceSrvMock, dependencies, datasource };
+}
 
 describe('data source actions', () => {
   variableAdapters.setInit(() => [createDataSourceVariableAdapter()]);
@@ -22,26 +41,15 @@ describe('data source actions', () => {
   describe('when updateDataSourceVariableOptions is dispatched', () => {
     describe('and there is no regex', () => {
       it('then the correct actions are dispatched', async () => {
-        const sources: DataSourceSelectItem[] = [
-          {
-            name: 'first-name',
-            value: 'first-value',
-            meta: getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' }),
-          },
-          {
-            name: 'second-name',
-            value: 'second-value',
-            meta: getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' }),
-          },
+        const meta = getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' });
+        const sources: DataSourceInstanceSettings[] = [
+          getDataSourceInstanceSetting('first-name', meta),
+          getDataSourceInstanceSetting('second-name', meta),
         ];
-
-        const getMetricSourcesMock = jest.fn().mockResolvedValue(sources);
-        const getDatasourceSrvMock = jest.fn().mockReturnValue({ getMetricSources: getMetricSourcesMock });
-        const dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrvMock };
-        const datasource = datasourceBuilder()
-          .withId('0')
-          .withQuery('mock-data-id')
-          .build();
+        const { datasource, dependencies, getListMock, getDatasourceSrvMock } = getTestContext({
+          sources,
+          query: 'mock-data-id',
+        });
 
         const tester = await reduxTester<{ templating: TemplatingState }>()
           .givenRootReducer(getRootReducer())
@@ -55,7 +63,16 @@ describe('data source actions', () => {
 
         await tester.thenDispatchedActionsShouldEqual(
           createDataSourceOptions(
-            toVariablePayload({ type: 'datasource', id: '0' }, { sources, regex: (undefined as unknown) as RegExp })
+            toVariablePayload(
+              { type: 'datasource', id: '0' },
+              {
+                sources: [
+                  { name: 'first-name', value: 'first-name', meta },
+                  { name: 'second-name', value: 'second-name', meta },
+                ],
+                regex: (undefined as unknown) as RegExp,
+              }
+            )
           ),
           setCurrentVariableValue(
             toVariablePayload(
@@ -65,35 +82,26 @@ describe('data source actions', () => {
           )
         );
 
-        expect(getMetricSourcesMock).toHaveBeenCalledTimes(1);
-        expect(getMetricSourcesMock).toHaveBeenCalledWith({ skipVariables: true });
+        expect(getListMock).toHaveBeenCalledTimes(1);
+        expect(getListMock).toHaveBeenCalledWith({ metrics: true, variables: false });
         expect(getDatasourceSrvMock).toHaveBeenCalledTimes(1);
       });
     });
 
     describe('and there is a regex', () => {
       it('then the correct actions are dispatched', async () => {
-        const sources: DataSourceSelectItem[] = [
-          {
-            name: 'first-name',
-            value: 'first-value',
-            meta: getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' }),
-          },
-          {
-            name: 'second-name',
-            value: 'second-value',
-            meta: getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' }),
-          },
+        const meta = getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' });
+        const sources: DataSourceInstanceSettings[] = [
+          getDataSourceInstanceSetting('first-name', meta),
+          getDataSourceInstanceSetting('second-name', meta),
         ];
 
-        const getMetricSourcesMock = jest.fn().mockResolvedValue(sources);
-        const getDatasourceSrvMock = jest.fn().mockReturnValue({ getMetricSources: getMetricSourcesMock });
-        const dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrvMock };
-        const datasource = datasourceBuilder()
-          .withId('0')
-          .withQuery('mock-data-id')
-          .withRegEx('/.*(second-name).*/')
-          .build();
+        const { datasource, dependencies, getListMock, getDatasourceSrvMock } = getTestContext({
+          sources,
+          query: 'mock-data-id',
+          regex: '/.*(second-name).*/',
+        });
+
         const tester = await reduxTester<{ templating: TemplatingState }>()
           .givenRootReducer(getRootReducer())
           .whenActionIsDispatched(
@@ -106,7 +114,16 @@ describe('data source actions', () => {
 
         await tester.thenDispatchedActionsShouldEqual(
           createDataSourceOptions(
-            toVariablePayload({ type: 'datasource', id: '0' }, { sources, regex: /.*(second-name).*/ })
+            toVariablePayload(
+              { type: 'datasource', id: '0' },
+              {
+                sources: [
+                  { name: 'first-name', value: 'first-name', meta },
+                  { name: 'second-name', value: 'second-name', meta },
+                ],
+                regex: /.*(second-name).*/,
+              }
+            )
           ),
           setCurrentVariableValue(
             toVariablePayload(
@@ -116,8 +133,8 @@ describe('data source actions', () => {
           )
         );
 
-        expect(getMetricSourcesMock).toHaveBeenCalledTimes(1);
-        expect(getMetricSourcesMock).toHaveBeenCalledWith({ skipVariables: true });
+        expect(getListMock).toHaveBeenCalledTimes(1);
+        expect(getListMock).toHaveBeenCalledWith({ metrics: true, variables: false });
         expect(getDatasourceSrvMock).toHaveBeenCalledTimes(1);
       });
     });
@@ -125,49 +142,47 @@ describe('data source actions', () => {
 
   describe('when initDataSourceVariableEditor is dispatched', () => {
     it('then the correct actions are dispatched', async () => {
-      const sources: DataSourceSelectItem[] = [
-        {
-          name: 'first-name',
-          value: 'first-value',
-          meta: getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' }),
-        },
-        {
-          name: 'second-name',
-          value: 'second-value',
-          meta: getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' }),
-        },
-        {
-          name: 'mixed-name',
-          value: 'mixed-value',
-          meta: getMockPlugin(({
-            name: 'mixed-data-name',
-            id: 'mixed-data-id',
-            mixed: true,
-          } as unknown) as DataSourcePluginMeta),
-        },
+      const meta = getMockPlugin({ name: 'mock-data-name', id: 'mock-data-id' });
+      const mixedMeta = getMockPlugin(({
+        name: 'mixed-data-name',
+        id: 'mixed-data-id',
+        mixed: true,
+      } as unknown) as DataSourcePluginMeta);
+      const sources: DataSourceInstanceSettings[] = [
+        getDataSourceInstanceSetting('first-name', meta),
+        getDataSourceInstanceSetting('second-name', meta),
+        getDataSourceInstanceSetting('mixed-name', mixedMeta),
       ];
 
-      const getMetricSourcesMock = jest.fn().mockResolvedValue(sources);
-      const getDatasourceSrvMock = jest.fn().mockReturnValue({ getMetricSources: getMetricSourcesMock });
-      const dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrvMock };
+      const { dependencies, getListMock, getDatasourceSrvMock } = getTestContext({ sources });
 
-      const tester = await reduxTester<{ templating: TemplatingState }>()
+      await reduxTester<{ templating: TemplatingState }>()
         .givenRootReducer(getRootReducer())
-        .whenAsyncActionIsDispatched(initDataSourceVariableEditor(dependencies));
+        .whenActionIsDispatched(initDataSourceVariableEditor(dependencies))
+        .thenDispatchedActionsShouldEqual(
+          changeVariableEditorExtended({
+            propName: 'dataSourceTypes',
+            propValue: [
+              { text: '', value: '' },
+              { text: 'mock-data-name', value: 'mock-data-id' },
+            ],
+          })
+        );
 
-      await tester.thenDispatchedActionsShouldEqual(
-        changeVariableEditorExtended({
-          propName: 'dataSourceTypes',
-          propValue: [
-            { text: '', value: '' },
-            { text: 'mock-data-name', value: 'mock-data-id' },
-          ],
-        })
-      );
-
-      expect(getMetricSourcesMock).toHaveBeenCalledTimes(1);
-      expect(getMetricSourcesMock).toHaveBeenCalledWith();
+      expect(getListMock).toHaveBeenCalledTimes(1);
+      expect(getListMock).toHaveBeenCalledWith({ metrics: true, variables: true });
       expect(getDatasourceSrvMock).toHaveBeenCalledTimes(1);
     });
   });
 });
+
+function getDataSourceInstanceSetting(name: string, meta: DataSourcePluginMeta): DataSourceInstanceSettings {
+  return {
+    id: 1,
+    uid: '',
+    type: '',
+    name,
+    meta,
+    jsonData: ({} as unknown) as DataSourceJsonData,
+  };
+}

--- a/public/app/features/variables/datasource/actions.ts
+++ b/public/app/features/variables/datasource/actions.ts
@@ -2,7 +2,7 @@ import { toVariablePayload, VariableIdentifier } from '../state/types';
 import { ThunkResult } from '../../../types';
 import { createDataSourceOptions } from './reducer';
 import { validateVariableSelectionState } from '../state/actions';
-import { DataSourceInstanceSettings, DataSourceSelectItem, stringToJsRegex } from '@grafana/data';
+import { DataSourceInstanceSettings, stringToJsRegex } from '@grafana/data';
 import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { getVariable } from '../state/selectors';
 import { DataSourceVariableModel } from '../types';
@@ -37,12 +37,9 @@ export const updateDataSourceVariableOptions = (
 export const initDataSourceVariableEditor = (
   dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrv }
 ): ThunkResult<void> => dispatch => {
-  const dataSources: DataSourceSelectItem[] = dependencies
+  const dataSources = dependencies
     .getDatasourceSrv()
     .getList({ metrics: true, variables: true })
-    .filter(setting => {
-      return !setting.meta.mixed && !setting.isDefault;
-    })
     .map(toDataSourceSelectItem);
   const dataSourceTypes = _(dataSources)
     .uniqBy('meta.id')

--- a/public/app/features/variables/datasource/actions.ts
+++ b/public/app/features/variables/datasource/actions.ts
@@ -2,7 +2,7 @@ import { toVariablePayload, VariableIdentifier } from '../state/types';
 import { ThunkResult } from '../../../types';
 import { createDataSourceOptions } from './reducer';
 import { validateVariableSelectionState } from '../state/actions';
-import { DataSourceSelectItem, stringToJsRegex } from '@grafana/data';
+import { DataSourceInstanceSettings, DataSourceSelectItem, stringToJsRegex } from '@grafana/data';
 import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { getVariable } from '../state/selectors';
 import { DataSourceVariableModel } from '../types';
@@ -18,7 +18,10 @@ export const updateDataSourceVariableOptions = (
   identifier: VariableIdentifier,
   dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrv }
 ): ThunkResult<void> => async (dispatch, getState) => {
-  const sources = await dependencies.getDatasourceSrv().getMetricSources({ skipVariables: true });
+  const sources = dependencies
+    .getDatasourceSrv()
+    .getList({ metrics: true, variables: false })
+    .map(toDataSourceSelectItem);
   const variableInState = getVariable<DataSourceVariableModel>(identifier.id, getState());
   let regex;
 
@@ -27,16 +30,21 @@ export const updateDataSourceVariableOptions = (
     regex = stringToJsRegex(regex);
   }
 
-  await dispatch(createDataSourceOptions(toVariablePayload(identifier, { sources, regex })));
+  dispatch(createDataSourceOptions(toVariablePayload(identifier, { sources, regex })));
   await dispatch(validateVariableSelectionState(identifier));
 };
 
 export const initDataSourceVariableEditor = (
   dependencies: DataSourceVariableActionDependencies = { getDatasourceSrv: getDatasourceSrv }
-): ThunkResult<void> => async dispatch => {
-  const dataSources: DataSourceSelectItem[] = await dependencies.getDatasourceSrv().getMetricSources();
-  const filtered = dataSources.filter(ds => !ds.meta.mixed && ds.value !== null);
-  const dataSourceTypes = _(filtered)
+): ThunkResult<void> => dispatch => {
+  const dataSources: DataSourceSelectItem[] = dependencies
+    .getDatasourceSrv()
+    .getList({ metrics: true, variables: true })
+    .filter(setting => {
+      return !setting.meta.mixed && !setting.isDefault;
+    })
+    .map(toDataSourceSelectItem);
+  const dataSourceTypes = _(dataSources)
     .uniqBy('meta.id')
     .map((ds: any) => {
       return { text: ds.meta.name, value: ds.meta.id };
@@ -52,3 +60,11 @@ export const initDataSourceVariableEditor = (
     })
   );
 };
+
+function toDataSourceSelectItem(setting: DataSourceInstanceSettings) {
+  return {
+    name: setting.name,
+    value: setting.name,
+    meta: setting.meta,
+  };
+}

--- a/public/app/features/variables/state/onTimeRangeUpdated.test.ts
+++ b/public/app/features/variables/state/onTimeRangeUpdated.test.ts
@@ -133,10 +133,11 @@ describe('when onTimeRangeUpdated is dispatched', () => {
         startRefreshMock,
       } = getTestContext();
 
-      const tester = await reduxTester<{ templating: TemplatingState }>({ preloadedState })
+      const base = await reduxTester<{ templating: TemplatingState }>({ preloadedState })
         .givenRootReducer(getRootReducer())
-        .whenActionIsDispatched(setOptionAsCurrent(toVariableIdentifier(interval), interval.options[0], false))
-        .whenAsyncActionIsDispatched(onTimeRangeUpdated(range, dependencies), true);
+        .whenAsyncActionIsDispatched(setOptionAsCurrent(toVariableIdentifier(interval), interval.options[0], false));
+
+      const tester = await base.whenAsyncActionIsDispatched(onTimeRangeUpdated(range, dependencies), true);
 
       tester.thenDispatchedActionsShouldEqual(
         variableStateFetching(toVariablePayload({ type: 'interval', id: 'interval-0' })),


### PR DESCRIPTION
**What this PR does / why we need it**:
When initializing variables we tried to upgrade legacy queries for Prometheus because Prometheus is now using the Standard Variable Support. 

When I tried to fix this in #29375 I missed the case when a query variable depended on a datasource variable so #29375 upgrades legacy queries to early in the initialization process of variables.

This PR moves the upgrade legacy query action to places later on in the initialization process of variables. I also refactored the actions for datasource variables as they were using the now deprecated function __`getMetricSources`__. 

Enjoy your review

**Which issue(s) this PR fixes**:
Fixes #29703

**Special notes for your reviewer**:

