### PR TITLE
Logging: add frontend logging helpers to @grafana/runtime package

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -9,5 +9,6 @@ export * from './types';
 export * from './measurement';
 export { loadPluginCss, SystemJS, PluginCssOptions } from './utils/plugin';
 export { reportMetaAnalytics } from './utils/analytics';
+export { LogLevel, logMessage, logError } from './utils/logging';
 export { DataSourceWithBackend, HealthCheckResult, HealthStatus } from './utils/DataSourceWithBackend';
 export { toDataQueryError, toDataQueryResponse, frameToMetricFindValue } from './utils/queryResponse';

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -9,6 +9,6 @@ export * from './types';
 export * from './measurement';
 export { loadPluginCss, SystemJS, PluginCssOptions } from './utils/plugin';
 export { reportMetaAnalytics } from './utils/analytics';
-export { LogLevel, logMessage, logError } from './utils/logging';
+export { logInfo, logDebug, logWarning, logError } from './utils/logging';
 export { DataSourceWithBackend, HealthCheckResult, HealthStatus } from './utils/DataSourceWithBackend';
 export { toDataQueryError, toDataQueryResponse, frameToMetricFindValue } from './utils/queryResponse';

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -1,0 +1,26 @@
+import { captureMessage, captureException, Severity as LogLevel } from '@sentry/browser';
+export { LogLevel };
+
+// a bit stricter than what Sentry allows
+type Contexts = Record<string, Record<string, number | string | Record<string, string | number>>>;
+
+/**
+ * Log a message. Depending on configuration might be forwarded to backend and logged to stdout or sent to Sentry
+ *
+ * @public
+ */
+export function logMessage(message: string, contexts?: Contexts, level = LogLevel.Info) {
+  captureMessage(message, {
+    level,
+    contexts,
+  });
+}
+
+/**
+ * Log an error. Depending on configuration might be forwarded to backend and logged to stdout or sent to Sentry
+ *
+ * @public
+ */
+export function logError(err: Error, contexts?: Contexts) {
+  captureException(err, { contexts });
+}

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -5,13 +5,37 @@ export { LogLevel };
 type Contexts = Record<string, Record<string, number | string | Record<string, string | number>>>;
 
 /**
- * Log a message. Depending on configuration might be forwarded to backend and logged to stdout or sent to Sentry
+ * Log a message at INFO level. Depending on configuration might be forwarded to backend and logged to stdout or sent to Sentry
  *
  * @public
  */
-export function logMessage(message: string, contexts?: Contexts, level = LogLevel.Info) {
+export function logInfo(message: string, contexts?: Contexts) {
   captureMessage(message, {
-    level,
+    level: LogLevel.Info,
+    contexts,
+  });
+}
+
+/**
+ * Log a message at WARNING level. Depending on configuration might be forwarded to backend and logged to stdout or sent to Sentry
+ *
+ * @public
+ */
+export function logWarning(message: string, contexts?: Contexts) {
+  captureMessage(message, {
+    level: LogLevel.Warning,
+    contexts,
+  });
+}
+
+/**
+ * Log a message at DEBUG level. Depending on configuration might be forwarded to backend and logged to stdout or sent to Sentry
+ *
+ * @public
+ */
+export function logDebug(message: string, contexts?: Contexts) {
+  captureMessage(message, {
+    level: LogLevel.Debug,
     contexts,
   });
 }


### PR DESCRIPTION
Adds public `logInfo`, `logWarning`, `logDebug` and `logError` helpers to `@grafana/runtime`. Intended to be used by plugins for any custom reporting, so plugin doesn't have to install own Sentry client. Also exposes stricter interface than Sentry client.

Related to #27993


