### PR TITLE
Chore: Lint all files for no-only-tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ vendor
 devenv
 data
 dist
+e2e/tmp

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,10 @@
   "plugins": [
     "no-only-tests"
   ],
+  "rules": {
+    "no-only-tests/no-only-tests": "error",
+    "react/prop-types": "off"
+  },
   "overrides": [
     {
       "files": [
@@ -13,9 +17,7 @@
       ],
       "rules": {
         "react-hooks/rules-of-hooks": "off",
-        "react-hooks/exhaustive-deps": "off",
-        "react/prop-types": "off",
-        "no-only-tests/no-only-tests": "error"
+        "react-hooks/exhaustive-deps": "off"
       }
     }
   ]


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds `e2e/tmp` to eslintignore and adds react/prop-types and no-only-test rules to rules instead of the overrides section. This way eslint will detect lint issues everywhere.


