### PR TITLE
Elasticsearch: Sort results by index order as well as @timestamp

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -125,7 +125,14 @@ export class ElasticQueryBuilder {
   documentQuery(query: any, size: number) {
     query.size = size;
     query.sort = {};
-    query.sort[this.timeField] = { order: 'desc', unmapped_type: 'boolean' };
+    query.sort = [
+      {
+        [this.timeField]: { order: 'desc', unmapped_type: 'boolean' },
+      },
+      {
+        _doc: { order: 'desc' },
+      },
+    ];
 
     // fields field not supported on ES 5.x
     if (this.esVersion < 5) {

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -224,12 +224,7 @@ describe('ElasticQueryBuilder', () => {
               ],
             },
           },
-          sort: {
-            '@timestamp': {
-              order: 'desc',
-              unmapped_type: 'boolean',
-            },
-          },
+          sort: [{ '@timestamp': { order: 'desc', unmapped_type: 'boolean' } }, { _doc: { order: 'desc' } }],
           script_fields: {},
         });
       });

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -547,7 +547,10 @@ describe('ElasticQueryBuilder', () => {
           };
           expect(query.query).toEqual(expectedQuery);
 
-          expect(query.sort).toEqual({ '@timestamp': { order: 'desc', unmapped_type: 'boolean' } });
+          expect(query.sort).toEqual([
+            { '@timestamp': { order: 'desc', unmapped_type: 'boolean' } },
+            { _doc: { order: 'desc' } },
+          ]);
 
           const expectedAggs = {
             2: {


### PR DESCRIPTION
**What this PR does / why we need it**:

Logs sometimes show up in the wrong order because Grafana is not respecting the index order of the documents. This was fixed as part of https://github.com/grafana/grafana/pull/28764 but I am picking some of those changes on here because I would like it to be part of a patch release rather than 7.4.

**Which issue(s) this PR fixes**:

Fixes #29700

**Special notes for your reviewer**:

