### PR TITLE
chore: bump lodash to 4.17.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "is-hotkey": "0.1.6",
     "jquery": "3.5.1",
     "jsurl": "^0.1.5",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "lru-cache": "^5.1.1",
     "md5": "^2.2.1",
     "memoize-one": "5.1.1",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -26,7 +26,7 @@
     "@types/d3-interpolate": "^1.3.1",
     "apache-arrow": "0.16.0",
     "eventemitter3": "4.0.7",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "marked": "1.2.2",
     "rxjs": "6.6.3",
     "xss": "1.0.6"

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "26.0.15",
     "@types/rollup-plugin-visualizer": "2.6.0",
     "@types/systemjs": "^0.20.6",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "pretty-format": "25.1.0",
     "rollup": "2.33.3",
     "rollup-plugin-sourcemaps": "0.6.3",

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -79,7 +79,7 @@
     "jest-junit": "^6.4.0",
     "less": "^3.11.1",
     "less-loader": "^5.0.0",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "md5-file": "^4.0.0",
     "mini-css-extract-plugin": "^0.7.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -49,7 +49,7 @@
     "hoist-non-react-statics": "3.3.2",
     "immutable": "3.8.2",
     "jquery": "3.5.1",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "moment": "2.24.0",
     "monaco-editor": "0.20.0",
     "papaparse": "5.3.0",

--- a/packages/jaeger-ui-components/package.json
+++ b/packages/jaeger-ui-components/package.json
@@ -33,7 +33,7 @@
     "fuzzy": "^0.1.3",
     "hoist-non-react-statics": "^3.3.2",
     "json-markup": "^1.1.0",
-    "lodash": "^4.17.4",
+    "lodash": "4.17.20",
     "lru-memoize": "^1.1.0",
     "memoize-one": "^5.0.0",
     "moment": "^2.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17453,12 +17453,7 @@ lodash@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@4.17.19, lodash@^4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.15:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.17.20, lodash@^4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.15:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
There is a prototype pollution attack when using _.zipObjectDeep in lodash before 4.17.20. Output from webpack `inspectpack` plugin looks good:

```shell
lodash (Found 1 resolved, 2 installed, 13 depended. Latest 4.17.20.)
  4.17.20 ~/lodash
    @grafana/data@7.4.0-pre.0 -> lodash@4.17.20
    @grafana/runtime@7.4.0-pre.0 -> lodash@4.17.20
    @grafana/ui@7.4.0-pre.0 -> @grafana/slate-react@0.22.9-grafana -> lodash@^4.1.1
    @grafana/ui@7.4.0-pre.0 -> react-color@2.18.0 -> lodash@^4.17.11
    @grafana/ui@7.4.0-pre.0 -> react-color@2.18.0 -> reactcss@^1.2.0 -> lodash@^4.0.1
    @grafana/ui@7.4.0-pre.0 -> slate@0.47.8 -> lodash@^4.17.4
    @jaegertracing/jaeger-ui-components@7.4.0-pre.0 -> lodash@4.17.20
    grafana@7.4.0-pre -> lodash@4.17.20
    grafana@7.4.0-pre -> @grafana/slate-react@0.22.9-grafana -> lodash@^4.1.1
    grafana@7.4.0-pre -> @welldone-software/why-did-you-render@4.0.6 -> lodash@^4
    grafana@7.4.0-pre -> react-hot-loader@4.8.0 -> lodash@^4.17.11
    grafana@7.4.0-pre -> slate@0.47.8 -> lodash@^4.17.4
  4.17.20 packages/grafana-ui/~/lodash
    @grafana/ui@7.4.0-pre.0 -> lodash@4.17.20
```

Have had a click around the app and cannot see any errors.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #30345

**Special notes for your reviewer**:
