### PR TITLE
Chore: Restrict internal imports from other packages

### DIFF
--- a/packages/grafana-data/.eslintrc
+++ b/packages/grafana-data/.eslintrc
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime", "@grafana/ui", "@grafana/data"] }]
+    "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime", "@grafana/ui", "@grafana/data", "@grafana/e2e/*"] }]
   },
   "overrides": [
     {

--- a/packages/grafana-runtime/.eslintrc
+++ b/packages/grafana-runtime/.eslintrc
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime"] }]
+    "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime", "@grafana/data/*", "@grafana/ui/*", "@grafana/e2e/*"] }]
   }
 }

--- a/packages/grafana-ui/.eslintrc
+++ b/packages/grafana-ui/.eslintrc
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime", "@grafana/ui", "@grafana/e2e"] }]
+    "no-restricted-imports": ["error", { "patterns": ["@grafana/runtime", "@grafana/data/*", "@grafana/ui", "@grafana/e2e"] }]
   },
   "overrides": [
     {


### PR DESCRIPTION
Imports directly from `package/src/...` won't work when package is published and use in a plugin. 