### PR TITLE
Variables: Fixes so queries work for numbers values too

### DIFF
--- a/public/app/features/variables/query/operators.test.ts
+++ b/public/app/features/variables/query/operators.test.ts
@@ -289,6 +289,7 @@ describe('areMetricFindValues', () => {
     ${[{ text: () => {} }]}      | ${false}
     ${[{ text: { foo: 1 } }]}    | ${false}
     ${[{ text: Symbol('foo') }]} | ${false}
+    ${[{ text: true }]}          | ${false}
     ${[]}                        | ${true}
     ${[{ text: '' }]}            | ${true}
     ${[{ Text: '' }]}            | ${true}
@@ -297,9 +298,9 @@ describe('areMetricFindValues', () => {
     ${[{ text: '', value: '' }]} | ${true}
     ${[{ Text: '', Value: '' }]} | ${true}
     ${[{ text: 1 }]}             | ${true}
-    ${[{ Text: false }]}         | ${true}
+    ${[{ Text: 1 }]}             | ${true}
     ${[{ value: 1 }]}            | ${true}
-    ${[{ Value: true }]}         | ${true}
+    ${[{ Value: 1 }]}            | ${true}
     ${[{ text: 1, value: 1 }]}   | ${true}
     ${[{ Text: 1, Value: 1 }]}   | ${true}
   `('when called with values:$values', ({ values, expected }) => {

--- a/public/app/features/variables/query/operators.test.ts
+++ b/public/app/features/variables/query/operators.test.ts
@@ -277,10 +277,18 @@ describe('operators', () => {
 });
 
 describe('areMetricFindValues', () => {
+  const frame = toDataFrame({
+    fields: [{ name: 'text', type: FieldType.number, values: [1] }],
+  });
+
   it.each`
     values                       | expected
     ${null}                      | ${false}
     ${undefined}                 | ${false}
+    ${[frame]}                   | ${false}
+    ${[{ text: () => {} }]}      | ${false}
+    ${[{ text: { foo: 1 } }]}    | ${false}
+    ${[{ text: Symbol('foo') }]} | ${false}
     ${[]}                        | ${true}
     ${[{ text: '' }]}            | ${true}
     ${[{ Text: '' }]}            | ${true}
@@ -288,6 +296,12 @@ describe('areMetricFindValues', () => {
     ${[{ Value: '' }]}           | ${true}
     ${[{ text: '', value: '' }]} | ${true}
     ${[{ Text: '', Value: '' }]} | ${true}
+    ${[{ text: 1 }]}             | ${true}
+    ${[{ Text: false }]}         | ${true}
+    ${[{ value: 1 }]}            | ${true}
+    ${[{ Value: true }]}         | ${true}
+    ${[{ text: 1, value: 1 }]}   | ${true}
+    ${[{ Text: 1, Value: 1 }]}   | ${true}
   `('when called with values:$values', ({ values, expected }) => {
     expect(areMetricFindValues(values)).toBe(expected);
   });

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -186,12 +186,11 @@ export function areMetricFindValues(data: any[]): data is MetricFindValue[] {
   }
 
   for (const firstValueKey in firstValue) {
-    if (
-      !firstValue.hasOwnProperty(firstValueKey) ||
-      typeof firstValue[firstValueKey] === 'object' ||
-      typeof firstValue[firstValueKey] === 'function' ||
-      typeof firstValue[firstValueKey] === 'symbol'
-    ) {
+    if (!firstValue.hasOwnProperty(firstValueKey)) {
+      continue;
+    }
+
+    if (typeof firstValue[firstValueKey] !== 'string' && typeof firstValue[firstValueKey] !== 'number') {
       continue;
     }
 

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -5,12 +5,10 @@ import { QueryVariableModel } from '../types';
 import { ThunkDispatch } from '../../../types';
 import { toVariableIdentifier, toVariablePayload } from '../state/types';
 import { validateVariableSelectionState } from '../state/actions';
-import { DataSourceApi, FieldType, getFieldDisplayName, MetricFindValue, PanelData } from '@grafana/data';
+import { DataSourceApi, FieldType, getFieldDisplayName, isDataFrame, MetricFindValue, PanelData } from '@grafana/data';
 import { updateVariableOptions, updateVariableTags } from './reducer';
 import { getTimeSrv, TimeSrv } from '../../dashboard/services/TimeSrv';
 import { getLegacyQueryOptions, getTemplatedRegex } from '../utils';
-
-const metricFindValueProps = ['text', 'Text', 'value', 'Value'];
 
 export function toMetricFindValues(): OperatorFunction<PanelData, MetricFindValue[]> {
   return (source) =>
@@ -183,5 +181,26 @@ export function areMetricFindValues(data: any[]): data is MetricFindValue[] {
   }
 
   const firstValue: any = data[0];
-  return metricFindValueProps.some((prop) => firstValue.hasOwnProperty(prop) && typeof firstValue[prop] === 'string');
+  if (isDataFrame(firstValue)) {
+    return false;
+  }
+
+  for (const firstValueKey in firstValue) {
+    if (
+      !firstValue.hasOwnProperty(firstValueKey) ||
+      typeof firstValue[firstValueKey] === 'object' ||
+      typeof firstValue[firstValueKey] === 'function' ||
+      typeof firstValue[firstValueKey] === 'symbol'
+    ) {
+      continue;
+    }
+
+    const key = firstValueKey.toLowerCase();
+
+    if (key === 'text' || key === 'value') {
+      return true;
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When we check if the data from the data source is a metric find value or not I made a silly mistake and only allowed return values of string type. This PR opens up so other types are valid for metric find values.

**Which issue(s) this PR fixes**:
Fixes #30595

**Special notes for your reviewer**:

