### PR TITLE
Update mysql.go

### DIFF
--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -36,7 +36,7 @@ func newMysqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoin
 		protocol = "unix"
 	}
 
-	cnnstr := fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&parseTime=true&loc=UTC&allowNativePasswords=true",
+	cnnstr := fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&parseTime=true&loc=UTC&allowNativePasswords=true&allowCleartextPasswords=1",
 		characterEscape(datasource.User, ":"),
 		datasource.DecryptedPassword(),
 		protocol,

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -36,7 +36,7 @@ func newMysqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoin
 		protocol = "unix"
 	}
 
-	cnnstr := fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&parseTime=true&loc=UTC&allowNativePasswords=true&allowCleartextPasswords=1",
+	cnnstr := fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&parseTime=true&loc=UTC&allowNativePasswords=true",
 		characterEscape(datasource.User, ":"),
 		datasource.DecryptedPassword(),
 		protocol,
@@ -54,6 +54,7 @@ func newMysqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoin
 		if err := mysql.RegisterTLSConfig(tlsConfigString, tlsConfig); err != nil {
 			return nil, err
 		}
+		cnnstr += "&allowCleartextPasswords=1"
 		cnnstr += "&tls=" + tlsConfigString
 	}
 


### PR DESCRIPTION
when add mysql datasource, it says:
this user requires clear text authentication. If you still want to use it, please add 'allowCleartextPasswords=1' to your DSN
 i suggest add the allowCleartextPasswords=1 as default uri configuration...