### PR TITLE
Docs: update license expiration behavior for reporting

### DIFF
--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -47,7 +47,7 @@ SAML authentication is not affected by an expired license.
 ### Reporting
 
 - You're unable to configure new reports or generate previews.
-- Scheduled reports are not generated or sent.
+- Existing reports continue to be sent.
 
 ### Enterprise plugins
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update documentation about license expiration and reporting.

**Special notes for your reviewer**:
For information, we display this in the reporting UI when the license is expired:
> Creating new reports is not available with an expired license. Existing reports continue to be processed but you need to update your license to create a new one.

