### PR TITLE
GraphNG: Custom point symbols

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -13,7 +13,7 @@ import {
 import { alignDataFrames } from './utils';
 import { UPlotChart } from '../uPlot/Plot';
 import { PlotProps } from '../uPlot/types';
-import { AxisPlacement, DrawStyle, GraphFieldConfig, PointVisibility } from '../uPlot/config';
+import { AxisPlacement, DrawStyle, GraphFieldConfig, PointSymbol, PointVisibility } from '../uPlot/config';
 import { useTheme } from '../../themes';
 import { VizLayout } from '../VizLayout/VizLayout';
 import { LegendDisplayMode, LegendItem, LegendOptions } from '../Legend/Legend';
@@ -179,6 +179,7 @@ export const GraphNG: React.FC<GraphNGProps> = ({
         showPoints,
         pointSize: customConfig.pointSize,
         pointColor: customConfig.pointColor ?? seriesColor,
+        pointSymbol: customConfig.pointSymbol ?? PointSymbol.Dot,
         fillOpacity: customConfig.fillOpacity,
         spanNulls: customConfig.spanNulls || false,
         show: !customConfig.hideFrom?.graph,

--- a/packages/grafana-ui/src/components/uPlot/config.ts
+++ b/packages/grafana-ui/src/components/uPlot/config.ts
@@ -92,7 +92,19 @@ export interface PointsConfig {
   showPoints?: PointVisibility;
   pointSize?: number;
   pointColor?: string;
-  pointSymbol?: string; // eventually dot,star, etc
+  pointSymbol?: PointSymbol;
+}
+
+/**
+ * @alpha
+ */
+export enum PointSymbol {
+  Dot = 'dot',
+  Marble = 'marble',
+  Triangle = 'triangle',
+  Square = 'square',
+  Star = 'star',
+  Cross = 'cross',
 }
 
 /**
@@ -166,4 +178,13 @@ export const graphFieldOptions = {
     { label: 'Opacity', value: FillGradientMode.Opacity },
     { label: 'Hue', value: FillGradientMode.Hue },
   ] as Array<SelectableValue<FillGradientMode>>,
+
+  pointSymbol: [
+    { label: 'Dot', value: PointSymbol.Dot },
+    { label: 'Marble', value: PointSymbol.Marble },
+    { label: 'Square', value: PointSymbol.Square },
+    { label: 'Triangle', value: PointSymbol.Triangle },
+    { label: 'Star', value: PointSymbol.Star },
+    { label: 'Cross', value: PointSymbol.Cross },
+  ] as Array<SelectableValue<PointSymbol>>,
 };

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -76,7 +76,6 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
 
     if (pointsConfig.points!.show) {
       if (pointSymbol && pointSymbol !== PointSymbol.Dot) {
-        console.log(pointSize);
         pointsConfig.points!.show = getCustomPointRenderer(pointSymbol, pointColor!, pointSize!);
       }
     }
@@ -256,6 +255,8 @@ function getCustomPointRenderer(shape: PointSymbol, color: string, size: number)
       ctx.fill();
       j++;
     }
+
+    return undefined;
   };
 }
 

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -41,6 +41,7 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
       <TooltipPlugin mode={options.tooltipOptions.mode as any} timeZone={timeZone} />
       <ZoomPlugin onZoom={onChangeTimeRange} />
       <ContextMenuPlugin timeZone={timeZone} replaceVariables={replaceVariables} />
+      {/*<CustomPointsPlugin />*/}
       {data.annotations ? <ExemplarsPlugin exemplars={data.annotations} timeZone={timeZone} /> : <></>}
       {data.annotations ? <AnnotationsPlugin annotations={data.annotations} timeZone={timeZone} /> : <></>}
     </GraphNG>

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -41,7 +41,6 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
       <TooltipPlugin mode={options.tooltipOptions.mode as any} timeZone={timeZone} />
       <ZoomPlugin onZoom={onChangeTimeRange} />
       <ContextMenuPlugin timeZone={timeZone} replaceVariables={replaceVariables} />
-      {/*<CustomPointsPlugin />*/}
       {data.annotations ? <ExemplarsPlugin exemplars={data.annotations} timeZone={timeZone} /> : <></>}
       {data.annotations ? <AnnotationsPlugin annotations={data.annotations} timeZone={timeZone} /> : <></>}
     </GraphNG>

--- a/public/app/plugins/panel/timeseries/config.ts
+++ b/public/app/plugins/panel/timeseries/config.ts
@@ -116,6 +116,15 @@ export function getGraphFieldConfig(cfg: GraphFieldConfig): SetFieldConfigOption
             options: graphFieldOptions.showPoints,
           },
         })
+        .addRadio({
+          path: 'pointSymbol',
+          name: 'Point shape',
+          defaultValue: graphFieldOptions.pointSymbol[0].value,
+          settings: {
+            options: graphFieldOptions.pointSymbol,
+          },
+          showIf: c => c.showPoints !== PointVisibility.Never || c.drawStyle === DrawStyle.Points,
+        })
         .addSliderInput({
           path: 'pointSize',
           name: 'Point size',


### PR DESCRIPTION
WIP

Adds possitbility to customize the shape of a point on the graph. Available shapes are dot, square, triangle, marble, star and cross:

![image](https://user-images.githubusercontent.com/2376619/104195182-92982d80-5422-11eb-8234-1f73a9ff0f76.png)
![image](https://user-images.githubusercontent.com/2376619/104194595-d179b380-5421-11eb-91b0-4390636d12f4.png)

TODO:

-  [ ] Tinker more with shape sizings

@leeoniya is ther any way to customize the hover highlight of the point? Not sure why it renders a circle with a transparent border, probably you have encountered some alignment issues? At least that's what I've seen when I've played with modifying uPlot code. The highlight with custom shapes work quite weird with the shapes going outside of the inner circle and that looks not so nice.