### PR TITLE
Grafana/UI: Unit picker should not set a category as unit

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -13,6 +13,8 @@ interface CascaderProps {
   separator?: string;
   placeholder?: string;
   options: CascaderOption[];
+  /** Changes the value for every selection, including branch nodes */
+  changeOnSelect?: boolean;
   onSelect(val: string): void;
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
   width?: number;
@@ -68,6 +70,8 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
       activeLabel,
     };
   }
+
+  static defaultProps = { changeOnSelect: true };
 
   flattenOptions = (options: CascaderOption[], optionPath: CascaderOption[] = []) => {
     let selectOptions: Array<SelectableValue<string[]>> = [];
@@ -174,7 +178,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
   };
 
   render() {
-    const { allowCustomValue, placeholder, width } = this.props;
+    const { allowCustomValue, placeholder, width, changeOnSelect } = this.props;
     const { focusCascade, isSearching, searchableOptions, rcValue, activeLabel } = this.state;
 
     return (
@@ -195,7 +199,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
           <RCCascader
             onChange={onChangeCascader(this.onChange)}
             options={this.props.options}
-            changeOnSelect
+            changeOnSelect={changeOnSelect}
             value={rcValue.value}
             fieldNames={{ label: 'label', value: 'value', children: 'items' }}
             expandIcon={null}

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -13,7 +13,7 @@ interface CascaderProps {
   separator?: string;
   placeholder?: string;
   options: CascaderOption[];
-  /** Changes the value for every selection, including branch nodes */
+  /** Changes the value for every selection, including branch nodes. Defaults to true. */
   changeOnSelect?: boolean;
   onSelect(val: string): void;
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/

--- a/packages/grafana-ui/src/components/UnitPicker/UnitPicker.tsx
+++ b/packages/grafana-ui/src/components/UnitPicker/UnitPicker.tsx
@@ -56,6 +56,7 @@ export class UnitPicker extends PureComponent<Props> {
         width={width}
         initialValue={current && current.label}
         allowCustomValue
+        changeOnSelect={false}
         formatCreateLabel={formatCreateLabel}
         options={groupOptions as CascaderOption[]}
         placeholder="Choose"


### PR DESCRIPTION
**What this PR does / why we need it**:
When clicking categories for units, the category is set as the unit, until a leaf node is selected.
This change exposes the changeOnSelect property from rc-cascader, and sets it to false for the unit picker.

**Which issue(s) this PR fixes**:
Fixes #30599