### PR TITLE
Variables: Fixes so clicking on Selected in drop down will exclude All value from selection

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
@@ -15,7 +15,7 @@ import {
   updateSearchQuery,
 } from './reducer';
 import { reducerTester } from '../../../../../test/core/redux/reducerTester';
-import { QueryVariableModel, VariableTag, VariableOption } from '../../types';
+import { QueryVariableModel, VariableOption, VariableTag } from '../../types';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../../state/types';
 
 const getVariableTestContext = (extend: Partial<OptionsPickerState>) => {
@@ -570,7 +570,7 @@ describe('optionsPickerReducer', () => {
   });
 
   describe('when toggleAllOptions is dispatched', () => {
-    it('should toggle all values to true', () => {
+    it('should toggle all values except All to true', () => {
       const { initialState } = getVariableTestContext({
         options: [
           { text: 'All', value: '$__all', selected: false },
@@ -587,12 +587,11 @@ describe('optionsPickerReducer', () => {
         .thenStateShouldEqual({
           ...initialState,
           options: [
-            { text: 'All', value: '$__all', selected: true },
+            { text: 'All', value: '$__all', selected: false },
             { text: 'A', value: 'A', selected: true },
             { text: 'B', value: 'B', selected: true },
           ],
           selectedValues: [
-            { text: 'All', value: '$__all', selected: true },
             { text: 'A', value: 'A', selected: true },
             { text: 'B', value: 'B', selected: true },
           ],

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -221,10 +221,12 @@ const optionsPickerSlice = createSlice({
         return applyStateChanges(state, updateOptions);
       }
 
-      state.selectedValues = state.options.map(option => ({
-        ...option,
-        selected: true,
-      }));
+      state.selectedValues = state.options
+        .filter(option => option.value !== ALL_VARIABLE_VALUE)
+        .map(option => ({
+          ...option,
+          selected: true,
+        }));
 
       return applyStateChanges(state, updateOptions);
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the behaviour when the user clicks `Selected` in a variable drop down menu. Previously it would include the `All` value when selecting all values. With this PR it will change to exclude the `All` value.

Enjoy the review. 

**Which issue(s) this PR fixes**:
Fixes #28751

**Special notes for your reviewer**:

