### PR TITLE
Usage Stats: Introduce an interface for usage stats service

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -21,6 +21,12 @@ func init() {
 	registry.RegisterService(&UsageStatsService{})
 }
 
+type UsageStats interface {
+	GetUsageReport() (UsageReport, error)
+
+	RegisterMetric(name string, fn MetricFunc)
+}
+
 type MetricFunc func() (interface{}, error)
 
 type UsageStatsService struct {

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -25,6 +25,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// This is to ensure that the interface contract is held by the implementation
+func Test_InterfaceContractValidity(t *testing.T) {
+	newUsageStats := func() UsageStats {
+		return &UsageStatsService{}
+	}
+	v, ok := newUsageStats().(*UsageStatsService)
+
+	assert.NotNil(t, v)
+	assert.True(t, ok)
+}
+
 func TestMetrics(t *testing.T) {
 	t.Run("When sending usage stats", func(t *testing.T) {
 		uss := &UsageStatsService{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding an interface type for usage stats service allows us to not depend on the implementation outside of the package, for example when testing we can easily mock the service

**Which issue(s) this PR fixes**:
For more context, please have a look at the conversation in [this PR](https://github.com/grafana/grafana-enterprise/pull/938#discussion_r544296228). 

**Special notes for your reviewer**:
The usage stats service is not used elsewhere, outside of the package within OSS. It is going to be heavily used in the enterprise, once we start instrumenting enterprise features with more metrics. Thus, the change here is sufficient and we don't need extra refactoring to leverage the interface instead of passing the implementation type.

