### PR TITLE
Dashboard: Remove template variables option from ShareModal

### DIFF
--- a/packages/grafana-ui/src/components/Modal/ModalTabContent.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalTabContent.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import { cx } from 'emotion';
 import { IconName } from '../../types';
-import { Icon } from '../Icon/Icon';
 
 interface Props {
+  /** @deprecated */
   icon?: IconName;
+  /** @deprecated */
   iconClass?: string;
 }
 
-export const ModalTabContent: React.FC<Props> = ({ icon, iconClass, children }) => {
+/** @internal */
+export const ModalTabContent: React.FC<Props> = ({ children }) => {
   return (
     <div className="share-modal-body">
       <div className="share-modal-header">
-        {icon && <Icon name={icon} size="xxl" className={cx(iconClass, 'share-modal-big-icon')} />}
         <div className="share-modal-content">{children}</div>
       </div>
     </div>

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -6,9 +6,9 @@ import { appEvents } from 'app/core/core';
 import { buildIframeHtml } from './utils';
 
 const themeOptions: Array<SelectableValue<string>> = [
-  { label: 'current', value: 'current' },
-  { label: 'dark', value: 'dark' },
-  { label: 'light', value: 'light' },
+  { label: 'Current', value: 'current' },
+  { label: 'Dark', value: 'dark' },
+  { label: 'Light', value: 'light' },
 ];
 
 interface Props {

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Select, Switch, Field, FieldSet } from '@grafana/ui';
+import { RadioButtonGroup, Switch, Field, FieldSet, TextArea } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { buildIframeHtml } from './utils';
@@ -17,7 +17,7 @@ interface Props {
 
 interface State {
   useCurrentTimeRange: boolean;
-  selectedTheme: SelectableValue<string>;
+  selectedTheme: string;
   iframeHtml: string;
 }
 
@@ -26,7 +26,7 @@ export class ShareEmbed extends PureComponent<Props, State> {
     super(props);
     this.state = {
       useCurrentTimeRange: true,
-      selectedTheme: themeOptions[0],
+      selectedTheme: 'current',
       iframeHtml: '',
     };
   }
@@ -39,7 +39,7 @@ export class ShareEmbed extends PureComponent<Props, State> {
     const { panel } = this.props;
     const { useCurrentTimeRange, selectedTheme } = this.state;
 
-    const iframeHtml = buildIframeHtml(useCurrentTimeRange, selectedTheme.value, panel);
+    const iframeHtml = buildIframeHtml(useCurrentTimeRange, selectedTheme, panel);
     this.setState({ iframeHtml });
   };
 
@@ -52,13 +52,8 @@ export class ShareEmbed extends PureComponent<Props, State> {
     );
   };
 
-  onThemeChange = (value: SelectableValue<string>) => {
-    this.setState(
-      {
-        selectedTheme: value,
-      },
-      this.buildIframeHtml
-    );
+  onThemeChange = (value: string) => {
+    this.setState({ selectedTheme: value }, this.buildIframeHtml);
   };
 
   render() {
@@ -83,19 +78,16 @@ export class ShareEmbed extends PureComponent<Props, State> {
                 />
               </Field>
               <Field label="Theme">
-                <Select width={20} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
+                <RadioButtonGroup options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
+              </Field>
+              <Field
+                label="Embed html"
+                description="The html code below can be pasted and included in another web page. Unless anonymous access is enabled, 
+                the user viewing that page need to be signed into grafana for the graph to load."
+              >
+                <TextArea rows={5} readOnly value={iframeHtml}></TextArea>
               </Field>
             </FieldSet>
-            <p className="share-modal-info-text">
-              The html code below can be pasted and included in another web page. Unless anonymous access is enabled,
-              the user viewing that page need to be signed into grafana for the graph to load.
-            </p>
-
-            <div className="gf-form-group gf-form--grow">
-              <div className="gf-form">
-                <textarea rows={5} data-share-panel-url className="gf-form-input" defaultValue={iframeHtml}></textarea>
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -77,33 +77,29 @@ export class ShareEmbed extends PureComponent<Props, State> {
       <div className="share-modal-body">
         <div className="share-modal-header">
           <div className="share-modal-content">
-            <FieldSet>
-              <Field
-                label="Current time range"
-                description={
-                  isRelativeTime ? 'Transforms the current relative time range to an absolute time range' : ''
-                }
-              >
-                <Switch
-                  id="share-current-time-range"
-                  value={useCurrentTimeRange}
-                  onChange={this.onUseCurrentTimeRangeChange}
-                />
-              </Field>
-              <Field label="Theme">
-                <RadioButtonGroup options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
-              </Field>
-              <Field
-                label="Embed html"
-                description="The html code below can be pasted and included in another web page. Unless anonymous access is enabled, 
+            <Field
+              label="Current time range"
+              description={isRelativeTime ? 'Transforms the current relative time range to an absolute time range' : ''}
+            >
+              <Switch
+                id="share-current-time-range"
+                value={useCurrentTimeRange}
+                onChange={this.onUseCurrentTimeRangeChange}
+              />
+            </Field>
+            <Field label="Theme">
+              <RadioButtonGroup options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
+            </Field>
+            <Field
+              label="Embed html"
+              description="The html code below can be pasted and included in another web page. Unless anonymous access is enabled, 
                 the user viewing that page need to be signed into grafana for the graph to load."
-              >
-                <TextArea rows={5} value={iframeHtml} onChange={this.onIframeHtmlChange}></TextArea>
-              </Field>
-              <ClipboardButton variant="primary" getText={this.getIframeHtml} onClipboardCopy={this.onIframeHtmlCopy}>
-                <Icon name="copy" /> Copy
-              </ClipboardButton>
-            </FieldSet>
+            >
+              <TextArea rows={5} value={iframeHtml} onChange={this.onIframeHtmlChange}></TextArea>
+            </Field>
+            <ClipboardButton variant="primary" getText={this.getIframeHtml} onClipboardCopy={this.onIframeHtmlCopy}>
+              <Icon name="copy" /> Copy
+            </ClipboardButton>
           </div>
         </div>
       </div>

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Select, Switch, Icon, InlineField } from '@grafana/ui';
+import { Select, Switch, Icon, Field, FieldSet } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { buildIframeHtml } from './utils';
@@ -17,7 +17,6 @@ interface Props {
 
 interface State {
   useCurrentTimeRange: boolean;
-  includeTemplateVars: boolean;
   selectedTheme: SelectableValue<string>;
   iframeHtml: string;
 }
@@ -27,7 +26,6 @@ export class ShareEmbed extends PureComponent<Props, State> {
     super(props);
     this.state = {
       useCurrentTimeRange: true,
-      includeTemplateVars: true,
       selectedTheme: themeOptions[0],
       iframeHtml: '',
     };
@@ -39,9 +37,9 @@ export class ShareEmbed extends PureComponent<Props, State> {
 
   buildIframeHtml = () => {
     const { panel } = this.props;
-    const { useCurrentTimeRange, includeTemplateVars, selectedTheme } = this.state;
+    const { useCurrentTimeRange, selectedTheme } = this.state;
 
-    const iframeHtml = buildIframeHtml(useCurrentTimeRange, includeTemplateVars, selectedTheme.value, panel);
+    const iframeHtml = buildIframeHtml(useCurrentTimeRange, selectedTheme.value, panel);
     this.setState({ iframeHtml });
   };
 
@@ -49,15 +47,6 @@ export class ShareEmbed extends PureComponent<Props, State> {
     this.setState(
       {
         useCurrentTimeRange: !this.state.useCurrentTimeRange,
-      },
-      this.buildIframeHtml
-    );
-  };
-
-  onIncludeTemplateVarsChange = () => {
-    this.setState(
-      {
-        includeTemplateVars: !this.state.includeTemplateVars,
       },
       this.buildIframeHtml
     );
@@ -73,32 +62,31 @@ export class ShareEmbed extends PureComponent<Props, State> {
   };
 
   render() {
-    const { useCurrentTimeRange, includeTemplateVars, selectedTheme, iframeHtml } = this.state;
+    const { useCurrentTimeRange, selectedTheme, iframeHtml } = this.state;
+    const isRelativeTime = this.props.dashboard ? this.props.dashboard.time.to === 'now' : false;
 
     return (
       <div className="share-modal-body">
         <div className="share-modal-header">
           <Icon name="link" className="share-modal-big-icon" size="xxl" />
           <div className="share-modal-content">
-            <div className="gf-form-group">
-              <InlineField labelWidth={24} label="Current time range">
+            <FieldSet>
+              <Field
+                label="Current time range"
+                description={
+                  isRelativeTime ? 'Transforms the current relative time range to an absolute time range' : ''
+                }
+              >
                 <Switch
                   id="share-current-time-range"
                   value={useCurrentTimeRange}
                   onChange={this.onUseCurrentTimeRangeChange}
                 />
-              </InlineField>
-              <InlineField labelWidth={24} label="Template variables">
-                <Switch
-                  id="share-template-variables"
-                  value={includeTemplateVars}
-                  onChange={this.onIncludeTemplateVarsChange}
-                />
-              </InlineField>
-              <InlineField labelWidth={24} label="Theme">
+              </Field>
+              <Field label="Theme">
                 <Select width={20} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
-              </InlineField>
-            </div>
+              </Field>
+            </FieldSet>
             <p className="share-modal-info-text">
               The html code below can be pasted and included in another web page. Unless anonymous access is enabled,
               the user viewing that page need to be signed into grafana for the graph to load.

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, PureComponent } from 'react';
-import { RadioButtonGroup, Switch, Field, FieldSet, TextArea, Icon, ClipboardButton } from '@grafana/ui';
+import { RadioButtonGroup, Switch, Field, TextArea, Icon, ClipboardButton } from '@grafana/ui';
 import { SelectableValue, AppEvents } from '@grafana/data';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { appEvents } from 'app/core/core';
@@ -77,6 +77,7 @@ export class ShareEmbed extends PureComponent<Props, State> {
       <div className="share-modal-body">
         <div className="share-modal-header">
           <div className="share-modal-content">
+            <p className="share-modal-info-text">Generate HTML for embedding an iframe with this panel.</p>
             <Field
               label="Current time range"
               description={isRelativeTime ? 'Transforms the current relative time range to an absolute time range' : ''}

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Select, Switch, Icon, Field, FieldSet } from '@grafana/ui';
+import { Select, Switch, Field, FieldSet } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { buildIframeHtml } from './utils';
@@ -68,7 +68,6 @@ export class ShareEmbed extends PureComponent<Props, State> {
     return (
       <div className="share-modal-body">
         <div className="share-modal-header">
-          <Icon name="link" className="share-modal-big-icon" size="xxl" />
           <div className="share-modal-content">
             <FieldSet>
               <Field

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -1,7 +1,8 @@
-import React, { PureComponent } from 'react';
-import { RadioButtonGroup, Switch, Field, FieldSet, TextArea } from '@grafana/ui';
-import { SelectableValue } from '@grafana/data';
+import React, { FormEvent, PureComponent } from 'react';
+import { RadioButtonGroup, Switch, Field, FieldSet, TextArea, Icon, ClipboardButton } from '@grafana/ui';
+import { SelectableValue, AppEvents } from '@grafana/data';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
+import { appEvents } from 'app/core/core';
 import { buildIframeHtml } from './utils';
 
 const themeOptions: Array<SelectableValue<string>> = [
@@ -43,6 +44,10 @@ export class ShareEmbed extends PureComponent<Props, State> {
     this.setState({ iframeHtml });
   };
 
+  onIframeHtmlChange = (event: FormEvent<HTMLTextAreaElement>) => {
+    this.setState({ iframeHtml: event.currentTarget.value });
+  };
+
   onUseCurrentTimeRangeChange = () => {
     this.setState(
       {
@@ -54,6 +59,14 @@ export class ShareEmbed extends PureComponent<Props, State> {
 
   onThemeChange = (value: string) => {
     this.setState({ selectedTheme: value }, this.buildIframeHtml);
+  };
+
+  onIframeHtmlCopy = () => {
+    appEvents.emit(AppEvents.alertSuccess, ['Content copied to clipboard']);
+  };
+
+  getIframeHtml = () => {
+    return this.state.iframeHtml;
   };
 
   render() {
@@ -85,8 +98,11 @@ export class ShareEmbed extends PureComponent<Props, State> {
                 description="The html code below can be pasted and included in another web page. Unless anonymous access is enabled, 
                 the user viewing that page need to be signed into grafana for the graph to load."
               >
-                <TextArea rows={5} readOnly value={iframeHtml}></TextArea>
+                <TextArea rows={5} value={iframeHtml} onChange={this.onIframeHtmlChange}></TextArea>
               </Field>
+              <ClipboardButton variant="primary" getText={this.getIframeHtml} onClipboardCopy={this.onIframeHtmlCopy}>
+                <Icon name="copy" /> Copy
+              </ClipboardButton>
             </FieldSet>
           </div>
         </div>

--- a/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { saveAs } from 'file-saver';
-import { Button, Field, Switch, Icon } from '@grafana/ui';
+import { Button, Field, Switch } from '@grafana/ui';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { DashboardExporter } from 'app/features/dashboard/components/DashExportModal';
 import { appEvents } from 'app/core/core';
@@ -90,7 +90,6 @@ export class ShareExport extends PureComponent<Props, State> {
     return (
       <div className="share-modal-body">
         <div className="share-modal-header">
-          <Icon name="cloud-upload" size="xxl" className="share-modal-big-icon" />
           <div className="share-modal-content">
             <Field label="Export for sharing externally">
               <Switch value={shareExternally} onChange={this.onShareExternallyChange} />

--- a/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
@@ -91,6 +91,7 @@ export class ShareExport extends PureComponent<Props, State> {
       <div className="share-modal-body">
         <div className="share-modal-header">
           <div className="share-modal-content">
+            <p className="share-modal-info-text">Export this dashboard.</p>
             <Field label="Export for sharing externally">
               <Switch value={shareExternally} onChange={this.onShareExternallyChange} />
             </Field>

--- a/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareExport.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { saveAs } from 'file-saver';
-import { Button, InlineField, Switch, Icon } from '@grafana/ui';
+import { Button, Field, Switch, Icon } from '@grafana/ui';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { DashboardExporter } from 'app/features/dashboard/components/DashExportModal';
 import { appEvents } from 'app/core/core';
@@ -92,9 +92,9 @@ export class ShareExport extends PureComponent<Props, State> {
         <div className="share-modal-header">
           <Icon name="cloud-upload" size="xxl" className="share-modal-big-icon" />
           <div className="share-modal-content">
-            <InlineField labelWidth={32} label="Export for sharing externally">
+            <Field label="Export for sharing externally">
               <Switch value={shareExternally} onChange={this.onShareExternallyChange} />
-            </InlineField>
+            </Field>
             <div className="gf-form-button-row">
               <Button variant="primary" onClick={this.onSaveAsFile}>
                 Save to file

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
@@ -175,35 +175,13 @@ describe('ShareModal', () => {
       expect(state?.imageUrl).toContain('?from=1000&to=2000&orgId=1&panelId=1&width=1000&height=500&tz=UTC');
     });
 
-    describe('template variables', () => {
-      beforeEach(() => {
-        templateSrv = initTemplateSrv([
-          { type: 'query', name: 'app', current: { value: 'mupp' } },
-          { type: 'query', name: 'server', current: { value: 'srv-01' } },
-        ]);
-        setTemplateSrv(templateSrv);
-      });
-
-      it('should include template variables in url', async () => {
-        mockLocationHref('http://server/#!/test');
-        ctx.mount();
-        ctx.wrapper?.setState({ includeTemplateVars: true });
-
+    it('should shorten url', () => {
+      mockLocationHref('http://server/#!/test');
+      ctx.mount();
+      ctx.wrapper?.setState({ useShortUrl: true }, async () => {
         await ctx.wrapper?.instance().buildUrl();
         const state = ctx.wrapper?.state();
-        expect(state?.shareUrl).toContain(
-          'http://server/#!/test?from=1000&to=2000&orgId=1&var-app=mupp&var-server=srv-01'
-        );
-      });
-
-      it('should shorten url', () => {
-        mockLocationHref('http://server/#!/test');
-        ctx.mount();
-        ctx.wrapper?.setState({ includeTemplateVars: true, useShortUrl: true }, async () => {
-          await ctx.wrapper?.instance().buildUrl();
-          const state = ctx.wrapper?.state();
-          expect(state?.shareUrl).toContain(`/goto/${mockUid}`);
-        });
+        expect(state?.shareUrl).toContain(`/goto/${mockUid}`);
       });
     });
   });

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
@@ -156,7 +156,7 @@ describe('ShareModal', () => {
 
     it('should add theme when specified', async () => {
       ctx.wrapper?.setProps({ panel: undefined });
-      ctx.wrapper?.setState({ selectedTheme: { label: 'light', value: 'light' } });
+      ctx.wrapper?.setState({ selectedTheme: 'light' });
 
       await ctx.wrapper?.instance().buildUrl();
       const state = ctx.wrapper?.state();

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -92,7 +92,6 @@ export class ShareLink extends PureComponent<Props, State> {
     return (
       <div className="share-modal-body">
         <div className="share-modal-header">
-          <Icon name="link" className="share-modal-big-icon" size="xxl" />
           <div className="share-modal-content">
             <p className="share-modal-info-text">
               Create a direct link to this dashboard or panel, customized with the options below.
@@ -118,15 +117,17 @@ export class ShareLink extends PureComponent<Props, State> {
               </Field>
             </FieldSet>
             <FieldSet>
-              <Input
-                value={shareUrl}
-                readOnly
-                addonAfter={
-                  <ClipboardButton variant="primary" getText={this.getShareUrl} onClipboardCopy={this.onShareUrlCopy}>
-                    <Icon name="copy" /> Copy
-                  </ClipboardButton>
-                }
-              />
+              <Field label="Link URL">
+                <Input
+                  value={shareUrl}
+                  readOnly
+                  addonAfter={
+                    <ClipboardButton variant="primary" getText={this.getShareUrl} onClipboardCopy={this.onShareUrlCopy}>
+                      <Icon name="copy" /> Copy
+                    </ClipboardButton>
+                  }
+                />
+              </Field>
             </FieldSet>
             {panel && config.rendererAvailable && (
               <div className="gf-form">

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
-import { Field, Select, Switch, ClipboardButton, Icon, InfoBox, Input, FieldSet } from '@grafana/ui';
+import { Field, RadioButtonGroup, Switch, ClipboardButton, Icon, InfoBox, Input, FieldSet } from '@grafana/ui';
 import { SelectableValue, PanelModel, AppEvents } from '@grafana/data';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { buildImageUrl, buildShareUrl } from './utils';
@@ -21,7 +21,7 @@ export interface Props {
 export interface State {
   useCurrentTimeRange: boolean;
   useShortUrl: boolean;
-  selectedTheme: SelectableValue<string>;
+  selectedTheme: string;
   shareUrl: string;
   imageUrl: string;
 }
@@ -32,7 +32,7 @@ export class ShareLink extends PureComponent<Props, State> {
     this.state = {
       useCurrentTimeRange: true,
       useShortUrl: false,
-      selectedTheme: themeOptions[0],
+      selectedTheme: 'current',
       shareUrl: '',
       imageUrl: '',
     };
@@ -46,7 +46,7 @@ export class ShareLink extends PureComponent<Props, State> {
     const { useCurrentTimeRange, useShortUrl, selectedTheme } = this.state;
     if (
       prevState.useCurrentTimeRange !== useCurrentTimeRange ||
-      prevState.selectedTheme.value !== selectedTheme.value ||
+      prevState.selectedTheme !== selectedTheme ||
       prevState.useShortUrl !== useShortUrl
     ) {
       this.buildUrl();
@@ -57,8 +57,8 @@ export class ShareLink extends PureComponent<Props, State> {
     const { panel } = this.props;
     const { useCurrentTimeRange, useShortUrl, selectedTheme } = this.state;
 
-    const shareUrl = await buildShareUrl(useCurrentTimeRange, selectedTheme.value, panel, useShortUrl);
-    const imageUrl = buildImageUrl(useCurrentTimeRange, selectedTheme.value, panel);
+    const shareUrl = await buildShareUrl(useCurrentTimeRange, selectedTheme, panel, useShortUrl);
+    const imageUrl = buildImageUrl(useCurrentTimeRange, selectedTheme, panel);
 
     this.setState({ shareUrl, imageUrl });
   };
@@ -71,7 +71,7 @@ export class ShareLink extends PureComponent<Props, State> {
     this.setState({ useShortUrl: !this.state.useShortUrl });
   };
 
-  onThemeChange = (value: SelectableValue<string>) => {
+  onThemeChange = (value: string) => {
     this.setState({ selectedTheme: value });
   };
 
@@ -110,7 +110,7 @@ export class ShareLink extends PureComponent<Props, State> {
                 />
               </Field>
               <Field label="Theme">
-                <Select width={20} options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
+                <RadioButtonGroup options={themeOptions} value={selectedTheme} onChange={this.onThemeChange} />
               </Field>
               <Field label="Shorten URL">
                 <Switch id="share-shorten-url" value={useShortUrl} onChange={this.onUrlShorten} />

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -115,8 +115,7 @@ export class ShareLink extends PureComponent<Props, State> {
               <Field label="Shorten URL">
                 <Switch id="share-shorten-url" value={useShortUrl} onChange={this.onUrlShorten} />
               </Field>
-            </FieldSet>
-            <FieldSet>
+
               <Field label="Link URL">
                 <Input
                   value={shareUrl}

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -8,9 +8,9 @@ import { appEvents } from 'app/core/core';
 import config from 'app/core/config';
 
 const themeOptions: Array<SelectableValue<string>> = [
-  { label: 'current', value: 'current' },
-  { label: 'dark', value: 'dark' },
-  { label: 'light', value: 'light' },
+  { label: 'Current', value: 'current' },
+  { label: 'Dark', value: 'dark' },
+  { label: 'Light', value: 'light' },
 ];
 
 export interface Props {

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -219,28 +219,26 @@ export class ShareSnapshot extends PureComponent<Props, State> {
             URL. Share wisely.
           </p>
         </div>
-        <FieldSet>
-          <Field label="Snapshot name">
-            <Input width={30} value={snapshotName} onChange={this.onSnapshotNameChange} />
-          </Field>
-          <Field label="Expire">
-            <Select width={30} options={expireOptions} value={selectedExpireOption} onChange={this.onExpireChange} />
-          </Field>
-          <Field
-            label="Timeout (seconds)"
-            description="You may need to configure the timeout value if it takes a long time to collect your dashboard's
+        <Field label="Snapshot name">
+          <Input width={30} value={snapshotName} onChange={this.onSnapshotNameChange} />
+        </Field>
+        <Field label="Expire">
+          <Select width={30} options={expireOptions} value={selectedExpireOption} onChange={this.onExpireChange} />
+        </Field>
+        <Field
+          label="Timeout (seconds)"
+          description="You may need to configure the timeout value if it takes a long time to collect your dashboard's
             metrics."
-          >
-            <Input type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} />
-          </Field>
-        </FieldSet>
+        >
+          <Input type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} />
+        </Field>
 
-        <div>
-          <Button className="width-10" variant="primary" disabled={isLoading} onClick={this.createSnapshot()}>
+        <div className="gf-form-button-row">
+          <Button variant="primary" disabled={isLoading} onClick={this.createSnapshot()}>
             Local Snapshot
           </Button>
           {externalEnabled && (
-            <Button className="width-16" variant="secondary" disabled={isLoading} onClick={this.createSnapshot(true)}>
+            <Button variant="secondary" disabled={isLoading} onClick={this.createSnapshot(true)}>
               {sharingButtonText}
             </Button>
           )}

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -235,7 +235,7 @@ export class ShareSnapshot extends PureComponent<Props, State> {
           </Field>
         </FieldSet>
 
-        <div className="gf-form-button-row">
+        <div>
           <Button className="width-10" variant="primary" disabled={isLoading} onClick={this.createSnapshot()}>
             Local Snapshot
           </Button>

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -1,15 +1,5 @@
 import React, { PureComponent } from 'react';
-import {
-  Button,
-  ClipboardButton,
-  Icon,
-  Spinner,
-  Select,
-  Input,
-  LinkButton,
-  InlineField,
-  InlineFieldRow,
-} from '@grafana/ui';
+import { Button, ClipboardButton, Icon, Spinner, Select, Input, LinkButton, Field, FieldSet } from '@grafana/ui';
 import { AppEvents, SelectableValue } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
@@ -229,24 +219,24 @@ export class ShareSnapshot extends PureComponent<Props, State> {
             URL. Share wisely.
           </p>
         </div>
-        <InlineFieldRow className="share-modal-options">
-          <InlineField labelWidth={24} label="Snapshot name">
+        <FieldSet>
+          <Field label="Snapshot name">
             <Input width={30} value={snapshotName} onChange={this.onSnapshotNameChange} />
-          </InlineField>
-          <InlineField labelWidth={24} label="Expire">
+          </Field>
+          <Field label="Expire">
             <Select width={30} options={expireOptions} value={selectedExpireOption} onChange={this.onExpireChange} />
-          </InlineField>
-        </InlineFieldRow>
+          </Field>
+        </FieldSet>
 
         <p className="share-modal-info-text">
           You may need to configure the timeout value if it takes a long time to collect your dashboard&apos;s metrics.
         </p>
 
-        <InlineFieldRow className="share-modal-options">
-          <InlineField labelWidth={24} label="Timeout (seconds)">
+        <FieldSet className="share-modal-options">
+          <Field label="Timeout (seconds)">
             <Input type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} />
-          </InlineField>
-        </InlineFieldRow>
+          </Field>
+        </FieldSet>
 
         <div className="gf-form-button-row">
           <Button className="width-10" variant="primary" disabled={isLoading} onClick={this.createSnapshot()}>

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -226,14 +226,11 @@ export class ShareSnapshot extends PureComponent<Props, State> {
           <Field label="Expire">
             <Select width={30} options={expireOptions} value={selectedExpireOption} onChange={this.onExpireChange} />
           </Field>
-        </FieldSet>
-
-        <p className="share-modal-info-text">
-          You may need to configure the timeout value if it takes a long time to collect your dashboard&apos;s metrics.
-        </p>
-
-        <FieldSet className="share-modal-options">
-          <Field label="Timeout (seconds)">
+          <Field
+            label="Timeout (seconds)"
+            description="You may need to configure the timeout value if it takes a long time to collect your dashboard's
+            metrics."
+          >
             <Input type="number" width={21} value={timeoutSeconds} onChange={this.onTimeoutChange} />
           </Field>
         </FieldSet>
@@ -299,17 +296,11 @@ export class ShareSnapshot extends PureComponent<Props, State> {
     return (
       <div className="share-modal-body">
         <div className="share-modal-header">
-          {isLoading ? (
-            <div className="share-modal-big-icon">
-              <Spinner inline={true} />
-            </div>
-          ) : (
-            <Icon name="camera" className="share-modal-big-icon" size="xxl" />
-          )}
           <div className="share-modal-content">
             {step === 1 && this.renderStep1()}
             {step === 2 && this.renderStep2()}
             {step === 3 && this.renderStep3()}
+            {isLoading && <Spinner inline={true} />}
           </div>
         </div>
       </div>

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Button, ClipboardButton, Icon, Spinner, Select, Input, LinkButton, Field, FieldSet } from '@grafana/ui';
+import { Button, ClipboardButton, Icon, Spinner, Select, Input, LinkButton, Field } from '@grafana/ui';
 import { AppEvents, SelectableValue } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';

--- a/public/app/features/dashboard/components/ShareModal/utils.ts
+++ b/public/app/features/dashboard/components/ShareModal/utils.ts
@@ -2,14 +2,8 @@ import { config } from '@grafana/runtime';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { createShortLink } from 'app/core/utils/shortLinks';
 import { PanelModel, dateTime, urlUtil } from '@grafana/data';
-import { getAllVariableValuesForUrl } from 'app/features/variables/getAllVariableValuesForUrl';
 
-export function buildParams(
-  useCurrentTimeRange: boolean,
-  includeTemplateVars: boolean,
-  selectedTheme?: string,
-  panel?: PanelModel
-) {
+export function buildParams(useCurrentTimeRange: boolean, selectedTheme?: string, panel?: PanelModel) {
   let params = urlUtil.getUrlSearchParams();
 
   const range = getTimeSrv().timeRange();
@@ -20,13 +14,6 @@ export function buildParams(
   if (!useCurrentTimeRange) {
     delete params.from;
     delete params.to;
-  }
-
-  if (includeTemplateVars) {
-    params = {
-      ...params,
-      ...getAllVariableValuesForUrl(),
-    };
   }
 
   if (selectedTheme !== 'current') {
@@ -55,13 +42,12 @@ export function buildBaseUrl() {
 
 export async function buildShareUrl(
   useCurrentTimeRange: boolean,
-  includeTemplateVars: boolean,
   selectedTheme?: string,
   panel?: PanelModel,
   shortenUrl?: boolean
 ) {
   const baseUrl = buildBaseUrl();
-  const params = buildParams(useCurrentTimeRange, includeTemplateVars, selectedTheme, panel);
+  const params = buildParams(useCurrentTimeRange, selectedTheme, panel);
   const shareUrl = urlUtil.appendQueryToUrl(baseUrl, urlUtil.toUrlParams(params));
   if (shortenUrl) {
     return await createShortLink(shareUrl);
@@ -69,14 +55,9 @@ export async function buildShareUrl(
   return shareUrl;
 }
 
-export function buildSoloUrl(
-  useCurrentTimeRange: boolean,
-  includeTemplateVars: boolean,
-  selectedTheme?: string,
-  panel?: PanelModel
-) {
+export function buildSoloUrl(useCurrentTimeRange: boolean, selectedTheme?: string, panel?: PanelModel) {
   const baseUrl = buildBaseUrl();
-  const params = buildParams(useCurrentTimeRange, includeTemplateVars, selectedTheme, panel);
+  const params = buildParams(useCurrentTimeRange, selectedTheme, panel);
 
   let soloUrl = baseUrl.replace(config.appSubUrl + '/dashboard/', config.appSubUrl + '/dashboard-solo/');
   soloUrl = soloUrl.replace(config.appSubUrl + '/d/', config.appSubUrl + '/d-solo/');
@@ -88,13 +69,8 @@ export function buildSoloUrl(
   return urlUtil.appendQueryToUrl(soloUrl, urlUtil.toUrlParams(params));
 }
 
-export function buildImageUrl(
-  useCurrentTimeRange: boolean,
-  includeTemplateVars: boolean,
-  selectedTheme?: string,
-  panel?: PanelModel
-) {
-  let soloUrl = buildSoloUrl(useCurrentTimeRange, includeTemplateVars, selectedTheme, panel);
+export function buildImageUrl(useCurrentTimeRange: boolean, selectedTheme?: string, panel?: PanelModel) {
+  let soloUrl = buildSoloUrl(useCurrentTimeRange, selectedTheme, panel);
 
   let imageUrl = soloUrl.replace(config.appSubUrl + '/dashboard-solo/', config.appSubUrl + '/render/dashboard-solo/');
   imageUrl = imageUrl.replace(config.appSubUrl + '/d-solo/', config.appSubUrl + '/render/d-solo/');
@@ -102,13 +78,8 @@ export function buildImageUrl(
   return imageUrl;
 }
 
-export function buildIframeHtml(
-  useCurrentTimeRange: boolean,
-  includeTemplateVars: boolean,
-  selectedTheme?: string,
-  panel?: PanelModel
-) {
-  let soloUrl = buildSoloUrl(useCurrentTimeRange, includeTemplateVars, selectedTheme, panel);
+export function buildIframeHtml(useCurrentTimeRange: boolean, selectedTheme?: string, panel?: PanelModel) {
+  let soloUrl = buildSoloUrl(useCurrentTimeRange, selectedTheme, panel);
   return '<iframe src="' + soloUrl + '" width="450" height="200" frameborder="0"></iframe>';
 }
 

--- a/public/sass/components/_modals.scss
+++ b/public/sass/components/_modals.scss
@@ -127,12 +127,6 @@
 }
 
 .share-modal-body {
-  padding: 10px 0;
-
-  .tight-form {
-    text-align: left;
-  }
-
   .share-modal-options {
     margin: 11px 0px 33px 0px;
     display: inline-block;
@@ -158,10 +152,6 @@
 
   .share-modal-content {
     flex-grow: 1;
-  }
-
-  .tight-form {
-    text-align: left;
   }
 
   .share-modal-link {


### PR DESCRIPTION
Also updates the styling of the ShareModal

**What this PR does / why we need it**:
The option to not use the template variables does not make sense if the dashboard/panel depends on template variables. The option is not respected by the link generator.

The styling is out of date and should be updated.

Fixes #29191
