### PR TITLE
Metrics: Stream response

### DIFF
--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -16,6 +16,7 @@ var (
 )
 
 type Response interface {
+	// WriteTo writes to the provided context.
 	WriteTo(ctx *models.ReqContext)
 	// Status gets the response's status.
 	Status() int

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -15,23 +15,6 @@ var (
 	}
 )
 
-type Response interface {
-	// WriteTo writes to the provided context.
-	WriteTo(ctx *models.ReqContext)
-	// Status gets the response's status.
-	Status() int
-	// Body gets the response's body.
-	Body() []byte
-}
-
-type NormalResponse struct {
-	status     int
-	body       []byte
-	header     http.Header
-	errMessage string
-	err        error
-}
-
 func Wrap(action interface{}) macaron.Handler {
 	return func(c *models.ReqContext) {
 		var res Response
@@ -46,44 +29,20 @@ func Wrap(action interface{}) macaron.Handler {
 	}
 }
 
-// Status gets the response's status.
-func (r *NormalResponse) Status() int {
-	return r.status
-}
-
-// Body gets the response's body.
-func (r *NormalResponse) Body() []byte {
-	return r.body
-}
-
-func (r *NormalResponse) WriteTo(ctx *models.ReqContext) {
-	if r.err != nil {
-		ctx.Logger.Error(r.errMessage, "error", r.err, "remote_addr", ctx.RemoteAddr())
-	}
-
-	header := ctx.Resp.Header()
-	for k, v := range r.header {
-		header[k] = v
-	}
-	ctx.Resp.WriteHeader(r.status)
-	if _, err := ctx.Resp.Write(r.body); err != nil {
-		ctx.Logger.Error("Error writing to response", "err", err)
-	}
-}
-
-func (r *NormalResponse) Header(key, value string) *NormalResponse {
-	r.header.Set(key, value)
-	return r
-}
-
-// Empty creates an empty response.
-func Empty(status int) *NormalResponse {
-	return Respond(status, nil)
-}
-
-// JSON create a JSON response
+// JSON creates a JSON response.
 func JSON(status int, body interface{}) *NormalResponse {
 	return Respond(status, body).Header("Content-Type", "application/json")
+}
+
+// jsonStreaming creates a streaming JSON response.
+func jsonStreaming(status int, body interface{}) streamingResponse {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	return streamingResponse{
+		status: status,
+		body:   body,
+		header: header,
+	}
 }
 
 // Success create a successful response
@@ -124,16 +83,16 @@ func Error(status int, message string, err error) *NormalResponse {
 	return resp
 }
 
-// Respond create a response
+// Respond creates a response.
 func Respond(status int, body interface{}) *NormalResponse {
 	var b []byte
-	var err error
 	switch t := body.(type) {
 	case []byte:
 		b = t
 	case string:
 		b = []byte(t)
 	default:
+		var err error
 		if b, err = json.Marshal(body); err != nil {
 			return Error(500, "body json marshal", err)
 		}
@@ -143,28 +102,6 @@ func Respond(status int, body interface{}) *NormalResponse {
 		status: status,
 		header: make(http.Header),
 	}
-}
-
-// RedirectResponse represents a redirect response.
-type RedirectResponse struct {
-	location string
-}
-
-// WriteTo writes to a response.
-func (r *RedirectResponse) WriteTo(ctx *models.ReqContext) {
-	ctx.Redirect(r.location)
-}
-
-// Status gets the response's status.
-// Required to implement api.Response.
-func (*RedirectResponse) Status() int {
-	return http.StatusFound
-}
-
-// Body gets the response's body.
-// Required to implement api.Response.
-func (r *RedirectResponse) Body() []byte {
-	return nil
 }
 
 func Redirect(location string) *RedirectResponse {

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -16,22 +16,22 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// QueryMetricsV2 returns query metrics
+// QueryMetricsV2 returns query metrics.
 // POST /api/ds/query   DataSource query w/ expressions
-func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDto dtos.MetricRequest) Response {
-	if len(reqDto.Queries) == 0 {
+func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricRequest) Response {
+	if len(reqDTO.Queries) == 0 {
 		return Error(400, "No queries found in query", nil)
 	}
 
 	request := &tsdb.TsdbQuery{
-		TimeRange: tsdb.NewTimeRange(reqDto.From, reqDto.To),
-		Debug:     reqDto.Debug,
+		TimeRange: tsdb.NewTimeRange(reqDTO.From, reqDTO.To),
+		Debug:     reqDTO.Debug,
 		User:      c.SignedInUser,
 	}
 
 	hasExpr := false
 	var ds *models.DataSource
-	for i, query := range reqDto.Queries {
+	for i, query := range reqDTO.Queries {
 		hs.log.Debug("Processing metrics query", "query", query)
 		name := query.Get("datasource").MustString("")
 		if name == expr.DatasourceName {
@@ -95,7 +95,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDto dtos.MetricReq
 		}
 	}
 
-	return JSON(statusCode, &resp)
+	return jsonStreaming(statusCode, resp)
 }
 
 // QueryMetrics returns query metrics

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/models"
+)
+
+// Response is an HTTP response interface.
+type Response interface {
+	// WriteTo writes to a context.
+	WriteTo(ctx *models.ReqContext)
+	// Body gets the response's body.
+	Body() []byte
+	// Status gets the response's status.
+	Status() int
+}
+
+type NormalResponse struct {
+	status     int
+	body       []byte
+	header     http.Header
+	errMessage string
+	err        error
+}
+
+// Status gets the response's status.
+func (r *NormalResponse) Status() int {
+	return r.status
+}
+
+// Body gets the response's body.
+func (r *NormalResponse) Body() []byte {
+	return r.body
+}
+
+func (r *NormalResponse) WriteTo(ctx *models.ReqContext) {
+	if r.err != nil {
+		ctx.Logger.Error(r.errMessage, "error", r.err, "remote_addr", ctx.RemoteAddr())
+	}
+
+	header := ctx.Resp.Header()
+	for k, v := range r.header {
+		header[k] = v
+	}
+	ctx.Resp.WriteHeader(r.status)
+	if _, err := ctx.Resp.Write(r.body); err != nil {
+		ctx.Logger.Error("Error writing to response", "err", err)
+	}
+}
+
+func (r *NormalResponse) Header(key, value string) *NormalResponse {
+	r.header.Set(key, value)
+	return r
+}
+
+// Empty creates an empty NormalResponse.
+func Empty(status int) *NormalResponse {
+	return Respond(status, nil)
+}
+
+// streamingResponse is a response that streams itself back to the client.
+type streamingResponse struct {
+	body   interface{}
+	status int
+	header http.Header
+}
+
+// Status gets the response's status.
+func (r streamingResponse) Status() int {
+	return r.status
+}
+
+// Body gets the response's body.
+func (r streamingResponse) Body() []byte {
+	return nil
+}
+
+// WriteTo writes the response to the provided context.
+func (r streamingResponse) WriteTo(ctx *models.ReqContext) {
+	header := ctx.Resp.Header()
+	for k, v := range r.header {
+		header[k] = v
+	}
+	ctx.Resp.WriteHeader(r.status)
+	enc := json.NewEncoder(ctx.Resp)
+	if err := enc.Encode(r.body); err != nil {
+		ctx.Logger.Error("Error writing to response", "err", err)
+	}
+}
+
+// RedirectResponse represents a redirect response.
+type RedirectResponse struct {
+	location string
+}
+
+// WriteTo writes to a response.
+func (r *RedirectResponse) WriteTo(ctx *models.ReqContext) {
+	ctx.Redirect(r.location)
+}
+
+// Status gets the response's status.
+// Required to implement api.Response.
+func (*RedirectResponse) Status() int {
+	return http.StatusFound
+}
+
+// Body gets the response's body.
+// Required to implement api.Response.
+func (r *RedirectResponse) Body() []byte {
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies the /api/ds/query endpoint to stream the JSON response, instead of encoding it all into memory before writing it back to the client. This _should_ improve memory consumption, although I wasn't able to measure a big improvement.

I discovered this potential for optimization while investigating Azure Data Explorer performance.

As part of the PR I also move the different response types into pkg/api/response.go, for easier navigation since I add another type.