### PR TITLE
InlineSwitch: Added missing InlineSwitch component and fixed two places that used unaligned inline switch

### DIFF
--- a/e2e/suite1/specs/variables/new-query-variable.ts
+++ b/e2e/suite1/specs/variables/new-query-variable.ts
@@ -66,27 +66,11 @@ describe('Variables - Add variable', () => {
       .within(select => {
         e2e.components.Select.singleValue().should('have.text', 'Disabled');
       });
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsMultiSwitch()
-      .should('be.visible')
-      .within(select => {
-        e2e()
-          .get('input')
-          .should('not.be.checked');
-      });
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsIncludeAllSwitch()
-      .should('be.visible')
-      .within(select => {
-        e2e()
-          .get('input')
-          .should('not.be.checked');
-      });
-    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.valueGroupsTagsEnabledSwitch()
-      .should('be.visible')
-      .within(select => {
-        e2e()
-          .get('input')
-          .should('not.be.checked');
-      });
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsMultiSwitch().should('not.be.checked');
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsIncludeAllSwitch().should('not.be.checked');
+
+    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.valueGroupsTagsEnabledSwitch().should('not.be.checked');
+
     e2e.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption().should('not.exist');
     e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInput().should('not.exist');
   });
@@ -190,7 +174,7 @@ describe('Variables - Add variable', () => {
       .blur();
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsMultiSwitch()
-      .click()
+      .click({ force: true })
       .within(() => {
         e2e()
           .get('input')
@@ -198,7 +182,7 @@ describe('Variables - Add variable', () => {
       });
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsIncludeAllSwitch()
-      .click()
+      .click({ force: true })
       .within(() => {
         e2e()
           .get('input')

--- a/packages/grafana-ui/src/components/Forms/getFormStyles.ts
+++ b/packages/grafana-ui/src/components/Forms/getFormStyles.ts
@@ -6,7 +6,6 @@ import { getFieldValidationMessageStyles } from './FieldValidationMessage';
 import { getButtonStyles, ButtonVariant } from '../Button';
 import { ComponentSize } from '../../types/size';
 import { getInputStyles } from '../Input/Input';
-import { getSwitchStyles } from '../Switch/Switch';
 import { getCheckboxStyles } from './Checkbox';
 
 export const getFormStyles = stylesFactory(
@@ -23,7 +22,6 @@ export const getFormStyles = stylesFactory(
         hasText: true,
       }),
       input: getInputStyles({ theme, invalid: options.invalid }),
-      switch: getSwitchStyles(theme),
       checkbox: getCheckboxStyles(theme),
     };
   }

--- a/packages/grafana-ui/src/components/Switch/Switch.mdx
+++ b/packages/grafana-ui/src/components/Switch/Switch.mdx
@@ -22,3 +22,9 @@ import { Switch } from '@grafana/ui';
 ### Props
 
 <Props of={Switch} />
+
+# InlineSwitch
+
+### When to use
+
+Same as for Switch but for inline forms.

--- a/packages/grafana-ui/src/components/Switch/Switch.story.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.story.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useCallback } from 'react';
 import { boolean } from '@storybook/addon-knobs';
 import { withCenteredStory, withHorizontallyCenteredStory } from '../../utils/storybook/withCenteredStory';
-import { Switch } from '@grafana/ui';
+import { InlineField, Switch, InlineSwitch } from '@grafana/ui';
 import mdx from './Switch.mdx';
+import { InlineFieldRow } from '../Forms/InlineFieldRow';
+import { Field } from '../Forms/Field';
 
 export default {
   title: 'Forms/Switch',
@@ -20,7 +22,23 @@ export const Controlled = () => {
   const onChange = useCallback(e => setChecked(e.currentTarget.checked), [setChecked]);
   const BEHAVIOUR_GROUP = 'Behaviour props';
   const disabled = boolean('Disabled', false, BEHAVIOUR_GROUP);
-  return <Switch value={checked} disabled={disabled} onChange={onChange} />;
+
+  return (
+    <div>
+      <p>
+        <Field label="Normal switch" description="For horizontal forms">
+          <Switch value={checked} disabled={disabled} onChange={onChange} />
+        </Field>
+      </p>
+      <p>
+        <InlineFieldRow>
+          <InlineField label="My switch">
+            <InlineSwitch value={checked} disabled={disabled} onChange={onChange} />
+          </InlineField>
+        </InlineFieldRow>
+      </p>
+    </div>
+  );
 };
 
 export const Uncontrolled = () => {

--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -5,11 +5,55 @@ import { GrafanaTheme, deprecationWarning } from '@grafana/data';
 import { stylesFactory, useTheme } from '../../themes';
 import { focusCss } from '../../themes/mixins';
 
-export interface SwitchProps extends Omit<HTMLProps<HTMLInputElement>, 'value'> {
+export interface Props extends Omit<HTMLProps<HTMLInputElement>, 'value'> {
   value?: boolean;
 }
 
-export const getSwitchStyles = stylesFactory((theme: GrafanaTheme) => {
+export const Switch = React.forwardRef<HTMLInputElement, Props>(
+  ({ value, checked, disabled = false, onChange, id, ...inputProps }, ref) => {
+    if (checked) {
+      deprecationWarning('Switch', 'checked prop', 'value');
+    }
+
+    const theme = useTheme();
+    const styles = getSwitchStyles(theme);
+    const switchIdRef = useRef(id ? id : uniqueId('switch-'));
+
+    return (
+      <div className={cx(styles.switch)}>
+        <input
+          type="checkbox"
+          disabled={disabled}
+          checked={value}
+          onChange={event => {
+            onChange?.(event);
+          }}
+          id={switchIdRef.current}
+          {...inputProps}
+          ref={ref}
+        />
+        <label htmlFor={switchIdRef.current} />
+      </div>
+    );
+  }
+);
+
+Switch.displayName = 'Switch';
+
+export const InlineSwitch = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+  const theme = useTheme();
+  const styles = getSwitchStyles(theme);
+
+  return (
+    <div className={styles.inlineContainer}>
+      <Switch {...props} ref={ref} />
+    </div>
+  );
+});
+
+InlineSwitch.displayName = 'Switch';
+
+const getSwitchStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
     switch: css`
       width: 32px;
@@ -71,36 +115,14 @@ export const getSwitchStyles = stylesFactory((theme: GrafanaTheme) => {
         }
       }
     `,
+    inlineContainer: css`
+      padding: 0 ${theme.spacing.sm};
+      height: ${theme.spacing.formInputHeight}px;
+      display: flex;
+      align-items: center;
+      background: ${theme.colors.formInputBg};
+      border: 1px solid ${theme.colors.formInputBorder};
+      border-radius: ${theme.border.radius.md};
+    `,
   };
 });
-
-export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(
-  ({ value, checked, disabled = false, onChange, id, ...inputProps }, ref) => {
-    if (checked) {
-      deprecationWarning('Switch', 'checked prop', 'value');
-    }
-
-    const theme = useTheme();
-    const styles = getSwitchStyles(theme);
-    const switchIdRef = useRef(id ? id : uniqueId('switch-'));
-
-    return (
-      <div className={cx(styles.switch)}>
-        <input
-          type="checkbox"
-          disabled={disabled}
-          checked={value}
-          onChange={event => {
-            onChange?.(event);
-          }}
-          id={switchIdRef.current}
-          {...inputProps}
-          ref={ref}
-        />
-        <label htmlFor={switchIdRef.current} />
-      </div>
-    );
-  }
-);
-
-Switch.displayName = 'Switch';

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -168,7 +168,7 @@ export { RadioButtonGroup } from './Forms/RadioButtonGroup/RadioButtonGroup';
 export { Input } from './Input/Input';
 export { FormInputSize } from './Forms/types';
 
-export { Switch } from './Switch/Switch';
+export { Switch, InlineSwitch } from './Switch/Switch';
 export { Checkbox } from './Forms/Checkbox';
 
 export { TextArea } from './TextArea/TextArea';

--- a/public/app/features/variables/editor/VariableSwitchField.tsx
+++ b/public/app/features/variables/editor/VariableSwitchField.tsx
@@ -1,8 +1,5 @@
 import React, { ChangeEvent, PropsWithChildren, ReactElement } from 'react';
-import { InlineField, Switch, useStyles } from '@grafana/ui';
-import { GrafanaTheme } from '@grafana/data';
-import { css } from 'emotion';
-
+import { InlineField, InlineSwitch } from '@grafana/ui';
 interface VariableSwitchFieldProps {
   value: boolean;
   name: string;
@@ -18,22 +15,9 @@ export function VariableSwitchField({
   onChange,
   ariaLabel,
 }: PropsWithChildren<VariableSwitchFieldProps>): ReactElement {
-  const styles = useStyles(getStyles);
-
   return (
     <InlineField label={name} labelWidth={20} tooltip={tooltip}>
-      <div aria-label={ariaLabel} className={styles.switchContainer}>
-        <Switch label={name} value={value} onChange={onChange} />
-      </div>
+      <InlineSwitch label={name} value={value} onChange={onChange} aria-label={ariaLabel} />
     </InlineField>
   );
-}
-
-function getStyles(theme: GrafanaTheme) {
-  return {
-    switchContainer: css`
-      margin-left: ${theme.spacing.sm};
-      margin-right: ${theme.spacing.sm};
-    `,
-  };
 }

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
@@ -1,4 +1,4 @@
-import { InlineField, Input, Switch } from '@grafana/ui';
+import { InlineField, Input, InlineSwitch } from '@grafana/ui';
 import React, { FunctionComponent, ComponentProps, useState } from 'react';
 import { extendedStats } from '../../../../query_def';
 import { useDispatch } from '../../../../hooks/useStatelessReducer';
@@ -132,7 +132,11 @@ const ExtendedStatSetting: FunctionComponent<ExtendedStatSettingProps> = ({ stat
 
   return (
     <InlineField label={stat.label} {...inlineFieldProps} key={stat.value}>
-      <Switch id={id} onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked)} value={value} />
+      <InlineSwitch
+        id={id}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked)}
+        value={value}
+      />
     </InlineField>
   );
 };


### PR DESCRIPTION
Adds new component for InlineSwitch so we can share this common use case and updates the instances that I found where switch was used inline and was unaligned and without the proper inline input background.

* [x] Adds InlineSwitch component
* [x] Adds storybook story update that show both normal Switch use case & Inline

Before: 
![Screenshot from 2021-01-09 14-44-57](https://user-images.githubusercontent.com/10999/104093204-541b3b00-5289-11eb-87c6-e7ced424f796.png)
![Screenshot from 2021-01-09 14-44-44](https://user-images.githubusercontent.com/10999/104093209-567d9500-5289-11eb-9f55-52e295fee735.png)

After:
![Screenshot from 2021-01-09 14-44-17](https://user-images.githubusercontent.com/10999/104093234-7b720800-5289-11eb-907e-62038368c489.png)
![Screenshot from 2021-01-09 14-42-10](https://user-images.githubusercontent.com/10999/104093239-80cf5280-5289-11eb-9faa-801e588a2169.png)

Updated story:
![Screenshot from 2021-01-09 14-46-58](https://user-images.githubusercontent.com/10999/104093250-8dec4180-5289-11eb-86f9-8e1d935d7629.png)
