### PR TITLE
Plugins: prevent app plugin from rendering with wrong location

### DIFF
--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -50,6 +50,10 @@ class AppRootPage extends Component<Props, State> {
     };
   }
 
+  shouldComponentUpdate(nextProps: Props) {
+    return nextProps.path.startsWith('/a/');
+  }
+
   async componentDidMount() {
     const { pluginId } = this.props;
 


### PR DESCRIPTION
Navigating away from an app plugin causes it just before unmounting to be rendered with path prop that contains path of the page being navigated to, rather than some path belonging to this plugin. For example, if you navigate from a plugin to explore, it will render with`path='/explore'`. 
It's unexpected and can cause an error for plugins that trigger backend requests or nav model changes based on injected location data.

It happens because `AppRootPage` gets location data injected from redux, and location in redux store is updated before angular router destroys the `ReactContainer` directive. Angular routing and location state in redux are not perfectly in sync.

This PR fixes it by making `AppRootPage` prevent from rendering  using `shouldComponentUpdate` unless provided path is for the app plugins page, seems the simplest fix. Alternatively could have `ReactContainer` add location data from angular state into props, rather than using location data in redux store.

I know that this is a band-aid and the proper fix is to remove angular routing in favor of  react router :-) will try to work on that eventually.

Fixes #28182

