### PR TITLE
Prometheus: Remove running of duplicated metrics query

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -94,6 +94,55 @@ describe('PromQueryField', () => {
     checkMetricsInCascader(await screen.findByRole('button'), changedMetrics);
   });
 
+  it('does not refreshes metrics when after rounding to minute time range does not change', async () => {
+    const defaultProps = {
+      query: { expr: '', refId: '' },
+      onRunQuery: () => {},
+      onChange: () => {},
+      history: [],
+    };
+    const metrics = ['foo', 'bar'];
+    const changedMetrics = ['foo', 'baz'];
+    const range = {
+      from: dateTime('2020-10-28T00:00:00Z'),
+      to: dateTime('2020-10-28T01:00:00Z'),
+    };
+
+    const languageProvider = makeLanguageProvider({ metrics: [metrics, changedMetrics] });
+    const queryField = render(
+      <PromQueryField
+        // @ts-ignore
+        datasource={{ languageProvider }}
+        range={{
+          ...range,
+          raw: range,
+        }}
+        {...defaultProps}
+      />
+    );
+    checkMetricsInCascader(await screen.findByRole('button'), metrics);
+
+    const newRange = {
+      from: dateTime('2020-10-28T00:00:01Z'),
+      to: dateTime('2020-10-28T01:00:01Z'),
+    };
+    queryField.rerender(
+      <PromQueryField
+        // @ts-ignore
+        datasource={{ languageProvider }}
+        range={{
+          ...newRange,
+          raw: newRange,
+        }}
+        {...defaultProps}
+      />
+    );
+    let cascader = screen.getByRole('button');
+    // Should not show loading
+    expect(cascader.textContent).toContain('Metrics');
+    checkMetricsInCascader(await screen.findByRole('button'), metrics);
+  });
+
   it('refreshes metrics when time range changes but dont show loading state', async () => {
     const defaultProps = {
       query: { expr: '', refId: '' },
@@ -140,7 +189,7 @@ describe('PromQueryField', () => {
     let cascader = screen.getByRole('button');
     // Should not show loading
     expect(cascader.textContent).toContain('Metrics');
-    checkMetricsInCascader(cascader, metrics);
+    checkMetricsInCascader(await screen.findByRole('button'), changedMetrics);
   });
 });
 

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -189,7 +189,7 @@ describe('PromQueryField', () => {
     let cascader = screen.getByRole('button');
     // Should not show loading
     expect(cascader.textContent).toContain('Metrics');
-    checkMetricsInCascader(await screen.findByRole('button'), changedMetrics);
+    checkMetricsInCascader(cascader, metrics);
   });
 });
 

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -186,7 +186,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     }
 
     const changedRangeToRefresh = this.rangeChangedToRefresh(range, prevProps.range);
-    // We want to rehresh metrics when language provider changes and/or when range changes (we round up intervals to a minute)
+    // We want to refresh metrics when language provider changes and/or when range changes (we round up intervals to a minute)
     if (languageProvider !== prevProps.datasource.languageProvider || changedRangeToRefresh) {
       this.refreshMetrics();
     }

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -5,7 +5,13 @@ import { Value } from 'slate';
 import { dateTime, HistoryItem, LanguageProvider } from '@grafana/data';
 import { CompletionItem, CompletionItemGroup, TypeaheadInput, TypeaheadOutput } from '@grafana/ui';
 
-import { fixSummariesMetadata, parseSelector, processHistogramLabels, processLabels } from './language_utils';
+import {
+  fixSummariesMetadata,
+  parseSelector,
+  processHistogramLabels,
+  processLabels,
+  roundSecToMin,
+} from './language_utils';
 import PromqlSyntax, { FUNCTIONS, RATE_RANGES } from './promql';
 
 import { PrometheusDatasource } from './datasource';
@@ -421,10 +427,6 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     return { [key]: data };
   };
 
-  roundToMinutes(seconds: number): number {
-    return Math.floor(seconds / 60);
-  }
-
   /**
    * Fetch labels for a series. This is cached by it's args but also by the global timeRange currently selected as
    * they can change over requested time.
@@ -443,8 +445,8 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     // The rounding may seem strange but makes relative intervals like now-1h less prone to need separate request every
     // millisecond while still actually getting all the keys for the correct interval. This still can create problems
     // when user does not the newest values for a minute if already cached.
-    params.set('start', this.roundToMinutes(tRange['start']).toString());
-    params.set('end', this.roundToMinutes(tRange['end']).toString());
+    params.set('start', roundSecToMin(tRange['start']).toString());
+    params.set('end', roundSecToMin(tRange['end']).toString());
     params.append('withName', withName ? 'true' : 'false');
     const cacheKey = `/api/v1/series?${params.toString()}`;
     let value = this.labelsCache.get(cacheKey);

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -186,8 +186,8 @@ export function fixSummariesMetadata(metadata: PromMetricsMetadata): PromMetrics
   return { ...metadata, ...summaryMetadata };
 }
 
-export function roundMsToMin(miliseconds: number): number {
-  return roundSecToMin(miliseconds / 1000);
+export function roundMsToMin(milliseconds: number): number {
+  return roundSecToMin(milliseconds / 1000);
 }
 
 export function roundSecToMin(seconds: number): number {

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -185,3 +185,11 @@ export function fixSummariesMetadata(metadata: PromMetricsMetadata): PromMetrics
   }
   return { ...metadata, ...summaryMetadata };
 }
+
+export function roundMsToMin(miliseconds: number): number {
+  return roundSecToMin(miliseconds / 1000);
+}
+
+export function roundSecToMin(seconds: number): number {
+  return Math.floor(seconds / 60);
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently running metrics query `/api/v1/label/__name__/values?` when range changes (even if change is couple of milliseconds). This PR fixes this and only refreshes metrics when range changes, but we round up intervals to a minute.

**Master, running 3x the same requests:**
![image](https://user-images.githubusercontent.com/30407135/103897456-e689d600-50f3-11eb-972e-4fe4102353f0.png)


**This branch, not running the same queries over:**
![image](https://user-images.githubusercontent.com/30407135/103897480-ef7aa780-50f3-11eb-85fa-6fad00bfa6dd.png)

Little downside could be, that is that if a user introduces a new metric, it is not going to appear instantly, but it is still going to be shown within 1 minute. 

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/issues/21893


