### PR TITLE
GraphNG: uPlot 1.6.3 (fix bands not filling below 0). close #30523.

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -72,7 +72,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.2"
+    "uplot": "1.6.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25891,10 +25891,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.2.tgz#9dc8e9ff6e35e1ed05e4623ba56db6f5e050bf01"
-  integrity sha512-4GMn3ecJJetC5SGvLWK3h4uOerx+ayRzByWk5xg0HgaqnFI/MqGIJup7GVngF51so6Adyco/EN6z2oenSgoXkg==
+uplot@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.3.tgz#85b21f59b2e9db24976aa688cb267d950dfa45b5"
+  integrity sha512-aSqtBqJRqO7KkuZxRxVGumDi7+293HsBCdzg9HbOYkRZ8lxf2utLpkAu4oljejlwYy1zrn7DXBSvcZ5wnWig9w==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
fix bands not filling below 0.

Closes #30523.