### PR TITLE
GraphNG: remove y-axis position control from series color picker in the legend

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/SeriesColorPickerPopover.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/SeriesColorPickerPopover.tsx
@@ -12,11 +12,9 @@ export interface SeriesColorPickerPopoverProps extends ColorPickerProps, Popover
 
 export const SeriesColorPickerPopover: FunctionComponent<SeriesColorPickerPopoverProps> = props => {
   const { yaxis, onToggleAxis, color, ...colorPickerProps } = props;
-  return (
-    <ColorPickerPopover
-      {...colorPickerProps}
-      color={color || '#000000'}
-      customPickers={{
+
+  const customPickers = onToggleAxis
+    ? {
         yaxis: {
           name: 'Y-Axis',
           tabComponent() {
@@ -36,9 +34,9 @@ export const SeriesColorPickerPopover: FunctionComponent<SeriesColorPickerPopove
             );
           },
         },
-      }}
-    />
-  );
+      }
+    : undefined;
+  return <ColorPickerPopover {...colorPickerProps} color={color || '#000000'} customPickers={customPickers} />;
 };
 
 interface AxisSelectorProps {

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendListItem.tsx
@@ -27,7 +27,6 @@ export const VizLegendListItem: React.FunctionComponent<Props> = ({ item, onSeri
             onSeriesColorChange(item.label, color);
           }
         }}
-        yAxis={item.yAxis}
       />
       <div
         onClick={event => {

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
@@ -5,28 +5,14 @@ import { SeriesIcon } from './SeriesIcon';
 interface Props {
   disabled: boolean;
   color: string;
-  yAxis: number;
   onColorChange: (color: string) => void;
-  onToggleAxis?: () => void;
 }
 
-export const VizLegendSeriesIcon: React.FunctionComponent<Props> = ({
-  disabled,
-  yAxis,
-  color,
-  onColorChange,
-  onToggleAxis,
-}) => {
+export const VizLegendSeriesIcon: React.FunctionComponent<Props> = ({ disabled, color, onColorChange }) => {
   return disabled ? (
     <SeriesIcon color={color} />
   ) : (
-    <SeriesColorPicker
-      yaxis={yAxis}
-      color={color}
-      onChange={onColorChange}
-      onToggleAxis={onToggleAxis}
-      enableNamedColors
-    >
+    <SeriesColorPicker color={color} onChange={onColorChange} enableNamedColors>
       {({ ref, showColorPicker, hideColorPicker }) => (
         <SeriesIcon
           color={color}

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -35,7 +35,6 @@ export const LegendTableItem: React.FunctionComponent<Props> = ({
                 onSeriesColorChange(item.label, color);
               }
             }}
-            yAxis={item.yAxis}
           />
           <div
             onClick={event => {


### PR DESCRIPTION
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/2376619/104727943-781dc700-5736-11eb-9e4b-3920bf255a6c.png)|![image](https://user-images.githubusercontent.com/2376619/104728046-9be10d00-5736-11eb-96bf-c084887452f4.png)




