### PR TITLE
GraphNG: add bar alignment option

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -236,6 +236,7 @@ export const GraphNG: React.FC<GraphNGProps> = ({
         lineWidth: customConfig.lineWidth,
         lineInterpolation: customConfig.lineInterpolation,
         lineStyle: customConfig.lineStyle,
+        barAlignment: customConfig.barAlignment,
         pointSize: customConfig.pointSize,
         pointColor: customConfig.pointColor ?? seriesColor,
         spanNulls: customConfig.spanNulls || false,

--- a/packages/grafana-ui/src/components/Icon/custom/index.tsx
+++ b/packages/grafana-ui/src/components/Icon/custom/index.tsx
@@ -81,11 +81,67 @@ const IconNotFound: FC<SvgProps> = ({ size, ...rest }) => {
   return <svg width={size} height={size} {...rest} />;
 };
 
+const BarAlignmentAfter: FC<SvgProps> = ({ size, ...rest }) => {
+  return (
+    <svg width={'16px'} height={size} viewBox="0 0 16 19" version="1.1" xmlns="http://www.w3.org/2000/svg" {...rest}>
+      <g id="Page-1">
+        <g id="Group" transform="translate(0.500000, 0.000000)">
+          <circle id="Oval" cx="2.67" cy="2.67" r="2.67" />
+          <polygon id="Path" points="13.42 18.08 13.42 3.42 3.06 3.42 3.06 1.92 14.92 1.92 14.92 18.08" />
+          <polygon id="Path" points="1.92 18.08 1.92 16.58 1.92 2.67 3.42 2.67 3.42 18.08" />
+        </g>
+      </g>
+    </svg>
+  );
+};
+
+const BarAlignmentBefore: FC<SvgProps> = ({ size, ...rest }) => {
+  return (
+    <svg width={'16px'} height={size} viewBox="0 0 16 19" version="1.1" xmlns="http://www.w3.org/2000/svg" {...rest}>
+      <g id="Page-1">
+        <g
+          id="Group"
+          transform="translate(8.000000, 9.500000) scale(-1, 1) translate(-8.000000, -9.500000) translate(0.500000, 0.000000)"
+        >
+          <circle id="Oval" cx="2.67" cy="2.67" r="2.67" />
+          <polygon id="Path" points="13.42 18.08 13.42 3.42 3.06 3.42 3.06 1.92 14.92 1.92 14.92 18.08" />
+          <polygon id="Path" points="1.92 18.08 1.92 16.58 1.92 2.67 3.42 2.67 3.42 18.08" />
+        </g>
+      </g>
+    </svg>
+  );
+};
+
+const BarAlignmentCenter: FC<SvgProps> = ({ size, ...rest }) => {
+  return (
+    <svg width="16px" height={size} viewBox="0 0 16 19" version="1.1" xmlns="http://www.w3.org/2000/svg" {...rest}>
+      <g id="Page-1">
+        <g id="Group" transform="translate(2.500000, 0.000000)">
+          <circle id="Oval" cx="6.67" cy="2.67" r="2.67" />
+          <g id="Group-2" transform="translate(0.000000, 2.000000)">
+            <polygon
+              id="Path"
+              points="11.5 16.16 11.5 1.5 1.84741111e-13 1.5 1.84741111e-13 1.77635684e-14 13 1.77635684e-14 13 16.16"
+            />
+            <polygon
+              id="Path"
+              points="2.27373675e-13 16.16 2.27373675e-13 14.66 2.32286412e-13 0.75 1.5 0.75 1.5 16.16"
+            />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+};
+
 export const customIcons: Record<string, ComponentType<SvgProps>> = {
   'gf-interpolation-linear': InterpolationLinear,
   'gf-interpolation-smooth': InterpolationSmooth,
   'gf-interpolation-step-before': InterpolationStepBefore,
   'gf-interpolation-step-after': InterpolationStepAfter,
   'gf-logs': Logs,
+  'gf-bar-alignment-after': BarAlignmentAfter,
+  'gf-bar-alignment-before': BarAlignmentBefore,
+  'gf-bar-alignment-center': BarAlignmentCenter,
   notFoundDummy: IconNotFound,
 };

--- a/packages/grafana-ui/src/components/uPlot/config.ts
+++ b/packages/grafana-ui/src/components/uPlot/config.ts
@@ -43,6 +43,15 @@ export enum LineInterpolation {
 /**
  * @alpha
  */
+export enum BarAlignment {
+  Before = -1,
+  Center = 0,
+  After = 1,
+}
+
+/**
+ * @alpha
+ */
 export enum ScaleDistribution {
   Linear = 'linear',
   Logarithmic = 'log',
@@ -85,6 +94,13 @@ export interface LineConfig {
   lineInterpolation?: LineInterpolation;
   lineStyle?: LineStyle;
   spanNulls?: boolean;
+}
+
+/**
+ * @alpha
+ */
+export interface BarConfig {
+  barAlignment?: BarAlignment;
 }
 
 /**
@@ -156,7 +172,13 @@ export interface HideableFieldConfig {
 /**
  * @alpha
  */
-export interface GraphFieldConfig extends LineConfig, FillConfig, PointsConfig, AxisConfig, HideableFieldConfig {
+export interface GraphFieldConfig
+  extends LineConfig,
+    FillConfig,
+    PointsConfig,
+    AxisConfig,
+    BarConfig,
+    HideableFieldConfig {
   drawStyle?: DrawStyle;
   gradientMode?: GraphGradientMode;
 }
@@ -177,6 +199,12 @@ export const graphFieldOptions = {
     { description: 'Step before', value: LineInterpolation.StepBefore, icon: 'gf-interpolation-step-before' },
     { description: 'Step after', value: LineInterpolation.StepAfter, icon: 'gf-interpolation-step-after' },
   ] as Array<SelectableValue<LineInterpolation>>,
+
+  barAlignment: [
+    { description: 'Before', value: BarAlignment.Before, icon: 'gf-bar-alignment-before' },
+    { description: 'Center', value: BarAlignment.Center, icon: 'gf-bar-alignment-center' },
+    { description: 'After', value: BarAlignment.After, icon: 'gf-bar-alignment-after' },
+  ] as Array<SelectableValue<BarAlignment>>,
 
   showPoints: [
     { label: 'Auto', value: PointVisibility.Auto, description: 'Show points when the density is low' },

--- a/public/app/plugins/panel/timeseries/config.ts
+++ b/public/app/plugins/panel/timeseries/config.ts
@@ -12,6 +12,7 @@ import {
 } from '@grafana/data';
 import {
   AxisPlacement,
+  BarAlignment,
   DrawStyle,
   GraphFieldConfig,
   graphFieldOptions,
@@ -36,6 +37,7 @@ export const defaultGraphConfig: GraphFieldConfig = {
   lineWidth: 1,
   fillOpacity: 0,
   gradientMode: GraphGradientMode.None,
+  barAlignment: BarAlignment.Center,
 };
 
 export function getGraphFieldConfig(cfg: GraphFieldConfig): SetFieldConfigOptionsArgs<GraphFieldConfig> {
@@ -70,6 +72,15 @@ export function getGraphFieldConfig(cfg: GraphFieldConfig): SetFieldConfigOption
             options: graphFieldOptions.lineInterpolation,
           },
           showIf: (c) => c.drawStyle === DrawStyle.Line,
+        })
+        .addRadio({
+          path: 'barAlignment',
+          name: 'Bar alignment',
+          defaultValue: cfg.barAlignment,
+          settings: {
+            options: graphFieldOptions.barAlignment,
+          },
+          showIf: (c) => c.drawStyle === DrawStyle.Bars,
         })
         .addSliderInput({
           path: 'lineWidth',


### PR DESCRIPTION
Adds new option, `barAlignment`, that allows bars rendering alignment relative to data point.

UI:
![image](https://user-images.githubusercontent.com/2376619/105361107-a3eaf200-5bf9-11eb-8b1c-e0737cb96c11.png)

Closes https://github.com/grafana/grafana/issues/18220