### PR TITLE
Chore: Changes source map devtool to inline-source-map

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -12,7 +12,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = (env = {}) =>
   merge(common, {
-    devtool: 'cheap-module-source-map',
+    devtool: 'inline-source-map',
     mode: 'development',
 
     entry: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR helps to debug Grafana in the browser because of better support for breakpoints after `awaits` and the ability to add breakpoints within an expression.

**Before, not able to set breakpoint after `await` see line 29**
![image](https://user-images.githubusercontent.com/562238/103280635-2f91aa00-49d1-11eb-8613-c9ed8453ef1d.png)

**After, able to set breakpoint after `await` see line 29 and able to set breakpoint within expressions see line 37**
![image](https://user-images.githubusercontent.com/562238/103280698-5223c300-49d1-11eb-94bf-7b0f3ad12299.png)

The drawback to this is that it's a bit slower than before as shown below and described at [https://webpack.js.org/configuration/devtool](https://webpack.js.org/configuration/devtool):
|devtool | build | rebuild | production | quality|
|-- | -- | -- | -- | --|
|cheap-module-source-map | slow | slower | yes | original source (lines only)|
|inline-source-map | slowest | slowest | no | original source|

On my dev machine, the slowdown was not noticeable.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

