### PR TITLE
loki.md: Add example of Loki data source config

### DIFF
--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -240,6 +240,6 @@ datasources:
       type: jaeger
       url: http://jaeger-tracing-query:16686/
       access: proxy
-      # uid should be matching with datasourceUid in dervidedFields.
+      # UID should match the datasourceUid in dervidedFields.
       uid: my_jaeger_uid
 ```

--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -232,7 +232,7 @@ datasources:
           url: "http://localhost:16686/trace/$${__value.raw}"
 ```
 
-Here's example of Jaeger datasource corresponding to the above example. Note Jaeger's `uid` value does match with Loki's `datasourceUid` value.
+Here's an example of a Jaeger data source corresponding to the above example. Note that the Jaeger `uid` value does match the Loki `datasourceUid` value.
 
 ```
 datasources:

--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -231,3 +231,15 @@ datasources:
           name: TraceID
           url: "http://localhost:16686/trace/$${__value.raw}"
 ```
+
+Here's example of Jaeger datasource corresponding to the above example. Note Jaeger's `uid` value does match with Loki's `datasourceUid` value.
+
+```
+datasources:
+    - name: Jaeger
+      type: jaeger
+      url: http://jaeger-tracing-query:16686/
+      access: proxy
+      # uid should be matching with datasourceUid in dervidedFields.
+      uid: my_jaeger_uid
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

It was little difficult to find example of setting datasourceUid for Loki-Jaeger data source referencing.

I found the answer from [issue#26087](https://github.com/grafana/grafana/issues/26087) and thought it would be good to document it.

**Which issue(s) this PR fixes**:

I consider this is documentation for issue#26087 :)

