### PR TITLE
Docs: Add metadata to activating licensing page

### DIFF
--- a/docs/sources/enterprise/activate-license.md
+++ b/docs/sources/enterprise/activate-license.md
@@ -1,4 +1,9 @@
-
++++
+title = "Activate an Enterprise license"
+description = "Activate an Enterprise license"
+keywords = ["grafana", "licensing"]
+weight = 7
++++
 
 # Activate an Enterprise license
 

--- a/docs/sources/enterprise/activate-license.md
+++ b/docs/sources/enterprise/activate-license.md
@@ -1,7 +1,7 @@
 +++
 title = "Activate an Enterprise license"
 description = "Activate an Enterprise license"
-keywords = ["grafana", "licensing"]
+keywords = ["grafana", "licensing", "enterprise"]
 weight = 7
 +++
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We have a [documentation for activating an enterprise license](https://grafana.com/docs/grafana/latest/enterprise/activate-license/), however the page title is not visible in the left sub menu (see little invisible menu item at the bottom).

<img width="282" alt="Screenshot 2021-01-08 at 15 04 48" src="https://user-images.githubusercontent.com/1861190/104024076-dbea4200-51c2-11eb-82c9-684a7a6e97e2.png">

PR adds necessary metadata, so that the page will be visible. 