### PR TITLE
Prometheus: Change exemplars endpoint

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -663,7 +663,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   }
 
   getExemplars(query: PromQueryRequest) {
-    const url = '/api/v1/query_exemplar';
+    const url = '/api/v1/query_exemplars';
     return this._request<PromDataSuccessResponse<PromExemplarData>>(
       url,
       { query: query.expr, start: query.start.toString(), end: query.end.toString() },


### PR DESCRIPTION
**What this PR does / why we need it**:
As [Callum mentioned in slack](https://raintank-corp.slack.com/archives/C8C98CETS/p1610981315055100?thread_ts=1610975164.050300&cid=C8C98CETS):
the endpoint is 99% going to change from query_exemplar to query_exemplars.

