### PR TITLE
Chore: Bump grafana-plugin-ci Alpine Docker image version

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/common.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/common.sh
@@ -4,4 +4,4 @@
 ## Common variable declarations
 ##
 
-DOCKER_IMAGE_NAME="grafana/grafana-plugin-ci:1.1.1-alpine"
+DOCKER_IMAGE_NAME="grafana/grafana-plugin-ci:1.1.2-alpine"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump version of grafana-plugin-ci Alpine Docker image.
