### PR TITLE
TemplateSrv: Do not throw error for an unknown format but use glob as a fallback

### DIFF
--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -295,6 +295,13 @@ describe('templateSrv', () => {
       expect(result).toBe('test');
     });
 
+    it('should use glob format when unknown format provided', () => {
+      let result = _templateSrv.formatValue('test', 'nonexistentformat');
+      expect(result).toBe('test');
+      result = _templateSrv.formatValue(['test', 'test1'], 'nonexistentformat');
+      expect(result).toBe('{test,test1}');
+    });
+
     it('multi value and glob format should render glob string', () => {
       const result = _templateSrv.formatValue(['test', 'test2'], 'glob');
       expect(result).toBe('{test,test2}');

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -137,9 +137,11 @@ export class TemplateSrv implements BaseTemplateSrv {
       args = [];
     }
 
-    const formatItem = formatRegistry.getIfExists(format);
+    let formatItem = formatRegistry.getIfExists(format);
+
     if (!formatItem) {
-      throw new Error(`Variable format ${format} not found`);
+      console.error(`Variable format ${format} not found. Using glob format as fallback.`);
+      formatItem = formatRegistry.get('glob');
     }
 
     const options: FormatOptions = { value, args, text: text ?? value };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/29951

Instead of throwing an error, log the problem to the console and use glob as a fallback