### PR TITLE
Dashboard: check dashboard permission when open snapshot

### DIFF
--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -163,6 +163,14 @@ func GetDashboardSnapshot(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to get dashboard data for dashboard snapshot", err)
 	}
 
+	dashboardID := dashboard.Get("id").MustInt64()
+	guardian := guardian.New(dashboardID, c.OrgId, c.SignedInUser)
+	if snapshot.UserId != c.SignedInUser.UserId {
+		if canView, err := guardian.CanView(); err != nil || !canView {
+			return response.Error(404, "Dashboard snapshot not found", err)
+		}
+	}
+
 	dto := dtos.DashboardFullWithMeta{
 		Dashboard: dashboard,
 		Meta: dtos.DashboardMeta{

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -236,7 +236,8 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 
 		loggedInUserScenarioWithRole(t, "Should be able to read a snapshot's unencrypted data when calling GET on",
 			"GET", "/api/snapshots/12345", "/api/snapshots/:key", models.ROLE_EDITOR, func(sc *scenarioContext) {
-				setUpSnapshotTest(t)
+				mockSnapshotResult := setUpSnapshotTest(t)
+				mockSnapshotResult.UserId = testUserID
 
 				sc.handlerFunc = GetDashboardSnapshot
 				sc.fakeReqWithParams("GET", sc.url, map[string]string{"key": "12345"}).exec()
@@ -274,6 +275,7 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 					Key:                "12345",
 					DashboardEncrypted: encrypted,
 					Expires:            time.Now().Add(time.Duration(1000) * time.Second),
+					UserId:             testUserID,
 				}
 
 				setUpSnapshotTest(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
When respond snapshot GET API, check following condition whether user can get or not.
- The user is snapshot owner
- The user is belong to Team which has permission to open original dashboard

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/30415

**Special notes for your reviewer**:

