### PR TITLE
Chore: remove unused datasource status enum

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -341,11 +341,6 @@ export interface QueryEditorProps<
   history?: HistoryItem[];
 }
 
-export enum DataSourceStatus {
-  Connected,
-  Disconnected,
-}
-
 // TODO: not really needed but used as type in some data sources and in DataQueryRequest
 export enum ExploreMode {
   Logs = 'Logs',


### PR DESCRIPTION
I stumbled into this enum...  it is not used, so we should remove it