### PR TITLE
Fix LegendSeriesIcon positioning

### DIFF
--- a/public/app/plugins/panel/graph/Legend/LegendSeriesItem.tsx
+++ b/public/app/plugins/panel/graph/Legend/LegendSeriesItem.tsx
@@ -197,7 +197,7 @@ class LegendSeriesIcon extends PureComponent<LegendSeriesIconProps, LegendSeries
         enableNamedColors
       >
         {({ ref, showColorPicker, hideColorPicker }) => (
-          <span ref={ref} onClick={showColorPicker} onMouseLeave={hideColorPicker}>
+          <span ref={ref} onClick={showColorPicker} onMouseLeave={hideColorPicker} className="graph-legend-icon">
             <SeriesIcon color={this.props.color} />
           </span>
         )}


### PR DESCRIPTION
**What this PR does / why we need it**:

Legend series icon got broken in referenced PR

![image](https://user-images.githubusercontent.com/327717/104731745-72c37b00-573c-11eb-89b2-d90c14069518.png)


**Which issue(s) this PR fixes**:

Fixes issue from #30165

