### PR TITLE
GraphNG: check cross-axis presence when auto-padding. close #30121.

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/hooks.ts
+++ b/packages/grafana-ui/src/components/uPlot/hooks.ts
@@ -86,7 +86,9 @@ export const usePlotPlugins = () => {
 };
 
 const paddingSide: PaddingSide = (u, side, sidesWithAxes, cycleNum) => {
-  return sidesWithAxes[side] ? 0 : 8;
+  let hasCrossAxis = side % 2 ? sidesWithAxes[0] || sidesWithAxes[2] : sidesWithAxes[1] || sidesWithAxes[3];
+
+  return sidesWithAxes[side] || !hasCrossAxis ? 0 : 8;
 };
 
 export const DEFAULT_PLOT_CONFIG: Partial<Options> = {


### PR DESCRIPTION
i accidentally regressed this in the uPlot 1.5.0 upgrade :grimacing: https://github.com/grafana/grafana/commit/77d6100b44708e85d5b1233e4454847e88dcc306

