### PR TITLE
Docs: include Makefile option for local assets

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,13 +3,14 @@
 IMAGE = grafana/grafana-docs-dev:latest
 CONTENT_PATH = /hugo/content/docs/grafana/latest
 LOCAL_STATIC_PATH = ../../website/static
+PORT = 3002:3002 
 
 docs:
 	docker pull $(IMAGE)
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p 3002:3002 --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p $(PORT) --rm -it $(IMAGE)
 
 docs-no-pull:
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p 3002:3002 --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p $(PORT) --rm -it $(IMAGE)
 
 docs-test:
 	docker pull $(IMAGE)
@@ -19,4 +20,5 @@ docs-test:
 docs-local-static:
 	docker pull $(IMAGE)
 	if [ ! -d "$(LOCAL_STATIC_PATH)" ]; then echo "local path (website project) $(LOCAL_STATIC_PATH) not found"]; exit 1; fi
-	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -v $(shell pwd)/$(LOCAL_STATIC_PATH):/hugo/static -p 3002:3002 --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) \
+		-v $(shell pwd)/$(LOCAL_STATIC_PATH):/hugo/static -p $(PORT) --rm -it $(IMAGE)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,14 +1,21 @@
-.PHONY: docs docs-no-pull docs-test
+.PHONY: docs docs-no-pull docs-test docs-local-static
 
 IMAGE = grafana/grafana-docs-dev:latest
+CONTENT_PATH = /hugo/content/docs/grafana/latest
+LOCAL_STATIC_PATH= ../../website/static
 
 docs:
 	docker pull $(IMAGE)
-	docker run -v $(shell pwd)/sources:/hugo/content/docs/grafana/latest -p 3002:3002 --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p 3002:3002 --rm -it $(IMAGE)
 
 docs-no-pull:
-	docker run -v $(shell pwd)/sources:/hugo/content/docs/grafana/latest -p 3002:3002 --rm -it $(IMAGE)
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -p 3002:3002 --rm -it $(IMAGE)
 
 docs-test:
 	docker pull $(IMAGE)
-	docker run -v $(shell pwd)/sources:/hugo/content/docs/grafana/latest --rm -it $(IMAGE) /bin/bash -c 'make prod'
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) --rm -it $(IMAGE) /bin/bash -c 'make prod'
+
+docs-local-static:
+	docker pull $(IMAGE)
+	if [ ! -d "$(LOCAL_STATIC_PATH)" ]; then echo "local path (website project) $(LOCAL_STATIC_PATH) not found"]; exit 1; fi
+	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) -v $(shell pwd)/$(LOCAL_STATIC_PATH):/hugo/static -p 3002:3002 --rm -it $(IMAGE)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 
 IMAGE = grafana/grafana-docs-dev:latest
 CONTENT_PATH = /hugo/content/docs/grafana/latest
-LOCAL_STATIC_PATH= ../../website/static
+LOCAL_STATIC_PATH = ../../website/static
 
 docs:
 	docker pull $(IMAGE)
@@ -15,6 +15,7 @@ docs-test:
 	docker pull $(IMAGE)
 	docker run -v $(shell pwd)/sources:$(CONTENT_PATH) --rm -it $(IMAGE) /bin/bash -c 'make prod'
 
+# expects that you have grafana/website checked out in same path as the grafana repo.
 docs-local-static:
 	docker pull $(IMAGE)
 	if [ ! -d "$(LOCAL_STATIC_PATH)" ]; then echo "local path (website project) $(LOCAL_STATIC_PATH) not found"]; exit 1; fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ Yarn >= 1.22.4
 1. On the command line, first change to the docs folder: `cd docs`.
 1. Run `make docs`. This launches a preview of the docs website at `http://localhost:3002/docs/grafana/latest/` which will refresh automatically when changes are made to content in the `sources` directory.
 
+If you have the grafana/website repo checked out in the same directory as the grafana repo, then you can run `make docs-local-static` to use local assets (such as images).
+
 ---
 
 ## Content guidelines


### PR DESCRIPTION
for use when also having the grafana/website repo checked out, and you want local images.

**What this PR does / why we need it**:

Convenience, adds `make docs-local-static` to the *docs* `Makefile` which additionally mounts the website repo for using local static assets (e.g. images).
