### PR TITLE
Elasticsearch: Fix broken alerting when using pipeline aggregations

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.test.tsx
@@ -12,11 +12,19 @@ const query: ElasticsearchQuery = {
 };
 
 describe('ElasticsearchQueryContext', () => {
-  it('Should call onChange with the default query when the query is empty', () => {
+  it('Should call onChange and onRunQuery with the default query when the query is empty', () => {
     const datasource = { timeField: 'TIMEFIELD' } as ElasticDatasource;
     const onChange = jest.fn();
+    const onRunQuery = jest.fn();
 
-    render(<ElasticsearchProvider query={{ refId: 'A' }} onChange={onChange} datasource={datasource} />);
+    render(
+      <ElasticsearchProvider
+        query={{ refId: 'A' }}
+        onChange={onChange}
+        datasource={datasource}
+        onRunQuery={onRunQuery}
+      />
+    );
 
     const changedQuery: ElasticsearchQuery = onChange.mock.calls[0][0];
     expect(changedQuery.query).toBeDefined();
@@ -26,6 +34,8 @@ describe('ElasticsearchQueryContext', () => {
 
     // Should also set timeField to the configured `timeField` option in datasource configuration
     expect(changedQuery.timeField).toBe(datasource.timeField);
+
+    expect(onRunQuery).toHaveBeenCalled();
   });
 
   describe('useQuery Hook', () => {
@@ -37,7 +47,12 @@ describe('ElasticsearchQueryContext', () => {
 
     it('Should return the current query object', () => {
       const wrapper: FunctionComponent = ({ children }) => (
-        <ElasticsearchProvider datasource={{} as ElasticDatasource} query={query} onChange={() => {}}>
+        <ElasticsearchProvider
+          datasource={{} as ElasticDatasource}
+          query={query}
+          onChange={() => {}}
+          onRunQuery={() => {}}
+        >
           {children}
         </ElasticsearchProvider>
       );
@@ -61,7 +76,7 @@ describe('ElasticsearchQueryContext', () => {
       const datasource = {} as ElasticDatasource;
 
       const wrapper: FunctionComponent = ({ children }) => (
-        <ElasticsearchProvider datasource={datasource} query={query} onChange={() => {}}>
+        <ElasticsearchProvider datasource={datasource} query={query} onChange={() => {}} onRunQuery={() => {}}>
           {children}
         </ElasticsearchProvider>
       );

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -150,6 +150,7 @@ interface Logs extends BaseMetricAggregation {
 
 export interface BasePipelineMetricAggregation extends MetricAggregationWithField {
   type: PipelineMetricAggregationType;
+  pipelineAgg?: string;
 }
 
 interface PipelineMetricAggregationWithMultipleBucketPaths extends BaseMetricAggregation {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.test.ts
@@ -106,7 +106,7 @@ describe('Metric Aggregations Reducer', () => {
   it("Should correctly change aggregation's field", () => {
     const firstAggregation: MetricAggregation = {
       id: '1',
-      type: 'count',
+      type: 'min',
     };
     const secondAggregation: MetricAggregation = {
       id: '2',
@@ -116,12 +116,22 @@ describe('Metric Aggregations Reducer', () => {
     const expectedSecondAggregation = {
       ...secondAggregation,
       field: 'new field',
+      pipelineAgg: 'new field',
+    };
+
+    const expectedFirstAggregation = {
+      ...firstAggregation,
+      field: 'new field',
     };
 
     reducerTester()
       .givenReducer(reducer, [firstAggregation, secondAggregation])
+      // When changing a a pipelineAggregation field we set both pipelineAgg and field
       .whenActionIsDispatched(changeMetricField(secondAggregation.id, expectedSecondAggregation.field))
-      .thenStateShouldEqual([firstAggregation, expectedSecondAggregation]);
+      .thenStateShouldEqual([firstAggregation, expectedSecondAggregation])
+      // otherwhise only field
+      .whenActionIsDispatched(changeMetricField(firstAggregation.id, expectedFirstAggregation.field))
+      .thenStateShouldEqual([expectedFirstAggregation, expectedSecondAggregation]);
   });
 
   it('Should correctly toggle `hide` field', () => {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
@@ -2,7 +2,12 @@ import { defaultMetricAgg } from '../../../../query_def';
 import { ElasticsearchQuery } from '../../../../types';
 import { removeEmpty } from '../../../../utils';
 import { INIT, InitAction } from '../../state';
-import { isMetricAggregationWithMeta, isMetricAggregationWithSettings, MetricAggregation } from '../aggregations';
+import {
+  isMetricAggregationWithMeta,
+  isMetricAggregationWithSettings,
+  isPipelineAggregation,
+  MetricAggregation,
+} from '../aggregations';
 import { getChildren, metricAggregationConfig } from '../utils';
 import {
   ADD_METRIC,
@@ -64,10 +69,16 @@ export const reducer = (
           return metric;
         }
 
-        return {
+        const newMetric = {
           ...metric,
           field: action.payload.field,
         };
+
+        if (isPipelineAggregation(metric)) {
+          return { ...newMetric, pipelineAgg: action.payload.field };
+        }
+
+        return newMetric;
       });
 
     case TOGGLE_METRIC_VISIBILITY:

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -12,8 +12,13 @@ import { useNextId } from '../../hooks/useNextId';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions>;
 
-export const QueryEditor: FunctionComponent<ElasticQueryEditorProps> = ({ query, onChange, datasource }) => (
-  <ElasticsearchProvider datasource={datasource} onChange={onChange} query={query}>
+export const QueryEditor: FunctionComponent<ElasticQueryEditorProps> = ({
+  query,
+  onChange,
+  onRunQuery,
+  datasource,
+}) => (
+  <ElasticsearchProvider datasource={datasource} onChange={onChange} onRunQuery={onRunQuery} query={query}>
     <QueryEditorForm value={query} />
   </ElasticsearchProvider>
 );

--- a/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
@@ -13,7 +13,7 @@ describe('useNextId', () => {
     };
     const wrapper: FunctionComponent = ({ children }) => {
       return (
-        <ElasticsearchProvider query={query} datasource={{} as any} onChange={() => {}}>
+        <ElasticsearchProvider query={query} datasource={{} as any} onChange={() => {}} onRunQuery={() => {}}>
           {children}
         </ElasticsearchProvider>
       );


### PR DESCRIPTION


**What this PR does / why we need it**:
In the previous data source version, when selecting a field for a pipeline aggregation type, both `field` and `pipelineAgg` were populated in the query model. The react refactoring introduced a bug for which pipeline aggregations don't have `pipelineAgg` set anymore, this is not used in the FE query builder but the BE rely on that field to build the query for alerts.

This PR ensures that when selecting a field for a pipeline metric aggregation, both `field` and `pipelineAgg` in the query model are set.

Also, `onRunQuery` should be called after query change (ie. after each interaction with the query editor), somehow it slipped through and it wasn't being called. https://github.com/grafana/grafana/pull/29903/files#diff-47bf7d4f258d138e6a3eb152d14cfbf5c3d5581b6866a77154e27d627f428354R1 this fixes this behavior.


to test this out I created those 2 dashoards: https://gist.github.com/Elfo404/bd73e0749597e86b8ffb3ed5f4b14208, the interesting bits are in the "targets" array, where the query model is saved. the alert threshold is only based on random data, but when testing the rule you can see in the non-working version `"Condition[0]: Eval: false, Metric: Derivative Average 1, Value: null"` 

```json
// ...
    {
      "field": "1",
      "id": "3",
      "type": "derivative"
    }
```

while the new one:
```json
// ...
    {
      "field": "1",
      "id": "3",
      "pipelineAgg": "1",
      "type": "derivative"
    }
```