### PR TITLE
feat(Loki):  loki label_values() function with left hand subquery component

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -542,6 +542,40 @@ describe('LokiDatasource', () => {
         expect(res).toEqual([{ text: 'label1' }]);
       });
     });
+
+    mocks.forEach((mock, index) => {
+      it(`should return label values for subquery for Loki v${index}`, async () => {
+        const { ds } = getTestContext(mock);
+
+        const res = await ds.metricFindQuery('label_values({app="foo", namespace="prod"},instance)');
+
+        expect(res).toEqual([{ text: 'label1' }]);
+      });
+    });
+
+    mocks.forEach((mock, index) => {
+      it(`should return label values for subquery for Loki v${index}`, async () => {
+        const { ds } = getTestContext(mock);
+
+        const res = await ds.metricFindQuery(
+          'label_values(label_values({filename="/var/log/nginx/json_access.log"} | json, status)'
+        );
+
+        expect(res).toEqual([{ text: 'label1' }]);
+      });
+    });
+
+    mocks.forEach((mock, index) => {
+      it(`should return label values for subquery for Loki v${index}`, async () => {
+        const { ds } = getTestContext(mock);
+
+        const res = await ds.metricFindQuery(
+          'label_values({compose_service=~$service, compose_project=~$project}, container_name)'
+        );
+
+        expect(res).toEqual([{ text: 'label1' }]);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:    
At the moment it is not possible to run nested queries in Grafana variables for Loki     

e.g. `label_values({compose_service=~$service, compose_project=~$project}, container_name)`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #25205

**Special notes for your reviewer**:
I need some direction regarding topics like:
-  how to get  specific data like the other defined variables for later interpolation   
- do I need a start time if the range has been provided as both are required
- the same goes for `interval` and `intervalMs`
