### PR TITLE
Elasticsearch: Fix date histogram auto interval handling for alert queries

### DIFF
--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -313,7 +313,7 @@ func (p *timeSeriesQueryParser) parse(tsdbQuery *tsdb.TsdbQuery) ([]*Query, erro
 			return nil, err
 		}
 		alias := model.Get("alias").MustString("")
-		interval := strconv.FormatInt(q.IntervalMs, 10) + "ms"
+		interval := model.Get("interval").MustString("0ms")
 
 		queries = append(queries, &Query{
 			TimeField:  timeField,

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -313,7 +313,7 @@ func (p *timeSeriesQueryParser) parse(tsdbQuery *tsdb.TsdbQuery) ([]*Query, erro
 			return nil, err
 		}
 		alias := model.Get("alias").MustString("")
-		interval := model.Get("interval").MustString("0ms")
+		interval := model.Get("interval").MustString("")
 
 		queries = append(queries, &Query{
 			TimeField:  timeField,

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -807,6 +807,7 @@ func TestTimeSeriesQueryParser(t *testing.T) {
 				"timeField": "@timestamp",
 				"query": "@metric:cpu",
 				"alias": "{{@hostname}} {{metric}}",
+        "interval": "10m",
 				"metrics": [
 					{
 						"field": "@value",
@@ -863,6 +864,7 @@ func TestTimeSeriesQueryParser(t *testing.T) {
 			So(q.TimeField, ShouldEqual, "@timestamp")
 			So(q.RawQuery, ShouldEqual, "@metric:cpu")
 			So(q.Alias, ShouldEqual, "{{@hostname}} {{metric}}")
+			So(q.Interval, ShouldEqual, "10m")
 
 			So(q.Metrics, ShouldHaveLength, 2)
 			So(q.Metrics[0].Field, ShouldEqual, "@value")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The current backend Golang code doesn't honor the minimum interval set in the UI for alerts. This means that the data the alerts are triggering against will never match the data in the visualization. For example, if you're monitoring AWS Cloudwatch EC2 data that only reports every 5 minutes and you set the minimum interval to `5m`, the alerts will not trigger correctly because it will use the `auto` interval instead which for `5m` of data defaults to `200ms`.

This PR fixes that by setting the minimum interval to the same value in the UI.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #22082

**Special notes for your reviewer**:
