### PR TITLE
chore: bump react-popper to 1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "react-grid-layout": "0.17.1",
     "react-highlight-words": "0.16.0",
     "react-loadable": "5.5.0",
-    "react-popper": "1.3.3",
+    "react-popper": "1.3.4",
     "react-redux": "7.2.0",
     "react-reverse-portal": "^2.0.1",
     "react-sizeme": "2.6.12",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -64,7 +64,7 @@
     "react-highlight-words": "0.16.0",
     "react-hook-form": "5.1.3",
     "react-monaco-editor": "0.36.0",
-    "react-popper": "1.3.3",
+    "react-popper": "1.3.4",
     "react-storybook-addon-props-combinations": "1.1.0",
     "react-table": "7.0.0",
     "react-transition-group": "4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22659,7 +22659,7 @@ react-popper@1.3.3:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-popper@^1.3.4:
+react-popper@1.3.4, react-popper@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.4.tgz#f0cd3b0d30378e1f663b0d79bcc8614221652ced"
   integrity sha512-9AcQB29V+WrBKk6X7p0eojd1f25/oJajVdMZkywIoAV6Ag7hzE1Mhyeup2Q1QnvFRtGQFQvtqfhlEoDAPfKAVA==


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR bumps react-popper to v1.3.4 to solve a [node-fetch 2.6.1 vulnerability](https://github.com/advisories/GHSA-w7rc-rwvf-8q5r).

```yarn why node-fetch
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "node-fetch"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "node-fetch@2.6.0"
info Has been hoisted to "node-fetch"
info Reasons this module exists
   - "workspace-aggregator-c9998205-fb05-4b7c-b3c2-e2e9916e1437" depends on it
   - Hoisted from "_project_#lerna#@lerna#version#@lerna#gitlab-client#node-fetch"
   - Hoisted from "_project_#@grafana#ui#@storybook#react#@storybook#core#node-fetch"
   - Hoisted from "_project_#@grafana#ui#@storybook#addon-actions#react-inspector#storybook-chromatic#node-fetch"
   - Hoisted from "_project_#lerna#@lerna#version#@lerna#github-client#@octokit#rest#@octokit#request#node-fetch"
info Disk size without dependencies: "172KB"
info Disk size with unique dependencies: "172KB"
info Disk size with transitive dependencies: "172KB"
info Number of shared dependencies: 0
=> Found "isomorphic-fetch#node-fetch@1.7.3"
info This module exists because "_project_#react-popper#create-react-context#fbjs#isomorphic-fetch" depends on it.
```
`react-popper@1.3.4` bumps `create-react-context` to `>=0.3.0` which removes the dependency on `fbjs` and in turn removes the `node-fetch@1.7.3` from the dependency tree above.


**Special notes for your reviewer**:
Grafana v7.4.x already bumps react-popper to v2.x. Rather than try to backport I felt it was safer to patch bump react-popper in the v7.3.x branch (which this branch is based on).
