### PR TITLE
Chore: Remove unused method for getting user stats

### DIFF
--- a/pkg/models/stats.go
+++ b/pkg/models/stats.go
@@ -98,9 +98,3 @@ type UserStats struct {
 	Editors int64
 	Viewers int64
 }
-
-type GetUserStatsQuery struct {
-	MustUpdate bool
-	Active     bool
-	Result     UserStats
-}

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -14,7 +14,6 @@ func init() {
 	bus.AddHandler("sql", GetDataSourceStats)
 	bus.AddHandler("sql", GetDataSourceAccessStats)
 	bus.AddHandler("sql", GetAdminStats)
-	bus.AddHandlerCtx("sql", GetUserStats)
 	bus.AddHandlerCtx("sql", GetAlertNotifiersUsageStats)
 	bus.AddHandlerCtx("sql", GetSystemUserCountStats)
 }
@@ -183,21 +182,6 @@ func GetSystemUserCountStats(ctx context.Context, query *models.GetSystemUserCou
 
 		return nil
 	})
-}
-
-func GetUserStats(ctx context.Context, query *models.GetUserStatsQuery) error {
-	err := updateUserRoleCountsIfNecessary(ctx, query.MustUpdate)
-	if err != nil {
-		return err
-	}
-
-	if query.Active {
-		query.Result = userStatsCache.active
-	} else {
-		query.Result = userStatsCache.total
-	}
-
-	return nil
 }
 
 func updateUserRoleCountsIfNecessary(ctx context.Context, forced bool) error {

--- a/pkg/services/sqlstore/stats_integration_test.go
+++ b/pkg/services/sqlstore/stats_integration_test.go
@@ -3,14 +3,9 @@
 package sqlstore
 
 import (
-	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,90 +15,4 @@ func TestIntegration_GetAdminStats(t *testing.T) {
 	query := models.GetAdminStatsQuery{}
 	err := GetAdminStats(&query)
 	require.NoError(t, err)
-}
-
-func TestIntegration_GetUserStats(t *testing.T) {
-	InitTestDB(t)
-
-	cmd := &models.CreateUserCommand{
-		Email:   "admin@test.com",
-		Name:    "Admin",
-		Login:   "admin",
-		OrgName: mainOrgName,
-		IsAdmin: true,
-	}
-	err := CreateUser(context.Background(), cmd)
-	require.NoError(t, err)
-	firstUser := cmd.Result
-
-	{
-		defaultAutoAssign := setting.AutoAssignOrg
-		defaultOrgID := setting.AutoAssignOrgId
-		defaultRole := setting.AutoAssignOrgRole
-
-		setting.AutoAssignOrg = true
-		setting.AutoAssignOrgId = int(firstUser.OrgId)
-		setting.AutoAssignOrgRole = "Editor"
-
-		defer func() {
-			setting.AutoAssignOrg = defaultAutoAssign
-			setting.AutoAssignOrgId = defaultOrgID
-			setting.AutoAssignOrgRole = defaultRole
-		}()
-	}
-
-	const nUsers = 100
-	users := make([]models.User, nUsers)
-
-	for i := range users {
-		cmd := &models.CreateUserCommand{
-			Email: fmt.Sprintf("usertest%v@test.com", i),
-			Name:  fmt.Sprintf("user name %v", i),
-			Login: fmt.Sprintf("user_test_%v_login", i),
-			OrgId: firstUser.OrgId,
-		}
-		err := CreateUser(context.Background(), cmd)
-		require.NoError(t, err)
-		users[i] = cmd.Result
-	}
-
-	orgs := make([]models.Org, 10)
-
-	for i := range orgs {
-		cmd := &models.CreateOrgCommand{
-			Name:   fmt.Sprintf("org %d", i),
-			UserId: firstUser.Id,
-		}
-		err := CreateOrg(cmd)
-		require.NoError(t, err)
-		orgs[i] = cmd.Result
-	}
-
-	for _, u := range users {
-		for _, o := range orgs {
-			cmd := &models.AddOrgUserCommand{
-				Role:   "Viewer",
-				UserId: u.Id,
-				OrgId:  o.Id,
-			}
-			err := AddOrgUser(cmd)
-			require.NoErrorf(t, err, "uID %d oID %d", u.Id, o.Id)
-		}
-	}
-
-	query := models.GetUserStatsQuery{
-		MustUpdate: true,
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	err = GetUserStats(ctx, &query)
-	require.NoError(t, err)
-	assert.EqualValues(t, models.UserStats{
-		Users:   nUsers + 1,
-		Admins:  1,
-		Editors: nUsers,
-		Viewers: 0,
-	}, query.Result)
 }

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -55,19 +55,6 @@ func TestStatsDataAccess(t *testing.T) {
 		err := GetAdminStats(&query)
 		assert.NoError(t, err)
 	})
-
-	t.Run("Get active user count stats should not result in error", func(t *testing.T) {
-		query := models.GetUserStatsQuery{
-			MustUpdate: true,
-			Active:     true,
-		}
-		err := GetUserStats(context.Background(), &query)
-		require.NoError(t, err)
-		assert.Equal(t, int64(1), query.Result.Users)
-		assert.Equal(t, int64(1), query.Result.Admins)
-		assert.Equal(t, int64(0), query.Result.Editors)
-		assert.Equal(t, int64(0), query.Result.Viewers)
-	})
 }
 
 func populateDB(t *testing.T) {
@@ -128,13 +115,5 @@ func populateDB(t *testing.T) {
 		UserId: users[0].Id,
 	}
 	err = UpdateUserLastSeenAt(updateUserLastSeenAtCmd)
-	require.NoError(t, err)
-
-	// force renewal of user stats
-	query := models.GetUserStatsQuery{
-		MustUpdate: true,
-		Active:     true,
-	}
-	err = GetUserStats(context.Background(), &query)
 	require.NoError(t, err)
 }

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -116,4 +116,8 @@ func populateDB(t *testing.T) {
 	}
 	err = UpdateUserLastSeenAt(updateUserLastSeenAtCmd)
 	require.NoError(t, err)
+
+	// force renewal of user stats
+	err = updateUserRoleCountsIfNecessary(context.Background(), true)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This was used in enterprise codebase and [is no longer in use](https://github.com/grafana/grafana-enterprise/commit/3e2445e4497e3a33f0bcc115d5d8a629d098c3e0#diff-b9818df8bfef986d0227958371f518605d46509698c5e2f57d540adb5aeebf27L272), thus can be safely removed.

cc @grafana/enterprise-squad 