### PR TITLE
Docs: Update organization_roles.md

### DIFF
--- a/docs/sources/permissions/organization_roles.md
+++ b/docs/sources/permissions/organization_roles.md
@@ -48,5 +48,8 @@ This role can be changed with the Grafana server setting [editors_can_admin]({{<
 - Cannot access Explore.
 - Cannot manage other organizations, users, and teams.
 
-This role can be changed with the Grafana server setting [viewers_can_edit]({{< relref "../administration/configuration.md#viewers-can-edit" >}}). If you set this to `true`, then users with the Viewer role can also make transient dashboard edits, meaning they can modify panels and queries but not save the changes (nor create new dashboards).
+This role can be changed with the Grafana server setting [viewers_can_edit]({{< relref "../administration/configuration.md#viewers-can-edit" >}}). If you set this to `true`, then users with the Viewer role can:
+- Make transient dashboard edits, meaning they can modify panels and queries but not save the changes or create new dashboards.
+- Access and use [Explore]({{< relref "../explore/_index.md" >}}).
+
 This is especially useful for public Grafana installations where you want anonymous users to be able to edit panels and queries but not save or create new dashboards.


### PR DESCRIPTION
A user on public Slack pointed out that we do not say anywhere in the docs that viewers_can_edit allows Viewers to use Explore. Fixing that now.