### PR TITLE
Cloud Monitoring: Fix legend naming with display name override

### DIFF
--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -175,6 +175,12 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 
 					frameName := formatLegendKeys(series.Metric.Type, defaultMetricName, nil, additionalLabels, timeSeriesFilter)
 					valueField.Name = frameName
+					valueField.Labels = seriesLabels
+					if valueField.Config == nil {
+						valueField.Config = &data.FieldConfig{}
+					}
+					valueField.Config.DisplayNameFromDS = valueField.Name
+
 					buckets[i] = &data.Frame{
 						Name: frameName,
 						Fields: []*data.Field{
@@ -198,6 +204,12 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 					valueField := data.NewField(data.TimeSeriesValueFieldName, nil, []float64{})
 					frameName := formatLegendKeys(series.Metric.Type, defaultMetricName, seriesLabels, additionalLabels, timeSeriesFilter)
 					valueField.Name = frameName
+					valueField.Labels = seriesLabels
+					if valueField.Config == nil {
+						valueField.Config = &data.FieldConfig{}
+					}
+					valueField.Config.DisplayNameFromDS = valueField.Name
+
 					buckets[i] = &data.Frame{
 						Name: frameName,
 						Fields: []*data.Field{

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -259,6 +259,11 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) handleNonDistributionSe
 	dataField := frame.Fields[1]
 	dataField.Name = metricName
 	dataField.Labels = seriesLabels
+
+	if dataField.Config == nil {
+		dataField.Config = &data.FieldConfig{}
+	}
+	dataField.Config.DisplayNameFromDS = dataField.Name
 }
 
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseToAnnotations(queryRes *tsdb.QueryResult, data cloudMonitoringResponse, title string, text string, tags string) error {

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -176,10 +176,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 					frameName := formatLegendKeys(series.Metric.Type, defaultMetricName, nil, additionalLabels, timeSeriesFilter)
 					valueField.Name = frameName
 					valueField.Labels = seriesLabels
-					if valueField.Config == nil {
-						valueField.Config = &data.FieldConfig{}
-					}
-					valueField.Config.DisplayNameFromDS = valueField.Name
+					setDisplayNameAsFieldName(valueField)
 
 					buckets[i] = &data.Frame{
 						Name: frameName,
@@ -205,10 +202,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 					frameName := formatLegendKeys(series.Metric.Type, defaultMetricName, seriesLabels, additionalLabels, timeSeriesFilter)
 					valueField.Name = frameName
 					valueField.Labels = seriesLabels
-					if valueField.Config == nil {
-						valueField.Config = &data.FieldConfig{}
-					}
-					valueField.Config.DisplayNameFromDS = valueField.Name
+					setDisplayNameAsFieldName(valueField)
 
 					buckets[i] = &data.Frame{
 						Name: frameName,
@@ -271,11 +265,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) handleNonDistributionSe
 	dataField := frame.Fields[1]
 	dataField.Name = metricName
 	dataField.Labels = seriesLabels
-
-	if dataField.Config == nil {
-		dataField.Config = &data.FieldConfig{}
-	}
-	dataField.Config.DisplayNameFromDS = dataField.Name
+	setDisplayNameAsFieldName(dataField)
 }
 
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseToAnnotations(queryRes *tsdb.QueryResult, data cloudMonitoringResponse, title string, text string, tags string) error {
@@ -374,6 +364,13 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) buildDeepLink() string 
 	accountChooserURL.RawQuery = accountChooserQuery.Encode()
 
 	return accountChooserURL.String()
+}
+
+func setDisplayNameAsFieldName(f *data.Field) {
+	if f.Config == nil {
+		f.Config = &data.FieldConfig{}
+	}
+	f.Config.DisplayNameFromDS = f.Name
 }
 
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) getRefID() string {

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -161,11 +161,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *ts
 				dataField := frame.Fields[1]
 				dataField.Name = metricName
 				dataField.Labels = seriesLabels
-
-				if dataField.Config == nil {
-					dataField.Config = &data.FieldConfig{}
-				}
-				dataField.Config.DisplayNameFromDS = dataField.Name
+				setDisplayNameAsFieldName(dataField)
 
 				frames = append(frames, frame)
 				continue
@@ -197,10 +193,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *ts
 						frameName := formatLegendKeys(d.Key, defaultMetricName, nil, additionalLabels, &cloudMonitoringTimeSeriesFilter{ProjectName: timeSeriesQuery.ProjectName, AliasBy: timeSeriesQuery.AliasBy})
 						valueField.Name = frameName
 						valueField.Labels = seriesLabels
-						if valueField.Config == nil {
-							valueField.Config = &data.FieldConfig{}
-						}
-						valueField.Config.DisplayNameFromDS = valueField.Name
+						setDisplayNameAsFieldName(valueField)
 
 						buckets[i] = &data.Frame{
 							Name: frameName,
@@ -228,10 +221,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *ts
 						frameName := formatLegendKeys(d.Key, defaultMetricName, seriesLabels, additionalLabels, &cloudMonitoringTimeSeriesFilter{ProjectName: timeSeriesQuery.ProjectName, AliasBy: timeSeriesQuery.AliasBy})
 						valueField.Name = frameName
 						valueField.Labels = seriesLabels
-						if valueField.Config == nil {
-							valueField.Config = &data.FieldConfig{}
-						}
-						valueField.Config.DisplayNameFromDS = valueField.Name
+						setDisplayNameAsFieldName(valueField)
 
 						buckets[i] = &data.Frame{
 							Name: frameName,

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -160,6 +160,12 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *ts
 				metricName := formatLegendKeys(d.Key, defaultMetricName, seriesLabels, nil, &cloudMonitoringTimeSeriesFilter{ProjectName: timeSeriesQuery.ProjectName, AliasBy: timeSeriesQuery.AliasBy})
 				dataField := frame.Fields[1]
 				dataField.Name = metricName
+				dataField.Labels = seriesLabels
+
+				if dataField.Config == nil {
+					dataField.Config = &data.FieldConfig{}
+				}
+				dataField.Config.DisplayNameFromDS = dataField.Name
 
 				frames = append(frames, frame)
 				continue

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -196,6 +196,12 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *ts
 
 						frameName := formatLegendKeys(d.Key, defaultMetricName, nil, additionalLabels, &cloudMonitoringTimeSeriesFilter{ProjectName: timeSeriesQuery.ProjectName, AliasBy: timeSeriesQuery.AliasBy})
 						valueField.Name = frameName
+						valueField.Labels = seriesLabels
+						if valueField.Config == nil {
+							valueField.Config = &data.FieldConfig{}
+						}
+						valueField.Config.DisplayNameFromDS = valueField.Name
+
 						buckets[i] = &data.Frame{
 							Name: frameName,
 							Fields: []*data.Field{
@@ -221,6 +227,12 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *ts
 						valueField := data.NewField(data.TimeSeriesValueFieldName, nil, []float64{})
 						frameName := formatLegendKeys(d.Key, defaultMetricName, seriesLabels, additionalLabels, &cloudMonitoringTimeSeriesFilter{ProjectName: timeSeriesQuery.ProjectName, AliasBy: timeSeriesQuery.AliasBy})
 						valueField.Name = frameName
+						valueField.Labels = seriesLabels
+						if valueField.Config == nil {
+							valueField.Config = &data.FieldConfig{}
+						}
+						valueField.Config.DisplayNameFromDS = valueField.Name
+
 						buckets[i] = &data.Frame{
 							Name: frameName,
 							Fields: []*data.Field{


### PR DESCRIPTION
Since setting the frame field labels, the legend will end up being more extensive. So this change is to override it with the field config, so that we just use the dataframe name (which is the default when there are no frame field labels)

Before:
![before](https://user-images.githubusercontent.com/1173299/105347092-af80ed80-5be6-11eb-8073-9ab363ac2638.png)

After:
![after](https://user-images.githubusercontent.com/1173299/105347096-b0b21a80-5be6-11eb-9418-01e8e52d011c.png)