### PR TITLE
Badge: Increase contrast, remove rocket icon for plugin beta/alpha state

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -49,20 +49,20 @@ const getStyles = stylesFactory((theme: GrafanaTheme, color: BadgeColor) => {
 
   if (theme.isDark) {
     bgColor = tinycolor(sourceColor)
-      .setAlpha(0.1)
+      .setAlpha(0.15)
       .toString();
     borderColor = tinycolor(sourceColor)
-      .darken(35)
+      .darken(30)
       .toString();
     textColor = tinycolor(sourceColor)
       .lighten(15)
       .toString();
   } else {
     bgColor = tinycolor(sourceColor)
-      .setAlpha(0.1)
+      .setAlpha(0.15)
       .toString();
     borderColor = tinycolor(sourceColor)
-      .lighten(25)
+      .lighten(20)
       .toString();
     textColor = tinycolor(sourceColor)
       .darken(15)
@@ -78,6 +78,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, color: BadgeColor) => {
       background: ${bgColor};
       border: 1px solid ${borderColor};
       color: ${textColor};
+      font-weight: ${theme.typography.weight.regular};
 
       > span {
         position: relative;

--- a/public/app/features/dashboard/components/VizTypePicker/VizTypePickerPlugin.tsx
+++ b/public/app/features/dashboard/components/VizTypePicker/VizTypePickerPlugin.tsx
@@ -121,7 +121,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
     badge: css`
       position: absolute;
-      background: ${theme.colors.bg2};
+      background: ${theme.colors.bg1};
       bottom: ${theme.spacing.xs};
       right: ${theme.spacing.xs};
       z-index: 1;
@@ -153,21 +153,18 @@ function getPanelStateBadgeDisplayModel(panel: PanelPluginMeta): BadgeProps | nu
     case PluginState.deprecated:
       return {
         text: 'Deprecated',
-        icon: 'exclamation-triangle',
         color: 'red',
         tooltip: `${panel.name} panel is deprecated`,
       };
     case PluginState.alpha:
       return {
         text: 'Alpha',
-        icon: 'rocket',
         color: 'blue',
         tooltip: `${panel.name} panel is experimental`,
       };
     case PluginState.beta:
       return {
         text: 'Beta',
-        icon: 'rocket',
         color: 'blue',
         tooltip: `${panel.name} panel is in beta`,
       };

--- a/public/app/features/plugins/PluginSignatureBadge.tsx
+++ b/public/app/features/plugins/PluginSignatureBadge.tsx
@@ -49,24 +49,27 @@ function getSignatureDisplayModel(signature?: PluginSignatureStatus): BadgeProps
     case PluginSignatureStatus.invalid:
       return {
         text: 'Invalid signature',
+        icon: 'exclamation-triangle',
         color: 'red',
         tooltip: 'Invalid plugin signature',
       };
     case PluginSignatureStatus.modified:
       return {
         text: 'Modified signature',
+        icon: 'exclamation-triangle',
         color: 'red',
         tooltip: 'Valid signature but content has been modified',
       };
     case PluginSignatureStatus.missing:
       return {
         text: 'Missing signature',
+        icon: 'exclamation-triangle',
         color: 'red',
         tooltip: 'Missing plugin signature',
       };
   }
 
-  return { text: 'Unsigned', color: 'red', tooltip: 'Unsigned external plugin' };
+  return { text: 'Unsigned', icon: 'exclamation-triangle', color: 'red', tooltip: 'Unsigned external plugin' };
 }
 
 PluginSignatureBadge.displayName = 'PluginSignatureBadge';

--- a/public/app/features/plugins/PluginSignatureBadge.tsx
+++ b/public/app/features/plugins/PluginSignatureBadge.tsx
@@ -43,33 +43,30 @@ function getSignatureDisplayModel(signature?: PluginSignatureStatus): BadgeProps
 
   switch (signature) {
     case PluginSignatureStatus.internal:
-      return { text: 'Core', icon: 'cube', color: 'blue', tooltip: 'Core plugin that is bundled with Grafana' };
+      return { text: 'Core', color: 'blue', tooltip: 'Core plugin that is bundled with Grafana' };
     case PluginSignatureStatus.valid:
       return { text: 'Signed', icon: 'lock', color: 'green', tooltip: 'Signed and verified plugin' };
     case PluginSignatureStatus.invalid:
       return {
         text: 'Invalid signature',
-        icon: 'exclamation-triangle',
         color: 'red',
         tooltip: 'Invalid plugin signature',
       };
     case PluginSignatureStatus.modified:
       return {
         text: 'Modified signature',
-        icon: 'exclamation-triangle',
         color: 'red',
         tooltip: 'Valid signature but content has been modified',
       };
     case PluginSignatureStatus.missing:
       return {
         text: 'Missing signature',
-        icon: 'exclamation-triangle',
         color: 'red',
         tooltip: 'Missing plugin signature',
       };
   }
 
-  return { text: 'Unsigned', icon: 'exclamation-triangle', color: 'red', tooltip: 'Unsigned external plugin' };
+  return { text: 'Unsigned', color: 'red', tooltip: 'Unsigned external plugin' };
 }
 
 PluginSignatureBadge.displayName = 'PluginSignatureBadge';


### PR DESCRIPTION
Reduced the contrast a bit too much in previous PR. Fixes it and removes rocket icon to make the badge less distracting and more clean
![Screenshot from 2021-01-18 14-03-49](https://user-images.githubusercontent.com/10999/104919142-0f348a00-5996-11eb-8d19-22b82f2a8b22.png)
![Screenshot from 2021-01-18 14-03-41](https://user-images.githubusercontent.com/10999/104919147-10fe4d80-5996-11eb-8d51-266a99b1a04a.png)
