### PR TITLE
TimeSeriesPanel: Fixes default value for Gradient mode

### DIFF
--- a/public/app/plugins/panel/timeseries/config.ts
+++ b/public/app/plugins/panel/timeseries/config.ts
@@ -89,7 +89,7 @@ export function getGraphFieldConfig(cfg: GraphFieldConfig): SetFieldConfigOption
         .addRadio({
           path: 'gradientMode',
           name: 'Gradient mode',
-          defaultValue: graphFieldOptions.fillGradient[0],
+          defaultValue: graphFieldOptions.fillGradient[0].value,
           settings: {
             options: graphFieldOptions.fillGradient,
           },


### PR DESCRIPTION

Think my last fix for this got lost in a merge when the config was moved to another file
