### PR TITLE
[dashboard api] manage error when data in dashboard table is not valid json

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -50,7 +50,6 @@ func (hs *HTTPServer) GetDashboard(c *models.ReqContext) Response {
 	slug := c.Params(":slug")
 	uid := c.Params(":uid")
 	dash, rsp := getDashboardHelper(c.OrgId, slug, 0, uid)
-
 	if rsp != nil {
 		return rsp
 	}

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -50,8 +50,23 @@ func (hs *HTTPServer) GetDashboard(c *models.ReqContext) Response {
 	slug := c.Params(":slug")
 	uid := c.Params(":uid")
 	dash, rsp := getDashboardHelper(c.OrgId, slug, 0, uid)
+
 	if rsp != nil {
 		return rsp
+	}
+
+	// When dash contains only keys id, uid that means dashboard data is not valid and json decode failed.
+	if dash.Data != nil {
+		isEmptyData := true
+		for k := range dash.Data.MustMap() {
+			if k != "id" && k != "uid" {
+				isEmptyData = false
+				break
+			}
+		}
+		if isEmptyData {
+			return Error(500, "Error while loading dashboard, dashboard data is invalid", nil)
+		}
 	}
 
 	guardian := guardian.New(dash.Id, c.OrgId, c.SignedInUser)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1009,7 +1009,8 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				return nil
 			})
 			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
-				query.Result = &models.Dashboard{Id: 1, Data: &simplejson.Json{}}
+				dataValue, _ := simplejson.NewJson([]byte(`{"id": 1, "editable": true, "style": "dark"}`))
+				query.Result = &models.Dashboard{Id: 1, Data: dataValue}
 				return nil
 			})
 

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1009,7 +1009,8 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				return nil
 			})
 			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
-				dataValue, _ := simplejson.NewJson([]byte(`{"id": 1, "editable": true, "style": "dark"}`))
+				dataValue, err := simplejson.NewJson([]byte(`{"id": 1, "editable": true, "style": "dark"}`))
+				require.NoError(t, err)
 				query.Result = &models.Dashboard{Id: 1, Data: dataValue}
 				return nil
 			})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: now when data from the dashboard table is not valid JSON, the response is HTTP 200 and with empty content, which is confusing for the customer.

The fix is done on GetDashboard of API level, it is because the GetDashboardQuery is used not only by retrieve dashboard API, but also by folder service and file reader, etc.

Error code is 500 in this case.
 
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26910 

**Special notes for your reviewer**:

