### PR TITLE
Variables: Add deprecation warning for value group tags

### DIFF
--- a/docs/sources/variables/variable-selection-options.md
+++ b/docs/sources/variables/variable-selection-options.md
@@ -1,9 +1,9 @@
 +++
-title = "Enter variable Selection Options"
+title = "Variable selection options"
 weight = 400
 +++
 
-# Enter variable selection options
+# Configure variable selection options
 
 **Selection Options** are a feature you can use to manage variable option selections. All selection options are optional, and they are off by default.
 

--- a/docs/sources/variables/variable-value-tags.md
+++ b/docs/sources/variables/variable-value-tags.md
@@ -5,7 +5,7 @@ weight = 500
 
 # Configure variable value group tags 
 
-> Experimental feature that will be deprecated in Grafana v8.
+> **Note:** This is an experimental feature that will be deprecated in Grafana v8.
 
 Value groups/tags are a feature you can use to organize variable options. If you have many options in the dropdown for a multi-value variable, then you can use this feature to group the values into selectable tags.
 

--- a/docs/sources/variables/variable-value-tags.md
+++ b/docs/sources/variables/variable-value-tags.md
@@ -1,9 +1,10 @@
 +++
-title = "Enter Value tags"
+title = "Variable value group tags"
 weight = 500
 +++
+# Configure variable value group tags 
 
-# Enter variable value groups/tags (experimental feature)
+> Experimental feature that will be deprecated in Grafana v8.
 
 Value groups/tags are a feature you can use to organize variable options. If you have many options in the dropdown for a multi-value variable, then you can use this feature to group the values into selectable tags.
 

--- a/docs/sources/variables/variable-value-tags.md
+++ b/docs/sources/variables/variable-value-tags.md
@@ -2,6 +2,7 @@
 title = "Variable value group tags"
 weight = 500
 +++
+
 # Configure variable value group tags 
 
 > Experimental feature that will be deprecated in Grafana v8.

--- a/public/app/features/variables/editor/VariableSwitchField.tsx
+++ b/public/app/features/variables/editor/VariableSwitchField.tsx
@@ -32,8 +32,13 @@ export function VariableSwitchField({
 function getStyles(theme: GrafanaTheme) {
   return {
     switchContainer: css`
-      margin-left: ${theme.spacing.sm};
-      margin-right: ${theme.spacing.sm};
+      padding-left: ${theme.spacing.sm};
+      padding-right: ${theme.spacing.sm};
+      height: 100%;
+      display: flex;
+      align-items: center;
+      background: ${theme.colors.formInputBg};
+      border: 1px solid ${theme.colors.formInputBorder};
     `,
   };
 }

--- a/public/app/features/variables/editor/VariableSwitchField.tsx
+++ b/public/app/features/variables/editor/VariableSwitchField.tsx
@@ -32,13 +32,8 @@ export function VariableSwitchField({
 function getStyles(theme: GrafanaTheme) {
   return {
     switchContainer: css`
-      padding-left: ${theme.spacing.sm};
-      padding-right: ${theme.spacing.sm};
-      height: 100%;
-      display: flex;
-      align-items: center;
-      background: ${theme.colors.formInputBg};
-      border: 1px solid ${theme.colors.formInputBorder};
+      margin-left: ${theme.spacing.sm};
+      margin-right: ${theme.spacing.sm};
     `,
   };
 }

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -231,7 +231,9 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
           />
 
           <VerticalGroup spacing="none">
-            <h5>Value groups/tags (Experimental feature)</h5>
+            <h5>Value group tags</h5>
+            <em className="muted p-b-1">Experimental feature, will be deprecated in Grafana v8.</em>
+
             <VariableSwitchField
               value={this.props.variable.useTags}
               name="Enabled"


### PR DESCRIPTION
* [x] Adds deprecation notice in the UI 
* [x] Adds deprecation notice in the docs

# Deprecation notice 

#### Query variable value group tags

This option to group query variable values into groups by tags has been an experimental feature since it was introduced. It was introduced to work around the lack of tags support in time series databases at the time. Now that tags (ie. labels) are the norm there is no longer any great need for this feature. This feature will be removed in Grafana v8 later this year. 