### PR TITLE
Explore: Fix loading visualisation on the top of the new time series panel

### DIFF
--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -21,6 +21,7 @@ const dummyProps: ExploreProps = {
   } as DataSourceApi,
   datasourceMissing: false,
   exploreId: ExploreId.left,
+  loading: false,
   initializeExplore: jest.fn(),
   initialized: true,
   modifyQueries: jest.fn(),

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -110,6 +110,7 @@ export interface ExploreProps {
   originPanelId: number;
   addQueryRow: typeof addQueryRow;
   theme: GrafanaTheme;
+  loading: boolean;
   showMetrics: boolean;
   showTable: boolean;
   showLogs: boolean;
@@ -287,8 +288,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
   }
 
   renderGraphPanel(width: number) {
-    const { graphResult, absoluteRange, timeZone, splitOpen, queryResponse } = this.props;
-    const isLoading = queryResponse.state === LoadingState.Loading;
+    const { graphResult, absoluteRange, timeZone, splitOpen, queryResponse, loading } = this.props;
     return (
       <ExploreGraphNGPanel
         data={graphResult!}
@@ -298,7 +298,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
         onUpdateTimeRange={this.onUpdateTimeRange}
         annotations={queryResponse.annotations}
         splitOpenFn={splitOpen}
-        isLoading={isLoading}
+        isLoading={loading}
       />
     );
   }
@@ -482,6 +482,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
     absoluteRange,
     queryResponse,
     showNodeGraph,
+    loading,
   } = item;
 
   const { datasource, queries, range: urlRange, originPanelId } = (urlState || {}) as ExploreUrlState;
@@ -514,6 +515,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
     showTable,
     showTrace,
     showNodeGraph,
+    loading,
   };
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes loading visualisation on the top of the new time series graph in Explore. We weren't passing the loading state from redux as we do in [other used visualisations](https://github.com/grafana/grafana/blob/master/public/app/features/explore/LogsContainer.tsx#L202) that we use in Explore. This PR fixes it. 
![Kapture 2021-01-22 at 17 14 25](https://user-images.githubusercontent.com/30407135/105517431-51800300-5cd7-11eb-82d6-68a02b79d512.gif)

