### PR TITLE
Provisioning: Add organizations provisioning

### DIFF
--- a/conf/provisioning/orgs/sample.yaml
+++ b/conf/provisioning/orgs/sample.yaml
@@ -12,3 +12,8 @@ apiVersion: 1
 #  name: First Org.
 #- id: 2
 #  name: Second Org.
+#  preferences:
+#    # Needs to be known up front
+#    homeDashboardId: 1
+#    timezone: browser
+#    theme: light

--- a/conf/provisioning/orgs/sample.yaml
+++ b/conf/provisioning/orgs/sample.yaml
@@ -1,0 +1,14 @@
+# # config file version
+apiVersion: 1
+
+# # list of orgs that should be deleted from the database
+#deleteOrgs:
+#- id: 1
+
+# # list of orgs to be insert/updated depending
+# # on what's available in the database
+#orgs:
+#- id: 1
+#  name: First Org.
+#- id: 2
+#  name: Second Org.

--- a/pkg/models/org.go
+++ b/pkg/models/org.go
@@ -31,6 +31,7 @@ type Org struct {
 // COMMANDS
 
 type CreateOrgCommand struct {
+	Id   int64  `json:"id"`
 	Name string `json:"name" binding:"Required"`
 
 	// initial admin user for account

--- a/pkg/services/provisioning/orgs/config_reader.go
+++ b/pkg/services/provisioning/orgs/config_reader.go
@@ -1,0 +1,69 @@
+package orgs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"gopkg.in/yaml.v2"
+)
+
+type configReader struct {
+	log log.Logger
+}
+
+func (cr *configReader) readConfig(path string) ([]*configs, error) {
+	var orgs []*configs
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		cr.log.Error("can't read org provisioning files from directory", "path", path, "error", err)
+		return orgs, nil
+	}
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml") {
+			org, err := cr.parseOrgConfig(path, file)
+			if err != nil {
+				return nil, err
+			}
+
+			if org != nil {
+				orgs = append(orgs, org)
+			}
+		}
+	}
+
+	return orgs, nil
+}
+
+func (cr *configReader) parseOrgConfig(path string, file os.FileInfo) (*configs, error) {
+	filename, _ := filepath.Abs(filepath.Join(path, file.Name()))
+
+	// nolint:gosec
+	// We can ignore the gosec G304 warning on this one because `filename` comes from ps.Cfg.ProvisioningPath
+	yamlFile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var apiVersion *configVersion
+	err = yaml.Unmarshal(yamlFile, &apiVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if apiVersion == nil {
+		apiVersion = &configVersion{APIVersion: 1}
+	}
+
+	v1 := &configsV1{log: cr.log}
+	err = yaml.Unmarshal(yamlFile, v1)
+	if err != nil {
+		return nil, err
+	}
+
+	return v1.mapToOrgFromConfig(apiVersion.APIVersion), nil
+}

--- a/pkg/services/provisioning/orgs/config_reader.go
+++ b/pkg/services/provisioning/orgs/config_reader.go
@@ -1,6 +1,7 @@
 package orgs
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,7 +15,7 @@ type configReader struct {
 	log log.Logger
 }
 
-func (cr *configReader) readConfig(path string) ([]*configs, error) {
+func (cr *configReader) readConfig(ctx context.Context, path string) ([]*configs, error) {
 	var orgs []*configs
 
 	files, err := ioutil.ReadDir(path)

--- a/pkg/services/provisioning/orgs/config_reader_test.go
+++ b/pkg/services/provisioning/orgs/config_reader_test.go
@@ -1,0 +1,135 @@
+package orgs
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	logger log.Logger = log.New("fake.log")
+
+	twoOrgsConfig            = "testdata/two-orgs"
+	twoOrgsConfigPurgeOthers = "testdata/insert-two-delete-two"
+	brokenYaml               = "testdata/broken-yaml"
+
+	fakeRepo *fakeRepository
+)
+
+func TestOrgAsConfig(t *testing.T) {
+	Convey("Testing org as configuration", t, func() {
+		fakeRepo = &fakeRepository{}
+		bus.ClearBusHandlers()
+		bus.AddHandler("test", mockDelete)
+		bus.AddHandler("test", mockInsert)
+		bus.AddHandler("test", mockUpdate)
+		bus.AddHandler("test", mockGet)
+
+		Convey("Two configured orgs", func() {
+			Convey("no org in database", func() {
+				dc := newOrgProvisioner(logger)
+				err := dc.applyChanges(twoOrgsConfig)
+				if err != nil {
+					t.Fatalf("applyChanges return an error %v", err)
+				}
+
+				So(len(fakeRepo.deleted), ShouldEqual, 0)
+				So(len(fakeRepo.inserted), ShouldEqual, 2)
+				So(len(fakeRepo.updated), ShouldEqual, 0)
+			})
+
+			Convey("One org in database with same ID", func() {
+				fakeRepo.loadAll = []*models.Org{
+					{Id: 1, Name: "Main Org."},
+				}
+
+				Convey("should update one org", func() {
+					dc := newOrgProvisioner(logger)
+					err := dc.applyChanges(twoOrgsConfig)
+					if err != nil {
+						t.Fatalf("applyChanges return an error %v", err)
+					}
+
+					So(len(fakeRepo.deleted), ShouldEqual, 0)
+					So(len(fakeRepo.inserted), ShouldEqual, 1)
+					So(len(fakeRepo.updated), ShouldEqual, 1)
+				})
+			})
+		})
+
+		Convey("Two configured orgs and purge others ", func() {
+			Convey("two other orgs in database", func() {
+				fakeRepo.loadAll = []*models.Org{
+					{Id: 3, Name: "old-org"},
+					{Id: 4, Name: "old-org2"},
+				}
+
+				Convey("should have two new orgs", func() {
+					dc := newOrgProvisioner(logger)
+					err := dc.applyChanges(twoOrgsConfigPurgeOthers)
+					if err != nil {
+						t.Fatalf("applyChanges return an error %v", err)
+					}
+
+					So(len(fakeRepo.deleted), ShouldEqual, 2)
+					So(len(fakeRepo.inserted), ShouldEqual, 2)
+					So(len(fakeRepo.updated), ShouldEqual, 0)
+				})
+			})
+		})
+
+		Convey("broken yaml should return error", func() {
+			reader := &configReader{}
+			_, err := reader.readConfig(brokenYaml)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("skip invalid directory", func() {
+			cfgProvider := &configReader{log: log.New("test logger")}
+			cfg, err := cfgProvider.readConfig("./invalid-directory")
+			if err != nil {
+				t.Fatalf("readConfig return an error %v", err)
+			}
+
+			So(len(cfg), ShouldEqual, 0)
+		})
+	})
+}
+
+type fakeRepository struct {
+	inserted []*models.CreateOrgCommand
+	deleted  []*models.DeleteOrgCommand
+	updated  []*models.UpdateOrgCommand
+
+	loadAll []*models.Org
+}
+
+func mockDelete(cmd *models.DeleteOrgCommand) error {
+	fakeRepo.deleted = append(fakeRepo.deleted, cmd)
+	return nil
+}
+
+func mockUpdate(cmd *models.UpdateOrgCommand) error {
+	fakeRepo.updated = append(fakeRepo.updated, cmd)
+	return nil
+}
+
+func mockInsert(cmd *models.CreateOrgCommand) error {
+	fakeRepo.inserted = append(fakeRepo.inserted, cmd)
+	return nil
+}
+
+func mockGet(cmd *models.GetOrgByIdQuery) error {
+	for _, v := range fakeRepo.loadAll {
+		if cmd.Id == v.Id {
+			cmd.Result = v
+			return nil
+		}
+	}
+
+	return models.ErrOrgNotFound
+}

--- a/pkg/services/provisioning/orgs/config_reader_test.go
+++ b/pkg/services/provisioning/orgs/config_reader_test.go
@@ -28,6 +28,7 @@ func TestOrgAsConfig(t *testing.T) {
 		bus.AddHandler("test", mockInsert)
 		bus.AddHandler("test", mockUpdate)
 		bus.AddHandler("test", mockGet)
+		bus.AddHandler("test", mockSavePreferences)
 
 		Convey("Two configured orgs", func() {
 			Convey("no org in database", func() {
@@ -40,6 +41,7 @@ func TestOrgAsConfig(t *testing.T) {
 				So(len(fakeRepo.deleted), ShouldEqual, 0)
 				So(len(fakeRepo.inserted), ShouldEqual, 2)
 				So(len(fakeRepo.updated), ShouldEqual, 0)
+				So(len(fakeRepo.savedPreferences), ShouldEqual, 1)
 			})
 
 			Convey("One org in database with same ID", func() {
@@ -57,6 +59,7 @@ func TestOrgAsConfig(t *testing.T) {
 					So(len(fakeRepo.deleted), ShouldEqual, 0)
 					So(len(fakeRepo.inserted), ShouldEqual, 1)
 					So(len(fakeRepo.updated), ShouldEqual, 1)
+					So(len(fakeRepo.savedPreferences), ShouldEqual, 1)
 				})
 			})
 		})
@@ -78,6 +81,7 @@ func TestOrgAsConfig(t *testing.T) {
 					So(len(fakeRepo.deleted), ShouldEqual, 2)
 					So(len(fakeRepo.inserted), ShouldEqual, 2)
 					So(len(fakeRepo.updated), ShouldEqual, 0)
+					So(len(fakeRepo.savedPreferences), ShouldEqual, 1)
 				})
 			})
 		})
@@ -101,9 +105,10 @@ func TestOrgAsConfig(t *testing.T) {
 }
 
 type fakeRepository struct {
-	inserted []*models.CreateOrgCommand
-	deleted  []*models.DeleteOrgCommand
-	updated  []*models.UpdateOrgCommand
+	inserted         []*models.CreateOrgCommand
+	deleted          []*models.DeleteOrgCommand
+	updated          []*models.UpdateOrgCommand
+	savedPreferences []*models.SavePreferencesCommand
 
 	loadAll []*models.Org
 }
@@ -132,4 +137,9 @@ func mockGet(cmd *models.GetOrgByIdQuery) error {
 	}
 
 	return models.ErrOrgNotFound
+}
+
+func mockSavePreferences(cmd *models.SavePreferencesCommand) error {
+	fakeRepo.savedPreferences = append(fakeRepo.savedPreferences, cmd)
+	return nil
 }

--- a/pkg/services/provisioning/orgs/orgs.go
+++ b/pkg/services/provisioning/orgs/orgs.go
@@ -3,6 +3,7 @@ package orgs
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -52,6 +53,14 @@ func (provisioner *OrgProvisioner) apply(cfg *configs) error {
 			provisioner.log.Debug("updating org from configuration", "id", org.Id, "name", org.Name)
 			updateCmd := createUpdateCommand(org)
 			if err := bus.Dispatch(updateCmd); err != nil {
+				return err
+			}
+		}
+
+		if savePreferencesCmd := createSavePreferencesCommand(org); savePreferencesCmd != nil {
+			provisioner.log.Debug("updating org preferences from configuration", "id", org.Id, "name", org.Name)
+			fmt.Println(savePreferencesCmd)
+			if err := bus.Dispatch(savePreferencesCmd); err != nil {
 				return err
 			}
 		}

--- a/pkg/services/provisioning/orgs/orgs.go
+++ b/pkg/services/provisioning/orgs/orgs.go
@@ -1,0 +1,87 @@
+package orgs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+// Provision scans a directory for provisioning config files
+// and provisions the orgs in those files.
+func Provision(ctx context.Context, configDirectory string) error {
+	provisioner := newOrgProvisioner(log.New("provisioning.orgs"))
+	return provisioner.applyChanges(configDirectory)
+}
+
+// OrgProvisioner is responsible for provisioning orgs based on
+// configuration read by the `configReader`
+type OrgProvisioner struct {
+	log         log.Logger
+	cfgProvider *configReader
+}
+
+func newOrgProvisioner(log log.Logger) OrgProvisioner {
+	return OrgProvisioner{
+		log:         log,
+		cfgProvider: &configReader{log: log},
+	}
+}
+
+func (provisioner *OrgProvisioner) apply(cfg *configs) error {
+	if err := provisioner.deleteOrgs(cfg.DeleteOrgs); err != nil {
+		return err
+	}
+
+	for _, org := range cfg.Orgs {
+		cmd := &models.GetOrgByIdQuery{Id: org.Id}
+		err := bus.Dispatch(cmd)
+		if err != nil && !errors.Is(err, models.ErrOrgNotFound) {
+			return err
+		}
+
+		if errors.Is(err, models.ErrOrgNotFound) {
+			provisioner.log.Info("inserting org from configuration ", "id", org.Id, "name", org.Name)
+			insertCmd := createInsertCommand(org)
+			if err := bus.Dispatch(insertCmd); err != nil {
+				return err
+			}
+		} else {
+			provisioner.log.Debug("updating org from configuration", "id", org.Id, "name", org.Name)
+			updateCmd := createUpdateCommand(org)
+			if err := bus.Dispatch(updateCmd); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (provisioner *OrgProvisioner) applyChanges(configPath string) error {
+	configs, err := provisioner.cfgProvider.readConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	for _, cfg := range configs {
+		if err := provisioner.apply(cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (provisioner *OrgProvisioner) deleteOrgs(orgsToDelete []*deleteOrgConfig) error {
+	for _, org := range orgsToDelete {
+		cmd := &models.DeleteOrgCommand{Id: org.Id}
+		if err := bus.Dispatch(cmd); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/provisioning/orgs/testdata/broken-yaml/broken.yaml
+++ b/pkg/services/provisioning/orgs/testdata/broken-yaml/broken.yaml
@@ -1,0 +1,6 @@
+#sfxzgnsxzcvnbzcvn
+cvbn
+cvbn
+c
+vbn
+cvbncvbn

--- a/pkg/services/provisioning/orgs/testdata/broken-yaml/commented.yaml
+++ b/pkg/services/provisioning/orgs/testdata/broken-yaml/commented.yaml
@@ -1,0 +1,11 @@
+# # list of orgs that should be deleted from the database
+#deleteOrgs:
+#   - id: 1
+
+# # list of orgs to insert/update depending
+# # what's available in the database
+#orgs:
+#   # <int, required> id of the org. Required
+# - id: 1
+#   # <string, required> name of the org. Required
+#   name: Main Org.

--- a/pkg/services/provisioning/orgs/testdata/insert-two-delete-two/one-orgs.yaml
+++ b/pkg/services/provisioning/orgs/testdata/insert-two-delete-two/one-orgs.yaml
@@ -1,0 +1,5 @@
+orgs:
+  - id: 1
+    name: New First Org
+deleteOrgs:
+  - id: 3

--- a/pkg/services/provisioning/orgs/testdata/insert-two-delete-two/two-orgs.yml
+++ b/pkg/services/provisioning/orgs/testdata/insert-two-delete-two/two-orgs.yml
@@ -1,0 +1,5 @@
+orgs:
+  - id: 2
+    name: New Second Org
+deleteOrgs:
+  - id: 4

--- a/pkg/services/provisioning/orgs/testdata/insert-two-delete-two/two-orgs.yml
+++ b/pkg/services/provisioning/orgs/testdata/insert-two-delete-two/two-orgs.yml
@@ -1,5 +1,9 @@
 orgs:
   - id: 2
     name: New Second Org
+    preferences:
+      homeDashboardId: 0
+      timezone: browser
+      theme: dark
 deleteOrgs:
   - id: 4

--- a/pkg/services/provisioning/orgs/testdata/two-orgs/two-orgs.yaml
+++ b/pkg/services/provisioning/orgs/testdata/two-orgs/two-orgs.yaml
@@ -1,0 +1,5 @@
+orgs:
+  - id: 1
+    name: First Org
+  - id: 2
+    name: Second Org

--- a/pkg/services/provisioning/orgs/testdata/two-orgs/two-orgs.yaml
+++ b/pkg/services/provisioning/orgs/testdata/two-orgs/two-orgs.yaml
@@ -3,3 +3,7 @@ orgs:
     name: First Org
   - id: 2
     name: Second Org
+    preferences:
+      homeDashboardId: 0
+      timezone: browser
+      theme: dark

--- a/pkg/services/provisioning/orgs/types.go
+++ b/pkg/services/provisioning/orgs/types.go
@@ -1,0 +1,85 @@
+package orgs
+
+import (
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/provisioning/values"
+)
+
+// ConfigVersion is used to figure out which API version a config uses.
+type configVersion struct {
+	APIVersion int64 `json:"apiVersion" yaml:"apiVersion"`
+}
+
+type configs struct {
+	APIVersion int64
+
+	Orgs       []*upsertOrgFromConfig
+	DeleteOrgs []*deleteOrgConfig
+}
+
+type deleteOrgConfig struct {
+	Id   int64
+	Name string
+}
+
+type upsertOrgFromConfig struct {
+	Id   int64
+	Name string
+}
+
+type configsV1 struct {
+	configVersion
+	log log.Logger
+
+	Orgs       []*upsertOrgFromConfigV1 `json:"orgs" yaml:"orgs"`
+	DeleteOrgs []*deleteOrgConfigV1     `json:"deleteOrgs" yaml:"deleteOrgs"`
+}
+
+type deleteOrgConfigV1 struct {
+	Id values.Int64Value `json:"id" yaml:"id"`
+}
+
+type upsertOrgFromConfigV1 struct {
+	Id   values.Int64Value  `json:"id" yaml:"id"`
+	Name values.StringValue `json:"name" yaml:"name"`
+}
+
+func (cfg *configsV1) mapToOrgFromConfig(apiVersion int64) *configs {
+	r := &configs{}
+
+	r.APIVersion = apiVersion
+
+	if cfg == nil {
+		return r
+	}
+
+	for _, org := range cfg.Orgs {
+		r.Orgs = append(r.Orgs, &upsertOrgFromConfig{
+			Id:   org.Id.Value(),
+			Name: org.Name.Value(),
+		})
+	}
+
+	for _, org := range cfg.DeleteOrgs {
+		r.DeleteOrgs = append(r.DeleteOrgs, &deleteOrgConfig{
+			Id: org.Id.Value(),
+		})
+	}
+
+	return r
+}
+
+func createInsertCommand(org *upsertOrgFromConfig) *models.CreateOrgCommand {
+	return &models.CreateOrgCommand{
+		Id:   org.Id,
+		Name: org.Name,
+	}
+}
+
+func createUpdateCommand(org *upsertOrgFromConfig) *models.UpdateOrgCommand {
+	return &models.UpdateOrgCommand{
+		OrgId: org.Id,
+		Name:  org.Name,
+	}
+}

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -99,7 +99,7 @@ func (ps *ProvisioningServiceImpl) RunInitProvisioners(ctx context.Context) erro
 		return err
 	}
 
-	err := ps.ProvisionDatasources(ctx)
+	err = ps.ProvisionDatasources(ctx)
 	if err != nil {
 		return err
 	}
@@ -156,10 +156,14 @@ func (ps *ProvisioningServiceImpl) ProvisionDatasources(ctx context.Context) err
 	return nil
 }
 
-func (ps *provisioningServiceImpl) ProvisionOrgs() error {
-	datasourcePath := filepath.Join(ps.Cfg.ProvisioningPath, "orgs")
-	err := ps.provisionOrgs(datasourcePath)
-	return errutil.Wrap("Org provisioning error", err)
+func (ps *ProvisioningServiceImpl) ProvisionOrgs(ctx context.Context) error {
+	orgPath := filepath.Join(ps.Cfg.ProvisioningPath, "orgs")
+	if err := ps.provisionOrgs(ctx, orgPath); err != nil {
+		err = errutil.Wrap("Org provisioning error", err)
+		ps.log.Error("Failed to provision orgs", "error", err)
+		return err
+	}
+	return nil
 }
 
 func (ps *ProvisioningServiceImpl) ProvisionPlugins(ctx context.Context) error {

--- a/pkg/services/provisioning/provisioning_mock.go
+++ b/pkg/services/provisioning/provisioning_mock.go
@@ -8,6 +8,7 @@ type Calls struct {
 	ProvisionPlugins                    []interface{}
 	ProvisionNotifications              []interface{}
 	ProvisionDashboards                 []interface{}
+	ProvisionOrgs                       []interface{}
 	GetDashboardProvisionerResolvedPath []interface{}
 	GetAllowUIUpdatesFromConfig         []interface{}
 	Run                                 []interface{}
@@ -20,6 +21,7 @@ type ProvisioningServiceMock struct {
 	ProvisionPluginsFunc                    func() error
 	ProvisionNotificationsFunc              func() error
 	ProvisionDashboardsFunc                 func() error
+	ProvisionOrgsFunc                       func() error
 	GetDashboardProvisionerResolvedPathFunc func(name string) string
 	GetAllowUIUpdatesFromConfigFunc         func(name string) bool
 	RunFunc                                 func(ctx context.Context) error
@@ -35,6 +37,14 @@ func (mock *ProvisioningServiceMock) RunInitProvisioners(ctx context.Context) er
 	mock.Calls.RunInitProvisioners = append(mock.Calls.RunInitProvisioners, nil)
 	if mock.RunInitProvisionersFunc != nil {
 		return mock.RunInitProvisionersFunc(ctx)
+	}
+	return nil
+}
+
+func (mock *ProvisioningServiceMock) ProvisionOrgs() error {
+	mock.Calls.ProvisionOrgs = append(mock.Calls.ProvisionOrgs, nil)
+	if mock.ProvisionOrgsFunc != nil {
+		return mock.ProvisionOrgsFunc()
 	}
 	return nil
 }

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -98,6 +98,7 @@ func setup() *serviceTestStruct {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	serviceTest.service.Cfg = setting.NewCfg()
 

--- a/pkg/services/sqlstore/org.go
+++ b/pkg/services/sqlstore/org.go
@@ -108,6 +108,14 @@ func isOrgNameTaken(name string, existingId int64, sess *DBSession) (bool, error
 	return false, nil
 }
 
+func insertOrg(sess *DBSession, org *models.Org) (int64, error) {
+	if org.Id != 0 {
+		return sess.InsertId(org)
+	}
+
+	return sess.Insert(org)
+}
+
 func createOrg(id int64, name string, userID int64, engine *xorm.Engine) (models.Org, error) {
 	org := models.Org{
 		Id:      id,
@@ -122,14 +130,8 @@ func createOrg(id int64, name string, userID int64, engine *xorm.Engine) (models
 			return models.ErrOrgNameTaken
 		}
 
-		if org.Id != 0 {
-			if _, err := sess.InsertId(&org); err != nil {
-				return err
-			}
-		} else {
-			if _, err := sess.Insert(&org); err != nil {
-				return err
-			}
+		if _, err := insertOrg(sess, &org); err != nil {
+			return err
 		}
 
 		var err error


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds a provisioner that allows the creation, modification and deletion of orgs from a config file as follows:
```
orgs:
- id: 1
  name: First Org
- id: 2
  name: Second Org
  preferences:
    # Needs to be known up front
    homeDashboardId: 1
    timezone: browser
    theme: light
deleteOrgs:
- id: 3 
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Closes #12119

**Special notes for your reviewer**:

From my point of view, this already implements the core requirement, which is org provisioning. I'm still unclear on a couple things, hence the Draft PR:

* I've only added a v1 config - is a v0 config needed?
* There's no auto assigned admin for these orgs. In case of initial_admin_creation, should I do a get for the admin_user and add that userId as admin to these orgs?
* As it is now, this will simply run after the initial creation of admin and org, hence it can rename/overwrite the default org. That appears to be fine to me, but it might lead to some confusion.
* Selecting any of theses orgs as auto_assign_org_id should work fine.
* Org preferences: Are optionally updated, if present in the config (pointer), which seems to be uncommon for the codebase (Comments?). Needing to know the dashboard ID in order to set it as home dashboard defeats the purpose I think. Would it make sense to add a IsHomeDashboard option to the dashboard provisioning, similar to "default datasource"?

I have not yet updated any docs until I have more info on the above.