### PR TITLE
Cloudwatch: Move deep link creation to the backend

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -66,7 +66,6 @@ export interface QueryResultMeta {
   /**
    * Legacy data source specific, should be moved to custom
    * */
-  gmdMeta?: any[]; // used by cloudwatch
   alignmentPeriod?: number; // used by cloud monitoring
   searchWords?: string[]; // used by log models and loki
   limit?: number; // used by log models and loki

--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -209,11 +209,14 @@ func buildDeepLink(refID string, requestQueries []*requestQuery, executedQueries
 }
 
 func isMathExpression(executedQueries []executedQuery) bool {
+	isMathExpression := false
 	for _, query := range executedQueries {
-		if query.Expression != "" && strings.Contains(query.Expression, "SEARCH(") {
+		if strings.Contains(query.Expression, "SEARCH(") {
 			return false
+		} else if query.Expression != "" {
+			isMathExpression = true
 		}
 	}
 
-	return len(executedQueries) > 0
+	return isMathExpression
 }

--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -101,12 +101,12 @@ func (e *cloudWatchExecutor) transformQueryResponsesToQueryResult(cloudwatchResp
 
 		eq, err := json.Marshal(executedQueries)
 		if err != nil {
-			return nil, fmt.Errorf("Could not marshal executedString struct: %w", err)
+			return nil, fmt.Errorf("could not marshal executedString struct: %w", err)
 		}
 
 		link, err := buildDeepLink(refID, requestQueries, executedQueries, startTime, endTime)
 		if err != nil {
-			return nil, fmt.Errorf("Could not build deep link: %w", err)
+			return nil, fmt.Errorf("could not build deep link: %w", err)
 		}
 
 		for _, frame := range frames {

--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -109,6 +109,14 @@ func (e *cloudWatchExecutor) transformQueryResponsesToQueryResult(cloudwatchResp
 			return nil, fmt.Errorf("could not build deep link: %w", err)
 		}
 
+		createDataLinks := func(link string) []data.DataLink {
+			return []data.DataLink{{
+				Title:       "View in CloudWatch console",
+				TargetBlank: true,
+				URL:         link,
+			}}
+		}
+
 		for _, frame := range frames {
 			frame.Meta = &data.FrameMeta{
 				ExecutedQueryString: string(eq),
@@ -119,15 +127,9 @@ func (e *cloudWatchExecutor) transformQueryResponsesToQueryResult(cloudwatchResp
 			}
 
 			for _, field := range frame.Fields {
-				field.Config = &data.FieldConfig{
-					Links: []data.DataLink{
-						{
-							Title:       "View in CloudWatch console",
-							TargetBlank: true,
-							URL:         link,
-						},
-					},
-				}
+				field.SetConfig(&data.FieldConfig{
+					Links: createDataLinks(link),
+				})
 			}
 		}
 

--- a/pkg/tsdb/cloudwatch/query_transformer.go
+++ b/pkg/tsdb/cloudwatch/query_transformer.go
@@ -122,15 +122,13 @@ func (e *cloudWatchExecutor) transformQueryResponsesToQueryResult(cloudwatchResp
 				ExecutedQueryString: string(eq),
 			}
 
-			if link == "" {
+			if link == "" || len(frame.Fields) < 2 {
 				continue
 			}
 
-			for _, field := range frame.Fields {
-				field.SetConfig(&data.FieldConfig{
-					Links: createDataLinks(link),
-				})
-			}
+			frame.Fields[1].SetConfig(&data.FieldConfig{
+				Links: createDataLinks(link),
+			})
 		}
 
 		queryResult.Dataframes = tsdb.NewDecodedDataFrames(frames)

--- a/pkg/tsdb/cloudwatch/query_transformer_test.go
+++ b/pkg/tsdb/cloudwatch/query_transformer_test.go
@@ -180,7 +180,13 @@ func TestQueryTransformer(t *testing.T) {
 		end, err := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
 		require.NoError(t, err)
 
-		link, err := buildDeepLink("E", requestQueries, []executedQuery{}, start, end)
+		executedQueries := []executedQuery{{
+			Expression: ``,
+			ID:         "D",
+			Period:     600,
+		}}
+
+		link, err := buildDeepLink("E", requestQueries, executedQueries, start, end)
 		require.NoError(t, err)
 
 		parsedURL, err := url.Parse(link)

--- a/pkg/tsdb/cloudwatch/query_transformer_test.go
+++ b/pkg/tsdb/cloudwatch/query_transformer_test.go
@@ -1,7 +1,9 @@
 package cloudwatch
 
 import (
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
@@ -149,5 +151,80 @@ func TestQueryTransformer(t *testing.T) {
 		res, err := executor.transformRequestQueriesToCloudWatchQueries(requestQueries)
 		require.Nil(t, res)
 		assert.Error(t, err)
+	})
+
+	requestQueries := []*requestQuery{
+		{
+			RefId:      "D",
+			Region:     "us-east-1",
+			Namespace:  "ec2",
+			MetricName: "CPUUtilization",
+			Statistics: aws.StringSlice([]string{"Sum"}),
+			Period:     600,
+			Id:         "myId",
+		},
+		{
+			RefId:      "E",
+			Region:     "us-east-1",
+			Namespace:  "ec2",
+			MetricName: "CPUUtilization",
+			Statistics: aws.StringSlice([]string{"Average", "p46.32"}),
+			Period:     600,
+			Id:         "myId",
+		},
+	}
+
+	t.Run("A deep link that reference two metric stat metrics is created based on a request query with two stats", func(t *testing.T) {
+		start, _ := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
+		end, _ := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+
+		link, err := buildDeepLink("E", requestQueries, []executedQuery{}, start, end)
+		require.NoError(t, err)
+
+		parsedURL, err := url.Parse(link)
+		require.NoError(t, err)
+
+		decodedLink, _ := url.PathUnescape(parsedURL.String())
+		expected := `https://us-east-1.console.aws.amazon.com/cloudwatch/deeplink.js?region=us-east-1#metricsV2:graph={"view":"timeSeries","stacked":false,"title":"E","start":"2018-03-15T13:00:00Z","end":"2018-03-18T13:34:00Z","region":"us-east-1","metrics":[["ec2","CPUUtilization",{"stat":"Average","period":600}],["ec2","CPUUtilization",{"stat":"p46.32","period":600}]]}`
+		assert.Equal(t, expected, decodedLink)
+	})
+
+	t.Run("A deep link that reference an expression based metric is created based on a request query with one stat", func(t *testing.T) {
+		start, _ := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
+		end, _ := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		executedQueries := []executedQuery{{
+			Expression: `REMOVE_EMPTY(SEARCH('Namespace="AWS/EC2" MetricName="CPUUtilization"', 'Sum', 600))`,
+			ID:         "D",
+			Period:     600,
+		}}
+
+		link, err := buildDeepLink("E", requestQueries, executedQueries, start, end)
+		require.NoError(t, err)
+
+		parsedURL, err := url.Parse(link)
+		require.NoError(t, err)
+
+		decodedLink, _ := url.PathUnescape(parsedURL.String())
+		expected := `https://us-east-1.console.aws.amazon.com/cloudwatch/deeplink.js?region=us-east-1#metricsV2:graph={"view":"timeSeries","stacked":false,"title":"E","start":"2018-03-15T13:00:00Z","end":"2018-03-18T13:34:00Z","region":"us-east-1","metrics":[{"expression":"REMOVE_EMPTY(SEARCH('Namespace=\"AWS/EC2\"+MetricName=\"CPUUtilization\"',+'Sum',+600))"}]}`
+		assert.Equal(t, expected, decodedLink)
+	})
+
+	t.Run("A deep link is not built in case any of the executedQueries are math expressions", func(t *testing.T) {
+		start, _ := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
+		end, _ := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		executedQueries := []executedQuery{{
+			Expression: `a * 2`,
+			ID:         "D",
+			Period:     600,
+		}}
+
+		link, err := buildDeepLink("E", requestQueries, executedQueries, start, end)
+		require.NoError(t, err)
+
+		parsedURL, err := url.Parse(link)
+		require.NoError(t, err)
+
+		decodedLink, _ := url.PathUnescape(parsedURL.String())
+		assert.Equal(t, "", decodedLink)
 	})
 }

--- a/pkg/tsdb/cloudwatch/query_transformer_test.go
+++ b/pkg/tsdb/cloudwatch/query_transformer_test.go
@@ -175,8 +175,10 @@ func TestQueryTransformer(t *testing.T) {
 	}
 
 	t.Run("A deep link that reference two metric stat metrics is created based on a request query with two stats", func(t *testing.T) {
-		start, _ := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
-		end, _ := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		start, err := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
+		require.NoError(t, err)
+		end, err := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		require.NoError(t, err)
 
 		link, err := buildDeepLink("E", requestQueries, []executedQuery{}, start, end)
 		require.NoError(t, err)
@@ -184,14 +186,18 @@ func TestQueryTransformer(t *testing.T) {
 		parsedURL, err := url.Parse(link)
 		require.NoError(t, err)
 
-		decodedLink, _ := url.PathUnescape(parsedURL.String())
+		decodedLink, err := url.PathUnescape(parsedURL.String())
+		require.NoError(t, err)
 		expected := `https://us-east-1.console.aws.amazon.com/cloudwatch/deeplink.js?region=us-east-1#metricsV2:graph={"view":"timeSeries","stacked":false,"title":"E","start":"2018-03-15T13:00:00Z","end":"2018-03-18T13:34:00Z","region":"us-east-1","metrics":[["ec2","CPUUtilization",{"stat":"Average","period":600}],["ec2","CPUUtilization",{"stat":"p46.32","period":600}]]}`
 		assert.Equal(t, expected, decodedLink)
 	})
 
 	t.Run("A deep link that reference an expression based metric is created based on a request query with one stat", func(t *testing.T) {
-		start, _ := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
-		end, _ := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		start, err := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
+		require.NoError(t, err)
+		end, err := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		require.NoError(t, err)
+
 		executedQueries := []executedQuery{{
 			Expression: `REMOVE_EMPTY(SEARCH('Namespace="AWS/EC2" MetricName="CPUUtilization"', 'Sum', 600))`,
 			ID:         "D",
@@ -204,14 +210,19 @@ func TestQueryTransformer(t *testing.T) {
 		parsedURL, err := url.Parse(link)
 		require.NoError(t, err)
 
-		decodedLink, _ := url.PathUnescape(parsedURL.String())
+		decodedLink, err := url.PathUnescape(parsedURL.String())
+		require.NoError(t, err)
+
 		expected := `https://us-east-1.console.aws.amazon.com/cloudwatch/deeplink.js?region=us-east-1#metricsV2:graph={"view":"timeSeries","stacked":false,"title":"E","start":"2018-03-15T13:00:00Z","end":"2018-03-18T13:34:00Z","region":"us-east-1","metrics":[{"expression":"REMOVE_EMPTY(SEARCH('Namespace=\"AWS/EC2\"+MetricName=\"CPUUtilization\"',+'Sum',+600))"}]}`
 		assert.Equal(t, expected, decodedLink)
 	})
 
 	t.Run("A deep link is not built in case any of the executedQueries are math expressions", func(t *testing.T) {
-		start, _ := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
-		end, _ := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		start, err := time.Parse(time.RFC3339, "2018-03-15T13:00:00Z")
+		require.NoError(t, err)
+		end, err := time.Parse(time.RFC3339, "2018-03-18T13:34:00Z")
+		require.NoError(t, err)
+
 		executedQueries := []executedQuery{{
 			Expression: `a * 2`,
 			ID:         "D",

--- a/pkg/tsdb/cloudwatch/query_transformer_test.go
+++ b/pkg/tsdb/cloudwatch/query_transformer_test.go
@@ -235,7 +235,8 @@ func TestQueryTransformer(t *testing.T) {
 		parsedURL, err := url.Parse(link)
 		require.NoError(t, err)
 
-		decodedLink, _ := url.PathUnescape(parsedURL.String())
+		decodedLink, err := url.PathUnescape(parsedURL.String())
+		require.NoError(t, err)
 		assert.Equal(t, "", decodedLink)
 	})
 }

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -97,7 +97,17 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, queryCo
 			}
 
 			cloudwatchResponses = append(cloudwatchResponses, responses...)
-			res := e.transformQueryResponsesToQueryResult(cloudwatchResponses, requestQueries, startTime, endTime)
+			res, err := e.transformQueryResponsesToQueryResult(cloudwatchResponses, requestQueries, startTime, endTime)
+			if err != nil {
+				for _, query := range requestQueries {
+					resultChan <- &tsdb.QueryResult{
+						RefId: query.RefId,
+						Error: err,
+					}
+				}
+				return nil
+			}
+
 			for _, queryRes := range res {
 				resultChan <- queryRes
 			}

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -97,7 +97,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, queryCo
 			}
 
 			cloudwatchResponses = append(cloudwatchResponses, responses...)
-			res := e.transformQueryResponsesToQueryResult(cloudwatchResponses)
+			res := e.transformQueryResponsesToQueryResult(cloudwatchResponses, requestQueries)
 			for _, queryRes := range res {
 				resultChan <- queryRes
 			}

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -97,7 +97,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, queryCo
 			}
 
 			cloudwatchResponses = append(cloudwatchResponses, responses...)
-			res := e.transformQueryResponsesToQueryResult(cloudwatchResponses, requestQueries)
+			res := e.transformQueryResponsesToQueryResult(cloudwatchResponses, requestQueries, startTime, endTime)
 			for _, queryRes := range res {
 				resultChan <- queryRes
 			}

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -42,6 +42,11 @@ func (e *queryError) Error() string {
 	return fmt.Sprintf("error parsing query %q, %s", e.RefID, e.err)
 }
 
+type executedQuery struct {
+	Expression, ID string
+	Period         int
+}
+
 type cloudWatchLink struct {
 	View    string        `json:"view"`
 	Stacked bool          `json:"stacked"`
@@ -52,6 +57,11 @@ type cloudWatchLink struct {
 	Metrics []interface{} `json:"metrics"`
 }
 
-// type cloudWatchLinkMetric struct {
-// 	Expression string `json:"expression"`
-// }
+type metricExpression struct {
+	Expression string `json:"expression"`
+} 
+
+type metricStatMeta struct {
+	Stat   string `json:"stat"`
+	Period int `json:"period"`
+}

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -59,9 +59,9 @@ type cloudWatchLink struct {
 
 type metricExpression struct {
 	Expression string `json:"expression"`
-} 
+}
 
 type metricStatMeta struct {
 	Stat   string `json:"stat"`
-	Period int `json:"period"`
+	Period int    `json:"period"`
 }

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -41,3 +41,17 @@ type queryError struct {
 func (e *queryError) Error() string {
 	return fmt.Sprintf("error parsing query %q, %s", e.RefID, e.err)
 }
+
+type cloudWatchLink struct {
+	View    string        `json:"view"`
+	Stacked bool          `json:"stacked"`
+	Title   string        `json:"title"`
+	Start   string        `json:"start"`
+	End     string        `json:"end"`
+	Region  string        `json:"region"`
+	Metrics []interface{} `json:"metrics"`
+}
+
+// type cloudWatchLinkMetric struct {
+// 	Expression string `json:"expression"`
+// }

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
@@ -70,7 +70,10 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
     const metricsQuery = this.props.query as CloudWatchMetricsQuery;
     const { showMeta } = this.state;
     const query = normalizeQuery(metricsQuery);
-    const metaDataExist = data && Object.values(data).length && data.state === 'Done';
+    const executedQueries =
+      data && data.series.length && data.series[0].meta && data.state === 'Done'
+        ? data.series[0].meta.executedQueryString
+        : null;
 
     return (
       <>
@@ -150,20 +153,21 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
             <label className="gf-form-label">
               <a
                 onClick={() =>
-                  metaDataExist &&
+                  executedQueries &&
                   this.setState({
                     showMeta: !showMeta,
                   })
                 }
               >
-                <Icon name={showMeta ? 'angle-down' : 'angle-right'} /> {showMeta ? 'Hide' : 'Show'} Query Preview
+                <Icon name={showMeta && executedQueries ? 'angle-down' : 'angle-right'} />{' '}
+                {showMeta && executedQueries ? 'Hide' : 'Show'} Query Preview
               </a>
             </label>
           </div>
           <div className="gf-form gf-form--grow">
             <div className="gf-form-label gf-form-label--grow" />
           </div>
-          {showMeta && metaDataExist && (
+          {showMeta && executedQueries && (
             <table className="filter-table form-inline">
               <thead>
                 <tr>
@@ -174,7 +178,7 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
                 </tr>
               </thead>
               <tbody>
-                {data?.series?.[0]?.meta?.gmdMeta?.map(({ ID, Expression, Period }: any) => (
+                {JSON.parse(executedQueries).map(({ ID, Expression, Period }: any) => (
                   <tr key={ID}>
                     <td>{ID}</td>
                     <td>{Expression}</td>

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -51,8 +51,6 @@ describe('datasource', () => {
           },
         },
       });
-      const buildCloudwatchConsoleUrlMock = jest.spyOn(datasource, 'buildCloudwatchConsoleUrl');
-      buildCloudwatchConsoleUrlMock.mockImplementation(() => '');
 
       const observable = datasource.performTimeSeriesQuery(
         {

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -46,8 +46,8 @@ describe('datasource', () => {
       const { datasource } = setup({
         data: {
           results: {
-            a: { refId: 'a', series: [{ name: 'cpu', points: [1, 1] }], meta: { gmdMeta: '' } },
-            b: { refId: 'b', series: [{ name: 'memory', points: [2, 2] }], meta: { gmdMeta: '' } },
+            a: { refId: 'a', series: [{ name: 'cpu', points: [1, 1] }], meta: {} },
+            b: { refId: 'b', series: [{ name: 'memory', points: [2, 2] }], meta: {} },
           },
         },
       });

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -610,16 +610,16 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
 
           const requestQuery = request.queries.find(q => q.refId === frame.refId!) as any;
 
-          const link = this.buildCloudwatchConsoleUrl(
-            requestQuery!,
-            from.toISOString(),
-            to.toISOString(),
-            frame.refId!,
-            queryResult.meta.gmdMeta
-          );
+          for (const field of frame.fields) {
+            const link = this.buildCloudwatchConsoleUrl(
+              requestQuery!,
+              from.toISOString(),
+              to.toISOString(),
+              frame.refId!,
+              frame.meta?.executedQueryString ? JSON.parse(frame.meta?.executedQueryString) : {}
+            );
 
-          if (link) {
-            for (const field of frame.fields) {
+            if (link) {
               field.config.links = [
                 {
                   url: link,
@@ -629,6 +629,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
               ];
             }
           }
+
           return { frame, error };
         });
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -542,57 +542,6 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
     return period || '';
   }
 
-  buildCloudwatchConsoleUrl(
-    { region, namespace, metricName, dimensions, statistics, expression }: CloudWatchMetricsQuery,
-    start: string,
-    end: string,
-    title: string,
-    gmdMeta: Array<{ Expression: string; Period: string }>
-  ) {
-    region = this.getActualRegion(region);
-    let conf = {
-      view: 'timeSeries',
-      stacked: false,
-      title,
-      start,
-      end,
-      region,
-    } as any;
-
-    const isSearchExpression =
-      gmdMeta && gmdMeta.length && gmdMeta.every(({ Expression: expression }) => /SEARCH().*/.test(expression));
-    const isMathExpression = !isSearchExpression && expression;
-
-    if (isMathExpression) {
-      return '';
-    }
-
-    if (isSearchExpression) {
-      const metrics: any =
-        gmdMeta && gmdMeta.length ? gmdMeta.map(({ Expression: expression }) => ({ expression })) : [{ expression }];
-      conf = { ...conf, metrics };
-    } else {
-      conf = {
-        ...conf,
-        metrics: [
-          ...statistics.map(stat => [
-            namespace,
-            metricName,
-            ...Object.entries(dimensions).reduce((acc, [key, value]) => [...acc, key, value[0]], []),
-            {
-              stat,
-              period: gmdMeta.length ? gmdMeta[0].Period : 60,
-            },
-          ]),
-        ],
-      };
-    }
-
-    return `https://${region}.console.aws.amazon.com/cloudwatch/deeplink.js?region=${region}#metricsV2:graph=${encodeURIComponent(
-      JSON.stringify(conf)
-    )}`;
-  }
-
   performTimeSeriesQuery(request: MetricRequest, { from, to }: TimeRange): Observable<any> {
     return this.awsRequest(TSDB_QUERY_ENDPOINT, request).pipe(
       map(res => {
@@ -601,42 +550,12 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
           return { data: [] };
         }
 
-        const data = dataframes.map(frame => {
-          const queryResult = res.results[frame.refId!];
-          const error = queryResult.error ? { message: queryResult.error } : null;
-          if (!queryResult) {
-            return { frame, error };
-          }
-
-          const requestQuery = request.queries.find(q => q.refId === frame.refId!) as any;
-
-          for (const field of frame.fields) {
-            const link = this.buildCloudwatchConsoleUrl(
-              requestQuery!,
-              from.toISOString(),
-              to.toISOString(),
-              frame.refId!,
-              frame.meta?.executedQueryString ? JSON.parse(frame.meta?.executedQueryString) : {}
-            );
-
-            if (link) {
-              field.config.links = [
-                {
-                  url: link,
-                  title: 'View in CloudWatch console',
-                  targetBlank: true,
-                },
-              ];
-            }
-          }
-
-          return { frame, error };
-        });
-
         return {
-          data: data.map(o => o.frame),
-          error: data
-            .map(o => o.error)
+          data: dataframes,
+          error: Object.values(res.results)
+            .map(o => ({
+              message: o.error,
+            }))
             .reduce((err, error) => {
               return err || error;
             }, null),

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -339,7 +339,7 @@ describe('CloudWatchDatasource', () => {
           type: 'Metrics',
           error: '',
           refId: 'A',
-          meta: { gmdMeta: [] },
+          meta: {},
           series: [
             {
               name: 'CPUUtilization_Average',
@@ -690,13 +690,7 @@ describe('CloudWatchDatasource', () => {
         A: {
           error: '',
           refId: 'A',
-          meta: {
-            gmdMeta: [
-              {
-                Period: 300,
-              },
-            ],
-          },
+          meta: {},
           series: [
             {
               name: 'TargetResponseTime_p90.00',

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -452,68 +452,6 @@ describe('CloudWatchDatasource', () => {
       });
     });
 
-    describe('a correct cloudwatch url should be built for each time series in the response', () => {
-      it('should be built correctly if theres one search expressions returned in meta for a given query row', async () => {
-        const { ds } = getTestContext({ response });
-
-        response.results['A'].meta.gmdMeta = [{ Expression: `REMOVE_EMPTY(SEARCH('some expression'))`, Period: '300' }];
-
-        await expect(ds.query(query)).toEmitValuesWith(received => {
-          const result = received[0];
-          expect(getFrameDisplayName(result.data[0])).toBe(response.results.A.series[0].name);
-          expect(result.data[0].fields[1].config.links[0].title).toBe('View in CloudWatch console');
-          expect(decodeURIComponent(result.data[0].fields[1].config.links[0].url)).toContain(
-            `region=us-east-1#metricsV2:graph={"view":"timeSeries","stacked":false,"title":"A","start":"2016-12-31T15:00:00.000Z","end":"2016-12-31T16:00:00.000Z","region":"us-east-1","metrics":[{"expression":"REMOVE_EMPTY(SEARCH(\'some expression\'))"}]}`
-          );
-        });
-      });
-
-      it('should be built correctly if theres two search expressions returned in meta for a given query row', async () => {
-        const { ds } = getTestContext({ response });
-
-        response.results['A'].meta.gmdMeta = [
-          { Expression: `REMOVE_EMPTY(SEARCH('first expression'))` },
-          { Expression: `REMOVE_EMPTY(SEARCH('second expression'))` },
-        ];
-
-        await expect(ds.query(query)).toEmitValuesWith(received => {
-          const result = received[0];
-          expect(getFrameDisplayName(result.data[0])).toBe(response.results.A.series[0].name);
-          expect(result.data[0].fields[1].config.links[0].title).toBe('View in CloudWatch console');
-          expect(decodeURIComponent(result.data[0].fields[0].config.links[0].url)).toContain(
-            `region=us-east-1#metricsV2:graph={"view":"timeSeries","stacked":false,"title":"A","start":"2016-12-31T15:00:00.000Z","end":"2016-12-31T16:00:00.000Z","region":"us-east-1","metrics":[{"expression":"REMOVE_EMPTY(SEARCH(\'first expression\'))"},{"expression":"REMOVE_EMPTY(SEARCH(\'second expression\'))"}]}`
-          );
-        });
-      });
-
-      it('should be built correctly if the query is a metric stat query', async () => {
-        const { ds } = getTestContext({ response });
-
-        response.results['A'].meta.gmdMeta = [{ Period: '300' }];
-
-        await expect(ds.query(query)).toEmitValuesWith(received => {
-          const result = received[0];
-          expect(getFrameDisplayName(result.data[0])).toBe(response.results.A.series[0].name);
-          expect(result.data[0].fields[1].config.links[0].title).toBe('View in CloudWatch console');
-          expect(decodeURIComponent(result.data[0].fields[0].config.links[0].url)).toContain(
-            `region=us-east-1#metricsV2:graph={\"view\":\"timeSeries\",\"stacked\":false,\"title\":\"A\",\"start\":\"2016-12-31T15:00:00.000Z\",\"end\":\"2016-12-31T16:00:00.000Z\",\"region\":\"us-east-1\",\"metrics\":[[\"AWS/EC2\",\"CPUUtilization\",\"InstanceId\",\"i-12345678\",{\"stat\":\"Average\",\"period\":\"300\"}]]}`
-          );
-        });
-      });
-
-      it('should not be added at all if query is a math expression', async () => {
-        const { ds } = getTestContext({ response });
-
-        query.targets[0].expression = 'a * 2';
-        response.results['A'].meta.searchExpressions = [];
-
-        await expect(ds.query(query)).toEmitValuesWith(received => {
-          const result = received[0];
-          expect(result.data[0].fields[1].config.links).toBeUndefined();
-        });
-      });
-    });
-
     describe('and throttling exception is thrown', () => {
       const partialQuery = {
         type: 'Metrics',


### PR DESCRIPTION
Moving the deep link code from the frontend to the backend also enabled fixing #30204 and that is also done in this PR. 

Fixes #30204
Fixes #30205

