### PR TITLE
MS SQL: Integrated security

### DIFF
--- a/docs/sources/datasources/mssql.md
+++ b/docs/sources/datasources/mssql.md
@@ -12,18 +12,19 @@ Grafana ships with a built-in Microsoft SQL Server (MS SQL) data source plugin t
 
 ### Data source options
 
-Name           | Description
-------------   | -------------
-`Name`         | The data source name. This is how you refer to the data source in panels and queries.
-`Default`      | Default data source means that it will be pre-selected for new panels.
-`Host`         | The IP address/hostname and optional port of your MS SQL instance. If port is omitted, default 1433 will be used.
-`Database`     | Name of your MS SQL database.
-`User`         | Database user's login/username
-`Password`     | Database user's password
-`Encrypt`      | This option determines whether or to which extent a secure SSL TCP/IP connection will be negotiated with the server, default `false`.
-`Max open`     | The maximum number of open connections to the database, default `unlimited`.
-`Max idle`     | The maximum number of connections in the idle connection pool, default `2`.
-`Max lifetime` | The maximum amount of time in seconds a connection may be reused, default `14400`/4 hours.
+| Name             | Description                                                                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `Name`           | The data source name. This is how you refer to the data source in panels and queries.                                                 |
+| `Default`        | Default data source means that it will be pre-selected for new panels.                                                                |
+| `Host`           | The IP address/hostname and optional port of your MS SQL instance. If port is omitted, default 1433 will be used.                     |
+| `Database`       | Name of your MS SQL database.                                                                                                         |
+| `Authentication` | Authentication mode. Either using SQL Server Authentication or Windows Authentication (single sign on for Windows users).             |
+| `User`           | Database user's login/username                                                                                                        |
+| `Password`       | Database user's password                                                                                                              |
+| `Encrypt`        | This option determines whether or to which extent a secure SSL TCP/IP connection will be negotiated with the server, default `false`. |
+| `Max open`       | The maximum number of open connections to the database, default `unlimited`.                                                          |
+| `Max idle`       | The maximum number of connections in the idle connection pool, default `2`.                                                           |
+| `Max lifetime`   | The maximum amount of time in seconds a connection may be reused, default `14400`/4 hours.                                            |
 
 ### Min time interval
 
@@ -32,16 +33,16 @@ Recommended to be set to write frequency, for example `1m` if your data is writt
 This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value **needs** to be formatted as a
 number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 seconds). The following time identifiers are supported:
 
-Identifier   | Description
------------- | -------------
-`y`          | year
-`M`          | month
-`w`          | week
-`d`          | day
-`h`          | hour
-`m`          | minute
-`s`          | second
-`ms`         | millisecond
+| Identifier | Description |
+| ---------- | ----------- |
+| `y`        | year        |
+| `M`        | month       |
+| `w`        | week        |
+| `d`        | day         |
+| `h`        | hour        |
+| `m`        | minute      |
+| `s`        | second      |
+| `ms`       | millisecond |
 
 ### Database user permissions
 
@@ -71,7 +72,7 @@ If possible, we recommend you to use the latest service pack available for optim
 You will find the MSSQL query editor in the metrics tab in Graph, Singlestat or Table panel's edit mode. You enter edit mode by clicking the
 panel title, then edit. The editor allows you to define a SQL query to select data to be visualized.
 
-1. Select *Format as* `Time series` (for use in Graph or Singlestat panel's among others) or `Table` (for use in Table panel among others).
+1. Select _Format as_ `Time series` (for use in Graph or Singlestat panel's among others) or `Table` (for use in Table panel among others).
 1. This is the actual editor where you write your SQL queries.
 1. Show help section for MSSQL below the query editor.
 1. Show actual executed SQL query. Will be available first after a successful query has been executed.
@@ -83,26 +84,26 @@ panel title, then edit. The editor allows you to define a SQL query to select da
 
 To simplify syntax and to allow for dynamic parts, like date range filters, the query can contain macros.
 
-Macro example                                           | Description
-------------------------------------------------------- | -------------
-`$__time(dateColumn)`                                   | Will be replaced by an expression to rename the column to *time*. For example, *dateColumn as time*
-`$__timeEpoch(dateColumn)`                              | Will be replaced by an expression to convert a DATETIME column type to Unix timestamp and rename it to *time*. <br/>For example, *DATEDIFF(second, '1970-01-01', dateColumn) AS time*
-`$__timeFilter(dateColumn)`                             | Will be replaced by a time range filter using the specified column name. <br/>For example, *dateColumn BETWEEN '2017-04-21T05:01:17Z' AND '2017-04-21T05:06:17Z'*
-`$__timeFrom()`                                         | Will be replaced by the start of the currently active time selection. For example, *'2017-04-21T05:01:17Z'*
-`$__timeTo()`                                           | Will be replaced by the end of the currently active time selection. For example, *'2017-04-21T05:06:17Z'*
-`$__timeGroup(dateColumn,'5m'[, fillvalue])`            | Will be replaced by an expression usable in GROUP BY clause. Providing a *fillValue* of *NULL* or *floating value* will automatically fill empty series in timerange with that value. <br/>For example, *CAST(ROUND(DATEDIFF(second, '1970-01-01', time_column)/300.0, 0) as bigint)\*300*.
-`$__timeGroup(dateColumn,'5m', 0)`                      | Same as above but with a fill parameter so missing points in that series will be added by grafana and 0 will be used as value.
-`$__timeGroup(dateColumn,'5m', NULL)`                   | Same as above but NULL will be used as value for missing points.
-`$__timeGroup(dateColumn,'5m', previous)`               | Same as above but the previous value in that series will be used as fill value if no value has been seen yet NULL will be used (only available in Grafana 5.3+).
-`$__timeGroupAlias(dateColumn,'5m')`                    | Will be replaced identical to $__timeGroup but with an added column alias (only available in Grafana 5.3+).
-`$__unixEpochFilter(dateColumn)`                        | Will be replaced by a time range filter using the specified column name with times represented as Unix timestamp. For example, *dateColumn > 1494410783 AND dateColumn < 1494497183*
-`$__unixEpochFrom()`                                    | Will be replaced by the start of the currently active time selection as Unix timestamp. For example, *1494410783*
-`$__unixEpochTo()`                                      | Will be replaced by the end of the currently active time selection as Unix timestamp. For example, *1494497183*
-`$__unixEpochNanoFilter(dateColumn)`                    | Will be replaced by a time range filter using the specified column name with times represented as nanosecond timestamp. For example, *dateColumn > 1494410783152415214 AND dateColumn < 1494497183142514872*
-`$__unixEpochNanoFrom()`                                | Will be replaced by the start of the currently active time selection as nanosecond timestamp. For example, *1494410783152415214*
-`$__unixEpochNanoTo()`                                  | Will be replaced by the end of the currently active time selection as nanosecond timestamp. For example, *1494497183142514872*
-`$__unixEpochGroup(dateColumn,'5m', [fillmode])`        | Same as $__timeGroup but for times stored as Unix timestamp (only available in Grafana 5.3+).
-`$__unixEpochGroupAlias(dateColumn,'5m', [fillmode])`   | Same as above but also adds a column alias (only available in Grafana 5.3+).
+| Macro example                                         | Description                                                                                                                                                                                                                                                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$__time(dateColumn)`                                 | Will be replaced by an expression to rename the column to _time_. For example, _dateColumn as time_                                                                                                                                                                                         |
+| `$__timeEpoch(dateColumn)`                            | Will be replaced by an expression to convert a DATETIME column type to Unix timestamp and rename it to _time_. <br/>For example, _DATEDIFF(second, '1970-01-01', dateColumn) AS time_                                                                                                       |
+| `$__timeFilter(dateColumn)`                           | Will be replaced by a time range filter using the specified column name. <br/>For example, _dateColumn BETWEEN '2017-04-21T05:01:17Z' AND '2017-04-21T05:06:17Z'_                                                                                                                           |
+| `$__timeFrom()`                                       | Will be replaced by the start of the currently active time selection. For example, _'2017-04-21T05:01:17Z'_                                                                                                                                                                                 |
+| `$__timeTo()`                                         | Will be replaced by the end of the currently active time selection. For example, _'2017-04-21T05:06:17Z'_                                                                                                                                                                                   |
+| `$__timeGroup(dateColumn,'5m'[, fillvalue])`          | Will be replaced by an expression usable in GROUP BY clause. Providing a _fillValue_ of _NULL_ or _floating value_ will automatically fill empty series in timerange with that value. <br/>For example, _CAST(ROUND(DATEDIFF(second, '1970-01-01', time_column)/300.0, 0) as bigint)\*300_. |
+| `$__timeGroup(dateColumn,'5m', 0)`                    | Same as above but with a fill parameter so missing points in that series will be added by grafana and 0 will be used as value.                                                                                                                                                              |
+| `$__timeGroup(dateColumn,'5m', NULL)`                 | Same as above but NULL will be used as value for missing points.                                                                                                                                                                                                                            |
+| `$__timeGroup(dateColumn,'5m', previous)`             | Same as above but the previous value in that series will be used as fill value if no value has been seen yet NULL will be used (only available in Grafana 5.3+).                                                                                                                            |
+| `$__timeGroupAlias(dateColumn,'5m')`                  | Will be replaced identical to \$\_\_timeGroup but with an added column alias (only available in Grafana 5.3+).                                                                                                                                                                              |
+| `$__unixEpochFilter(dateColumn)`                      | Will be replaced by a time range filter using the specified column name with times represented as Unix timestamp. For example, _dateColumn > 1494410783 AND dateColumn < 1494497183_                                                                                                        |
+| `$__unixEpochFrom()`                                  | Will be replaced by the start of the currently active time selection as Unix timestamp. For example, _1494410783_                                                                                                                                                                           |
+| `$__unixEpochTo()`                                    | Will be replaced by the end of the currently active time selection as Unix timestamp. For example, _1494497183_                                                                                                                                                                             |
+| `$__unixEpochNanoFilter(dateColumn)`                  | Will be replaced by a time range filter using the specified column name with times represented as nanosecond timestamp. For example, _dateColumn > 1494410783152415214 AND dateColumn < 1494497183142514872_                                                                                |
+| `$__unixEpochNanoFrom()`                              | Will be replaced by the start of the currently active time selection as nanosecond timestamp. For example, _1494410783152415214_                                                                                                                                                            |
+| `$__unixEpochNanoTo()`                                | Will be replaced by the end of the currently active time selection as nanosecond timestamp. For example, _1494497183142514872_                                                                                                                                                              |
+| `$__unixEpochGroup(dateColumn,'5m', [fillmode])`      | Same as \$\_\_timeGroup but for times stored as Unix timestamp (only available in Grafana 5.3+).                                                                                                                                                                                            |
+| `$__unixEpochGroupAlias(dateColumn,'5m', [fillmode])` | Same as above but also adds a column alias (only available in Grafana 5.3+).                                                                                                                                                                                                                |
 
 We plan to add many more macros. If you have suggestions for what macros you would like to see, please [open an issue](https://github.com/grafana/grafana) in our GitHub repo.
 
@@ -144,14 +145,13 @@ Query editor with example query:
 
 {{< docs-imagebox img="/img/docs/v51/mssql_table_query.png" max-width="500px" class="docs-image--no-shadow" >}}
 
-
 The query:
 
 ```sql
 SELECT * FROM [mssql_types]
 ```
 
-You can control the name of the Table panel columns by using regular `AS ` SQL column selection syntax. Example:
+You can control the name of the Table panel columns by using regular `AS` SQL column selection syntax. Example:
 
 ```sql
 SELECT
@@ -180,7 +180,6 @@ CREATE TABLE [event] (
   tags nvarchar(100),
 )
 ```
-
 
 ```sql
 CREATE TABLE metric_values (
@@ -240,7 +239,7 @@ When the above query is used in a graph panel, it will produce two series named 
 
 {{< docs-imagebox img="/img/docs/v51/mssql_time_series_three.png" class="docs-image--no-shadow docs-image--right" >}}
 
-**Example using the $__timeGroup macro:**
+**Example using the \$\_\_timeGroup macro:**
 
 ```sql
 SELECT
@@ -264,7 +263,7 @@ Any two series lacking a value in a three-minute window will render a line betwe
 
 {{< docs-imagebox img="/img/docs/v51/mssql_time_series_four.png" class="docs-image--no-shadow docs-image--right" >}}
 
-**Example using the $__timeGroup macro with fill parameter set to zero:**
+**Example using the \$\_\_timeGroup macro with fill parameter set to zero:**
 
 ```sql
 SELECT
@@ -330,7 +329,7 @@ If the variable is a multi-value variable then use the `IN` comparison operator 
 
 There are two syntaxes:
 
-`$<varname>`  Example with a template variable named `hostname`:
+`$<varname>` Example with a template variable named `hostname`:
 
 ```sql
 SELECT
@@ -341,7 +340,7 @@ WHERE $__timeFilter(atimestamp) and hostname in($hostname)
 ORDER BY atimestamp
 ```
 
-`[[varname]]`  Example with a template variable named `hostname`:
+`[[varname]]` Example with a template variable named `hostname`:
 
 ```sql
 SELECT
@@ -366,12 +365,12 @@ Read more about variable formatting options in the [Variables]({{< relref "../va
 
 **Columns:**
 
-Name        | Description
------------ | -------------
-`time`      | The name of the date/time field. Could be a column with a native SQL date/time data type or epoch value.
-`timeend`   | Optional name of the end date/time field. Could be a column with a native SQL date/time data type or epoch value. (Grafana v6.6+)
-`text`      | Event description field.
-`tags`      | Optional field name to use for event tags as a comma separated string.
+| Name      | Description                                                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `time`    | The name of the date/time field. Could be a column with a native SQL date/time data type or epoch value.                          |
+| `timeend` | Optional name of the end date/time field. Could be a column with a native SQL date/time data type or epoch value. (Grafana v6.6+) |
+| `text`    | Event description field.                                                                                                          |
+| `tags`    | Optional field name to use for event tags as a comma separated string.                                                            |
 
 **Example database tables:**
 
@@ -460,6 +459,7 @@ ORDER BY 1
 ```
 
 **Second query:**
+
 ```sql
 SELECT
   $__timeGroup(time, '5m') as time,
@@ -599,10 +599,9 @@ datasources:
     database: grafana
     user: grafana
     jsonData:
-      maxOpenConns: 0         # Grafana v5.4+
-      maxIdleConns: 2         # Grafana v5.4+
-      connMaxLifetime: 14400  # Grafana v5.4+
+      maxOpenConns: 0 # Grafana v5.4+
+      maxIdleConns: 2 # Grafana v5.4+
+      connMaxLifetime: 14400 # Grafana v5.4+
     secureJsonData:
-      password: "Password!"
-
+      password: 'Password!'
 ```

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/cortexproject/cortex v1.4.1-0.20201022071705-85942c5703cf
 	github.com/crewjam/saml v0.4.6-0.20201227203850-bca570abb2ce
 	github.com/davecgh/go-spew v1.1.1
-	github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec
+	github.com/denisenkom/go-mssqldb v0.0.0-20200910202707-1e08a3fab204
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect
 	github.com/facebookgo/inject v0.0.0-20180706035515-f23751cae28b
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -243,6 +243,7 @@ func UpdateDataSource(cmd *models.UpdateDataSourceCommand) error {
 		// plain text fields to SecureJsonData.
 		sess.MustCols("password")
 		sess.MustCols("basic_auth_password")
+		sess.MustCols("user")
 
 		var updateSession *xorm.Session
 		if cmd.Version != 0 {

--- a/public/app/plugins/datasource/mssql/config_ctrl.ts
+++ b/public/app/plugins/datasource/mssql/config_ctrl.ts
@@ -10,11 +10,26 @@ export class MssqlConfigCtrl {
   current: any;
   onPasswordReset: ReturnType<typeof createResetHandler>;
   onPasswordChange: ReturnType<typeof createChangeHandler>;
+  showUserCredentials: boolean;
 
   /** @ngInject */
   constructor($scope: any) {
     this.current.jsonData.encrypt = this.current.jsonData.encrypt || 'false';
+    this.current.jsonData.authenticationType = this.current.jsonData.authenticationType || 'SQL Server Authentication';
     this.onPasswordReset = createResetHandler(this, PasswordFieldEnum.Password);
     this.onPasswordChange = createChangeHandler(this, PasswordFieldEnum.Password);
+    this.showUserCredentials = this.current.jsonData.authenticationType !== 'Windows Authentication';
+  }
+
+  onAuthenticationTypeChange() {
+    // Workaround to reset the user value in the database and xorm ignoring empty strings. Needs to be an empty string for the Windows auth to work.
+    // This is using the fallback in https://github.com/denisenkom/go-mssqldb to use Windows Auth if login/user id is empty.
+    if (this.current.jsonData.authenticationType === 'Windows Authentication') {
+      this.current.user = ' ';
+    } else {
+      this.current.user = '';
+    }
+
+    this.showUserCredentials = this.current.jsonData.authenticationType !== 'Windows Authentication';
   }
 }

--- a/public/app/plugins/datasource/mssql/config_ctrl.ts
+++ b/public/app/plugins/datasource/mssql/config_ctrl.ts
@@ -22,12 +22,10 @@ export class MssqlConfigCtrl {
   }
 
   onAuthenticationTypeChange() {
-    // Workaround to reset the user value in the database and xorm ignoring empty strings. Needs to be an empty string for the Windows auth to work.
     // This is using the fallback in https://github.com/denisenkom/go-mssqldb to use Windows Auth if login/user id is empty.
     if (this.current.jsonData.authenticationType === 'Windows Authentication') {
-      this.current.user = ' ';
-    } else {
       this.current.user = '';
+      this.current.password = '';
     }
 
     this.showUserCredentials = this.current.jsonData.authenticationType !== 'Windows Authentication';

--- a/public/app/plugins/datasource/mssql/partials/config.html
+++ b/public/app/plugins/datasource/mssql/partials/config.html
@@ -12,21 +12,33 @@
 		<input type="text" class="gf-form-input" style="width: 352px" ng-model='ctrl.current.database' placeholder="database name" required></input>
 	</div>
 
-	<div class="gf-form-inline">
+	<div class="gf-form">
+		<label class="gf-form-label width-7">Authentication</label>
+		<div class="gf-form-select-wrapper max-width-15 gf-form-select-wrapper--has-help-icon">
+			<select class="gf-form-input" ng-model="ctrl.current.jsonData.authenticationType" ng-options="mode for mode in ['Windows Authentication', 'SQL Server Authentication']" ng-init="ctrl.current.jsonData.authenticationType" ng-change="ctrl.onAuthenticationTypeChange()"></select>
+			<info-popover mode="right-absolute">
+				<ul>
+					<li><i>SQL Server Authentication</i> This is the default mechanism to connect to MS SQL Server. Enter the SQL Server Authentication login or the Windows Authentication login in the DOMAIN\User format.</li>
+					<li><i>Windows Authentication</i> Windows Integrated Security - single sign on for users who are already logged onto Windows and have enabled this option for MS SQL Server.</li>
+				</ul>
+			</info-popover>
+		</div>
+	</div>
+	<div class="gf-form-inline" ng-show="ctrl.showUserCredentials">
 		<div class="gf-form max-width-15">
 			<span class="gf-form-label width-7">User</span>
 			<input type="text" class="gf-form-input" ng-model='ctrl.current.user' placeholder="user"></input>
 		</div>
-    <div class="gf-form">
-      <secret-form-field
-        isConfigured="ctrl.current.secureJsonFields.password"
-        value="ctrl.current.secureJsonData.password"
-        on-reset="ctrl.onPasswordReset"
-        on-change="ctrl.onPasswordChange"
-        labelWidth="7"
-        inputWidth="7"
-      />
-    </div>
+		<div class="gf-form">
+			<secret-form-field
+				isConfigured="ctrl.current.secureJsonFields.password"
+				value="ctrl.current.secureJsonData.password"
+				on-reset="ctrl.onPasswordReset"
+				on-change="ctrl.onPasswordChange"
+				labelWidth="7"
+				inputWidth="7"
+			/>
+		</div>
 	</div>
 
 	<div class="gf-form">


### PR DESCRIPTION
Fixes #11876

## The Xorm workaround

This feature works if the [login/user id is empty](https://github.com/denisenkom/go-mssqldb#common-parameters). It will then fallback to Windows authentication (providing the user is on Windows and Sql Server has Windows Auth enabled and the user has been given access). 

~~I couldn't figure out how to set the user id to empty (same problem has always existed with the password field). Xorm will ignore empty fields when [updating the database table](https://github.com/grafana/grafana/blob/master/pkg/services/sqlstore/datasource.go#L257).~~

~~My workaround/hack is to set the user id to `' '` (one space). Is there a better way to do this? Should I instead send a reset flag in the update command or explicitly overwrite the User field with the empty value in datasource.go?~~

## How to test

This feature adds support for Windows authentication and therefore can only really be tested on Windows. 

On Linux, the user will see the error message:

`Login error: mssql: Login failed for user ''.`

Steps for testing:
1. Install Sql Server (Developer Edition and Managment Studio). There are a [couple of settings that will need to set](https://stackoverflow.com/questions/12774827/cant-connect-to-localhost-on-sql-server-express-2012-2016). 
2. Create a database for unit tests ([create a database and user](https://github.com/grafana/grafana/blob/master/pkg/tsdb/mssql/mssql_test.go#L22))
3. Set the mixed mode authentication for your Sql Server instance to be able to run the unit tests and remove the [Skip from this line](https://github.com/grafana/grafana/blob/master/pkg/tsdb/mssql/mssql_test.go#L32) 
4. Run [devenv setup](https://github.com/grafana/grafana/blob/master/devenv/setup.sh) to get the provisioned data source and dashboards for MSSQL. You will need to restart Grafana on Windows afterwards for Grafana to detect them. 
5. To run the unit tests with Windows authentication then change the [connection string](https://github.com/grafana/grafana/blob/master/pkg/services/sqlstore/sqlutil/sqlutil.go#L65) to: `server=%s;port=%s;database=grafanatest`
6. `go test ./pkg/tsdb/mssql/...`