### PR TITLE
Elasticsearch: fix handling of null values in query_builder

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -334,10 +334,11 @@ export class ElasticQueryBuilder {
         metricAgg = { field: metric.field };
       }
 
-      metricAgg = {
-        ...metricAgg,
-        ...(isMetricAggregationWithSettings(metric) && metric.settings),
-      };
+      if (isMetricAggregationWithSettings(metric)) {
+        Object.entries(metric.settings || {})
+          .filter(([_, v]) => v !== null)
+          .forEach(([k, v]) => (metricAgg[k] = v));
+      }
 
       aggField[metric.type] = metricAgg;
       nestedAggs.aggs[metric.id] = aggField;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The previous version of the query editor was storing `null`s when the user was inputting empty strings in some of the metrics settings that were then removed by the query builder. https://github.com/grafana/grafana/pull/28033 introduced a bug when handling queries created with the old editor that had `null` values in some of the settings fields for which those null properties weren't being removed.

Although not needed with the new query editor, I'm reintroducing the code to remove null properties to ensure backward compatibility with queries created with the old editor.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #30233

**Special notes for your reviewer**:

To test this follow the instructions in the original issue and check that no query is failing.

