### PR TITLE
Graph: Consider reverse sorted data points on isOutsideRange check

### DIFF
--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -94,7 +94,11 @@ export class DataProcessor {
       const from = range.from;
 
       if (last - from.valueOf() < -10000) {
-        series.isOutsideRange = true;
+        // If the data is in reverse order
+        const first = datapoints[0][1];
+        if (first - from.valueOf() < -10000) {
+          series.isOutsideRange = true;
+        }
       }
     }
     return series;


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation of the `isOutsideRange` check within the `Graph` panel assumes the data points are chronologically sorted, so this PR introduces the changes needed to add support also for reverse sorted data points.

**Special notes for your reviewer**:

During some tests related with the transformation introduced [here](https://github.com/grafana/grafana/pull/30284), I realized that due to the date adjustments applied by the transformation (all the data points that happened on `YYYY-MM-DD HH:MM:SS` are grouped at `YYYY-MM-DD 00:00:00`), sometimes you end up with a data point before the `timeRange.from` (the left-most one, because`YYYY-MM-DD 00:00:00` < `YYYY-MM-DD HH:MM:SS`).

So, after some debugging with the super valuable help of @ryantxu, we realized the `isOutsideRange` check is only calculating the difference between the `last` data point and the `timeRange.from`, assuming the "last" (right-most) data point is the last in the array, so assuming the data points are chronologically sorted, which makes the warning to appear for reverse sorted data points in situations it's not expected. See the screenshots attached below.

![image](https://user-images.githubusercontent.com/5459617/104628124-2888be00-5698-11eb-98e5-5f8d05645c51.png)
![image (1)](https://user-images.githubusercontent.com/5459617/104628145-2cb4db80-5698-11eb-9da9-7de677f6a89b.png)
