### PR TITLE
Elasticsearch: add datasource's configured timeField to query model

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.test.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
+import { render } from '@testing-library/react';
 import { ElasticsearchProvider, useDatasource, useQuery } from './ElasticsearchQueryContext';
 import { ElasticsearchQuery } from '../../types';
 import { ElasticDatasource } from '../../datasource';
@@ -11,6 +12,22 @@ const query: ElasticsearchQuery = {
 };
 
 describe('ElasticsearchQueryContext', () => {
+  it('Should call onChange with the default query when the query is empty', () => {
+    const datasource = { timeField: 'TIMEFIELD' } as ElasticDatasource;
+    const onChange = jest.fn();
+
+    render(<ElasticsearchProvider query={{ refId: 'A' }} onChange={onChange} datasource={datasource} />);
+
+    const changedQuery: ElasticsearchQuery = onChange.mock.calls[0][0];
+    expect(changedQuery.query).toBeDefined();
+    expect(changedQuery.alias).toBeDefined();
+    expect(changedQuery.metrics).toBeDefined();
+    expect(changedQuery.bucketAggs).toBeDefined();
+
+    // Should also set timeField to the configured `timeField` option in datasource configuration
+    expect(changedQuery.timeField).toBe(datasource.timeField);
+  });
+
   describe('useQuery Hook', () => {
     it('Should throw when used outside of ElasticsearchQueryContext', () => {
       const { result } = renderHook(() => useQuery());

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -24,7 +24,12 @@ export const ElasticsearchProvider: FunctionComponent<Props> = ({ children, onCh
     bucketAggs: bucketAggsReducer,
   });
 
-  const dispatch = useStatelessReducer(newState => onChange({ ...query, ...newState }), query, reducer);
+  const dispatch = useStatelessReducer(
+    // timeField is part of the query model, but its value is always set to be the one from datasource settings.
+    newState => onChange({ ...query, ...newState, timeField: datasource.timeField }),
+    query,
+    reducer
+  );
 
   // This initializes the query by dispatching an init action to each reducer.
   // useStatelessReducer will then call `onChange` with the newly generated query


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
After the React migration, `timeField` was not being persisted in the query model. Queries were working on the frontend because the query builder sets it every time before running a query, but it breaks alerting as the backend only look for it in the query model.

With this we ensure that `timeField` is always persisted in the query model with the one configured in datasource settings.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #29788

**Special notes for your reviewer**:


