### PR TITLE
Docs: Add missing httpMethod field to webhook notification provisioning docs

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -554,11 +554,12 @@ The following sections detail the supported settings and secure settings for eac
 
 #### Alert notification `webhook`
 
-| Name     | Secure setting |
-| -------- | -------------- |
-| url      |                |
-| username |                |
-| password | yes            |
+| Name       | Secure setting |
+| ---------- | -------------- |
+| url        |                |
+| httpMethod |                |
+| username   |                |
+| password   | yes            |
 
 #### Alert notification `googlechat`
 


### PR DESCRIPTION
The values appear like they can be "POST" or "PUT" but there doesn't appear to be a place for that info in the documentation.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Documentation clarification for `webook` Notification Channels.

**Which issue(s) this PR fixes**:

n/a
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:

