### PR TITLE
Explore: Fix remounting of query row

### DIFF
--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -272,6 +272,7 @@ export const paneReducer = (state: ExploreItemState = makeExplorePaneState(), ac
 
   if (initializeExploreAction.match(action)) {
     const { containerWidth, eventBridge, queries, range, originPanelId, datasourceInstance, history } = action.payload;
+
     return {
       ...state,
       containerWidth,

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -279,7 +279,7 @@ export const paneReducer = (state: ExploreItemState = makeExplorePaneState(), ac
       range,
       queries,
       initialized: true,
-      queryKeys: getQueryKeys(queries, state.datasourceInstance),
+      queryKeys: getQueryKeys(queries, datasourceInstance),
       originPanelId,
       update: makeInitialUpdateState(),
       datasourceInstance,


### PR DESCRIPTION
Because in init it used data source from state, which wasn't inited yet, it created temp row key which got changed later, which resulted in remounting of whole query row. Usually it did not have any visual effect but if there was some initialisation in the QueryEditor with some loading state this would be annoying.