### PR TITLE
Panels: remove beta flag from stat and bargauge panels

### DIFF
--- a/public/app/plugins/panel/bargauge/plugin.json
+++ b/public/app/plugins/panel/bargauge/plugin.json
@@ -2,7 +2,6 @@
   "type": "panel",
   "name": "Bar gauge",
   "id": "bargauge",
-  "state": "beta",
 
   "info": {
     "author": {

--- a/public/app/plugins/panel/stat/plugin.json
+++ b/public/app/plugins/panel/stat/plugin.json
@@ -2,7 +2,6 @@
   "type": "panel",
   "name": "Stat",
   "id": "stat",
-  "state": "beta",
 
   "info": {
     "description": "Singlestat Panel for Grafana",


### PR DESCRIPTION
These have not changed in a while, and feel pretty stable:
![image](https://user-images.githubusercontent.com/705951/104782012-663d2380-5738-11eb-8b4a-924a18a41458.png)

for sure a different category from Timeseries panel!