### PR TITLE
Chore: Upgrade Docker build image wrt. Go/golangci-lint/Node

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -28,7 +28,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -37,7 +37,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -45,21 +45,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -69,7 +69,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -78,7 +78,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
   depends_on:
@@ -87,7 +87,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -95,7 +95,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
@@ -103,7 +103,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
   depends_on:
@@ -117,7 +117,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -137,7 +137,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -147,7 +147,7 @@ steps:
   - package
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
@@ -164,7 +164,7 @@ steps:
   - build-frontend-docs
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -180,7 +180,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -197,7 +197,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -248,7 +248,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -274,7 +274,7 @@ steps:
       from_secret: drone_token
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -283,7 +283,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -291,21 +291,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -315,7 +315,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -324,7 +324,7 @@ steps:
   - initialize
 
 - name: publish-frontend-metrics
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
   environment:
@@ -335,7 +335,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -344,7 +344,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -352,7 +352,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -363,7 +363,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -388,7 +388,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -408,7 +408,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -431,14 +431,14 @@ steps:
   - end-to-end-tests
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -468,7 +468,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -485,7 +485,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -501,7 +501,7 @@ steps:
   - test-frontend
 
 - name: release-canary-npm-packages
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./scripts/circle-release-canary-packages.sh
   environment:
@@ -612,7 +612,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -697,7 +697,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -712,7 +712,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -721,7 +721,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -729,21 +729,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -753,7 +753,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -762,7 +762,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -774,7 +774,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise ${DRONE_TAG}
   depends_on:
@@ -782,7 +782,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -793,7 +793,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -818,7 +818,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -838,7 +838,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -848,7 +848,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -878,7 +878,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -895,7 +895,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -938,7 +938,7 @@ steps:
   - end-to-end-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./scripts/build/release-packages.sh ${DRONE_TAG}
   environment:
@@ -1035,7 +1035,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -1048,7 +1048,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -1068,7 +1068,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -1077,7 +1077,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1085,21 +1085,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -1109,7 +1109,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1118,7 +1118,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -1130,7 +1130,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise ${DRONE_TAG}
   depends_on:
@@ -1138,7 +1138,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -1149,7 +1149,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -1174,7 +1174,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -1196,7 +1196,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -1226,7 +1226,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1243,7 +1243,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1272,7 +1272,7 @@ steps:
   - postgres-integration-tests
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend --build-tags=enterprise2
   environment:
@@ -1281,7 +1281,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --build-tags enterprise2
@@ -1291,7 +1291,7 @@ steps:
   - lint-backend-enterprise2
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-tags enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -1303,7 +1303,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-tags enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -1328,7 +1328,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -1468,7 +1468,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -1573,7 +1573,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -1588,7 +1588,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -1597,7 +1597,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1605,21 +1605,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -1629,7 +1629,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1638,7 +1638,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -1650,7 +1650,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise v7.3.0-test
   depends_on:
@@ -1658,7 +1658,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -1669,7 +1669,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -1694,7 +1694,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -1714,7 +1714,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1724,7 +1724,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -1748,7 +1748,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1765,7 +1765,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1805,7 +1805,7 @@ steps:
   - end-to-end-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   environment:
     NPM_TOKEN:
       from_secret: npm_token
@@ -1900,7 +1900,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -1913,7 +1913,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -1933,7 +1933,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -1942,7 +1942,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1950,21 +1950,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -1974,7 +1974,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1983,7 +1983,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -1995,7 +1995,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise v7.3.0-test
   depends_on:
@@ -2003,7 +2003,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -2014,7 +2014,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -2039,7 +2039,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -2061,7 +2061,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -2085,7 +2085,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2102,7 +2102,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2131,7 +2131,7 @@ steps:
   - postgres-integration-tests
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend --build-tags=enterprise2
   environment:
@@ -2140,7 +2140,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --build-tags enterprise2
@@ -2150,7 +2150,7 @@ steps:
   - lint-backend-enterprise2
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-tags enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -2162,7 +2162,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-tags enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -2187,7 +2187,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -2327,7 +2327,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -2432,7 +2432,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -2446,7 +2446,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -2455,7 +2455,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2463,21 +2463,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -2487,7 +2487,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2496,7 +2496,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2505,7 +2505,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2513,7 +2513,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -2524,7 +2524,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -2549,7 +2549,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -2569,7 +2569,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -2579,7 +2579,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -2603,7 +2603,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2620,7 +2620,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2732,7 +2732,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.30/grabpl
@@ -2745,7 +2745,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -2764,7 +2764,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend
   environment:
@@ -2773,7 +2773,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2781,21 +2781,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend
@@ -2805,7 +2805,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2814,7 +2814,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2823,7 +2823,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2831,7 +2831,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -2842,7 +2842,7 @@ steps:
   - lint-backend
 
 - name: package
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -2867,7 +2867,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -2889,7 +2889,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -2899,7 +2899,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
@@ -2923,7 +2923,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2940,7 +2940,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2969,7 +2969,7 @@ steps:
   - postgres-integration-tests
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl lint-backend --build-tags=enterprise2
   environment:
@@ -2978,7 +2978,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --build-tags enterprise2
@@ -2988,7 +2988,7 @@ steps:
   - lint-backend-enterprise2
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-tags enterprise2 --build-id ${DRONE_BUILD_NUMBER} --variants linux-x64 --no-pull-enterprise
   depends_on:
@@ -2997,7 +2997,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-tags enterprise2 --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64 --sign
   environment:
@@ -3022,7 +3022,7 @@ steps:
   - check-dashboard-schemas
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.3.0
+  image: grafana/build-container:1.3.1
   detach: true
   commands:
   - ./e2e/start-server

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/common.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/common.sh
@@ -4,4 +4,4 @@
 ## Common variable declarations
 ##
 
-DOCKER_IMAGE_NAME="grafana/grafana-plugin-ci:1.1.0-alpine"
+DOCKER_IMAGE_NAME="grafana/grafana-plugin-ci:1.1.1-alpine"

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -18,16 +18,16 @@ apk add --no-cache curl nodejs npm yarn build-base openssh git-lfs perl-utils co
 # apk add --no-cache xvfb glib nss nspr gdk-pixbuf "gtk+3.0" pango atk cairo dbus-libs libxcomposite libxrender libxi libxtst libxrandr libxscrnsaver alsa-lib at-spi2-atk at-spi2-core cups-libs gcompat libc6-compat
 
 # Install Go
-filename="go1.15.3.linux-amd64.tar.gz"
-get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d"
+filename="go1.15.6.linux-amd64.tar.gz"
+get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844"
 untar_file "/tmp/$filename"
 
 # Install golangci-lint
-GOLANGCILINT_VERSION=1.32.2
+GOLANGCILINT_VERSION=1.34.1
 filename="golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64"
 get_file "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCILINT_VERSION}/$filename.tar.gz" \
     "/tmp/${filename}.tar.gz" \
-    "e7ab86d833bf9faed39801ab3b5cd294f026d26f9a7da63a42390943ead486cc"
+    "23e4a9d8f89729007c6d749c245f725c2dbcfb194f4099003f9b826f1d386ad1"
 untar_file "/tmp/${filename}.tar.gz"
 ln -s /usr/local/${filename}/golangci-lint /usr/local/bin/golangci-lint
 ln -s /usr/local/go/bin/go /usr/local/bin/go

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -1,5 +1,5 @@
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
-FROM debian:stretch-20201012-slim AS toolchain
+FROM debian:stretch-20201209 AS toolchain
 
 ENV OSX_MIN=10.10 \
     CTNG=1.24.0 \
@@ -73,8 +73,8 @@ RUN cd /tmp && \
     rm -rf /tmp/x86_64-centos6-linux-gnu/ && \
     rm -rf /tmp/crosstool-ng-${CTNG}
 
-ARG GOLANGCILINT_VERSION=1.33.0
-ARG GOLANGCILINT_CHKSUM=e2d6082f1df53c5d2c280765000f9e82783ea909ba419c6c4e172936b076031e
+ARG GOLANGCILINT_VERSION=1.34.1
+ARG GOLANGCILINT_CHKSUM=23e4a9d8f89729007c6d749c245f725c2dbcfb194f4099003f9b826f1d386ad1
 
 RUN curl -fLO https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCILINT_VERSION}/golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64.tar.gz
 RUN echo ${GOLANGCILINT_CHKSUM} golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64.tar.gz | sha256sum --check --strict --status
@@ -95,12 +95,12 @@ RUN tar xf cue_${CUE_VERSION}_Linux_x86_64.tar.gz -C /tmp cue
 
 # Base image to crossbuild grafana.
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
-FROM debian:stretch-20201012
+FROM debian:stretch-20201209
 
-ENV GOVERSION=1.15.5 \
+ENV GOVERSION=1.15.6 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=14.15.1-1nodesource1 \
+    NODEVERSION=14.15.4-1nodesource1 \
     YARNVERSION=1.22.5-1 \
     GO111MODULE=on
 

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.3.0"
+_version="1.3.1"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,5 +1,5 @@
 grabpl_version = '0.5.30'
-build_image = 'grafana/build-container:1.3.0'
+build_image = 'grafana/build-container:1.3.1'
 publish_image = 'grafana/grafana-ci-deploy:1.2.7'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 alpine_image = 'alpine:3.12'


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade Docker build image with Go 1.15.6, golangci-lint 1.34, Node 14.5.4 and latest Debian Stretch for base image.
