### PR TITLE
Table: Fixes BarGauge cell display mode font size so that it is fixed to the default cell font size

### DIFF
--- a/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
@@ -52,6 +52,7 @@ export const BarGaugeCell: FC<TableCellProps> = props => {
         height={tableStyles.cellHeightInner}
         field={config}
         display={field.display}
+        text={{ valueSize: 14 }}
         value={displayValue}
         orientation={VizOrientation.Horizontal}
         theme={tableStyles.theme}


### PR DESCRIPTION
Fixes #24776
