### PR TITLE
Chore: add as prop to InlineLabel to control rendered element

### DIFF
--- a/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
@@ -18,21 +18,31 @@ export interface Props extends Omit<LabelProps, 'css' | 'description' | 'categor
   /** @deprecated */
   /** This prop is deprecated and is not used anymore */
   isInvalid?: boolean;
+  /** @beta */
+  /** Controls which element the InlineLabel should be rendered into */
+  as?: React.ElementType;
 }
 
-export const InlineLabel: FunctionComponent<Props> = ({ children, className, tooltip, width, ...rest }) => {
+export const InlineLabel: FunctionComponent<Props> = ({
+  children,
+  className,
+  tooltip,
+  width,
+  as: Component = 'label',
+  ...rest
+}) => {
   const theme = useTheme();
   const styles = getInlineLabelStyles(theme, width);
 
   return (
-    <label className={cx(styles.label, className)} {...rest}>
+    <Component className={cx(styles.label, className)} {...rest}>
       {children}
       {tooltip && (
         <Tooltip placement="top" content={tooltip} theme="info">
           <Icon name="info-circle" size="sm" className={styles.icon} />
         </Tooltip>
       )}
-    </label>
+    </Component>
   );
 };
 


### PR DESCRIPTION
Adds a `as` prop to control the rendered element for `InlineLabel`

this way it can be used like: 

```tsx
<InlineLabel  as="span">
// ...
</InlineLabel>
```

that would result in 

```html
<span class="css-1fh8o8p-label">Simple label</span>
```

technically, as can receive any other element including other react components.

the simplest solution here would maybe be to have a boolean prop to switch between `label` and `div`, but I felt this could have been an interesting approach. What do you think @torkelo ?