### PR TITLE
devenv: remove deprecated promtail config param

### DIFF
--- a/devenv/docker/blocks/loki/config.yaml
+++ b/devenv/docker/blocks/loki/config.yaml
@@ -9,19 +9,17 @@ client:
   url: http://loki:3100/api/prom/push
 
 scrape_configs:
-- job_name: system
-  entry_parser: raw
-  static_configs:
-  - targets:
-      - localhost
-    labels:
-      job: varlogs
-      __path__: /var/log/*log
-- job_name: grafana
-  entry_parser: raw
-  static_configs:
-  - targets:
-      - localhost
-    labels:
-      job: grafana
-      __path__: /var/log/grafana/*log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs
+          __path__: /var/log/*log
+  - job_name: grafana
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: grafana
+          __path__: /var/log/grafana/*log


### PR DESCRIPTION
During Loki devenv setup via docker-compose promtail fails due to config parse error.

Remove the deprecated 'entry_parser' config key.