### PR TITLE
e2e: fix dashboard settings variables failing test

### DIFF
--- a/e2e/suite1/specs/variables/new-query-variable.ts
+++ b/e2e/suite1/specs/variables/new-query-variable.ts
@@ -175,19 +175,11 @@ describe('Variables - Add variable', () => {
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsMultiSwitch()
       .click({ force: true })
-      .within(() => {
-        e2e()
-          .get('input')
-          .should('be.checked');
-      });
+      .should('be.checked');
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsIncludeAllSwitch()
       .click({ force: true })
-      .within(() => {
-        e2e()
-          .get('input')
-          .should('be.checked');
-      });
+      .should('be.checked');
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInput().within(input => {
       expect(input.attr('placeholder')).equals('blank = auto');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes failing e2e test. Aria label moved from div to the input itself making the previous selector fail due to looking for an input in an input.


