### PR TITLE
Loki: Remove showing of unique labels with the empty string value

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogLabels.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabels.test.tsx
@@ -20,4 +20,9 @@ describe('<LogLabels />', () => {
     expect(wrapper.text()).not.toContain('42');
     expect(wrapper.text()).not.toContain('13');
   });
+  it('excludes labels with empty string values', () => {
+    const wrapper = shallow(<LogLabels labels={{ foo: 'bar', baz: '' }} theme={getTheme()} />);
+    expect(wrapper.text()).toContain('bar');
+    expect(wrapper.html()).not.toContain('baz');
+  });
 });

--- a/packages/grafana-ui/src/components/Logs/LogLabels.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabels.tsx
@@ -59,7 +59,7 @@ export const UnThemedLogLabels: FunctionComponent<Props> = ({ labels, theme }) =
     <span className={cx([styles.logsLabels])}>
       {displayLabels.sort().map(label => {
         const value = labels[label];
-        if (!Boolean(value)) {
+        if (!value) {
           return;
         }
         const tooltip = `${label}: ${value}`;

--- a/packages/grafana-ui/src/components/Logs/LogLabels.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabels.tsx
@@ -59,6 +59,9 @@ export const UnThemedLogLabels: FunctionComponent<Props> = ({ labels, theme }) =
     <span className={cx([styles.logsLabels])}>
       {displayLabels.sort().map(label => {
         const value = labels[label];
+        if (!Boolean(value)) {
+          return;
+        }
         const tooltip = `${label}: ${value}`;
         return (
           <span key={label} className={cx([styles.logsLabel])}>


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes showing of unique labels with the empty string value.

**Before:** (see the empty highlighted rectangles):
![image](https://user-images.githubusercontent.com/30407135/104944117-04d6b800-59b7-11eb-976f-fa9e767ae2ad.png)

**After:**
![image](https://user-images.githubusercontent.com/30407135/104944642-c8f02280-59b7-11eb-9953-9dcbceb111be.png)
