### PR TITLE
CODEOWNERS: Make backend squad owners of backend style guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@ go.mod @grafana/backend-platform
 go.sum @grafana/backend-platform
 
 # Backend code docs
-/contribute/style-guides/backend.md
+/contribute/style-guides/backend.md @grafana/backend-platform
 
 /e2e @grafana/grafana-frontend-platform
 /packages @grafana/grafana-frontend-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,9 @@
 go.mod @grafana/backend-platform
 go.sum @grafana/backend-platform
 
+# Backend code docs
+/contribute/style-guides/backend.md
+
 /e2e @grafana/grafana-frontend-platform
 /packages @grafana/grafana-frontend-platform
 /plugins-bundled @grafana/grafana-frontend-platform


### PR DESCRIPTION
**What this PR does / why we need it**:
In .github/CODEOWNERS, make backend squad owners of backend code style guidelines. This change makes sense since we are responsible for the Grafana backend code, and reviewers from said squad should be picked when PRs are made to this document.