### PR TITLE
Style guide: Document avoidance of globals in Go code

### DIFF
--- a/contribute/style-guides/backend.md
+++ b/contribute/style-guides/backend.md
@@ -40,7 +40,6 @@ The majority of our tests uses [GoConvey](http://goconvey.co/) but that's someth
 
 In the `sqlstore` package we do database operations in tests and while some might say that's not suited for unit tests. We think they are fast enough and provide a lot of value.
 
-
 ## Globals
 
 As a general rule of thumb, avoid using global variables, since they make the code difficult to maintain and reason

--- a/contribute/style-guides/backend.md
+++ b/contribute/style-guides/backend.md
@@ -39,3 +39,10 @@ Tests must use the standard library, `testing`. For assertions, prefer using [te
 The majority of our tests uses [GoConvey](http://goconvey.co/) but that's something we want to avoid going forward.
 
 In the `sqlstore` package we do database operations in tests and while some might say that's not suited for unit tests. We think they are fast enough and provide a lot of value.
+
+
+## Globals
+
+As a general rule of thumb, avoid using global variables, since they make the code difficult to maintain and reason
+about, and to write tests for. The Grafana codebase currently does use a lot of global variables, especially when
+it comes to configuration, but that is a problem we're trying to solve.


### PR DESCRIPTION
**What this PR does / why we need it**:
In the backend style guide, document that global variables should generally be avoided.
