### PR TITLE
Docs: Add CloudWatch `resource_arns()` Multiple Tag Example

### DIFF
--- a/docs/sources/datasources/cloudwatch.md
+++ b/docs/sources/datasources/cloudwatch.md
@@ -278,6 +278,7 @@ Example dimension queries which will return list of resources for individual AWS
 | `dimension_values(us-east-1,AWS/S3,BucketSizeBytes,BucketName)`                                                               | S3               |
 | `dimension_values(us-east-1,CWAgent,disk_used_percent,device,{"InstanceId":"$instance_id"})`                                  | CloudWatch Agent |
 | `resource_arns(eu-west-1,elasticloadbalancing:loadbalancer,{"elasticbeanstalk:environment-name":["myApp-dev","myApp-prod"]})` | ELB              |
+| `resource_arns(eu-west-1,elasticloadbalancing:loadbalancer,{"Component":["$service"],"Environment":["$environment"]})`        | ELB              |
 | `resource_arns(eu-west-1,ec2:instance,{"elasticbeanstalk:environment-name":["myApp-dev","myApp-prod"]})`                      | EC2              |
 
 ## ec2_instance_attribute examples


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds a small example to documentation outlining how multiple AWS tags can be used with the `resource_arns()` function of the AWS CloudWatch integration ([link](https://grafana.com/docs/grafana/latest/datasources/cloudwatch/)).  This example would have helped me when using this function by showing me how to specify multiple tags as part of the query.

**Which issue(s) this PR fixes**: 
Fixes #29499 

**Special notes for your reviewer**: Let me know if there's a different format you'd prefer this to take - I see there is one ELB example already, and I wasn't sure if you'd object to there being two with slightly different tag specification formats.  