### PR TITLE
Chore: Remove internal import for QueryEditorRow

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
@@ -1,6 +1,5 @@
 import { GrafanaTheme } from '@grafana/data';
 import { IconButton, stylesFactory, useTheme } from '@grafana/ui';
-import { getInlineLabelStyles } from '@grafana/ui/src/components/Forms/InlineLabel';
 import { css } from 'emotion';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
@@ -24,7 +23,7 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
 
   return (
     <fieldset className={styles.root}>
-      <div className={getInlineLabelStyles(theme, 17).label}>
+      <div className={styles.wrapper}>
         <legend className={styles.label}>{label}</legend>
         {onHideClick && (
           <IconButton
@@ -57,6 +56,25 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     root: css`
       display: flex;
       margin-bottom: ${theme.spacing.xs};
+    `,
+    // FIXME: this is taken from  `getInlineLabelStyles` in '@grafana/ui/src/components/Forms/InlineLabel' with width = 17
+    // We should have a better way to access / use these styles.
+    wrapper: css`
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-shrink: 0;
+      padding: 0 ${theme.spacing.sm};
+      font-weight: ${theme.typography.weight.semibold};
+      font-size: ${theme.typography.size.sm};
+      background-color: ${theme.colors.bg2};
+      height: ${theme.height.md}px;
+      line-height: ${theme.height.md}px;
+      margin-right: ${theme.spacing.xs};
+      border-radius: ${theme.border.radius.md};
+      border: none;
+      width: 136px;
+      color: ${theme.colors.textHeading};
     `,
     label: css`
       font-size: ${theme.typography.size.sm};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Removes the internal import from `@grafana/ui/src/components/Forms/InlineLabel` of `getInlineLabelStyles`.


**Special notes for your reviewer**:
Not an ideal solution as I'm basically just copying the resulting styles, I added a FIXME comment to tackle this in a better way in a follow-up PR.
We need this as a part of work on extracting Elasticsearch data source into a separate plugin.

