### PR TITLE
Add WeCom Notification Channel

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -71,6 +71,7 @@ Threema | `threema` | yes, external only | no
 VictorOps | `victorops` | yes, external only | no
 [Webhook](#webhook) | `webhook` | yes, external only | yes
 [Zenduty](#zenduty) | `webhook` | yes, external only | yes
+[Wecom](#wecom) | `wecom` | yes, external only | no
 
 ### Email
 
@@ -216,6 +217,14 @@ Alertmanager handles alerts sent by client applications such as Prometheus serve
 ### Sensu Go
 
 [Sensu](https://sensu.io) is a complete solution for monitoring and observability at scale. Sensu Go is designed to give you visibility into everything you care about: traditional server closets, containers, applications, the cloud, and more. Grafana notifications can be sent to Sensu Go as events via the API. This operation requires an API Key. Refer to the [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication) for information on creating this key.
+
+### WeCom
+
+In WeCom PC Client:
+
+1. Right Click the group chat that you wanted to add the robot
+2. Click "Add Group Robot", select "New Robot" and give your robot a name. Click "Add Robot"
+3. There should be a Webhook URL in the panel. Click "Copy URL" and paste it in Grafana WeCom setting page and click "finish"
 
 ## Enable images in notifications {#external-image-store}
 

--- a/pkg/services/alerting/notifiers/wecom.go
+++ b/pkg/services/alerting/notifiers/wecom.go
@@ -1,0 +1,92 @@
+package notifiers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+// WecomNotifier is responsible for sending alert notification to Wecom group robot
+type WecomNotifier struct {
+	NotifierBase
+	Webhook string
+	log     log.Logger
+}
+
+func init() {
+	alerting.RegisterNotifier(&alerting.NotifierPlugin{
+		Type:        "wecom",
+		Name:        "Wecom",
+		Description: "Sends notifications using Wecom group robot",
+		Factory:     newWecomNotifier,
+		Options: []alerting.NotifierOption{
+			{
+				Label:        "Webhook",
+				Element:      alerting.ElementTypeInput,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "Your Wecom Group Robot Webhook URL",
+				PropertyName: "webhook",
+				Required:     true,
+			},
+		},
+	})
+}
+
+func newWecomNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+	webhook := model.Settings.Get("webhook").MustString()
+	if webhook == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find webhook in settings"}
+	}
+	return &WecomNotifier{
+		NotifierBase: NewNotifierBase(model),
+		Webhook:      model.Settings.Get("webhook").MustString(),
+		log:          log.New("alerting.notifier.wecom"),
+	}, nil
+}
+
+// Notify sends the alert notification to Wecom group robot
+func (w *WecomNotifier) Notify(evalContext *alerting.EvalContext) error {
+	w.log.Info("Sending Wecom Group Robot")
+
+	content := fmt.Sprintf("%v\n%v\n",
+		evalContext.GetNotificationTitle(),
+		evalContext.Rule.Message,
+	)
+
+	if evalContext.ImagePublicURL != "" {
+		content += fmt.Sprintf("[%s](%s)\n", evalContext.ImagePublicURL, evalContext.ImagePublicURL)
+	}
+
+	for i, match := range evalContext.EvalMatches {
+		content += fmt.Sprintf("\n%2d. %s: `%s`", i+1, match.Metric, match.Value)
+	}
+
+	body := map[string]interface{}{
+		"msgtype": "markdown",
+		"markdown": map[string]string{
+			"content": content,
+		},
+	}
+
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		w.log.Error("Failed to marshal body", "error", err)
+		return err
+	}
+
+	cmd := &models.SendWebhookSync{
+		Url:  w.Webhook,
+		Body: string(bodyJSON),
+	}
+
+	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
+		w.log.Error("Failed to send Wecom", "error", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/services/alerting/notifiers/wecom.go
+++ b/pkg/services/alerting/notifiers/wecom.go
@@ -10,8 +10,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/alerting"
 )
 
-// WecomNotifier is responsible for sending alert notification to Wecom group robot
-type WecomNotifier struct {
+// WeComNotifier is responsible for sending alert notification to WeCom group robot
+type WeComNotifier struct {
 	NotifierBase
 	Webhook string
 	log     log.Logger
@@ -20,15 +20,15 @@ type WecomNotifier struct {
 func init() {
 	alerting.RegisterNotifier(&alerting.NotifierPlugin{
 		Type:        "wecom",
-		Name:        "Wecom",
-		Description: "Sends notifications using Wecom group robot",
-		Factory:     newWecomNotifier,
+		Name:        "WeCom",
+		Description: "Sends notifications using WeCom group robot",
+		Factory:     newWeComNotifier,
 		Options: []alerting.NotifierOption{
 			{
 				Label:        "Webhook",
 				Element:      alerting.ElementTypeInput,
 				InputType:    alerting.InputTypeText,
-				Placeholder:  "Your Wecom Group Robot Webhook URL",
+				Placeholder:  "Your WeCom Group Robot Webhook URL",
 				PropertyName: "webhook",
 				Required:     true,
 			},
@@ -36,21 +36,21 @@ func init() {
 	})
 }
 
-func newWecomNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+func newWeComNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
 	webhook := model.Settings.Get("webhook").MustString()
 	if webhook == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find webhook in settings"}
 	}
-	return &WecomNotifier{
+	return &WeComNotifier{
 		NotifierBase: NewNotifierBase(model),
 		Webhook:      model.Settings.Get("webhook").MustString(),
 		log:          log.New("alerting.notifier.wecom"),
 	}, nil
 }
 
-// Notify sends the alert notification to Wecom group robot
-func (w *WecomNotifier) Notify(evalContext *alerting.EvalContext) error {
-	w.log.Info("Sending Wecom Group Robot")
+// Notify sends the alert notification to WeCom group robot
+func (w *WeComNotifier) Notify(evalContext *alerting.EvalContext) error {
+	w.log.Info("Sending WeCom Group Robot")
 
 	content := fmt.Sprintf("%v\n%v\n",
 		evalContext.GetNotificationTitle(),
@@ -84,7 +84,7 @@ func (w *WecomNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 
 	if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
-		w.log.Error("Failed to send Wecom", "error", err)
+		w.log.Error("Failed to send WeCom", "error", err)
 		return err
 	}
 

--- a/pkg/services/alerting/notifiers/wecom_test.go
+++ b/pkg/services/alerting/notifiers/wecom_test.go
@@ -18,7 +18,7 @@ func TestWecomNotifier(t *testing.T) {
 				Type:     "wecom",
 				Settings: settingsJSON,
 			}
-			_, err := newWecomNotifier(model)
+			_, err := newWeComNotifier(model)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("settings should trigger incident", func() {
@@ -29,8 +29,8 @@ func TestWecomNotifier(t *testing.T) {
 				Type:     "wecom",
 				Settings: settingsJSON,
 			}
-			not, err := newWecomNotifier(model)
-			notifier := not.(*WecomNotifier)
+			not, err := newWeComNotifier(model)
+			notifier := not.(*WeComNotifier)
 			So(err, ShouldBeNil)
 			So(notifier.Name, ShouldEqual, "wecom_testing")
 			So(notifier.Type, ShouldEqual, "wecom")

--- a/pkg/services/alerting/notifiers/wecom_test.go
+++ b/pkg/services/alerting/notifiers/wecom_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestWecomNotifier(t *testing.T) {
-	Convey("Wecom notifier tests", t, func() {
+func TestWeComNotifier(t *testing.T) {
+	Convey("WeCom notifier tests", t, func() {
 		Convey("empty settings should return error", func() {
 			json := `{ }`
 			settingsJSON, _ := simplejson.NewJson([]byte(json))

--- a/pkg/services/alerting/notifiers/wecom_test.go
+++ b/pkg/services/alerting/notifiers/wecom_test.go
@@ -1,0 +1,41 @@
+package notifiers
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestWecomNotifier(t *testing.T) {
+	Convey("Wecom notifier tests", t, func() {
+		Convey("empty settings should return error", func() {
+			json := `{ }`
+			settingsJSON, _ := simplejson.NewJson([]byte(json))
+			model := &models.AlertNotification{
+				Name:     "wecom_testing",
+				Type:     "wecom",
+				Settings: settingsJSON,
+			}
+			_, err := newWecomNotifier(model)
+			So(err, ShouldNotBeNil)
+		})
+		Convey("settings should trigger incident", func() {
+			json := `{ "webhook": "https://www.google.com" }`
+			settingsJSON, _ := simplejson.NewJson([]byte(json))
+			model := &models.AlertNotification{
+				Name:     "wecom_testing",
+				Type:     "wecom",
+				Settings: settingsJSON,
+			}
+			not, err := newWecomNotifier(model)
+			notifier := not.(*WecomNotifier)
+			So(err, ShouldBeNil)
+			So(notifier.Name, ShouldEqual, "wecom_testing")
+			So(notifier.Type, ShouldEqual, "wecom")
+			So(notifier.Webhook, ShouldEqual, "https://www.google.com")
+
+		})
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**: 

Added WeCom Notification Channel Support

Test file passed and included

Documentation is updated accordingly

Fixes https://github.com/grafana/grafana/issues/21211.

**Special notes for your reviewer**:

I am excited to send this pull request to add WeCom notification channel support for Grafana.

WeCom is a communication platform for enterprises that is similar to WeChat.

Please do let me know if any other info is needed for this to be merged : )