### PR TITLE
Licensing: Send map of environment variables to plugins

### DIFF
--- a/pkg/models/licensing.go
+++ b/pkg/models/licensing.go
@@ -16,6 +16,9 @@ type Licensing interface {
 	LicenseURL(user *SignedInUser) string
 
 	StateInfo() string
+}
 
-	TokenRaw() string
+type LicenseEnvironment interface {
+	// Environment is a map of environment variables
+	Environment() map[string]string
 }

--- a/pkg/plugins/backendplugin/manager.go
+++ b/pkg/plugins/backendplugin/manager.go
@@ -98,8 +98,13 @@ func (m *manager) Register(pluginID string, factory PluginFactoryFunc) error {
 		hostEnv = append(
 			hostEnv,
 			fmt.Sprintf("GF_ENTERPRISE_LICENSE_PATH=%s", m.Cfg.EnterpriseLicensePath),
-			fmt.Sprintf("GF_ENTERPRISE_LICENSE_TEXT=%s", m.License.TokenRaw()),
 		)
+
+		if envProvider, ok := m.License.(models.LicenseEnvironment); ok {
+			for k, v := range envProvider.Environment() {
+				hostEnv = append(hostEnv, fmt.Sprintf("%s=%s", k, v))
+			}
+		}
 	}
 
 	env := pluginSettings.ToEnv("GF_PLUGIN", hostEnv)

--- a/pkg/plugins/backendplugin/manager_test.go
+++ b/pkg/plugins/backendplugin/manager_test.go
@@ -411,6 +411,6 @@ func (t *testLicensingService) HasValidLicense() bool {
 	return false
 }
 
-func (t *testLicensingService) TokenRaw() string {
-	return t.tokenRaw
+func (t *testLicensingService) Environment() map[string]string {
+	return map[string]string{"GF_ENTERPRISE_LICENSE_TEXT": t.tokenRaw}
 }

--- a/pkg/services/licensing/oss.go
+++ b/pkg/services/licensing/oss.go
@@ -60,7 +60,3 @@ func (l *OSSLicensingService) Init() error {
 func (*OSSLicensingService) HasValidLicense() bool {
 	return false
 }
-
-func (*OSSLicensingService) TokenRaw() string {
-	return ""
-}


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace hard-coded `GF_ENTERPRISE_LICENSE_TEXT` with a `map[string]string` to allow the licensing service to allow sending any environment variable through to the plugins for licensing purposes.

This is to prevent the need for further expansion of the general `Licensing` model to support future extensions for enterprise environment variables that needs to be passed to the plugins.

**Which issue(s) this PR fixes**:

Internal, attached PR for Enterprise modifications links to issue.

