### PR TITLE
AlertingNG: Enforce unique alert definition title (non empty)/UID per organisation

### DIFF
--- a/pkg/services/ngalert/database.go
+++ b/pkg/services/ngalert/database.go
@@ -169,6 +169,9 @@ func (ng *AlertNG) updateAlertDefinition(cmd *updateAlertDefinitionCommand) erro
 
 		_, err = sess.ID(existingAlertDefinition.ID).Update(alertDefinition)
 		if err != nil {
+			if ng.SQLStore.Dialect.IsUniqueConstraintViolation(err) && strings.Contains(err.Error(), "title") {
+				return fmt.Errorf("an alert definition with the title '%s' already exists: %w", cmd.Title, err)
+			}
 			return err
 		}
 

--- a/pkg/services/ngalert/database.go
+++ b/pkg/services/ngalert/database.go
@@ -93,7 +93,7 @@ func (ng *AlertNG) saveAlertDefinition(cmd *saveAlertDefinitionCommand) error {
 
 		if _, err := sess.Insert(alertDefinition); err != nil {
 			if ng.SQLStore.Dialect.IsUniqueConstraintViolation(err) && strings.Contains(err.Error(), "title") {
-				return fmt.Errorf("an alert definition with the title '%s' already exits: %w", cmd.Title, err)
+				return fmt.Errorf("an alert definition with the title '%s' already exists: %w", cmd.Title, err)
 			}
 			return err
 		}

--- a/pkg/services/ngalert/database.go
+++ b/pkg/services/ngalert/database.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/util"
@@ -91,6 +92,9 @@ func (ng *AlertNG) saveAlertDefinition(cmd *saveAlertDefinitionCommand) error {
 		}
 
 		if _, err := sess.Insert(alertDefinition); err != nil {
+			if ng.SQLStore.Dialect.IsUniqueConstraintViolation(err) && strings.Contains(err.Error(), "title") {
+				return fmt.Errorf("an alert definition with the title '%s' already exits: %w", cmd.Title, err)
+			}
 			return err
 		}
 

--- a/pkg/services/ngalert/database_mig.go
+++ b/pkg/services/ngalert/database_mig.go
@@ -36,6 +36,16 @@ func addAlertDefinitionMigrations(mg *migrator.Migrator) {
 
 	mg.AddMigration("alter alert_definition table data column to mediumtext in mysql", migrator.NewRawSQLMigration("").
 		Mysql("ALTER TABLE alert_definition MODIFY data MEDIUMTEXT;"))
+
+	mg.AddMigration("drop index in alert_definition on org_id and title columns", migrator.NewDropIndexMigration(alertDefinition, alertDefinition.Indices[0]))
+	mg.AddMigration("drop index in alert_definition on org_id and uid columns", migrator.NewDropIndexMigration(alertDefinition, alertDefinition.Indices[1]))
+
+	uniqueIndices := []*migrator.Index{
+		{Cols: []string{"org_id", "title"}, Type: migrator.UniqueIndex},
+		{Cols: []string{"org_id", "uid"}, Type: migrator.UniqueIndex},
+	}
+	mg.AddMigration("add unique index in alert_definition on org_id and title columns", migrator.NewAddIndexMigration(alertDefinition, uniqueIndices[0]))
+	mg.AddMigration("add unique index in alert_definition on org_id and uid columns", migrator.NewAddIndexMigration(alertDefinition, uniqueIndices[1]))
 }
 
 func addAlertDefinitionVersionMigrations(mg *migrator.Migrator) {

--- a/pkg/services/ngalert/database_test.go
+++ b/pkg/services/ngalert/database_test.go
@@ -38,7 +38,8 @@ func TestCreatingAlertDefinition(t *testing.T) {
 		inputTitle           string
 		expectedError        error
 		expectedInterval     int64
-		expectedUpdated      time.Time
+
+		expectedUpdated time.Time
 	}{
 		{
 			desc:                 "should create successfuly an alert definition with default interval",
@@ -57,8 +58,14 @@ func TestCreatingAlertDefinition(t *testing.T) {
 		{
 			desc:                 "should fail to create an alert definition with too big name",
 			inputIntervalSeconds: &customIntervalSeconds,
-			inputTitle:           getLongString(alertDefinitionMaxNameLength + 1),
+			inputTitle:           getLongString(alertDefinitionMaxTitleLength + 1),
 			expectedError:        errors.New(""),
+		},
+		{
+			desc:                 "should fail to create an alert definition with empty title",
+			inputIntervalSeconds: &customIntervalSeconds,
+			inputTitle:           "",
+			expectedError:        errEmptyTitleError,
 		},
 	}
 	for _, tc := range testCases {
@@ -195,6 +202,7 @@ func TestUpdatingAlertDefinition(t *testing.T) {
 			expectedError           error
 			expectedIntervalSeconds int64
 			expectedUpdated         time.Time
+			expectedTitle           string
 		}{
 			{
 				desc:                    "should not update previous interval if it's not provided",
@@ -203,6 +211,7 @@ func TestUpdatingAlertDefinition(t *testing.T) {
 				inputTitle:              "something completely different",
 				expectedIntervalSeconds: initialInterval,
 				expectedUpdated:         time.Unix(1, 0).UTC(),
+				expectedTitle:           "something completely different",
 			},
 			{
 				desc:                    "should update interval if it's provided",
@@ -211,6 +220,7 @@ func TestUpdatingAlertDefinition(t *testing.T) {
 				inputTitle:              "something completely different",
 				expectedIntervalSeconds: customInterval,
 				expectedUpdated:         time.Unix(2, 0).UTC(),
+				expectedTitle:           "something completely different",
 			},
 			{
 				desc:                    "should not update organisation if it's provided",
@@ -219,19 +229,28 @@ func TestUpdatingAlertDefinition(t *testing.T) {
 				inputTitle:              "something completely different",
 				expectedIntervalSeconds: customInterval,
 				expectedUpdated:         time.Unix(3, 0).UTC(),
+				expectedTitle:           "something completely different",
 			},
 			{
-				desc:          "should not update alert definition if the name it's too big",
+				desc:          "should not update alert definition if the title it's too big",
 				inputInterval: &customInterval,
 				inputOrgID:    0,
-				inputTitle:    getLongString(alertDefinitionMaxNameLength + 1),
+				inputTitle:    getLongString(alertDefinitionMaxTitleLength + 1),
 				expectedError: errors.New(""),
+			},
+			{
+				desc:                    "should not update alert definition title if the title is empty",
+				inputInterval:           &customInterval,
+				inputOrgID:              0,
+				inputTitle:              "",
+				expectedIntervalSeconds: customInterval,
+				expectedUpdated:         time.Unix(4, 0).UTC(),
+				expectedTitle:           "something completely different",
 			},
 		}
 
 		q := updateAlertDefinitionCommand{
-			UID:   (*alertDefinition).UID,
-			Title: "something completely different",
+			UID: (*alertDefinition).UID,
 			Condition: eval.Condition{
 				RefID: "B",
 				QueriesAndExpressions: []eval.AlertQuery{

--- a/pkg/services/ngalert/eval/alert_query.go
+++ b/pkg/services/ngalert/eval/alert_query.go
@@ -40,8 +40,8 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 // RelativeTimeRange is the per query start and end time
 // for requests.
 type RelativeTimeRange struct {
-	From Duration
-	To   Duration
+	From Duration `json:"from"`
+	To   Duration `json:"to"`
 }
 
 // isValid checks that From duration is greater than To duration.

--- a/pkg/services/ngalert/eval/alert_query_test.go
+++ b/pkg/services/ngalert/eval/alert_query_test.go
@@ -204,7 +204,6 @@ func TestAlertQuery(t *testing.T) {
 				err = json.Unmarshal(blob, &model)
 				require.NoError(t, err)
 
-				fmt.Printf(">>>>>>> %+v %+v\n", tc.alertQuery, model)
 				i, ok := model["datasource"]
 				require.True(t, ok)
 				datasource, ok := i.(string)

--- a/pkg/services/ngalert/instance.go
+++ b/pkg/services/ngalert/instance.go
@@ -63,14 +63,14 @@ type listAlertInstancesQuery struct {
 
 // listAlertInstancesQueryResult represents the result of listAlertInstancesQuery.
 type listAlertInstancesQueryResult struct {
-	DefinitionOrgID   int64  `xorm:"def_org_id"`
-	DefinitionUID     string `xorm:"def_uid"`
-	DefinitionTitle   string `xorm:"def_title"`
-	Labels            InstanceLabels
-	LabelsHash        string
-	CurrentState      InstanceStateType
-	CurrentStateSince time.Time
-	LastEvalTime      time.Time
+	DefinitionOrgID   int64             `xorm:"def_org_id" json:"definitionOrgId"`
+	DefinitionUID     string            `xorm:"def_uid" json:"definitionUid"`
+	DefinitionTitle   string            `xorm:"def_title" json:"definitionTitle"`
+	Labels            InstanceLabels    `json:"labels"`
+	LabelsHash        string            `json:"labeHash"`
+	CurrentState      InstanceStateType `json:"currentState"`
+	CurrentStateSince time.Time         `json:"currentStateSince"`
+	LastEvalTime      time.Time         `json:"lastEvalTime"`
 }
 
 // validateAlertInstance validates that the alert instance contains an alert definition id,

--- a/pkg/services/ngalert/models.go
+++ b/pkg/services/ngalert/models.go
@@ -12,15 +12,15 @@ var errAlertDefinitionFailedGenerateUniqueUID = errors.New("failed to generate a
 
 // AlertDefinition is the model for alert definitions in Alerting NG.
 type AlertDefinition struct {
-	ID              int64 `xorm:"pk autoincr 'id'"`
-	OrgID           int64 `xorm:"org_id"`
-	Title           string
-	Condition       string
-	Data            []eval.AlertQuery
-	Updated         time.Time
-	IntervalSeconds int64
-	Version         int64
-	UID             string `xorm:"uid"`
+	ID              int64             `xorm:"pk autoincr 'id'" json:"id"`
+	OrgID           int64             `xorm:"org_id" json:"orgId"`
+	Title           string            `json:"title"`
+	Condition       string            `json:"condition"`
+	Data            []eval.AlertQuery `json:"data"`
+	Updated         time.Time         `json:"updated"`
+	IntervalSeconds int64             `json:"intervalSeconds"`
+	Version         int64             `json:"version"`
+	UID             string            `xorm:"uid" json:"uid"`
 }
 
 type alertDefinitionKey struct {

--- a/pkg/services/ngalert/validator.go
+++ b/pkg/services/ngalert/validator.go
@@ -1,6 +1,7 @@
 package ngalert
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -8,7 +9,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 )
 
-const alertDefinitionMaxNameLength = 190
+const alertDefinitionMaxTitleLength = 190
+
+var errEmptyTitleError = errors.New("title is empty")
 
 // validateAlertDefinition validates the alert definition interval and organisation.
 // If requireData is true checks that it contains at least one alert query
@@ -17,13 +20,17 @@ func (ng *AlertNG) validateAlertDefinition(alertDefinition *AlertDefinition, req
 		return fmt.Errorf("no queries or expressions are found")
 	}
 
+	if alertDefinition.Title == "" {
+		return errEmptyTitleError
+	}
+
 	if alertDefinition.IntervalSeconds%int64(ng.schedule.baseInterval.Seconds()) != 0 {
 		return fmt.Errorf("invalid interval: %v: interval should be divided exactly by scheduler interval: %v", time.Duration(alertDefinition.IntervalSeconds)*time.Second, ng.schedule.baseInterval)
 	}
 
 	// enfore max name length in SQLite
-	if len(alertDefinition.Title) > alertDefinitionMaxNameLength {
-		return fmt.Errorf("name length should not be greater than %d", alertDefinitionMaxNameLength)
+	if len(alertDefinition.Title) > alertDefinitionMaxTitleLength {
+		return fmt.Errorf("name length should not be greater than %d", alertDefinitionMaxTitleLength)
 	}
 
 	if alertDefinition.OrgID == 0 {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Following [this](https://github.com/grafana/grafana/pull/30223#pullrequestreview-570541856) comment, it drops and creates alert definition indices as unique ones.
It modifies alert definition creation to fail if the title is missing.
Also it changes the JSON properties to camelCase.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
If there are conflicting alert definitions, they should be deleted (using the respective API endpoint) before applying the database migration (otherwise it will fail).