### PR TITLE
Sparkline: Fixes issue with sparkline that sent in custom fillColor instead of fillOpacity

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -81,7 +81,7 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
     }
 
     if (fillOpacityNumber !== 0) {
-      fillConfig.fill = tinycolor(lineColor)
+      fillConfig.fill = tinycolor(fillColor ?? lineColor)
         .setAlpha(fillOpacityNumber / 100)
         .toRgbString();
     }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -73,12 +73,17 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
 
     let fillConfig: any | undefined;
     let fillOpacityNumber = fillOpacity ?? 0;
-    if (fillColor && fillOpacityNumber !== 0) {
+
+    if (fillColor) {
       fillConfig = {
-        fill: tinycolor(fillColor)
-          .setAlpha(fillOpacityNumber / 100)
-          .toRgbString(),
+        fill: fillColor,
       };
+    }
+
+    if (fillOpacityNumber !== 0) {
+      fillConfig.fill = tinycolor(lineColor)
+        .setAlpha(fillOpacityNumber / 100)
+        .toRgbString();
     }
 
     return {


### PR DESCRIPTION
Introduced by PR merged earlier today where I changed the logic a bit and accidentally removed the feature to send in fillColor but not fillOpacity
