### PR TITLE
AlertingNG: pause/unpause definitions via the API

### DIFF
--- a/pkg/services/ngalert/api.go
+++ b/pkg/services/ngalert/api.go
@@ -183,7 +183,7 @@ func (ng *AlertNG) unpauseScheduler() response.Response {
 	return response.JSON(200, util.DynMap{"message": "alert definition scheduler unpaused"})
 }
 
-// alertDefinitionPauseEndpoint handles PUT /api/alert-definitions/pause/:alertDefinitionUID.
+// alertDefinitionPauseEndpoint handles POST /api/alert-definitions/pause/:alertDefinitionUID.
 func (ng *AlertNG) alertDefinitionPauseEndpoint(c *models.ReqContext) response.Response {
 	cmd := updateAlertDefinitionPausedCommand{
 		OrgID:  c.SignedInUser.OrgId,
@@ -198,7 +198,7 @@ func (ng *AlertNG) alertDefinitionPauseEndpoint(c *models.ReqContext) response.R
 	return response.JSON(200, util.DynMap{"message": "alert definition paused"})
 }
 
-// alertDefinitionUnpauseEndpoint handles PUT /api/alert-definitions/unpause/:alertDefinitionUID.
+// alertDefinitionUnpauseEndpoint handles POST /api/alert-definitions/unpause/:alertDefinitionUID.
 func (ng *AlertNG) alertDefinitionUnpauseEndpoint(c *models.ReqContext) response.Response {
 	cmd := updateAlertDefinitionPausedCommand{
 		OrgID:  c.SignedInUser.OrgId,

--- a/pkg/services/ngalert/api.go
+++ b/pkg/services/ngalert/api.go
@@ -194,7 +194,7 @@ func (ng *AlertNG) alertDefinitionPauseEndpoint(c *models.ReqContext, cmd update
 	if err != nil {
 		return response.Error(500, "Failed to pause alert definition", err)
 	}
-	return response.JSON(200, util.DynMap{"message": fmt.Sprintf("%d alert definition paused", cmd.ResultCount)})
+	return response.JSON(200, util.DynMap{"message": fmt.Sprintf("%d alert definitions paused", cmd.ResultCount)})
 }
 
 // alertDefinitionUnpauseEndpoint handles POST /api/alert-definitions/unpause.
@@ -206,5 +206,5 @@ func (ng *AlertNG) alertDefinitionUnpauseEndpoint(c *models.ReqContext, cmd upda
 	if err != nil {
 		return response.Error(500, "Failed to unpause alert definition", err)
 	}
-	return response.JSON(200, util.DynMap{"message": fmt.Sprintf("%d alert definition unpaused", cmd.ResultCount)})
+	return response.JSON(200, util.DynMap{"message": fmt.Sprintf("%d alert definitions unpaused", cmd.ResultCount)})
 }

--- a/pkg/services/ngalert/database.go
+++ b/pkg/services/ngalert/database.go
@@ -212,7 +212,7 @@ func (ng *AlertNG) getOrgAlertDefinitions(query *listAlertDefinitionsQuery) erro
 func (ng *AlertNG) getAlertDefinitions(query *listAlertDefinitionsQuery) error {
 	return ng.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		alerts := make([]*AlertDefinition, 0)
-		q := "SELECT uid, org_id, interval_seconds, version FROM alert_definition"
+		q := "SELECT uid, org_id, interval_seconds, version, paused FROM alert_definition"
 		if err := sess.SQL(q).Find(&alerts); err != nil {
 			return err
 		}
@@ -221,6 +221,17 @@ func (ng *AlertNG) getAlertDefinitions(query *listAlertDefinitionsQuery) error {
 		return nil
 	})
 }
+
+func (ng *AlertNG) updateAlertDefinitionPaused(cmd *updateAlertDefinitionPausedCommand) error {
+	return ng.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		_, err := sess.Exec(`UPDATE alert_definition SET paused = ? WHERE org_id = ? AND uid = ?`, cmd.Paused, cmd.OrgID, cmd.UID)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
 func generateNewAlertDefinitionUID(sess *sqlstore.DBSession, orgID int64) (string, error) {
 	for i := 0; i < 3; i++ {
 		uid := util.GenerateShortUID()

--- a/pkg/services/ngalert/database_mig.go
+++ b/pkg/services/ngalert/database_mig.go
@@ -46,6 +46,10 @@ func addAlertDefinitionMigrations(mg *migrator.Migrator) {
 	}
 	mg.AddMigration("add unique index in alert_definition on org_id and title columns", migrator.NewAddIndexMigration(alertDefinition, uniqueIndices[0]))
 	mg.AddMigration("add unique index in alert_definition on org_id and uid columns", migrator.NewAddIndexMigration(alertDefinition, uniqueIndices[1]))
+
+	mg.AddMigration("Add column paused in alert_definition", migrator.NewAddColumnMigration(alertDefinition, &migrator.Column{
+		Name: "paused", Type: migrator.DB_Bool, Nullable: false, Default: "0",
+	}))
 }
 
 func addAlertDefinitionVersionMigrations(mg *migrator.Migrator) {

--- a/pkg/services/ngalert/models.go
+++ b/pkg/services/ngalert/models.go
@@ -104,7 +104,9 @@ type listAlertDefinitionsQuery struct {
 }
 
 type updateAlertDefinitionPausedCommand struct {
-	OrgID  int64  `json:"-"`
-	UID    string `json:"-"`
-	Paused bool   `json:"-"`
+	OrgID  int64    `json:"-"`
+	UIDs   []string `json:"uids"`
+	Paused bool     `json:"-"`
+
+	ResultCount int64
 }

--- a/pkg/services/ngalert/models.go
+++ b/pkg/services/ngalert/models.go
@@ -21,6 +21,7 @@ type AlertDefinition struct {
 	IntervalSeconds int64             `json:"intervalSeconds"`
 	Version         int64             `json:"version"`
 	UID             string            `xorm:"uid" json:"uid"`
+	Paused          bool              `json:"paused"`
 }
 
 type alertDefinitionKey struct {
@@ -100,4 +101,10 @@ type listAlertDefinitionsQuery struct {
 	OrgID int64 `json:"-"`
 
 	Result []*AlertDefinition
+}
+
+type updateAlertDefinitionPausedCommand struct {
+	OrgID  int64  `json:"-"`
+	UID    string `json:"-"`
+	Paused bool   `json:"-"`
 }

--- a/pkg/services/ngalert/schedule.go
+++ b/pkg/services/ngalert/schedule.go
@@ -185,6 +185,10 @@ func (ng *AlertNG) alertingTicker(grafanaCtx context.Context) error {
 			}
 			readyToRun := make([]readyToRunItem, 0)
 			for _, item := range alertDefinitions {
+				if item.Paused {
+					continue
+				}
+
 				key := item.getKey()
 				itemVersion := item.Version
 				newRoutine := !ng.schedule.registry.exists(key)

--- a/pkg/services/ngalert/schedule_test.go
+++ b/pkg/services/ngalert/schedule_test.go
@@ -123,6 +123,33 @@ func TestAlertingTicker(t *testing.T) {
 		tick := advanceClock(t, mockedClock)
 		assertEvalRun(t, evalAppliedCh, tick, expectedAlertDefinitionsEvaluated...)
 	})
+
+	// pause alert definition
+	err = ng.updateAlertDefinitionPaused(&updateAlertDefinitionPausedCommand{UID: alerts[2].UID, OrgID: alerts[2].OrgID, Paused: true})
+	require.NoError(t, err)
+	t.Logf("alert definition: %v paused", alerts[2].getKey())
+
+	expectedAlertDefinitionsEvaluated = []alertDefinitionKey{}
+	t.Run(fmt.Sprintf("on 8th tick alert definitions: %s should be evaluated", concatenate(expectedAlertDefinitionsEvaluated)), func(t *testing.T) {
+		tick := advanceClock(t, mockedClock)
+		assertEvalRun(t, evalAppliedCh, tick, expectedAlertDefinitionsEvaluated...)
+	})
+
+	expectedAlertDefinitionsStopped = []alertDefinitionKey{alerts[2].getKey()}
+	t.Run(fmt.Sprintf("on 8th tick alert definitions: %s should be stopped", concatenate(expectedAlertDefinitionsStopped)), func(t *testing.T) {
+		assertStopRun(t, stopAppliedCh, expectedAlertDefinitionsStopped...)
+	})
+
+	// unpause alert definition
+	err = ng.updateAlertDefinitionPaused(&updateAlertDefinitionPausedCommand{UID: alerts[2].UID, OrgID: alerts[2].OrgID, Paused: false})
+	require.NoError(t, err)
+	t.Logf("alert definition: %v unpaused", alerts[2].getKey())
+
+	expectedAlertDefinitionsEvaluated = []alertDefinitionKey{alerts[0].getKey(), alerts[2].getKey()}
+	t.Run(fmt.Sprintf("on 9th tick alert definitions: %s should be evaluated", concatenate(expectedAlertDefinitionsEvaluated)), func(t *testing.T) {
+		tick := advanceClock(t, mockedClock)
+		assertEvalRun(t, evalAppliedCh, tick, expectedAlertDefinitionsEvaluated...)
+	})
 }
 
 func assertEvalRun(t *testing.T, ch <-chan evalAppliedInfo, tick time.Time, keys ...alertDefinitionKey) {

--- a/pkg/services/ngalert/schedule_test.go
+++ b/pkg/services/ngalert/schedule_test.go
@@ -125,7 +125,7 @@ func TestAlertingTicker(t *testing.T) {
 	})
 
 	// pause alert definition
-	err = ng.updateAlertDefinitionPaused(&updateAlertDefinitionPausedCommand{UID: alerts[2].UID, OrgID: alerts[2].OrgID, Paused: true})
+	err = ng.updateAlertDefinitionPaused(&updateAlertDefinitionPausedCommand{UIDs: []string{alerts[2].UID}, OrgID: alerts[2].OrgID, Paused: true})
 	require.NoError(t, err)
 	t.Logf("alert definition: %v paused", alerts[2].getKey())
 
@@ -141,7 +141,7 @@ func TestAlertingTicker(t *testing.T) {
 	})
 
 	// unpause alert definition
-	err = ng.updateAlertDefinitionPaused(&updateAlertDefinitionPausedCommand{UID: alerts[2].UID, OrgID: alerts[2].OrgID, Paused: false})
+	err = ng.updateAlertDefinitionPaused(&updateAlertDefinitionPausedCommand{UIDs: []string{alerts[2].UID}, OrgID: alerts[2].OrgID, Paused: false})
 	require.NoError(t, err)
 	t.Logf("alert definition: %v unpaused", alerts[2].getKey())
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It introduces two new endpoints for pausing and unpausing an alert definition:
`/api/alert-definitions/pause`
`/api/alert-definitions/unpause`
 
Paused alert definitions aren't scheduled to be evaluated on certain intervals but they can still be evaluated using the API.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Pause example:
```
curl -H "Content-Type: application/json" -XPOST http://admin:admin@localhost:3000/api/alert-definitions/pause -d '{
    "uids": ["mh_hJLfGz","unknown"]
}'
{"message":"1 alert definitions paused"}
```

Unpause example:
```
curl -H "Content-Type: application/json" -XPOST http://admin:admin@localhost:3000/api/alert-definitions/unpause -d '{
    "uids": ["mh_hJLfGz","unknown"]
}'
{"message":"1 alert definitions unpaused"}
```
