### PR TITLE
Variables: Make TextBox variable width adjustable.

### DIFF
--- a/docs/sources/variables/variable-types/add-text-box-variable.md
+++ b/docs/sources/variables/variable-types/add-text-box-variable.md
@@ -23,5 +23,6 @@ _Text box_ variables display a free text input field with an optional default va
 ## Enter Text options
 
 1. (optional) In the **Default value** field, select the default value for the variable. If you do not enter anything in this field, then Grafana displays an empty text box for users to type text into.
+1. In the **Width** field, enter the width the Text Box should be if you need slightly more or less space for your users to enter their text. 
 1. In **Preview of values**, Grafana displays a list of the current variable values. Review them to ensure they match what you expect.
 1. Click **Add** to add the variable to the dashboard.

--- a/public/app/features/variables/editor/VariableTextField.tsx
+++ b/public/app/features/variables/editor/VariableTextField.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent, PropsWithChildren, ReactElement } from 'react';
 import { InlineField, Input, PopoverContent } from '@grafana/ui';
 
 interface VariableTextFieldProps {
+  type?: string;
   value: string;
   name: string;
   placeholder: string;
@@ -16,6 +17,7 @@ interface VariableTextFieldProps {
 }
 
 export function VariableTextField({
+  type,
   value,
   name,
   placeholder,
@@ -31,7 +33,7 @@ export function VariableTextField({
   return (
     <InlineField label={name} labelWidth={labelWidth ?? 12} tooltip={tooltip} grow={grow}>
       <Input
-        type="text"
+        type={type === undefined ? 'text' : type}
         id={name}
         name={name}
         placeholder={placeholder}

--- a/public/app/features/variables/shared/testing/textboxVariableBuilder.ts
+++ b/public/app/features/variables/shared/testing/textboxVariableBuilder.ts
@@ -6,4 +6,8 @@ export class TextBoxVariableBuilder<T extends TextBoxVariableModel> extends Opti
     this.variable.originalQuery = original;
     return this;
   }
+  withWidth(width: string) {
+    this.variable.width = width;
+    return this;
+  }
 }

--- a/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
@@ -9,7 +9,7 @@ import { selectors } from '@grafana/e2e-selectors';
 
 export interface Props extends VariableEditorProps<TextBoxVariableModel> {}
 
-export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Props): ReactElement {
+export function TextBoxVariableEditor({ onPropChange, variable: { query, width } }: Props): ReactElement {
   const updateVariable = useCallback(
     (event: ChangeEvent<HTMLInputElement>, updateOptions: boolean) => {
       event.preventDefault();
@@ -18,12 +18,22 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Pro
     },
     [onPropChange]
   );
+  const updateWidthVariable = useCallback(
+    (event: ChangeEvent<HTMLInputElement>, updateOptions: boolean) => {
+      event.preventDefault();
+      onPropChange({ propName: 'width', propValue: event.target.value, updateOptions });
+    },
+    [onPropChange]
+  );
 
   const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => updateVariable(e, false), [updateVariable]);
+  const onWidthChange = useCallback((e: ChangeEvent<HTMLInputElement>) => updateWidthVariable(e, false), [
+    updateVariable,
+  ]);
   const onBlur = useCallback((e: ChangeEvent<HTMLInputElement>) => updateVariable(e, true), [updateVariable]);
 
   return (
-    <VerticalGroup spacing="xs">
+    <VerticalGroup spacing="none">
       <VariableSectionHeader name="Text Options" />
       <VariableTextField
         value={query}
@@ -34,6 +44,14 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Pro
         labelWidth={20}
         grow
         ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
+      />
+      <VariableTextField
+        type="number"
+        value={width}
+        name="Width"
+        placeholder="defualt value, if any"
+        onChange={onWidthChange}
+        labelWidth={20}
       />
     </VerticalGroup>
   );

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -41,5 +41,14 @@ export function TextBoxVariablePicker({ variable }: Props): ReactElement {
     }
   };
 
-  return <Input type="text" value={updatedValue} onChange={onChange} onBlur={onBlur} onKeyDown={onKeyDown} />;
+  return (
+    <Input
+      type="text"
+      value={updatedValue}
+      width={Number(variable.width) / 8} // Component wants width in mulitples of 8px so we divide by 8 to allow the user to define TextBox width to be defined in px.
+      onChange={onChange}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+    />
+  );
 }

--- a/public/app/features/variables/textbox/adapter.test.ts
+++ b/public/app/features/variables/textbox/adapter.test.ts
@@ -28,6 +28,7 @@ describe('createTextBoxVariableAdapter', () => {
           current: { selected: false, text: 'original', value: 'original' },
           options: [{ selected: false, text: 'original', value: 'original' }],
           type: 'textbox',
+          width: '192',
           label: null,
           hide: VariableHide.dontHide,
           skipUrlSync: false,
@@ -58,12 +59,45 @@ describe('createTextBoxVariableAdapter', () => {
           current: { selected: true, text: 'query', value: 'query' },
           options: [{ selected: false, text: 'query', value: 'query' }],
           type: 'textbox',
+          width: '192',
           label: null,
           hide: VariableHide.dontHide,
           skipUrlSync: false,
           error: null,
           description: null,
         });
+      });
+    });
+  });
+
+  describe('when called and the width is changed', () => {
+    it('then the model should be correct', () => {
+      const text = textboxBuilder()
+        .withId('text')
+        .withName('text')
+        .withQuery('query')
+        .withWidth('200')
+        .withOriginalQuery('original')
+        .withCurrent('query')
+        .withOptions('query')
+        .build();
+
+      const adapter = variableAdapters.get('textbox');
+
+      const result = adapter.getSaveModel(text, true);
+
+      expect(result).toEqual({
+        name: 'text',
+        query: 'query',
+        current: { selected: true, text: 'query', value: 'query' },
+        options: [{ selected: false, text: 'query', value: 'query' }],
+        type: 'textbox',
+        width: '200',
+        label: null,
+        hide: VariableHide.dontHide,
+        skipUrlSync: false,
+        error: null,
+        description: null,
       });
     });
   });

--- a/public/app/features/variables/textbox/reducer.test.ts
+++ b/public/app/features/variables/textbox/reducer.test.ts
@@ -69,4 +69,13 @@ describe('textBoxVariableReducer', () => {
         });
     });
   });
+
+  describe('when the TextBox is initialized', () => {
+    it('then the default width should be correct', () => {
+      const { initialState } = getVariableTestContext(adapter);
+      const textBox = initialState['0'] as TextBoxVariableModel;
+
+      expect(textBox.width).toBe('192');
+    });
+  });
 });

--- a/public/app/features/variables/textbox/reducer.ts
+++ b/public/app/features/variables/textbox/reducer.ts
@@ -8,6 +8,7 @@ export const initialTextBoxVariableModelState: TextBoxVariableModel = {
   ...initialVariableModelState,
   type: 'textbox',
   query: '',
+  width: '192',
   current: {} as VariableOption,
   options: [],
   originalQuery: null,

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -88,6 +88,7 @@ export interface QueryVariableModel extends DataSourceVariableModel {
 
 export interface TextBoxVariableModel extends VariableWithOptions {
   originalQuery: string | null;
+  width: string;
 }
 
 export interface ConstantVariableModel extends VariableWithOptions {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will make the TextBox variable width adjustable.

![](https://i.imgur.com/KujdA4p.png)

![](https://i.imgur.com/YPMHRsG.png)

When creating dashboards especially ones to view logs it is often desirable to have a TextBox variable to allow a user to do complex queries to the data source and so the width of the TextBox needs to be wide to accommodate this.

However sometimes you don't want them to do this and the TextBox should be small so they only enter a small variable.

But ultimately what we need is the choice to decide how wide the TextBox should be. It should be up to the designer of the dashboard to decide this as they will know best.

**Which issue(s) this PR fixes**:

Fixes #29672

**Special notes for your reviewer**:

The default width of the TextBox is 192px so this is why I've set 192 as the default value in the reducer.
