### PR TITLE
Graph: Fixes so only users with correct permissions can add annotations

### DIFF
--- a/public/app/features/annotations/annotation_tooltip.ts
+++ b/public/app/features/annotations/annotation_tooltip.ts
@@ -59,7 +59,7 @@ export function annotationTooltipDirective(
       `;
 
       // Show edit icon only for users with at least Editor role
-      if (event.id && dashboard.meta.canEdit) {
+      if (event.id && dashboard.canAddAnnotations()) {
         header += `
           <span class="pointer graph-annotation__edit-icon" ng-click="onEdit()">
             <i class="fa fa-pencil-square"></i>

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -684,4 +684,25 @@ describe('DashboardModel', () => {
       expect(legendsOn.length).toBe(0);
     });
   });
+
+  describe('canAddAnnotations', () => {
+    it.each`
+      canEdit  | canMakeEditable | expected
+      ${false} | ${false}        | ${false}
+      ${false} | ${true}         | ${true}
+      ${true}  | ${false}        | ${true}
+      ${true}  | ${true}         | ${true}
+    `(
+      'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable} and expected:{$expected}',
+      ({ canEdit, canMakeEditable, expected }) => {
+        const dashboard = new DashboardModel({});
+        dashboard.meta.canEdit = canEdit;
+        dashboard.meta.canMakeEditable = canMakeEditable;
+
+        const result = dashboard.canAddAnnotations();
+
+        expect(result).toBe(expected);
+      }
+    );
+  });
 });

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1016,6 +1016,10 @@ export class DashboardModel {
     return this.getVariablesFromState();
   };
 
+  canAddAnnotations() {
+    return this.meta.canEdit || this.meta.canMakeEditable;
+  }
+
   private getPanelRepeatVariable(panel: PanelModel) {
     return this.getVariablesFromState().find((variable) => variable.name === panel.repeat);
   }

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -180,7 +180,7 @@ class GraphElement {
       return;
     }
 
-    if ((ranges.ctrlKey || ranges.metaKey) && (this.dashboard.meta.canEdit || this.dashboard.meta.canMakeEditable)) {
+    if ((ranges.ctrlKey || ranges.metaKey) && this.canAddAnnotations()) {
       // Add annotation
       setTimeout(() => {
         this.eventManager.updateTime(ranges.xaxis);
@@ -201,7 +201,7 @@ class GraphElement {
   ): (() => MenuItemsGroup[]) => {
     return () => {
       // Fixed context menu items
-      const items: MenuItemsGroup[] = this.dashboard?.editable
+      const items: MenuItemsGroup[] = this.canAddAnnotations()
         ? [
             {
               items: [
@@ -253,7 +253,7 @@ class GraphElement {
       }
 
       // skip if dashboard is not saved yet (exists in db) or user cannot edit
-      if (!this.dashboard.id || (!this.dashboard.meta.canEdit && !this.dashboard.meta.canMakeEditable)) {
+      if (!this.dashboard.id || !this.canAddAnnotations()) {
         return;
       }
 
@@ -924,6 +924,10 @@ class GraphElement {
       }
       return formattedValueToString(formatter(val, axis.tickDecimals, axis.scaledDecimals));
     };
+  }
+
+  canAddAnnotations() {
+    return (this.dashboard.meta.canEdit || this.dashboard.meta.canMakeEditable) && this.dashboard.editable;
   }
 }
 

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -180,7 +180,7 @@ class GraphElement {
       return;
     }
 
-    if ((ranges.ctrlKey || ranges.metaKey) && this.canAddAnnotations()) {
+    if ((ranges.ctrlKey || ranges.metaKey) && this.dashboard.canAddAnnotations()) {
       // Add annotation
       setTimeout(() => {
         this.eventManager.updateTime(ranges.xaxis);
@@ -201,7 +201,7 @@ class GraphElement {
   ): (() => MenuItemsGroup[]) => {
     return () => {
       // Fixed context menu items
-      const items: MenuItemsGroup[] = this.canAddAnnotations()
+      const items: MenuItemsGroup[] = this.dashboard.canAddAnnotations()
         ? [
             {
               items: [
@@ -253,7 +253,7 @@ class GraphElement {
       }
 
       // skip if dashboard is not saved yet (exists in db) or user cannot edit
-      if (!this.dashboard.id || !this.canAddAnnotations()) {
+      if (!this.dashboard.id || !this.dashboard.canAddAnnotations()) {
         return;
       }
 
@@ -924,10 +924,6 @@ class GraphElement {
       }
       return formattedValueToString(formatter(val, axis.tickDecimals, axis.scaledDecimals));
     };
-  }
-
-  canAddAnnotations() {
-    return (this.dashboard.meta.canEdit || this.dashboard.meta.canMakeEditable) && this.dashboard.editable;
   }
 }
 

--- a/public/app/plugins/panel/graph/specs/graph.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph.test.ts
@@ -1,3 +1,14 @@
+import '../module';
+import { GraphCtrl } from '../module';
+import { MetricsPanelCtrl } from 'app/features/panel/metrics_panel_ctrl';
+import { PanelCtrl } from 'app/features/panel/panel_ctrl';
+import config from 'app/core/config';
+
+import TimeSeries from 'app/core/time_series2';
+import $ from 'jquery';
+import { graphDirective, GraphElement } from '../graph';
+import { dateTime, EventBusSrv } from '@grafana/data';
+
 jest.mock('app/features/annotations/all', () => ({
   EventManager: () => {
     return {
@@ -15,17 +26,6 @@ jest.mock('app/core/core', () => ({
     on: () => {},
   },
 }));
-
-import '../module';
-import { GraphCtrl } from '../module';
-import { MetricsPanelCtrl } from 'app/features/panel/metrics_panel_ctrl';
-import { PanelCtrl } from 'app/features/panel/panel_ctrl';
-import config from 'app/core/config';
-
-import TimeSeries from 'app/core/time_series2';
-import $ from 'jquery';
-import { graphDirective, GraphElement } from '../graph';
-import { dateTime, EventBusSrv } from '@grafana/data';
 
 const ctx = {} as any;
 let ctrl: any;
@@ -1288,25 +1288,23 @@ describe('grafanaGraph', () => {
   });
 
   describe('getContextMenuItemsSupplier', () => {
-    function getGraphElement({ editable }: { editable?: boolean } = {}) {
-      const element = new GraphElement(
-        {
-          ctrl: {
-            contextMenuCtrl: {},
-            dashboard: { editable, events: { on: jest.fn() } },
-            events: { on: jest.fn() },
-          },
-        },
-        { mouseleave: jest.fn(), bind: jest.fn() } as any,
-        {} as any
-      );
-
-      return element;
-    }
-
-    describe('when called and dashboard is editable', () => {
+    describe('when called and dashboard is editable and user can edit the dashboard', () => {
       it('then the correct menu items should be returned', () => {
-        const element = getGraphElement({ editable: true });
+        const element = getGraphElement({ editable: true, canEdit: true, canMakeEditable: false });
+
+        const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
+
+        expect(result.length).toEqual(1);
+        expect(result[0].items.length).toEqual(1);
+        expect(result[0].items[0].label).toEqual('Add annotation');
+        expect(result[0].items[0].icon).toEqual('comment-alt');
+        expect(result[0].items[0].onClick).toBeDefined();
+      });
+    });
+
+    describe('when called and dashboard is editable and user can make the dashboard editable', () => {
+      it('then the correct menu items should be returned', () => {
+        const element = getGraphElement({ editable: true, canEdit: false, canMakeEditable: true });
 
         const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
 
@@ -1320,7 +1318,27 @@ describe('grafanaGraph', () => {
 
     describe('when called and dashboard is not editable', () => {
       it('then the correct menu items should be returned', () => {
-        const element = getGraphElement({ editable: false });
+        const element = getGraphElement({ editable: false, canMakeEditable: true, canEdit: true });
+
+        const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
+
+        expect(result.length).toEqual(0);
+      });
+    });
+
+    describe('when called and dashboard is editable and user can not make the dashboard editable', () => {
+      it('then the correct menu items should be returned', () => {
+        const element = getGraphElement({ editable: true, canMakeEditable: false });
+
+        const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
+
+        expect(result.length).toEqual(0);
+      });
+    });
+
+    describe('when called and dashboard is editable and user can not edit the dashboard', () => {
+      it('then the correct menu items should be returned', () => {
+        const element = getGraphElement({ editable: true, canEdit: false });
 
         const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
 
@@ -1328,4 +1346,43 @@ describe('grafanaGraph', () => {
       });
     });
   });
+
+  describe('canAddAnnotations', () => {
+    it.each`
+      canEdit  | canMakeEditable | editable | expected
+      ${false} | ${false}        | ${false} | ${false}
+      ${false} | ${false}        | ${true}  | ${false}
+      ${false} | ${true}         | ${false} | ${false}
+      ${true}  | ${false}        | ${false} | ${false}
+      ${false} | ${true}         | ${true}  | ${true}
+      ${true}  | ${false}        | ${true}  | ${true}
+      ${true}  | ${true}         | ${true}  | ${true}
+    `('when called with value:{$value}', ({ canEdit, canMakeEditable, editable, expected }) => {
+      const element = getGraphElement({ canEdit, canMakeEditable, editable });
+
+      const result = element.canAddAnnotations();
+
+      expect(result).toBe(expected);
+    });
+  });
 });
+
+function getGraphElement({
+  editable,
+  canEdit,
+  canMakeEditable,
+}: { canEdit?: boolean; canMakeEditable?: boolean; editable?: boolean } = {}) {
+  const element = new GraphElement(
+    {
+      ctrl: {
+        contextMenuCtrl: {},
+        dashboard: { editable, meta: { canEdit, canMakeEditable }, events: { on: jest.fn() } },
+        events: { on: jest.fn() },
+      },
+    },
+    { mouseleave: jest.fn(), bind: jest.fn() } as any,
+    {} as any
+  );
+
+  return element;
+}

--- a/public/app/plugins/panel/graph/specs/graph.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph.test.ts
@@ -8,6 +8,7 @@ import TimeSeries from 'app/core/time_series2';
 import $ from 'jquery';
 import { graphDirective, GraphElement } from '../graph';
 import { dateTime, EventBusSrv } from '@grafana/data';
+import { DashboardModel } from '../../../../features/dashboard/state';
 
 jest.mock('app/features/annotations/all', () => ({
   EventManager: () => {
@@ -1288,9 +1289,9 @@ describe('grafanaGraph', () => {
   });
 
   describe('getContextMenuItemsSupplier', () => {
-    describe('when called and dashboard is editable and user can edit the dashboard', () => {
+    describe('when called and user can edit the dashboard', () => {
       it('then the correct menu items should be returned', () => {
-        const element = getGraphElement({ editable: true, canEdit: true, canMakeEditable: false });
+        const element = getGraphElement({ canEdit: true, canMakeEditable: false });
 
         const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
 
@@ -1302,9 +1303,9 @@ describe('grafanaGraph', () => {
       });
     });
 
-    describe('when called and dashboard is editable and user can make the dashboard editable', () => {
+    describe('when called and user can make the dashboard editable', () => {
       it('then the correct menu items should be returned', () => {
-        const element = getGraphElement({ editable: true, canEdit: false, canMakeEditable: true });
+        const element = getGraphElement({ canEdit: false, canMakeEditable: true });
 
         const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
 
@@ -1316,70 +1317,28 @@ describe('grafanaGraph', () => {
       });
     });
 
-    describe('when called and dashboard is not editable', () => {
+    describe('when called and user can not edit the dashboard and can not make the dashboard editable', () => {
       it('then the correct menu items should be returned', () => {
-        const element = getGraphElement({ editable: false, canMakeEditable: true, canEdit: true });
+        const element = getGraphElement({ canEdit: false, canMakeEditable: false });
 
         const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
 
         expect(result.length).toEqual(0);
       });
     });
-
-    describe('when called and dashboard is editable and user can not make the dashboard editable', () => {
-      it('then the correct menu items should be returned', () => {
-        const element = getGraphElement({ editable: true, canMakeEditable: false });
-
-        const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
-
-        expect(result.length).toEqual(0);
-      });
-    });
-
-    describe('when called and dashboard is editable and user can not edit the dashboard', () => {
-      it('then the correct menu items should be returned', () => {
-        const element = getGraphElement({ editable: true, canEdit: false });
-
-        const result = element.getContextMenuItemsSupplier({ x: 1, y: 1 })();
-
-        expect(result.length).toEqual(0);
-      });
-    });
-  });
-
-  describe('canAddAnnotations', () => {
-    it.each`
-      canEdit  | canMakeEditable | editable | expected
-      ${false} | ${false}        | ${false} | ${false}
-      ${false} | ${false}        | ${true}  | ${false}
-      ${false} | ${true}         | ${false} | ${false}
-      ${true}  | ${false}        | ${false} | ${false}
-      ${false} | ${true}         | ${true}  | ${true}
-      ${true}  | ${false}        | ${true}  | ${true}
-      ${true}  | ${true}         | ${true}  | ${true}
-    `(
-      'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable}, editable:{$editable} and expected:{$expected}',
-      ({ canEdit, canMakeEditable, editable, expected }) => {
-        const element = getGraphElement({ canEdit, canMakeEditable, editable });
-
-        const result = element.canAddAnnotations();
-
-        expect(result).toBe(expected);
-      }
-    );
   });
 });
 
-function getGraphElement({
-  editable,
-  canEdit,
-  canMakeEditable,
-}: { canEdit?: boolean; canMakeEditable?: boolean; editable?: boolean } = {}) {
+function getGraphElement({ canEdit, canMakeEditable }: { canEdit?: boolean; canMakeEditable?: boolean } = {}) {
+  const dashboard = new DashboardModel({});
+  dashboard.events.on = jest.fn();
+  dashboard.meta.canEdit = canEdit;
+  dashboard.meta.canMakeEditable = canMakeEditable;
   const element = new GraphElement(
     {
       ctrl: {
         contextMenuCtrl: {},
-        dashboard: { editable, meta: { canEdit, canMakeEditable }, events: { on: jest.fn() } },
+        dashboard,
         events: { on: jest.fn() },
       },
     },

--- a/public/app/plugins/panel/graph/specs/graph.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph.test.ts
@@ -1357,13 +1357,16 @@ describe('grafanaGraph', () => {
       ${false} | ${true}         | ${true}  | ${true}
       ${true}  | ${false}        | ${true}  | ${true}
       ${true}  | ${true}         | ${true}  | ${true}
-    `('when called with value:{$value}', ({ canEdit, canMakeEditable, editable, expected }) => {
-      const element = getGraphElement({ canEdit, canMakeEditable, editable });
+    `(
+      'when called with canEdit:{$canEdit}, canMakeEditable:{$canMakeEditable}, editable:{$editable} and expected:{$expected}',
+      ({ canEdit, canMakeEditable, editable, expected }) => {
+        const element = getGraphElement({ canEdit, canMakeEditable, editable });
 
-      const result = element.canAddAnnotations();
+        const result = element.canAddAnnotations();
 
-      expect(result).toBe(expected);
-    });
+        expect(result).toBe(expected);
+      }
+    );
   });
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When fixing https://github.com/grafana/grafana/pull/29990 I forgot to add cases for when users don't have permissions to add annotations. This PR extracts the logic for when a user can add an annotation into the `canAddAnnotations` function and uses it accordingly where needed.

This is probably something that needs to migrate to GraphNG moving forward.

Enjoy the review 🎉 

**Which issue(s) this PR fixes**:
Fixes #29972

**Special notes for your reviewer**:
- test adding annotation by clicking in Graph (viewers shouldn't see Add annotations menu item)
- test adding annotation by selecting an area in the graph while holding down `cmd|ctrl` key
- test adding annotation by clicking in Graph while while holding down `cmd|ctrl` key
- test it with a user that has edit permissions
- test it with a user that has edit permissions and make the dashboard not editable => Settings => General => Editable toggle
![image](https://user-images.githubusercontent.com/562238/105160740-e389df00-5b10-11eb-97f8-9993167e69d0.png)
- test it with a user that has viewer permissions

