### PR TITLE
API: add Status() to RedirectResponse

### DIFF
--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -145,6 +145,11 @@ func (r *RedirectResponse) WriteTo(ctx *models.ReqContext) {
 	ctx.Redirect(r.location)
 }
 
+// Status gets the response's status.
+func (*RedirectResponse) Status() int {
+	return http.StatusFound
+}
+
 func Redirect(location string) *RedirectResponse {
 	return &RedirectResponse{location: location}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an update to `RedirectResponse` to meet the updated `Response` interface (updated in this PR: https://github.com/grafana/grafana/pull/29642).

**Special notes for your reviewer**:
The status code returned by the new `Status` function is the same as the default one used by the `Redirect` function of macaron as the `RedirectResponse` struct does not allow to change it. 
