### PR TITLE
Explore: Clear errors after running a new query

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -312,7 +312,8 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     const isLoading = queryResponse.state === LoadingState.Loading;
 
     // gets an error without a refID, so non-query-row-related error, like a connection error
-    const queryErrors = queryResponse.error ? [queryResponse.error] : undefined;
+    const queryErrors =
+      queryResponse.state === LoadingState.Error && queryResponse.error ? [queryResponse.error] : undefined;
     const queryError = getFirstNonQueryRowSpecificError(queryErrors);
 
     const showRichHistory = openDrawer === ExploreDrawer.RichHistory;

--- a/public/app/features/explore/__snapshots__/Explore.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/Explore.test.tsx.snap
@@ -37,9 +37,7 @@ exports[`Explore should render component 1`] = `
         richHistoryButtonActive={false}
       />
     </div>
-    <ErrorContainer
-      queryError={Object {}}
-    />
+    <ErrorContainer />
     <AutoSizer
       disableHeight={true}
       disableWidth={false}

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -657,7 +657,7 @@ export const processQueryResponse = (
 
     return {
       ...state,
-      loading: false,
+      loading: loadingState === LoadingState.Loading || loadingState === LoadingState.Streaming,
       queryResponse: response,
       graphResult: null,
       tableResult: null,


### PR DESCRIPTION
**Issue:**
Any query error creates the red box. Changing and re-submitting query does not clear the error nor does it indicate a query was submitted, only if the follow up comes back with a 200 does it clear the error. +cc @slim-bean 

**What this PR does / why we need it**:
This PR fixes the issue on 2 levels:
- It clears the red box if the queryResponse.state changes from **Error** to **Loading**, so we don't have to wait for the new queryResponse. 
- When processing query response, we don't assume that loading was finished, but rely on actual loading state.

**Before:**
![before](https://user-images.githubusercontent.com/30407135/104949884-f8a32880-59bf-11eb-86e7-9694d700ea17.gif)
**After:**
![after](https://user-images.githubusercontent.com/30407135/104949877-f4770b00-59bf-11eb-93fb-e29023744042.gif)


**Fixes:**
 #29242

