### PR TITLE
Analytics: add data source type in data-request events

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -175,6 +175,11 @@ export abstract class DataSourceApi<
   readonly id: number;
 
   /**
+   *  Set in constructor
+   */
+  readonly type: string;
+
+  /**
    *  min interval range
    */
   interval?: string;
@@ -182,6 +187,7 @@ export abstract class DataSourceApi<
   constructor(instanceSettings: DataSourceInstanceSettings<TOptions>) {
     this.name = instanceSettings.name;
     this.id = instanceSettings.id;
+    this.type = instanceSettings.type;
     this.meta = {} as DataSourcePluginMeta;
   }
 

--- a/packages/grafana-runtime/src/types/analytics.ts
+++ b/packages/grafana-runtime/src/types/analytics.ts
@@ -20,7 +20,8 @@ export interface DashboardInfo {
  */
 export interface DataRequestInfo extends Partial<DashboardInfo> {
   datasourceName: string;
-  datasourceId?: number;
+  datasourceId: number;
+  datasourceType: string;
   panelId?: number;
   panelName?: string;
   duration: number;

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -23,6 +23,7 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
       eventName: MetaAnalyticsEventName.DataRequest,
       datasourceName: datasource.name,
       datasourceId: datasource.id,
+      datasourceType: datasource.type,
       panelId: data.request.panelId,
       dashboardId: data.request.dashboardId,
       dataSize: 0,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the data source type information in the meta analytics `data-request` events (as it's expected in the Enterprise backend and I think it's a useful information - although not a key information)
