### PR TITLE
metric raw document aggregation with options

### DIFF
--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -311,7 +311,7 @@ Example connstr: `addr=127.0.0.1:6379,pool_size=100,db=0,ssl=false`
 
 - `addr` is the host `:` port of the redis server.
 - `pool_size` (optional) is the number of underlying connections that can be made to redis.
-- `db` (optional) is the number indentifer of the redis database you want to use.
+- `db` (optional) is the number identifer of the redis database you want to use.
 - `ssl` (optional) is if SSL should be used to connect to redis server. The value may be `true`, `false`, or `insecure`. Setting the value to `insecure` skips verification of the certificate chain and hostname when making the connection.
 
 #### Memcache

--- a/public/app/plugins/datasource/elasticsearch/metric_agg.ts
+++ b/public/app/plugins/datasource/elasticsearch/metric_agg.ts
@@ -19,6 +19,9 @@ export class ElasticMetricAggCtrl {
       $scope.validateModel();
       $scope.updatePipelineAggOptions();
     };
+    $scope.getOrderOptions = () => {
+      return queryDef.orderOptions;
+    };
 
     $scope.updatePipelineAggOptions = () => {
       $scope.pipelineAggOptions = queryDef.getPipelineAggOptions($scope.target);
@@ -103,9 +106,11 @@ export class ElasticMetricAggCtrl {
         }
         case 'raw_document': {
           $scope.agg.settings.size = $scope.agg.settings.size || 500;
-          $scope.settingsLinkText = 'Size: ' + $scope.agg.settings.size;
+          let orderBy = $scope.agg.settings.orderBy;
+          orderBy = orderBy && orderBy.charAt(0).toUpperCase() + orderBy.slice(1);
+          const sizeText = 'Size: ' + $scope.agg.settings.size;
+          $scope.settingsLinkText = orderBy ? sizeText + ' , Order by: ' + orderBy : sizeText;
           $scope.target.metrics.splice(0, $scope.target.metrics.length, $scope.agg);
-
           $scope.target.bucketAggs = [];
           break;
         }

--- a/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
+++ b/public/app/plugins/datasource/elasticsearch/partials/metric_agg.html
@@ -1,3 +1,4 @@
+
 <div class="gf-form-inline" ng-class="{'gf-form-disabled': agg.hide}">
 	<div class="gf-form">
 		<label class="gf-form-label query-keyword width-7">
@@ -96,9 +97,32 @@
     <label class="gf-form-label width-10">Percentiles</label>
     <input type="text" class="gf-form-input max-width-12" ng-model="agg.settings.percents" array-join ng-blur="onChange()"></input>
   </div>
-  <div class="gf-form offset-width-7" ng-if="agg.type === 'raw_document'">
-    <label class="gf-form-label width-10">Size</label>
-    <input type="number" class="gf-form-input max-width-12" ng-model="agg.settings.size" ng-blur="onChange()"></input>
+  <div class="offset-width-7" ng-if="agg.type === 'raw_document'">
+
+      <div class="gf-form ">
+        <label class="gf-form-label width-10">Order</label>
+        <gf-form-dropdown model="agg.settings.order"
+                          lookup-text="true"
+                          get-options="getOrderOptions()"
+                          on-change="onChangeInternal()"
+                          label-mode="true"
+                          css-class="width-12">
+        </gf-form-dropdown>
+      </div>
+      <div class="gf-form ">
+          <label class="gf-form-label width-10">Size</label>
+          <input type="number" class="gf-form-input max-width-12" ng-model="agg.settings.size" ng-blur="onChange()"></input>      
+      </div>
+      <div class="gf-form ">
+        <label class="gf-form-label width-10">Order By</label>
+        <gf-form-dropdown model="agg.settings.orderBy"
+                          lookup-text="true"
+                          get-options="getFieldsInternal()"
+                          on-change="onChangeInternal()"
+                          label-mode="true"
+                          css-class="width-12">
+        </gf-form-dropdown>
+      </div>
   </div>
 
 

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -118,11 +118,15 @@ export class ElasticQueryBuilder {
     return filterObj;
   }
 
-  documentQuery(query: any, size: number) {
+  documentQuery(query: any, size: number, metric?: any) {
     query.size = size;
     query.sort = {};
-    query.sort[this.timeField] = { order: 'desc', unmapped_type: 'boolean' };
-
+    if (metric.type === 'raw_document' && metric.settings.orderBy) {
+      query.size = metric.settings.size;
+      query.sort[metric.settings.orderBy] = { order: metric.settings.order, unmapped_type: 'boolean' };
+    } else {
+      query.sort[this.timeField] = { order: 'desc', unmapped_type: 'boolean' };
+    }
     // fields field not supported on ES 5.x
     if (this.esVersion < 5) {
       query.fields = ['*', '_source'];
@@ -213,7 +217,7 @@ export class ElasticQueryBuilder {
       }
 
       const size = (metric.settings && metric.settings.size) || 500;
-      return this.documentQuery(query, size);
+      return this.documentQuery(query, size, metric);
     }
 
     nestedAggs = query;


### PR DESCRIPTION
Issue: Not able to add the sort for metric type Raw document 

Added  sort options for Raw documents



What would you like to be added:

When using the ES data source, the query "metric=raw document" supports the specified field sort

Why is this needed:

While timestamp is a common sort, sorting by specified field should be more common