### PR TITLE
GraphNG: assume uPlot's series stroke is always a function

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -48,8 +48,8 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({ mode = 'single', t
             <SeriesTable
               series={[
                 {
-                  // stroke is typed as CanvasRenderingContext2D['strokeStyle'] - we are using strings only for now
-                  color: plotContext.getSeries()[focusedSeriesIdx!].stroke as string,
+                  // TODO: align with uPlot typings
+                  color: (plotContext.getSeries()[focusedSeriesIdx!].stroke as any)(),
                   label: getFieldDisplayName(field, data),
                   value: fieldFmt(field.values.get(focusedPointIdx)).text,
                 },
@@ -76,8 +76,8 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({ mode = 'single', t
                 return [
                   ...agg,
                   {
-                    // stroke is typed as CanvasRenderingContext2D['strokeStyle'] - we are using strings only for now
-                    color: plotContext.getSeries()[i].stroke as string,
+                    // TODO: align with uPlot typings
+                    color: (plotContext.getSeries()[i].stroke as any)!(),
                     label: getFieldDisplayName(f, data),
                     value: formattedValueToString(f.display!(f.values.get(focusedPointIdx!))),
                     isActive: focusedSeriesIdx === i,


### PR DESCRIPTION
Fixes toolitps's series icon not being visible.

But... I have questions and this PR will require followup. Since in the tooltip plugin we are using uPlot's series config to retrieve the series color, we used assume stroke is not a function (according to https://github.com/leeoniya/uPlot/blob/71994d3a6f79cbf478ecf3880205880cc4a17037/dist/uPlot.d.ts#L645 and https://github.com/leeoniya/uPlot/blob/71994d3a6f79cbf478ecf3880205880cc4a17037/dist/uPlot.d.ts#L544 typings). Investigating the code though I found this line https://github.com/leeoniya/uPlot/blob/master/src/uPlot.js#L759 that converts no matter what stroke value to a function. Which leads me to a question what is the missmatch here? Is the typing wrong or is it the stroke type returned incorrect @leeoniya?