### PR TITLE
Badge: Design improvement & reduce contrast

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -62,7 +62,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, color: BadgeColor) => {
       .setAlpha(0.1)
       .toString();
     borderColor = tinycolor(sourceColor)
-      .lighten(15)
+      .lighten(25)
       .toString();
     textColor = tinycolor(sourceColor)
       .darken(15)

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -49,23 +49,23 @@ const getStyles = stylesFactory((theme: GrafanaTheme, color: BadgeColor) => {
 
   if (theme.isDark) {
     bgColor = tinycolor(sourceColor)
-      .darken(38)
+      .setAlpha(0.1)
       .toString();
     borderColor = tinycolor(sourceColor)
-      .darken(25)
+      .darken(35)
       .toString();
     textColor = tinycolor(sourceColor)
-      .lighten(45)
+      .lighten(15)
       .toString();
   } else {
     bgColor = tinycolor(sourceColor)
-      .lighten(30)
+      .setAlpha(0.1)
       .toString();
     borderColor = tinycolor(sourceColor)
       .lighten(15)
       .toString();
     textColor = tinycolor(sourceColor)
-      .darken(40)
+      .darken(15)
       .toString();
   }
 
@@ -75,7 +75,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme, color: BadgeColor) => {
       display: inline-flex;
       padding: 1px 4px;
       border-radius: 3px;
-      margin-top: 6px;
       background: ${bgColor};
       border: 1px solid ${borderColor};
       color: ${textColor};

--- a/public/app/core/components/Card/Card.tsx
+++ b/public/app/core/components/Card/Card.tsx
@@ -30,7 +30,7 @@ export const Card: React.FC<CardProps> = ({
       <div className="add-data-source-item-text-wrapper">
         <span className="add-data-source-item-text">{title}</span>
         {description && <span className="add-data-source-item-desc">{description}</span>}
-        {labels && <div>{labels}</div>}
+        {labels && <div className="add-data-source-item-badge">{labels}</div>}
       </div>
       {actions && <div className="add-data-source-item-actions">{actions}</div>}
     </div>

--- a/public/app/features/dashboard/components/VizTypePicker/VizTypePickerPlugin.tsx
+++ b/public/app/features/dashboard/components/VizTypePicker/VizTypePickerPlugin.tsx
@@ -121,6 +121,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
     badge: css`
       position: absolute;
+      background: ${theme.colors.bg2};
       bottom: ${theme.spacing.xs};
       right: ${theme.spacing.xs};
       z-index: 1;

--- a/public/app/features/datasources/NewDataSourcePage.tsx
+++ b/public/app/features/datasources/NewDataSourcePage.tsx
@@ -156,13 +156,7 @@ const DataSourceTypeCard: FC<DataSourceTypeCardProps> = props => {
           {!isPhantom && <Button disabled={plugin.unlicensed}>Select</Button>}
         </>
       }
-      labels={
-        !isPhantom && (
-          <div>
-            <PluginSignatureBadge status={plugin.signature} />
-          </div>
-        )
-      }
+      labels={!isPhantom && <PluginSignatureBadge status={plugin.signature} />}
       className={isPhantom ? 'add-data-source-item--phantom' : ''}
       onClick={onClick}
       aria-label={selectors.pages.AddDataSource.dataSourcePlugins(plugin.name)}

--- a/public/app/features/plugins/PluginListItem.tsx
+++ b/public/app/features/plugins/PluginListItem.tsx
@@ -15,7 +15,9 @@ const PluginListItem: FC<Props> = props => {
       <a className="card-item" href={`plugins/${plugin.id}/`}>
         <div className="card-item-header">
           <div className="card-item-type">{plugin.type}</div>
-          <PluginSignatureBadge status={plugin.signature} />
+          <div className="card-item-badge">
+            <PluginSignatureBadge status={plugin.signature} />
+          </div>
           {plugin.hasUpdate && (
             <div className="card-item-notice">
               <span bs-tooltip="plugin.latestVersion">Update available!</span>

--- a/public/app/features/plugins/__snapshots__/PluginListItem.test.tsx.snap
+++ b/public/app/features/plugins/__snapshots__/PluginListItem.test.tsx.snap
@@ -17,7 +17,11 @@ exports[`Render should render component 1`] = `
       >
         panel
       </div>
-      <PluginSignatureBadge />
+      <div
+        className="card-item-badge"
+      >
+        <PluginSignatureBadge />
+      </div>
     </div>
     <div
       className="card-item-body"
@@ -65,7 +69,11 @@ exports[`Render should render has plugin section 1`] = `
       >
         panel
       </div>
-      <PluginSignatureBadge />
+      <div
+        className="card-item-badge"
+      >
+        <PluginSignatureBadge />
+      </div>
       <div
         className="card-item-notice"
       >

--- a/public/sass/components/_add_data_source.scss
+++ b/public/sass/components/_add_data_source.scss
@@ -53,6 +53,10 @@
   color: $text-color-weak;
 }
 
+.add-data-source-item-badge {
+  margin-top: 6px;
+}
+
 .add-data-source-item-text {
   font-size: $font-size-h5;
 }

--- a/public/sass/components/_cards.scss
+++ b/public/sass/components/_cards.scss
@@ -84,6 +84,10 @@
   font-weight: $font-weight-semi-bold;
 }
 
+.card-item-badge {
+  margin: 6px 0;
+}
+
 .card-item-notice {
   font-size: $font-size-sm;
 }


### PR DESCRIPTION
I felt the badges where to bright distracting from the main icon/text.

Before:  
![Screenshot from 2021-01-16 14-02-58](https://user-images.githubusercontent.com/10999/104812602-a74e3a00-5803-11eb-8012-4314a94c983d.png)

After:
![Screenshot from 2021-01-16 14-01-40](https://user-images.githubusercontent.com/10999/104812607-addcb180-5803-11eb-84c5-2289696d387c.png)

 
Before Light
![Screenshot from 2021-01-16 14-04-37](https://user-images.githubusercontent.com/10999/104812676-378c7f00-5804-11eb-9a56-bf7e9ae57300.png)

After Light:
![Screenshot from 2021-01-16 14-06-26](https://user-images.githubusercontent.com/10999/104812663-1deb3780-5804-11eb-9bf0-b9b9d5ada3eb.png)