### PR TITLE
PanelEvents: Isolating angular panel events into it's own event bus + more event refactoring 

### DIFF
--- a/packages/grafana-data/src/types/legacyEvents.ts
+++ b/packages/grafana-data/src/types/legacyEvents.ts
@@ -22,7 +22,6 @@ export const PanelEvents = {
   dataSnapshotLoad: eventFactory<DataQueryResponseData[]>('data-snapshot-load'),
   editModeInitialized: eventFactory('init-edit-mode'),
   initPanelActions: eventFactory<AngularPanelMenuItem[]>('init-panel-actions'),
-  panelSizeChanged: eventFactory('panel-size-changed'),
   panelTeardown: eventFactory('panel-teardown'),
   render: eventFactory<any>('render'),
 };

--- a/public/app/features/annotations/annotations_srv.ts
+++ b/public/app/features/annotations/annotations_srv.ts
@@ -26,6 +26,7 @@ import { map, mergeMap } from 'rxjs/operators';
 import { AnnotationQueryOptions, AnnotationQueryResponse } from './types';
 import { standardAnnotationSupport } from './standardAnnotationSupport';
 import { runRequest } from '../query/state/runRequest';
+import { RefreshEvent } from 'app/types/events';
 
 let counter = 100;
 function getNextRequestId() {
@@ -41,7 +42,7 @@ export class AnnotationsSrv {
     // always clearPromiseCaches when loading new dashboard
     this.clearPromiseCaches();
     // clear promises on refresh events
-    dashboard.on(PanelEvents.refresh, this.clearPromiseCaches.bind(this));
+    dashboard.events.subscribe(RefreshEvent, this.clearPromiseCaches.bind(this));
   }
 
   clearPromiseCaches() {

--- a/public/app/features/annotations/annotations_srv.ts
+++ b/public/app/features/annotations/annotations_srv.ts
@@ -14,7 +14,6 @@ import {
   CoreApp,
   DataQueryRequest,
   DataSourceApi,
-  PanelEvents,
   rangeUtil,
   ScopedVars,
 } from '@grafana/data';

--- a/public/app/features/dashboard/components/Inspector/QueryInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/QueryInspector.tsx
@@ -10,8 +10,9 @@ import { getPanelInspectorStyles } from './styles';
 import { supportsDataQuery } from '../PanelEditor/utils';
 import { config } from '@grafana/runtime';
 import { css } from 'emotion';
-import { Unsubscribable } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { RefreshEvent } from 'app/types/events';
 
 interface DsQuery {
   isLoading: boolean;
@@ -39,9 +40,8 @@ interface State {
 }
 
 export class QueryInspector extends PureComponent<Props, State> {
-  formattedJson: any;
-  clipboard: any;
-  subscription?: Unsubscribable;
+  private formattedJson: any;
+  private subs = new Subscription();
 
   constructor(props: Props) {
     super(props);
@@ -58,11 +58,15 @@ export class QueryInspector extends PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    this.subscription = backendSrv.getInspectorStream().subscribe({
-      next: response => this.onDataSourceResponse(response),
-    });
+    const { panel } = this.props;
 
-    this.props.panel.events.on(PanelEvents.refresh, this.onPanelRefresh);
+    this.subs.add(
+      backendSrv.getInspectorStream().subscribe({
+        next: response => this.onDataSourceResponse(response),
+      })
+    );
+
+    this.subs.add(panel.events.subscribe(RefreshEvent, this.onPanelRefresh));
     this.updateQueryList();
   }
 
@@ -112,13 +116,7 @@ export class QueryInspector extends PureComponent<Props, State> {
   };
 
   componentWillUnmount() {
-    const { panel } = this.props;
-
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
-
-    panel.events.off(PanelEvents.refresh, this.onPanelRefresh);
+    this.subs.unsubscribe();
   }
 
   onPanelRefresh = () => {

--- a/public/app/features/dashboard/components/Inspector/QueryInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/QueryInspector.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Button, JSONFormatter, LoadingPlaceholder } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
-import { AppEvents, PanelEvents, DataFrame } from '@grafana/data';
+import { AppEvents, DataFrame } from '@grafana/data';
 
 import appEvents from 'app/core/app_events';
 import { CopyToClipboard } from 'app/core/components/CopyToClipboard/CopyToClipboard';

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -165,9 +165,9 @@ export class DashboardGrid extends PureComponent<Props> {
   };
 
   onWidthChange = () => {
-    for (const panel of this.props.dashboard.panels) {
-      panel.resizeDone();
-    }
+    // for (const panel of this.props.dashboard.panels) {
+    //   panel.resizeDone();
+    // }
   };
 
   updateGridPos = (item: ReactGridLayout.Layout, layout: ReactGridLayout.Layout[]) => {

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -28,7 +28,6 @@ interface GridWrapperProps {
   onDragStop: ItemCallback;
   onResize: ItemCallback;
   onResizeStop: ItemCallback;
-  onWidthChange: () => void;
   className: string;
   isResizable?: boolean;
   isDraggable?: boolean;
@@ -43,7 +42,6 @@ function GridWrapper({
   onDragStop,
   onResize,
   onResizeStop,
-  onWidthChange,
   className,
   isResizable,
   isDraggable,
@@ -56,7 +54,6 @@ function GridWrapper({
     if (ignoreNextWidthChange) {
       ignoreNextWidthChange = false;
     } else if (!viewPanel && Math.abs(width - lastGridWidth) > 8) {
-      onWidthChange();
       lastGridWidth = width;
     }
   }
@@ -164,12 +161,6 @@ export class DashboardGrid extends PureComponent<Props> {
     this.forceUpdate();
   };
 
-  onWidthChange = () => {
-    // for (const panel of this.props.dashboard.panels) {
-    //   panel.resizeDone();
-    // }
-  };
-
   updateGridPos = (item: ReactGridLayout.Layout, layout: ReactGridLayout.Layout[]) => {
     this.panelMap[item.i!].updateGridPos(item);
 
@@ -184,7 +175,6 @@ export class DashboardGrid extends PureComponent<Props> {
 
   onResizeStop: ItemCallback = (layout, oldItem, newItem) => {
     this.updateGridPos(newItem, layout);
-    this.panelMap[newItem.i!].resizeDone();
   };
 
   onDragStop: ItemCallback = (layout, oldItem, newItem) => {
@@ -277,7 +267,6 @@ export class DashboardGrid extends PureComponent<Props> {
         isResizable={dashboard.meta.canEdit}
         isDraggable={dashboard.meta.canEdit}
         onLayoutChange={this.onLayoutChange}
-        onWidthChange={this.onWidthChange}
         onDragStop={this.onDragStop}
         onResize={this.onResize}
         onResizeStop={this.onResizeStop}

--- a/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import { Unsubscribable } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 // Components
 import { PanelHeader } from './PanelHeader/PanelHeader';
@@ -13,10 +13,11 @@ import config from 'app/core/config';
 // Types
 import { DashboardModel, PanelModel } from '../state';
 import { StoreState } from 'app/types';
-import { DefaultTimeRange, LoadingState, PanelData, PanelEvents, PanelPlugin } from '@grafana/data';
+import { DefaultTimeRange, LoadingState, PanelData, PanelPlugin } from '@grafana/data';
 import { updateLocation } from 'app/core/actions';
 import { PANEL_BORDER } from 'app/core/constants';
 import { selectors } from '@grafana/e2e-selectors';
+import { RenderEvent } from 'app/types/events';
 
 interface OwnProps {
   panel: PanelModel;
@@ -59,7 +60,7 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
   element: HTMLElement | null = null;
   timeSrv: TimeSrv = getTimeSrv();
   scopeProps?: AngularScopeProps;
-  querySubscription: Unsubscribable;
+  subs = new Subscription();
 
   constructor(props: Props) {
     super(props);
@@ -80,16 +81,13 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
     const queryRunner = panel.getQueryRunner();
 
     // we are not displaying any of this data so no need for transforms or field config
-    this.querySubscription = queryRunner.getData({ withTransforms: false, withFieldConfig: false }).subscribe({
-      next: (data: PanelData) => this.onPanelDataUpdate(data),
-    });
-  }
+    this.subs.add(
+      queryRunner.getData({ withTransforms: false, withFieldConfig: false }).subscribe({
+        next: (data: PanelData) => this.onPanelDataUpdate(data),
+      })
+    );
 
-  subscribeToRenderEvent() {
-    // Subscribe to render event, this is as far as I know only needed for changes to title & transparent
-    // These changes are modified in the model and only way to communicate that change is via this event
-    // Need to find another solution for this in tthe future (panel title in redux?)
-    this.props.panel.events.on(PanelEvents.render, this.onPanelRenderEvent);
+    this.subs.add(panel.events.subscribe(RenderEvent, this.onPanelRenderEvent));
   }
 
   onPanelRenderEvent = (payload?: any) => {
@@ -126,16 +124,11 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
 
   componentWillUnmount() {
     this.cleanUpAngularPanel();
-
-    if (this.querySubscription) {
-      this.querySubscription.unsubscribe();
-    }
-
-    this.props.panel.events.off(PanelEvents.render, this.onPanelRenderEvent);
+    this.subs.unsubscribe();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const { plugin, height, width, panel } = this.props;
+    const { plugin, height, width } = this.props;
 
     if (prevProps.plugin !== plugin) {
       this.cleanUpAngularPanel();
@@ -146,7 +139,6 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
       if (this.scopeProps) {
         this.scopeProps.size.height = this.getInnerPanelHeight();
         this.scopeProps.size.width = this.getInnerPanelWidth();
-        panel.events.emit(PanelEvents.panelSizeChanged);
       }
     }
   }
@@ -189,9 +181,6 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
       panelId: panel.id,
       angularComponent: loader.load(this.element, this.scopeProps, template),
     });
-
-    // need to to this every time we load an angular as all events are unsubscribed when panel is destroyed
-    this.subscribeToRenderEvent();
   }
 
   cleanUpAngularPanel() {

--- a/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
@@ -128,7 +128,7 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const { plugin, height, width } = this.props;
+    const { plugin, height, width, panel } = this.props;
 
     if (prevProps.plugin !== plugin) {
       this.cleanUpAngularPanel();
@@ -139,6 +139,7 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
       if (this.scopeProps) {
         this.scopeProps.size.height = this.getInnerPanelHeight();
         this.scopeProps.size.width = this.getInnerPanelWidth();
+        panel.render();
       }
     }
   }

--- a/public/app/features/dashboard/dashgrid/__snapshots__/DashboardGrid.test.tsx.snap
+++ b/public/app/features/dashboard/dashgrid/__snapshots__/DashboardGrid.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`DashboardGrid Can render dashboard grid Should render 1`] = `
   onLayoutChange={[Function]}
   onResize={[Function]}
   onResizeStop={[Function]}
-  onWidthChange={[Function]}
   viewPanel={null}
 >
   <div

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -16,7 +16,6 @@ import {
   DateTimeInput,
   EventBusExtended,
   EventBusSrv,
-  PanelEvents,
   TimeRange,
   TimeZone,
   UrlQueryValue,
@@ -27,7 +26,7 @@ import { variableAdapters } from 'app/features/variables/adapters';
 import { onTimeRangeUpdated } from 'app/features/variables/state/actions';
 import { dispatch } from '../../../store/store';
 import { isAllVariable } from '../../variables/utils';
-import { DashboardPanelsChangedEvent } from 'app/types/events';
+import { DashboardPanelsChangedEvent, RefreshEvent, RenderEvent } from 'app/types/events';
 
 export interface CloneOptions {
   saveVariables?: boolean;
@@ -265,7 +264,7 @@ export class DashboardModel {
   }
 
   startRefresh() {
-    this.events.emit(PanelEvents.refresh);
+    this.events.publish(new RefreshEvent());
 
     if (this.panelInEdit) {
       this.panelInEdit.refresh();
@@ -280,8 +279,7 @@ export class DashboardModel {
   }
 
   render() {
-    this.events.emit(PanelEvents.render);
-
+    this.events.publish(new RenderEvent());
     for (const panel of this.panels) {
       panel.render();
     }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -883,10 +883,12 @@ export class DashboardModel {
     return rowPanels;
   }
 
+  /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
     this.events.on(event, callback);
   }
 
+  /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
     this.events.off(event, callback);
   }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -883,11 +883,13 @@ export class DashboardModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
+    console.log('DashboardModel.on is deprecated use events.subscribe');
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
+    console.log('DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -31,7 +31,6 @@ import { PanelQueryRunner } from '../../query/state/PanelQueryRunner';
 import {
   PanelOptionsChangedEvent,
   PanelQueriesChangedEvent,
-  PanelSizeChangedEvent,
   PanelTransformationsChangedEvent,
   RefreshEvent,
   RenderEvent,
@@ -264,12 +263,6 @@ export class PanelModel implements DataConfigSource {
   }
 
   updateGridPos(newPos: GridPos) {
-    let sizeChanged = false;
-
-    if (this.gridPos.w !== newPos.w || this.gridPos.h !== newPos.h) {
-      sizeChanged = true;
-    }
-
     this.gridPos.x = newPos.x;
     this.gridPos.y = newPos.y;
     this.gridPos.w = newPos.w;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -28,7 +28,14 @@ import {
 import { EDIT_PANEL_ID } from 'app/core/constants';
 import config from 'app/core/config';
 import { PanelQueryRunner } from '../../query/state/PanelQueryRunner';
-import { PanelOptionsChangedEvent, PanelQueriesChangedEvent, PanelTransformationsChangedEvent } from 'app/types/events';
+import {
+  PanelOptionsChangedEvent,
+  PanelQueriesChangedEvent,
+  PanelSizeChangedEvent,
+  PanelTransformationsChangedEvent,
+  RefreshEvent,
+  RenderEvent,
+} from 'app/types/events';
 import { getTimeSrv } from '../services/TimeSrv';
 import { getAllVariableValuesForUrl } from '../../variables/getAllVariableValuesForUrl';
 
@@ -267,26 +274,18 @@ export class PanelModel implements DataConfigSource {
     this.gridPos.y = newPos.y;
     this.gridPos.w = newPos.w;
     this.gridPos.h = newPos.h;
-
-    if (sizeChanged) {
-      this.events.emit(PanelEvents.panelSizeChanged);
-    }
-  }
-
-  resizeDone() {
-    this.events.emit(PanelEvents.panelSizeChanged);
   }
 
   refresh() {
     this.hasRefreshed = true;
-    this.events.emit(PanelEvents.refresh);
+    this.events.publish(new RefreshEvent());
   }
 
   render() {
     if (!this.hasRefreshed) {
       this.refresh();
     } else {
-      this.events.emit(PanelEvents.render);
+      this.events.publish(new RenderEvent());
     }
   }
 

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -2,7 +2,14 @@ import _ from 'lodash';
 import config from 'app/core/config';
 import { profiler } from 'app/core/core';
 import { auto } from 'angular';
-import { AppEvent, PanelEvents, PanelPluginMeta, AngularPanelMenuItem, EventBusExtended } from '@grafana/data';
+import {
+  AppEvent,
+  PanelEvents,
+  PanelPluginMeta,
+  AngularPanelMenuItem,
+  EventBusExtended,
+  EventBusSrv,
+} from '@grafana/data';
 import { DashboardModel } from '../dashboard/state';
 
 export class PanelCtrl {
@@ -30,7 +37,7 @@ export class PanelCtrl {
     this.$scope = $scope;
     this.$timeout = $injector.get('$timeout');
     this.editorTabs = [];
-    this.events = this.panel.events;
+    this.events = new EventBusSrv();
     this.timing = {}; // not used but here to not break plugins
 
     const plugin = config.panels[this.panel.type];
@@ -43,6 +50,7 @@ export class PanelCtrl {
   }
 
   panelDidMount() {
+    console.log('panelDidMount');
     this.events.emit(PanelEvents.componentDidMount);
     this.dashboard.panelInitialized(this.panel);
   }

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -50,7 +50,6 @@ export class PanelCtrl {
   }
 
   panelDidMount() {
-    console.log('panelDidMount');
     this.events.emit(PanelEvents.componentDidMount);
     this.dashboard.panelInitialized(this.panel);
   }

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -5,7 +5,7 @@ import { PanelEvents } from '@grafana/data';
 import { PanelModel } from '../dashboard/state';
 import { PanelCtrl } from './panel_ctrl';
 import { Subscription } from 'rxjs';
-import { PanelSizeChangedEvent, RefreshEvent, RenderEvent } from 'app/types/events';
+import { RefreshEvent, RenderEvent } from 'app/types/events';
 
 const module = angular.module('grafana.directives');
 
@@ -61,13 +61,6 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
         }
       });
 
-      function onPanelSizeChanged() {
-        $timeout(() => {
-          resizeScrollableContent();
-          ctrl.render();
-        });
-      }
-
       function updateDimensionsFromParentScope() {
         ctrl.height = scope.$parent.$parent.size.height;
         ctrl.width = scope.$parent.$parent.size.width;
@@ -84,11 +77,13 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
       subs.add(
         panel.events.subscribe(RenderEvent, () => {
           updateDimensionsFromParentScope();
-          ctrl.events.emit('refresh');
+
+          $timeout(() => {
+            resizeScrollableContent();
+            ctrl.events.emit('render');
+          });
         })
       );
-
-      subs.add(panel.events.subscribe(PanelSizeChangedEvent, onPanelSizeChanged));
 
       scope.$on('$destroy', () => {
         elem.off();

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -22,9 +22,9 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
     link: (scope: any, elem) => {
       const ctrl: PanelCtrl = scope.ctrl;
       const panel: PanelModel = scope.ctrl.panel;
+      const subs = new Subscription();
 
       let panelScrollbar: any;
-      let subs = new Subscription();
 
       function resizeScrollableContent() {
         if (panelScrollbar) {

--- a/public/app/features/plugins/plugin_component.ts
+++ b/public/app/features/plugins/plugin_component.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import config from 'app/core/config';
 import coreModule from 'app/core/core_module';
 
-import { DataSourceApi } from '@grafana/data';
+import { DataSourceApi, PanelEvents } from '@grafana/data';
 import { importPanelPlugin, importDataSourcePlugin, importAppPlugin } from './plugin_loader';
 import DatasourceSrv from './datasource_srv';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
@@ -229,7 +229,7 @@ function pluginDirectiveLoader(
         elem.append(child);
         setTimeout(() => {
           scope.$applyAsync(() => {
-            scope.$broadcast('component-did-mount');
+            scope.$broadcast(PanelEvents.componentDidMount.name);
           });
         });
       });

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -148,3 +148,15 @@ export class PanelOptionsChangedEvent extends BusEventBase {
 export class DashboardPanelsChangedEvent extends BusEventBase {
   static type = 'dashboard-panels-changed';
 }
+
+export class RefreshEvent extends BusEventBase {
+  static type = 'refresh';
+}
+
+export class RenderEvent extends BusEventBase {
+  static type = 'refresh';
+}
+
+export class PanelSizeChangedEvent extends BusEventBase {
+  static type = 'refresh';
+}

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -154,9 +154,5 @@ export class RefreshEvent extends BusEventBase {
 }
 
 export class RenderEvent extends BusEventBase {
-  static type = 'refresh';
-}
-
-export class PanelSizeChangedEvent extends BusEventBase {
-  static type = 'refresh';
+  static type = 'render';
 }


### PR DESCRIPTION
Fixes #29815 

We have some problems with panel events, for angular we have to destroy and unsub to all the events subscribed by the angular controller and plugin code, but the PanelEditor will then lose its subscriptions. Feels like it's best to separate these into two different emitters. Then it becomes easy to clean up the angular state without any messy logic. 

This also updates the core Refresh & Render events to the new model and removes events that we no longer need. 

