### PR TITLE
Fix raw format variable docs

### DIFF
--- a/docs/sources/variables/advanced-variable-format-options.md
+++ b/docs/sources/variables/advanced-variable-format-options.md
@@ -105,9 +105,9 @@ Interpolation result: 'test1.|test2'
 Turns off data source-specific formatting, such as single quotes in an SQL query.
 
 ```bash
-servers = ['test1.', 'test2']
+servers = ['test.1', 'test2']
 String to interpolate: '${var_name:raw}'
-Interpolation result: '{test.1,test2}'
+Interpolation result: 'test.1,test2'
 ```
 
 ## Regex


### PR DESCRIPTION
Seems like [raw variable formatting docs](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/#raw) are and were incorrect for some time. This probably leads to confusion as the one described in https://github.com/grafana/grafana/issues/29943