### PR TITLE
Zipkin: Remove browser access mode

### DIFF
--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -15,14 +15,14 @@ Just add it as a data source and you are ready to query your traces in [Explore]
 
 To access Zipkin settings, click the **Configuration** (gear) icon, then click **Data Sources** > **Zipkin**.
 
-| Name         | Description                                                                                     |
-| ------------ | ----------------------------------------------------------------------------------------------- |
-| `Name`       | The data source name. This is how you refer to the data source in panels, queries, and Explore. |
-| `Default`    | Data source will be pre-selected for new panels.                                                |
-| `URL`        | The URL of the Zipkin instance, e.g., `http://localhost:9411`.                                  |
-| `Basic Auth` | Enable basic authentication to the Zipkin data source.                                          |
-| `User`       | User name for basic authentication.                                                             |
-| `Password`   | Password for basic authentication.                                                              |
+| Name         | Description                                                           |
+| ------------ | --------------------------------------------------------------------- |
+| `Name`       | The data source name in panels, queries, and Explore.                 |
+| `Default`    | The pre-selected data source for a new panel.                         |
+| `URL`        | The URL of the Zipkin instance. For example, `http://localhost:9411`. |
+| `Basic Auth` | Enable basic authentication for the Zipkin data source.               |
+| `User`       | Specify a user name for basic authentication.                         |
+| `Password`   | Specify a password for basic authentication.                          |
 
 ### Trace to logs
 

--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -15,15 +15,14 @@ Just add it as a data source and you are ready to query your traces in [Explore]
 
 To access Zipkin settings, click the **Configuration** (gear) icon, then click **Data Sources** > **Zipkin**.
 
-| Name         | Description                                                                                                                           |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`       | The data source name. This is how you refer to the data source in panels, queries, and Explore.                                       |
-| `Default`    | Data source will be pre-selected for new panels.                                                                                      |
-| `URL`        | The URL of the Zipkin instance, e.g., `http://localhost:9411`.                                                                        |
-| `Access`     | Server (default) = URL needs to be accessible from the Grafana backend/server. Browser = URL needs to be accessible from the browser. |
-| `Basic Auth` | Enable basic authentication to the Zipkin data source.                                                                                |
-| `User`       | User name for basic authentication.                                                                                                   |
-| `Password`   | Password for basic authentication.                                                                                                    |
+| Name         | Description                                                                                     |
+| ------------ | ----------------------------------------------------------------------------------------------- |
+| `Name`       | The data source name. This is how you refer to the data source in panels, queries, and Explore. |
+| `Default`    | Data source will be pre-selected for new panels.                                                |
+| `URL`        | The URL of the Zipkin instance, e.g., `http://localhost:9411`.                                  |
+| `Basic Auth` | Enable basic authentication to the Zipkin data source.                                          |
+| `User`       | User name for basic authentication.                                                             |
+| `Password`   | Password for basic authentication.                                                              |
 
 ### Trace to logs
 

--- a/public/app/plugins/datasource/zipkin/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/zipkin/ConfigEditor.tsx
@@ -11,7 +11,7 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
       <DataSourceHttpSettings
         defaultUrl="http://localhost:9411"
         dataSourceConfig={options}
-        showAccessOptions={true}
+        showAccessOptions={false}
         onChange={onOptionsChange}
       />
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As we removed the browser access mode from Jaeger, it made sense to remove it from Zipkin as well.

Related to https://github.com/grafana/grafana/issues/25699

