### PR TITLE
Docs: Update Document Content Security Policy options

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -508,6 +508,14 @@ Set to `true` to enable the X-Content-Type-Options response header. The X-Conten
 
 Set to `false` to disable the X-XSS-Protection header, which tells browsers to stop pages from loading when they detect reflected cross-site scripting (XSS) attacks. The default value is `false` until the next minor release, `6.3`.
 
+### content_security_policy
+
+Set to `true` to add the Content-Security-Policy header to your requests. CSP allows to control resources the user agent is allowed to load and helps prevent XSS attacks.
+
+### content_security_policy_template
+
+Set Content Security Policy template used when adding the Content-Security-Policy header to your requests. `$NONCE` in the template includes a random nonce.
+
 <hr />
 
 ## [snapshots]

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -510,7 +510,7 @@ Set to `false` to disable the X-XSS-Protection header, which tells browsers to s
 
 ### content_security_policy
 
-Set to `true` to add the Content-Security-Policy header to your requests. CSP allows to control resources the user agent is allowed to load and helps prevent XSS attacks.
+Set to `true` to add the Content-Security-Policy header to your requests. CSP allows to control resources that the user agent can load and helps prevent XSS attacks.
 
 ### content_security_policy_template
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update docs/sources/administration/configuration.md with Content Security Policy options.

Fixes #30411.