### PR TITLE
Plugins: Prevent users with no enough permission to navigate to applications

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -73,7 +73,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/plugins/:id/", reqSignedIn, hs.Index)
 	r.Get("/plugins/:id/edit", reqSignedIn, hs.Index) // deprecated
 	r.Get("/plugins/:id/page/:page", reqSignedIn, hs.Index)
-	r.Get("/a/:id/*", reqSignedIn, hs.Index) // App Root Page
+	r.Get("/a/:id/", reqSignedIn, middleware.ReqAppRoles, hs.Index)  // App root page
+	r.Get("/a/:id/*", reqSignedIn, middleware.ReqAppRoles, hs.Index) // App sub pages
 
 	r.Get("/d/:uid/:slug", reqSignedIn, redirectFromLegacyPanelEditURL, hs.Index)
 	r.Get("/d/:uid", reqSignedIn, redirectFromLegacyPanelEditURL, hs.Index)

--- a/pkg/middleware/plugins.go
+++ b/pkg/middleware/plugins.go
@@ -22,11 +22,11 @@ func ReqAppRoles(c *models.ReqContext) {
 
 	ok := false
 	for _, include := range plugin.Includes {
-		if !c.OrgRole.Includes(include.Role) {
+		if !strings.Contains(c.Req.RequestURI, include.Path) {
 			continue
 		}
 
-		if strings.Contains(c.Req.RequestURI, include.Path) {
+		if c.OrgRole.Includes(include.Role) {
 			ok = true
 			break
 		}

--- a/pkg/middleware/plugins.go
+++ b/pkg/middleware/plugins.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func ReqAppRoles(c *models.ReqContext) {
+	pluginID := c.Params("id")
+
+	plugin, exists := plugins.Plugins[pluginID]
+	if !exists {
+		return
+	}
+
+	if len(plugin.Includes) == 0 {
+		return
+	}
+
+	ok := false
+	for _, include := range plugin.Includes {
+		if !c.OrgRole.Includes(include.Role) {
+			continue
+		}
+
+		if strings.Contains(c.Req.RequestURI, include.Path) {
+			ok = true
+			break
+		}
+	}
+
+	if !ok {
+		c.Redirect(setting.AppSubUrl + "/")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new middleware middleware to check for permission on loading app plugin paths.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #30196 

**Special notes for your reviewer**:

- Expected behaviour:
  - If the application has no includes, do nothing (since there's no role setting at application/plugin level).
  - Otherwise, it looks for the (URL) matching include and checks if the logged in user has enough permission.
  - If it's not, it's redirected to the home page. 
- Few additional comments left inline.