### PR TITLE
AzureMonitor: Add deprecation message for App Insights/Insights Analytics

### DIFF
--- a/docs/sources/datasources/azuremonitor.md
+++ b/docs/sources/datasources/azuremonitor.md
@@ -165,7 +165,7 @@ Grafana alerting is supported for the Azure Monitor service. This is not Azure A
 
 {{< docs-imagebox img="/img/docs/v60/azuremonitor-alerting.png" class="docs-image--no-shadow" caption="Azure Monitor Alerting" >}}
 
-## Querying the Logs service
+## Query the Logs service
 
 Queries are written in the [Kusto Query Language](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/). A Logs query can be formatted as time series data or as table data.
 

--- a/docs/sources/datasources/azuremonitor.md
+++ b/docs/sources/datasources/azuremonitor.md
@@ -313,6 +313,8 @@ Grafana alerting is supported for Application Insights. This is not Azure Alerts
 
 ## Query the Application Insights Service
 
+> In an upcoming major release, "Application Insights" will be deprecated in favor of Metrics queries.
+
 {{< docs-imagebox img="/img/docs/azuremonitor/insights_metrics_multi-dim.png" class="docs-image--no-shadow" caption="Application Insights Query Editor" >}}
 
 As of Grafana 7.1, you can select more than one group by dimension.
@@ -375,6 +377,8 @@ Grafana alerting is supported for Application Insights. This is not Azure Alerts
 
 ## Query the Application Insights Analytics service
 
+> In an upcoming major release, "Insights Analytics" will be deprecated in favor of Logs queries.
+
 If you change the service type to **Insights Analytics**, then a similar editor to the Log Analytics service is available. This service also uses the Kusto language, so the instructions for querying data are identical to [querying the log analytics service]({{< relref "#querying-the-azure-log-analytics-service" >}}), except that you query Application Insights Analytics data instead.
 
 {{< docs-imagebox img="/img/docs/azuremonitor/insights_analytics_multi-dim.png" class="docs-image--no-shadow" caption="Azure Application Insights Analytics query with multiple dimensions" >}}
@@ -409,3 +413,17 @@ datasources:
       logAnalyticsClientSecret: <log-analytics-client-secret>
     version: 1
 ```
+
+## Deprecating Application Insights and Insights Analytics
+
+TODO:
+
+In 8.0, Application Insights and Application Insights will be deprecated and made read-only, and users encouraged to migrate to Metrics and Logs.
+
+Application Insights can be migrated manually to Metrics now before 8.0
+
+- namespace "microsoft.insights" or something like that
+
+Insights Analytics cannot be migrated right now - will be able to in 8.0
+
+API keys will not be supported for Metrics/Logs, will need to create an Application(?) and use Client ID/Secret.

--- a/docs/sources/datasources/azuremonitor.md
+++ b/docs/sources/datasources/azuremonitor.md
@@ -165,68 +165,6 @@ Grafana alerting is supported for the Azure Monitor service. This is not Azure A
 
 {{< docs-imagebox img="/img/docs/v60/azuremonitor-alerting.png" class="docs-image--no-shadow" caption="Azure Monitor Alerting" >}}
 
-## Query the Application Insights Service
-
-{{< docs-imagebox img="/img/docs/azuremonitor/insights_metrics_multi-dim.png" class="docs-image--no-shadow" caption="Application Insights Query Editor" >}}
-
-As of Grafana 7.1, you can select more than one group by dimension.
-
-### Formatting legend keys with aliases for Application Insights
-
-The default legend formatting is:
-
-`metricName{dimensionName=dimensionValue,dimensionTwoName=DimensionTwoValue}`
-
-In the Legend Format field, the aliases which are defined below can be combined any way you want.
-
-Application Insights examples:
-
-- `city: {{ client/city }}`
-- `{{ metric }} [Location: {{ client/countryOrRegion }}, {{ client/city }}]`
-
-### Alias patterns for Application Insights
-
-- `{{ groupbyvalue }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with the first dimension's key/label (as sorted by the key/label)
-- `{{ groupbyname }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with first dimension's value (as sorted by the key/label) (e.g. BlockBlob)
-- `{{ metric }}` = replaced with metric name (e.g. requests/count)
-- `{{ arbitraryDim }}` = _Available in 7.1+_ replaced with the value of the corresponding dimension. (e.g. `{{ client/city }}` becomes Chicago)
-
-### Filter expressions for Application Insights
-
-The filter field takes an OData filter expression.
-
-Examples:
-
-- `client/city eq 'Boydton'`
-- `client/city ne 'Boydton'`
-- `client/city ne 'Boydton' and client/city ne 'Dublin'`
-- `client/city eq 'Boydton' or client/city eq 'Dublin'`
-
-### Templating with variables for Application Insights
-
-Use the one of the following queries in the `Query` field in the Variable edit view.
-
-Check out the [Templating]({{< relref "../variables/_index.md" >}}) documentation for an introduction to the templating feature and the different types of template variables.
-
-| Name                               | Description                                                  |
-| ---------------------------------- | ------------------------------------------------------------ |
-| `AppInsightsMetricNames()`         | Returns a list of metric names.                              |
-| `AppInsightsGroupBys(aMetricName)` | Returns a list of "group bys" for the specified metric name. |
-
-Examples:
-
-- Metric Names query: `AppInsightsMetricNames()`
-- Passing in metric name variable: `AppInsightsGroupBys(requests/count)`
-- Chaining template variables: `AppInsightsGroupBys($metricnames)`
-
-{{< docs-imagebox img="/img/docs/v60/appinsights-service-variables.png" class="docs-image--no-shadow" caption="Nested Application Insights Template Variables" >}}
-
-### Application Insights alerting
-
-Grafana alerting is supported for Application Insights. This is not Azure Alerts support. For more information about Grafana alerting, refer to [Alerts overview]({{< relref "../alerting/_index.md" >}}).
-
-{{< docs-imagebox img="/img/docs/v60/azuremonitor-alerting.png" class="docs-image--no-shadow" caption="Azure Monitor Alerting" >}}
-
 ## Querying the Logs service
 
 Queries are written in the [Kusto Query Language](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/). A Logs query can be formatted as time series data or as table data.
@@ -372,6 +310,68 @@ If you're not currently logged in to the Azure Portal, then the link opens the l
 > Only available in Grafana v7.0+.
 
 Grafana alerting is supported for Application Insights. This is not Azure Alerts support. Read more about how alerting in Grafana works in [Alerting rules]({{< relref "../alerting/_index.md" >}}).
+
+## Query the Application Insights Service
+
+{{< docs-imagebox img="/img/docs/azuremonitor/insights_metrics_multi-dim.png" class="docs-image--no-shadow" caption="Application Insights Query Editor" >}}
+
+As of Grafana 7.1, you can select more than one group by dimension.
+
+### Formatting legend keys with aliases for Application Insights
+
+The default legend formatting is:
+
+`metricName{dimensionName=dimensionValue,dimensionTwoName=DimensionTwoValue}`
+
+In the Legend Format field, the aliases which are defined below can be combined any way you want.
+
+Application Insights examples:
+
+- `city: {{ client/city }}`
+- `{{ metric }} [Location: {{ client/countryOrRegion }}, {{ client/city }}]`
+
+### Alias patterns for Application Insights
+
+- `{{ groupbyvalue }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with the first dimension's key/label (as sorted by the key/label)
+- `{{ groupbyname }}` = _Legacy as of 7.1+ (for backwards compatibility)_ replaced with first dimension's value (as sorted by the key/label) (e.g. BlockBlob)
+- `{{ metric }}` = replaced with metric name (e.g. requests/count)
+- `{{ arbitraryDim }}` = _Available in 7.1+_ replaced with the value of the corresponding dimension. (e.g. `{{ client/city }}` becomes Chicago)
+
+### Filter expressions for Application Insights
+
+The filter field takes an OData filter expression.
+
+Examples:
+
+- `client/city eq 'Boydton'`
+- `client/city ne 'Boydton'`
+- `client/city ne 'Boydton' and client/city ne 'Dublin'`
+- `client/city eq 'Boydton' or client/city eq 'Dublin'`
+
+### Templating with variables for Application Insights
+
+Use the one of the following queries in the `Query` field in the Variable edit view.
+
+Check out the [Templating]({{< relref "../variables/_index.md" >}}) documentation for an introduction to the templating feature and the different types of template variables.
+
+| Name                               | Description                                                  |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `AppInsightsMetricNames()`         | Returns a list of metric names.                              |
+| `AppInsightsGroupBys(aMetricName)` | Returns a list of "group bys" for the specified metric name. |
+
+Examples:
+
+- Metric Names query: `AppInsightsMetricNames()`
+- Passing in metric name variable: `AppInsightsGroupBys(requests/count)`
+- Chaining template variables: `AppInsightsGroupBys($metricnames)`
+
+{{< docs-imagebox img="/img/docs/v60/appinsights-service-variables.png" class="docs-image--no-shadow" caption="Nested Application Insights Template Variables" >}}
+
+### Application Insights alerting
+
+Grafana alerting is supported for Application Insights. This is not Azure Alerts support. For more information about Grafana alerting, refer to [Alerts overview]({{< relref "../alerting/_index.md" >}}).
+
+{{< docs-imagebox img="/img/docs/v60/azuremonitor-alerting.png" class="docs-image--no-shadow" caption="Azure Monitor Alerting" >}}
 
 ## Query the Application Insights Analytics service
 

--- a/docs/sources/datasources/azuremonitor.md
+++ b/docs/sources/datasources/azuremonitor.md
@@ -311,9 +311,9 @@ If you're not currently logged in to the Azure Portal, then the link opens the l
 
 Grafana alerting is supported for Application Insights. This is not Azure Alerts support. Read more about how alerting in Grafana works in [Alerting rules]({{< relref "../alerting/_index.md" >}}).
 
-## Query the Application Insights Service
+## Query Application Insights service
 
-> In an upcoming major release, "Application Insights" will be made read-only and deprecated in favor of Metrics queries.
+> In a future release, "Application Insights" will be made read-only and deprecated in favor of Metrics queries.
 
 {{< docs-imagebox img="/img/docs/azuremonitor/insights_metrics_multi-dim.png" class="docs-image--no-shadow" caption="Application Insights Query Editor" >}}
 
@@ -416,8 +416,8 @@ datasources:
 
 ## Deprecating Application Insights and Insights Analytics
 
-Within the Azure Monitor data source, Application Insights and Insights Analytics are two ways to query the same Azure Application Insights data. Additionally, that same data can also be queried from Metrics. In Grafana 8.0 the Logs query type will be improved to allow querying of Application Insights data using KQL.
+Application Insights and Insights Analytics are two ways to query the same Azure Application Insights data. That same data can also be queried from Metrics. In the upcoming Grafana 8.0 release, the Logs query type will be improved to allow querying of Application Insights data using KQL.
 
-In Grafana 8.0, Application Insights and Insights Analytics will be deprecated and made read-only in favor of querying this data through Metrics and Logs. Existing queries will continue to work, but they may not be edited.
+>**Note** In Grafana 8.0, Application Insights and Insights Analytics will be deprecated and made read-only in favor of querying this data through Metrics and Logs. Existing queries will continue to work, but you cannot edit them.
 
-To prepare for this upcoming change, Application Insights queries can now be made in Metrics instead, under the "microsoft.insights/components" Namespace. Insights Analytics queries cannot yet be made within Logs with KQL.
+To prepare for this upcoming change, Application Insights queries can now be made in Metrics, under the "microsoft.insights/components" Namespace. Insights Analytics queries cannot be made within Logs with KQL at this time.

--- a/docs/sources/datasources/azuremonitor.md
+++ b/docs/sources/datasources/azuremonitor.md
@@ -313,8 +313,6 @@ Grafana alerting is supported for Application Insights. This is not Azure Alerts
 
 ## Query Application Insights service
 
-> In a future release, "Application Insights" will be made read-only and deprecated in favor of Metrics queries.
-
 {{< docs-imagebox img="/img/docs/azuremonitor/insights_metrics_multi-dim.png" class="docs-image--no-shadow" caption="Application Insights Query Editor" >}}
 
 As of Grafana 7.1, you can select more than one group by dimension.
@@ -377,8 +375,6 @@ Grafana alerting is supported for Application Insights. This is not Azure Alerts
 
 ## Query the Application Insights Analytics service
 
-> In an upcoming major release, "Insights Analytics" will be made read-only and deprecated in favor of Logs queries.
-
 If you change the service type to **Insights Analytics**, then a similar editor to the Log Analytics service is available. This service also uses the Kusto language, so the instructions for querying data are identical to [querying the log analytics service]({{< relref "#querying-the-azure-log-analytics-service" >}}), except that you query Application Insights Analytics data instead.
 
 {{< docs-imagebox img="/img/docs/azuremonitor/insights_analytics_multi-dim.png" class="docs-image--no-shadow" caption="Azure Application Insights Analytics query with multiple dimensions" >}}
@@ -418,6 +414,6 @@ datasources:
 
 Application Insights and Insights Analytics are two ways to query the same Azure Application Insights data. That same data can also be queried from Metrics. In the upcoming Grafana 8.0 release, the Logs query type will be improved to allow querying of Application Insights data using KQL.
 
->**Note** In Grafana 8.0, Application Insights and Insights Analytics will be deprecated and made read-only in favor of querying this data through Metrics and Logs. Existing queries will continue to work, but you cannot edit them.
+> **Note** In Grafana 8.0, Application Insights and Insights Analytics will be deprecated and made read-only in favor of querying this data through Metrics and Logs. Existing queries will continue to work, but you cannot edit them.
 
 To prepare for this upcoming change, Application Insights queries can now be made in Metrics, under the "microsoft.insights/components" Namespace. Insights Analytics queries cannot be made within Logs with KQL at this time.

--- a/docs/sources/datasources/azuremonitor.md
+++ b/docs/sources/datasources/azuremonitor.md
@@ -313,7 +313,7 @@ Grafana alerting is supported for Application Insights. This is not Azure Alerts
 
 ## Query the Application Insights Service
 
-> In an upcoming major release, "Application Insights" will be deprecated in favor of Metrics queries.
+> In an upcoming major release, "Application Insights" will be made read-only and deprecated in favor of Metrics queries.
 
 {{< docs-imagebox img="/img/docs/azuremonitor/insights_metrics_multi-dim.png" class="docs-image--no-shadow" caption="Application Insights Query Editor" >}}
 
@@ -377,7 +377,7 @@ Grafana alerting is supported for Application Insights. This is not Azure Alerts
 
 ## Query the Application Insights Analytics service
 
-> In an upcoming major release, "Insights Analytics" will be deprecated in favor of Logs queries.
+> In an upcoming major release, "Insights Analytics" will be made read-only and deprecated in favor of Logs queries.
 
 If you change the service type to **Insights Analytics**, then a similar editor to the Log Analytics service is available. This service also uses the Kusto language, so the instructions for querying data are identical to [querying the log analytics service]({{< relref "#querying-the-azure-log-analytics-service" >}}), except that you query Application Insights Analytics data instead.
 
@@ -416,14 +416,8 @@ datasources:
 
 ## Deprecating Application Insights and Insights Analytics
 
-TODO:
+Within the Azure Monitor data source, Application Insights and Insights Analytics are two ways to query the same Azure Application Insights data. Additionally, that same data can also be queried from Metrics. In Grafana 8.0 the Logs query type will be improved to allow querying of Application Insights data using KQL.
 
-In 8.0, Application Insights and Application Insights will be deprecated and made read-only, and users encouraged to migrate to Metrics and Logs.
+In Grafana 8.0, Application Insights and Insights Analytics will be deprecated and made read-only in favor of querying this data through Metrics and Logs. Existing queries will continue to work, but they may not be edited.
 
-Application Insights can be migrated manually to Metrics now before 8.0
-
-- namespace "microsoft.insights" or something like that
-
-Insights Analytics cannot be migrated right now - will be able to in 8.0
-
-API keys will not be supported for Metrics/Logs, will need to create an Application(?) and use Client ID/Secret.
+To prepare for this upcoming change, Application Insights queries can now be made in Metrics instead, under the "microsoft.insights/components" Namespace. Insights Analytics queries cannot yet be made within Logs with KQL.

--- a/docs/sources/datasources/azuremonitor.md
+++ b/docs/sources/datasources/azuremonitor.md
@@ -319,7 +319,7 @@ Grafana alerting is supported for Application Insights. This is not Azure Alerts
 
 As of Grafana 7.1, you can select more than one group by dimension.
 
-### Formatting legend keys with aliases for Application Insights
+### Format legend keys with aliases for Application Insights
 
 The default legend formatting is:
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -278,8 +278,8 @@
       <div class="gf-form">
         <label class="gf-form-label query-keyword" ng-click="ctrl.showHelp = !ctrl.showHelp">
           Show Help
-          <icon name="'angle-down'" ng-show="ctrl.showHelp" style="margin-top: 3px;"></icon>
-          <icon name="'angle-right'" ng-hide="ctrl.showHelp" style="margin-top: 3px;"></icon>
+          <icon name="'angle-down'" ng-show="ctrl.showHelp" style="margin-top: 3px"></icon>
+          <icon name="'angle-right'" ng-hide="ctrl.showHelp" style="margin-top: 3px"></icon>
         </label>
       </div>
       <div class="gf-form" ng-show="ctrl.lastQuery">
@@ -405,7 +405,7 @@
         onmouseover="this.style['text-decoration'] = 'line-through';"
         onmouseout="this.style['text-decoration'] = '';"
       >
-        <label class="gf-form-label" style="cursor: pointer;">{{d}} <icon name="'times'"></icon></label>
+        <label class="gf-form-label" style="cursor: pointer">{{d}} <icon name="'times'"></icon></label>
       </div>
       <div>
         <gf-form-dropdown
@@ -501,5 +501,16 @@
 
   <div class="gf-form" ng-show="ctrl.lastQueryError">
     <pre class="gf-form-pre alert alert-error">{{ctrl.lastQueryError}}</pre>
+  </div>
+
+  <div
+    class="gf-form"
+    ng-if="ctrl.target.queryType === 'Application Insights' || ctrl.target.queryType === 'Insights Analytics'"
+  >
+    <p class="gf-form-pre alert alert-info">
+      Insights Analytics and Application Insights will be merged with Logs in an upcomming release. See
+      <a class="text-link" href="https://github.com/grafana/grafana/issues/30184">this issue</a> for more details and
+      migration instructions.
+    </p>
   </div>
 </query-editor-row>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -508,7 +508,7 @@
     ng-if="ctrl.target.queryType === 'Application Insights' || ctrl.target.queryType === 'Insights Analytics'"
   >
     <p class="gf-form-pre alert alert-info">
-      Insights Analytics and Application Insights will be merged with Logs in an upcomming release. See
+      Insights Analytics and Application Insights will be merged with Metrics and Logs in an upcomming release. See
       <a class="text-link" href="https://github.com/grafana/grafana/issues/30184">this issue</a> for more details and
       migration instructions.
     </p>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -510,8 +510,12 @@
     <p class="gf-form-pre alert alert-info">
       Application Insights and Insights Analytics will be deprecated and merged with Metrics and Logs in an upcomming
       release. See
-      <a class="text-link" href="https://github.com/grafana/grafana/issues/30184">the documentation</a> for more
-      details.
+      <a
+        class="text-link"
+        href="https://grafana.com/docs/grafana/latest/datasources/azuremonitor/#deprecating-application-insights-and-insights-analytics"
+        >the documentation</a
+      >
+      for more details.
     </p>
   </div>
 </query-editor-row>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/partials/query.editor.html
@@ -508,9 +508,10 @@
     ng-if="ctrl.target.queryType === 'Application Insights' || ctrl.target.queryType === 'Insights Analytics'"
   >
     <p class="gf-form-pre alert alert-info">
-      Insights Analytics and Application Insights will be merged with Metrics and Logs in an upcomming release. See
-      <a class="text-link" href="https://github.com/grafana/grafana/issues/30184">this issue</a> for more details and
-      migration instructions.
+      Application Insights and Insights Analytics will be deprecated and merged with Metrics and Logs in an upcomming
+      release. See
+      <a class="text-link" href="https://github.com/grafana/grafana/issues/30184">the documentation</a> for more
+      details.
     </p>
   </div>
 </query-editor-row>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
@@ -22,9 +22,9 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
   dummyDiminsionString = '+';
 
   queryQueryTypeOptions = [
-    { id: AzureQueryType.ApplicationInsights, label: 'Application Insights' },
     { id: AzureQueryType.AzureMonitor, label: 'Metrics' },
     { id: AzureQueryType.LogAnalytics, label: 'Logs' },
+    { id: AzureQueryType.ApplicationInsights, label: 'Application Insights' },
     { id: AzureQueryType.InsightsAnalytics, label: 'Insights Analytics' },
   ];
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In Grafana 8.0, Application Insights and Insights Analytics queries will be deprecated and made read-only in favor of using Metrics and Logs. 

This adds a message informing the user that in an upcoming release App Insights/Insights Analytics will be deprecated. 

**Which issue(s) this PR fixes**:

Related to #30184

**Special notes for your reviewer**:

Have a nice day :) 

