### PR TITLE
Folders: Removes the possibility to delete the General folder

### DIFF
--- a/public/app/features/search/constants.ts
+++ b/public/app/features/search/constants.ts
@@ -4,3 +4,4 @@ export const SEARCH_ITEM_HEIGHT = 48;
 export const SEARCH_ITEM_MARGIN = 4;
 export const DEFAULT_SORT = { label: 'A-Z', value: 'alpha-asc' };
 export const SECTION_STORAGE_KEY = 'search.sections';
+export const GENERAL_FOLDER_ID = 0;

--- a/public/app/features/search/hooks/useManageDashboards.test.ts
+++ b/public/app/features/search/hooks/useManageDashboards.test.ts
@@ -4,7 +4,8 @@ import { renderHook } from '@testing-library/react-hooks';
 import * as useSearch from './useSearch';
 import { DashboardQuery, DashboardSearchItemType, DashboardSection, SearchAction } from '../types';
 import { ManageDashboardsState } from '../reducers/manageDashboards';
-import { GENERAL_FOLDER_ID, useManageDashboards } from './useManageDashboards';
+import { useManageDashboards } from './useManageDashboards';
+import { GENERAL_FOLDER_ID } from '../constants';
 
 describe('useManageDashboards', () => {
   const useSearchMock = jest.spyOn(useSearch, 'useSearch');

--- a/public/app/features/search/hooks/useManageDashboards.test.ts
+++ b/public/app/features/search/hooks/useManageDashboards.test.ts
@@ -1,0 +1,97 @@
+import { Dispatch } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import * as useSearch from './useSearch';
+import { DashboardQuery, DashboardSearchItemType, DashboardSection, SearchAction } from '../types';
+import { ManageDashboardsState } from '../reducers/manageDashboards';
+import { GENERAL_FOLDER_ID, useManageDashboards } from './useManageDashboards';
+
+describe('useManageDashboards', () => {
+  const useSearchMock = jest.spyOn(useSearch, 'useSearch');
+  const toggle = async (section: DashboardSection) => section;
+
+  function setupTestContext({ results = [] }: { results?: DashboardSection[] } = {}) {
+    jest.clearAllMocks();
+
+    const state: ManageDashboardsState = {
+      results,
+      loading: false,
+      selectedIndex: 0,
+      initialLoading: false,
+      allChecked: false,
+    };
+    const dispatch: Dispatch<SearchAction> = (null as unknown) as Dispatch<SearchAction>;
+    useSearchMock.mockReturnValue({ state, dispatch, onToggleSection: toggle });
+    const dashboardQuery: DashboardQuery = ({} as unknown) as DashboardQuery;
+
+    const { result } = renderHook(() => useManageDashboards(dashboardQuery, {}));
+
+    return { result };
+  }
+
+  describe('when called and only General folder is selected', () => {
+    it('then canDelete should be false', () => {
+      const results: DashboardSection[] = [
+        { id: 1, checked: false, items: [], title: 'One', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+        {
+          id: GENERAL_FOLDER_ID,
+          checked: true,
+          items: [],
+          title: 'General',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
+        { id: 2, checked: false, items: [], title: 'Two', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+      ];
+
+      const { result } = setupTestContext({ results });
+
+      expect(result.current.canDelete).toBe(false);
+    });
+  });
+
+  describe('when called and General folder and another folder are selected', () => {
+    it('then canDelete should be true', () => {
+      const results: DashboardSection[] = [
+        { id: 1, checked: true, items: [], title: 'One', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+        {
+          id: GENERAL_FOLDER_ID,
+          checked: true,
+          items: [],
+          title: 'General',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
+        { id: 2, checked: false, items: [], title: 'Two', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+      ];
+
+      const { result } = setupTestContext({ results });
+
+      expect(result.current.canDelete).toBe(true);
+    });
+  });
+
+  describe('when called and no folder is selected', () => {
+    it('then canDelete should be false', () => {
+      const results: DashboardSection[] = [
+        { id: 1, checked: false, items: [], title: 'One', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+        {
+          id: GENERAL_FOLDER_ID,
+          checked: false,
+          items: [],
+          title: 'General',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
+        { id: 2, checked: false, items: [], title: 'Two', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+      ];
+
+      const { result } = setupTestContext({ results });
+
+      expect(result.current.canDelete).toBe(false);
+    });
+  });
+});

--- a/public/app/features/search/hooks/useManageDashboards.ts
+++ b/public/app/features/search/hooks/useManageDashboards.ts
@@ -5,8 +5,7 @@ import { DashboardQuery, DashboardSection, OnDeleteItems, OnMoveItems, OnToggleC
 import { DELETE_ITEMS, MOVE_ITEMS, TOGGLE_ALL_CHECKED, TOGGLE_CHECKED } from '../reducers/actionTypes';
 import { manageDashboardsReducer, manageDashboardsState, ManageDashboardsState } from '../reducers/manageDashboards';
 import { useSearch } from './useSearch';
-
-export const GENERAL_FOLDER_ID = 0;
+import { GENERAL_FOLDER_ID } from '../constants';
 
 export const useManageDashboards = (
   query: DashboardQuery,

--- a/public/app/features/search/hooks/useManageDashboards.ts
+++ b/public/app/features/search/hooks/useManageDashboards.ts
@@ -6,6 +6,8 @@ import { DELETE_ITEMS, MOVE_ITEMS, TOGGLE_ALL_CHECKED, TOGGLE_CHECKED } from '..
 import { manageDashboardsReducer, manageDashboardsState, ManageDashboardsState } from '../reducers/manageDashboards';
 import { useSearch } from './useSearch';
 
+export const GENERAL_FOLDER_ID = 0;
+
 export const useManageDashboards = (
   query: DashboardQuery,
   state: Partial<ManageDashboardsState> = {},
@@ -42,10 +44,10 @@ export const useManageDashboards = (
     () => results.some((result: DashboardSection) => result.items && result.items.some(item => item.checked)),
     [results]
   );
-  const canDelete = useMemo(() => canMove || results.some((result: DashboardSection) => result.checked), [
-    canMove,
-    results,
-  ]);
+  const canDelete = useMemo(
+    () => canMove || results.some((result: DashboardSection) => result.checked && result.id !== GENERAL_FOLDER_ID),
+    [canMove, results]
+  );
 
   const canSave = folder?.canSave;
   const hasEditPermissionInFolders = folder ? canSave : contextSrv.hasEditPermissionInFolders;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents the Delete button to appear when checking only the `General` folder for deletion, because that leads to a confusing state as described in #29880.

We could also make it so whenever you select folders for deletion, including the `General` folder, the Delete button will not be available. Not sure this is a good user experience, though. Please let me know if I should include this as well.

Enjoy the review 🎉 

**Which issue(s) this PR fixes**:
Fixes #29880

**Special notes for your reviewer**:

