### PR TITLE
Loki: Fix logs context for Loki

### DIFF
--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -91,11 +91,11 @@ export class LogsContainer extends PureComponent<LogsContainerProps> {
     return [];
   };
 
-  showContextToggle = (): boolean => {
+  showContextToggle = (row?: LogRowModel): boolean => {
     const { datasourceInstance } = this.props;
 
     if (datasourceInstance?.showContextToggle) {
-      return datasourceInstance.showContextToggle();
+      return datasourceInstance.showContextToggle(row);
     }
 
     return false;


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to https://github.com/grafana/grafana/pull/28764/files. We weren't passing the log row to the `datasourceInstance.showContextToggle` and therefore for Loki, it always returned false - the context didn't work. 

