### PR TITLE
Logs: Do not filter default message field

### DIFF
--- a/packages/grafana-ui/src/components/Logs/logParser.ts
+++ b/packages/grafana-ui/src/components/Logs/logParser.ts
@@ -64,10 +64,8 @@ const getDerivedFields = memoizeOne(
     return (
       row.dataFrame.fields
         .map((field, index) => ({ ...field, index }))
-        // Remove Id which we use for react key and entry field which we are showing as the log message. Also remove hidden fields.
-        .filter(
-          (field, index) => !('id' === field.name || row.entryFieldIndex === index || field.config.custom?.hidden)
-        )
+        // Remove Id which we use for react key and hidden fields.
+        .filter((field) => !('id' === field.name || field.config.custom?.hidden))
         // Filter out fields without values. For example in elastic the fields are parsed from the document which can
         // have different structure per row and so the dataframe is pretty sparse.
         .filter((field) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Elasticsearch data source
- (Explore-Mode)
- Logs view

The field, which is configured as default message field in the data source settings, is filtered out.
It's not possible to _add_ another field in addition to the default message field (toggling the visibility of the available fields in a log message).

To be checked: Maybe this makes sense for other data sources, to filter this out?