### PR TITLE
DataFrame: add a writable flag to fields

### DIFF
--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -49,6 +49,11 @@ export interface FieldConfig<TOptions extends object = any> {
   path?: string;
 
   /**
+   * True if data source can write a value to the path.  Auth/authz are supported separately
+   */
+  writeable?: boolean;
+
+  /**
    * True if data source field supports ad-hoc filters
    */
   filterable?: boolean;


### PR DESCRIPTION
For data sources that support writing values, this provides a consistent way to tell the front end that we can send a write request.

NOTE:  actually writing values is under development in some plugin repositories, eventually this will be promoted to the standard plugin API