### PR TITLE
Field overrides: extracting the field config factory into its own reusable module.

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -19,3 +19,4 @@ export {
   RangeValueMatcherOptions,
 } from './transformations/matchers/valueMatchers/types';
 export { PanelPlugin } from './panel/PanelPlugin';
+export { createFieldConfigRegistry } from './panel/registryFactories';

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -13,7 +13,8 @@ import { FieldConfigEditorBuilder, PanelOptionsEditorBuilder } from '../utils/Op
 import { ComponentClass, ComponentType } from 'react';
 import set from 'lodash/set';
 import { deprecationWarning } from '../utils';
-import { FieldConfigOptionsRegistry, standardFieldConfigEditorRegistry } from '../field';
+import { FieldConfigOptionsRegistry } from '../field';
+import { createFieldConfigRegistry } from './registryFactories';
 
 type StandardOptionConfig = {
   defaultValue?: any;
@@ -312,55 +313,7 @@ export class PanelPlugin<TOptions = any, TFieldConfigOptions extends object = an
    */
   useFieldConfig(config: SetFieldConfigOptionsArgs<TFieldConfigOptions> = {}) {
     // builder is applied lazily when custom field configs are accessed
-    this._initConfigRegistry = () => {
-      const registry = new FieldConfigOptionsRegistry();
-
-      // Add custom options
-      if (config.useCustomConfig) {
-        const builder = new FieldConfigEditorBuilder<TFieldConfigOptions>();
-        config.useCustomConfig(builder);
-
-        for (const customProp of builder.getRegistry().list()) {
-          customProp.isCustom = true;
-          customProp.category = [`${this.meta.name} options`].concat(customProp.category || []);
-          // need to do something to make the custom items not conflict with standard ones
-          // problem is id (registry index) is used as property path
-          // so sort of need a property path on the FieldPropertyEditorItem
-          customProp.id = 'custom.' + customProp.id;
-          registry.register(customProp);
-        }
-      }
-
-      for (let fieldConfigProp of standardFieldConfigEditorRegistry.list()) {
-        if (config.disableStandardOptions) {
-          const isDisabled = config.disableStandardOptions.indexOf(fieldConfigProp.id as FieldConfigProperty) > -1;
-          if (isDisabled) {
-            continue;
-          }
-        }
-        if (config.standardOptions) {
-          const customDefault: any = config.standardOptions[fieldConfigProp.id as FieldConfigProperty]?.defaultValue;
-          const customSettings: any = config.standardOptions[fieldConfigProp.id as FieldConfigProperty]?.settings;
-          if (customDefault) {
-            fieldConfigProp = {
-              ...fieldConfigProp,
-              defaultValue: customDefault,
-            };
-          }
-
-          if (customSettings) {
-            fieldConfigProp = {
-              ...fieldConfigProp,
-              settings: fieldConfigProp.settings ? { ...fieldConfigProp.settings, ...customSettings } : customSettings,
-            };
-          }
-        }
-
-        registry.register(fieldConfigProp);
-      }
-
-      return registry;
-    };
+    this._initConfigRegistry = () => createFieldConfigRegistry(config, this.meta.name);
 
     return this;
   }

--- a/packages/grafana-data/src/panel/registryFactories.ts
+++ b/packages/grafana-data/src/panel/registryFactories.ts
@@ -1,0 +1,58 @@
+import { FieldConfigOptionsRegistry } from '../field/FieldConfigOptionsRegistry';
+import { standardFieldConfigEditorRegistry } from '../field/standardFieldConfigEditorRegistry';
+import { FieldConfigProperty } from '../types/fieldOverrides';
+import { FieldConfigEditorBuilder } from '../utils/OptionsUIBuilders';
+import { SetFieldConfigOptionsArgs } from './PanelPlugin';
+
+export function createFieldConfigRegistry<TFieldConfigOptions>(
+  config: SetFieldConfigOptionsArgs<TFieldConfigOptions> = {},
+  pluginName: string
+): FieldConfigOptionsRegistry {
+  const registry = new FieldConfigOptionsRegistry();
+
+  // Add custom options
+  if (config.useCustomConfig) {
+    const builder = new FieldConfigEditorBuilder<TFieldConfigOptions>();
+    config.useCustomConfig(builder);
+
+    for (const customProp of builder.getRegistry().list()) {
+      customProp.isCustom = true;
+      customProp.category = [`${pluginName} options`].concat(customProp.category || []);
+      // need to do something to make the custom items not conflict with standard ones
+      // problem is id (registry index) is used as property path
+      // so sort of need a property path on the FieldPropertyEditorItem
+      customProp.id = 'custom.' + customProp.id;
+      registry.register(customProp);
+    }
+  }
+
+  for (let fieldConfigProp of standardFieldConfigEditorRegistry.list()) {
+    if (config.disableStandardOptions) {
+      const isDisabled = config.disableStandardOptions.indexOf(fieldConfigProp.id as FieldConfigProperty) > -1;
+      if (isDisabled) {
+        continue;
+      }
+    }
+    if (config.standardOptions) {
+      const customDefault: any = config.standardOptions[fieldConfigProp.id as FieldConfigProperty]?.defaultValue;
+      const customSettings: any = config.standardOptions[fieldConfigProp.id as FieldConfigProperty]?.settings;
+      if (customDefault) {
+        fieldConfigProp = {
+          ...fieldConfigProp,
+          defaultValue: customDefault,
+        };
+      }
+
+      if (customSettings) {
+        fieldConfigProp = {
+          ...fieldConfigProp,
+          settings: fieldConfigProp.settings ? { ...fieldConfigProp.settings, ...customSettings } : customSettings,
+        };
+      }
+    }
+
+    registry.register(fieldConfigProp);
+  }
+
+  return registry;
+}

--- a/packages/grafana-data/src/panel/registryFactories.ts
+++ b/packages/grafana-data/src/panel/registryFactories.ts
@@ -4,6 +4,13 @@ import { FieldConfigProperty } from '../types/fieldOverrides';
 import { FieldConfigEditorBuilder } from '../utils/OptionsUIBuilders';
 import { SetFieldConfigOptionsArgs } from './PanelPlugin';
 
+/**
+ * Helper functionality to create a field config registry.
+ *
+ * @param config - configuration to base the registry on.
+ * @param pluginName - name of the plugin that will use the registry.
+ * @internal
+ */
 export function createFieldConfigRegistry<TFieldConfigOptions>(
   config: SetFieldConfigOptionsArgs<TFieldConfigOptions> = {},
   pluginName: string


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the GraphNG in explore we need to recreate the field config registry in Explore to be able to use the `applyFieldOverrides` helper functionality to apply the proper state onto the `DataFrame[]` data set.

**Special notes for your reviewer**:
I'm not sure we want to expose this from the `@grafana/data` but this PR is used as a reference of discussion.


The idea would then be to do something like the following when applying the field config overrides when processing the data set in Explore:

```ts
// imagine that the data is the incoming data set.
const registry = createFieldConfigRegistry(getGraphFieldConfig(defaultGraphConfig), 'Explore');
const applied = applyFieldOverrides({
        fieldConfig: configWithOverrides,
        data,
        timeZone,
        replaceVariables: value => value, // TODO: replace with real replace
        theme,
        fieldConfigRegistry: registry,
});

```
