### PR TITLE
Loki: Timeseries should not produce 0-values for missing data

### DIFF
--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -185,7 +185,10 @@ function lokiMatrixToTimeSeries(matrixResult: LokiMatrixResult, options: Transfo
   };
 }
 
-function lokiPointsToTimeseriesPoints(data: Array<[number, string]>, options: TransformerOptions): TimeSeriesValue[][] {
+export function lokiPointsToTimeseriesPoints(
+  data: Array<[number, string]>,
+  options: TransformerOptions
+): TimeSeriesValue[][] {
   const stepMs = options.step * 1000;
   const datapoints: TimeSeriesValue[][] = [];
 
@@ -199,7 +202,7 @@ function lokiPointsToTimeseriesPoints(data: Array<[number, string]>, options: Tr
 
     const timestamp = time * 1000;
     for (let t = baseTimestampMs; t < timestamp; t += stepMs) {
-      datapoints.push([0, t]);
+      datapoints.push([null, t]);
     }
 
     baseTimestampMs = timestamp + stepMs;
@@ -208,7 +211,7 @@ function lokiPointsToTimeseriesPoints(data: Array<[number, string]>, options: Tr
 
   const endTimestamp = options.end / 1e6;
   for (let t = baseTimestampMs; t <= endTimestamp; t += stepMs) {
-    datapoints.push([0, t]);
+    datapoints.push([null, t]);
   }
 
   return datapoints;


### PR DESCRIPTION
It should produce NULL values instead, to be in line with Prometheus.


Before:
![Screenshot 2021-01-07 at 13 27 01](https://user-images.githubusercontent.com/859729/103915692-d2ea6980-510b-11eb-80c0-9b3c55e4bf76.png)

After:
![Screenshot 2021-01-07 at 13 34 52](https://user-images.githubusercontent.com/859729/103915718-d8e04a80-510b-11eb-807c-2e277305c564.png)

