### PR TITLE
Grafana/UI: Add disable prop to Segment

### DIFF
--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -33,10 +33,8 @@ export function Segment<T>({
         disabled={disabled}
         Component={
           Component || (
-            <span
+             <InlineLabel
               className={cx(
-                'gf-form-label',
-                'query-part',
                 styles.clickable,
                 {
                   ['query-placeholder']: placeholder !== undefined && !value,
@@ -45,6 +43,8 @@ export function Segment<T>({
                 className
               )}
             >
+              {label || placeholder}
+            </InlineLabel>
               {label || placeholder}
             </span>
           )

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -3,7 +3,9 @@ import { cx } from 'emotion';
 import _ from 'lodash';
 import { SelectableValue } from '@grafana/data';
 import { SegmentSelect, useExpandableLabel, SegmentProps } from './';
-import { getStyles } from './styles';
+import { getSegmentStyles } from './styles';
+import { InlineLabel } from '../Forms/InlineLabel';
+import { useTheme } from '../../themes/ThemeContext';
 
 export interface SegmentSyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
@@ -26,18 +28,19 @@ export function Segment<T>({
 
   if (!expanded) {
     const label = _.isObject(value) ? value.label : value;
-    const styles = getStyles();
+    const theme = useTheme();
+    const styles = getSegmentStyles(theme);
 
     return (
       <Label
         disabled={disabled}
         Component={
           Component || (
-             <InlineLabel
+            <InlineLabel
               className={cx(
-                styles.clickable,
+                styles.segment,
                 {
-                  ['query-placeholder']: placeholder !== undefined && !value,
+                  [styles.queryPlaceholder]: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,
                 },
                 className
@@ -45,8 +48,6 @@ export function Segment<T>({
             >
               {label || placeholder}
             </InlineLabel>
-              {label || placeholder}
-            </span>
           )
         }
       />

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -56,7 +56,7 @@ export function Segment<T>({
       width={width}
       onClickOutside={() => setExpanded(false)}
       allowCustomValue={allowCustomValue}
-      onChange={item => {
+      onChange={(item) => {
         setExpanded(false);
         onChange(item);
       }}

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -3,6 +3,7 @@ import { cx } from 'emotion';
 import _ from 'lodash';
 import { SelectableValue } from '@grafana/data';
 import { SegmentSelect, useExpandableLabel, SegmentProps } from './';
+import { getStyles } from './styles';
 
 export interface SegmentSyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
@@ -18,6 +19,7 @@ export function Segment<T>({
   className,
   allowCustomValue,
   placeholder,
+  disabled,
   ...rest
 }: React.PropsWithChildren<SegmentSyncProps<T>>) {
   const [Label, width, expanded, setExpanded] = useExpandableLabel(false);
@@ -26,9 +28,18 @@ export function Segment<T>({
     const label = _.isObject(value) ? value.label : value;
     return (
       <Label
+        disabled={disabled}
         Component={
           Component || (
-            <a className={cx('gf-form-label', 'query-part', !value && placeholder && 'query-placeholder', className)}>
+            <a
+              className={cx(
+                'gf-form-label',
+                'query-part',
+                !value && placeholder && 'query-placeholder',
+                getStyles<T>({ disabled: disabled }).link,
+                className
+              )}
+            >
               {label || placeholder}
             </a>
           )
@@ -45,7 +56,7 @@ export function Segment<T>({
       width={width}
       onClickOutside={() => setExpanded(false)}
       allowCustomValue={allowCustomValue}
-      onChange={(item) => {
+      onChange={item => {
         setExpanded(false);
         onChange(item);
       }}

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -37,6 +37,7 @@ export function Segment<T>({
               className={cx(
                 'gf-form-label',
                 'query-part',
+                styles.clickable,
                 {
                   ['query-placeholder']: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -26,6 +26,8 @@ export function Segment<T>({
 
   if (!expanded) {
     const label = _.isObject(value) ? value.label : value;
+    const styles = getStyles();
+
     return (
       <Label
         disabled={disabled}
@@ -35,8 +37,10 @@ export function Segment<T>({
               className={cx(
                 'gf-form-label',
                 'query-part',
-                !value && placeholder && 'query-placeholder',
-                getStyles<T>({ disabled: disabled }).link,
+                {
+                  ['query-placeholder']: placeholder !== undefined && value === undefined,
+                  [styles.disabled]: disabled,
+                },
                 className
               )}
             >

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -33,19 +33,19 @@ export function Segment<T>({
         disabled={disabled}
         Component={
           Component || (
-            <a
+            <span
               className={cx(
                 'gf-form-label',
                 'query-part',
                 {
-                  ['query-placeholder']: placeholder !== undefined && value === undefined,
+                  ['query-placeholder']: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,
                 },
                 className
               )}
             >
               {label || placeholder}
-            </a>
+            </span>
           )
         }
       />

--- a/packages/grafana-ui/src/components/Segment/Segment.tsx
+++ b/packages/grafana-ui/src/components/Segment/Segment.tsx
@@ -5,7 +5,7 @@ import { SelectableValue } from '@grafana/data';
 import { SegmentSelect, useExpandableLabel, SegmentProps } from './';
 import { getSegmentStyles } from './styles';
 import { InlineLabel } from '../Forms/InlineLabel';
-import { useTheme } from '../../themes/ThemeContext';
+import { useStyles } from '../../themes';
 
 export interface SegmentSyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
@@ -25,11 +25,10 @@ export function Segment<T>({
   ...rest
 }: React.PropsWithChildren<SegmentSyncProps<T>>) {
   const [Label, width, expanded, setExpanded] = useExpandableLabel(false);
+  const styles = useStyles(getSegmentStyles);
 
   if (!expanded) {
     const label = _.isObject(value) ? value.label : value;
-    const theme = useTheme();
-    const styles = getSegmentStyles(theme);
 
     return (
       <Label

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -38,19 +38,20 @@ export function SegmentAsync<T>({
         disabled={disabled}
         Component={
           Component || (
-            <a
+            <span
               className={cx(
                 'gf-form-label',
                 'query-part',
+                styles.clickable,
                 {
-                  ['query-placeholder']: placeholder !== undefined && value === undefined,
+                  ['query-placeholder']: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,
                 },
                 className
               )}
             >
               {label || placeholder}
-            </a>
+            </span>
           )
         }
       />

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -33,7 +33,6 @@ export function SegmentAsync<T>({
   if (!expanded) {
     const label = _.isObject(value) ? value.label : value;
     const theme = useTheme();
-    console.log(theme);
     const styles = getSegmentStyles(theme);
 
     return (

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -30,6 +30,8 @@ export function SegmentAsync<T>({
 
   if (!expanded) {
     const label = _.isObject(value) ? value.label : value;
+    const styles = getStyles();
+
     return (
       <Label
         onClick={fetchOptions}
@@ -40,8 +42,10 @@ export function SegmentAsync<T>({
               className={cx(
                 'gf-form-label',
                 'query-part',
-                !value && placeholder && 'query-placeholder',
-                getStyles<T>({ disabled: disabled }).link,
+                {
+                  ['query-placeholder']: placeholder !== undefined && value === undefined,
+                  [styles.disabled]: disabled,
+                },
                 className
               )}
             >

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -64,7 +64,7 @@ export function SegmentAsync<T>({
       onClickOutside={() => {
         setExpanded(false);
       }}
-      onChange={item => {
+      onChange={(item) => {
         setExpanded(false);
         onChange(item);
       }}

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -8,7 +8,7 @@ import { useAsyncFn } from 'react-use';
 import { AsyncState } from 'react-use/lib/useAsync';
 import { getSegmentStyles } from './styles';
 import { InlineLabel } from '../Forms/InlineLabel';
-import { useTheme } from '../../themes/ThemeContext';
+import { useStyles } from '../../themes';
 
 export interface SegmentAsyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
@@ -29,11 +29,10 @@ export function SegmentAsync<T>({
 }: React.PropsWithChildren<SegmentAsyncProps<T>>) {
   const [state, fetchOptions] = useAsyncFn(loadOptions, [loadOptions]);
   const [Label, width, expanded, setExpanded] = useExpandableLabel(false);
+  const styles = useStyles(getSegmentStyles);
 
   if (!expanded) {
     const label = _.isObject(value) ? value.label : value;
-    const theme = useTheme();
-    const styles = getSegmentStyles(theme);
 
     return (
       <Label

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -6,6 +6,7 @@ import { SelectableValue } from '@grafana/data';
 import { useExpandableLabel, SegmentProps } from '.';
 import { useAsyncFn } from 'react-use';
 import { AsyncState } from 'react-use/lib/useAsync';
+import { getStyles } from './styles';
 
 export interface SegmentAsyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
@@ -20,6 +21,7 @@ export function SegmentAsync<T>({
   Component,
   className,
   allowCustomValue,
+  disabled,
   placeholder,
   ...rest
 }: React.PropsWithChildren<SegmentAsyncProps<T>>) {
@@ -31,9 +33,18 @@ export function SegmentAsync<T>({
     return (
       <Label
         onClick={fetchOptions}
+        disabled={disabled}
         Component={
           Component || (
-            <a className={cx('gf-form-label', 'query-part', !value && placeholder && 'query-placeholder', className)}>
+            <a
+              className={cx(
+                'gf-form-label',
+                'query-part',
+                !value && placeholder && 'query-placeholder',
+                getStyles<T>({ disabled: disabled }).link,
+                className
+              )}
+            >
               {label || placeholder}
             </a>
           )
@@ -53,7 +64,7 @@ export function SegmentAsync<T>({
       onClickOutside={() => {
         setExpanded(false);
       }}
-      onChange={(item) => {
+      onChange={item => {
         setExpanded(false);
         onChange(item);
       }}

--- a/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentAsync.tsx
@@ -6,7 +6,9 @@ import { SelectableValue } from '@grafana/data';
 import { useExpandableLabel, SegmentProps } from '.';
 import { useAsyncFn } from 'react-use';
 import { AsyncState } from 'react-use/lib/useAsync';
-import { getStyles } from './styles';
+import { getSegmentStyles } from './styles';
+import { InlineLabel } from '../Forms/InlineLabel';
+import { useTheme } from '../../themes/ThemeContext';
 
 export interface SegmentAsyncProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: T | SelectableValue<T>;
@@ -30,7 +32,9 @@ export function SegmentAsync<T>({
 
   if (!expanded) {
     const label = _.isObject(value) ? value.label : value;
-    const styles = getStyles();
+    const theme = useTheme();
+    console.log(theme);
+    const styles = getSegmentStyles(theme);
 
     return (
       <Label
@@ -38,20 +42,18 @@ export function SegmentAsync<T>({
         disabled={disabled}
         Component={
           Component || (
-            <span
+            <InlineLabel
               className={cx(
-                'gf-form-label',
-                'query-part',
-                styles.clickable,
+                styles.segment,
                 {
-                  ['query-placeholder']: placeholder !== undefined && !value,
+                  [styles.queryPlaceholder]: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,
                 },
                 className
               )}
             >
               {label || placeholder}
-            </span>
+            </InlineLabel>
           )
         }
       />

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -46,7 +46,7 @@ export function SegmentInput<T>({
                 'gf-form-label',
                 'query-part',
                 {
-                  ['query-placeholder']: placeholder !== undefined && value === undefined,
+                  ['query-placeholder']: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,
                 },
                 className

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -41,10 +41,11 @@ export function SegmentInput<T>({
         disabled={disabled}
         Component={
           Component || (
-            <a
+            <span
               className={cx(
                 'gf-form-label',
                 'query-part',
+                styles.clickable,
                 {
                   ['query-placeholder']: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,
@@ -53,7 +54,7 @@ export function SegmentInput<T>({
               )}
             >
               {initialValue || placeholder}
-            </a>
+            </span>
           )
         }
       />

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -3,7 +3,9 @@ import { cx, css } from 'emotion';
 import useClickAway from 'react-use/lib/useClickAway';
 import { measureText } from '../../utils/measureText';
 import { useExpandableLabel, SegmentProps } from '.';
-import { getStyles } from './styles';
+import { getSegmentStyles } from './styles';
+import { InlineLabel } from '../Forms/InlineLabel';
+import { useTheme } from '../../themes/ThemeContext';
 
 export interface SegmentInputProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
   value: string | number;
@@ -34,27 +36,26 @@ export function SegmentInput<T>({
   });
 
   if (!expanded) {
-    const styles = getStyles();
+    const theme = useTheme();
+    const styles = getSegmentStyles(theme);
 
     return (
       <Label
         disabled={disabled}
         Component={
           Component || (
-            <span
+            <InlineLabel
               className={cx(
-                'gf-form-label',
-                'query-part',
-                styles.clickable,
+                styles.segment,
                 {
-                  ['query-placeholder']: placeholder !== undefined && !value,
+                  [styles.queryPlaceholder]: placeholder !== undefined && !value,
                   [styles.disabled]: disabled,
                 },
                 className
               )}
             >
               {initialValue || placeholder}
-            </span>
+            </InlineLabel>
           )
         }
       />

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -34,6 +34,8 @@ export function SegmentInput<T>({
   });
 
   if (!expanded) {
+    const styles = getStyles();
+
     return (
       <Label
         disabled={disabled}
@@ -43,8 +45,10 @@ export function SegmentInput<T>({
               className={cx(
                 'gf-form-label',
                 'query-part',
-                !value && placeholder && 'query-placeholder',
-                getStyles<T>({ disabled: disabled }).link,
+                {
+                  ['query-placeholder']: placeholder !== undefined && value === undefined,
+                  [styles.disabled]: disabled,
+                },
                 className
               )}
             >

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -67,7 +67,7 @@ export function SegmentInput<T>({
       autoFocus
       className={cx(`gf-form gf-form-input`, inputWidthStyle)}
       value={value}
-      onChange={item => {
+      onChange={(item) => {
         const { width } = measureText(item.target.value, FONT_SIZE);
         setInputWidth(width);
         setValue(item.target.value);
@@ -76,7 +76,7 @@ export function SegmentInput<T>({
         setExpanded(false);
         onChange(value);
       }}
-      onKeyDown={e => {
+      onKeyDown={(e) => {
         if ([13, 27].includes(e.keyCode)) {
           setExpanded(false);
           onChange(value);

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -3,6 +3,7 @@ import { cx, css } from 'emotion';
 import useClickAway from 'react-use/lib/useClickAway';
 import { measureText } from '../../utils/measureText';
 import { useExpandableLabel, SegmentProps } from '.';
+import { getStyles } from './styles';
 
 export interface SegmentInputProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
   value: string | number;
@@ -18,6 +19,7 @@ export function SegmentInput<T>({
   Component,
   className,
   placeholder,
+  disabled,
   autofocus = false,
   ...rest
 }: React.PropsWithChildren<SegmentInputProps<T>>) {
@@ -34,9 +36,18 @@ export function SegmentInput<T>({
   if (!expanded) {
     return (
       <Label
+        disabled={disabled}
         Component={
           Component || (
-            <a className={cx('gf-form-label', 'query-part', !value && placeholder && 'query-placeholder', className)}>
+            <a
+              className={cx(
+                'gf-form-label',
+                'query-part',
+                !value && placeholder && 'query-placeholder',
+                getStyles<T>({ disabled: disabled }).link,
+                className
+              )}
+            >
               {initialValue || placeholder}
             </a>
           )
@@ -56,7 +67,7 @@ export function SegmentInput<T>({
       autoFocus
       className={cx(`gf-form gf-form-input`, inputWidthStyle)}
       value={value}
-      onChange={(item) => {
+      onChange={item => {
         const { width } = measureText(item.target.value, FONT_SIZE);
         setInputWidth(width);
         setValue(item.target.value);
@@ -65,7 +76,7 @@ export function SegmentInput<T>({
         setExpanded(false);
         onChange(value);
       }}
-      onKeyDown={(e) => {
+      onKeyDown={e => {
         if ([13, 27].includes(e.keyCode)) {
           setExpanded(false);
           onChange(value);

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -5,7 +5,7 @@ import { measureText } from '../../utils/measureText';
 import { useExpandableLabel, SegmentProps } from '.';
 import { getSegmentStyles } from './styles';
 import { InlineLabel } from '../Forms/InlineLabel';
-import { useTheme } from '../../themes/ThemeContext';
+import { useStyles } from '../../themes';
 
 export interface SegmentInputProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
   value: string | number;
@@ -29,6 +29,7 @@ export function SegmentInput<T>({
   const [value, setValue] = useState<number | string>(initialValue);
   const [inputWidth, setInputWidth] = useState<number>(measureText((initialValue || '').toString(), FONT_SIZE).width);
   const [Label, , expanded, setExpanded] = useExpandableLabel(autofocus);
+  const styles = useStyles(getSegmentStyles);
 
   useClickAway(ref, () => {
     setExpanded(false);
@@ -36,9 +37,6 @@ export function SegmentInput<T>({
   });
 
   if (!expanded) {
-    const theme = useTheme();
-    const styles = getSegmentStyles(theme);
-
     return (
       <Label
         disabled={disabled}

--- a/packages/grafana-ui/src/components/Segment/styles.ts
+++ b/packages/grafana-ui/src/components/Segment/styles.ts
@@ -1,8 +1,7 @@
 import { GrafanaTheme } from '@grafana/data';
 import { css } from 'emotion';
-import { stylesFactory } from '../../themes';
 
-export const getSegmentStyles = stylesFactory((theme: GrafanaTheme) => {
+export const getSegmentStyles = (theme: GrafanaTheme) => {
   return {
     segment: css`
       cursor: pointer;
@@ -19,4 +18,4 @@ export const getSegmentStyles = stylesFactory((theme: GrafanaTheme) => {
       box-shadow: none;
     `,
   };
-});
+};

--- a/packages/grafana-ui/src/components/Segment/styles.ts
+++ b/packages/grafana-ui/src/components/Segment/styles.ts
@@ -3,6 +3,9 @@ import { stylesFactory } from '../../themes';
 
 export const getStyles = stylesFactory(() => {
   return {
+    clickable: css`
+      cursor: pointer;
+    `,
     disabled: css`
       cursor: not-allowed;
       opacity: 0.65;

--- a/packages/grafana-ui/src/components/Segment/styles.ts
+++ b/packages/grafana-ui/src/components/Segment/styles.ts
@@ -1,11 +1,18 @@
+import { GrafanaTheme } from '@grafana/data';
 import { css } from 'emotion';
 import { stylesFactory } from '../../themes';
 
-export const getStyles = stylesFactory(() => {
+export const getSegmentStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
-    clickable: css`
+    segment: css`
       cursor: pointer;
+      width: auto;
     `,
+
+    queryPlaceholder: css`
+      color: ${theme.palette.gray2};
+    `,
+
     disabled: css`
       cursor: not-allowed;
       opacity: 0.65;

--- a/packages/grafana-ui/src/components/Segment/styles.ts
+++ b/packages/grafana-ui/src/components/Segment/styles.ts
@@ -1,0 +1,15 @@
+import { css } from 'emotion';
+import { stylesFactory } from '../../themes';
+import { SegmentProps } from './types';
+
+export const getStyles = stylesFactory(<T>(props: Pick<SegmentProps<T>, 'disabled'>) => {
+  return {
+    link: props.disabled
+      ? css`
+          cursor: not-allowed;
+          opacity: 0.65;
+          box-shadow: none;
+        `
+      : '',
+  };
+});

--- a/packages/grafana-ui/src/components/Segment/styles.ts
+++ b/packages/grafana-ui/src/components/Segment/styles.ts
@@ -1,15 +1,12 @@
 import { css } from 'emotion';
 import { stylesFactory } from '../../themes';
-import { SegmentProps } from './types';
 
-export const getStyles = stylesFactory(<T>(props: Pick<SegmentProps<T>, 'disabled'>) => {
+export const getStyles = stylesFactory(() => {
   return {
-    link: props.disabled
-      ? css`
-          cursor: not-allowed;
-          opacity: 0.65;
-          box-shadow: none;
-        `
-      : '',
+    disabled: css`
+      cursor: not-allowed;
+      opacity: 0.65;
+      box-shadow: none;
+    `,
   };
 });

--- a/packages/grafana-ui/src/components/Segment/types.ts
+++ b/packages/grafana-ui/src/components/Segment/types.ts
@@ -5,4 +5,5 @@ export interface SegmentProps<T> {
   className?: string;
   allowCustomValue?: boolean;
   placeholder?: string;
+  disabled?: boolean;
 }

--- a/packages/grafana-ui/src/components/Segment/useExpandableLabel.tsx
+++ b/packages/grafana-ui/src/components/Segment/useExpandableLabel.tsx
@@ -3,6 +3,7 @@ import React, { useState, useRef, ReactElement } from 'react';
 interface LabelProps {
   Component: ReactElement;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 export const useExpandableLabel = (
@@ -12,18 +13,22 @@ export const useExpandableLabel = (
   const [expanded, setExpanded] = useState<boolean>(initialExpanded);
   const [width, setWidth] = useState(0);
 
-  const Label: React.FC<LabelProps> = ({ Component, onClick }) => (
+  const Label: React.FC<LabelProps> = ({ Component, onClick, disabled }) => (
     <div
       ref={ref}
-      onClick={() => {
-        setExpanded(true);
-        if (ref && ref.current) {
-          setWidth(ref.current.clientWidth * 1.25);
-        }
-        if (onClick) {
-          onClick();
-        }
-      }}
+      onClick={
+        disabled
+          ? undefined
+          : () => {
+              setExpanded(true);
+              if (ref && ref.current) {
+                setWidth(ref.current.clientWidth * 1.25);
+              }
+              if (onClick) {
+                onClick();
+              }
+            }
+      }
     >
       {Component}
     </div>

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.test.tsx
@@ -107,9 +107,9 @@ describe('QueryEditor', () => {
         const props = setup();
         props.query.region = (null as unknown) as string;
         const wrapper = mount(<MetricsQueryEditor {...props} />);
-        expect(wrapper.find('.gf-form-inline').first().find('.gf-form-label.query-part').first().text()).toEqual(
-          'default'
-        );
+        expect(
+          wrapper.find('.gf-form-inline').first().find('Segment').find('InlineLabel').find('label').text()
+        ).toEqual('default');
       });
     });
 


### PR DESCRIPTION
SegmentSync, SegmentAsync and SegmentInput had the disable prop inherited from HTMLProp but it did not disable the component. The disable prop should now disable the component.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**Which issue(s) this PR fixes**:

Fixes #29573
