### PR TITLE
runRequest: Fixes issue with request time range and time range returned to panels are off causing data points to be cut off (outside)

### DIFF
--- a/public/app/features/query/state/runRequest.test.ts
+++ b/public/app/features/query/state/runRequest.test.ts
@@ -218,7 +218,7 @@ describe('runRequest', () => {
       // wait a bit
       await sleep(20);
 
-      ctx.emitPacket({ data: [{ name: 'DataB-1' } as DataFrame] });
+      ctx.emitPacket({ data: [{ name: 'DataB-1' } as DataFrame], state: LoadingState.Streaming });
     });
 
     it('should add the correct timeRange property and the request range should not be mutated', () => {
@@ -277,7 +277,6 @@ const expectThatRangeHasNotMutated = (ctx: ScenarioCtx) => {
   // Make sure that the range for request is not changed and that deepfreeze hasn't thrown
   expect(ctx.results[0].request?.range?.to.valueOf()).toBe(ctx.toStartTime.valueOf());
   expect(ctx.results[0].error).not.toBeDefined();
-  expect(ctx.results[0].state).toBe(LoadingState.Done);
 };
 
 async function sleep(ms: number) {


### PR DESCRIPTION
We have a problem with runRequest in that in always interpolates the time range after a response has been received.

This causes the time range that is returned in the request and later past to panels to be off from what the actual request from & to where (by the time the query took)

So if query takes 50ms the from time is 50ms later than the first data point, and this causes it to not be renderd as it outside the time range bounds.

This is a very simple initial fix, might need a more complex solution.
