### PR TITLE
PanelEdit: Update UI if panel plugin changes field config

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -127,12 +127,11 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   };
 
   onFieldConfigChange = (config: FieldConfigSource) => {
-    const { panel } = this.props;
-
-    panel.updateFieldConfig({
+    // we do not need to trigger force update here as the function call below
+    // fires PanelOptionsChangedEvent which we subscribe to above
+    this.props.panel.updateFieldConfig({
       ...config,
     });
-    this.forceUpdate();
   };
 
   onPanelOptionsChanged = (options: any) => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -223,6 +223,7 @@ export class PanelModel implements DataConfigSource {
 
   updateFieldConfig(config: FieldConfigSource) {
     this.fieldConfig = config;
+    this.events.publish(new PanelOptionsChangedEvent());
 
     this.resendLastResult();
     this.render();


### PR DESCRIPTION
Fixes so that the panel edit ui updates when field config is changed from panel plugin

Opted to reuse the event we already have as they both serve the exact same purpose (trigger re-render in PanelEditor) 