### PR TITLE
Loki: Lower min step to 1ms

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1,6 +1,6 @@
 import { of, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { AnnotationQueryRequest, CoreApp, DataFrame, dateTime, FieldCache, TimeRange, TimeSeries } from '@grafana/data';
+import { AnnotationQueryRequest, CoreApp, DataFrame, dateTime, FieldCache, TimeSeries } from '@grafana/data';
 import { BackendSrvRequest, FetchResponse } from '@grafana/runtime';
 
 import LokiDatasource from './datasource';

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -117,6 +117,37 @@ describe('LokiDatasource', () => {
       expect(req.end).toBeDefined();
       expect(adjustIntervalSpy).toHaveBeenCalledWith(2000, expect.anything());
     });
+
+    it('should set the minimal step to 100ms', () => {
+      const target = { expr: '{job="grafana"}', refId: 'B' };
+      const raw = { from: 'now', to: 'now-1h' };
+      const range = { from: dateTime('2020-10-14T00:00:00'), to: dateTime('2020-10-14T00:10:00'), raw: raw };
+      const options = {
+        range,
+        intervalMs: 50,
+      };
+
+      const req = ds.createRangeQuery(target, options as any, 1000);
+      expect(req.start).toBeDefined();
+      expect(req.end).toBeDefined();
+      expect(adjustIntervalSpy).toHaveBeenCalledWith(50, expect.anything());
+      // Step is in seconds (100 ms === 0.1 s)
+      expect(req.step).toEqual(0.1);
+    });
+    it('should use provided intervalMs', () => {
+      const target = { expr: '{job="grafana"}', refId: 'B' };
+      const raw = { from: 'now', to: 'now-1h' };
+      const range = { from: dateTime(), to: dateTime(), raw: raw };
+      const options = {
+        range,
+        intervalMs: 2000,
+      };
+
+      const req = ds.createRangeQuery(target, options as any, 1000);
+      expect(req.start).toBeDefined();
+      expect(req.end).toBeDefined();
+      expect(adjustIntervalSpy).toHaveBeenCalledWith(2000, expect.anything());
+    });
   });
 
   describe('when doing logs queries with limits', () => {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -118,21 +118,21 @@ describe('LokiDatasource', () => {
       expect(adjustIntervalSpy).toHaveBeenCalledWith(2000, expect.anything());
     });
 
-    it('should set the minimal step to 100ms', () => {
+    it('should set the minimal step to 1ms', () => {
       const target = { expr: '{job="grafana"}', refId: 'B' };
       const raw = { from: 'now', to: 'now-1h' };
-      const range = { from: dateTime('2020-10-14T00:00:00'), to: dateTime('2020-10-14T00:10:00'), raw: raw };
+      const range = { from: dateTime('2020-10-14T00:00:00'), to: dateTime('2020-10-14T00:00:01'), raw: raw };
       const options = {
         range,
-        intervalMs: 50,
+        intervalMs: 0.0005,
       };
 
       const req = ds.createRangeQuery(target, options as any, 1000);
       expect(req.start).toBeDefined();
       expect(req.end).toBeDefined();
-      expect(adjustIntervalSpy).toHaveBeenCalledWith(50, expect.anything());
-      // Step is in seconds (100 ms === 0.1 s)
-      expect(req.step).toEqual(0.1);
+      expect(adjustIntervalSpy).toHaveBeenCalledWith(0.0005, expect.anything());
+      // Step is in seconds (1 ms === 0.001 s)
+      expect(req.step).toEqual(0.001);
     });
   });
 
@@ -440,24 +440,6 @@ describe('LokiDatasource', () => {
         expect(result.status).toEqual('error');
         expect(result.message).toBe('Loki: Bad Gateway. 502');
       });
-    });
-  });
-
-  describe('when creating a range query', () => {
-    // Loki v1 API has an issue with float step parameters, can be removed when API is fixed
-    it('should produce an integer step parameter', () => {
-      const ds = createLokiDSForTests();
-      const query: LokiQuery = { expr: 'foo', refId: 'bar' };
-      const range: TimeRange = {
-        from: dateTime(0),
-        to: dateTime(1e9 + 1),
-        raw: { from: '0', to: '1000000001' },
-      };
-
-      // Odd timerange/interval combination that would lead to a float step
-      const options = { range, intervalMs: 2000 };
-
-      expect(Number.isInteger(ds.createRangeQuery(query, options as any, 1000).step!)).toBeTruthy();
     });
   });
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -134,20 +134,6 @@ describe('LokiDatasource', () => {
       // Step is in seconds (100 ms === 0.1 s)
       expect(req.step).toEqual(0.1);
     });
-    it('should use provided intervalMs', () => {
-      const target = { expr: '{job="grafana"}', refId: 'B' };
-      const raw = { from: 'now', to: 'now-1h' };
-      const range = { from: dateTime(), to: dateTime(), raw: raw };
-      const options = {
-        range,
-        intervalMs: 2000,
-      };
-
-      const req = ds.createRangeQuery(target, options as any, 1000);
-      expect(req.start).toBeDefined();
-      expect(req.end).toBeDefined();
-      expect(adjustIntervalSpy).toHaveBeenCalledWith(2000, expect.anything());
-    });
   });
 
   describe('when doing logs queries with limits', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -173,8 +173,8 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const rangeMs = Math.ceil((endNs - startNs) / 1e6);
       const adjustedInterval =
         this.adjustInterval((options as DataQueryRequest<LokiQuery>).intervalMs || 1000, rangeMs) / 1000;
-      // We want to ceil to 1 decimal place
-      const step = Math.ceil(adjustedInterval * 10) / 10;
+      // We want to ceil to 3 decimal places
+      const step = Math.ceil(adjustedInterval * 1000) / 1000;
       const alignedTimes = {
         start: startNs - (startNs % 1e9),
         end: endNs + (1e9 - (endNs % 1e9)),
@@ -544,8 +544,8 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     if (interval !== 0 && range / interval > 11000) {
       interval = Math.ceil(range / 11000);
     }
-    // The min interval is set to 100ms
-    return Math.max(interval, 100);
+    // The min interval is set to 1ms
+    return Math.max(interval, 1);
   }
 }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -171,10 +171,10 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const startNs = this.getTime(options.range.from, false);
       const endNs = this.getTime(options.range.to, true);
       const rangeMs = Math.ceil((endNs - startNs) / 1e6);
-      const adjustedIntervalInSec =
+      const adjustedInterval =
         this.adjustInterval((options as DataQueryRequest<LokiQuery>).intervalMs || 1000, rangeMs) / 1000;
       // We want to ceil to 1 decimal place
-      const step = Math.ceil(adjustedIntervalInSec * 10) / 10;
+      const step = Math.ceil(adjustedInterval * 10) / 10;
       const alignedTimes = {
         start: startNs - (startNs % 1e9),
         end: endNs + (1e9 - (endNs % 1e9)),

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -171,9 +171,10 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       const startNs = this.getTime(options.range.from, false);
       const endNs = this.getTime(options.range.to, true);
       const rangeMs = Math.ceil((endNs - startNs) / 1e6);
-      const step = Math.ceil(
-        this.adjustInterval((options as DataQueryRequest<LokiQuery>).intervalMs || 1000, rangeMs) / 1000
-      );
+      const adjustedIntervalInSec =
+        this.adjustInterval((options as DataQueryRequest<LokiQuery>).intervalMs || 1000, rangeMs) / 1000;
+      // We want to ceil to 1 decimal place
+      const step = Math.ceil(adjustedIntervalInSec * 10) / 10;
       const alignedTimes = {
         start: startNs - (startNs % 1e9),
         end: endNs + (1e9 - (endNs % 1e9)),
@@ -543,7 +544,8 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     if (interval !== 0 && range / interval > 11000) {
       interval = Math.ceil(range / 11000);
     }
-    return Math.max(interval, 1000);
+    // The min interval is set to 100ms
+    return Math.max(interval, 100);
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The lowest for Loki queries is currently set to 1s. This PR changes this to 100ms. See https://github.com/grafana/grafana/issues/29210 for more details. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/29210

