### PR TITLE
GraphNG: Do not set fillColor from GraphNG only opacity

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -157,12 +157,12 @@ export const GraphNG: React.FC<GraphNGProps> = ({
       builder.addSeries({
         scaleKey,
         drawStyle: customConfig.drawStyle!,
-        lineColor: seriesColor,
+        lineColor: customConfig.lineColor ?? seriesColor,
         lineWidth: customConfig.lineWidth,
         lineInterpolation: customConfig.lineInterpolation,
         showPoints,
         pointSize: customConfig.pointSize,
-        pointColor: seriesColor,
+        pointColor: customConfig.pointColor ?? seriesColor,
         fillOpacity: customConfig.fillOpacity,
         spanNulls: customConfig.spanNulls || false,
       });

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -164,7 +164,6 @@ export const GraphNG: React.FC<GraphNGProps> = ({
         pointSize: customConfig.pointSize,
         pointColor: seriesColor,
         fillOpacity: customConfig.fillOpacity,
-        fillColor: seriesColor,
         spanNulls: customConfig.spanNulls || false,
       });
 

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -81,9 +81,11 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
     }
 
     if (fillOpacityNumber !== 0) {
-      fillConfig.fill = tinycolor(fillColor ?? lineColor)
-        .setAlpha(fillOpacityNumber / 100)
-        .toRgbString();
+      fillConfig = {
+        fill: tinycolor(fillColor ?? lineColor)
+          .setAlpha(fillOpacityNumber / 100)
+          .toRgbString(),
+      };
     }
 
     return {


### PR DESCRIPTION
I am not sure what the logic should be here, it's a bit messy.

The Sparkline needs to send in different line + fill color, but in GraphNG we only have series color, which we passed in via both lineColor and fillColor so
there is no easy way in the builder to figure out when set the fill color and to what.

One option is from GraphNG not to set the fillColor and only set lineColor and opacity, that way the SeriesBuilder will only set the fill when fillOpacity > 0 or when fillColor is set. 

An alternative would be to require a fillOpacity = > 0 for any fillColor to be used. Would require that users of Sparkline set fillColor and fillOpacity > 0 for the fillColor to be used 
