### PR TITLE
Elasticsearch: remove timeSrv dependency for logs context

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EventsWithValidation, regexValidation, LegacyForms } from '@grafana/ui';
 const { Select, Input, FormField } = LegacyForms;
-import { ElasticsearchOptions } from '../types';
+import { ElasticsearchOptions, Interval } from '../types';
 import { DataSourceSettings, SelectableValue } from '@grafana/data';
 
 const indexPatternTypes = [
@@ -170,7 +170,9 @@ const jsonDataChangeHandler = (key: keyof ElasticsearchOptions, value: Props['va
   });
 };
 
-const intervalHandler = (value: Props['value'], onChange: Props['onChange']) => (option: SelectableValue<string>) => {
+const intervalHandler = (value: Props['value'], onChange: Props['onChange']) => (
+  option: SelectableValue<Interval | 'none'>
+) => {
   const { database } = value;
   // If option value is undefined it will send its label instead so we have to convert made up value to undefined here.
   const newInterval = option.value === 'none' ? undefined : option.value;

--- a/public/app/plugins/datasource/elasticsearch/index_pattern.ts
+++ b/public/app/plugins/datasource/elasticsearch/index_pattern.ts
@@ -33,23 +33,20 @@ export class IndexPattern {
   }
 
   getIndexList(from?: DateTime, to?: DateTime) {
+    // When no `from` or `to` is provided, we request data from 7 subsequent/previous indices
+    // for the provided index pattern.
+    // This is useful when requesting log context where the only time data we have is the log
+    // timestamp.
+    const indexOffset = 7;
     if (!this.interval) {
       return this.pattern;
     }
 
     const intervalInfo = intervalMap[this.interval];
-
-    if (!from) {
-      from = dateTime(to).add(-7, intervalInfo.amount);
-    }
-    if (!to) {
-      to = dateTime(from).add(7, intervalInfo.amount);
-    }
-
-    const start = dateTime(from)
+    const start = dateTime(from || dateTime(to).add(-indexOffset, intervalInfo.amount))
       .utc()
       .startOf(intervalInfo.startOf);
-    const endEpoch = dateTime(to)
+    const endEpoch = dateTime(to || dateTime(from).add(indexOffset, intervalInfo.amount))
       .utc()
       .startOf(intervalInfo.startOf)
       .valueOf();

--- a/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
@@ -1,7 +1,7 @@
 ///<amd-dependency path="test/specs/helpers" name="helpers" />
 
 import { IndexPattern } from '../index_pattern';
-import { toUtc, getLocale, setLocale } from '@grafana/data';
+import { toUtc, getLocale, setLocale, dateTime } from '@grafana/data';
 
 describe('IndexPattern', () => {
   const originalLocale = getLocale();
@@ -31,8 +31,8 @@ describe('IndexPattern', () => {
     describe('no interval', () => {
       test('should return correct index', () => {
         const pattern = new IndexPattern('my-metrics');
-        const from = new Date(2015, 4, 30, 1, 2, 3);
-        const to = new Date(2015, 5, 1, 12, 5, 6);
+        const from = dateTime(new Date(2015, 4, 30, 1, 2, 3));
+        const to = dateTime(new Date(2015, 5, 1, 12, 5, 6));
         expect(pattern.getIndexList(from, to)).toEqual('my-metrics');
       });
     });
@@ -40,8 +40,8 @@ describe('IndexPattern', () => {
     describe('daily', () => {
       test('should return correct index list', () => {
         const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
-        const from = new Date(1432940523000);
-        const to = new Date(1433153106000);
+        const from = dateTime(new Date(1432940523000));
+        const to = dateTime(new Date(1433153106000));
 
         const expected = ['asd-2015.05.29', 'asd-2015.05.30', 'asd-2015.05.31', 'asd-2015.06.01'];
 
@@ -51,13 +51,51 @@ describe('IndexPattern', () => {
       test('should format date using western arabic numerals regardless of locale', () => {
         setLocale('ar_SA'); // saudi-arabic, formatting for YYYY.MM.DD looks like "٢٠٢٠.٠٩.٠٣"
         const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
-        const from = new Date(1432940523000);
-        const to = new Date(1433153106000);
+        const from = dateTime(new Date(1432940523000));
+        const to = dateTime(new Date(1433153106000));
 
         const expected = ['asd-2015.05.29', 'asd-2015.05.30', 'asd-2015.05.31', 'asd-2015.06.01'];
 
         expect(pattern.getIndexList(from, to)).toEqual(expected);
       });
+    });
+  });
+
+  describe('when getting index list from single date', () => {
+    it('Should return index matching the starting time and subsequent ones', () => {
+      const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
+      const from = dateTime(new Date(1432940523000));
+
+      const expected = [
+        'asd-2015.05.29',
+        'asd-2015.05.30',
+        'asd-2015.05.31',
+        'asd-2015.06.01',
+        'asd-2015.06.02',
+        'asd-2015.06.03',
+        'asd-2015.06.04',
+        'asd-2015.06.05',
+      ];
+
+      expect(pattern.getIndexList(from)).toEqual(expected);
+    });
+
+    it('Should return index matching the starting time and previous ones', () => {
+      const pattern = new IndexPattern('[asd-]YYYY.MM.DD', 'Daily');
+      const to = dateTime(new Date(1432940523000));
+
+      const expected = [
+        'asd-2015.05.22',
+        'asd-2015.05.23',
+        'asd-2015.05.24',
+        'asd-2015.05.25',
+        'asd-2015.05.26',
+        'asd-2015.05.27',
+        'asd-2015.05.28',
+        'asd-2015.05.29',
+      ];
+
+      expect(pattern.getIndexList(undefined, to)).toEqual(expected);
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -8,10 +8,12 @@ import {
   MetricAggregationType,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 
+export type Interval = 'Hourly' | 'Daily' | 'Weekly' | 'Monthly' | 'Yearly';
+
 export interface ElasticsearchOptions extends DataSourceJsonData {
   timeField: string;
   esVersion: number;
-  interval?: string;
+  interval?: Interval;
   timeInterval: string;
   maxConcurrentShardRequests?: number;
   logMessageField?: string;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Removes the dependency on timeSrv for log rows context as part of https://github.com/grafana/grafana/pull/29770

**Special notes for your reviewer**:
instead of limiting the contextual logs to the currently selected timeframe, we use the timestamp of the log we are visualizing the context for as a starting point to request logs.

Since not having a predefined time range doesn't allow us to calculate all the indices we need to query, when generating indices without a `from` or a `to` param, we default to generating 7 indices according to the configured index pattern.