### PR TITLE
PanelOptionsGroups: Only restore styles from PanelOptionsGroup

### DIFF
--- a/public/sass/components/_panel_editor.scss
+++ b/public/sass/components/_panel_editor.scss
@@ -36,3 +36,39 @@
   min-width: 200px;
   max-width: 300px;
 }
+
+/* Used by old angular panels */
+.panel-options-group {
+  border-bottom: $panel-border;
+}
+
+.panel-options-group__header {
+  padding: 8px 16px 8px 8px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-weight: 500;
+  color: $text-color-semi-weak;
+
+  &:hover {
+    color: $text-color;
+
+    .panel-options-group__icon {
+      color: $text-color;
+    }
+  }
+}
+
+.panel-options-group__icon {
+  color: $text-color-weak;
+  margin-right: 8px;
+}
+
+.panel-options-group__title {
+  position: relative;
+}
+
+.panel-options-group__body {
+  padding: 8px 16px 16px 32px;
+}


### PR DESCRIPTION
I removed the PanelOptionsGroup component but the styles where still in use by angular panels so adding the styles only back

#30157
