### PR TITLE
Plugins: Use the includes.path (if exists) on sidebar includes links

### DIFF
--- a/public/app/features/plugins/PluginPage.tsx
+++ b/public/app/features/plugins/PluginPage.tsx
@@ -212,8 +212,9 @@ class PluginPage extends PureComponent<Props, State> {
     if (item.type === PluginIncludeType.page) {
       const pluginId = this.state.plugin!.meta.id;
       const page = item.name.toLowerCase().replace(' ', '-');
+      const url = item.path ?? `plugins/${pluginId}/page/${page}`;
       return (
-        <a href={`plugins/${pluginId}/page/${page}`}>
+        <a href={url}>
           <i className={getPluginIcon(item.type)} />
           {item.name}
         </a>


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the `includes.path` for `page`s included in `app` plugins are not being used to render the links present on the sidebar from the plugin page. So, this PR introduces a small change to use the `path` if present, instead of build the pre-defined `/page/${page}` url.

**Special notes for your reviewer**:

I attach here some screenshots to point out the section described above:

![Captura de pantalla 2021-01-14 a las 19 36 12](https://user-images.githubusercontent.com/5459617/104634016-53771000-56a0-11eb-83ee-55a44bb01625.png)
![Captura de pantalla 2021-01-14 a las 19 35 57](https://user-images.githubusercontent.com/5459617/104634013-52de7980-56a0-11eb-80f7-55ba4137c0c0.png)