### PR TITLE
PanelEdit: Need new data after plugin change

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -282,7 +282,6 @@ export class PanelChrome extends Component<Props, State> {
       'panel-content--no-padding': plugin.noPadding,
     });
     const panelOptions = panel.getOptions();
-    console.log('rendering panel');
 
     return (
       <>

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { Unsubscribable } from 'rxjs';
 // Components
@@ -51,7 +51,7 @@ export interface State {
   data: PanelData;
 }
 
-export class PanelChrome extends PureComponent<Props, State> {
+export class PanelChrome extends Component<Props, State> {
   readonly timeSrv: TimeSrv = getTimeSrv();
 
   querySubscription?: Unsubscribable;
@@ -122,6 +122,19 @@ export class PanelChrome extends PureComponent<Props, State> {
         }
       }
     }
+  }
+
+  shouldComponentUpdate(prevProps: Props, prevState: State) {
+    const { plugin, panel } = this.props;
+
+    // If plugin changed we need to process fieldOverrides again
+    // We do this by asking panel query runner to resend last result
+    if (prevProps.plugin !== plugin) {
+      panel.getQueryRunner().resendLastResult();
+      return false;
+    }
+
+    return true;
   }
 
   // Updates the response with information from the stream
@@ -269,6 +282,7 @@ export class PanelChrome extends PureComponent<Props, State> {
       'panel-content--no-padding': plugin.noPadding,
     });
     const panelOptions = panel.getOptions();
+    console.log('rendering panel');
 
     return (
       <>


### PR DESCRIPTION
Fixes issue when switching between React panels.

The data was not re-processed with the new panel plugins field options so we rendered the new panel with the old panel's custom field config, this
could lead to crashing the new panel plugin as it expected it's default custom config to have been applied.

Easiest fix was to detect this in PanelChrome and ignore rendering and instead ask the panel query runner to resend last result (which will pass it through applyFieldOverrides)

I could not find anyway to access the default implementation for PureComponent/react.memo to reuse the shallow compare, without adding new npm packages. This is
annonying.
