### PR TITLE
Docs: Add info about typing of connected props to Redux style guide

### DIFF
--- a/contribute/style-guides/redux.md
+++ b/contribute/style-guides/redux.md
@@ -46,3 +46,37 @@ const dispatchedActions = await thunkTester(initialState)
 
 expect(dispatchedActions).toEqual([someAction('reducer tests')]);
 ```
+
+## Typing of connected props
+
+It is possible to infer connected props automatically from `mapStateToProps` and `mapDispatchToProps` using a helper type `ConnectedProps` from Redux. For this to work the `connect` call has to be split into two parts.
+
+```typescript
+import { connect, ConnectedProps } from 'react-redux'
+
+const mapStateToProps = (state: StoreState) => {
+  return {
+    location: state.location,
+    initDone: state.panelEditor.initDone,
+    uiState: state.panelEditor.ui,
+  };
+};
+
+const mapDispatchToProps = {
+  updateLocation,
+  initPanelEditor,
+  panelEditorCleanUp,
+  setDiscardChanges,
+  updatePanelEditorUIState,
+  updateTimeZoneForSession,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+class PanelEditorUnconnected extends PureComponent<Props> {};
+
+export const PanelEditor = connector(PanelEditorUnconnected);
+```
+More examples can be found in the [Redux docs](https://react-redux.js.org/using-react-redux/static-typing#inferring-the-connected-props-automatically).

--- a/contribute/style-guides/redux.md
+++ b/contribute/style-guides/redux.md
@@ -79,4 +79,4 @@ class PanelEditorUnconnected extends PureComponent<Props> {};
 
 export const PanelEditor = connector(PanelEditorUnconnected);
 ```
-More examples can be found in the [Redux docs](https://react-redux.js.org/using-react-redux/static-typing#inferring-the-connected-props-automatically).
+For more examples, refer to the [Redux docs](https://react-redux.js.org/using-react-redux/static-typing#inferring-the-connected-props-automatically).


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Add info about typing of connected props to Redux style guide with examples and link to Redux docs.

