### PR TITLE
Prometheus: Fix autocomplete does not work on incomplete input

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -169,7 +169,6 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const operatorsPattern = /[+\-*/^%]/;
     const isNextOperand = text.match(operatorsPattern);
 
-    console.log(wrapperClasses);
 
     // Determine candidates by CSS context
     if (wrapperClasses.includes('context-range')) {

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -169,7 +169,6 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const operatorsPattern = /[+\-*/^%]/;
     const isNextOperand = text.match(operatorsPattern);
 
-
     // Determine candidates by CSS context
     if (wrapperClasses.includes('context-range')) {
       // Suggestions for metric[|]

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -329,14 +329,11 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const suffix = line.substr(cursorOffset);
     const prefix = line.substr(0, cursorOffset);
     const isValueStart = text.match(/^(=|=~|!=|!~)/);
-    const isValueEnd = suffix.match(/^"?[,}]/);
-    // detect cursor in front of value, e.g., {key=|"}
+    // Detect cursor in front of value, e.g., {key=|"}
     const isPreValue = prefix.match(/(=|=~|!=|!~)$/) && suffix.match(/^"/);
 
-    // Don't suggestq anything at the beginning or inside a value
-    const isValueEmpty = isValueStart && isValueEnd;
-    const hasValuePrefix = isValueEnd && !isValueStart;
-    if ((!isValueEmpty && !hasValuePrefix) || isPreValue) {
+    // Don't suggest anything at the beginning or inside a value
+    if (isPreValue) {
       return { suggestions };
     }
 

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -169,6 +169,8 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const operatorsPattern = /[+\-*/^%]/;
     const isNextOperand = text.match(operatorsPattern);
 
+    console.log(wrapperClasses);
+
     // Determine candidates by CSS context
     if (wrapperClasses.includes('context-range')) {
       // Suggestions for metric[|]
@@ -329,11 +331,14 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const suffix = line.substr(cursorOffset);
     const prefix = line.substr(0, cursorOffset);
     const isValueStart = text.match(/^(=|=~|!=|!~)/);
+    const isValueEnd = suffix.match(/^"?[,}]|$/);
     // Detect cursor in front of value, e.g., {key=|"}
     const isPreValue = prefix.match(/(=|=~|!=|!~)$/) && suffix.match(/^"/);
 
     // Don't suggest anything at the beginning or inside a value
-    if (isPreValue) {
+    const isValueEmpty = isValueStart && isValueEnd;
+    const hasValuePrefix = isValueEnd && !isValueStart;
+    if ((!isValueEmpty && !hasValuePrefix) || isPreValue) {
       return { suggestions };
     }
 

--- a/public/app/plugins/datasource/prometheus/language_utils.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.test.ts
@@ -9,8 +9,9 @@ describe('parseSelector()', () => {
     expect(parsed.labelKeys).toEqual([]);
   });
 
-  it('throws if selector is broken', () => {
-    expect(() => parseSelector('{foo')).toThrow();
+  it('returns a clean selector from an unclosed selector', () => {
+    const parsed = parseSelector('{foo');
+    expect(parsed.selector).toBe('{}');
   });
 
   it('returns the selector sorted by label key', () => {

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -42,7 +42,7 @@ export function processLabels(labels: Array<{ [key: string]: string }>, withName
 }
 
 // const cleanSelectorRegexp = /\{(\w+="[^"\n]*?")(,\w+="[^"\n]*?")*\}/;
-export const selectorRegexp = /\{[^}]*?\}/;
+export const selectorRegexp = /\{[^}]*?\}?/;
 export const labelRegexp = /\b(\w+)(!?=~?)("[^"\n]*?")/g;
 export function parseSelector(query: string, cursorOffset = 1): { labelKeys: any[]; selector: string } {
   if (!query.match(selectorRegexp)) {

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -42,7 +42,7 @@ export function processLabels(labels: Array<{ [key: string]: string }>, withName
 }
 
 // const cleanSelectorRegexp = /\{(\w+="[^"\n]*?")(,\w+="[^"\n]*?")*\}/;
-export const selectorRegexp = /\{[^}]*?\}?/;
+export const selectorRegexp = /\{[^}]*?(\}|$)/;
 export const labelRegexp = /\b(\w+)(!?=~?)("[^"\n]*?")/g;
 export function parseSelector(query: string, cursorOffset = 1): { labelKeys: any[]; selector: string } {
   if (!query.match(selectorRegexp)) {

--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -393,7 +393,7 @@ const tokenizer: Grammar = {
     },
   },
   'context-labels': {
-    pattern: /\{[^}]*(?=})/,
+    pattern: /\{[^}]*(?=}?)/,
     greedy: true,
     inside: {
       comment: {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes autocomplete on incomplete input. 
![image](https://user-images.githubusercontent.com/30407135/102381577-b1dd9f80-3fc9-11eb-9521-09d499521afd.png)
![image](https://user-images.githubusercontent.com/30407135/102381685-d2a5f500-3fc9-11eb-8afa-7fc873677d5a.png)
![image](https://user-images.githubusercontent.com/30407135/102382992-501e3500-3fcb-11eb-99da-6be9c4f9907a.png)

This is unfortunately not going to work for metrics wrapped in functions if the function has correct ending brackets`)`, as we can't determine what is the end of the label. Autocomplete works in a way, where if the value from autocomplete is selected, we rewrite the content of the value up until the end of section/context. And as we don't know what is the end of the label-context is (`}` is missing), we would rewrite the whole end of the query. Therefore this is not implemented in this cases. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/20445

**Special notes for your reviewer**:

