### PR TITLE
Expressions: support ${my var} syntax

### DIFF
--- a/pkg/expr/mathexp/parse/lex.go
+++ b/pkg/expr/mathexp/parse/lex.go
@@ -288,6 +288,21 @@ func lexFunc(l *lexer) stateFn {
 
 func lexVar(l *lexer) stateFn {
 	hasChar := false
+	if l.peek() == '{' {
+		_ = l.next()
+		for {
+			switch r := l.next(); {
+			case r == '}':
+				l.emit(itemVar)
+				return lexItem
+			case r == eof:
+				return l.errorf("unterminated variable missing closing }")
+			default:
+				// absorb
+			}
+		}
+	}
+
 	for {
 		switch r := l.next(); {
 		case unicode.IsLetter(r):

--- a/pkg/expr/mathexp/parse/lex.go
+++ b/pkg/expr/mathexp/parse/lex.go
@@ -343,7 +343,6 @@ func isSpace(r rune) bool {
 
 // isVarchar should maybe be used in place of unicode is letter above,
 // but do not want to modify it at this time, so adding lint exception.
-// nolint:unused,deadcode
 func isVarchar(r rune) bool {
 	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
 }

--- a/pkg/expr/mathexp/parse/lex.go
+++ b/pkg/expr/mathexp/parse/lex.go
@@ -293,19 +293,24 @@ func lexVar(l *lexer) stateFn {
 		for {
 			switch r := l.next(); {
 			case r == '}':
+				if !hasChar {
+					return l.errorf("incomplete variable")
+				}
 				l.emit(itemVar)
 				return lexItem
 			case r == eof:
 				return l.errorf("unterminated variable missing closing }")
+			case isVarchar(r) || isSpace(r):
+				hasChar = true
 			default:
-				// absorb
+				return l.errorf("unsupported variable character")
 			}
 		}
 	}
 
 	for {
 		switch r := l.next(); {
-		case unicode.IsLetter(r):
+		case isVarchar(r):
 			hasChar = true
 			// absorb
 		default:

--- a/pkg/expr/mathexp/parse/lex.go
+++ b/pkg/expr/mathexp/parse/lex.go
@@ -341,8 +341,6 @@ func isSpace(r rune) bool {
 	return unicode.IsSpace(r)
 }
 
-// isVarchar should maybe be used in place of unicode is letter above,
-// but do not want to modify it at this time, so adding lint exception.
 func isVarchar(r rune) bool {
 	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
 }

--- a/pkg/expr/mathexp/parse/lex_test.go
+++ b/pkg/expr/mathexp/parse/lex_test.go
@@ -97,6 +97,16 @@ var lexTests = []lexTest{
 		{itemNumber, 0, "1.2e-4"},
 		tEOF,
 	}},
+	{"curly brace var", "${My Var}", []item{
+		{itemVar, 0, "${My Var}"},
+		tEOF,
+	}},
+	{"curly brace var plus 1", "${My Var} + 1", []item{
+		{itemVar, 0, "${My Var}"},
+		tPlus,
+		{itemNumber, 0, "1"},
+		tEOF,
+	}},
 	{"number plus var", "1 + $A", []item{
 		{itemNumber, 0, "1"},
 		tPlus,
@@ -112,6 +122,9 @@ var lexTests = []lexTest{
 	}},
 	{"invalid var", "$", []item{
 		{itemError, 0, "incomplete variable"},
+	}},
+	{"invalid curly var", "${adf sd", []item{
+		{itemError, 0, "unterminated variable missing closing }"},
 	}},
 }
 

--- a/pkg/expr/mathexp/parse/node.go
+++ b/pkg/expr/mathexp/parse/node.go
@@ -88,7 +88,7 @@ func (t NodeType) String() string {
 type VarNode struct {
 	NodeType
 	Pos
-	Name string // Without the $
+	Name string // Without the $ or {}
 	Text string // Raw
 }
 

--- a/pkg/expr/mathexp/parse/parse.go
+++ b/pkg/expr/mathexp/parse/parse.go
@@ -300,8 +300,9 @@ func (t *Tree) v() Node {
 func (t *Tree) Var() (v *VarNode) {
 	token := t.next()
 	varNoPrefix := strings.TrimPrefix(token.val, "$")
-	t.VarNames = append(t.VarNames, varNoPrefix)
-	return newVar(token.pos, varNoPrefix, token.val)
+	varNoBraces := strings.TrimSuffix(strings.TrimPrefix(varNoPrefix, "{"), "}")
+	t.VarNames = append(t.VarNames, varNoBraces)
+	return newVar(token.pos, varNoBraces, token.val)
 }
 
 // Func parses a FuncNode.


### PR DESCRIPTION
Allow variables with spaces if in curly braces, e.g. `${my var}`. This is so expressions are less limited with what refId names can be when that (https://github.com/grafana/grafana/pull/29779) is merged.
