### PR TITLE
Chore: Fix intermittent time-related test failure in explore datasource instance update

### DIFF
--- a/packages/grafana-data/src/types/time.ts
+++ b/packages/grafana-data/src/types/time.ts
@@ -43,9 +43,11 @@ export type TimeFragment = string | DateTime;
 export const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 export function getDefaultTimeRange(): TimeRange {
+  const now = dateTime();
+
   return {
-    from: dateTime().subtract(6, 'hour'),
-    to: dateTime(),
+    from: dateTime(now).subtract(6, 'hour'),
+    to: now,
     raw: { from: 'now-6h', to: 'now' },
   };
 }

--- a/public/app/features/explore/state/datasource.test.ts
+++ b/public/app/features/explore/state/datasource.test.ts
@@ -22,7 +22,13 @@ describe('Datasource reducer', () => {
       queries,
       queryKeys,
     } as unknown) as ExploreItemState;
-    const expectedState: any = {
+
+    const result = datasourceReducer(
+      initialState,
+      updateDatasourceInstanceAction({ exploreId: ExploreId.left, datasourceInstance, history: [] })
+    );
+
+    const expectedState: Partial<ExploreItemState> = {
       datasourceInstance,
       queries,
       queryKeys,
@@ -31,13 +37,14 @@ describe('Datasource reducer', () => {
       tableResult: null,
       latency: 0,
       loading: false,
-      queryResponse: createEmptyQueryResponse(),
+      queryResponse: {
+        // When creating an empty query response we also create a timeRange object with the current time.
+        // Copying the range from the reducer here prevents intermittent failures when creating them at different times.
+        ...createEmptyQueryResponse(),
+        timeRange: result.queryResponse.timeRange,
+      },
     };
 
-    const result = datasourceReducer(
-      initialState,
-      updateDatasourceInstanceAction({ exploreId: ExploreId.left, datasourceInstance, history: [] })
-    );
     expect(result).toMatchObject(expectedState);
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
#30003 Introduced a `getDefaultTimeRange` function that generates a TimeRange object out of the current time.
This lead to an intermittent test failure because we were comparing 2 different TimeRange objects that may be created at 2 different times.

Also made a small change in `getDefaultTimeRange` to ensure that `from` is calculated starting from the `to` property.


