### PR TITLE
Chore: Automatically infer types for dashgrid connected components 

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx
@@ -1,4 +1,4 @@
-// Libaries
+// Libraries
 import React, { Component } from 'react';
 import { dateMath, GrafanaTheme, TimeZone } from '@grafana/data';
 import { css } from 'emotion';
@@ -7,9 +7,6 @@ import { css } from 'emotion';
 import { DashboardModel } from '../../state';
 import { LocationState, CoreEvents } from 'app/types';
 import { TimeRange } from '@grafana/data';
-
-// State
-import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 
 // Components
 import { RefreshPicker, withTheme, stylesFactory, Themeable, defaultIntervals } from '@grafana/ui';
@@ -31,7 +28,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
 export interface Props extends Themeable {
   dashboard: DashboardModel;
   location: LocationState;
-  onChangeTimeZone: typeof updateTimeZoneForSession;
+  onChangeTimeZone: (timeZone: TimeZone) => void;
 }
 class UnthemedDashNavTimeControls extends Component<Props> {
   componentDidMount() {

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -43,6 +43,30 @@ interface OwnProps {
   sourcePanel: PanelModel;
 }
 
+const mapStateToProps = (state: StoreState) => {
+  const panel = state.panelEditor.getPanel();
+  const { plugin } = getPanelStateById(state.dashboard, panel.id);
+
+  return {
+    location: state.location,
+    plugin: plugin,
+    panel,
+    initDone: state.panelEditor.initDone,
+    tabs: getPanelEditorTabs(state.location, plugin),
+    uiState: state.panelEditor.ui,
+    variables: getVariables(state),
+  };
+};
+
+const mapDispatchToProps = {
+  updateLocation,
+  initPanelEditor,
+  panelEditorCleanUp,
+  setDiscardChanges,
+  updatePanelEditorUIState,
+  updateTimeZoneForSession,
+};
+
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type Props = OwnProps & ConnectedProps<typeof connector>;
@@ -302,32 +326,6 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
       </div>
     );
   }
-}
-
-function mapStateToProps(state: StoreState) {
-  const panel = state.panelEditor.getPanel();
-  const { plugin } = getPanelStateById(state.dashboard, panel.id);
-
-  return {
-    location: state.location,
-    plugin: plugin,
-    panel,
-    initDone: state.panelEditor.initDone,
-    tabs: getPanelEditorTabs(state.location, plugin),
-    uiState: state.panelEditor.ui,
-    variables: getVariables(state),
-  };
-}
-
-function mapDispatchToProps() {
-  return {
-    updateLocation,
-    initPanelEditor,
-    panelEditorCleanUp,
-    setDiscardChanges,
-    updatePanelEditorUIState,
-    updateTimeZoneForSession,
-  };
 }
 
 export const PanelEditor = connector(PanelEditorUnconnected);

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -1,10 +1,10 @@
 import React, { PureComponent } from 'react';
-import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { css, cx } from 'emotion';
 import { Subscription } from 'rxjs';
 
-import { FieldConfigSource, GrafanaTheme, PanelPlugin } from '@grafana/data';
+import { FieldConfigSource, GrafanaTheme } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Button, HorizontalGroup, Icon, RadioButtonGroup, stylesFactory } from '@grafana/ui';
 
@@ -27,15 +27,14 @@ import { initPanelEditor, panelEditorCleanUp, updatePanelEditorUIState } from '.
 
 import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 import { updateLocation } from 'app/core/reducers/location';
-import { PanelEditorUIState, setDiscardChanges } from './state/reducers';
+import { setDiscardChanges } from './state/reducers';
 
 import { getPanelEditorTabs } from './state/selectors';
 import { getPanelStateById } from '../../state/selectors';
 import { getVariables } from 'app/features/variables/state/selectors';
 
-import { CoreEvents, LocationState, StoreState } from 'app/types';
+import { CoreEvents, StoreState } from 'app/types';
 import { DisplayMode, displayModes, PanelEditorTab } from './types';
-import { VariableModel } from 'app/features/variables/types';
 import { DashboardModel, PanelModel } from '../../state';
 import { PanelOptionsChangedEvent } from 'app/types/events';
 
@@ -44,26 +43,11 @@ interface OwnProps {
   sourcePanel: PanelModel;
 }
 
-interface ConnectedProps {
-  location: LocationState;
-  plugin?: PanelPlugin;
-  panel: PanelModel;
-  initDone: boolean;
-  tabs: PanelEditorTab[];
-  uiState: PanelEditorUIState;
-  variables: VariableModel[];
-}
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
-interface DispatchProps {
-  updateLocation: typeof updateLocation;
-  initPanelEditor: typeof initPanelEditor;
-  panelEditorCleanUp: typeof panelEditorCleanUp;
-  setDiscardChanges: typeof setDiscardChanges;
-  updatePanelEditorUIState: typeof updatePanelEditorUIState;
-  updateTimeZoneForSession: typeof updateTimeZoneForSession;
-}
+type PropsFromRedux = ConnectedProps<typeof connector>;
 
-type Props = OwnProps & ConnectedProps & DispatchProps;
+type Props = OwnProps & PropsFromRedux;
 
 export class PanelEditorUnconnected extends PureComponent<Props> {
   private eventSubs?: Subscription;
@@ -322,7 +306,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = state => {
+function mapStateToProps(state: StoreState) {
   const panel = state.panelEditor.getPanel();
   const { plugin } = getPanelStateById(state.dashboard, panel.id);
 
@@ -335,18 +319,20 @@ const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = s
     uiState: state.panelEditor.ui,
     variables: getVariables(state),
   };
-};
+}
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = {
-  updateLocation,
-  initPanelEditor,
-  panelEditorCleanUp,
-  setDiscardChanges,
-  updatePanelEditorUIState,
-  updateTimeZoneForSession,
-};
+function mapDispatchToProps() {
+  return {
+    updateLocation,
+    initPanelEditor,
+    panelEditorCleanUp,
+    setDiscardChanges,
+    updatePanelEditorUIState,
+    updateTimeZoneForSession,
+  };
+}
 
-export const PanelEditor = connect(mapStateToProps, mapDispatchToProps)(PanelEditorUnconnected);
+export const PanelEditor = connector(PanelEditorUnconnected);
 
 /*
  * Styles

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -45,8 +45,6 @@ interface OwnProps {
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 export class PanelEditorUnconnected extends PureComponent<Props> {

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -47,7 +47,7 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
-type Props = OwnProps & PropsFromRedux;
+type Props = OwnProps & ConnectedProps<typeof connector>;
 
 export class PanelEditorUnconnected extends PureComponent<Props> {
   private eventSubs?: Subscription;

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -1,4 +1,4 @@
-// Libaries
+// Libraries
 import React, { PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
 import ReactGridLayout, { ItemCallback } from 'react-grid-layout';
@@ -102,7 +102,7 @@ export interface Props {
 }
 
 export class DashboardGrid extends PureComponent<Props> {
-  private panelMap: { [id: string]: PanelModel };
+  private panelMap: { [id: string]: PanelModel } = {};
   private panelRef: { [id: string]: HTMLElement } = {};
   private eventSubs = new Subscription();
 

--- a/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { connect, MapStateToProps, MapDispatchToProps } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 
 // Components
 import { PanelChrome } from './PanelChrome';
@@ -25,23 +25,30 @@ export interface OwnProps {
   isInView: boolean;
 }
 
-export interface ConnectedProps {
-  plugin?: PanelPlugin | null;
-}
-
-export interface DispatchProps {
-  initDashboardPanel: typeof initDashboardPanel;
-  updateLocation: typeof updateLocation;
-}
-
-export type Props = OwnProps & ConnectedProps & DispatchProps;
-
 export interface State {
   isLazy: boolean;
 }
 
+const mapStateToProps = (state: StoreState, props: OwnProps) => {
+  const panelState = state.dashboard.panels[props.panel.id];
+  if (!panelState) {
+    return { plugin: null };
+  }
+
+  return {
+    plugin: panelState.plugin,
+  };
+};
+
+const mapDispatchToProps = { initDashboardPanel, updateLocation };
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+export type Props = OwnProps & PropsFromRedux;
+
 export class DashboardPanelUnconnected extends PureComponent<Props, State> {
-  element: HTMLElement;
   specialPanels: { [key: string]: Function } = {};
 
   constructor(props: Props) {
@@ -140,17 +147,4 @@ export class DashboardPanelUnconnected extends PureComponent<Props, State> {
   }
 }
 
-const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = (state, props) => {
-  const panelState = state.dashboard.panels[props.panel.id];
-  if (!panelState) {
-    return { plugin: null };
-  }
-
-  return {
-    plugin: panelState.plugin,
-  };
-};
-
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = { initDashboardPanel, updateLocation };
-
-export const DashboardPanel = connect(mapStateToProps, mapDispatchToProps)(DashboardPanelUnconnected);
+export const DashboardPanel = connector(DashboardPanelUnconnected);

--- a/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardPanel.tsx
@@ -44,9 +44,7 @@ const mapDispatchToProps = { initDashboardPanel, updateLocation };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-type PropsFromRedux = ConnectedProps<typeof connector>;
-
-export type Props = OwnProps & PropsFromRedux;
+export type Props = OwnProps & ConnectedProps<typeof connector>;
 
 export class DashboardPanelUnconnected extends PureComponent<Props, State> {
   specialPanels: { [key: string]: Function } = {};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Refactor types for dashgrid components so the types for connected props are automatically inferred. This removes the need to automatically declare types for those props and fixes type errors in strict mode related to connected components. 
