### PR TITLE
Docs: fix typo in what's new doc

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -102,7 +102,7 @@ Grafana 7.4 includes the following enhancements
 - Added support to the terms aggregation for ordering by percentiles and extended stats.
 - Updated date histogram auto interval handling for alert queries.
 
-> **Note:** We have deprecated browser access mode. Iit will be removed in a future release.
+> **Note:** We have deprecated browser access mode. It will be removed in a future release.
 
 ### Azure Monitor updates
 


### PR DESCRIPTION
Fix a small typo in "What's new in 7.4"