### PR TITLE
Chore: Expose TimeSrv from grafana/runtime package

### DIFF
--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -6,3 +6,4 @@ export * from './EchoSrv';
 export * from './templateSrv';
 export * from './legacyAngularInjector';
 export * from './live';
+export * from './timeSrv';

--- a/packages/grafana-runtime/src/services/timeSrv.ts
+++ b/packages/grafana-runtime/src/services/timeSrv.ts
@@ -1,0 +1,37 @@
+import { RawTimeRange, TimeRange } from '@grafana/data';
+
+/**
+ * TimeSrv allows to get and control dashboard time range.
+ *
+ * @public
+ */
+export interface TimeSrv {
+  /**
+   * Get a current time range or default one.
+   */
+  timeRange(): TimeRange;
+
+  /**
+   * Get a raw time range for current URL.
+   */
+  timeRangeForUrl(): RawTimeRange;
+}
+
+let singletonInstance: TimeSrv;
+
+/**
+ * Used during startup by Grafana to set the DataSourceSrv so it is available
+ * via the {@link getTimeSrv} to the rest of the application.
+ *
+ * @internal
+ */
+export const setTimeSrv = (instance: TimeSrv) => {
+  singletonInstance = instance;
+};
+
+/**
+ * Used to retrieve the {@link TimeSrv} that allows to get and control dashboard time range.
+ *
+ * @public
+ */
+export const getTimeSrv = (): TimeSrv => singletonInstance;

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -13,6 +13,7 @@ import {
   isDateTime,
   rangeUtil,
 } from '@grafana/data';
+import { TimeSrv as TimeService, getTimeSrv as getTimeService } from '@grafana/runtime';
 import { ITimeoutService, ILocationService } from 'angular';
 import { ContextSrv } from 'app/core/services/context_srv';
 import { DashboardModel } from '../state/DashboardModel';
@@ -23,7 +24,7 @@ import { CoreEvents } from '../../../types';
 
 import { config } from 'app/core/config';
 
-export class TimeSrv {
+export class TimeSrv implements TimeService {
   time: any;
   refreshTimer: any;
   refresh: any;
@@ -305,14 +306,9 @@ export class TimeSrv {
   }
 }
 
-let singleton: TimeSrv;
-
-export function setTimeSrv(srv: TimeSrv) {
-  singleton = srv;
-}
-
 export function getTimeSrv(): TimeSrv {
-  return singleton;
+  return getTimeService() as TimeSrv;
 }
 
 coreModule.service('timeSrv', TimeSrv);
+export default TimeSrv;

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -4,7 +4,7 @@ import Wrapper from './Wrapper';
 import { configureStore } from '../../store/configureStore';
 import { Provider } from 'react-redux';
 import { store } from '../../store/store';
-import { setDataSourceSrv } from '@grafana/runtime';
+import { setDataSourceSrv, setTimeSrv } from '@grafana/runtime';
 import {
   ArrayDataFrame,
   DataQueryResponse,
@@ -16,7 +16,6 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
-import { setTimeSrv } from '../dashboard/services/TimeSrv';
 import { from, Observable } from 'rxjs';
 import { updateLocation } from '../../core/reducers/location';
 import { LokiDatasource } from '../../plugins/datasource/loki/datasource';

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -35,6 +35,7 @@ import {
 import * as flatten from 'app/core/utils/flatten';
 import * as ticks from 'app/core/utils/ticks';
 import { BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';
+import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { promiseToDigest } from 'app/core/utils/promiseToDigest';
 import impressionSrv from 'app/core/services/impression_srv';
 import builtInPlugins from './built_in_plugins';
@@ -126,6 +127,11 @@ exposeToPlugin('app/features/dashboard/impression_store', {
 exposeToPlugin('app/core/services/backend_srv', {
   BackendSrv,
   getBackendSrv,
+});
+
+exposeToPlugin('app/features/dashboard/services/TimeSrv', {
+  TimeSrv,
+  getTimeSrv,
 });
 
 exposeToPlugin('app/plugins/sdk', sdk);

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -35,7 +35,6 @@ import {
 import * as flatten from 'app/core/utils/flatten';
 import * as ticks from 'app/core/utils/ticks';
 import { BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';
-import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { promiseToDigest } from 'app/core/utils/promiseToDigest';
 import impressionSrv from 'app/core/services/impression_srv';
 import builtInPlugins from './built_in_plugins';
@@ -127,11 +126,6 @@ exposeToPlugin('app/features/dashboard/impression_store', {
 exposeToPlugin('app/core/services/backend_srv', {
   BackendSrv,
   getBackendSrv,
-});
-
-exposeToPlugin('app/features/dashboard/services/TimeSrv', {
-  TimeSrv,
-  getTimeSrv,
 });
 
 exposeToPlugin('app/plugins/sdk', sdk);

--- a/public/app/features/variables/interval/actions.test.ts
+++ b/public/app/features/variables/interval/actions.test.ts
@@ -13,7 +13,8 @@ import {
 import { variableAdapters } from '../adapters';
 import { createIntervalVariableAdapter } from './adapter';
 import { dateTime } from '@grafana/data';
-import { getTimeSrv, setTimeSrv, TimeSrv } from '../../dashboard/services/TimeSrv';
+import { getTimeSrv, setTimeSrv } from '@grafana/runtime';
+import { TimeSrv } from '../../dashboard/services/TimeSrv';
 import { TemplateSrv } from '../../templating/template_srv';
 import { intervalBuilder } from '../shared/testing/builders';
 import { updateOptions } from '../state/actions';

--- a/public/app/features/variables/query/actions.test.ts
+++ b/public/app/features/variables/query/actions.test.ts
@@ -35,9 +35,9 @@ import { expect } from 'test/lib/common';
 import { updateOptions } from '../state/actions';
 import { notifyApp } from '../../../core/reducers/appNotification';
 import { silenceConsoleOutput } from '../../../../test/core/utils/silenceConsoleOutput';
-import { getTimeSrv, setTimeSrv, TimeSrv } from '../../dashboard/services/TimeSrv';
+import { TimeSrv } from '../../dashboard/services/TimeSrv';
 import { setVariableQueryRunner, VariableQueryRunner } from './VariableQueryRunner';
-import { setDataSourceSrv } from '@grafana/runtime';
+import { setDataSourceSrv, getTimeSrv, setTimeSrv } from '@grafana/runtime';
 
 const mocks: Record<string, any> = {
   datasource: {

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -6,12 +6,19 @@ import Drop from 'tether-drop';
 
 // Utils and servies
 import { colors } from '@grafana/ui';
-import { getTemplateSrv, setBackendSrv, setDataSourceSrv, setLegacyAngularInjector } from '@grafana/runtime';
+import {
+  getTemplateSrv,
+  setBackendSrv,
+  setDataSourceSrv,
+  setLegacyAngularInjector,
+  setTimeSrv,
+  getTimeSrv,
+} from '@grafana/runtime';
 import config from 'app/core/config';
 import coreModule from 'app/core/core_module';
 import { profiler } from 'app/core/profiler';
 import appEvents from 'app/core/app_events';
-import { TimeSrv, setTimeSrv, getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { KeybindingSrv, setKeybindingSrv } from 'app/core/services/keybindingSrv';
 import { AngularLoader, setAngularLoader } from 'app/core/services/AngularLoader';


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it possible to use `TimeSrv` from `@grafna/runtime` package. This change required for extracting Elasticsearch data source (and potentially for other core data sources) into standalone plugin.

**Special notes for your reviewer**:
The only function used by elasticsearch data source is a `timeRange()`. `timeRangeForUrl()` required for initializing `locationUtil` in `GrafanaCtrl`. We can export more methods if we need it, but I only found these two so far.