### PR TITLE
Chore: Add enterprise reporting fonts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ vendor/
 /emails/templates/enterprise_*
 /public/emails/enterprise_*
 
+# Enterprise reporting fonts
+/public/fonts/dejavu
+
 # Enterprise devenv
 /devenv/docker/blocks/grafana-enterprise
 


### PR DESCRIPTION
Ignore fonts used in enterprise reporting for PDFs generation.
