### PR TITLE
adding curl to plugin ci build container

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -10,7 +10,7 @@ mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 rm /bin/cp
 mv /usr/local/bin/cp /bin/cp
 
-apk add --no-cache curl nodejs npm yarn build-base openssh git-lfs perl-utils coreutils python3
+apk add --no-cache curl nodejs npm yarn build-base openssh git-lfs perl-utils coreutils python3 curl
 
 #
 # Only relevant for testing, but cypress does not work with musl/alpine.


### PR DESCRIPTION
The utility provided for security scanning requires `curl` to be present on the system for it's interactions. This PR is only adding `curl` to the base dependencies for the `grafana-plugin-ci-alpine` docker image.