### PR TITLE
Explore: Keep query keys consistent when removing query row

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -551,13 +551,11 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       nextQueries.push(generateNewKeyAndAddRefIdIfMissing(query, nextQueries, i));
     });
 
-    const nextQueryKeys: string[] = nextQueries.map(query => query.key!);
-
     return {
       ...state,
       queries: nextQueries,
       logsHighlighterExpressions: undefined,
-      queryKeys: nextQueryKeys,
+      queryKeys: getQueryKeys(nextQueries, state.datasourceInstance),
     };
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For the *queryKeys* that we are updating within Explore we use `getQueryKeys` function that generates queryKeys in the `datasource-index` form. However, in `removeQueryRow` we were using query.keys (that have different pattern and form) which means, that when we remove 1 query row, all others row's queryKeys are changed and all queryRows are  unmounted and new components are mounted. 

This PR fixes this. 