### PR TITLE
POC: Panel's Quick actions/edits

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -7,7 +7,7 @@ import { LegacyGraphHoverClearEvent, locationUtil } from '@grafana/data';
 import coreModule from 'app/core/core_module';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
-import { store } from 'app/store/store';
+import { store, dispatch } from 'app/store/store';
 import { AppEventEmitter, CoreEvents } from 'app/types';
 import { GrafanaRootScope } from 'app/routes/GrafanaCtrl';
 import { DashboardModel } from 'app/features/dashboard/state';
@@ -15,6 +15,7 @@ import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { SaveDashboardModalProxy } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
 import { defaultQueryParams } from 'app/features/search/reducers/searchQueryReducer';
 import { ContextSrv } from './context_srv';
+import { initQuickEdit } from 'app/features/dashboard/state/actions';
 
 export class KeybindingSrv {
   helpModal: boolean;
@@ -356,6 +357,11 @@ export class KeybindingSrv {
       const queryParams = store.getState().location.query;
       const newUrlParam = queryParams.autofitpanels ? '' : '&autofitpanels';
       window.location.href = window.location.href + newUrlParam;
+    });
+
+    this.bind('q', () => {
+      console.log(dashboard.meta.focusPanelId);
+      dispatch(initQuickEdit(dashboard.meta.focusPanelId as string));
     });
   }
 }

--- a/public/app/features/dashboard/state/actions.ts
+++ b/public/app/features/dashboard/state/actions.ts
@@ -8,6 +8,7 @@ import {
   loadDashboardPermissions,
   panelModelAndPluginReady,
   setPanelAngularComponent,
+  startQuickEdit,
 } from './reducers';
 import { notifyApp } from 'app/core/actions';
 import { loadPanelPlugin } from 'app/features/plugins/state/actions';
@@ -163,4 +164,8 @@ export function changePanelPlugin(panel: PanelModel, pluginId: string): ThunkRes
 export const cleanUpDashboardAndVariables = (): ThunkResult<void> => (dispatch) => {
   dispatch(cleanUpDashboard());
   dispatch(cancelVariables());
+};
+
+export const initQuickEdit = (panelId: string): ThunkResult<void> => (dispatch) => {
+  dispatch(startQuickEdit({ panelId }));
 };

--- a/public/app/features/dashboard/state/reducers.ts
+++ b/public/app/features/dashboard/state/reducers.ts
@@ -23,6 +23,7 @@ export const initialState: DashboardState = {
   modifiedQueries: null,
   panels: {},
   initError: null,
+  quickEditPanelId: null,
 };
 
 const dashbardSlice = createSlice({
@@ -90,6 +91,12 @@ const dashbardSlice = createSlice({
       // TODO: refactor, since the state should be mutated by copying only
       state.panels[action.payload.id] = { pluginId: action.payload.type };
     },
+    startQuickEdit: (state, action: PayloadAction<{ panelId: string }>) => {
+      state.quickEditPanelId = action.payload.panelId;
+    },
+    closeQuickEdit: (state) => {
+      state.quickEditPanelId = null;
+    },
   },
 });
 
@@ -125,6 +132,8 @@ export const {
   addPanel,
   cleanUpEditPanel,
   setPanelAngularComponent,
+  startQuickEdit,
+  closeQuickEdit,
 } = dashbardSlice.actions;
 
 export const dashboardReducer = dashbardSlice.reducer;

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -84,4 +84,5 @@ export interface DashboardState {
   permissions: DashboardAcl[];
   modifiedQueries: QueriesToUpdateOnDashboardLoad | null;
   panels: { [id: string]: PanelState };
+  quickEditPanelId: string | null;
 }


### PR DESCRIPTION
Quick POC of Quick action/edit (you name it) to enable rapid viz settings directly fromthe dashboard. Includes copying settings from another panel too. Supports field options only corrently

Quick actions/edits menu is available when you press q when hovering over a panel. 

This is just to get some initial feedback. Don't look at the code, it's a mess done in 2h:)

https://user-images.githubusercontent.com/2376619/105501753-e4637200-5cc4-11eb-8f2c-73cd6ea16ecb.mp4

