### PR TITLE
Panel/inspect:  Enable to export csv file with filtered data

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -1,9 +1,10 @@
-import React, { FC, memo, useCallback, useMemo } from 'react';
+import React, { FC, memo, useCallback, useEffect, useMemo } from 'react';
 import { DataFrame, Field, getFieldDisplayName } from '@grafana/data';
 import {
   Cell,
   Column,
   HeaderGroup,
+  Row,
   useAbsoluteLayout,
   useFilters,
   UseFiltersState,
@@ -43,6 +44,7 @@ export interface Props {
   onColumnResize?: TableColumnResizeActionCallback;
   onSortByChange?: TableSortByActionCallback;
   onCellFilterAdded?: TableFilterActionCallback;
+  onRowsChange?: (rows: Row[]) => void;
 }
 
 interface ReactTableInternalState extends UseResizeColumnsState<{}>, UseSortByState<{}>, UseFiltersState<{}> {}
@@ -122,6 +124,7 @@ export const Table: FC<Props> = memo((props: Props) => {
     noHeader,
     resizable = true,
     initialSortBy,
+    onRowsChange,
   } = props;
   const theme = useTheme();
   const tableStyles = getTableStyles(theme);
@@ -164,6 +167,12 @@ export const Table: FC<Props> = memo((props: Props) => {
   );
 
   const { fields } = data;
+
+  useEffect(() => {
+    if (onRowsChange) {
+      onRowsChange(rows);
+    }
+  }, [rows.length]);
 
   const RenderRow = React.useCallback(
     ({ index, style }) => {

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -172,7 +172,7 @@ export const Table: FC<Props> = memo((props: Props) => {
     if (onRowsChange) {
       onRowsChange(rows);
     }
-  }, [rows.length]);
+  }, [rows]);
 
   const RenderRow = React.useCallback(
     ({ index, style }) => {

--- a/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
@@ -23,6 +23,7 @@ import { GetDataOptions } from '../../../query/state/PanelQueryRunner';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 import { PanelModel } from 'app/features/dashboard/state';
 import { DetailText } from './DetailText';
+import { filterDataFrameByRowIds } from './utils';
 
 interface Props {
   panel: PanelModel;
@@ -43,6 +44,8 @@ interface State {
 }
 
 export class InspectDataTab extends PureComponent<Props, State> {
+  filterRowIds?: number[];
+
   constructor(props: Props) {
     super(props);
 
@@ -280,7 +283,11 @@ export class InspectDataTab extends PureComponent<Props, State> {
           <div className={styles.dataDisplayOptions}>{this.renderDataOptions(dataFrames)}</div>
           <Button
             variant="primary"
-            onClick={() => this.exportCsv(dataFrames[dataFrameIndex], { useExcelHeader: this.state.downloadForExcel })}
+            onClick={() =>
+              this.exportCsv(filterDataFrameByRowIds(data, this.filterRowIds), {
+                useExcelHeader: this.state.downloadForExcel,
+              })
+            }
             className={css`
               margin-bottom: 10px;
             `}
@@ -297,7 +304,14 @@ export class InspectDataTab extends PureComponent<Props, State> {
 
               return (
                 <div style={{ width, height }}>
-                  <Table width={width} height={height} data={data} />
+                  <Table
+                    width={width}
+                    height={height}
+                    data={data}
+                    onRowsChange={rows => {
+                      this.filterRowIds = rows.map(row => parseInt(row.id, 10));
+                    }}
+                  />
                 </div>
               );
             }}

--- a/public/app/features/dashboard/components/Inspector/utils.test.ts
+++ b/public/app/features/dashboard/components/Inspector/utils.test.ts
@@ -1,0 +1,53 @@
+import { ArrayVector, DataFrame, FieldType } from '@grafana/data';
+import { filterDataFrameByRowIds } from './utils';
+
+describe('filterDataFrameByRowIds', () => {
+  const df: DataFrame = {
+    name: 'hello',
+    fields: [
+      {
+        name: 'fname',
+        labels: {
+          a: 'AAA',
+          b: 'BBB',
+        },
+        config: {},
+        type: FieldType.number,
+        values: new ArrayVector([1, 2, 3, 4]),
+      },
+      {
+        name: 'fname',
+        labels: {
+          a: 'AAA',
+          b: 'BBB',
+        },
+        config: {},
+        type: FieldType.time,
+        values: new ArrayVector([5, 6, 7, 8]),
+      },
+    ],
+    length: 2,
+  };
+
+  it('should filter the dataframe by row ids', () => {
+    const rowIds = [1, 3];
+    const expected = {
+      ...df,
+      fields: [
+        {
+          ...df.fields[0],
+          values: new ArrayVector([2, 4]),
+        },
+        {
+          ...df.fields[1],
+          values: new ArrayVector([6, 8]),
+        },
+      ],
+    };
+    expect(filterDataFrameByRowIds(df, rowIds)).toEqual(expected);
+  });
+
+  it('should return df without filtering when rowIds is undefined', () => {
+    expect(filterDataFrameByRowIds(df, undefined)).toEqual(df);
+  });
+});

--- a/public/app/features/dashboard/components/Inspector/utils.ts
+++ b/public/app/features/dashboard/components/Inspector/utils.ts
@@ -1,0 +1,15 @@
+import { ArrayVector, DataFrame } from '@grafana/data';
+
+export const filterDataFrameByRowIds = (dataFrame: DataFrame, rowIds: number[] | undefined) => {
+  if (!rowIds) {
+    return dataFrame;
+  }
+
+  return {
+    ...dataFrame,
+    fields: dataFrame.fields.map(({ values, ...rest }) => ({
+      ...rest,
+      values: new ArrayVector(values.toArray().filter((_: any, index: number) => rowIds.includes(index))),
+    })),
+  };
+};


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes it possible to export csv file with filtered data rather than origin all data.

**Which issue(s) this PR fixes**:

Fixes #29113

