### PR TITLE
Loki: Align query interval with step

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -174,9 +174,10 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const step = Math.ceil(
         this.adjustInterval((options as DataQueryRequest<LokiQuery>).intervalMs || 1000, rangeMs) / 1000
       );
+      const tempStep = step * 1e9;
       const alignedTimes = {
-        start: startNs - (startNs % 1e9),
-        end: endNs + (1e9 - (endNs % 1e9)),
+        start: Math.floor(startNs / tempStep) * tempStep,
+        end: Math.floor(endNs / tempStep) * tempStep,
       };
 
       range = {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
For example, with 15s step:
2020-12-20 10:55:03\~2020-12-20 10:55:18
will align to
2020-12-20 10:55:00\~2020-12-20 10:55:15,
then about-same-time query results look the same.
