### PR TITLE
GraphNG: Overhaul of main test dashboard and update to null & gaps dashboard

### DIFF
--- a/devenv/dev-dashboards/panel-graph/graph-ng-nulls.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-nulls.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 345,
   "links": [],
   "panels": [
     {
@@ -31,9 +30,17 @@
             "drawStyle": "line",
             "fillGradient": 0,
             "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 7,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": false
           },
@@ -124,9 +131,17 @@
             "drawStyle": "line",
             "fillGradient": 0,
             "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": false
           },
@@ -226,9 +241,17 @@
             "drawStyle": "line",
             "fillGradient": 0,
             "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": false
           },
@@ -347,9 +370,17 @@
             "drawStyle": "line",
             "fillGradient": 0,
             "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 7,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": true
           },
@@ -440,9 +471,17 @@
             "drawStyle": "line",
             "fillGradient": 0,
             "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": true
           },
@@ -542,9 +581,17 @@
             "drawStyle": "line",
             "fillGradient": 0,
             "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "spanNulls": true
           },
@@ -649,6 +696,332 @@
       "timeShift": null,
       "title": "Same as above but connected",
       "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "Temperature",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 8,
+              "show": true
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "A-series"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C-series"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 14
+      },
+      "id": 11,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "list",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "10,25,null,null,50,10"
+        },
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,90,30,5,0"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Null values in first series & show gaps ",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "Temperature",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 8,
+              "show": true
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "A-series"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C-series"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 7,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "list",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,90,30,5,0"
+        },
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "10,25,null,null,50,10"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Null values in second series show gaps (bugged)",
+      "transformations": [],
+      "type": "graph3"
     }
   ],
   "schemaVersion": 27,
@@ -665,5 +1038,5 @@
   "timezone": "",
   "title": "Panel Tests - Graph NG - Gaps and Connected",
   "uid": "8mmCAF1Mz",
-  "version": 10
+  "version": 1
 }

--- a/devenv/dev-dashboards/panel-graph/graph-ng.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng.json
@@ -15,9 +15,21 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 90,
+  "id": 371,
   "links": [],
   "panels": [
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 50,
+      "title": "Lines",
+      "type": "row"
+    },
     {
       "datasource": null,
       "fieldConfig": {
@@ -32,21 +44,41 @@
               "side": 3,
               "width": 60
             },
+            "axisLabel": "",
+            "axisPlacement": "auto",
             "bars": {
               "show": false
             },
+            "drawStyle": "line",
             "fill": {
               "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
             },
             "line": {
               "show": true,
               "width": 1
             },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
             "nullValues": "null",
+            "pointSize": 5,
             "points": {
               "radius": 4,
               "show": false
-            }
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
           },
           "mappings": [],
           "thresholds": {
@@ -66,18 +98,20 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
-        "w": 12,
+        "h": 8,
+        "w": 6,
         "x": 0,
-        "y": 0
+        "y": 1
       },
-      "id": 40,
+      "id": 47,
+      "maxDataPoints": 500,
       "options": {
         "graph": {
           "realTimeUpdates": false
         },
         "legend": {
           "asTable": false,
+          "displayMode": "hidden",
           "isVisible": true,
           "placement": "bottom"
         },
@@ -88,64 +122,970 @@
       "pluginVersion": "7.3.0-pre",
       "targets": [
         {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
           "refId": "A",
-          "scenarioId": "random_walk"
-        },
-        {
-          "refId": "B",
-          "scenarioId": "random_walk"
-        },
-        {
-          "refId": "C",
-          "scenarioId": "random_walk"
-        },
-        {
-          "refId": "D",
-          "scenarioId": "random_walk"
-        },
-        {
-          "refId": "E",
-          "scenarioId": "random_walk"
+          "scenarioId": "random_walk",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "React NG graph",
+      "title": "Lines 500 data points",
       "type": "graph3"
     },
     {
-      "aliasColors": {
-        "B-series": "purple"
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 8,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 48,
+      "maxDataPoints": 20,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.3.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,50,30,5,0,20,40,90,50"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "10 data points, auto points mode",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 55,
+      "maxDataPoints": 20,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.3.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,50,30,5,0,20,40,90,50"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "20 data points, auto points never",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 8,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 56,
+      "maxDataPoints": 20,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.3.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,50,30,5,0,20,40,90,50"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "20 data points, points mode always",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 52,
+      "maxDataPoints": 10,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.3.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,50,30,5,0,20,40,90,50"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Interpolation: linear",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
+      "id": 53,
+      "maxDataPoints": 10,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.3.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,50,30,5,0,20,40,90,50"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Interpolation: Smooth",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
+      "id": 54,
+      "maxDataPoints": 10,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.3.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,50,30,5,0,20,40,90,50"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Interpolation: Step before",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "id": 57,
+      "maxDataPoints": 10,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.3.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "seriesCount": 1,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": "1,20,50,30,5,0,20,40,90,50"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Interpolation: Step before",
+      "type": "graph3"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 34,
+      "panels": [],
+      "title": "Legend rendering",
+      "type": "row"
+    },
+    {
       "datasource": "gdev-testdata",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "align": null,
             "axis": {
               "grid": true,
               "label": "",
               "side": 3,
-              "width": 80
+              "width": 40
             },
+            "axisLabel": "",
+            "axisPlacement": "auto",
             "bars": {
               "show": false
             },
+            "drawStyle": "line",
             "fill": {
-              "alpha": 0
+              "alpha": 0.2
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
             },
             "line": {
-              "show": false,
+              "show": true,
               "width": 1
             },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
             "nullValues": "null",
+            "pointSize": 5,
             "points": {
-              "radius": 2,
-              "show": true
-            }
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
           },
           "decimals": 2,
           "mappings": [],
@@ -184,84 +1124,1549 @@
                 "value": true
               },
               {
-                "id": "custom.axis.label",
-                "value": "Temperature (F)"
+                "id": "custom.axis.width",
+                "value": 40
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "id": 32,
+      "maxDataPoints": 100,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "list",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "hide": false,
+          "refId": "A",
+          "scenarioId": "random_walk"
+        },
+        {
+          "hide": false,
+          "refId": "B",
+          "scenarioId": "random_walk"
+        },
+        {
+          "refId": "C",
+          "scenarioId": "random_walk"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "List",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": null,
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 40
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.2
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
+          "unit": "celsius"
+        },
+        "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "C-series"
+              "options": "B-series"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "kelvin"
-              },
-              {
-                "id": "custom.axis.label",
-                "value": "Temperature (K)"
+                "value": "fahrenheit"
               },
               {
                 "id": "custom.axis.side",
                 "value": 1
               },
               {
-                "id": "custom.axis.grid",
-                "value": false
+                "id": "custom.line.show",
+                "value": true
+              },
+              {
+                "id": "custom.axis.width",
+                "value": 40
               }
             ]
           }
         ]
       },
-      "fill": 1,
-      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "id": 35,
+      "maxDataPoints": 100,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "list",
+          "isVisible": false,
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "hide": false,
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 3,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "List legend to the right ",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": null,
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 40
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.2
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "B-series"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "fahrenheit"
+              },
+              {
+                "id": "custom.axis.side",
+                "value": 1
+              },
+              {
+                "id": "custom.line.show",
+                "value": true
+              },
+              {
+                "id": "custom.axis.width",
+                "value": 40
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "id": 31,
+      "maxDataPoints": 200,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": true,
+          "displayMode": "table",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 8,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Table",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": null,
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 40
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.2
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 0,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "B-series"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "fahrenheit"
+              },
+              {
+                "id": "custom.axis.side",
+                "value": 1
+              },
+              {
+                "id": "custom.line.show",
+                "value": true
+              },
+              {
+                "id": "custom.axis.width",
+                "value": 40
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      },
+      "id": 51,
+      "maxDataPoints": 200,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": true,
+          "displayMode": "table",
+          "isVisible": true,
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 8,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Table to the right",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 17,
+      "panels": [],
+      "title": "Tooltip",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": null,
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 27
+      },
+      "id": 19,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "random_walk"
+        },
+        {
+          "refId": "B",
+          "scenarioId": "random_walk"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Single mode",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": null,
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 27
+      },
+      "id": 20,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "random_walk"
+        },
+        {
+          "refId": "B",
+          "scenarioId": "random_walk"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Multi mode",
+      "type": "graph3"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 27
+      },
+      "id": 21,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "none"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "random_walk"
+        },
+        {
+          "refId": "B",
+          "scenarioId": "random_walk"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "No tooltip",
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "Temperature",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 8,
+              "show": true
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 27
+      },
+      "id": 9,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "1,20,90,30,5,0"
+        },
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "10,25,40"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Diff number of datapoints and multi series tooltip",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Show gaps & Connected",
+      "type": "row"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "Temperature",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 8,
+              "show": true
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 35
+      },
+      "id": 43,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "1,20,90,30,5,0"
+        },
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "10,25,40"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Diff num datapoints & show gaps",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "Temperature",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 8,
+              "show": true
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 35
+      },
+      "id": 8,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "1,20,90,30,5,0"
+        },
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "10,25,null,null,50,10"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Null values & show gaps",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "Temperature",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 8,
+              "show": true
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 35
+      },
+      "id": 58,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "10,25,null,null,50,10"
+        },
+        {
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "1,20,90,30,5,0"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Null values & show gaps 2",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "datasource": "gdev-testdata",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "custom": {
+              "axis": {
+                "grid": true,
+                "label": "Temperature",
+                "side": 3
+              },
+              "bars": {
+                "show": false
+              },
+              "line": {
+                "show": true
+              },
+              "points": {
+                "radius": 8,
+                "show": true
+              }
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "asZero",
+            "pointSize": 5,
+            "points": {
+              "radius": 5,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 35
+      },
+      "id": 13,
+      "options": {
+        "graph": {
+          "realTimeUpdates": false
+        },
+        "legend": {
+          "asTable": false,
+          "displayMode": "hidden",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.2.0-pre",
+      "targets": [
+        {
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "1,20,90,30,5,0"
+        },
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "10,25,null,null,50,10"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Null values & show connected",
+      "transformations": [],
+      "type": "graph3"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 45,
+      "panels": [],
+      "title": "Annotations",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axis": {
+              "grid": true,
+              "label": "",
+              "side": 3,
+              "width": 60
+            },
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "bars": {
+              "show": false
+            },
+            "drawStyle": "line",
+            "fill": {
+              "alpha": 0.1
+            },
+            "fillGradient": {
+              "label": "None"
+            },
+            "fillOpacity": 10,
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "line": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "show": true,
+              "width": 1
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "nullValues": "null",
+            "pointSize": 5,
+            "points": {
+              "radius": 4,
+              "show": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 11,
         "w": 12,
-        "x": 12,
-        "y": 0
+        "x": 0,
+        "y": 44
       },
-      "hiddenSeries": false,
-      "id": 22,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 46,
       "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.3.0-pre",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "C-series",
-          "yaxis": 2
+        "graph": {
+          "realTimeUpdates": false
         },
-        {
-          "alias": "B-series",
-          "yaxis": 2
+        "legend": {
+          "asTable": false,
+          "displayMode": "list",
+          "isVisible": true,
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
         }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      },
+      "pluginVersion": "7.3.0-pre",
       "targets": [
         {
-          "labels": "",
           "refId": "A",
           "scenarioId": "random_walk"
         },
@@ -283,2202 +2688,31 @@
         },
         {
           "refId": "F",
-          "scenarioId": "random_walk"
-        },
-        {
-          "refId": "G",
-          "scenarioId": "random_walk"
-        },
-        {
-          "refId": "H",
-          "scenarioId": "random_walk"
-        },
-        {
-          "refId": "I",
-          "scenarioId": "random_walk"
+          "scenarioId": "annotations",
+          "stringInput": ""
         }
       ],
-      "thresholds": [],
       "timeFrom": null,
-      "timeRegions": [],
       "timeShift": null,
-      "title": "Angular graph",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "celsius",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "kelvin",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 11
-      },
-      "id": 34,
-      "panels": [
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 40
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 8,
-            "x": 0,
-            "y": 12
-          },
-          "id": 31,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": true,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "hide": false,
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            },
-            {
-              "labels": "",
-              "refId": "D",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "E",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "F",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "G",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "H",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "I",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "J",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "K",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "L",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "M",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "N",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "O",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "P",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "Q",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "R",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "S",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "T",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "U",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Table",
-          "transformations": [],
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 40
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 8,
-            "x": 8,
-            "y": 12
-          },
-          "id": 32,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "hide": false,
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "List",
-          "transformations": [],
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 40
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 8,
-            "x": 16,
-            "y": 12
-          },
-          "id": 35,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": false,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "hide": false,
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "No legend",
-          "transformations": [],
-          "type": "graph3"
-        }
-      ],
-      "title": "Legend rendering",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 12
-      },
-      "id": 24,
-      "panels": [
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 40
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "show": false,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "C-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "kelvin"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.axis.grid",
-                    "value": false
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "purple",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 6,
-            "x": 0,
-            "y": 24
-          },
-          "id": 25,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "hide": false,
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Bottom",
-          "transformations": [],
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 40
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "show": false,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "C-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "kelvin"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.axis.grid",
-                    "value": false
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "purple",
-                      "mode": "palette-classic"
-                    }
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 6,
-            "x": 6,
-            "y": 24
-          },
-          "id": 26,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "top"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "hide": false,
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Top",
-          "transformations": [],
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 40
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "show": false,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "C-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "kelvin"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.axis.grid",
-                    "value": false
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "purple",
-                      "mode": "palette-classic"
-                    }
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 6,
-            "x": 12,
-            "y": 24
-          },
-          "id": 28,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "left"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "hide": false,
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Left",
-          "transformations": [],
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 40
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "show": false,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "C-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "kelvin"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.axis.grid",
-                    "value": false
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "purple",
-                      "mode": "palette-classic"
-                    }
-                  },
-                  {
-                    "id": "custom.axis.width",
-                    "value": 40
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 6,
-            "x": 18,
-            "y": 24
-          },
-          "id": 27,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "right"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "hide": false,
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "hide": false,
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Right",
-          "transformations": [],
-          "type": "graph3"
-        }
-      ],
-      "title": "Legend placement",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 13
-      },
-      "id": 17,
-      "panels": [
-        {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 0,
-            "y": 14
-          },
-          "id": 19,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "B",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Single mode",
-          "type": "graph3"
-        },
-        {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 8,
-            "y": 14
-          },
-          "id": 20,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "multi"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "B",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Multi mode",
-          "type": "graph3"
-        },
-        {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 16,
-            "y": 14
-          },
-          "id": 21,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "none"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "B",
-              "scenarioId": "random_walk"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "No tooltip",
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axis": {
-                  "grid": true,
-                  "label": "Temperature",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 8,
-                  "show": true
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 22
-          },
-          "id": 9,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "multi"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "C",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "1,20,90,30,5,0"
-            },
-            {
-              "refId": "A",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "10,25,40"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Diff number of datapoints milt multi series tooltip",
-          "transformations": [],
-          "type": "graph3"
-        }
-      ],
-      "title": "Tooltip",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 14
-      },
-      "id": 11,
-      "panels": [
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axis": {
-                  "grid": true,
-                  "label": "Temperature",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 8,
-                  "show": true
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 8,
-            "x": 0,
-            "y": 15
-          },
-          "id": 8,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "C",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "1,20,90,30,5,0"
-            },
-            {
-              "refId": "A",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "10,25,null,null,50,10"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "As null",
-          "transformations": [],
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "custom": {
-                  "axis": {
-                    "grid": true,
-                    "label": "Temperature",
-                    "side": 3
-                  },
-                  "bars": {
-                    "show": false
-                  },
-                  "line": {
-                    "show": true
-                  },
-                  "points": {
-                    "radius": 8,
-                    "show": true
-                  }
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "asZero",
-                "points": {
-                  "radius": 5,
-                  "show": false
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 8,
-            "x": 8,
-            "y": 15
-          },
-          "id": 13,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "C",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "1,20,90,30,5,0"
-            },
-            {
-              "refId": "A",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "10,25,null,null,50,10"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "As zero",
-          "transformations": [],
-          "type": "graph3"
-        },
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axis": {
-                  "grid": true,
-                  "label": "Temperature",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "connected",
-                "points": {
-                  "radius": 8,
-                  "show": true
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 8,
-            "x": 16,
-            "y": 15
-          },
-          "id": 12,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "C",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "1,20,90,30,5,0"
-            },
-            {
-              "refId": "A",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "10,25,null,null,50,10"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Connected",
-          "transformations": [],
-          "type": "graph3"
-        }
-      ],
-      "title": "Null values rendering",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
-      "id": 15,
-      "panels": [
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axis": {
-                  "grid": true,
-                  "label": "Temperature",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 8,
-                  "show": true
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 16
-          },
-          "id": 43,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "C",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "1,20,90,30,5,0"
-            },
-            {
-              "refId": "A",
-              "scenarioId": "csv_metric_values",
-              "stringInput": "10,25,40"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Diff number of datapoints",
-          "transformations": [],
-          "type": "graph3"
-        }
-      ],
-      "title": "Misaligned data",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "id": 38,
-      "panels": [
-        {
-          "datasource": "gdev-testdata",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "align": null,
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 80
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.2
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": false,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 4,
-                  "show": false
-                }
-              },
-              "decimals": 2,
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "celsius"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "B-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "fahrenheit"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.line.show",
-                    "value": true
-                  },
-                  {
-                    "id": "custom.axis.label",
-                    "value": "Temperature (F)"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "C-series"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "kelvin"
-                  },
-                  {
-                    "id": "custom.axis.label",
-                    "value": "Temperature (K)"
-                  },
-                  {
-                    "id": "custom.axis.side",
-                    "value": 1
-                  },
-                  {
-                    "id": "custom.axis.grid",
-                    "value": false
-                  },
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "purple",
-                      "mode": "palette-classic"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 12,
-            "x": 0,
-            "y": 17
-          },
-          "id": 5,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.2.0-pre",
-          "targets": [
-            {
-              "refId": "C",
-              "scenarioId": "streaming_client",
-              "stream": {
-                "bands": 1,
-                "noise": 2.2,
-                "speed": 250,
-                "spread": 3.5,
-                "type": "signal"
-              },
-              "stringInput": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Graph ng",
-          "transformations": [],
-          "type": "graph3"
-        }
-      ],
-      "title": "Streaming",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
-      "id": 45,
-      "panels": [
-        {
-          "datasource": null,
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axis": {
-                  "grid": true,
-                  "label": "",
-                  "side": 3,
-                  "width": 60
-                },
-                "bars": {
-                  "show": false
-                },
-                "fill": {
-                  "alpha": 0.1
-                },
-                "line": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "show": true,
-                  "width": 1
-                },
-                "nullValues": "null",
-                "points": {
-                  "radius": 4,
-                  "show": false
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 12,
-            "x": 0,
-            "y": 18
-          },
-          "id": 46,
-          "options": {
-            "graph": {
-              "realTimeUpdates": false
-            },
-            "legend": {
-              "asTable": false,
-              "isVisible": true,
-              "placement": "bottom"
-            },
-            "tooltipOptions": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "7.3.0-pre",
-          "targets": [
-            {
-              "refId": "A",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "B",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "C",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "D",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "E",
-              "scenarioId": "random_walk"
-            },
-            {
-              "refId": "F",
-              "scenarioId": "annotations",
-              "stringInput": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "React NG graph",
-          "type": "graph3"
-        }
-      ],
-      "title": "Annotations",
-      "type": "row"
+      "title": "React NG graph",
+      "type": "graph3"
     }
   ],
   "refresh": false,
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": ["gdev", "panel-tests"],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
     "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
   },
-  "timezone": "Africa/Accra",
   "title": "Panel Tests - Graph NG",
   "uid": "TkZXxlNG3",
-  "version": 65
+  "version": 11
 }

--- a/devenv/dev-dashboards/panel-graph/graph-ng.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 371,
   "links": [],
   "panels": [
     {
@@ -275,7 +274,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "10 data points, auto points mode",
+      "title": "10 data points, points auto",
       "type": "graph3"
     },
     {
@@ -399,7 +398,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "20 data points, auto points never",
+      "title": "20 data points, points never",
       "type": "graph3"
     },
     {
@@ -441,7 +440,7 @@
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "nullValues": "null",
-            "pointSize": 8,
+            "pointSize": 5,
             "points": {
               "radius": 4,
               "show": false
@@ -476,7 +475,7 @@
         "y": 1
       },
       "id": 56,
-      "maxDataPoints": 20,
+      "maxDataPoints": 90,
       "options": {
         "graph": {
           "realTimeUpdates": false
@@ -509,7 +508,7 @@
             "timeStep": 60
           },
           "refId": "A",
-          "scenarioId": "csv_metric_values",
+          "scenarioId": "random_walk",
           "seriesCount": 1,
           "stream": {
             "bands": 1,
@@ -523,7 +522,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "20 data points, points mode always",
+      "title": "20 data points, points always",
       "type": "graph3"
     },
     {
@@ -2712,7 +2711,8 @@
   "timepicker": {
     "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
   },
+  "timezone": "",
   "title": "Panel Tests - Graph NG",
   "uid": "TkZXxlNG3",
-  "version": 11
+  "version": 2
 }


### PR DESCRIPTION
* Started overhaul of the main GraphNG test dashboard to test line modes & interpolation modes 

Found a bug in the gaps logic while doing this, if the second series contains nulls they are not shown as gaps. Updated the gaps & connected test dashboard with new test cases. 

Updated main dashboard:
![Screenshot from 2021-01-07 10-47-43](https://user-images.githubusercontent.com/10999/103877776-d06d1d00-50d5-11eb-9479-a411c163eb21.png)

Updated gaps dashboard with these panels. They are identical, only difference is the order of the series. But if the series with nulls comes last the gaps are not shown. 

![Screenshot from 2021-01-07 10-48-44](https://user-images.githubusercontent.com/10999/103877911-feeaf800-50d5-11eb-8e2f-f6165bede58d.png)




