### PR TITLE
InlineForms: Changes to make inline forms more flexible for query editors 

### DIFF
--- a/packages/grafana-ui/src/components/Forms/InlineField.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.tsx
@@ -59,19 +59,11 @@ const getStyles = (theme: GrafanaTheme, grow?: boolean) => {
     container: css`
       display: flex;
       flex-direction: row;
-      align-items: center;
+      align-items: flex-start;
       text-align: left;
       position: relative;
       flex: ${grow ? 1 : 0} 0 auto;
-      margin: 0 ${theme.spacing.xs};
-    `,
-    wrapper: css`
-      display: flex;
-      width: 100%;
-    `,
-
-    fillContainer: css`
-      flex-grow: 1;
+      margin: 0 ${theme.spacing.xs} ${theme.spacing.xs} 0;
     `,
   };
 };

--- a/packages/grafana-ui/src/components/Forms/InlineField.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.tsx
@@ -63,7 +63,7 @@ const getStyles = (theme: GrafanaTheme, grow?: boolean) => {
       text-align: left;
       position: relative;
       flex: ${grow ? 1 : 0} 0 auto;
-      margin: 0 ${theme.spacing.xs} ${theme.spacing.xs} 0;
+      margin: 0 ${theme.spacing.xs};
     `,
     wrapper: css`
       display: flex;

--- a/packages/grafana-ui/src/components/Forms/InlineFieldRow.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineFieldRow.tsx
@@ -24,7 +24,6 @@ const getStyles = (theme: GrafanaTheme) => {
       flex-direction: row;
       flex-wrap: wrap;
       align-content: flex-start;
-      margin-bottom: ${theme.spacing.xs};
     `,
   };
 };

--- a/packages/grafana-ui/src/components/Forms/InlineFieldRow.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineFieldRow.tsx
@@ -1,6 +1,7 @@
 import React, { FC, HTMLProps, ReactNode } from 'react';
 import { css, cx } from 'emotion';
 import { useStyles } from '../../themes';
+import { GrafanaTheme } from '@grafana/data';
 
 export interface Props extends Omit<HTMLProps<HTMLDivElement>, 'css'> {
   children: ReactNode | ReactNode[];
@@ -15,7 +16,7 @@ export const InlineFieldRow: FC<Props> = ({ children, className, ...htmlProps })
   );
 };
 
-const getStyles = () => {
+const getStyles = (theme: GrafanaTheme) => {
   return {
     container: css`
       label: InlineFieldRow;
@@ -23,6 +24,7 @@ const getStyles = () => {
       flex-direction: row;
       flex-wrap: wrap;
       align-content: flex-start;
+      margin-bottom: ${theme.spacing.xs};
     `,
   };
 };

--- a/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
@@ -18,21 +18,31 @@ export interface Props extends Omit<LabelProps, 'css' | 'description' | 'categor
   /** @deprecated */
   /** This prop is deprecated and is not used anymore */
   isInvalid?: boolean;
+  /** @beta */
+  /** Controls which element the InlineLabel should be rendered into */
+  as?: React.ElementType;
 }
 
-export const InlineLabel: FunctionComponent<Props> = ({ children, className, tooltip, width, ...rest }) => {
+export const InlineLabel: FunctionComponent<Props> = ({
+  children,
+  className,
+  tooltip,
+  width,
+  as: Component = 'label',
+  ...rest
+}) => {
   const theme = useTheme();
   const styles = getInlineLabelStyles(theme, width);
 
   return (
-    <label className={cx(styles.label, className)} {...rest}>
+    <Component className={cx(styles.label, className)} {...rest}>
       {children}
       {tooltip && (
         <Tooltip placement="top" content={tooltip} theme="info">
           <Icon name="info-circle" size="sm" className={styles.icon} />
         </Tooltip>
       )}
-    </label>
+    </Component>
   );
 };
 

--- a/packages/grafana-ui/src/components/Forms/InlineSegmentGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineSegmentGroup.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react';
+import { cx, css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+import { useTheme } from '../../themes';
+
+export interface Props {
+  grow?: boolean;
+  className?: string;
+}
+
+export const InlineSegmentGroup: FC<Props> = ({ children, className, grow, ...htmlProps }) => {
+  const theme = useTheme();
+  const styles = getStyles(theme, grow);
+
+  return (
+    <div className={cx(styles.container, className)} {...htmlProps}>
+      {children}
+    </div>
+  );
+};
+
+InlineSegmentGroup.displayName = 'InlineSegmentGroup';
+
+const getStyles = (theme: GrafanaTheme, grow?: boolean) => {
+  return {
+    container: css`
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      text-align: left;
+      position: relative;
+      flex: ${grow ? 1 : 0} 0 auto;
+      margin-bottom: ${theme.spacing.xs};
+    `,
+  };
+};

--- a/packages/grafana-ui/src/components/Forms/InlineSegmentGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineSegmentGroup.tsx
@@ -8,6 +8,7 @@ export interface Props {
   className?: string;
 }
 
+/** @beta */
 export const InlineSegmentGroup: FC<Props> = ({ children, className, grow, ...htmlProps }) => {
   const theme = useTheme();
   const styles = getStyles(theme, grow);

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -151,6 +151,7 @@ export { Legend } from './Forms/Legend';
 export { FieldSet } from './Forms/FieldSet';
 export { FieldValidationMessage } from './Forms/FieldValidationMessage';
 export { InlineField } from './Forms/InlineField';
+export { InlineSegmentGroup } from './Forms/InlineSegmentGroup';
 export { InlineLabel } from './Forms/InlineLabel';
 export { InlineFieldRow } from './Forms/InlineFieldRow';
 export { FieldArray } from './Forms/FieldArray';

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/BucketAggregationEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/BucketAggregationEditor.tsx
@@ -1,5 +1,5 @@
 import { MetricFindValue, SelectableValue } from '@grafana/data';
-import { Segment, SegmentAsync } from '@grafana/ui';
+import { InlineSegmentGroup, Segment, SegmentAsync } from '@grafana/ui';
 import React, { FunctionComponent } from 'react';
 import { useDispatch } from '../../../hooks/useStatelessReducer';
 import { useDatasource } from '../ElasticsearchQueryContext';
@@ -53,22 +53,24 @@ export const BucketAggregationEditor: FunctionComponent<QueryMetricEditorProps> 
 
   return (
     <>
-      <Segment
-        className={segmentStyles}
-        options={bucketAggOptions}
-        onChange={e => dispatch(changeBucketAggregationType(value.id, e.value!))}
-        value={toOption(value)}
-      />
-
-      {isBucketAggregationWithField(value) && (
-        <SegmentAsync
+      <InlineSegmentGroup>
+        <Segment
           className={segmentStyles}
-          loadOptions={getFields}
-          onChange={e => dispatch(changeBucketAggregationField(value.id, e.value))}
-          placeholder="Select Field"
-          value={value.field}
+          options={bucketAggOptions}
+          onChange={e => dispatch(changeBucketAggregationType(value.id, e.value!))}
+          value={toOption(value)}
         />
-      )}
+
+        {isBucketAggregationWithField(value) && (
+          <SegmentAsync
+            className={segmentStyles}
+            loadOptions={getFields}
+            onChange={e => dispatch(changeBucketAggregationField(value.id, e.value))}
+            placeholder="Select Field"
+            value={value.field}
+          />
+        )}
+      </InlineSegmentGroup>
 
       <SettingsEditor bucketAgg={value} />
     </>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
@@ -1,5 +1,5 @@
 import { MetricFindValue, SelectableValue } from '@grafana/data';
-import { Segment, SegmentAsync, useTheme } from '@grafana/ui';
+import { InlineSegmentGroup, Segment, SegmentAsync, useTheme } from '@grafana/ui';
 import { cx } from 'emotion';
 import React, { FunctionComponent } from 'react';
 import { useDatasource, useQuery } from '../ElasticsearchQueryContext';
@@ -88,31 +88,33 @@ export const MetricEditor: FunctionComponent<Props> = ({ value }) => {
 
   return (
     <>
-      <Segment
-        className={cx(styles.color, segmentStyles)}
-        options={getTypeOptions(previousMetrics, datasource.esVersion)}
-        onChange={e => dispatch(changeMetricType(value.id, e.value!))}
-        value={toOption(value)}
-      />
-
-      {isMetricAggregationWithField(value) && !isPipelineAggregation(value) && (
-        <SegmentAsync
+      <InlineSegmentGroup>
+        <Segment
           className={cx(styles.color, segmentStyles)}
-          loadOptions={getFields}
-          onChange={e => dispatch(changeMetricField(value.id, e.value!))}
-          placeholder="Select Field"
-          value={value.field}
+          options={getTypeOptions(previousMetrics, datasource.esVersion)}
+          onChange={e => dispatch(changeMetricType(value.id, e.value!))}
+          value={toOption(value)}
         />
-      )}
 
-      {isPipelineAggregation(value) && !isPipelineAggregationWithMultipleBucketPaths(value) && (
-        <MetricPicker
-          className={cx(styles.color, segmentStyles)}
-          onChange={e => dispatch(changeMetricField(value.id, e.value?.id!))}
-          options={previousMetrics}
-          value={value.field}
-        />
-      )}
+        {isMetricAggregationWithField(value) && !isPipelineAggregation(value) && (
+          <SegmentAsync
+            className={cx(styles.color, segmentStyles)}
+            loadOptions={getFields}
+            onChange={e => dispatch(changeMetricField(value.id, e.value!))}
+            placeholder="Select Field"
+            value={value.field}
+          />
+        )}
+
+        {isPipelineAggregation(value) && !isPipelineAggregationWithMultipleBucketPaths(value) && (
+          <MetricPicker
+            className={cx(styles.color, segmentStyles)}
+            onChange={e => dispatch(changeMetricField(value.id, e.value?.id!))}
+            options={previousMetrics}
+            value={value.field}
+          />
+        )}
+      </InlineSegmentGroup>
 
       {isMetricAggregationWithSettings(value) && <SettingsEditor metric={value} previousMetrics={previousMetrics} />}
     </>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
@@ -1,5 +1,5 @@
 import { GrafanaTheme } from '@grafana/data';
-import { IconButton, stylesFactory, useTheme } from '@grafana/ui';
+import { IconButton, InlineFieldRow, InlineFormLabel, InlineLabel, stylesFactory, useTheme } from '@grafana/ui';
 import { css } from 'emotion';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
@@ -22,9 +22,9 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
   const styles = getStyles(theme);
 
   return (
-    <fieldset className={styles.root}>
-      <div className={styles.wrapper}>
-        <legend className={styles.label}>{label}</legend>
+    <InlineFieldRow>
+      <InlineLabel width={17}>
+        <span>{label}</span>
         {onHideClick && (
           <IconButton
             name={hidden ? 'eye-slash' : 'eye'}
@@ -45,9 +45,9 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
           disabled={!onRemoveClick}
           aria-label="remove metric"
         />
-      </div>
+      </InlineLabel>
       {children}
-    </fieldset>
+    </InlineFieldRow>
   );
 };
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
@@ -1,6 +1,5 @@
 import { GrafanaTheme } from '@grafana/data';
 import { IconButton, stylesFactory, useTheme } from '@grafana/ui';
-import { getInlineLabelStyles } from '@grafana/ui/src/components/Forms/InlineLabel';
 import { css } from 'emotion';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
@@ -24,7 +23,7 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
 
   return (
     <fieldset className={styles.root}>
-      <div className={getInlineLabelStyles(theme, 17).label}>
+      <div className={styles.wrapper}>
         <legend className={styles.label}>{label}</legend>
         {onHideClick && (
           <IconButton
@@ -57,6 +56,25 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     root: css`
       display: flex;
       margin-bottom: ${theme.spacing.xs};
+    `,
+    // FIXME: this is taken from  `getInlineLabelStyles` in '@grafana/ui/src/components/Forms/InlineLabel' with width = 17
+    // We should have a better way to access / use these styles.
+    wrapper: css`
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-shrink: 0;
+      padding: 0 ${theme.spacing.sm};
+      font-weight: ${theme.typography.weight.semibold};
+      font-size: ${theme.typography.size.sm};
+      background-color: ${theme.colors.bg2};
+      height: ${theme.height.md}px;
+      line-height: ${theme.height.md}px;
+      margin-right: ${theme.spacing.xs};
+      border-radius: ${theme.border.radius.md};
+      border: none;
+      width: 136px;
+      color: ${theme.colors.textHeading};
     `,
     label: css`
       font-size: ${theme.typography.size.sm};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
@@ -1,5 +1,5 @@
 import { GrafanaTheme } from '@grafana/data';
-import { IconButton, InlineFieldRow, InlineFormLabel, InlineLabel, stylesFactory, useTheme } from '@grafana/ui';
+import { IconButton, InlineFieldRow, InlineLabel, InlineSegmentGroup, stylesFactory, useTheme } from '@grafana/ui';
 import { css } from 'emotion';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
@@ -23,29 +23,31 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
 
   return (
     <InlineFieldRow>
-      <InlineLabel width={17}>
-        <span>{label}</span>
-        {onHideClick && (
+      <InlineSegmentGroup>
+        <InlineLabel width={17}>
+          <span>{label}</span>
+          {onHideClick && (
+            <IconButton
+              name={hidden ? 'eye-slash' : 'eye'}
+              onClick={onHideClick}
+              surface="header"
+              size="sm"
+              aria-pressed={hidden}
+              aria-label="hide metric"
+              className={styles.icon}
+            />
+          )}
           <IconButton
-            name={hidden ? 'eye-slash' : 'eye'}
-            onClick={onHideClick}
+            name="trash-alt"
             surface="header"
             size="sm"
-            aria-pressed={hidden}
-            aria-label="hide metric"
             className={styles.icon}
+            onClick={onRemoveClick || noop}
+            disabled={!onRemoveClick}
+            aria-label="remove metric"
           />
-        )}
-        <IconButton
-          name="trash-alt"
-          surface="header"
-          size="sm"
-          className={styles.icon}
-          onClick={onRemoveClick || noop}
-          disabled={!onRemoveClick}
-          aria-label="remove metric"
-        />
-      </InlineLabel>
+        </InlineLabel>
+      </InlineSegmentGroup>
       {children}
     </InlineFieldRow>
   );

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
@@ -24,28 +24,30 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
   return (
     <InlineFieldRow>
       <InlineSegmentGroup>
-        <InlineLabel width={17}>
+        <InlineLabel width={17} as="div">
           <span>{label}</span>
-          {onHideClick && (
+          <span className={styles.iconWrapper}>
+            {onHideClick && (
+              <IconButton
+                name={hidden ? 'eye-slash' : 'eye'}
+                onClick={onHideClick}
+                surface="header"
+                size="sm"
+                aria-pressed={hidden}
+                aria-label="hide metric"
+                className={styles.icon}
+              />
+            )}
             <IconButton
-              name={hidden ? 'eye-slash' : 'eye'}
-              onClick={onHideClick}
+              name="trash-alt"
               surface="header"
               size="sm"
-              aria-pressed={hidden}
-              aria-label="hide metric"
               className={styles.icon}
+              onClick={onRemoveClick || noop}
+              disabled={!onRemoveClick}
+              aria-label="remove metric"
             />
-          )}
-          <IconButton
-            name="trash-alt"
-            surface="header"
-            size="sm"
-            className={styles.icon}
-            onClick={onRemoveClick || noop}
-            disabled={!onRemoveClick}
-            aria-label="remove metric"
-          />
+          </span>
         </InlineLabel>
       </InlineSegmentGroup>
       {children}
@@ -55,32 +57,8 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
-    root: css`
+    iconWrapper: css`
       display: flex;
-      margin-bottom: ${theme.spacing.xs};
-    `,
-    // FIXME: this is taken from  `getInlineLabelStyles` in '@grafana/ui/src/components/Forms/InlineLabel' with width = 17
-    // We should have a better way to access / use these styles.
-    wrapper: css`
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-shrink: 0;
-      padding: 0 ${theme.spacing.sm};
-      font-weight: ${theme.typography.weight.semibold};
-      font-size: ${theme.typography.size.sm};
-      background-color: ${theme.colors.bg2};
-      height: ${theme.height.md}px;
-      line-height: ${theme.height.md}px;
-      margin-right: ${theme.spacing.xs};
-      border-radius: ${theme.border.radius.md};
-      border: none;
-      width: 136px;
-      color: ${theme.colors.textHeading};
-    `,
-    label: css`
-      font-size: ${theme.typography.size.sm};
-      margin: 0;
     `,
     icon: css`
       color: ${theme.colors.textWeak};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/SettingsEditorContainer.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/SettingsEditorContainer.tsx
@@ -1,5 +1,5 @@
 import { GrafanaTheme } from '@grafana/data';
-import { Icon, stylesFactory, useTheme } from '@grafana/ui';
+import { Icon, InlineSegmentGroup, stylesFactory, useTheme } from '@grafana/ui';
 import { css, cx } from 'emotion';
 import React, { FunctionComponent, useState } from 'react';
 import { segmentStyles } from './styles';
@@ -32,21 +32,22 @@ interface Props {
 
 export const SettingsEditorContainer: FunctionComponent<Props> = ({ label, children, hidden = false }) => {
   const [open, setOpen] = useState(false);
-
   const styles = getStyles(useTheme(), hidden);
 
   return (
-    <div className={cx(styles.wrapper)}>
-      <button
-        className={cx('gf-form-label query-part', styles.button, segmentStyles)}
-        onClick={() => setOpen(!open)}
-        aria-expanded={open}
-      >
-        <Icon name={open ? 'angle-down' : 'angle-right'} aria-hidden="true" className={styles.icon} />
-        {label}
-      </button>
+    <InlineSegmentGroup>
+      <div className={cx(styles.wrapper)}>
+        <button
+          className={cx('gf-form-label query-part', styles.button, segmentStyles)}
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+        >
+          <Icon name={open ? 'angle-down' : 'angle-right'} aria-hidden="true" className={styles.icon} />
+          {label}
+        </button>
 
-      {open && <div className={styles.settingsWrapper}>{children}</div>}
-    </div>
+        {open && <div className={styles.settingsWrapper}>{children}</div>}
+      </div>
+    </InlineSegmentGroup>
   );
 };


### PR DESCRIPTION
Introduced InlineGroupSegment to group inline elements together, only has bottom margin. 

![Screenshot from 2020-12-12 12-03-40](https://user-images.githubusercontent.com/10999/101982210-89c10a00-3c72-11eb-8a8d-3875e248fd27.png)

![Screenshot from 2020-12-12 12-03-48](https://user-images.githubusercontent.com/10999/101982212-8c236400-3c72-11eb-92e0-86f09ec1c63d.png)

![Screenshot from 2020-12-12 12-05-13](https://user-images.githubusercontent.com/10999/101982215-8ded2780-3c72-11eb-91df-f2b1151610df.png)
