### PR TITLE
AngularQueryEditors: Fixes to Graphite query editor and other who refer to other queries

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -221,7 +221,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
 
   onDisableQuery = () => {
     this.props.query.hide = !this.props.query.hide;
-    this.onRunQuery();
+    this.props.onRunQuery();
     this.forceUpdate();
   };
 

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -72,9 +72,9 @@ export class QueryEditorRow extends PureComponent<Props, State> {
   }
 
   getAngularQueryComponentScope(): AngularQueryComponentScope {
-    const { query, onChange } = this.props;
+    const { query, onChange, onRunQuery, queries } = this.props;
     const { datasource } = this.state;
-    const panel = new PanelModel({});
+    const panel = new PanelModel({ targets: queries });
     const dashboard = {} as DashboardModel;
 
     return {
@@ -85,6 +85,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
       refresh: () => {
         // Old angular editors modify the query model and just call refresh
         onChange(query);
+        onRunQuery();
       },
       render: () => () => console.log('legacy render function called, it does nothing'),
       events: panel.events,
@@ -170,12 +171,8 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     this.renderAngularQueryEditor();
   };
 
-  onRunQuery = () => {
-    this.props.onRunQuery();
-  };
-
   renderPluginEditor = () => {
-    const { query, onChange, queries } = this.props;
+    const { query, onChange, queries, onRunQuery } = this.props;
     const { datasource, data } = this.state;
 
     if (datasource?.components?.QueryCtrl) {
@@ -191,7 +188,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
           query={query}
           datasource={datasource}
           onChange={onChange}
-          onRunQuery={this.onRunQuery}
+          onRunQuery={onRunQuery}
           data={data}
           range={getTimeSrv().timeRange()}
           queries={queries}


### PR DESCRIPTION
Fixes to angular query editors that used panel.targets to refer to other queries, caused by recent (in master) changes.

Also fixes so that angular editors that call refresh also triggers a onRunQuery
