### PR TITLE
GraphOG: Fix height issue in Firefox

### DIFF
--- a/packages/grafana-ui/src/components/Graph/GraphWithLegend.tsx
+++ b/packages/grafana-ui/src/components/Graph/GraphWithLegend.tsx
@@ -26,7 +26,6 @@ const getGraphWithLegendStyles = stylesFactory(({ placement }: GraphWithLegendPr
   wrapper: css`
     display: flex;
     flex-direction: ${placement === 'bottom' ? 'column' : 'row'};
-    height: 100%;
   `,
   graphContainer: css`
     min-height: 65%;


### PR DESCRIPTION
**What this PR does / why we need it**:

@slim-bean found an issue after #29776 that the logs panel in Explore looks like this in Firefox.

![Screenshot 2021-01-22 at 21 05 36](https://user-images.githubusercontent.com/13729989/105540686-e21a0b80-5cf6-11eb-9563-d6118e7ebc2c.png)

After the changes it looks like this.
![Screenshot 2021-01-22 at 21 00 41](https://user-images.githubusercontent.com/13729989/105540737-fb22bc80-5cf6-11eb-8e59-54b6e6f4abb5.png)


