### PR TITLE
DataSourceWithBackend: Throw error if health check fails in DataSourceWithBackend

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -172,6 +172,7 @@ export class DataSourceWithBackend<
 
   /**
    * Checks the plugin health
+   * see public/app/features/datasources/state/actions.ts for what needs to be returned here
    */
   async testDatasource(): Promise<any> {
     return this.callHealthCheck().then(res => {
@@ -181,10 +182,7 @@ export class DataSourceWithBackend<
           message: res.message,
         };
       }
-      return {
-        status: 'fail',
-        message: res.message,
-      };
+      throw new Error(res.message);
     });
   }
 }


### PR DESCRIPTION
The `testDataSource` action requires error to be thrown to show correct alert with red background.

https://github.com/grafana/grafana/blob/38caa80acdbb3f18d2ade47f66ced9ab514b8fe5/public/app/features/datasources/state/actions.ts#L76
https://github.com/grafana/x-ray-datasource/pull/59#pullrequestreview-548125748