### PR TITLE
Grafana-UI: Add story/docs for ErrorBoundary

### DIFF
--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -15,7 +15,6 @@ import lightTheme from '../../../public/sass/grafana.light.scss';
 // @ts-ignore
 import darkTheme from '../../../public/sass/grafana.dark.scss';
 import { GrafanaLight, GrafanaDark } from './storybookTheme';
-import { configure } from '@storybook/react';
 import addons from '@storybook/addons';
 
 const handleThemeChange = (theme: any) => {

--- a/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.mdx
+++ b/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.mdx
@@ -1,0 +1,56 @@
+import { ArgsTable } from "@storybook/addon-docs/blocks";
+import { ErrorBoundary, ErrorBoundaryAlert } from "./ErrorBoundary";
+import { ErrorWithStack } from "./ErrorWithStack";
+
+# ErrorBoundary
+
+A React component that catches errors in child components. Useful for logging or displaying a fallback UI in case of errors. More information about error boundaries is available at [React documentation website](https://reactjs.org/docs/error-boundaries.html).
+
+### Usage
+
+```jsx
+import { ErrorBoundary, Alert } from '@grafana/ui';
+
+<ErrorBoundary>
+  {({ error }) => {
+    if (error) {
+      return <Alert title={error.message} />;
+    }
+    return <Component />;
+  }}
+</ErrorBoundary>
+```
+
+# ErrorBoundaryAlert
+
+An error boundary component with built-in alert to display in case of error.
+
+### Usage
+
+```jsx
+import { ErrorBoundaryAlert } from '@grafana/ui';
+
+<ErrorBoundaryAlert>
+  <Component />
+</ErrorBoundaryAlert>
+```
+
+### Props
+<ArgsTable of={ErrorBoundaryAlert}/>
+
+
+# ErrorWithStack
+A component that displays error together with its stack trace.
+
+### Usage
+
+```jsx
+import { ErrorWithStack } from '@grafana/ui';
+
+<ErrorWithStack error={new Error('Test error')} title={'Unexpected error'} errorInfo={null} />
+```
+
+### Props
+<ArgsTable of={ErrorWithStack}/>
+
+

--- a/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.story.tsx
+++ b/packages/grafana-ui/src/components/ErrorBoundary/ErrorBoundary.story.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { ErrorBoundary, ErrorBoundaryAlert } from './ErrorBoundary';
+import { withCenteredStory } from '@grafana/ui/src/utils/storybook/withCenteredStory';
+import mdx from './ErrorBoundary.mdx';
+import { Button } from '../Button';
+import { ErrorWithStack } from './ErrorWithStack';
+import { Alert } from '../Alert/Alert';
+
+export default {
+  title: 'General/ErrorBoundary',
+  component: ErrorBoundary,
+  decorators: [withCenteredStory],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+const BuggyComponent = () => {
+  const [count, setCount] = useState(0);
+
+  if (count > 2) {
+    throw new Error('Crashed');
+  }
+
+  return (
+    <div>
+      <p>Increase the count to 3 to trigger error</p>
+      <Button onClick={() => setCount(count + 1)}>{count.toString()}</Button>
+    </div>
+  );
+};
+
+export const Basic = () => {
+  return (
+    <ErrorBoundary>
+      {({ error }) => {
+        if (error) {
+          return <Alert title={error.message} />;
+        }
+        return <BuggyComponent />;
+      }}
+    </ErrorBoundary>
+  );
+};
+
+export const WithStack = () => {
+  return <ErrorWithStack error={new Error('Test error')} title={'Unexpected error'} errorInfo={null} />;
+};
+
+export const BoundaryAlert = () => {
+  return (
+    <ErrorBoundaryAlert>
+      <BuggyComponent />
+    </ErrorBoundaryAlert>
+  );
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Add ErrorBoundary to Storybook. 

**Special notes for your reviewer**:
It seems like Storybook has it's own mechanism for catching errors, which comes on top of our alerts and needs to be closed first:
![Screenshot 2021-01-15 at 14 54 32](https://user-images.githubusercontent.com/8878045/104729764-963cf480-5741-11eb-850c-b6a1df9e3547.png)

I couldn't find a way to disable it for specific stories, maybe @jackw or @peterholmberg have any ideas here? 

