### PR TITLE
QueryEditor: do not auto refresh on every update

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
@@ -56,7 +56,6 @@ export class PanelEditorQueries extends PureComponent<Props, State> {
     panel.hideTimeOverride = options.timeRange?.hide;
     panel.interval = options.minInterval;
     panel.maxDataPoints = options.maxDataPoints;
-    panel.refresh();
 
     this.setState({ options: options });
   };


### PR DESCRIPTION
The recent changes to query editors now issue a query with every update -- previously you needed to call `onRunQueries()` explicitly.

This change means that query editors now need to keep state and only call update when the query is ready -- this is a kinda big change for some editors.

That said, many editors have bad auto-refresh behavior and require hitting the refresh link when it should be automatic.  Perhaps we should add a parameter to `onOptionsChange` that would also trigger refresh?  then it would at least be more clear that we are not triggering refesh
