### PR TITLE
Explore: Improve Explore performance by removing unnecessary re-renders

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -51,7 +51,6 @@ interface StateProps {
   hasLiveOption: boolean;
   isLive: boolean;
   isPaused: boolean;
-  originPanelId?: number | null;
   datasourceLoading?: boolean | null;
   containerWidth: number;
   datasourceName?: string;
@@ -114,7 +113,6 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
       hasLiveOption,
       isLive,
       isPaused,
-      originPanelId,
       containerWidth,
       onChangeTimeZone,
     } = this.props;
@@ -165,11 +163,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
                 </div>
               </div>
             ) : null}
-
-            {originPanelId && Number.isInteger(originPanelId) && !splitted && (
-              <ReturnToDashboardButton originPanelId={originPanelId} exploreId={exploreId} />
-            )}
-
+            <ReturnToDashboardButton exploreId={exploreId} />
             {exploreId === 'left' && !splitted ? (
               <div className="explore-toolbar-content-item explore-icon-align">
                 <ResponsiveButton
@@ -268,7 +262,6 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     loading,
     isLive,
     isPaused,
-    originPanelId,
     containerWidth,
   } = exploreItem;
 
@@ -285,7 +278,6 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps): StateProps
     hasLiveOption,
     isLive,
     isPaused,
-    originPanelId,
     syncedTimes,
     containerWidth,
   };

--- a/public/app/features/explore/ReturnToDashboardButton.test.tsx
+++ b/public/app/features/explore/ReturnToDashboardButton.test.tsx
@@ -6,6 +6,7 @@ import { ExploreId } from 'app/types/explore';
 const createProps = (propsOverride?: Partial<ComponentProps<typeof ReturnToDashboardButton>>) => {
   const defaultProps = {
     originPanelId: 1,
+    splitted: false,
     exploreId: ExploreId.left,
     queries: [],
     updateLocation: jest.fn(),
@@ -23,6 +24,10 @@ describe('ReturnToDashboardButton', () => {
   it('should render 1 button if dashboard is not editable', () => {
     render(<ReturnToDashboardButton {...createProps({ originPanelId: undefined })} />);
     expect(screen.getAllByTestId(/returnButton/i)).toHaveLength(1);
+  });
+  it('should not render any button if split view', () => {
+    render(<ReturnToDashboardButton {...createProps({ splitted: true })} />);
+    expect(screen.queryByTestId(/returnButton/i)).toBeNull();
   });
   it('should show option to return to dashboard with changes', () => {
     render(<ReturnToDashboardButton {...createProps()} />);

--- a/public/app/features/explore/ReturnToDashboardButton.test.tsx
+++ b/public/app/features/explore/ReturnToDashboardButton.test.tsx
@@ -17,13 +17,13 @@ const createProps = (propsOverride?: Partial<ComponentProps<typeof ReturnToDashb
 };
 
 describe('ReturnToDashboardButton', () => {
-  it('should render 2 buttons if dashboard is editable', () => {
+  it('should render 2 buttons if originPanelId is provided', () => {
     render(<ReturnToDashboardButton {...createProps()} />);
     expect(screen.getAllByTestId(/returnButton/i)).toHaveLength(2);
   });
-  it('should render 1 button if dashboard is not editable', () => {
+  it('should not render any button if originPanelId is not provided', () => {
     render(<ReturnToDashboardButton {...createProps({ originPanelId: undefined })} />);
-    expect(screen.getAllByTestId(/returnButton/i)).toHaveLength(1);
+    expect(screen.queryByTestId(/returnButton/i)).toBeNull();
   });
   it('should not render any button if split view', () => {
     render(<ReturnToDashboardButton {...createProps({ splitted: true })} />);

--- a/public/app/features/explore/ReturnToDashboardButton.test.tsx
+++ b/public/app/features/explore/ReturnToDashboardButton.test.tsx
@@ -1,0 +1,36 @@
+import React, { ComponentProps } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UnconnectedReturnToDashboardButton as ReturnToDashboardButton } from './ReturnToDashboardButton';
+import { ExploreId } from 'app/types/explore';
+
+const createProps = (propsOverride?: Partial<ComponentProps<typeof ReturnToDashboardButton>>) => {
+  const defaultProps = {
+    originPanelId: 1,
+    exploreId: ExploreId.left,
+    queries: [],
+    updateLocation: jest.fn(),
+    setDashboardQueriesToUpdateOnLoad: jest.fn(),
+  };
+
+  return Object.assign(defaultProps, propsOverride) as ComponentProps<typeof ReturnToDashboardButton>;
+};
+
+describe('ReturnToDashboardButton', () => {
+  it('should render 2 buttons if dashboard is editable', () => {
+    render(<ReturnToDashboardButton {...createProps()} />);
+    expect(screen.getAllByTestId(/returnButton/i)).toHaveLength(2);
+  });
+  it('should render 1 button if dashboard is not editable', () => {
+    render(<ReturnToDashboardButton {...createProps({ originPanelId: undefined })} />);
+    expect(screen.getAllByTestId(/returnButton/i)).toHaveLength(1);
+  });
+  it('should show option to return to dashboard with changes', () => {
+    render(<ReturnToDashboardButton {...createProps()} />);
+    const returnWithChangesButton = screen.getByTestId('returnButtonWithChanges');
+    const selectButton = returnWithChangesButton.querySelector('.select-button');
+    if (selectButton) {
+      fireEvent.click(selectButton);
+    }
+    expect(screen.getAllByText('Return to panel with changes')).toHaveLength(1);
+  });
+});

--- a/public/app/features/explore/ReturnToDashboardButton.tsx
+++ b/public/app/features/explore/ReturnToDashboardButton.tsx
@@ -22,7 +22,7 @@ interface Props {
   setDashboardQueriesToUpdateOnLoad: typeof setDashboardQueriesToUpdateOnLoad;
 }
 
-const ReturnToDashboardButton: FC<Props> = ({
+export const UnconnectedReturnToDashboardButton: FC<Props> = ({
   originPanelId,
   updateLocation,
   setDashboardQueriesToUpdateOnLoad,
@@ -68,17 +68,24 @@ const ReturnToDashboardButton: FC<Props> = ({
   return (
     <div className="explore-toolbar-content-item">
       <Tooltip content={'Return to panel'} placement="bottom">
-        <button className={panelReturnClasses} onClick={() => returnToPanel()}>
+        <button
+          data-testid="returnButton"
+          title={'Return to panel'}
+          className={panelReturnClasses}
+          onClick={() => returnToPanel()}
+        >
           <Icon name="arrow-left" />
         </button>
       </Tooltip>
       {originDashboardIsEditable && (
-        <ButtonSelect
-          className="navbar-button--attached btn--radius-left-0$"
-          options={[{ label: 'Return to panel with changes', value: '' }]}
-          onChange={() => returnToPanel({ withChanges: true })}
-          maxMenuHeight={380}
-        />
+        <div data-testid="returnButtonWithChanges">
+          <ButtonSelect
+            className="navbar-button--attached btn--radius-left-0$"
+            options={[{ label: 'Return to panel with changes', value: '' }]}
+            onChange={() => returnToPanel({ withChanges: true })}
+            maxMenuHeight={380}
+          />
+        </div>
       )}
     </div>
   );
@@ -98,4 +105,4 @@ const mapDispatchToProps = {
   updateLocation,
   setDashboardQueriesToUpdateOnLoad,
 };
-export default hot(module)(connect(mapStateToProps, mapDispatchToProps)(ReturnToDashboardButton));
+export default hot(module)(connect(mapStateToProps, mapDispatchToProps)(UnconnectedReturnToDashboardButton));

--- a/public/app/features/explore/ReturnToDashboardButton.tsx
+++ b/public/app/features/explore/ReturnToDashboardButton.tsx
@@ -1,0 +1,101 @@
+import React, { FC } from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { hot } from 'react-hot-loader';
+import { Icon, Tooltip, LegacyForms } from '@grafana/ui';
+import { DataQuery } from '@grafana/data';
+
+import kbn from '../../core/utils/kbn';
+import { getDashboardSrv } from '../dashboard/services/DashboardSrv';
+import { StoreState } from 'app/types';
+import { ExploreId } from 'app/types/explore';
+import { updateLocation } from 'app/core/actions';
+import { setDashboardQueriesToUpdateOnLoad } from '../dashboard/state/reducers';
+
+const { ButtonSelect } = LegacyForms;
+
+interface Props {
+  originPanelId: number;
+  exploreId: ExploreId;
+  queries: DataQuery[];
+  updateLocation: typeof updateLocation;
+  setDashboardQueriesToUpdateOnLoad: typeof setDashboardQueriesToUpdateOnLoad;
+}
+
+const ReturnToDashboardButton: FC<Props> = ({
+  originPanelId,
+  updateLocation,
+  setDashboardQueriesToUpdateOnLoad,
+  queries,
+}) => {
+  const originDashboardIsEditable = originPanelId && Number.isInteger(originPanelId);
+  const panelReturnClasses = classNames('btn', 'navbar-button', {
+    'btn--radius-right-0': originDashboardIsEditable,
+    'navbar-button navbar-button--border-right-0': originDashboardIsEditable,
+  });
+
+  const cleanQueries = (queries: DataQuery[]) => {
+    return queries.map((query: DataQuery & { context?: string }) => {
+      delete query.context;
+      delete query.key;
+      return query;
+    });
+  };
+
+  const returnToPanel = async ({ withChanges = false } = {}) => {
+    const dashboardSrv = getDashboardSrv();
+    const dash = dashboardSrv.getCurrent();
+    const titleSlug = kbn.slugifyForUrl(dash.title);
+
+    if (withChanges) {
+      setDashboardQueriesToUpdateOnLoad({
+        panelId: originPanelId!,
+        queries: cleanQueries(queries),
+      });
+    }
+
+    const query: any = {};
+
+    if (withChanges || dash.panelInEdit) {
+      query.editPanel = originPanelId;
+    } else if (dash.panelInView) {
+      query.viewPanel = originPanelId;
+    }
+
+    updateLocation({ path: `/d/${dash.uid}/:${titleSlug}`, query });
+  };
+
+  return (
+    <div className="explore-toolbar-content-item">
+      <Tooltip content={'Return to panel'} placement="bottom">
+        <button className={panelReturnClasses} onClick={() => returnToPanel()}>
+          <Icon name="arrow-left" />
+        </button>
+      </Tooltip>
+      {originDashboardIsEditable && (
+        <ButtonSelect
+          className="navbar-button--attached btn--radius-left-0$"
+          options={[{ label: 'Return to panel with changes', value: '' }]}
+          onChange={() => returnToPanel({ withChanges: true })}
+          maxMenuHeight={380}
+        />
+      )}
+    </div>
+  );
+};
+
+function mapStateToProps(state: StoreState, { exploreId }: { exploreId: ExploreId }) {
+  const explore = state.explore;
+  const { datasourceInstance, queries } = explore[exploreId];
+  return {
+    exploreId,
+    datasourceInstance,
+    queries,
+  };
+}
+
+const mapDispatchToProps = {
+  updateLocation,
+  setDashboardQueriesToUpdateOnLoad,
+};
+export default hot(module)(connect(mapStateToProps, mapDispatchToProps)(ReturnToDashboardButton));

--- a/public/app/features/explore/ReturnToDashboardButton.tsx
+++ b/public/app/features/explore/ReturnToDashboardButton.tsx
@@ -30,15 +30,16 @@ export const UnconnectedReturnToDashboardButton: FC<Props> = ({
   queries,
   splitted,
 }) => {
-  // If in split mode, escape early and return null
-  if (splitted) {
+  const withOriginId = originPanelId && Number.isInteger(originPanelId);
+
+  // If in split mode, or no origin id, escape early and return null
+  if (splitted || !withOriginId) {
     return null;
   }
 
-  const originDashboardIsEditable = originPanelId && Number.isInteger(originPanelId);
   const panelReturnClasses = classNames('btn', 'navbar-button', {
-    'btn--radius-right-0': originDashboardIsEditable,
-    'navbar-button navbar-button--border-right-0': originDashboardIsEditable,
+    'btn--radius-right-0': withOriginId,
+    'navbar-button navbar-button--border-right-0': withOriginId,
   });
 
   const cleanQueries = (queries: DataQuery[]) => {
@@ -84,16 +85,14 @@ export const UnconnectedReturnToDashboardButton: FC<Props> = ({
           <Icon name="arrow-left" />
         </button>
       </Tooltip>
-      {originDashboardIsEditable && (
-        <div data-testid="returnButtonWithChanges">
-          <ButtonSelect
-            className="navbar-button--attached btn--radius-left-0$"
-            options={[{ label: 'Return to panel with changes', value: '' }]}
-            onChange={() => returnToPanel({ withChanges: true })}
-            maxMenuHeight={380}
-          />
-        </div>
-      )}
+      <div data-testid="returnButtonWithChanges">
+        <ButtonSelect
+          className="navbar-button--attached btn--radius-left-0$"
+          options={[{ label: 'Return to panel with changes', value: '' }]}
+          onChange={() => returnToPanel({ withChanges: true })}
+          maxMenuHeight={380}
+        />
+      </div>
     </div>
   );
 };

--- a/public/app/features/explore/ReturnToDashboardButton.tsx
+++ b/public/app/features/explore/ReturnToDashboardButton.tsx
@@ -15,9 +15,10 @@ import { setDashboardQueriesToUpdateOnLoad } from '../dashboard/state/reducers';
 const { ButtonSelect } = LegacyForms;
 
 interface Props {
-  originPanelId: number;
   exploreId: ExploreId;
+  splitted: boolean;
   queries: DataQuery[];
+  originPanelId?: number | null;
   updateLocation: typeof updateLocation;
   setDashboardQueriesToUpdateOnLoad: typeof setDashboardQueriesToUpdateOnLoad;
 }
@@ -27,7 +28,13 @@ export const UnconnectedReturnToDashboardButton: FC<Props> = ({
   updateLocation,
   setDashboardQueriesToUpdateOnLoad,
   queries,
+  splitted,
 }) => {
+  // If in split mode, escape early and return null
+  if (splitted) {
+    return null;
+  }
+
   const originDashboardIsEditable = originPanelId && Number.isInteger(originPanelId);
   const panelReturnClasses = classNames('btn', 'navbar-button', {
     'btn--radius-right-0': originDashboardIsEditable,
@@ -93,11 +100,15 @@ export const UnconnectedReturnToDashboardButton: FC<Props> = ({
 
 function mapStateToProps(state: StoreState, { exploreId }: { exploreId: ExploreId }) {
   const explore = state.explore;
-  const { datasourceInstance, queries } = explore[exploreId];
+  const splitted = state.explore.split;
+  const { datasourceInstance, queries, originPanelId } = explore[exploreId];
+
   return {
     exploreId,
     datasourceInstance,
     queries,
+    originPanelId,
+    splitted,
   };
 }
 

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -1,5 +1,5 @@
 import { AnyAction } from 'redux';
-
+import { isEqual } from 'lodash';
 import { getQueryKeys } from 'app/core/utils/explore';
 import { ExploreId, ExploreItemState } from 'app/types/explore';
 import { queryReducer } from './query';
@@ -258,8 +258,13 @@ export const paneReducer = (state: ExploreItemState = makeExplorePaneState(), ac
   }
 
   if (highlightLogsExpressionAction.match(action)) {
-    const { expressions } = action.payload;
-    return { ...state, logsHighlighterExpressions: expressions };
+    const { expressions: newExpressions } = action.payload;
+    const { logsHighlighterExpressions: currentExpressions } = state;
+
+    return {
+      ...state,
+      logsHighlighterExpressions: isEqual(newExpressions, currentExpressions) ? currentExpressions : newExpressions,
+    };
   }
 
   if (changeDedupStrategyAction.match(action)) {

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -263,6 +263,7 @@ export const paneReducer = (state: ExploreItemState = makeExplorePaneState(), ac
 
     return {
       ...state,
+      // Prevents re-renders. As logsHighlighterExpressions [] comes from datasource, we cannot control if it returns new array or not.
       logsHighlighterExpressions: isEqual(newExpressions, currentExpressions) ? currentExpressions : newExpressions,
     };
   }

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -1,6 +1,5 @@
 import { map, mergeMap, throttleTime } from 'rxjs/operators';
 import { identity, Unsubscribable } from 'rxjs';
-import { isEqual } from 'lodash';
 import {
   DataQuery,
   DataQueryErrorType,
@@ -467,19 +466,17 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
   }
 
   if (changeQueryAction.match(action)) {
-    const { queries, queryKeys: currentQueryKeys } = state;
+    const { queries } = state;
     const { query, index } = action.payload;
 
     // Override path: queries are completely reset
     const nextQuery: DataQuery = generateNewKeyAndAddRefIdIfMissing(query, queries, index);
     const nextQueries = [...queries];
     nextQueries[index] = nextQuery;
-    const nextQueryKeys = getQueryKeys(nextQueries, state.datasourceInstance);
 
     return {
       ...state,
       queries: nextQueries,
-      queryKeys: isEqual(currentQueryKeys, nextQueryKeys) ? currentQueryKeys : nextQueryKeys,
     };
   }
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -1,5 +1,6 @@
 import { map, mergeMap, throttleTime } from 'rxjs/operators';
 import { identity, Unsubscribable } from 'rxjs';
+import { isEqual } from 'lodash';
 import {
   DataQuery,
   DataQueryErrorType,
@@ -466,18 +467,19 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
   }
 
   if (changeQueryAction.match(action)) {
-    const { queries } = state;
+    const { queries, queryKeys: currentQueryKeys } = state;
     const { query, index } = action.payload;
 
     // Override path: queries are completely reset
     const nextQuery: DataQuery = generateNewKeyAndAddRefIdIfMissing(query, queries, index);
     const nextQueries = [...queries];
     nextQueries[index] = nextQuery;
+    const nextQueryKeys = getQueryKeys(nextQueries, state.datasourceInstance);
 
     return {
       ...state,
       queries: nextQueries,
-      queryKeys: getQueryKeys(nextQueries, state.datasourceInstance),
+      queryKeys: isEqual(currentQueryKeys, nextQueryKeys) ? currentQueryKeys : nextQueryKeys,
     };
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes redundant re-renders of:
- **Explore** - We are passing `queryKeys` from store. We were creating a new `queryKeys` array on each key stroke, but  `queryKeys` don't change in `changeQueryAction` as they[ are based on the data source name and index](https://github.com/grafana/grafana/blob/master/public/app/core/utils/explore.ts#L343-L350). None of this changes in `changeQueryAction`.

```
const primaryKey = datasourceInstance && datasourceInstance.name ? datasourceInstance.name : query.key;
return newQueryKeys.concat(`${primaryKey}-${index}`);
```

This also removes re-renders of **QueryRows** as we are passing the same `queryKeys`.

 - **ExploreToolbar** - ExploreToolbar was re-rendering on each keystroke as we are passing `queries` from store which are changing on every key stroke. However, we use these queries only in 1 case - when we are coming to Explore from Dashboard panel and we want to return to dashboard panel and apply those changes. This is done very very rarely and we can remove majority of re-renders but extracting `ReturnToDashboardButton` to its own component that is rendered only when we access Explore from Dashboard panel. 

- **LogsContainer** & **LogRows** & **LogRow** - `logsHighlighterExpressions` array was re-created on each key stroke. In this PR we fix it bt always checking if anything in `logsHighlighterExpressions` array changed.  If not, we return the same array. If yes, we return the new one. 

For more details see [this document](https://docs.google.com/document/d/1CL_0EjvTsmgDf176z5H8f542Qf2d6jvhXJsd5mKa6O4/edit#heading=h.1of22r847lh1).

**Before:**
https://github.com/grafana/grafana/issues/25457#issuecomment-724717353

**Fixed:**
![Kapture 2020-12-10 at 15 52 43](https://user-images.githubusercontent.com/30407135/101788597-932a6500-3b00-11eb-8033-6388189d8a57.gif)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/25457

**Special notes for your reviewer**:

