### PR TITLE
Icon: Fix font awesome icons and spinner

### DIFF
--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -61,7 +61,7 @@ export const Icon = React.forwardRef<HTMLDivElement, IconProps>(
     const svgSize = getSvgSize(size);
 
     /* Temporary solution to display also font awesome icons */
-    if (name?.startsWith('fa-')) {
+    if (name?.startsWith('fa fa-')) {
       return <i className={cx(name, className)} {...divElementProps} style={style} />;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Related to https://github.com/grafana/grafana/pull/30277 that broke spinner and remaining FontAwesome icons. All of the remaining FontAwesome icons starts with `fa fa-`. I noticed this in Explore toolbar which looks broken when running queries.

E.g. 
![image](https://user-images.githubusercontent.com/30407135/104616882-1eac8e00-568b-11eb-85ea-3be41e9aa182.png)
