### PR TITLE
AngularPanels: Fixes issue with some panels not rendering when going into edit mode due to no height

### DIFF
--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -66,6 +66,8 @@ module.directive('grafanaPanel', ($rootScope, $document, $timeout) => {
         ctrl.width = scope.$parent.$parent.size.width;
       }
 
+      updateDimensionsFromParentScope();
+
       // Pass PanelModel events down to angular controller event emitter
       subs.add(
         panel.events.subscribe(RefreshEvent, () => {

--- a/public/app/plugins/panel/heatmap/display_editor.ts
+++ b/public/app/plugins/panel/heatmap/display_editor.ts
@@ -7,8 +7,6 @@ export class HeatmapDisplayEditorCtrl {
     $scope.editor = this;
     this.panelCtrl = $scope.ctrl;
     this.panel = this.panelCtrl.panel;
-
-    this.panelCtrl.render();
   }
 }
 


### PR DESCRIPTION
Introduced by recent angular panels refactorings  (so bug in master only)
