### PR TITLE
GraphNG: Hide grid for right-y axis if left x-axis exists

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -68,6 +68,10 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       space: calculateSpace,
     };
 
+    if (placement === AxisPlacement.Right) {
+      config.grid!.show = false;
+    }
+
     if (label !== undefined && label !== null && label.length > 0) {
       config.label = label;
       config.labelSize = 18;

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -68,10 +68,6 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       space: calculateSpace,
     };
 
-    if (placement === AxisPlacement.Right) {
-      config.grid!.show = false;
-    }
-
     if (label !== undefined && label !== null && label.length > 0) {
       config.label = label;
       config.labelSize = 18;

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -4,6 +4,7 @@ import { UPlotConfigBuilder } from './UPlotConfigBuilder';
 import { GrafanaTheme } from '@grafana/data';
 import { expect } from '../../../../../../public/test/lib/common';
 import { FillGradientMode, AxisPlacement, DrawStyle, PointVisibility, ScaleDistribution } from '../config';
+import darkTheme from '../../../themes/dark';
 
 describe('UPlotConfigBuilder', () => {
   describe('default config', () => {
@@ -34,17 +35,21 @@ describe('UPlotConfigBuilder', () => {
       `);
     });
   });
+
   describe('scales config', () => {
     it('allows scales configuration', () => {
       const builder = new UPlotConfigBuilder();
+
       builder.addScale({
         scaleKey: 'scale-x',
         isTime: true,
       });
+
       builder.addScale({
         scaleKey: 'scale-y',
         isTime: false,
       });
+
       expect(builder.getConfig()).toMatchInlineSnapshot(`
         Object {
           "axes": Array [],
@@ -85,10 +90,12 @@ describe('UPlotConfigBuilder', () => {
 
     it('prevents duplicate scales', () => {
       const builder = new UPlotConfigBuilder();
+
       builder.addScale({
         scaleKey: 'scale-x',
         isTime: true,
       });
+
       builder.addScale({
         scaleKey: 'scale-x',
         isTime: false,
@@ -229,6 +236,7 @@ describe('UPlotConfigBuilder', () => {
 
   it('allows axes configuration', () => {
     const builder = new UPlotConfigBuilder();
+
     builder.addAxis({
       scaleKey: 'scale-x',
       label: 'test label',
@@ -294,19 +302,22 @@ describe('UPlotConfigBuilder', () => {
 
   it('Handles auto axis placement', () => {
     const builder = new UPlotConfigBuilder();
+
     builder.addAxis({
       scaleKey: 'y1',
       placement: AxisPlacement.Auto,
-      theme: { isDark: true, palette: { gray25: '#ffffff' } } as GrafanaTheme,
+      theme: darkTheme,
     });
+
     builder.addAxis({
       scaleKey: 'y2',
       placement: AxisPlacement.Auto,
-      theme: { isDark: true, palette: { gray25: '#ffffff' } } as GrafanaTheme,
+      theme: darkTheme,
     });
 
     expect(builder.getAxisPlacement('y1')).toBe(AxisPlacement.Left);
     expect(builder.getAxisPlacement('y2')).toBe(AxisPlacement.Right);
+    expect(builder.getConfig().axes![1].grid!.show).toBe(false);
   });
 
   it('When fillColor is not set fill', () => {

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -3,7 +3,7 @@ import { ScaleProps, UPlotScaleBuilder } from './UPlotScaleBuilder';
 import { SeriesProps, UPlotSeriesBuilder } from './UPlotSeriesBuilder';
 import { AxisProps, UPlotAxisBuilder } from './UPlotAxisBuilder';
 import { AxisPlacement } from '../config';
-import { Cursor } from 'uplot';
+import { Cursor, Axis } from 'uplot';
 import { defaultsDeep } from 'lodash';
 
 export class UPlotConfigBuilder {
@@ -11,8 +11,8 @@ export class UPlotConfigBuilder {
   private axes: Record<string, UPlotAxisBuilder> = {};
   private scales: UPlotScaleBuilder[] = [];
   private cursor: Cursor | undefined;
-
-  hasLeftAxis = false;
+  private hasLeftAxis = false;
+  private hasBottomAxis = false;
 
   addAxis(props: AxisProps) {
     props.placement = props.placement ?? AxisPlacement.Auto;
@@ -27,8 +27,13 @@ export class UPlotConfigBuilder {
       props.placement = this.hasLeftAxis ? AxisPlacement.Right : AxisPlacement.Left;
     }
 
-    if (props.placement === AxisPlacement.Left) {
-      this.hasLeftAxis = true;
+    switch (props.placement) {
+      case AxisPlacement.Left:
+        this.hasLeftAxis = true;
+        break;
+      case AxisPlacement.Bottom:
+        this.hasBottomAxis = true;
+        break;
     }
 
     if (props.placement === AxisPlacement.Hidden) {
@@ -64,7 +69,7 @@ export class UPlotConfigBuilder {
 
   getConfig() {
     const config: PlotSeriesConfig = { series: [{}] };
-    config.axes = Object.values(this.axes).map(a => a.getConfig());
+    config.axes = this.ensureNonOverlappingAxes(Object.values(this.axes)).map(a => a.getConfig());
     config.series = [...config.series, ...this.series.map(s => s.getConfig())];
     config.scales = this.scales.reduce((acc, s) => {
       return { ...acc, ...s.getConfig() };
@@ -93,5 +98,18 @@ export class UPlotConfigBuilder {
     defaultsDeep(config.cursor, cursorDefaults);
 
     return config;
+  }
+
+  private ensureNonOverlappingAxes(axes: UPlotAxisBuilder[]): UPlotAxisBuilder[] {
+    for (const axis of axes) {
+      if (axis.props.placement === AxisPlacement.Right && this.hasLeftAxis) {
+        axis.props.grid = false;
+      }
+      if (axis.props.placement === AxisPlacement.Top && this.hasBottomAxis) {
+        axis.props.grid = false;
+      }
+    }
+
+    return axes;
   }
 }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -3,7 +3,7 @@ import { ScaleProps, UPlotScaleBuilder } from './UPlotScaleBuilder';
 import { SeriesProps, UPlotSeriesBuilder } from './UPlotSeriesBuilder';
 import { AxisProps, UPlotAxisBuilder } from './UPlotAxisBuilder';
 import { AxisPlacement } from '../config';
-import { Cursor, Axis } from 'uplot';
+import { Cursor } from 'uplot';
 import { defaultsDeep } from 'lodash';
 
 export class UPlotConfigBuilder {


### PR DESCRIPTION
Fixes so we do not render double grid lines for both left and right axis

Todo
* Fix so it works if you only have a right axis
