### PR TITLE
Grafana-ui: Allow context menu items to be open in new tab

### DIFF
--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -120,7 +120,14 @@ const MenuItemComponent: React.FC<MenuItemProps> = React.memo(({ url, icon, labe
         target={target}
         className={cx(className, styles.link)}
         onClick={e => {
+          // We can have both url and onClick and we want to allow user to open the link in new tab/window
+          const isSpecialKeyPressed = e.ctrlKey || e.metaKey || e.shiftKey;
+          if (isSpecialKeyPressed && url) {
+            return;
+          }
+
           if (onClick) {
+            e.preventDefault();
             onClick(e);
           }
         }}


### PR DESCRIPTION
Sometimes we need both url and onClick work in context menu. This allows to open the link with ctrl/meta + click as would be expected.