### PR TITLE
Fix two ini-file typos regarding LDAP

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -482,7 +482,7 @@ enabled = false
 config_file = /etc/grafana/ldap.toml
 allow_sign_up = true
 
-# LDAP backround sync (Enterprise only)
+# LDAP background sync (Enterprise only)
 # At 1 am every day
 sync_cron = "0 0 1 * * *"
 active_sync_enabled = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -471,7 +471,7 @@
 ;config_file = /etc/grafana/ldap.toml
 ;allow_sign_up = true
 
-# LDAP backround sync (Enterprise only)
+# LDAP background sync (Enterprise only)
 # At 1 am every day
 ;sync_cron = "0 0 1 * * *"
 ;active_sync_enabled = true


### PR DESCRIPTION

Fixes 
* two simple typos in conf/sample.ini and conf/defaults.in regarding LDAP

