### PR TITLE
Docs: Add more info to about access mode when provisioning Prometheus

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -166,6 +166,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
     access: proxy
     url: http://localhost:9090
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/grafana/grafana/issues/29597 for more context. 
I am not sure if this change is better/if it makes sense. I tried to make it more clear what does proxy/direct access mean when provisioning Prometheus data source. It is already mentioned [here](https://grafana.com/docs/grafana/latest/administration/provisioning/#example-data-source-config-file), but I think it would make sense to add information also to Prometheus docs.  

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/29597


