### PR TITLE
Chore: adds library panel header to JSON

### DIFF
--- a/pkg/services/librarypanels/database.go
+++ b/pkg/services/librarypanels/database.go
@@ -47,11 +47,12 @@ func (lps *LibraryPanelService) createLibraryPanel(c *models.ReqContext, cmd cre
 		CreatedBy: c.SignedInUser.UserId,
 		UpdatedBy: c.SignedInUser.UserId,
 	}
-	err := lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
-		err := setLibraryPanelHeader(&libraryPanel)
-		if err != nil {
-			return err
-		}
+	err := setLibraryPanelHeader(&libraryPanel)
+	if err != nil {
+		return libraryPanel, err
+	}
+
+	err = lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
 		if _, err := session.Insert(&libraryPanel); err != nil {
 			if lps.SQLStore.Dialect.IsUniqueConstraintViolation(err) {
 				return errLibraryPanelAlreadyExists

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -25,6 +25,19 @@ func TestCreateLibraryPanel(t *testing.T) {
 			response = sc.service.createHandler(sc.reqContext, command)
 			require.Equal(t, 400, response.Status())
 		})
+
+	testScenario(t, "When an admin tries to create a library panel that does not exist, it should succeed",
+		func(t *testing.T, sc scenarioContext) {
+			command := getCreateCommand(1, "Text - Library Panel")
+			response := sc.service.createHandler(sc.reqContext, command)
+			require.Equal(t, 200, response.Status())
+
+			var result libraryPanelResult
+			err := json.Unmarshal(response.Body(), &result)
+			l := result.Result.Model["libraryPanel"].(map[string]interface{})
+			require.NoError(t, err)
+			require.Equal(t, l["name"], "Text - Library Panel")
+		})
 }
 
 func TestConnectLibraryPanel(t *testing.T) {
@@ -345,6 +358,10 @@ func TestPatchLibraryPanel(t *testing.T) {
 			existing.Result.FolderID = int64(2)
 			existing.Result.Name = "Panel - New name"
 			existing.Result.Model["name"] = "Model - New name"
+			existing.Result.Model["libraryPanel"] = map[string]interface{}{
+				"uid":  existing.Result.UID,
+				"name": "Panel - New name",
+			}
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -396,6 +413,10 @@ func TestPatchLibraryPanel(t *testing.T) {
 			err = json.Unmarshal(response.Body(), &result)
 			require.NoError(t, err)
 			existing.Result.Name = "New Name"
+			existing.Result.Model["libraryPanel"] = map[string]interface{}{
+				"uid":  existing.Result.UID,
+				"name": "New Name",
+			}
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -422,6 +443,10 @@ func TestPatchLibraryPanel(t *testing.T) {
 			require.NoError(t, err)
 			existing.Result.Model = map[string]interface{}{
 				"name": "New Model Name",
+			}
+			existing.Result.Model["libraryPanel"] = map[string]interface{}{
+				"uid":  existing.Result.UID,
+				"name": existing.Result.Name,
 			}
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -34,9 +34,15 @@ func TestCreateLibraryPanel(t *testing.T) {
 
 			var result libraryPanelResult
 			err := json.Unmarshal(response.Body(), &result)
-			l := result.Result.Model["libraryPanel"].(map[string]interface{})
 			require.NoError(t, err)
-			require.Equal(t, l["name"], "Text - Library Panel")
+			var existing = map[string]interface{}{
+				"uid":  result.Result.UID,
+				"name": "Text - Library Panel",
+			}
+			actual := result.Result.Model["libraryPanel"].(map[string]interface{})
+			if diff := cmp.Diff(existing, actual, getCompareOptions()...); diff != "" {
+				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
+			}
 		})
 }
 

--- a/pkg/services/librarypanels/models.go
+++ b/pkg/services/librarypanels/models.go
@@ -33,6 +33,11 @@ type libraryPanelDashboard struct {
 	CreatedBy int64
 }
 
+type libraryPanelHeader struct {
+	UID  string `json:"uid"`
+	Name string `json:"name"`
+}
+
 var (
 	// errLibraryPanelAlreadyExists is an error for when the user tries to add a library panel that already exists.
 	errLibraryPanelAlreadyExists = errors.New("library panel with that name already exists")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure we include a `libraryPanel` property in the json model for library panels to distinguish them from "normal" panels. This could be easily be done in the Frontend instead, but I figure red that it would make more sense to have it in the backend.

First, I thought that we shouldn't store this in the db as the information is already in the table row as `uid` and `name` but that meant that we needed to add this header to all user facing requests like `post`, `patch`, `get`, `getAll`. 

Instead of doing the processing on all user facing requests I stored the header instead for `post` and `patch`. Let me know if what you think about this.

Enjoy the review 🎉 

**Which issue(s) this PR fixes**:
Relates #29610

**Special notes for your reviewer**:

