### PR TITLE
Storybook: Display palette and colors for dark and light themes 

### DIFF
--- a/packages/grafana-ui/src/components/ThemeColors/Colors.story.tsx
+++ b/packages/grafana-ui/src/components/ThemeColors/Colors.story.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Colors } from './Colors';
+
+export default {
+  title: 'Docs Overview/Colors',
+  component: Colors,
+  decorators: [],
+  parameters: {
+    options: {
+      showPanel: false,
+    },
+    docs: {},
+  },
+};
+
+export const ColorsDemo = () => {
+  return <Colors />;
+};

--- a/packages/grafana-ui/src/components/ThemeColors/Colors.tsx
+++ b/packages/grafana-ui/src/components/ThemeColors/Colors.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { css, cx } from 'emotion';
+import darkTheme from '../../themes/dark';
+import lightTheme from '../../themes/light';
+import { useStyles } from '../../themes';
+
+export const Colors = () => {
+  const styles = useStyles(getStyles);
+  const renderColors = (color: any) => {
+    return Object.entries(color)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([name, color]: [string, any]) => {
+        return (
+          <div key={name} className={styles.wrapper}>
+            <span className={styles.name}>
+              {name} ({color})
+            </span>
+            <span
+              className={cx(
+                styles.color,
+                css`
+                  background: ${color};
+                `
+              )}
+            />
+          </div>
+        );
+      });
+  };
+
+  return (
+    <div className={styles.container}>
+      <div>
+        <h2>Light theme</h2>
+        <h3 className={styles.subheader}>Palette</h3>
+        {renderColors(lightTheme.palette)}
+        <h3 className={styles.subheader}>Colors</h3>
+        {renderColors(lightTheme.colors)}
+      </div>
+
+      <div>
+        <h2>Dark theme</h2>
+        <h3 className={styles.subheader}>Palette</h3>
+        {renderColors(darkTheme.palette)}
+        <h3 className={styles.subheader}>Colors</h3>
+        {renderColors(darkTheme.colors)}
+      </div>
+    </div>
+  );
+};
+
+const getStyles = () => {
+  return {
+    subheader: css`
+      margin: 20px 0;
+    `,
+    container: css`
+      display: flex;
+      justify-content: space-around;
+      width: 100%;
+    `,
+    wrapper: css`
+      display: flex;
+      align-items: center;
+    `,
+    name: css`
+      width: 250px;
+    `,
+    color: css`
+      display: inline-block;
+      width: 50px;
+      height: 50px;
+    `,
+  };
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Display all the colors in storybook, grouped by theme and alphabetically sorted. Requested by the UX team as it helps to quickly see what colors we currently have. 

![Screenshot 2020-12-15 at 16 19 46](https://user-images.githubusercontent.com/8878045/102227683-850a8900-3ef2-11eb-91b4-bb6c722c0e0b.png)
