### PR TITLE
Metrics API: Use jsoniter for JSON encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.2.0
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/json-iterator/go v1.1.10
 	github.com/jung-kurt/gofpdf v1.10.1
 	github.com/lib/pq v1.9.0
 	github.com/linkedin/goavro/v2 v2.9.7

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -16,6 +16,7 @@ var (
 )
 
 type Response interface {
+	// WriteTo writes to the provided context.
 	WriteTo(ctx *models.ReqContext)
 	// Status gets the response's status.
 	Status() int

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -15,23 +15,6 @@ var (
 	}
 )
 
-type Response interface {
-	// WriteTo writes to the provided context.
-	WriteTo(ctx *models.ReqContext)
-	// Status gets the response's status.
-	Status() int
-	// Body gets the response's body.
-	Body() []byte
-}
-
-type NormalResponse struct {
-	status     int
-	body       []byte
-	header     http.Header
-	errMessage string
-	err        error
-}
-
 func Wrap(action interface{}) macaron.Handler {
 	return func(c *models.ReqContext) {
 		var res Response
@@ -46,44 +29,20 @@ func Wrap(action interface{}) macaron.Handler {
 	}
 }
 
-// Status gets the response's status.
-func (r *NormalResponse) Status() int {
-	return r.status
-}
-
-// Body gets the response's body.
-func (r *NormalResponse) Body() []byte {
-	return r.body
-}
-
-func (r *NormalResponse) WriteTo(ctx *models.ReqContext) {
-	if r.err != nil {
-		ctx.Logger.Error(r.errMessage, "error", r.err, "remote_addr", ctx.RemoteAddr())
-	}
-
-	header := ctx.Resp.Header()
-	for k, v := range r.header {
-		header[k] = v
-	}
-	ctx.Resp.WriteHeader(r.status)
-	if _, err := ctx.Resp.Write(r.body); err != nil {
-		ctx.Logger.Error("Error writing to response", "err", err)
-	}
-}
-
-func (r *NormalResponse) Header(key, value string) *NormalResponse {
-	r.header.Set(key, value)
-	return r
-}
-
-// Empty creates an empty response.
-func Empty(status int) *NormalResponse {
-	return Respond(status, nil)
-}
-
-// JSON create a JSON response
+// JSON creates a JSON response.
 func JSON(status int, body interface{}) *NormalResponse {
 	return Respond(status, body).Header("Content-Type", "application/json")
+}
+
+// jsonStreaming creates a streaming JSON response.
+func jsonStreaming(status int, body interface{}) streamingResponse {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	return streamingResponse{
+		status: status,
+		body:   body,
+		header: header,
+	}
 }
 
 // Success create a successful response
@@ -124,16 +83,16 @@ func Error(status int, message string, err error) *NormalResponse {
 	return resp
 }
 
-// Respond create a response
+// Respond creates a response.
 func Respond(status int, body interface{}) *NormalResponse {
 	var b []byte
-	var err error
 	switch t := body.(type) {
 	case []byte:
 		b = t
 	case string:
 		b = []byte(t)
 	default:
+		var err error
 		if b, err = json.Marshal(body); err != nil {
 			return Error(500, "body json marshal", err)
 		}
@@ -143,28 +102,6 @@ func Respond(status int, body interface{}) *NormalResponse {
 		status: status,
 		header: make(http.Header),
 	}
-}
-
-// RedirectResponse represents a redirect response.
-type RedirectResponse struct {
-	location string
-}
-
-// WriteTo writes to a response.
-func (r *RedirectResponse) WriteTo(ctx *models.ReqContext) {
-	ctx.Redirect(r.location)
-}
-
-// Status gets the response's status.
-// Required to implement api.Response.
-func (*RedirectResponse) Status() int {
-	return http.StatusFound
-}
-
-// Body gets the response's body.
-// Required to implement api.Response.
-func (r *RedirectResponse) Body() []byte {
-	return nil
 }
 
 func Redirect(location string) *RedirectResponse {

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -16,22 +16,22 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// QueryMetricsV2 returns query metrics
+// QueryMetricsV2 returns query metrics.
 // POST /api/ds/query   DataSource query w/ expressions
-func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDto dtos.MetricRequest) Response {
-	if len(reqDto.Queries) == 0 {
+func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricRequest) Response {
+	if len(reqDTO.Queries) == 0 {
 		return Error(400, "No queries found in query", nil)
 	}
 
 	request := &tsdb.TsdbQuery{
-		TimeRange: tsdb.NewTimeRange(reqDto.From, reqDto.To),
-		Debug:     reqDto.Debug,
+		TimeRange: tsdb.NewTimeRange(reqDTO.From, reqDTO.To),
+		Debug:     reqDTO.Debug,
 		User:      c.SignedInUser,
 	}
 
 	hasExpr := false
 	var ds *models.DataSource
-	for i, query := range reqDto.Queries {
+	for i, query := range reqDTO.Queries {
 		hs.log.Debug("Processing metrics query", "query", query)
 		name := query.Get("datasource").MustString("")
 		if name == expr.DatasourceName {
@@ -95,7 +95,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDto dtos.MetricReq
 		}
 	}
 
-	return JSON(statusCode, &resp)
+	return jsonStreaming(statusCode, resp)
 }
 
 // QueryMetrics returns query metrics

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -68,16 +68,19 @@ type streamingResponse struct {
 }
 
 // Status gets the response's status.
+// Required to implement api.Response.
 func (r streamingResponse) Status() int {
 	return r.status
 }
 
 // Body gets the response's body.
+// Required to implement api.Response.
 func (r streamingResponse) Body() []byte {
 	return nil
 }
 
 // WriteTo writes the response to the provided context.
+// Required to implement api.Response.
 func (r streamingResponse) WriteTo(ctx *models.ReqContext) {
 	header := ctx.Resp.Header()
 	for k, v := range r.header {

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/models"
+)
+
+// Response is an HTTP response interface.
+type Response interface {
+	// WriteTo writes to a context.
+	WriteTo(ctx *models.ReqContext)
+	// Body gets the response's body.
+	Body() []byte
+	// Status gets the response's status.
+	Status() int
+}
+
+type NormalResponse struct {
+	status     int
+	body       []byte
+	header     http.Header
+	errMessage string
+	err        error
+}
+
+// Status gets the response's status.
+func (r *NormalResponse) Status() int {
+	return r.status
+}
+
+// Body gets the response's body.
+func (r *NormalResponse) Body() []byte {
+	return r.body
+}
+
+func (r *NormalResponse) WriteTo(ctx *models.ReqContext) {
+	if r.err != nil {
+		ctx.Logger.Error(r.errMessage, "error", r.err, "remote_addr", ctx.RemoteAddr())
+	}
+
+	header := ctx.Resp.Header()
+	for k, v := range r.header {
+		header[k] = v
+	}
+	ctx.Resp.WriteHeader(r.status)
+	if _, err := ctx.Resp.Write(r.body); err != nil {
+		ctx.Logger.Error("Error writing to response", "err", err)
+	}
+}
+
+func (r *NormalResponse) Header(key, value string) *NormalResponse {
+	r.header.Set(key, value)
+	return r
+}
+
+// Empty creates an empty NormalResponse.
+func Empty(status int) *NormalResponse {
+	return Respond(status, nil)
+}
+
+// streamingResponse is a response that streams itself back to the client.
+type streamingResponse struct {
+	body   interface{}
+	status int
+	header http.Header
+}
+
+// Status gets the response's status.
+func (r streamingResponse) Status() int {
+	return r.status
+}
+
+// Body gets the response's body.
+func (r streamingResponse) Body() []byte {
+	return nil
+}
+
+// WriteTo writes the response to the provided context.
+func (r streamingResponse) WriteTo(ctx *models.ReqContext) {
+	header := ctx.Resp.Header()
+	for k, v := range r.header {
+		header[k] = v
+	}
+	ctx.Resp.WriteHeader(r.status)
+	enc := json.NewEncoder(ctx.Resp)
+	if err := enc.Encode(r.body); err != nil {
+		ctx.Logger.Error("Error writing to response", "err", err)
+	}
+}
+
+// RedirectResponse represents a redirect response.
+type RedirectResponse struct {
+	location string
+}
+
+// WriteTo writes to a response.
+func (r *RedirectResponse) WriteTo(ctx *models.ReqContext) {
+	ctx.Redirect(r.location)
+}
+
+// Status gets the response's status.
+// Required to implement api.Response.
+func (*RedirectResponse) Status() int {
+	return http.StatusFound
+}
+
+// Body gets the response's body.
+// Required to implement api.Response.
+func (r *RedirectResponse) Body() []byte {
+	return nil
+}

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -1,10 +1,10 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/models"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // Response is an HTTP response interface.
@@ -87,7 +87,7 @@ func (r streamingResponse) WriteTo(ctx *models.ReqContext) {
 		header[k] = v
 	}
 	ctx.Resp.WriteHeader(r.status)
-	enc := json.NewEncoder(ctx.Resp)
+	enc := jsoniter.NewEncoder(ctx.Resp)
 	if err := enc.Encode(r.body); err != nil {
 		ctx.Logger.Error("Error writing to response", "err", err)
 	}

--- a/pkg/tsdb/models.go
+++ b/pkg/tsdb/models.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // TsdbQuery contains all information about a query request.
@@ -263,5 +264,5 @@ func (df *dataFrames) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	return json.Marshal(encoded)
+	return jsoniter.Marshal(encoded)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
For the /api/ds/query endpoint, use [jsoniter](https://github.com/json-iterator/go) library for JSON encoding, for performance gains. I haven't seen huge gains in the actual request processing time, but profiling indicates a 3x-ish speedup. Not sure why that's not visible in terms of wall time, we should investigate.

I've been told that Prometheus and Cortex use jsoniter already.

## CPU profile jsoniter
![pprof-jsoniter](https://user-images.githubusercontent.com/281303/104441827-80d69780-5594-11eb-8328-fcbd5911a047.png)

## CPU profile stdlib
![pprof-stdlib](https://user-images.githubusercontent.com/281303/104441833-816f2e00-5594-11eb-8cbe-a6fa3a377cc1.png)


