### PR TITLE
Docs: Add Getting started with Grafana and Elasticsearch guide

### DIFF
--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -2,7 +2,6 @@
 title = "With Grafana and Elasticsearch"
 description = "Guide for getting started with Grafana"
 keywords = ["grafana", "intro", "guide", "started", "Elastic", "Elasticsearch"]
-aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
 weight = 400
 +++
 
@@ -10,58 +9,54 @@ weight = 400
 
 Elasticsearch is a popular open source search and analytics engine for which Grafana provides out-of-the-box support. This topic walks you through the steps to create your first Elasticsearch backed dashboard in grafana to display any kind of data stored in your Elasticsearch database.
 
-## Step 1. Install Grafana and build your first dashboard
+> **Note:** Before you begin, use the instructions in [Getting started with Grafana]({{< relref "getting-started.md" >}}) to install Grafana and build your first dashboard.
 
-Use the instructions in [Getting started with Grafana]({{< relref "getting-started.md" >}}) to:
-
-- Install Grafana.
-- Log in to Grafana.
-- Create your first dashboard.
-
-## Step 2. Download and install Elasticsearch
+## Step 1. Download and install Elasticsearch
 
 Elasticsearch can be installed on many different operating systems. Refer to the [Installing Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html) for a complete list of all available options.
 
 Alternately you can install Elasticsearch using the resources available in [grafana/grafana](https://github.com/grafana/grafana) GitHub repository. Here you will find a collection of supported data sources, including Elasticsearch, along with test data and preconfigured dashboards for use.
 
-Clone the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository to your local system.
-Install Docker or verify that it is installed on your machine.
+1. Clone the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository to your local system.
+1. Install Docker or verify that it is installed on your machine.
 
-Within your local `grafana` repository, change directory to [devenv](https://github.com/grafana/grafana/tree/master/devenv).
+1. Within your local `grafana` repository, change directory to [devenv](https://github.com/grafana/grafana/tree/master/devenv).
 
-```
-cd devenv
-```
+   ```
+   cd devenv
+   ```
 
-Run the bash command to setup data sources and dashboards.
+1. Run the bash command to setup data sources and dashboards.
 
-```
-./setup.sh
-```
+   ```
+   ./setup.sh
+   ```
 
-Restart the Grafana server.
-Change directory back to the root directory.
+1. Restart the Grafana server.
+1. Change directory back to the root directory.
 
-```
-cd ..
-```
+   ```
+   cd ..
+   ```
 
-Run the make command to create and start Elasticsearch.
+1. Run the make command to create and start Elasticsearch.
 
-```
+   ```
    make devenv sources=elastic7
-```
+   ```
 
 This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a process that sends random data to your new Elasticsearch instance.
 
 > **Note**: Filebeat, Metricbeat, and Kibana are outside the scope of this topic.
 
-## Step 3. Configure and add the Elasticsearch data source
+## Step 2. Configure and add the Elasticsearch data source
 
 Once you have your Elasticsearch instance up and running and some process pushing data to it, you can configure your data source within Grafana.
 
 For more information on how to add a datasource, refer to [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
 Check also out [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/) for a more detailed list of all available configuration options for Elasticsearch.
+
+> **Note**: We'll assume you used the instructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use-case.
 
 To add the Elasticsearch data source:
 
@@ -69,8 +64,6 @@ To add the Elasticsearch data source:
 1. Select the **Elasticsearch** option.
 1. Click **Add data source** in the top right header to open the configuration page.
 1. Enter the information specified in the tables below, then click **Save & Test**.
-
-> **Note**: We'll assume you used the instructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use-case.
 
 ### General Settings
 
@@ -94,11 +87,11 @@ To add the Elasticsearch data source:
 | `Time field name` | The name of the field that identiefies the timestamp of your documents.    | `@timestamp`           |
 | `Version`         | The Elasticsearch version you are running.                                 | `7.0+`                 |
 
-Once you click **Save & Test** the following message will appear, confirming that Grafana is able to communicate with your Elasticsearch instance:
+Click **Save & Test**. The following message opens, confirming that Grafana is able to communicate with your Elasticsearch instance:
 
 ![Elasticsearch confirmation message](/img/docs/getting-started/elasticsearch/confirmation-7-4.png)
 
-## Step 4. Create your first Elasticsearch backed dashboard
+## Step 3. Create your first Elasticsearch backed dashboard
 
 1. In the Grafana side menu, hover your cursor over the **Create** (plus) icon and then click **Dashboard**.
 1. Click the **Add new panel** button.

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -53,12 +53,12 @@ This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a proce
 
 Once you have your Elasticsearch instance up and running and some process pushing data to it, you can configure your data source within Grafana.
 
-For more information on how to add a datasource, refer to [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
-Check also out [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/) for a more detailed list of all available configuration options for Elasticsearch.
+For information on how to add a datasource, refer to [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
+See also, [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/) for detailed list of all available configuration options for Elasticsearch.
 
 > **Note**: We'll assume you used the instructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use-case.
 
-To add the Elasticsearch data source:
+To configure the Elasticsearch data source:
 
 1. In the Grafana side menu, hover your cursor over the **Configuration** (gear) icon and then click **Data Sources**.
 1. Select the **Elasticsearch** option.

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -56,7 +56,7 @@ Once you have your Elasticsearch instance up and running and some process pushin
 For information on how to add a datasource, refer to [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
 See also, [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/) for detailed list of all available configuration options for Elasticsearch.
 
-> **Note**: We'll assume you used the instructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use-case.
+> **Note**: We'll assume you used the instructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use case.
 
 To configure the Elasticsearch data source:
 

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -113,4 +113,4 @@ The default query will graph the number of received documents in our index over 
 
 Now that you have your Elasticsearch powered Grafana dashboard you can start [exploring](/docs/grafana/latest/explore/) different ways of querying your Elasticsearch index to get the most out of your data.
 
-For more information, refer to [Elasticsearch aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html), [metricbeat](https://www.elastic.co/beats/metricbeat) and [filebeat](https://www.elastic.co/beats/filebeat) on [Elastic's website](https://www.elastic.co).
+For more information, refer to [Elasticsearch aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html), [Metricbeat](https://www.elastic.co/beats/metricbeat) and [Filebeat](https://www.elastic.co/beats/filebeat) on [Elastic's website](https://www.elastic.co).

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -1,6 +1,6 @@
 +++
 title = "With Grafana and Elasticsearch"
-description = "Guide for getting started with Grafana"
+description = "Guide for getting started with Grafana and Elasticsearch"
 keywords = ["grafana", "intro", "guide", "started", "Elastic", "Elasticsearch"]
 weight = 400
 +++

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -54,7 +54,7 @@ This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a proce
 Once you have your Elasticsearch instance up and running and some process pushing data to it, you can configure your data source within Grafana.
 
 For information on how to add a datasource, refer to [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
-See also, [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/) for detailed list of all available configuration options for Elasticsearch.
+Refer to [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/) for detailed list of all available configuration options for Elasticsearch.
 
 > **Note**: We'll assume you used the instructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use case.
 

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -111,6 +111,6 @@ The default query will graph the number of received documents in our index over 
 
 ## Next steps
 
-Now that you have your Elasticsearch powered Grafana dashboard you can start [exploring](/docs/grafana/latest/explore/) different ways of querying your Elasticsearch index to get the most out of your data.
+Now that you have your Elasticsearch powered Grafana dashboard you can start [exploring](/docs/grafana/latest/explore/_index.md) different ways of querying your Elasticsearch index to get the most out of your data.
 
 For more information, refer to [Elasticsearch aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html), [Metricbeat](https://www.elastic.co/beats/metricbeat) and [Filebeat](https://www.elastic.co/beats/filebeat) on [Elastic's website](https://www.elastic.co).

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -91,7 +91,7 @@ Click **Save & Test**. The following message opens, confirming that Grafana is a
 
 ![Elasticsearch confirmation message](/img/docs/getting-started/elasticsearch/confirmation-7-4.png)
 
-## Step 3. Create your first Elasticsearch backed dashboard
+## Step 3. Create your first Elasticsearch-backed dashboard
 
 1. In the Grafana side menu, hover your cursor over the **Create** (plus) icon and then click **Dashboard**.
 1. Click the **Add new panel** button.

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -44,8 +44,9 @@ Alternately you can install Elasticsearch using the resources available in [graf
     make devenv sources=elastic7
    ```
 
-This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a process that sends random data to your new Elasticsearch instance. 
-> **Note**:  Filebeat, Metricbeat, and Kibana are outside the scope of this topic.
+This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a process that sends random data to your new Elasticsearch instance.
+
+> **Note**: Filebeat, Metricbeat, and Kibana are outside the scope of this topic.
 
 ## Step 3. Configure and add the Elasticsearch data source
 
@@ -103,6 +104,6 @@ You can now start editing your query to get data out of your Elasticsearch insta
 
 ## Next steps
 
-Now that you have your Elasticsearch powered Grafana dashboard you can start exploring different ways of querying your Elasticsearch index to get the most out of your data.
+Now that you have your Elasticsearch powered Grafana dashboard you can start [exploring](/docs/grafana/latest/explore/) different ways of querying your Elasticsearch index to get the most out of your data.
 
 For more information, refer to [Elasticsearch aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html), [metricbeat](https://www.elastic.co/beats/metricbeat) and [filebeat](https://www.elastic.co/beats/filebeat) on [Elastic's website](https://www.elastic.co).

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -22,7 +22,7 @@ Use the instructions in [Getting started with Grafana]({{< relref "getting-start
 
 Elasticsearch can be installed on many different operating systems. Refer to the [Installing Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html) for a complete list of all available options.
 
-Alternately you can install Elasticsearch using the resources available in [grafana/grafana](https://github.com/grafana/grafana) GitHub repository (recommended). Here you will find a collection of supported data sources, including Elasticsearch, along with test data and pre-configured dashboards for use.
+Alternately you can install Elasticsearch using the resources available in [grafana/grafana](https://github.com/grafana/grafana) GitHub repository. Here you will find a collection of supported data sources, including Elasticsearch, along with test data and preconfigured dashboards for use.
 
 1. Clone the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository to your local system.
 1. Install Docker or verify that it is installed on your machine.

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -1,0 +1,107 @@
++++
+title = "With Grafana and Elasticsearch"
+description = "Guide for getting started with Grafana"
+keywords = ["grafana", "intro", "guide", "started", "Elastic", "Elasticsearch"]
+aliases = ["/docs/grafana/latest/guides/gettingstarted","/docs/grafana/latest/guides/getting_started"]
+weight = 400
++++
+
+# Getting started with Grafana and Elasticsearch
+
+Elasticsearch is a popular open source search and analytics engine for which Grafana provides out-of-the-box support. This topic walks you through the steps to create your first Elasticsearch backed dashboard in grafana to display any kind of data stored in your Elasticsearch database.
+
+## Step 1. Install Grafana and build your first dashboard
+
+Use the instructions in [Getting started with Grafana]({{< relref "getting-started.md" >}}) to:
+
+- Install Grafana.
+- Log in to Grafana.
+- Create your first dashboard.
+
+## Step 2. Download and install Elasticsearch
+
+Elasticsearch can be installed on many different operating systems. Refer to the [Installing Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html) for a complete list of all available options.
+
+Alternately you can install Elasticsearch using the resources available in [grafana/grafana](https://github.com/grafana/grafana) GitHub repository (recommended). Here you will find a collection of supported data sources, including Elasticsearch, along with test data and pre-configured dashboards for use.
+
+1. Clone the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository to your local system.
+1. Install Docker or verify that it is installed on your machine.
+1. Within your local `grafana` repository, change directory to [devenv](https://github.com/grafana/grafana/tree/master/devenv).
+   ```
+   cd devenv
+   ```
+1. Run the bash command to setup data sources and dashboards.
+   ```
+   ./setup.sh
+   ```
+1. Restart the Grafana server.
+1. Change directory back to the root directory.
+   ```
+   cd ..
+   ```
+1. Run the make command to create and start Elasticsearch.
+   ```
+    make devenv sources=elastic7
+   ```
+
+This will create and start Elasticsearch, filebeat, metricbeat, kibana and a process that sends random data to your new Elasticsearch instance. We'll ignore filebeat, metricbeat and kibana in this guide.
+
+## Step 3. Configure and add the Elasticsearch data source
+
+Once you have your Elasticsearch instance up and running and some process pushing data to it, you can configure your data source within Grafana.
+
+To add the Elasticsearch data source:
+
+1. In the Grafana side menu, hover your cursor over the **Configuration** (gear) icon and then click **Data Sources**.
+1. Select the **Elasticsearch** option.
+1. Click **Add data source** in the top right header to open the configuration page.
+1. Enter the information specified in the tables below, then click **Save & Test**.
+
+> **Note**: We'll assume you used the intructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use-case.
+
+### General Settings
+
+| Name   | Description                                                                           |
+| ------ | ------------------------------------------------------------------------------------- |
+| `Name` | The data source name. This is how you refer to the data source in panels and queries. |
+
+### HTTP Settings
+
+| Name     | Description                                                                                              | Value                    |
+| -------- | -------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `URL`    | The IP address/hostname and optional port of your Elasticsearch instance.                                | `http://localhost:12200` |
+| `Access` | Wether to connect to your Elasticsearch instance from the browser or through Grafana's backend (Server). | `Server (default)`       |
+
+### Elasticsearch details
+
+| Name              | Description                                                                | Value                  |
+| ----------------- | -------------------------------------------------------------------------- | ---------------------- |
+| `Index name`      | The index pattern used to identify indices you want to query with grafana. | `[metrics-]YYYY.MM.DD` |
+| `Pattern`         | The time pattern for which the above index will be be interpolated.        | `Daily`                |
+| `Time field name` | The name of the field that identiefies the timestamp of your documents.    | `@timestamp`           |
+| `Version`         | The Elasticsearch version you are running.                                 | `7.0+`                 |
+
+Once you click **Save & Test** the following message will appear, confirming that Grafana is able to communicate with your elasticsearch instance:
+
+![Elasticsearch confirmation message](/img/docs/getting-started/elasticsearch/confirmation-7-4.png)
+
+## Step 4. Create your first Elasticsearch backed dashboard
+
+1. In the Grafana side menu, hover your cursor over the **Create** (plus) icon and then click **Dashboard**.
+1. Click the **Add new panel** button.
+
+If you made Elasticsearch your default data source by toggling `default` on when creating it, it should be already selected:
+
+![Elasticsearch panel edit](/img/docs/getting-started/elasticsearch/panel-edit-7-4.png)
+
+Otherwise you can select it from the data source picker:
+
+![data source picker](/img/docs/getting-started/elasticsearch/datasource-picker-7-4.png)
+
+You can now start editing your query to get data out of your Elasticsearch instance.
+
+## Next steps
+
+Now that you have your Elasticsearch powered Grafana dashboard you can start exploring different ways of querying your Elasticsearch index to get the most out of your data.
+
+You can read more about topics not covered in this guide, such as [Elasticsearch aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html), [metricbeat](https://www.elastic.co/beats/metricbeat) and [filebeat](https://www.elastic.co/beats/filebeat) on [Elastic's website](https://www.elastic.co).

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -81,7 +81,7 @@ To add the Elasticsearch data source:
 | `Time field name` | The name of the field that identiefies the timestamp of your documents.    | `@timestamp`           |
 | `Version`         | The Elasticsearch version you are running.                                 | `7.0+`                 |
 
-Once you click **Save & Test** the following message will appear, confirming that Grafana is able to communicate with your elasticsearch instance:
+Once you click **Save & Test** the following message will appear, confirming that Grafana is able to communicate with your Elasticsearch instance:
 
 ![Elasticsearch confirmation message](/img/docs/getting-started/elasticsearch/confirmation-7-4.png)
 

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -105,4 +105,4 @@ You can now start editing your query to get data out of your Elasticsearch insta
 
 Now that you have your Elasticsearch powered Grafana dashboard you can start exploring different ways of querying your Elasticsearch index to get the most out of your data.
 
-You can read more about topics not covered in this guide, such as [Elasticsearch aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html), [metricbeat](https://www.elastic.co/beats/metricbeat) and [filebeat](https://www.elastic.co/beats/filebeat) on [Elastic's website](https://www.elastic.co).
+For more information, refer to [Elasticsearch aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html), [metricbeat](https://www.elastic.co/beats/metricbeat) and [filebeat](https://www.elastic.co/beats/filebeat) on [Elastic's website](https://www.elastic.co).

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -112,6 +112,9 @@ Otherwise you can select it from the data source picker:
 ![data source picker](/img/docs/getting-started/elasticsearch/datasource-picker-7-4.png)
 
 You can now start editing your query to get data out of your Elasticsearch instance.
+The default query will graph the number of received documents in our index over the specidied period of time:
+
+![Default query](/img/docs/getting-started/elasticsearch/default-query-7-4.png)
 
 ## Next steps
 

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -44,7 +44,8 @@ Alternately you can install Elasticsearch using the resources available in [graf
     make devenv sources=elastic7
    ```
 
-This will create and start Elasticsearch, filebeat, metricbeat, kibana and a process that sends random data to your new Elasticsearch instance. We'll ignore filebeat, metricbeat and kibana in this guide.
+This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a process that sends random data to your new Elasticsearch instance. 
+> **Note**:  Filebeat, Metricbeat, and Kibana are outside the scope of this topic.
 
 ## Step 3. Configure and add the Elasticsearch data source
 

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -52,6 +52,8 @@ This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a proce
 
 Once you have your Elasticsearch instance up and running and some process pushing data to it, you can configure your data source within Grafana.
 
+For more information on Elasticsearch configuration, refer to [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/).
+
 To add the Elasticsearch data source:
 
 1. In the Grafana side menu, hover your cursor over the **Configuration** (gear) icon and then click **Data Sources**.

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -57,7 +57,7 @@ To add the Elasticsearch data source:
 1. Click **Add data source** in the top right header to open the configuration page.
 1. Enter the information specified in the tables below, then click **Save & Test**.
 
-> **Note**: We'll assume you used the intructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use-case.
+> **Note**: We'll assume you used the instructions from Grafana's devenv for simplicity, if this is not the case you may have to adapt the values in the tables below to match your use-case.
 
 ### General Settings
 
@@ -67,10 +67,10 @@ To add the Elasticsearch data source:
 
 ### HTTP Settings
 
-| Name     | Description                                                                                              | Value                    |
-| -------- | -------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `URL`    | The IP address/hostname and optional port of your Elasticsearch instance.                                | `http://localhost:12200` |
-| `Access` | Wether to connect to your Elasticsearch instance from the browser or through Grafana's backend (Server). | `Server (default)`       |
+| Name     | Description                                                                                               | Value                    |
+| -------- | --------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `URL`    | The IP address/hostname and optional port of your Elasticsearch instance.                                 | `http://localhost:12200` |
+| `Access` | whether to connect to your Elasticsearch instance from the browser or through Grafana's backend (Server). | `Server (default)`       |
 
 ### Elasticsearch details
 

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -24,25 +24,33 @@ Elasticsearch can be installed on many different operating systems. Refer to the
 
 Alternately you can install Elasticsearch using the resources available in [grafana/grafana](https://github.com/grafana/grafana) GitHub repository. Here you will find a collection of supported data sources, including Elasticsearch, along with test data and preconfigured dashboards for use.
 
-1. Clone the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository to your local system.
-1. Install Docker or verify that it is installed on your machine.
-1. Within your local `grafana` repository, change directory to [devenv](https://github.com/grafana/grafana/tree/master/devenv).
-   ```
-   cd devenv
-   ```
-1. Run the bash command to setup data sources and dashboards.
-   ```
-   ./setup.sh
-   ```
-1. Restart the Grafana server.
-1. Change directory back to the root directory.
-   ```
-   cd ..
-   ```
-1. Run the make command to create and start Elasticsearch.
-   ```
-    make devenv sources=elastic7
-   ```
+Clone the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository to your local system.
+Install Docker or verify that it is installed on your machine.
+
+Within your local `grafana` repository, change directory to [devenv](https://github.com/grafana/grafana/tree/master/devenv).
+
+```
+cd devenv
+```
+
+Run the bash command to setup data sources and dashboards.
+
+```
+./setup.sh
+```
+
+Restart the Grafana server.
+Change directory back to the root directory.
+
+```
+cd ..
+```
+
+Run the make command to create and start Elasticsearch.
+
+```
+   make devenv sources=elastic7
+```
 
 This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a process that sends random data to your new Elasticsearch instance.
 

--- a/docs/sources/getting-started/getting-started-elasticsearch.md
+++ b/docs/sources/getting-started/getting-started-elasticsearch.md
@@ -52,7 +52,8 @@ This creates and starts Elasticsearch, Filebeat, Metricbeat, Kibana, and a proce
 
 Once you have your Elasticsearch instance up and running and some process pushing data to it, you can configure your data source within Grafana.
 
-For more information on Elasticsearch configuration, refer to [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/).
+For more information on how to add a datasource, refer to [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
+Check also out [Using Elasticsearch in Grafana](/docs/grafana/latest/datasources/elasticsearch/) for a more detailed list of all available configuration options for Elasticsearch.
 
 To add the Elasticsearch data source:
 


### PR DESCRIPTION
Adds a Getting started with Grafana and Elasticsearch guide.

The screenshots are based on the editor in 7.4, so maybe we want to publish this only after the first beta release (although it would be easy enough to use the screenshots from 7.3).

I mostly based this on the MS SQL getting started guide with some modifications.

Also, this guide doesn't really cover everything possible with Elasticsearch in Grafana given its very broad use-cases, there are for example references to metricbeat and filebeat that would be nice to cover but I didn't include them here to keep the scope of this guide reasonably small.

We could potentially add more guides in the future to cover also those topics.