### PR TITLE
Collapse: Allow component children to use height: 100% styling.

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -14,6 +14,15 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => ({
   collapseBody: css`
     label: collapse__body;
     padding: ${theme.panelPadding}px;
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  `,
+  bodyContentWrapper: css`
+    label: bodyContentWrapper;
+    flex: 1;
+    overflow: hidden;
   `,
   loader: css`
     label: collapse__loader;
@@ -136,7 +145,7 @@ export const Collapse: FunctionComponent<Props> = ({ isOpen, label, loading, col
       {isOpen && (
         <div className={cx([style.collapseBody])}>
           <div className={loaderClass} />
-          {children}
+          <div className={style.bodyContentWrapper}>{children}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
In the collapsible element it was a bit hard to get proper sizing of the children if one wanted to size the children as 100% height.

- one issue was that there was another element in the same container (the loader) so if children were 100% height that loader just pushed them further down
- second was that the body container did not grow by default so if you had a content that did not have any intrinsic content height then 100% height wasn't really filling all the vertical space.

This should no affect much seems like we use this element only in Explore and there it does not seem to have any adverse effect on other visualisations.