### PR TITLE
Chore: Use Header.Set method instead of Header.Add

### DIFF
--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -107,13 +107,13 @@ func (a *CacheServer) Handler(ctx *models.ReqContext) {
 		}
 	}
 
-	ctx.Resp.Header().Add("Content-Type", "image/jpeg")
+	ctx.Resp.Header().Set("Content-Type", "image/jpeg")
 
 	if !setting.EnableGzip {
-		ctx.Resp.Header().Add("Content-Length", strconv.Itoa(len(avatar.data.Bytes())))
+		ctx.Resp.Header().Set("Content-Length", strconv.Itoa(len(avatar.data.Bytes())))
 	}
 
-	ctx.Resp.Header().Add("Cache-Control", "private, max-age=3600")
+	ctx.Resp.Header().Set("Cache-Control", "private, max-age=3600")
 
 	if err := avatar.Encode(ctx.Resp); err != nil {
 		log.Warnf("avatar encode error: %v", err)

--- a/pkg/api/basic_auth_test.go
+++ b/pkg/api/basic_auth_test.go
@@ -22,7 +22,7 @@ func TestBasicAuthenticatedRequest(t *testing.T) {
 			Request: httpReq,
 		}
 		encodedCreds := encodeBasicAuthCredentials(expectedUser, expectedPass)
-		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedCreds))
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedCreds))
 		authenticated := BasicAuthenticatedRequest(req, expectedUser, expectedPass)
 
 		assert.True(t, authenticated)
@@ -35,7 +35,7 @@ func TestBasicAuthenticatedRequest(t *testing.T) {
 			Request: httpReq,
 		}
 		encodedCreds := encodeBasicAuthCredentials("invaliduser", "invalidpass")
-		req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encodedCreds))
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", encodedCreds))
 		authenticated := BasicAuthenticatedRequest(req, expectedUser, expectedPass)
 
 		assert.False(t, authenticated)

--- a/pkg/api/pluginproxy/access_token_provider.go
+++ b/pkg/api/pluginproxy/access_token_provider.go
@@ -114,8 +114,8 @@ func (provider *accessTokenProvider) getAccessToken(data templateData) (string, 
 	}
 
 	getTokenReq, _ := http.NewRequest("POST", urlInterpolated, bytes.NewBufferString(params.Encode()))
-	getTokenReq.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	getTokenReq.Header.Add("Content-Length", strconv.Itoa(len(params.Encode())))
+	getTokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	getTokenReq.Header.Set("Content-Length", strconv.Itoa(len(params.Encode())))
 
 	resp, err := client.Do(getTokenReq)
 	if err != nil {

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -390,9 +390,9 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 		proxy, err := NewDataSourceProxy(ds, plugin, ctx, "/path/to/folder/", &setting.Cfg{})
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
-		req.Header.Add("Origin", "grafana.com")
-		req.Header.Add("Referer", "grafana.com")
-		req.Header.Add("X-Canary", "stillthere")
+		req.Header.Set("Origin", "grafana.com")
+		req.Header.Set("Referer", "grafana.com")
+		req.Header.Set("X-Canary", "stillthere")
 		require.NoError(t, err)
 
 		proxy.director(req)

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -51,24 +51,24 @@ func addSecurityHeaders(w macaron.ResponseWriter, cfg *setting.Cfg) {
 		if cfg.StrictTransportSecuritySubDomains {
 			strictHeaderValues = append(strictHeaderValues, "includeSubDomains")
 		}
-		w.Header().Add("Strict-Transport-Security", strings.Join(strictHeaderValues, "; "))
+		w.Header().Set("Strict-Transport-Security", strings.Join(strictHeaderValues, "; "))
 	}
 
 	if cfg.ContentTypeProtectionHeader {
-		w.Header().Add("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 	}
 
 	if cfg.XSSProtectionHeader {
-		w.Header().Add("X-XSS-Protection", "1; mode=block")
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
 	}
 }
 
 func addNoCacheHeaders(w macaron.ResponseWriter) {
-	w.Header().Add("Cache-Control", "no-cache")
-	w.Header().Add("Pragma", "no-cache")
-	w.Header().Add("Expires", "-1")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "-1")
 }
 
 func addXFrameOptionsDenyHeader(w macaron.ResponseWriter) {
-	w.Header().Add("X-Frame-Options", "deny")
+	w.Header().Set("X-Frame-Options", "deny")
 }

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -21,7 +21,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 		recoveryScenario(t, "recovery middleware should return json", apiURL, func(t *testing.T, sc *scenarioContext) {
 			sc.handlerFunc = panicHandler
 			sc.fakeReq("GET", apiURL).exec()
-			sc.req.Header.Add("content-type", "application/json")
+			sc.req.Header.Set("content-type", "application/json")
 
 			assert.Equal(t, 500, sc.resp.Code)
 			assert.Equal(t, "Internal Server Error - Check the Grafana server logs for the detailed error message.", sc.respJson["message"])

--- a/pkg/middleware/testing.go
+++ b/pkg/middleware/testing.go
@@ -88,12 +88,12 @@ func (sc *scenarioContext) exec() {
 
 	if sc.apiKey != "" {
 		sc.t.Logf(`Adding header "Authorization: Bearer %s"`, sc.apiKey)
-		sc.req.Header.Add("Authorization", "Bearer "+sc.apiKey)
+		sc.req.Header.Set("Authorization", "Bearer "+sc.apiKey)
 	}
 
 	if sc.authHeader != "" {
 		sc.t.Logf(`Adding header "Authorization: %s"`, sc.authHeader)
-		sc.req.Header.Add("Authorization", sc.authHeader)
+		sc.req.Header.Set("Authorization", sc.authHeader)
 	}
 
 	if sc.tokenSessionCookie != "" {

--- a/pkg/plugins/backendplugin/manager.go
+++ b/pkg/plugins/backendplugin/manager.go
@@ -343,6 +343,8 @@ func flushStream(plugin Plugin, stream CallResourceClientResponseStream, w http.
 				}
 
 				for _, v := range values {
+					// TODO: Figure out if we should use Set here instead
+					// nolint:gocritic
 					w.Header().Add(k, v)
 				}
 			}

--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -61,11 +61,11 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 		webhook.ContentType = "application/json"
 	}
 
-	request.Header.Add("Content-Type", webhook.ContentType)
-	request.Header.Add("User-Agent", "Grafana")
+	request.Header.Set("Content-Type", webhook.ContentType)
+	request.Header.Set("User-Agent", "Grafana")
 
 	if webhook.User != "" && webhook.Password != "" {
-		request.Header.Add("Authorization", util.GetBasicAuthHeader(webhook.User, webhook.Password))
+		request.Header.Set("Authorization", util.GetBasicAuthHeader(webhook.User, webhook.Password))
 	}
 
 	for k, v := range webhook.HttpHeader {

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -407,7 +407,7 @@ func httpClientScenario(t *testing.T, desc string, ds *models.DataSource, fn sce
 
 			sc.requestBody = bytes.NewBuffer(buf)
 
-			rw.Header().Add("Content-Type", "application/json")
+			rw.Header().Set("Content-Type", "application/json")
 			_, err = rw.Write([]byte(sc.responseBody))
 			require.Nil(t, err)
 			rw.WriteHeader(sc.responseStatus)

--- a/pkg/util/proxyutil/proxyutil_test.go
+++ b/pkg/util/proxyutil/proxyutil_test.go
@@ -11,9 +11,9 @@ func TestPrepareProxyRequest(t *testing.T) {
 	t.Run("Prepare proxy request should clear X-Forwarded headers", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/", nil)
 		require.NoError(t, err)
-		req.Header.Add("X-Forwarded-Host", "host")
-		req.Header.Add("X-Forwarded-Port", "123")
-		req.Header.Add("X-Forwarded-Proto", "http1")
+		req.Header.Set("X-Forwarded-Host", "host")
+		req.Header.Set("X-Forwarded-Port", "123")
+		req.Header.Set("X-Forwarded-Proto", "http1")
 
 		PrepareProxyRequest(req)
 		require.NotContains(t, req.Header, "X-Forwarded-Host")
@@ -34,7 +34,7 @@ func TestPrepareProxyRequest(t *testing.T) {
 	t.Run("Prepare proxy request should append client ip at the end of X-Forwarded-For", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/", nil)
 		req.RemoteAddr = "127.0.0.1:1234"
-		req.Header.Add("X-Forwarded-For", "192.168.0.1")
+		req.Header.Set("X-Forwarded-For", "192.168.0.1")
 		require.NoError(t, err)
 
 		PrepareProxyRequest(req)


### PR DESCRIPTION
**What this PR does / why we need it**:
Smaller PR extracted from #29781, converting calls to [Header.Add](https://golang.org/pkg/net/http/#Header.Add) to [Header.Set](https://golang.org/pkg/net/http/#Header.Set) since generally we want to set a header value and not append to it.

Please look it over making sure I'm right in my thinking that all these cases can be converted to Header.Set, i.e. that we want to set the header value rather than appending to it.