### PR TITLE
Query Editor: avoid word wrap

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -120,6 +120,7 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
     wrapper: css`
       margin-bottom: ${theme.spacing.md};
+      white-space: nowrap;
     `,
     header: css`
       padding: ${theme.spacing.xs} ${theme.spacing.sm};


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/705951/104997756-0025fa00-59df-11eb-8762-091eeed01e35.png)


After:
![image](https://user-images.githubusercontent.com/705951/104997625-bdfcb880-59de-11eb-944e-96167cac087a.png)


better would be if "MD = ..." collapsed as things got smaller 