### PR TITLE
Use Node.js 14.x in plugin CI

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -10,7 +10,7 @@ mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 rm /bin/cp
 mv /usr/local/bin/cp /bin/cp
 
-apk add --no-cache curl nodejs npm yarn build-base openssh git-lfs perl-utils coreutils python3
+apk add --no-cache curl 'nodejs-current=14.5.0-r0' npm yarn build-base openssh git-lfs perl-utils coreutils python3
 
 #
 # Only relevant for testing, but cypress does not work with musl/alpine.


### PR DESCRIPTION
Trying to avoid https://github.com/facebook/jest/issues/8769