### PR TITLE
Licensing Docs: Adding license restrictions docs

### DIFF
--- a/docs/sources/enterprise/activate-license.md
+++ b/docs/sources/enterprise/activate-license.md
@@ -2,7 +2,7 @@
 title = "Activate an Enterprise license"
 description = "Activate an Enterprise license"
 keywords = ["grafana", "licensing", "enterprise"]
-weight = 7
+weight = 100
 +++
 
 # Activate an Enterprise license

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -2,7 +2,7 @@
 title = "License Expiration"
 description = ""
 keywords = ["grafana", "licensing"]
-weight = 9
+weight = 120
 +++
 
 # License expiration

--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -2,7 +2,7 @@
 title = "License Expiration"
 description = ""
 keywords = ["grafana", "licensing"]
-weight = 8
+weight = 9
 +++
 
 # License expiration

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -18,7 +18,7 @@ In the context of licensing, each user is classified as either a viewer or an ed
 - An editor is a user who has permission to edit and save a dashboard. Examples of editors are as follows:
     - Grafana server administrators.
     - Users who are assigned an organizational role of `Editor` or `Admin`.
-    - Users that have been granted "Admin" or "Edit" permissions through [dashboard/folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
+    - Users that have been granted "Admin" or "Edit" permissions at the dashboard or folder level. Refer to [Dashboard and folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
 - A viewer is a user with the `Viewer` role, which does not permit the user to save a dashboard.
 
 Restrictions are applied separately for viewers and editors.

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -33,11 +33,13 @@ The license expiration date is the date when a license is no longer active. As t
 
 License URL is the root URL of your Grafana instance. The license will not work on an instance of Grafana with a different root URL.
 
-## Dashboard and folder permissions report
+## Download a dashboard and folder permissions report
 
-This CSV report helps to identify users, teams, and roles that have been granted `Admin` or `Edit` permissions at the dashboard or folder level.
+This CSV report helps to identify users, teams, and roles that have been granted Admin or Edit permissions at the dashboard or folder level.
 
-To download the report (in CSV format) go to the **Server Admin** > **Licensing**. From the bottom of the page, select **Download report**.
+To download the report:
+1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click **Licensing**.
+2. At the bottom of the page, click **Download report**.
 
 ## Updating license restrictions
 

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -1,5 +1,5 @@
 +++
-title = "License Restrictions"
+title = "License restrictions"
 description = "Grafana Enterprise license restrictions"
 keywords = ["grafana", "licensing", "enterprise"]
 weight = 8
@@ -35,4 +35,4 @@ License URL is the root URL of your Grafana instance. The license will not work 
 
 ## Updating license restrictions
 
-To increase the number of licensed users within Grafana, extend a license, or change your Licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, and you can apply the updated license within Grafana following the [Activate a license process](https://grafana.com/docs/grafana/latest/enterprise/activate-license/).
+To increase the number of licensed users within Grafana, extend a license, or change your licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, which you can activate from within Grafana. Refer to [Activate a license process](https://grafana.com/docs/grafana/latest/enterprise/activate-license/).

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -7,23 +7,23 @@ weight = 8
 
 # License restrictions
 
-Enterprise licenses are limited by the number of active viewers, the number of active editor/admins, a license expiration date, and the URL of the Grafana instance.
+Enterprise licenses are limited by the number of active users, a license expiration date, and the URL of the Grafana instance.
 
 **User limits**
 
-Grafana licenses allow a certain number of active users in an instance. An active user is any user that has signed in to Grafana within the past 30 days. 
+Grafana licenses allow a certain number of active users in an instance. An active user is any user that has signed in to Grafana within the past 30 days.
 
-Each user is classified as either Viewer or an Editor/Admin. 
+In the context of licensing, each user is classified as either a viewer or an editor, which are defined as follows:
 
-- All users who have the ability to edit and save dashboards are considered “Editors/Admins”, which includes: 
+- An editor is a user who has the ability to edit and save dashboards, which includes:
     - Grafana server admins
     - Users assigned an Org role of "Editor" or "Admin," 
-    - Users that have been granted "Admin" or "Edit" permissions through [dashboard/folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/). 
-- Viewers are users with the Viewer role who do not have the permissions to save dashboards.
+    - Users that have been granted "Admin" or "Edit" permissions through [dashboard/folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
+- A viewer is a user with the Viewer role who does not have the permissions to save dashboards.
 
-Editors and admins are counted the same from a licensing perspective. Restrictions are applied separately for Viewers and for Editor/Admins. 
+Restrictions are applied separately for viewers and editors.
 
-When the number of maximum active Viewers or Editor/Admins is reached, a warning banner is displayed within Grafana.
+When the number of maximum active viewers or editors is reached, a warning banner is displayed within Grafana.
 
 **Expiration date**
 

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -11,23 +11,23 @@ Enterprise licenses are limited by the number of active users, a license expirat
 
 **User limits**
 
-Grafana licenses allow a certain number of active users in an instance. An active user is any user that has signed in to Grafana within the past 30 days.
+Grafana licenses allow for a certain number of active users per instance. An active user is any user that has signed in to Grafana within the past 30 days.
 
-In the context of licensing, each user is classified as either a viewer or an editor, which are defined as follows:
+In the context of licensing, each user is classified as either a viewer or an editor:
 
-- An editor is a user who has the ability to edit and save dashboards, which includes:
-    - Grafana server admins
-    - Users assigned an Org role of "Editor" or "Admin," 
+- An editor is a user who has permission to edit and save a dashboard. Examples of editors are as follows:
+    - Grafana server administrators.
+    - Users who are assigned an organizational role of `Editor` or `Admin`.
     - Users that have been granted "Admin" or "Edit" permissions through [dashboard/folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
-- A viewer is a user with the Viewer role who does not have the permissions to save dashboards.
+- A viewer is a user with the `Viewer` role, which does not permit the user to save a dashboard.
 
 Restrictions are applied separately for viewers and editors.
 
-When the number of maximum active viewers or editors is reached, a warning banner is displayed within Grafana.
+When the number of maximum active viewers or editors is reached, Grafana displays a warning banner.
 
 **Expiration date**
 
-The license expiration date is the day when a license is no longer active. A banner will appear in Grafana Enterprise when the license expiration date approaches.
+The license expiration date is the date when a license is no longer active. As the license expiration date approaches, Grafana Enterprise displays a banner.
 
 **License URL**
 

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -33,6 +33,12 @@ The license expiration date is the date when a license is no longer active. As t
 
 License URL is the root URL of your Grafana instance. The license will not work on an instance of Grafana with a different root URL.
 
+## Dashboard and folder permissions report
+
+This CSV report helps to identify users, teams, and roles that have been granted `Admin` or `Edit` permissions at the dashboard or folder level.
+
+To download the report (in CSV format) go to the **Server Admin** > **Licensing**. From the bottom of the page, select **Download report**.
+
 ## Updating license restrictions
 
 To increase the number of licensed users within Grafana, extend a license, or change your licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, which you can activate from within Grafana. Refer to [Activate a license process](https://grafana.com/docs/grafana/latest/enterprise/activate-license/).

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -18,7 +18,7 @@ In the context of licensing, each user is classified as either a viewer or an ed
 - An editor is a user who has permission to edit and save a dashboard. Examples of editors are as follows:
     - Grafana server administrators.
     - Users who are assigned an organizational role of `Editor` or `Admin`.
-    - Users that have been granted "Admin" or "Edit" permissions at the dashboard or folder level. Refer to [Dashboard and folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
+    - Users that have been granted `Admin` or `Edit` permissions at the dashboard or folder level. Refer to [Dashboard and folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
 - A viewer is a user with the `Viewer` role, which does not permit the user to save a dashboard.
 
 Restrictions are applied separately for viewers and editors.

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -1,0 +1,38 @@
++++
+title = "License Restrictions"
+description = "Grafana Enterprise license restrictions"
+keywords = ["grafana", "licensing", "enterprise"]
+weight = 9
++++
+
+# License restrictions
+
+Enterprise licenses are limited by the number of active viewers, the number of active editor/admins, a license expiration date, and the URL of the Grafana instance.
+
+**User limits**
+
+Grafana licenses allow a certain number of active users in an instance. An active user is any user that has signed in to Grafana within the past 30 days. 
+
+Each user is classified as either Viewer or an Editor/Admin. 
+
+- All users who have the ability to edit and save dashboards are considered “Editors/Admins”, which includes: 
+    - Grafana server admins
+    - Users assigned an Org role of "Editor" or "Admin," 
+    - Users that have been granted "Admin" or "Edit" permissions through [dashboard/folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/). 
+- Viewers are users with the Viewer role who do not have the permissions to save dashboards.
+
+Editors and admins are counted the same from a licensing perspective. Restrictions are applied separately for Viewers and for Editor/Admins. 
+
+When the number of maximum active Viewers or Editor/Admins is reached, a warning banner is displayed within Grafana.
+
+**Expiration date**
+
+The license expiration date is the day when a license is no longer active. A banner will appear in Grafana Enterprise when the license expiration date approaches.
+
+**License URL**
+
+License URL is the root URL of your Grafana instance. The license will not work on an instance of Grafana with a different root URL.
+
+## Updating license restrictions
+
+To increase the number of licensed users within Grafana, extend a license, or change your Licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, and you can apply the updated license within Grafana following the [Activate a license process](https://grafana.com/docs/grafana/latest/enterprise/activate-license/).

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -2,7 +2,7 @@
 title = "License restrictions"
 description = "Grafana Enterprise license restrictions"
 keywords = ["grafana", "licensing", "enterprise"]
-weight = 8
+weight = 110
 +++
 
 # License restrictions
@@ -43,4 +43,7 @@ To download the report:
 
 ## Update license restrictions
 
-To increase the number of licensed users within Grafana, extend a license, or change your licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, which you can activate from within Grafana. Refer to [Activate a license process](https://grafana.com/docs/grafana/latest/enterprise/activate-license/).
+To increase the number of licensed users within Grafana, extend a license, or change your licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, which you can activate from within Grafana. 
+
+For instructions on how to activate your license after it is updated, refer to 
+[Activate an Enterprise license]({{< relref "./activate-license.md" >}})

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -2,7 +2,7 @@
 title = "License Restrictions"
 description = "Grafana Enterprise license restrictions"
 keywords = ["grafana", "licensing", "enterprise"]
-weight = 9
+weight = 8
 +++
 
 # License restrictions

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -9,7 +9,7 @@ weight = 8
 
 Enterprise licenses are limited by the number of active users, a license expiration date, and the URL of the Grafana instance.
 
-**User limits**
+## User limits
 
 Grafana licenses allow for a certain number of active users per instance. An active user is any user that has signed in to Grafana within the past 30 days.
 
@@ -17,19 +17,19 @@ In the context of licensing, each user is classified as either a viewer or an ed
 
 - An editor is a user who has permission to edit and save a dashboard. Examples of editors are as follows:
     - Grafana server administrators.
-    - Users who are assigned an organizational role of `Editor` or `Admin`.
-    - Users that have been granted `Admin` or `Edit` permissions at the dashboard or folder level. Refer to [Dashboard and folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
-- A viewer is a user with the `Viewer` role, which does not permit the user to save a dashboard.
+    - Users who are assigned an organizational role of Editor or Admin.
+    - Users that have been granted Admin or Edit permissions at the dashboard or folder level. Refer to [Dashboard and folder permissions](https://grafana.com/docs/grafana/latest/permissions/dashboard_folder_permissions/).     
+- A viewer is a user with the Viewer role, which does not permit the user to save a dashboard.
 
 Restrictions are applied separately for viewers and editors.
 
 When the number of maximum active viewers or editors is reached, Grafana displays a warning banner.
 
-**Expiration date**
+## Expiration date
 
 The license expiration date is the date when a license is no longer active. As the license expiration date approaches, Grafana Enterprise displays a banner.
 
-**License URL**
+## License URL
 
 License URL is the root URL of your Grafana instance. The license will not work on an instance of Grafana with a different root URL.
 
@@ -41,6 +41,6 @@ To download the report:
 1. Hover your cursor over the **Server Admin** (shield) icon in the side menu and then click **Licensing**.
 2. At the bottom of the page, click **Download report**.
 
-## Updating license restrictions
+## Update license restrictions
 
 To increase the number of licensed users within Grafana, extend a license, or change your licensed URL, contact [Grafana support](https://grafana.com/profile/org#support) or your Grafana Labs account team. They will update your license, which you can activate from within Grafana. Refer to [Activate a license process](https://grafana.com/docs/grafana/latest/enterprise/activate-license/).


### PR DESCRIPTION
**The docs are relevant for Grafana Release 7.4.0 and should be merged before the release.**

**What this PR does / why we need it**:

Provides an overview of license restrictions, such as applied user limits, expiration date and license URL.

**Special notes for your reviewer**:

While we need to evaluate the structure of licensing docs and potentially improve, this is probably good first step to fill in the gap, thus I added the new page as another subpage for [Grafana Enterprise](https://grafana.com/docs/grafana/latest/enterprise/) section. The page will appear after [activate a license](https://grafana.com/docs/grafana/latest/enterprise/activate-license/) and before [license expiration](https://grafana.com/docs/grafana/latest/enterprise/license-expiration/)

