### PR TITLE
@grafana/ui: Fix UI issues for cascader button dropdown and query input

### DIFF
--- a/public/sass/components/_slate_editor.scss
+++ b/public/sass/components/_slate_editor.scss
@@ -13,7 +13,6 @@
   padding: 6px 8px;
   min-height: $input-height;
   width: 100%;
-  cursor: text;
   line-height: $line-height-base;
   color: $text-color;
   background-color: $input-bg;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -435,6 +435,8 @@
 // React-component cascade fix: vertical alignment issue with Safari
 .rc-cascader-menu {
   vertical-align: top;
+  // To fix cascader button width issue in windows + firefox
+  scrollbar-width: thin;
 }
 
 // TODO Experimental


### PR DESCRIPTION
**What this PR does / why we need it**:
Cascader button Issue: https://github.com/grafana/grafana/issues/28652#issuecomment-724784802

**Before:**
Cascader button's dropdown has too wide scrollbar which makes metrics cut and uses ellipsis (`...`).
![130285621_957790628375973_2313806524652712144_n](https://user-images.githubusercontent.com/30407135/101649731-855edc00-3a3b-11eb-9789-b6533f854a61.png)

**After:**
Fixed with thinner scrollbar. It also looks so much better as the dropdown is pretty narrow.
![130878030_189872996102360_3512519855438933814_n](https://user-images.githubusercontent.com/30407135/101649743-86900900-3a3b-11eb-8ed8-acd9d08ec03e.png)

Buggy cursor behaviour https://github.com/grafana/grafana/issues/28649

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/28652
Fixes https://github.com/grafana/grafana/issues/28649
