### PR TITLE
OAuth: Added support for role mapping for GitLab accounts.

### DIFF
--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -26,9 +26,9 @@ instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
 http://203.0.113.31:3000/login/gitlab
 ```
 
-Finally, select _read_api as the _Scope_ and submit the form. Note that if you're
+Finally, select _read_api_ as the _Scope_ and submit the form. Note that if you're
 not going to use GitLab groups for authorization (i.e. not setting
-`allowed_groups`, see below), you can select _read_user_ instead of _read_api as
+`allowed_groups`, see below), you can select _read_user_ instead of _read_api_ as
 the _Scope_, thus giving a more restricted access to your GitLab API.
 
 You'll get an _Application Id_ and a _Secret_ in return; we'll call them
@@ -94,8 +94,8 @@ display name, especially if the display name contains spaces or special
 characters. Make sure you always use the group or subgroup name as it appears
 in the URL of the group or subgroup.
 
-Here's a complete example with `allow_sign_up` enabled, and access limited to
-the `example` and `foo/bar` groups it also promotes all GitLab Admins to Grafana Admins:
+Here's a complete example with `allow_sign_up` enabled, with access limited to
+the `example` and `foo/bar` groups. The example also promotes all GitLab Admins to Grafana Admins:
 
 ```ini
 [auth.gitlab]
@@ -113,9 +113,9 @@ role_attribute_path = is_admin && 'Admin' || 'Viewer'
 
 ### Map roles
 
-Grafana can attempt to do role mapping through GitLab OAuth. In order to achieve this, Grafana checks for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified via the `role_attribute_path` configuration option.
+Grafana can attempt role mapping through GitLab OAuth. To do so, Grafana checks for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified using the `role_attribute_path` configuration option.
 
-Grafana uses JSON obtained from querying GitLab's API [`/api/v4/user`](https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users) endpoint for the path lookup. The result after evaluating the `role_attribute_path` JMESPath expression needs to be a valid Grafana role, i.e. `Viewer`, `Editor` or `Admin`. Refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}) for more information about roles and permissions in Grafana.
+Grafana uses JSON obtained from querying GitLab's API [`/api/v4/user`](https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users) endpoint for the path lookup. The result after evaluating the `role_attribute_path` JMESPath expression needs to be a valid Grafana role; `Viewer`, `Editor`, or `Admin`. Refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}) for more information about roles and permissions in Grafana.
 
 An example Query could look like the following:
 
@@ -123,7 +123,7 @@ An example Query could look like the following:
 role_attribute_path = is_admin && 'Admin' || 'Viewer'
 ```
 
-This would allow you every GitLab Admin to be an Admin in Grafana.
+This allows every GitLab Admin to be an Admin in Grafana.
 
 ### Team Sync (Enterprise only)
 

--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -112,9 +112,9 @@ allowed_groups = example, foo/bar
 
 ### Map roles
 
-Grafana can attempt to do role mapping through Gitlab OAuth. In order to achieve this, Grafana checks for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified via the `role_attribute_path` configuration option.
+Grafana can attempt to do role mapping through GitLab OAuth. In order to achieve this, Grafana checks for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified via the `role_attribute_path` configuration option.
 
-Grafana uses JSON obtained from querying the `/api/v4/user` endpoint for the path lookup. The result after evaluating the `role_attribute_path` JMESPath expression needs to be a valid Grafana role, i.e. `Viewer`, `Editor` or `Admin`. Refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}) for more information about roles and permissions in Grafana.
+Grafana uses JSON obtained from querying GitLab's API [`/api/v4/user`](https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users) endpoint for the path lookup. The result after evaluating the `role_attribute_path` JMESPath expression needs to be a valid Grafana role, i.e. `Viewer`, `Editor` or `Admin`. Refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}) for more information about roles and permissions in Grafana.
 
 An example Query could look like the following:
 
@@ -122,7 +122,7 @@ An example Query could look like the following:
 role_attribute_path = is_admin && 'Admin' || 'Viewer'
 ```
 
-This would allow you every Gitlab Admin to be an Admin in Grafana.
+This would allow you every GitLab Admin to be an Admin in Grafana.
 
 ### Team Sync (Enterprise only)
 

--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -103,12 +103,26 @@ enabled = true
 allow_sign_up = true
 client_id = GITLAB_APPLICATION_ID
 client_secret = GITLAB_SECRET
-scopes = api
+scopes = read_api
 auth_url = https://gitlab.com/oauth/authorize
 token_url = https://gitlab.com/oauth/token
 api_url = https://gitlab.com/api/v4
 allowed_groups = example, foo/bar
 ```
+
+### Map roles
+
+Grafana can attempt to do role mapping through Gitlab OAuth. In order to achieve this, Grafana checks for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified via the `role_attribute_path` configuration option.
+
+Grafana uses JSON obtained from querying the `/api/v4/user` endpoint for the path lookup. The result after evaluating the `role_attribute_path` JMESPath expression needs to be a valid Grafana role, i.e. `Viewer`, `Editor` or `Admin`. Refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}) for more information about roles and permissions in Grafana.
+
+An example Query could look like the following:
+
+```bash
+role_attribute_path = is_admin && 'Admin' || 'Viewer'
+```
+
+This would allow you every Gitlab Admin to be an Admin in Grafana.
 
 ### Team Sync (Enterprise only)
 

--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -26,10 +26,10 @@ instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
 http://203.0.113.31:3000/login/gitlab
 ```
 
-Finally, select _read_api_as the_Scope_and submit the form. Note that if you're
+Finally, select _read_api as the _Scope_ and submit the form. Note that if you're
 not going to use GitLab groups for authorization (i.e. not setting
-`allowed_groups`, see below), you can select_read_user_ instead of _read_api_as
-the_Scope_, thus giving a more restricted access to your GitLab API.
+`allowed_groups`, see below), you can select _read_user_ instead of _read_api as
+the _Scope_, thus giving a more restricted access to your GitLab API.
 
 You'll get an _Application Id_ and a _Secret_ in return; we'll call them
 `GITLAB_APPLICATION_ID` and `GITLAB_SECRET` respectively for the rest of this

--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -26,10 +26,10 @@ instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
 http://203.0.113.31:3000/login/gitlab
 ```
 
-Finally, select _read_api_ as the _Scope_ and submit the form. Note that if you're
+Finally, select _read_api_as the_Scope_and submit the form. Note that if you're
 not going to use GitLab groups for authorization (i.e. not setting
-`allowed_groups`, see below), you can select _read_user_ instead of _read_api_ as
-the _Scope_, thus giving a more restricted access to your GitLab API.
+`allowed_groups`, see below), you can select_read_user_ instead of _read_api_as
+the_Scope_, thus giving a more restricted access to your GitLab API.
 
 You'll get an _Application Id_ and a _Secret_ in return; we'll call them
 `GITLAB_APPLICATION_ID` and `GITLAB_SECRET` respectively for the rest of this
@@ -95,7 +95,7 @@ characters. Make sure you always use the group or subgroup name as it appears
 in the URL of the group or subgroup.
 
 Here's a complete example with `allow_sign_up` enabled, and access limited to
-the `example` and `foo/bar` groups:
+the `example` and `foo/bar` groups it also promotes all GitLab Admins to Grafana Admins:
 
 ```ini
 [auth.gitlab]
@@ -108,6 +108,7 @@ auth_url = https://gitlab.com/oauth/authorize
 token_url = https://gitlab.com/oauth/token
 api_url = https://gitlab.com/api/v4
 allowed_groups = example, foo/bar
+role_attribute_path = is_admin && 'Admin' || 'Viewer'
 ```
 
 ### Map roles

--- a/docs/sources/auth/gitlab.md
+++ b/docs/sources/auth/gitlab.md
@@ -26,10 +26,10 @@ instance, if you access Grafana at `http://203.0.113.31:3000`, you should use
 http://203.0.113.31:3000/login/gitlab
 ```
 
-Finally, select _read_api_ as the _Scope_ and submit the form. Note that if you're
+Finally, select _read_api_as the_Scope_and submit the form. Note that if you're
 not going to use GitLab groups for authorization (i.e. not setting
-`allowed_groups`, see below), you can select _read_user_ instead of _read_api_ as
-the _Scope_, thus giving a more restricted access to your GitLab API.
+`allowed_groups`, see below), you can select_read_user_ instead of _read_api_as
+the_Scope_, thus giving a more restricted access to your GitLab API.
 
 You'll get an _Application Id_ and a _Secret_ in return; we'll call them
 `GITLAB_APPLICATION_ID` and `GITLAB_SECRET` respectively for the rest of this
@@ -113,9 +113,9 @@ role_attribute_path = is_admin && 'Admin' || 'Viewer'
 
 ### Map roles
 
-Grafana can attempt role mapping through GitLab OAuth. To do so, Grafana checks for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified using the `role_attribute_path` configuration option.
+You can use GitLab OAuth to map roles. During mapping, Grafana checks for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified via the `role_attribute_path` configuration option.
 
-Grafana uses JSON obtained from querying GitLab's API [`/api/v4/user`](https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users) endpoint for the path lookup. The result after evaluating the `role_attribute_path` JMESPath expression needs to be a valid Grafana role; `Viewer`, `Editor`, or `Admin`. Refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}) for more information about roles and permissions in Grafana.
+For the path lookup, Grafana uses JSON obtained from querying GitLab's API [`/api/v4/user`](https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users) endpoint. The result of evaluating the `role_attribute_path` JMESPath expression must be a valid Grafana role, for example, `Viewer`, `Editor` or `Admin`. For more information about roles and permissions in Grafana, refer to [Organization roles]({{< relref "../permissions/organization_roles.md" >}}).
 
 An example Query could look like the following:
 

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -13,8 +13,9 @@ import (
 
 type SocialGitlab struct {
 	*SocialBase
-	allowedGroups []string
-	apiUrl        string
+	allowedGroups     []string
+	apiUrl            string
+	roleAttributePath string
 }
 
 func (s *SocialGitlab) Type() int {
@@ -114,12 +115,18 @@ func (s *SocialGitlab) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 
 	groups := s.GetGroups(client)
 
+	role, err := s.extractRole(response.Body)
+	if err != nil {
+		s.log.Error("Failed to extract role", "error", err)
+	}
+
 	userInfo := &BasicUserInfo{
 		Id:     fmt.Sprintf("%d", data.Id),
 		Name:   data.Name,
 		Login:  data.Username,
 		Email:  data.Email,
 		Groups: groups,
+		Role:   role,
 	}
 
 	if !s.IsGroupMember(groups) {
@@ -127,4 +134,16 @@ func (s *SocialGitlab) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 	}
 
 	return userInfo, nil
+}
+
+func (s *SocialGitlab) extractRole(rawJSON []byte) (string, error) {
+	if s.roleAttributePath == "" {
+		return "", nil
+	}
+
+	role, err := s.searchJSONForAttr(s.roleAttributePath, rawJSON)
+	if err != nil {
+		return "", err
+	}
+	return role, nil
 }

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -126,9 +126,10 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// GitLab.
 		if name == "gitlab" {
 			ss.socialMap["gitlab"] = &SocialGitlab{
-				SocialBase:    newSocialBase(name, &config, info),
-				apiUrl:        info.ApiUrl,
-				allowedGroups: util.SplitString(sec.Key("allowed_groups").String()),
+				SocialBase:        newSocialBase(name, &config, info),
+				apiUrl:            info.ApiUrl,
+				allowedGroups:     util.SplitString(sec.Key("allowed_groups").String()),
+				roleAttributePath: info.RoleAttributePath,
 			}
 		}
 


### PR DESCRIPTION
Allow role mapping for GitLab accounts.

Example:

```ini
[auth.gitlab]
role_attribute_path = is_admin && 'Admin' || 'Viewer'
```

## Tasks

- [ ] Add tests
- [ ] Add documentation (see https://grafana.com/docs/grafana/latest/auth/okta/#map-roles)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds support for `role_attribute_path` JMESPath to allow role mapping for GitLab social login.

**Which issue(s) this PR fixes**:

Fixes #28892

**Special notes for your reviewer**:

