### PR TITLE
Plugins: Fix failing plugin builds because of wrong internal import

### DIFF
--- a/packages/grafana-data/src/field/index.ts
+++ b/packages/grafana-data/src/field/index.ts
@@ -15,4 +15,4 @@ export { sortThresholds, getActiveThreshold } from './thresholds';
 export { applyFieldOverrides, validateFieldConfig, applyRawFieldOverrides } from './fieldOverrides';
 export { getFieldDisplayValuesProxy } from './getFieldDisplayValuesProxy';
 export { getFieldDisplayName, getFrameDisplayName } from './fieldState';
-export { getScaleCalculator } from './scale';
+export { getScaleCalculator, getFieldConfigWithMinMax } from './scale';

--- a/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { ThresholdsConfig, ThresholdsMode, VizOrientation } from '@grafana/data';
 import { BarGauge, BarGaugeDisplayMode } from '../BarGauge/BarGauge';
 import { TableCellProps, TableCellDisplayMode } from './types';
-import { getFieldConfigWithMinMax } from '@grafana/data/src/field/scale';
+import { getFieldConfigWithMinMax } from '@grafana/data';
 
 const defaultScale: ThresholdsConfig = {
   mode: ThresholdsMode.Absolute,


### PR DESCRIPTION
These sort of imports does not work when importing the packages in other projects (plugins.).