### PR TITLE
Chore: Upgrade 6.7.x Ubuntu base image to 20.04

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -34,7 +34,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN ./node_modules/.bin/grunt build
 
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 EXPOSE 3000

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -64,7 +64,7 @@ docker_build () {
   else
     libc=""
     dockerfile="ubuntu.Dockerfile"
-    base_image="${base_arch}ubuntu:19.10"
+    base_image="${base_arch}ubuntu:20.04"
   fi
 
   grafana_tgz="grafana-latest.linux-${arch}${libc}.tar.gz"

--- a/packaging/docker/ubuntu.Dockerfile
+++ b/packaging/docker/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:19.10
+ARG BASE_IMAGE=ubuntu:20.04
 FROM ${BASE_IMAGE} AS grafana-builder
 
 ARG GRAFANA_TGZ="grafana-latest.linux-x64.tar.gz"


### PR DESCRIPTION
**What this PR does / why we need it**:
For 6.7.x, upgrade our Ubuntu based Docker images to 20.04, since 19.10 is EOL since July 2020, and consequently won't build.