### PR TITLE
AngularPanels: Fixes issue with discrete panel that used the initialized event

### DIFF
--- a/packages/grafana-data/src/types/legacyEvents.ts
+++ b/packages/grafana-data/src/types/legacyEvents.ts
@@ -22,6 +22,7 @@ export const PanelEvents = {
   dataSnapshotLoad: eventFactory<DataQueryResponseData[]>('data-snapshot-load'),
   editModeInitialized: eventFactory('init-edit-mode'),
   initPanelActions: eventFactory<AngularPanelMenuItem[]>('init-panel-actions'),
+  initialized: eventFactory('panel-initialized'),
   panelTeardown: eventFactory('panel-teardown'),
   render: eventFactory<any>('render'),
 };

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -51,6 +51,7 @@ export class PanelCtrl {
 
   panelDidMount() {
     this.events.emit(PanelEvents.componentDidMount);
+    this.events.emit(PanelEvents.initialized);
     this.dashboard.panelInitialized(this.panel);
   }
 


### PR DESCRIPTION
Angular panel events refactorings broke the discrete panel so added back this initilized event.
