### PR TITLE
package.json: Add grafana metadata section

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -308,7 +308,7 @@ Example connstr: `addr=127.0.0.1:6379,pool_size=100,db=0,ssl=false`
 
 - `addr` is the host `:` port of the redis server.
 - `pool_size` (optional) is the number of underlying connections that can be made to redis.
-- `db` (optional) is the number indentifer of the redis database you want to use.
+- `db` (optional) is the numerical identifier of the redis database you want to use.
 - `ssl` (optional) is if SSL should be used to connect to redis server. The value may be `true`, `false`, or `insecure`. Setting the value to `insecure` skips verification of the certificate chain and hostname when making the connection.
 
 #### Memcache

--- a/package.json
+++ b/package.json
@@ -186,6 +186,10 @@
     "typecheck": "tsc --noEmit",
     "watch": "yarn start -d watch,start core:start --watchTheme "
   },
+  "grafana": {
+    "whatsNewUrl": "https://grafana.com/docs/grafana/latest/guides/whats-new-in-v6-7/",
+    "releaseNotesUrl": "https://community.grafana.com/t/release-notes-v6-7-x/"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged && npm run precommit"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add "grafana" metadata section to package.json, containing what's new and release notes URLs. These are used by newer versions of the build pipeline tool, and come in handy during manual releases (the publishing logic uses this metadata).

