### PR TITLE
Alerting: Allow sending notification tags to Opsgenie as extra properties

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -541,6 +541,7 @@ The following sections detail the supported settings and secure settings for eac
 | apiUrl           |                |
 | autoClose        |                |
 | overridePriority |                |
+| sendTagsAs       |                |
 
 #### Alert notification `telegram`
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -122,7 +122,7 @@ API Key | The API Key as provided by Opsgenie for your configured Grafana integr
 Override priority | Configures the alert priority using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4`, or `P5`. Default is `False`.
 Send notification tags as | Specify how you would like [Notification Tags]({{< relref "create-alerts.md/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is `Tags`. (1)
 
-> **Note:** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
+> **(1):** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
 
 ### PagerDuty
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -119,7 +119,7 @@ Setting | Description
 --------|------------
 Alert API URL | The API URL for your Opsgenie instance. This will normally be either `https://api.opsgenie.com` or, for EU customers, `https://api.eu.opsgenie.com`.
 API Key | The API Key as provided by Opsgenie for your configured Grafana integration.
-Override priority | Configures the alert priority using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4,` or `P5`. Default is `False`.
+Override priority | Configures the alert priority using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4`, or `P5`. Default is `False`.
 Send notification tags as | Specify how you would like [Notification Tags]({{< relref "create-alerts.md/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is `Tags`. (1)
 
 > **Note:** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -59,7 +59,7 @@ Hipchat | `hipchat` | yes, external only | no
 [Kafka](#kafka) | `kafka` | yes, external only | no
 Line | `line` | yes, external only | no
 Microsoft Teams | `teams` | yes, external only | no
-OpsGenie | `opsgenie` | yes, external only | yes
+[Opsgenie](#opsgenie) | `opsgenie` | yes, external only | yes
 [Pagerduty](#pagerduty) | `pagerduty` | yes, external only | yes
 Prometheus Alertmanager | `prometheus-alertmanager` | yes, external only | yes
 [Pushover](#pushover) | `pushover` | yes | no
@@ -110,6 +110,19 @@ Mention Channel | Optionally mention either all channel members or just active o
 Token | If provided, Grafana will upload the generated image via Slack's file.upload API method, not the external image destination. If you use the `chat.postMessage` Slack API endpoint, this is required.
 
 If you are using the token for a slack bot, then you have to invite the bot to the channel you want to send notifications and add the channel to the recipient field.
+
+### Opsgenie
+
+To setup Opsgenie you will need an API Key and the Alert API Url. These can be obtained by configuring a new [Grafana Integration](https://docs.opsgenie.com/docs/grafana-integration).
+
+Setting | Description
+--------|------------
+Alert API URL | The API URL for your Opsgenie instance. This will normally be either `https://api.opsgenie.com` or, for EU customers, `https://api.eu.opsgenie.com`.
+API Key | The API Key as provided by Opsgenie for your configured Grafana Integration.
+Override priority | Allows the alert priority to be set using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4` or `P5`. Default is `False`.
+Send notification tags as | Allows you to specify how you would like [Notification Tags]({{< relref "create-alerts.md/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is `Tags`. (1)
+
+> **Note:** When notification tags are sent as `Tags` they will be concatenated into string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
 
 ### PagerDuty
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -118,11 +118,11 @@ To setup Opsgenie you will need an API Key and the Alert API Url. These can be o
 Setting | Description
 --------|------------
 Alert API URL | The API URL for your Opsgenie instance. This will normally be either `https://api.opsgenie.com` or, for EU customers, `https://api.eu.opsgenie.com`.
-API Key | The API Key as provided by Opsgenie for your configured Grafana Integration.
-Override priority | Allows the alert priority to be set using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4` or `P5`. Default is `False`.
-Send notification tags as | Allows you to specify how you would like [Notification Tags]({{< relref "create-alerts.md/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is `Tags`. (1)
+API Key | The API Key as provided by Opsgenie for your configured Grafana integration.
+Override priority | Configures the alert priority using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4,` or `P5`. Default is `False`.
+Send notification tags as | Specify how you would like [Notification Tags]({{< relref "create-alerts.md/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is `Tags`. (1)
 
-> **Note:** When notification tags are sent as `Tags` they will be concatenated into string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
+> **Note:** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
 
 ### PagerDuty
 

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -120,9 +120,9 @@ Setting | Description
 Alert API URL | The API URL for your Opsgenie instance. This will normally be either `https://api.opsgenie.com` or, for EU customers, `https://api.eu.opsgenie.com`.
 API Key | The API Key as provided by Opsgenie for your configured Grafana integration.
 Override priority | Configures the alert priority using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4`, or `P5`. Default is `False`.
-Send notification tags as | Specify how you would like [Notification Tags]({{< relref "create-alerts.md/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is `Tags`. (1)
+Send notification tags as | Specify how you would like [Notification Tags]({{< relref "create-alerts.md/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is Tags. See note below for more information.
 
-> **(1):** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
+> **Note:** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
 
 ### PagerDuty
 

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -168,11 +168,11 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 
 	tags := make([]string, 0)
 	for _, tag := range evalContext.Rule.AlertRuleTags {
-		if sendDetailsOrBoth(on.SendTagsAs) {
+		if on.sendDetails() {
 			details.Set(tag.Key, tag.Value)
 		}
 
-		if sendTagsOrBoth(on.SendTagsAs) {
+		if on.sendTags() {
 			if len(tag.Value) > 0 {
 				tags = append(tags, fmt.Sprintf("%s:%s", tag.Key, tag.Value))
 			} else {
@@ -235,10 +235,10 @@ func (on *OpsGenieNotifier) closeAlert(evalContext *alerting.EvalContext) error 
 	return nil
 }
 
-func sendDetailsOrBoth(sendTagsAs string) bool {
-	return sendTagsAs == sendDetails || sendTagsAs == sendBoth
+func (on *OpsGenieNotifier) sendDetails() bool {
+	return on.SendTagsAs == sendDetails || on.SendTagsAs == sendBoth
 }
 
-func sendTagsOrBoth(sendTagsAs string) bool {
-	return sendTagsAs == sendTags || sendTagsAs == sendBoth
+func (on *OpsGenieNotifier) sendTags() bool {
+	return on.SendTagsAs == sendTags || on.SendTagsAs == sendBoth
 }

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -11,6 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/alerting"
 )
 
+const (
+	sendTags    = "tags"
+	sendDetails = "details"
+	sendBoth    = "both"
+)
+
 func init() {
 	alerting.RegisterNotifier(&alerting.NotifierPlugin{
 		Type:        "opsgenie",
@@ -47,11 +53,31 @@ func init() {
 				Description:  "Allow the alert priority to be set using the og_priority tag",
 				PropertyName: "overridePriority",
 			},
+			{
+				Label:   "Send notification tags as",
+				Element: alerting.ElementTypeSelect,
+				SelectOptions: []alerting.SelectOption{
+					{
+						Value: sendTags,
+						Label: "Tags",
+					},
+					{
+						Value: sendDetails,
+						Label: "Extra Properties",
+					},
+					{
+						Value: sendBoth,
+						Label: "Tags & Extra Properties",
+					},
+				},
+				Description:  "Send the notification tags to Opsgenie as either Extra Properties, Tags or both",
+				PropertyName: "sendTagsAs",
+			},
 		},
 	})
 }
 
-var (
+const (
 	opsgenieAlertURL = "https://api.opsgenie.com/v2/alerts"
 )
 
@@ -68,12 +94,20 @@ func NewOpsGenieNotifier(model *models.AlertNotification) (alerting.Notifier, er
 		apiURL = opsgenieAlertURL
 	}
 
+	sendTagsAs := model.Settings.Get("sendTagsAs").MustString(sendTags)
+	if sendTagsAs != sendTags && sendTagsAs != sendDetails && sendTagsAs != sendBoth {
+		return nil, alerting.ValidationError{
+			Reason: fmt.Sprintf("Invalid value for sendTagsAs: %q", sendTagsAs),
+		}
+	}
+
 	return &OpsGenieNotifier{
 		NotifierBase:     NewNotifierBase(model),
 		APIKey:           apiKey,
 		APIUrl:           apiURL,
 		AutoClose:        autoClose,
 		OverridePriority: overridePriority,
+		SendTagsAs:       sendTagsAs,
 		log:              log.New("alerting.notifier.opsgenie"),
 	}, nil
 }
@@ -86,6 +120,7 @@ type OpsGenieNotifier struct {
 	APIUrl           string
 	AutoClose        bool
 	OverridePriority bool
+	SendTagsAs       string
 	log              log.Logger
 }
 
@@ -131,14 +166,18 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 		details.Set("image", evalContext.ImagePublicURL)
 	}
 
-	bodyJSON.Set("details", details)
-
 	tags := make([]string, 0)
 	for _, tag := range evalContext.Rule.AlertRuleTags {
-		if len(tag.Value) > 0 {
-			tags = append(tags, fmt.Sprintf("%s:%s", tag.Key, tag.Value))
-		} else {
-			tags = append(tags, tag.Key)
+		if sendDetailsOrBoth(on.SendTagsAs) {
+			details.Set(tag.Key, tag.Value)
+		}
+
+		if sendTagsOrBoth(on.SendTagsAs) {
+			if len(tag.Value) > 0 {
+				tags = append(tags, fmt.Sprintf("%s:%s", tag.Key, tag.Value))
+			} else {
+				tags = append(tags, tag.Key)
+			}
 		}
 		if tag.Key == "og_priority" {
 			if on.OverridePriority {
@@ -150,6 +189,7 @@ func (on *OpsGenieNotifier) createAlert(evalContext *alerting.EvalContext) error
 		}
 	}
 	bodyJSON.Set("tags", tags)
+	bodyJSON.Set("details", details)
 
 	body, _ := bodyJSON.MarshalJSON()
 
@@ -193,4 +233,12 @@ func (on *OpsGenieNotifier) closeAlert(evalContext *alerting.EvalContext) error 
 	}
 
 	return nil
+}
+
+func sendDetailsOrBoth(sendTagsAs string) bool {
+	return sendTagsAs == sendDetails || sendTagsAs == sendBoth
+}
+
+func sendTagsOrBoth(sendTagsAs string) bool {
+	return sendTagsAs == sendTags || sendTagsAs == sendBoth
 }

--- a/pkg/services/alerting/notifiers/opsgenie_test.go
+++ b/pkg/services/alerting/notifiers/opsgenie_test.go
@@ -150,7 +150,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 					Message:       "someMessage",
 					State:         models.AlertStateAlerting,
 					AlertRuleTags: tagPairs,
-				})
+				}, nil)
 				evalContext.IsTestRun = true
 
 				tags := make([]string, 0)
@@ -200,7 +200,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 					Message:       "someMessage",
 					State:         models.AlertStateAlerting,
 					AlertRuleTags: tagPairs,
-				})
+				}, nil)
 				evalContext.IsTestRun = true
 
 				tags := make([]string, 0)

--- a/pkg/services/alerting/notifiers/opsgenie_test.go
+++ b/pkg/services/alerting/notifiers/opsgenie_test.go
@@ -51,10 +51,30 @@ func TestOpsGenieNotifier(t *testing.T) {
 				So(opsgenieNotifier.Type, ShouldEqual, "opsgenie")
 				So(opsgenieNotifier.APIKey, ShouldEqual, "abcdefgh0123456789")
 			})
+		})
 
-			Convey("alert payload should include tag pairs in a ['key1:value1'] format when a value exists and in ['key2'] format when a value is absent", func() {
-				json := `
-				{
+		Convey("Handling notification tags", func() {
+			Convey("invalid sendTagsAs value should return error", func() {
+				json := `{
+          "apiKey": "abcdefgh0123456789",
+          "sendTagsAs": "not_a_valid_value"
+                                }`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "opsgenie_testing",
+					Type:     "opsgenie",
+					Settings: settingsJSON,
+				}
+
+				_, err := NewOpsGenieNotifier(model)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldHaveSameTypeAs, alerting.ValidationError{})
+				So(err.Error(), ShouldEndWith, "Invalid value for sendTagsAs: \"not_a_valid_value\"")
+			})
+
+			Convey("alert payload should include tag pairs only as an array in the tags key when sendAsTags is not set", func() {
+				json := `{
           "apiKey": "abcdefgh0123456789"
 				}`
 
@@ -83,11 +103,13 @@ func TestOpsGenieNotifier(t *testing.T) {
 				}, &validations.OSSPluginRequestValidator{})
 				evalContext.IsTestRun = true
 
-				receivedTags := make([]string, 0)
+				tags := make([]string, 0)
+				details := make(map[string]interface{})
 				bus.AddHandlerCtx("alerting", func(ctx context.Context, cmd *models.SendWebhookSync) error {
 					bodyJSON, err := simplejson.NewJson([]byte(cmd.Body))
 					if err == nil {
-						receivedTags = bodyJSON.Get("tags").MustStringArray([]string{})
+						tags = bodyJSON.Get("tags").MustStringArray([]string{})
+						details = bodyJSON.Get("details").MustMap(map[string]interface{}{})
 					}
 					return err
 				})
@@ -96,7 +118,108 @@ func TestOpsGenieNotifier(t *testing.T) {
 
 				So(notifierErr, ShouldBeNil)
 				So(alertErr, ShouldBeNil)
-				So(receivedTags, ShouldResemble, []string{"keyOnly", "aKey:aValue"})
+				So(tags, ShouldResemble, []string{"keyOnly", "aKey:aValue"})
+				So(details, ShouldResemble, map[string]interface{}{"url": ""})
+			})
+
+			Convey("alert payload should include tag pairs only as a map in the details key when sendAsTags=details", func() {
+				json := `{
+          "apiKey": "abcdefgh0123456789",
+          "sendTagsAs": "details"
+				}`
+
+				tagPairs := []*models.Tag{
+					{Key: "keyOnly"},
+					{Key: "aKey", Value: "aValue"},
+				}
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "opsgenie_testing",
+					Type:     "opsgenie",
+					Settings: settingsJSON,
+				}
+
+				notifier, notifierErr := NewOpsGenieNotifier(model) // unhandled error
+
+				opsgenieNotifier := notifier.(*OpsGenieNotifier)
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:            0,
+					Name:          "someRule",
+					Message:       "someMessage",
+					State:         models.AlertStateAlerting,
+					AlertRuleTags: tagPairs,
+				})
+				evalContext.IsTestRun = true
+
+				tags := make([]string, 0)
+				details := make(map[string]interface{})
+				bus.AddHandlerCtx("alerting", func(ctx context.Context, cmd *models.SendWebhookSync) error {
+					bodyJSON, err := simplejson.NewJson([]byte(cmd.Body))
+					if err == nil {
+						tags = bodyJSON.Get("tags").MustStringArray([]string{})
+						details = bodyJSON.Get("details").MustMap(map[string]interface{}{})
+					}
+					return err
+				})
+
+				alertErr := opsgenieNotifier.createAlert(evalContext)
+
+				So(notifierErr, ShouldBeNil)
+				So(alertErr, ShouldBeNil)
+				So(tags, ShouldResemble, []string{})
+				So(details, ShouldResemble, map[string]interface{}{"keyOnly": "", "aKey": "aValue", "url": ""})
+			})
+
+			Convey("alert payload should include tag pairs as both a map in the details key and an array in the tags key when sendAsTags=both", func() {
+				json := `{
+          "apiKey": "abcdefgh0123456789",
+          "sendTagsAs": "both"
+				}`
+
+				tagPairs := []*models.Tag{
+					{Key: "keyOnly"},
+					{Key: "aKey", Value: "aValue"},
+				}
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "opsgenie_testing",
+					Type:     "opsgenie",
+					Settings: settingsJSON,
+				}
+
+				notifier, notifierErr := NewOpsGenieNotifier(model) // unhandled error
+
+				opsgenieNotifier := notifier.(*OpsGenieNotifier)
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:            0,
+					Name:          "someRule",
+					Message:       "someMessage",
+					State:         models.AlertStateAlerting,
+					AlertRuleTags: tagPairs,
+				})
+				evalContext.IsTestRun = true
+
+				tags := make([]string, 0)
+				details := make(map[string]interface{})
+				bus.AddHandlerCtx("alerting", func(ctx context.Context, cmd *models.SendWebhookSync) error {
+					bodyJSON, err := simplejson.NewJson([]byte(cmd.Body))
+					if err == nil {
+						tags = bodyJSON.Get("tags").MustStringArray([]string{})
+						details = bodyJSON.Get("details").MustMap(map[string]interface{}{})
+					}
+					return err
+				})
+
+				alertErr := opsgenieNotifier.createAlert(evalContext)
+
+				So(notifierErr, ShouldBeNil)
+				So(alertErr, ShouldBeNil)
+				So(tags, ShouldResemble, []string{"keyOnly", "aKey:aValue"})
+				So(details, ShouldResemble, map[string]interface{}{"keyOnly": "", "aKey": "aValue", "url": ""})
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**: 

Allow users to select where to send notification tags when alerting via OpsGenie. 

Users will be able to select where to send the notification tags and then see those tags as key/values under extra properties or tags in an alert on the Opsgenie UI. This metadata can then be further used on the Opsgenie platform. 

Default will be the current behaviour (called `Tags` in the dropdown) with an option to send to both if users want to keep the current behaviour while moving new config to using extra properties.

  * Configurable delivery to either tags, extra properties or both

  * Default to current behaviour (tags only)

  * Support both so users can transition from tags to details

**Which issue(s) this PR fixes**:
Fixes #30331

**Special notes for your reviewer**:

I have added docs for this feature and also one that previously wasn't documented (`og_priority`) but would appreciate a copy-edit of the wording in case.

Ran all the tests locally and everything looked good, also have some screenshots of the final result on the Opsgenie side that I used for issue #30331.

I did read through the style guide but opted to keep this change using `SimpleJson` and `GoConvey` as there was already usage of it in the notifier and I didn't think this PR was suitable for a full refactor to either. I might be keen to submit a PR for that kind of refactor in the future though if you're looking for those kinds of submissions too.