### PR TITLE
Prometheus: Improve autocomplete performance and remove disabling of dynamic label lookup

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -1,7 +1,7 @@
 // @ts-ignore
 import RCCascader from 'rc-cascader';
 import React from 'react';
-import PromQlLanguageProvider, { DEFAULT_LOOKUP_METRICS_THRESHOLD } from '../language_provider';
+import PromQlLanguageProvider from '../language_provider';
 import PromQueryField, { groupMetricsByPrefix, RECORDING_RULES_GROUP } from './PromQueryField';
 import { DataSourceInstanceSettings, dateTime } from '@grafana/data';
 import { PromOptions } from '../types';
@@ -254,7 +254,6 @@ function makeLanguageProvider(options: { metrics: string[][] }) {
     metrics: [],
     metricsMetadata: {},
     lookupsDisabled: false,
-    lookupMetricsThreshold: DEFAULT_LOOKUP_METRICS_THRESHOLD,
     start() {
       this.metrics = metricsStack.shift();
       return Promise.resolve([]);

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -209,9 +209,9 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     let hint = hints.length > 0 ? hints[0] : null;
 
     // Hint for big disabled lookups
-    if (!hint && !datasource.lookupsDisabled && datasource.languageProvider.lookupsDisabled) {
+    if (!hint && datasource.lookupsDisabled) {
       hint = {
-        label: `Dynamic label lookup is disabled for datasources with more than ${datasource.languageProvider.lookupMetricsThreshold} metrics.`,
+        label: `Labels and metrics lookup was disabled in data source settings.`,
         type: 'INFO',
       };
     }

--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -226,7 +226,6 @@ describe('Language completion provider', () => {
   describe('label suggestions', () => {
     it('returns default label suggestions on label context and no metric', async () => {
       const instance = new LanguageProvider(datasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('{}');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(1).value;
@@ -246,7 +245,6 @@ describe('Language completion provider', () => {
         getTimeRange: () => ({ start: 0, end: 1 }),
       } as any) as PrometheusDatasource;
       const instance = new LanguageProvider(datasources);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('metric{}');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(7).value;
@@ -278,7 +276,6 @@ describe('Language completion provider', () => {
         getTimeRange: () => ({ start: 0, end: 1 }),
       } as any) as PrometheusDatasource;
       const instance = new LanguageProvider(datasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('{job1="foo",job2!="foo",job3=~"foo",__name__="metric",}');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(54).value;
@@ -299,7 +296,6 @@ describe('Language completion provider', () => {
           return { data: { data: ['value1', 'value2'] } };
         },
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('{job!=}');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(6).value;
@@ -321,7 +317,6 @@ describe('Language completion provider', () => {
 
     it('returns a refresher on label context and unavailable metric', async () => {
       const instance = new LanguageProvider(datasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('metric{}');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(7).value;
@@ -340,7 +335,6 @@ describe('Language completion provider', () => {
         ...datasource,
         metadataRequest: () => simpleMetricLabelsResponse,
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('metric{bar=ba}');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(13).value;
@@ -360,7 +354,6 @@ describe('Language completion provider', () => {
         ...datasource,
         metadataRequest: () => simpleMetricLabelsResponse,
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('sum(metric{foo="xx"}) by ()');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(26).value;
@@ -379,7 +372,6 @@ describe('Language completion provider', () => {
         ...datasource,
         metadataRequest: () => simpleMetricLabelsResponse,
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('sum(metric) by ()');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(16).value;
@@ -398,7 +390,6 @@ describe('Language completion provider', () => {
         ...datasource,
         metadataRequest: () => simpleMetricLabelsResponse,
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('sum(\nmetric\n)\nby ()');
       const aggregationTextBlock = value.document.getBlocks().get(3);
       const ed = new SlateEditor({ value });
@@ -424,7 +415,6 @@ describe('Language completion provider', () => {
         ...datasource,
         metadataRequest: () => simpleMetricLabelsResponse,
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('sum(rate(metric[1h])) by ()');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(26).value;
@@ -448,7 +438,6 @@ describe('Language completion provider', () => {
         ...datasource,
         metadataRequest: () => simpleMetricLabelsResponse,
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('sum(rate(metric{label1="value"}[1h])) by ()');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(42).value;
@@ -469,7 +458,6 @@ describe('Language completion provider', () => {
 
     it('returns no suggestions inside an unclear aggregation context using alternate syntax', async () => {
       const instance = new LanguageProvider(datasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('sum by ()');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(8).value;
@@ -488,7 +476,6 @@ describe('Language completion provider', () => {
         ...datasource,
         metadataRequest: () => simpleMetricLabelsResponse,
       } as any) as PrometheusDatasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('sum by () (metric)');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(8).value;
@@ -514,7 +501,6 @@ describe('Language completion provider', () => {
       } as any) as PrometheusDatasource;
 
       const instance = new LanguageProvider(datasource);
-      instance.lookupsDisabled = false;
       const value = Plain.deserialize('{}');
       const ed = new SlateEditor({ value });
       const valueWithSelection = ed.moveForward(1).value;
@@ -531,59 +517,6 @@ describe('Language completion provider', () => {
       expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(2);
       await Promise.all([promise1, promise2]);
       expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(2);
-    });
-  });
-
-  describe('dynamic lookup protection for big installations', () => {
-    it('dynamic lookup is enabled if number of metrics is reasonably low', async () => {
-      const datasource: PrometheusDatasource = ({
-        metadataRequest: () => ({ data: { data: ['foo'] as string[] } }),
-        getTimeRange: () => ({ start: 0, end: 1 }),
-      } as any) as PrometheusDatasource;
-
-      const instance = new LanguageProvider(datasource, { lookupMetricsThreshold: 1 });
-      expect(instance.lookupsDisabled).toBeTruthy();
-      await instance.start();
-      expect(instance.lookupsDisabled).toBeFalsy();
-    });
-
-    it('dynamic lookup is disabled if number of metrics is higher than threshold', async () => {
-      const datasource: PrometheusDatasource = ({
-        metadataRequest: () => ({ data: { data: ['foo', 'bar'] as string[] } }),
-        getTimeRange: () => ({ start: 0, end: 1 }),
-      } as any) as PrometheusDatasource;
-
-      const instance = new LanguageProvider(datasource, { lookupMetricsThreshold: 1 });
-      expect(instance.lookupsDisabled).toBeTruthy();
-      await instance.start();
-      expect(instance.lookupsDisabled).toBeTruthy();
-    });
-
-    it('does not issue label-based metadata requests when lookup is disabled', async () => {
-      const datasource: PrometheusDatasource = ({
-        metadataRequest: jest.fn(() => ({ data: { data: ['foo', 'bar'] as string[] } })),
-        getTimeRange: jest.fn(() => ({ start: 0, end: 1 })),
-      } as any) as PrometheusDatasource;
-
-      const instance = new LanguageProvider(datasource, { lookupMetricsThreshold: 1 });
-      const value = Plain.deserialize('{}');
-      const ed = new SlateEditor({ value });
-      const valueWithSelection = ed.moveForward(1).value;
-      const args = {
-        text: '',
-        prefix: '',
-        wrapperClasses: ['context-labels'],
-        value: valueWithSelection,
-      };
-      expect(instance.lookupsDisabled).toBeTruthy();
-      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(0);
-      await instance.start();
-      expect(instance.lookupsDisabled).toBeTruthy();
-      // Capture request count to metadata
-      const callCount = (datasource.metadataRequest as Mock).mock.calls.length;
-      expect((datasource.metadataRequest as Mock).mock.calls.length).toBeGreaterThan(0);
-      await instance.provideCompletionItems(args);
-      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(callCount);
     });
   });
 });

--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -519,6 +519,43 @@ describe('Language completion provider', () => {
       expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(2);
     });
   });
+  describe('disabled metrics lookup', () => {
+    it('does not issue any metadata requests when lookup is disabled', async () => {
+      const datasource: PrometheusDatasource = ({
+        metadataRequest: jest.fn(() => ({ data: { data: ['foo', 'bar'] as string[] } })),
+        getTimeRange: jest.fn(() => ({ start: 0, end: 1 })),
+        lookupsDisabled: true,
+      } as any) as PrometheusDatasource;
+      const instance = new LanguageProvider(datasource);
+      const value = Plain.deserialize('{}');
+      const ed = new SlateEditor({ value });
+      const valueWithSelection = ed.moveForward(1).value;
+      const args = {
+        text: '',
+        prefix: '',
+        wrapperClasses: ['context-labels'],
+        value: valueWithSelection,
+      };
+
+      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(0);
+      await instance.start();
+      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(0);
+      await instance.provideCompletionItems(args);
+      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(0);
+    });
+    it('issues metadata requests when lookup is not disabled', async () => {
+      const datasource: PrometheusDatasource = ({
+        metadataRequest: jest.fn(() => ({ data: { data: ['foo', 'bar'] as string[] } })),
+        getTimeRange: jest.fn(() => ({ start: 0, end: 1 })),
+        lookupsDisabled: false,
+      } as any) as PrometheusDatasource;
+      const instance = new LanguageProvider(datasource);
+
+      expect((datasource.metadataRequest as Mock).mock.calls.length).toBe(0);
+      await instance.start();
+      expect((datasource.metadataRequest as Mock).mock.calls.length).toBeGreaterThan(0);
+    });
+  });
 });
 
 const simpleMetricLabelsResponse = {

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -12,6 +12,7 @@ import {
   processLabels,
   roundSecToMin,
   addLimitInfo,
+  limitSuggestions,
 } from './language_utils';
 import PromqlSyntax, { FUNCTIONS, RATE_RANGES } from './promql';
 
@@ -23,7 +24,7 @@ const EMPTY_SELECTOR = '{}';
 const HISTORY_ITEM_COUNT = 5;
 const HISTORY_COUNT_CUTOFF = 1000 * 60 * 60 * 24; // 24h
 // Max number of items - metrics, labels, values - that we display. Prevents running out of memory.
-export const AUTOCOMPLETE_LIMIT = 10000;
+export const SUGGESTIONS_LIMIT = 10000;
 
 const wrapLabel = (label: string): CompletionItem => ({ label });
 
@@ -240,7 +241,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
       const limitInfo = addLimitInfo(metrics);
       suggestions.push({
         label: `Metrics${limitInfo}`,
-        items: metrics.slice(0, AUTOCOMPLETE_LIMIT).map(m => addMetricsMetadata(m, metricsMetadata)),
+        items: limitSuggestions(metrics).map(m => addMetricsMetadata(m, metricsMetadata)),
       });
     }
 

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -23,7 +23,7 @@ const DEFAULT_KEYS = ['job', 'instance'];
 const EMPTY_SELECTOR = '{}';
 const HISTORY_ITEM_COUNT = 5;
 const HISTORY_COUNT_CUTOFF = 1000 * 60 * 60 * 24; // 24h
-// Max number of items - metrics, labels, values - that we display. Prevents running out of memory.
+// Max number of items (metrics, labels, values) that we display as suggestions. Prevents from running out of memory.
 export const SUGGESTIONS_LIMIT = 10000;
 
 const wrapLabel = (label: string): CompletionItem => ({ label });

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -68,7 +68,6 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   metricsMetadata?: PromMetricsMetadata;
   startTask: Promise<any>;
   datasource: PrometheusDatasource;
-  lookupsDisabled: boolean; // Dynamically set to true for big/slow instances
 
   /**
    *  Cache for labels of series. This is bit simplistic in the sense that it just counts responses each as a 1 and does
@@ -84,7 +83,6 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     this.histogramMetrics = [];
     this.timeRange = { start: 0, end: 0 };
     this.metrics = [];
-    this.lookupsDisabled = true;
 
     Object.assign(this, initialValues);
   }
@@ -242,7 +240,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
       const limitInfo = addLimitInfo(metrics);
       suggestions.push({
         label: `Metrics${limitInfo}`,
-        items: metrics.slice(AUTOCOMPLETE_LIMIT).map(m => addMetricsMetadata(m, metricsMetadata)),
+        items: metrics.slice(0, AUTOCOMPLETE_LIMIT).map(m => addMetricsMetadata(m, metricsMetadata)),
       });
     }
 
@@ -381,7 +379,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
         context = 'context-label-values';
         const limitInfo = addLimitInfo(labelValues[labelKey]);
         suggestions.push({
-          label: `Label values for "${labelKey}"${limitInfo}.`,
+          label: `Label values for "${labelKey}"${limitInfo}`,
           items: labelValues[labelKey].map(wrapLabel),
         });
       }
@@ -395,7 +393,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
           context = 'context-labels';
           const newItems = possibleKeys.map(key => ({ label: key }));
           const limitInfo = addLimitInfo(newItems);
-          const newSuggestion: CompletionItemGroup = { label: `Labels${limitInfo}.`, items: newItems };
+          const newSuggestion: CompletionItemGroup = { label: `Labels${limitInfo}`, items: newItems };
           suggestions.push(newSuggestion);
         }
       }
@@ -405,7 +403,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   };
 
   async getLabelValues(selector: string, withName?: boolean) {
-    if (this.lookupsDisabled) {
+    if (this.datasource.lookupsDisabled) {
       return undefined;
     }
     try {

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -11,6 +11,7 @@ import {
   processHistogramLabels,
   processLabels,
   roundSecToMin,
+  addLimitInfo,
 } from './language_utils';
 import PromqlSyntax, { FUNCTIONS, RATE_RANGES } from './promql';
 
@@ -314,7 +315,11 @@ export default class PromQlLanguageProvider extends LanguageProvider {
 
     const labelValues = await this.getLabelValues(selector);
     if (labelValues) {
-      suggestions.push({ label: 'Labels', items: Object.keys(labelValues).map(wrapLabel) });
+      const limitInfo = addLimitInfo(labelValues[0]);
+      suggestions.push({
+        label: `Labels${limitInfo}`,
+        items: Object.keys(labelValues).map(wrapLabel),
+      });
     }
     return result;
   };
@@ -376,8 +381,9 @@ export default class PromQlLanguageProvider extends LanguageProvider {
       // Label values
       if (labelKey && labelValues[labelKey]) {
         context = 'context-label-values';
+        const limitInfo = addLimitInfo(labelValues[labelKey]);
         suggestions.push({
-          label: `Label values for "${labelKey}"`,
+          label: `Label values for "${labelKey}"${limitInfo}.`,
           items: labelValues[labelKey].map(wrapLabel),
         });
       }
@@ -390,7 +396,8 @@ export default class PromQlLanguageProvider extends LanguageProvider {
         if (possibleKeys.length) {
           context = 'context-labels';
           const newItems = possibleKeys.map(key => ({ label: key }));
-          const newSuggestion: CompletionItemGroup = { label: `Labels`, items: newItems };
+          const limitInfo = addLimitInfo(newItems);
+          const newSuggestion: CompletionItemGroup = { label: `Labels${limitInfo}.`, items: newItems };
           suggestions.push(newSuggestion);
         }
       }

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -45,9 +45,9 @@ export function processLabels(labels: Array<{ [key: string]: string }>, withName
   // valueArray that we are going to return in the object
   const valueArray: { [key: string]: string[] } = {};
   Object.keys(valueSet)
-    .slice(AUTOCOMPLETE_LIMIT)
+    .slice(0, AUTOCOMPLETE_LIMIT)
     .forEach(key => {
-      valueArray[key] = Array.from(valueSet[key]).slice(AUTOCOMPLETE_LIMIT);
+      valueArray[key] = Array.from(valueSet[key]).slice(0, AUTOCOMPLETE_LIMIT);
     });
 
   return { values: valueArray, keys: Object.keys(valueArray) };
@@ -206,6 +206,8 @@ export function roundSecToMin(seconds: number): number {
   return Math.floor(seconds / 60);
 }
 
-export function addLimitInfo(items: any[]): string {
-  return items.length >= AUTOCOMPLETE_LIMIT ? `, limited to the first ${AUTOCOMPLETE_LIMIT} received items` : '';
+export function addLimitInfo(items: any[] | undefined): string {
+  return items && items.length >= AUTOCOMPLETE_LIMIT
+    ? `, limited to the first ${AUTOCOMPLETE_LIMIT} received items`
+    : '';
 }

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -19,26 +19,35 @@ export const processHistogramLabels = (labels: string[]) => {
 };
 
 export function processLabels(labels: Array<{ [key: string]: string }>, withName = false) {
-  const values: { [key: string]: string[] } = {};
-  labels.forEach(l => {
-    const { __name__, ...rest } = l;
+  // We are using sets for computation as they have much better performance than array, but we will return array
+  const valueSet: { [key: string]: Set<string> } = {};
+  labels.forEach(label => {
+    const { __name__, ...rest } = label;
     if (withName) {
-      values['__name__'] = values['__name__'] || [];
-      if (!values['__name__'].includes(__name__)) {
-        values['__name__'].push(__name__);
+      valueSet['__name__'] = valueSet['__name__'] || new Set();
+      if (!valueSet['__name__'].has(__name__)) {
+        valueSet['__name__'].add(__name__);
       }
     }
 
     Object.keys(rest).forEach(key => {
-      if (!values[key]) {
-        values[key] = [];
+      if (!valueSet[key]) {
+        valueSet[key] = new Set();
       }
-      if (!values[key].includes(rest[key])) {
-        values[key].push(rest[key]);
+      if (!valueSet[key].has(rest[key])) {
+        valueSet[key].add(rest[key]);
       }
     });
   });
-  return { values, keys: Object.keys(values) };
+
+  // We return object with arrays created from sets
+  const valueArray: { [key: string]: string[] } = {};
+
+  Object.keys(valueSet).forEach(key => {
+    valueArray[key] = Array.from(valueSet[key]);
+  });
+
+  return { values: valueArray, keys: Object.keys(valueArray) };
 }
 
 // const cleanSelectorRegexp = /\{(\w+="[^"\n]*?")(,\w+="[^"\n]*?")*\}/;

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -1,8 +1,8 @@
 import { PromMetricsMetadata } from './types';
 import { addLabelToQuery } from './add_label_to_query';
+import { AUTOCOMPLETE_LIMIT } from './language_provider';
 
 export const RATE_RANGES = ['1m', '5m', '10m', '30m', '1h'];
-export const AUTOCOMPLETE_LIMIT = 10000;
 
 export const processHistogramLabels = (labels: string[]) => {
   const resultSet: Set<string> = new Set();

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -2,6 +2,7 @@ import { PromMetricsMetadata } from './types';
 import { addLabelToQuery } from './add_label_to_query';
 
 export const RATE_RANGES = ['1m', '5m', '10m', '30m', '1h'];
+export const AUTOCOMPLETE_LIMIT = 10000;
 
 export const processHistogramLabels = (labels: string[]) => {
   const resultSet: Set<string> = new Set();
@@ -43,9 +44,11 @@ export function processLabels(labels: Array<{ [key: string]: string }>, withName
 
   // valueArray that we are going to return in the object
   const valueArray: { [key: string]: string[] } = {};
-  Object.keys(valueSet).forEach(key => {
-    valueArray[key] = Array.from(valueSet[key]);
-  });
+  Object.keys(valueSet)
+    .slice(AUTOCOMPLETE_LIMIT)
+    .forEach(key => {
+      valueArray[key] = Array.from(valueSet[key]).slice(AUTOCOMPLETE_LIMIT);
+    });
 
   return { values: valueArray, keys: Object.keys(valueArray) };
 }
@@ -201,4 +204,8 @@ export function roundMsToMin(milliseconds: number): number {
 
 export function roundSecToMin(seconds: number): number {
   return Math.floor(seconds / 60);
+}
+
+export function addLimitInfo(items: any[]): string {
+  return items.length >= AUTOCOMPLETE_LIMIT ? `, limited to the first ${AUTOCOMPLETE_LIMIT} received items` : '';
 }

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -1,6 +1,6 @@
 import { PromMetricsMetadata } from './types';
 import { addLabelToQuery } from './add_label_to_query';
-import { AUTOCOMPLETE_LIMIT } from './language_provider';
+import { SUGGESTIONS_LIMIT } from './language_provider';
 
 export const RATE_RANGES = ['1m', '5m', '10m', '30m', '1h'];
 
@@ -44,11 +44,9 @@ export function processLabels(labels: Array<{ [key: string]: string }>, withName
 
   // valueArray that we are going to return in the object
   const valueArray: { [key: string]: string[] } = {};
-  Object.keys(valueSet)
-    .slice(0, AUTOCOMPLETE_LIMIT)
-    .forEach(key => {
-      valueArray[key] = Array.from(valueSet[key]).slice(0, AUTOCOMPLETE_LIMIT);
-    });
+  limitSuggestions(Object.keys(valueSet)).forEach(key => {
+    valueArray[key] = limitSuggestions(Array.from(valueSet[key]));
+  });
 
   return { values: valueArray, keys: Object.keys(valueArray) };
 }
@@ -206,8 +204,10 @@ export function roundSecToMin(seconds: number): number {
   return Math.floor(seconds / 60);
 }
 
+export function limitSuggestions(items: string[]) {
+  return items.slice(0, SUGGESTIONS_LIMIT);
+}
+
 export function addLimitInfo(items: any[] | undefined): string {
-  return items && items.length >= AUTOCOMPLETE_LIMIT
-    ? `, limited to the first ${AUTOCOMPLETE_LIMIT} received items`
-    : '';
+  return items && items.length >= SUGGESTIONS_LIMIT ? `, limited to the first ${SUGGESTIONS_LIMIT} received items` : '';
 }

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -19,7 +19,8 @@ export const processHistogramLabels = (labels: string[]) => {
 };
 
 export function processLabels(labels: Array<{ [key: string]: string }>, withName = false) {
-  // We are using sets for computation as they have much better performance than array, but we will return array
+  // For processing we are going to use sets as they have significantly better performance than arrays
+  // After we process labels, we will convert sets to arrays and return object with label values in arrays
   const valueSet: { [key: string]: Set<string> } = {};
   labels.forEach(label => {
     const { __name__, ...rest } = label;
@@ -40,9 +41,8 @@ export function processLabels(labels: Array<{ [key: string]: string }>, withName
     });
   });
 
-  // We return object with arrays created from sets
+  // valueArray that we are going to return in the object
   const valueArray: { [key: string]: string[] } = {};
-
   Object.keys(valueSet).forEach(key => {
     valueArray[key] = Array.from(valueSet[key]);
   });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PRs focues on improving Prometheus autocomplete in 3 ways:
 
1. It improves the way we process the labels. Currently we are using `arrays` and `include` method, which can be slow if the labels cardinality is high (too many iteration over the array with label values). 

This PR introduces usage of `sets` instead of arrays which has **MUCH** better performance with high labels cardinality and slightly better performance for low cardinality. (see more profiling in [here](https://docs.google.com/document/d/1CL_0EjvTsmgDf176z5H8f542Qf2d6jvhXJsd5mKa6O4/edit#heading=h.g9hblewhpsy8 ))

2. It removes the dynamic label lookup limit. We used to have limit of 10,000 metrics which determined if label & values lookup was disabled. However, the number of metrics have nothing to do with how many labels and values would be received, if we did a query. As we have significantly improved the processing of labels, number of received labels and values is no longer a problem, as the processing is fast. Moreover, we have recently (~2 months ago) added the sending of time range in queries, which limits the number of received items even more.  

3. To prevent from running out of memory, we have added the limit of 10,000 items (labels, values, metrics) that can be used for suggestions. If the number is higher and we need to slice the array with suggestions to 10,000, we will then inform the user directly in autocomplete. 

Example with limit of 2, if limit is reached:
![image](https://user-images.githubusercontent.com/30407135/104455605-d5374280-55a7-11eb-8779-79cb288a0fa0.png)

When limit is not reached:
![image](https://user-images.githubusercontent.com/30407135/104455685-f0a24d80-55a7-11eb-9c08-a18eb1d1fec6.png)

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/issues/21893

**Next steps:** 
Improving autocomplete, removing 10,000 metrics limit and limit the number of shown labels and values directly. This is going to be part of separate PR. 