### PR TITLE
Settings: add config options to disable config variable expansion

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -227,6 +227,11 @@ x_content_type_options = true
 # when they detect reflected cross-site scripting (XSS) attacks.
 x_xss_protection = true
 
+# Set to true to disable config variable expansion from environment variables
+disable_env_variable_expansion = false
+
+# Set to true to disable config variable expansion from a file path
+disable_file_variable_expansion = false
 
 #################################### Snapshots ###########################
 [snapshots]

--- a/pkg/setting/expanders.go
+++ b/pkg/setting/expanders.go
@@ -43,6 +43,17 @@ func AddExpander(name string, priority int64, e Expander) {
 	})
 }
 
+func removeExpander(name string) {
+	n := 0
+	for _, x := range expanders {
+		if x.name != name {
+			expanders[n] = x
+			n++
+		}
+	}
+	expanders = expanders[:n]
+}
+
 var regex = regexp.MustCompile(`\$(|__\w+){([^}]+)}`)
 
 func expandConfig(file *ini.File) error {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -236,6 +236,8 @@ type Cfg struct {
 	StrictTransportSecurityMaxAge     int
 	StrictTransportSecurityPreload    bool
 	StrictTransportSecuritySubDomains bool
+	DisableEnvVariableExpansion       bool
+	DisableFileVariableExpansion      bool
 
 	TempDataLifetime         time.Duration
 	PluginsEnableAlpha       bool
@@ -641,6 +643,18 @@ func (cfg *Cfg) loadConfiguration(args *CommandLineArgs) (*ini.File, error) {
 
 	// apply command line overrides
 	applyCommandLineProperties(commandLineProps, parsedFile)
+
+	// enable or disable env and file variable expansion
+	if security := parsedFile.Section("security"); security != nil {
+		cfg.DisableEnvVariableExpansion = security.Key("disable_env_variable_expansion").MustBool(false)
+		cfg.DisableFileVariableExpansion = security.Key("disable_file_variable_expansion").MustBool(false)
+	}
+	if cfg.DisableEnvVariableExpansion {
+		removeExpander("env")
+	}
+	if cfg.DisableFileVariableExpansion {
+		removeExpander("file")
+	}
 
 	// evaluate config values containing environment variables
 	err = expandConfig(parsedFile)

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -299,6 +299,21 @@ func TestLoadingSettings(t *testing.T) {
 			So(value, ShouldEqual, "default_url_val")
 		})
 	})
+
+	Convey("Test disabling variable expansion from env and file", t, func() {
+		cfg := NewCfg()
+		err := os.Setenv("APP_MODE", "production")
+		require.NoError(t, err)
+		err = cfg.Load(&CommandLineArgs{
+			HomePath: "../../",
+			Config:   filepath.Join(HomePath, "pkg/setting/testdata/expansion.ini"),
+		})
+
+		So(err, ShouldBeNil)
+
+		So(Env, ShouldEqual, "$__env{APP_MODE}")
+		So(cfg.MetricsEndpointBasicAuthPassword, ShouldEqual, "$__file{/etc/secrets/metrics_password}")
+	})
 }
 
 func TestParseAppURLAndSubURL(t *testing.T) {

--- a/pkg/setting/testdata/expansion.ini
+++ b/pkg/setting/testdata/expansion.ini
@@ -1,0 +1,8 @@
+app_mode = $__env{APP_MODE}
+
+[metrics]
+basic_auth_password = $__file{/etc/secrets/metrics_password}
+
+[security]
+disable_env_variable_expansion = true
+disable_file_variable_expansion = true


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Provides options for the server config to disable the filename variable expansion as well as the environment variable expansion in the server config file. This could be used to prevent possible security issues, if for instance config file is generated based on user input. An example of a possible exploit could be to set `google_analytics_ua_id` to something like `$__file{/proc/cpuinfo}` to obtain information or perhaps even security credentials stored to files.

The PR adds config variables `disable_env_variable_expansion` and `disable_file_variable_expansion` with boolean values that allow disabling each setting expander individually.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

n/a
