### PR TITLE
Dashboard: Remove Icon and change copy -> Copy to clipboard in the share embedded panel modal

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, PureComponent } from 'react';
-import { RadioButtonGroup, Switch, Field, TextArea, Icon, ClipboardButton } from '@grafana/ui';
+import { RadioButtonGroup, Switch, Field, TextArea, ClipboardButton } from '@grafana/ui';
 import { SelectableValue, AppEvents } from '@grafana/data';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { appEvents } from 'app/core/core';
@@ -99,7 +99,7 @@ export class ShareEmbed extends PureComponent<Props, State> {
               <TextArea rows={5} value={iframeHtml} onChange={this.onIframeHtmlChange}></TextArea>
             </Field>
             <ClipboardButton variant="primary" getText={this.getIframeHtml} onClipboardCopy={this.onIframeHtmlCopy}>
-              <Icon name="copy" /> Copy
+              Copy to clipboard
             </ClipboardButton>
           </div>
         </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

Small update to the copy and styling of the copy button in Share embedded panel, after some UX consultation.