### PR TITLE
PanelEditor: Render panel field config categories as separate option group sections 

### DIFF
--- a/packages/grafana-data/src/panel/registryFactories.ts
+++ b/packages/grafana-data/src/panel/registryFactories.ts
@@ -24,7 +24,6 @@ export function createFieldConfigRegistry<TFieldConfigOptions>(
 
     for (const customProp of builder.getRegistry().list()) {
       customProp.isCustom = true;
-      customProp.category = [`${pluginName} options`].concat(customProp.category || []);
       // need to do something to make the custom items not conflict with standard ones
       // problem is id (registry index) is used as property path
       // so sort of need a property path on the FieldPropertyEditorItem

--- a/packages/grafana-data/src/types/options.ts
+++ b/packages/grafana-data/src/types/options.ts
@@ -39,7 +39,7 @@ export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any> {
   /**
    * Array of strings representing category of the option. First element in the array will make option render as collapsible section.
    */
-  category?: string[];
+  category?: Array<string | undefined>;
 
   /**
    * Set this value if undefined

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -127,7 +127,7 @@ export const Components = {
     backArrow: 'Go Back button',
   },
   OptionsGroup: {
-    toggle: (title: string) => `Options group ${title}`,
+    toggle: (title?: string) => (title ? `Options group ${title}` : 'Options group'),
   },
   PluginVisualization: {
     item: (title: string) => `Plugin visualization item ${title}`,

--- a/public/app/features/dashboard/components/PanelEditor/DefaultFieldConfigEditor.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/DefaultFieldConfigEditor.test.tsx
@@ -86,4 +86,178 @@ describe('DefaultFieldConfigEditor', () => {
     const editors = queryAllByLabelText(selectors.components.PanelEditor.FieldOptions.propertyEditor('Custom'));
     expect(editors).toHaveLength(2);
   });
+
+  describe('categories', () => {
+    it('should render uncategorized options under panel category', () => {
+      const plugin = new PanelPlugin(() => null).useFieldConfig({
+        standardOptions: {},
+        useCustomConfig: b => {
+          b.addBooleanSwitch({
+            name: 'a',
+            path: 'a',
+          } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addBooleanSwitch({
+              name: 'c',
+              path: 'c',
+            } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addTextInput({
+              name: 'b',
+              path: 'b',
+            } as FieldConfigEditorConfig<FakeFieldOptions>);
+        },
+      });
+      plugin.meta.name = 'Test plugin';
+
+      const { queryAllByLabelText } = render(
+        <DefaultFieldConfigEditor data={[]} onChange={jest.fn()} plugin={plugin} config={fieldConfigMock} />
+      );
+
+      expect(
+        queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${plugin.meta.name} options/0`))
+      ).toHaveLength(1);
+
+      expect(queryAllByLabelText(selectors.components.OptionsGroup.toggle(), { exact: false })).toHaveLength(1);
+    });
+
+    it('should render categorized options under custom category', () => {
+      const CATEGORY_NAME = 'Cat1';
+      const plugin = new PanelPlugin(() => null).useFieldConfig({
+        standardOptions: {},
+        useCustomConfig: b => {
+          b.addTextInput({
+            name: 'b',
+            path: 'b',
+          } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addBooleanSwitch({
+              name: 'a',
+              path: 'a',
+              category: [CATEGORY_NAME],
+            } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addBooleanSwitch({
+              name: 'c',
+              path: 'c',
+              category: [CATEGORY_NAME],
+            } as FieldConfigEditorConfig<FakeFieldOptions>);
+        },
+      });
+      plugin.meta.name = 'Test plugin';
+
+      const { queryAllByLabelText } = render(
+        <DefaultFieldConfigEditor data={[]} onChange={jest.fn()} plugin={plugin} config={fieldConfigMock} />
+      );
+
+      expect(
+        queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${plugin.meta.name} options/0`))
+      ).toHaveLength(1);
+
+      expect(queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${CATEGORY_NAME}/1`))).toHaveLength(1);
+
+      expect(queryAllByLabelText(selectors.components.OptionsGroup.toggle(), { exact: false })).toHaveLength(2);
+    });
+
+    it('should allow subcategories in panel category', () => {
+      const SUBCATEGORY_NAME = 'Sub1';
+      const plugin = new PanelPlugin(() => null).useFieldConfig({
+        standardOptions: {},
+        useCustomConfig: b => {
+          b.addTextInput({
+            name: 'b',
+            path: 'b',
+            category: [undefined, SUBCATEGORY_NAME],
+          } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addBooleanSwitch({
+              name: 'a',
+              path: 'a',
+            } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addBooleanSwitch({
+              name: 'c',
+              path: 'c',
+            } as FieldConfigEditorConfig<FakeFieldOptions>);
+        },
+      });
+      plugin.meta.name = 'Test plugin';
+
+      const { queryAllByLabelText, queryAllByText } = render(
+        <DefaultFieldConfigEditor data={[]} onChange={jest.fn()} plugin={plugin} config={fieldConfigMock} />
+      );
+
+      expect(
+        queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${plugin.meta.name} options/0`))
+      ).toHaveLength(1);
+
+      expect(queryAllByText(SUBCATEGORY_NAME, { exact: false })).toHaveLength(1);
+    });
+
+    it('should allow subcategories in custom category', () => {
+      const CATEGORY_NAME = 'Cat1';
+      const SUBCATEGORY_NAME = 'Sub1';
+      const plugin = new PanelPlugin(() => null).useFieldConfig({
+        standardOptions: {},
+        useCustomConfig: b => {
+          b.addBooleanSwitch({
+            name: 'a',
+            path: 'a',
+          } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addBooleanSwitch({
+              name: 'c',
+              path: 'c',
+            } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addTextInput({
+              name: 'b',
+              path: 'b',
+              category: [CATEGORY_NAME, SUBCATEGORY_NAME],
+            } as FieldConfigEditorConfig<FakeFieldOptions>);
+        },
+      });
+      plugin.meta.name = 'Test plugin';
+
+      const { queryAllByLabelText, queryAllByText } = render(
+        <DefaultFieldConfigEditor data={[]} onChange={jest.fn()} plugin={plugin} config={fieldConfigMock} />
+      );
+
+      expect(
+        queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${plugin.meta.name} options/0`))
+      ).toHaveLength(1);
+      expect(queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${CATEGORY_NAME}/1`))).toHaveLength(1);
+
+      expect(queryAllByText(SUBCATEGORY_NAME, { exact: false })).toHaveLength(1);
+    });
+
+    it('should not render categories with hidden fields only', () => {
+      const CATEGORY_NAME = 'Cat1';
+      const SUBCATEGORY_NAME = 'Sub1';
+      const plugin = new PanelPlugin(() => null).useFieldConfig({
+        standardOptions: {},
+        useCustomConfig: b => {
+          b.addBooleanSwitch({
+            name: 'a',
+            path: 'a',
+          } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addBooleanSwitch({
+              name: 'c',
+              path: 'c',
+            } as FieldConfigEditorConfig<FakeFieldOptions>)
+            .addTextInput({
+              name: 'b',
+              path: 'b',
+              hideFromDefaults: true,
+              category: [CATEGORY_NAME, SUBCATEGORY_NAME],
+            } as FieldConfigEditorConfig<FakeFieldOptions>);
+        },
+      });
+      plugin.meta.name = 'Test plugin';
+
+      const { queryAllByLabelText, queryAllByText } = render(
+        <DefaultFieldConfigEditor data={[]} onChange={jest.fn()} plugin={plugin} config={fieldConfigMock} />
+      );
+
+      expect(
+        queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${plugin.meta.name} options/0`))
+      ).toHaveLength(1);
+
+      expect(queryAllByLabelText(selectors.components.OptionsGroup.toggle(`${CATEGORY_NAME}/1`))).toHaveLength(0);
+
+      expect(queryAllByText(SUBCATEGORY_NAME, { exact: false })).toHaveLength(0);
+    });
+  });
 });

--- a/public/app/features/dashboard/components/PanelEditor/DynamicConfigValueEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/DynamicConfigValueEditor.tsx
@@ -35,7 +35,10 @@ export const DynamicConfigValueEditor: React.FC<DynamicConfigValueEditorProps> =
   // eslint-disable-next-line react/display-name
   const renderLabel = (includeDescription = true, includeCounter = false) => (isExpanded = false) => (
     <HorizontalGroup justify="space-between">
-      <Label category={item.category?.splice(1)} description={includeDescription ? item.description : undefined}>
+      <Label
+        category={item.category?.filter(c => c !== undefined) as string[]}
+        description={includeDescription ? item.description : undefined}
+      >
         {item.name}
         {!isExpanded && includeCounter && item.getItemsCount && <Counter value={item.getItemsCount(property.value)} />}
       </Label>

--- a/public/app/features/dashboard/components/PanelEditor/PanelOptionsEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelOptionsEditor.tsx
@@ -22,7 +22,7 @@ interface PanelOptionsEditorProps<TOptions> {
   options: TOptions;
   onChange: (options: TOptions) => void;
 }
-
+const DISPLAY_OPTIONS_CATEGORY = 'Display';
 export const PanelOptionsEditor: React.FC<PanelOptionsEditorProps<any>> = ({
   plugin,
   options,
@@ -33,7 +33,10 @@ export const PanelOptionsEditor: React.FC<PanelOptionsEditorProps<any>> = ({
 }) => {
   const optionEditors = useMemo<Record<string, PanelOptionsEditorItem[]>>(() => {
     return groupBy(plugin.optionEditors.list(), i => {
-      return i.category ? i.category[0] : 'Display';
+      if (!i.category) {
+        return DISPLAY_OPTIONS_CATEGORY;
+      }
+      return i.category[0] ? i.category[0] : DISPLAY_OPTIONS_CATEGORY;
     });
   }, [plugin]);
 
@@ -62,7 +65,7 @@ export const PanelOptionsEditor: React.FC<PanelOptionsEditorProps<any>> = ({
             }
 
             const label = (
-              <Label description={e.description} category={e.category?.slice(1)}>
+              <Label description={e.description} category={e.category?.slice(1) as string[]}>
                 {e.name}
               </Label>
             );


### PR DESCRIPTION
This PR introduces **a breaking**  change to the way how panel/field options categories configuration is interpreted in the UI.

Try Time series Beta panel to see this in action.

### Field options categories (collapsible by default after this PR)

API:

```
category: ['Axis']
```
First category in the list serves as options group indicator.

| BEFORE   | AFTER   |
|---|---|
|![image](https://user-images.githubusercontent.com/2376619/104724965-b8c71180-5731-11eb-9ea2-228041e09d38.png)|  ![image](https://user-images.githubusercontent.com/2376619/104723435-87e5dd00-572f-11eb-821a-f0fcce0046f3.png)|
---
### Field options sub-categories

API:
`category: ['Axis', 'Subcategory']`
First category in the list serves as options group indicator.

| BEFORE   | AFTER   |
|---|---|
| ![image](https://user-images.githubusercontent.com/2376619/104724811-7a315700-5731-11eb-8104-5cbd43256b71.png)| ![image](https://user-images.githubusercontent.com/2376619/104723648-deebb200-572f-11eb-9249-ad69d7921779.png)|
---
### Field options sub-categories in the main field options pane

API:
| BEFORE   | AFTER   |
|---|---|
|`category: ['Main options subcategory']`|`category: [undefined, 'Main options subcategory'],`

First category set to `undefined` marks the option to be categorized under the panel's main options group

| BEFORE   | AFTER   |
|---|---|
|![image](https://user-images.githubusercontent.com/2376619/104724613-34748e80-5731-11eb-8ff2-50eb87392bc9.png)| ![image](https://user-images.githubusercontent.com/2376619/104724357-e6f82180-5730-11eb-9efe-0265ea75aa70.png)|
