### PR TITLE
Loki: Append refId to logs uid

### DIFF
--- a/public/app/plugins/datasource/loki/live_streams.test.ts
+++ b/public/app/plugins/datasource/loki/live_streams.test.ts
@@ -29,7 +29,7 @@ describe('Live Stream Tests', () => {
     dropped_entries: null,
   };
 
-  it('reads the values into the buffer', done => {
+  it('reads the values into the buffer', (done) => {
     fakeSocket = new Subject<any>();
     const labels: Labels = { job: 'varlogs' };
     const target = makeTarget('fake', labels);
@@ -55,7 +55,7 @@ describe('Live Stream Tests', () => {
       },
     ];
     stream.subscribe({
-      next: val => {
+      next: (val) => {
         const test = tests.shift();
         test!(val);
       },
@@ -140,7 +140,7 @@ describe('Live Stream Tests', () => {
       })
     ) as any;
     const liveStreams = new LiveStreams();
-    await expect(liveStreams.getStream(makeTarget('url_to_match'), 100)).toEmitValuesWith(received => {
+    await expect(liveStreams.getStream(makeTarget('url_to_match'), 100)).toEmitValuesWith((received) => {
       const data = received[0];
       const view = new DataFrameView(data[0]);
       const firstLog = { ...view.get(0) };

--- a/public/app/plugins/datasource/loki/live_streams.test.ts
+++ b/public/app/plugins/datasource/loki/live_streams.test.ts
@@ -48,7 +48,7 @@ describe('Live Stream Tests', () => {
         expect(last).toEqual({
           ts: '2019-08-28T20:50:40.118Z',
           tsNs: '1567025440118944705',
-          id: '8c50d09800ce8dda69a2ff25405c9f65',
+          id: '8c50d09800ce8dda69a2ff25405c9f65_A',
           line: 'Kittens',
           labels: { filename: '/var/log/sntpc.log' },
         });

--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -36,6 +36,7 @@ export class LiveStreams {
     data.addField({ name: 'labels', type: FieldType.other }); // The labels for each line
     data.addField({ name: 'id', type: FieldType.string });
     data.meta = { ...data.meta, preferredVisualisationType: 'logs' };
+    data.refId = target.refId;
 
     stream = webSocket(target.url).pipe(
       map((response: LokiTailResponse) => {

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -67,7 +67,7 @@ describe('loki result transformer', () => {
 
   describe('lokiStreamResultToDataFrame', () => {
     it('converts streams to series', () => {
-      const data = streamResult.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream));
+      const data = streamResult.map(stream => ResultTransformer.lokiStreamResultToDataFrame(stream));
 
       expect(data.length).toBe(2);
       expect(data[0].fields[1].labels!['foo']).toEqual('bar');
@@ -132,7 +132,7 @@ describe('loki result transformer', () => {
       });
 
       expect(ResultTransformer.enhanceDataFrame).toBeCalled();
-      dataFrames.forEach((frame) => {
+      dataFrames.forEach(frame => {
         expect(
           frame.fields.filter(field => field.name === 'test' && field.type === 'string').length
         ).toBeGreaterThanOrEqual(1);

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -67,7 +67,7 @@ describe('loki result transformer', () => {
 
   describe('lokiStreamResultToDataFrame', () => {
     it('converts streams to series', () => {
-      const data = streamResult.map(stream => ResultTransformer.lokiStreamResultToDataFrame(stream));
+      const data = streamResult.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream));
 
       expect(data.length).toBe(2);
       expect(data[0].fields[1].labels!['foo']).toEqual('bar');
@@ -101,7 +101,7 @@ describe('loki result transformer', () => {
         },
       ];
 
-      const data = streamResultWithDuplicateLogs.map(stream => ResultTransformer.lokiStreamResultToDataFrame(stream));
+      const data = streamResultWithDuplicateLogs.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream));
 
       expect(data[0].fields[2].values.get(0)).toEqual('65cee200875f58ee1430d8bd2e8b74e7');
       expect(data[0].fields[2].values.get(1)).toEqual('65cee200875f58ee1430d8bd2e8b74e7_1');
@@ -111,7 +111,7 @@ describe('loki result transformer', () => {
     });
 
     it('should append refId to the unique ids if refId is provided', () => {
-      const data = streamResult.map(stream => ResultTransformer.lokiStreamResultToDataFrame(stream, false, 'B'));
+      const data = streamResult.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream, false, 'B'));
       expect(data.length).toBe(2);
       expect(data[0].fields[2].values.get(0)).toEqual('2b431b8a98b80b3b2c2f4cd2444ae6cb_B');
       expect(data[1].fields[2].values.get(0)).toEqual('75d73d66cff40f9d1a1f2d5a0bf295d0_B');
@@ -132,9 +132,9 @@ describe('loki result transformer', () => {
       });
 
       expect(ResultTransformer.enhanceDataFrame).toBeCalled();
-      dataFrames.forEach(frame => {
+      dataFrames.forEach((frame) => {
         expect(
-          frame.fields.filter(field => field.name === 'test' && field.type === 'string').length
+          frame.fields.filter((field) => field.name === 'test' && field.type === 'string').length
         ).toBeGreaterThanOrEqual(1);
       });
     });

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -109,6 +109,13 @@ describe('loki result transformer', () => {
       expect(data[0].fields[2].values.get(3)).toEqual('65cee200875f58ee1430d8bd2e8b74e7_2');
       expect(data[1].fields[2].values.get(0)).not.toEqual('65cee200875f58ee1430d8bd2e8b74e7_3');
     });
+
+    it('should append refId to the unique ids if refId is provided', () => {
+      const data = streamResult.map(stream => ResultTransformer.lokiStreamResultToDataFrame(stream, false, 'B'));
+      expect(data.length).toBe(2);
+      expect(data[0].fields[2].values.get(0)).toEqual('2b431b8a98b80b3b2c2f4cd2444ae6cb_B');
+      expect(data[1].fields[2].values.get(0)).toEqual('75d73d66cff40f9d1a1f2d5a0bf295d0_B');
+    });
   });
 
   describe('lokiStreamsToDataFrames', () => {
@@ -196,14 +203,15 @@ describe('loki result transformer', () => {
       data.addField({ name: 'line', type: FieldType.string }).labels = { job: 'grafana' };
       data.addField({ name: 'labels', type: FieldType.other });
       data.addField({ name: 'id', type: FieldType.string });
+      data.refId = 'C';
 
       ResultTransformer.appendResponseToBufferedData(tailResponse, data);
-      expect(data.get(0).id).toEqual('870e4d105741bdfc2c67904ee480d4f3');
-      expect(data.get(1).id).toEqual('870e4d105741bdfc2c67904ee480d4f3_1');
-      expect(data.get(2).id).toEqual('707e4ec2b842f389dbb993438505856d');
-      expect(data.get(3).id).toEqual('78f044015a58fad3e257a855b167d85e');
-      expect(data.get(4).id).toEqual('870e4d105741bdfc2c67904ee480d4f3_2');
-      expect(data.get(5).id).toEqual('707e4ec2b842f389dbb993438505856d_1');
+      expect(data.get(0).id).toEqual('870e4d105741bdfc2c67904ee480d4f3_C');
+      expect(data.get(1).id).toEqual('870e4d105741bdfc2c67904ee480d4f3_1_C');
+      expect(data.get(2).id).toEqual('707e4ec2b842f389dbb993438505856d_C');
+      expect(data.get(3).id).toEqual('78f044015a58fad3e257a855b167d85e_C');
+      expect(data.get(4).id).toEqual('870e4d105741bdfc2c67904ee480d4f3_2_C');
+      expect(data.get(5).id).toEqual('707e4ec2b842f389dbb993438505856d_1_C');
     });
   });
 

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -67,7 +67,7 @@ describe('loki result transformer', () => {
 
   describe('lokiStreamResultToDataFrame', () => {
     it('converts streams to series', () => {
-      const data = streamResult.map(stream => ResultTransformer.lokiStreamResultToDataFrame(stream));
+      const data = streamResult.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream));
 
       expect(data.length).toBe(2);
       expect(data[0].fields[1].labels!['foo']).toEqual('bar');
@@ -132,7 +132,7 @@ describe('loki result transformer', () => {
       });
 
       expect(ResultTransformer.enhanceDataFrame).toBeCalled();
-      dataFrames.forEach(frame => {
+      dataFrames.forEach((frame) => {
         expect(
           frame.fields.filter(field => field.name === 'test' && field.type === 'string').length
         ).toBeGreaterThanOrEqual(1);

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -248,7 +248,7 @@ export function lokiResultsToTableModel(
   ];
 
   // Populate rows, set value to empty string when label not present.
-  lokiResults.forEach(series => {
+  lokiResults.forEach((series) => {
     const newSeries: LokiMatrixResult = {
       metric: series.metric,
       values: (series as LokiVectorResult).value
@@ -266,7 +266,7 @@ export function lokiResultsToTableModel(
       table.rows.push(
         ...newSeries.values.map(([a, b]) => [
           a * 1000,
-          ...sortedLabels.map(label => newSeries.metric[label] || ''),
+          ...sortedLabels.map((label) => newSeries.metric[label] || ''),
           parseFloat(b),
         ])
       );
@@ -297,13 +297,13 @@ function getOriginalMetricName(labelData: { [key: string]: string }) {
   const metricName = labelData.__name__ || '';
   delete labelData.__name__;
   const labelPart = Object.entries(labelData)
-    .map(label => `${label[0]}="${label[1]}"`)
+    .map((label) => `${label[0]}="${label[1]}"`)
     .join(',');
   return `${metricName}{${labelPart}}`;
 }
 
 export function decamelize(s: string): string {
-  return s.replace(/[A-Z]/g, m => ` ${m.toLowerCase()}`);
+  return s.replace(/[A-Z]/g, (m) => ` ${m.toLowerCase()}`);
 }
 
 // Turn loki stats { metric: value } into meta stat { title: metric, value: value }
@@ -356,11 +356,11 @@ export function lokiStreamsToDataFrames(
     preferredVisualisationType: 'logs',
   };
 
-  const series: DataFrame[] = data.map(stream => {
+  const series: DataFrame[] = data.map((stream) => {
     const dataFrame = lokiStreamResultToDataFrame(stream, reverse, target.refId);
     enhanceDataFrame(dataFrame, config);
 
-    if (meta.custom && dataFrame.fields.some(f => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {
+    if (meta.custom && dataFrame.fields.some((f) => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {
       meta.custom.error = 'Error when parsing some of the logs';
     }
 
@@ -483,11 +483,11 @@ export function rangeQueryResponseToTimeSeries(
 
   switch (response.data.resultType) {
     case LokiResultType.Vector:
-      return response.data.result.map(vecResult =>
+      return response.data.result.map((vecResult) =>
         lokiMatrixToTimeSeries({ metric: vecResult.metric, values: [vecResult.value] }, transformerOptions)
       );
     case LokiResultType.Matrix:
-      return response.data.result.map(matrixResult => lokiMatrixToTimeSeries(matrixResult, transformerOptions));
+      return response.data.result.map((matrixResult) => lokiMatrixToTimeSeries(matrixResult, transformerOptions));
     default:
       return [];
   }

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -243,12 +243,12 @@ export function lokiResultsToTableModel(
   table.meta = meta;
   table.columns = [
     { text: 'Time', type: FieldType.time },
-    ...sortedLabels.map(label => ({ text: label, filterable: true, type: FieldType.string })),
+    ...sortedLabels.map((label) => ({ text: label, filterable: true, type: FieldType.string })),
     { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value', type: FieldType.number },
   ];
 
   // Populate rows, set value to empty string when label not present.
-  lokiResults.forEach(series => {
+  lokiResults.forEach((series) => {
     const newSeries: LokiMatrixResult = {
       metric: series.metric,
       values: (series as LokiVectorResult).value
@@ -266,7 +266,7 @@ export function lokiResultsToTableModel(
       table.rows.push(
         ...newSeries.values.map(([a, b]) => [
           a * 1000,
-          ...sortedLabels.map(label => newSeries.metric[label] || ''),
+          ...sortedLabels.map((label) => newSeries.metric[label] || ''),
           parseFloat(b),
         ])
       );
@@ -297,13 +297,13 @@ function getOriginalMetricName(labelData: { [key: string]: string }) {
   const metricName = labelData.__name__ || '';
   delete labelData.__name__;
   const labelPart = Object.entries(labelData)
-    .map(label => `${label[0]}="${label[1]}"`)
+    .map((label) => `${label[0]}="${label[1]}"`)
     .join(',');
   return `${metricName}{${labelPart}}`;
 }
 
 export function decamelize(s: string): string {
-  return s.replace(/[A-Z]/g, m => ` ${m.toLowerCase()}`);
+  return s.replace(/[A-Z]/g, (m) => ` ${m.toLowerCase()}`);
 }
 
 // Turn loki stats { metric: value } into meta stat { title: metric, value: value }
@@ -356,11 +356,11 @@ export function lokiStreamsToDataFrames(
     preferredVisualisationType: 'logs',
   };
 
-  const series: DataFrame[] = data.map(stream => {
+  const series: DataFrame[] = data.map((stream) => {
     const dataFrame = lokiStreamResultToDataFrame(stream, reverse, target.refId);
     enhanceDataFrame(dataFrame, config);
 
-    if (meta.custom && dataFrame.fields.some(f => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {
+    if (meta.custom && dataFrame.fields.some((f) => f.labels && Object.keys(f.labels).some((l) => l === '__error__'))) {
       meta.custom.error = 'Error when parsing some of the logs';
     }
 
@@ -483,11 +483,11 @@ export function rangeQueryResponseToTimeSeries(
 
   switch (response.data.resultType) {
     case LokiResultType.Vector:
-      return response.data.result.map(vecResult =>
+      return response.data.result.map((vecResult) =>
         lokiMatrixToTimeSeries({ metric: vecResult.metric, values: [vecResult.value] }, transformerOptions)
       );
     case LokiResultType.Matrix:
-      return response.data.result.map(matrixResult => lokiMatrixToTimeSeries(matrixResult, transformerOptions));
+      return response.data.result.map((matrixResult) => lokiMatrixToTimeSeries(matrixResult, transformerOptions));
     default:
       return [];
   }

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -61,7 +61,7 @@ export function lokiStreamResultToDataFrame(stream: LokiStreamResult, reverse?: 
     times.add(new Date(parseInt(ts.substr(0, ts.length - 6), 10)).toISOString());
     timesNs.add(ts);
     lines.add(line);
-    uids.add(createUid(ts, labelsString, line, usedUids));
+    uids.add(createUid(ts, labelsString, line, usedUids, refId));
   }
 
   return constructDataFrame(times, timesNs, lines, uids, labels, reverse, refId);
@@ -148,12 +148,12 @@ export function appendResponseToBufferedData(response: LokiTailResponse, data: M
       tsNsField.values.add(ts);
       lineField.values.add(line);
       labelsField.values.add(unique);
-      idField.values.add(createUid(ts, allLabelsString, line, usedUids));
+      idField.values.add(createUid(ts, allLabelsString, line, usedUids, data.refId));
     }
   }
 }
 
-function createUid(ts: string, labelsString: string, line: string, usedUids: any): string {
+function createUid(ts: string, labelsString: string, line: string, usedUids: any, refId?: string): string {
   // Generate id as hashed nanosecond timestamp, labels and line (this does not have to be unique)
   let id = md5(`${ts}_${labelsString}_${line}`);
 
@@ -170,6 +170,9 @@ function createUid(ts: string, labelsString: string, line: string, usedUids: any
     usedUids[id] = 0;
   }
   // Return unique id
+  if (refId) {
+    return `${id}_${refId}`;
+  }
   return id;
 }
 
@@ -354,7 +357,7 @@ export function lokiStreamsToDataFrames(
   };
 
   const series: DataFrame[] = data.map(stream => {
-    const dataFrame = lokiStreamResultToDataFrame(stream, reverse);
+    const dataFrame = lokiStreamResultToDataFrame(stream, reverse, target.refId);
     enhanceDataFrame(dataFrame, config);
 
     if (meta.custom && dataFrame.fields.some(f => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -248,7 +248,7 @@ export function lokiResultsToTableModel(
   ];
 
   // Populate rows, set value to empty string when label not present.
-  lokiResults.forEach((series) => {
+  lokiResults.forEach(series => {
     const newSeries: LokiMatrixResult = {
       metric: series.metric,
       values: (series as LokiVectorResult).value
@@ -266,7 +266,7 @@ export function lokiResultsToTableModel(
       table.rows.push(
         ...newSeries.values.map(([a, b]) => [
           a * 1000,
-          ...sortedLabels.map((label) => newSeries.metric[label] || ''),
+          ...sortedLabels.map(label => newSeries.metric[label] || ''),
           parseFloat(b),
         ])
       );
@@ -297,13 +297,13 @@ function getOriginalMetricName(labelData: { [key: string]: string }) {
   const metricName = labelData.__name__ || '';
   delete labelData.__name__;
   const labelPart = Object.entries(labelData)
-    .map((label) => `${label[0]}="${label[1]}"`)
+    .map(label => `${label[0]}="${label[1]}"`)
     .join(',');
   return `${metricName}{${labelPart}}`;
 }
 
 export function decamelize(s: string): string {
-  return s.replace(/[A-Z]/g, (m) => ` ${m.toLowerCase()}`);
+  return s.replace(/[A-Z]/g, m => ` ${m.toLowerCase()}`);
 }
 
 // Turn loki stats { metric: value } into meta stat { title: metric, value: value }
@@ -356,11 +356,11 @@ export function lokiStreamsToDataFrames(
     preferredVisualisationType: 'logs',
   };
 
-  const series: DataFrame[] = data.map((stream) => {
+  const series: DataFrame[] = data.map(stream => {
     const dataFrame = lokiStreamResultToDataFrame(stream, reverse, target.refId);
     enhanceDataFrame(dataFrame, config);
 
-    if (meta.custom && dataFrame.fields.some((f) => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {
+    if (meta.custom && dataFrame.fields.some(f => f.labels && Object.keys(f.labels).some(l => l === '__error__'))) {
       meta.custom.error = 'Error when parsing some of the logs';
     }
 
@@ -483,11 +483,11 @@ export function rangeQueryResponseToTimeSeries(
 
   switch (response.data.resultType) {
     case LokiResultType.Vector:
-      return response.data.result.map((vecResult) =>
+      return response.data.result.map(vecResult =>
         lokiMatrixToTimeSeries({ metric: vecResult.metric, values: [vecResult.value] }, transformerOptions)
       );
     case LokiResultType.Matrix:
-      return response.data.result.map((matrixResult) => lokiMatrixToTimeSeries(matrixResult, transformerOptions));
+      return response.data.result.map(matrixResult => lokiMatrixToTimeSeries(matrixResult, transformerOptions));
     default:
       return [];
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Following issue was noticed by @annanay25. If we run 2 or more log queries which are equal (can happen if we switch from prometheus queries that use the same labels), the log uids for the same logs, received from different query rows, that are later used for keys in `LogRow` are the same (and not unique). And then, when we remove query rows with duplicated queries, old logs that should be removed are still visible cause React didn't know which log rows should it remove, as keys are duplicated. This is probably too confusing so see the the video below or check this [slack thread](https://raintank-corp.slack.com/archives/C036J5B39/p1611057767040200). 🙈 


