### PR TITLE
Added "curated dashboards" information and broke down, rearranged topics.

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -86,7 +86,7 @@ aliases = ["/docs/grafana/v1.1", "/docs/grafana/latest/guides/reference/admin", 
       <img src="/img/docs/logos/icon_prometheus.svg" >
       <h5>Prometheus</h5>
     </a>
-    <a href="{{< relref "datasources/cloudmonitoring.md" >}}" class="nav-cards__item nav-cards__item--ds">
+    <a href="{{< relref "datasources/google-cloud-monitoring/_index.md" >}}" class="nav-cards__item nav-cards__item--ds">
       <img src="/img/docs/logos/icon_cloudmonitoring.svg">
       <h5>Google Cloud Monitoring</h5>
     </a>

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -19,7 +19,7 @@ The following data sources are officially supported:
 - [AWS CloudWatch]({{< relref "cloudwatch.md" >}})
 - [Azure Monitor]({{< relref "azuremonitor.md" >}})
 - [Elasticsearch]({{< relref "elasticsearch.md" >}})
-- [Google Cloud Monitoring]({{< relref "cloudmonitoring.md" >}})
+- [Google Cloud Monitoring]({{< relref "google-cloud-monitoring/_index.md" >}})
 - [Graphite]({{< relref "graphite.md" >}})
 - [InfluxDB]({{< relref "influxdb.md" >}})
 - [Loki]({{< relref "loki.md" >}})

--- a/docs/sources/datasources/cloudmonitoring.md
+++ b/docs/sources/datasources/cloudmonitoring.md
@@ -8,25 +8,19 @@ weight = 200
 
 # Using Google Cloud Monitoring in Grafana
 
-Grafana ships with built-in support for Google Cloud Monitoring. Just add it as a data source and you are ready to build dashboards for your Google Cloud Monitoring metrics.
+Grafana ships with built-in support for Google Cloud Monitoring. Just add it as a data source and you are ready to build dashboards for your Google Cloud Monitoring metrics.  Refer to [Add a data source]({{< relref "add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 
 > **Note** Google Cloud Monitoring is supported in Grafana v6.0 and later versions. Before Grafana v7.1, it was referred to as Google Stackdriver.
 
-## Adding the data source
+## Google Cloud Monitoring settings
 
-1. Open the side menu by clicking the Grafana icon in the top header.
-1. In the side menu under the `Dashboards` link you should find a link named `Data Sources`.
-1. Click the `+ Add data source` button in the top header.
-1. Select `Google Cloud Monitoring` from the _Type_ dropdown.
-1. Upload or paste in the Service Account Key file. See below for steps on how to create a Service Account Key file.
-
-> **Note:** If you're not seeing the `Data Sources` link in your side menu, then your current user account does not have the `Admin` role for the current organization.
+To access Google Cloud Monitoring settings, hover your mouse over the **Configuration** (gear) icon, then click **Data Sources**, and then click the Google Cloud Monitoring data source.
 
 | Name                  | Description                                                                           |
 | --------------------- | ------------------------------------------------------------------------------------- |
 | `Name`                | The data source name. This is how you refer to the data source in panels and queries. |
 | `Default`             | Default data source means that it will be pre-selected for new panels.                |
-| `Service Account Key` | Service Account Key File for a GCP Project. Instructions below on how to create it.   |
+| `Service Account Key` | Upload or paste in the Service Account Key file for a GCP Project. Refer to [Using a Google Service Account Key File]({{< relref "add-a-data-source.md" >}}) for details.|
 
 ## Authentication
 
@@ -222,7 +216,7 @@ SLO queries use the same [alignment period functionality as metric queries]({{< 
 
 ### MQL (Monitoring Query Language) queries
 
-> **Note:** Only available in Grafana v7.4+.
+> **Note:** Available in Grafana v7.4 and later versions.
 
 The MQL query builder in the Google Cloud Monitoring data source allows you to display MQL results in time series format. To get an understanding of the basic concepts in MQL, refer to [Introduction to Monitoring Query Language](https://cloud.google.com/monitoring/mql).
 
@@ -342,32 +336,45 @@ datasources:
 
 ## Deep linking from Grafana panels to the Metrics Explorer in Google Cloud Console
 
-Only available in Grafana v7.1+.
+This feature is only available for Metric queries.
+
+>**Note:** Available in Grafana v7.1 and later versions.
 
 {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_deep_linking.png" max-width="500px" class="docs-image--right" caption="Google Cloud Monitoring deep linking" >}}
-
-> **Note:** This feature is only available for Metric queries.
 
 Click on a time series in the panel to see a context menu with a link to View in Metrics Explorer in Google Cloud Console. Clicking that link opens the Metrics Explorer in the Google Cloud Console and runs the query from the Grafana panel there.
 The link navigates the user first to the Google Account Chooser and after successfully selecting an account, the user is redirected to the Metrics Explorer. The provided link is valid for any account, but it only displays the query if your account has access to the GCP project specified in the query.
 
 ## Out-of-the-box dashboards
 
-> Only available in Grafana v7.3+.
+>**Note:** Available in Grafana v7.3 and later versions.
 
-The updated Cloud Monitoring data source ships with pre-configured dashboards for five of the most popular GCP services:
+Google Cloud Monitoring data source ships with pre-configured dashboards for five of the most popular GCP services:
 
-1. BigQuery
-1. Cloud Load Balancing
-1. Cloud SQL
-1. Google Compute Engine `GCE`
-1. Google Kubernetes Engine `GKE`
+- BigQuery
+- Cloud Load Balancing
+- Cloud SQL
+- Google Compute Engine `GCE`
+- Google Kubernetes Engine `GKE`
 
-To import the pre-configured dashboards, go to the configuration page of a Cloud monitoring data source and click on the `Dashboards` tab. Click `Import` for the dashboard you would like to use.
-The datasource of the newly created dashboard panels will be the one selected above.
+To import the pre-configured dashboards, go to the configuration page of a Cloud monitoring data source and click on the `Dashboards` tab.
 
-The dashboards have a template variable which is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
+1. Click `Import` for the dashboard you would like to use.
+
+The datasource of the newly created dashboard panels will be the one selected above. The dashboards have a template variable which is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
 
 To customize the dashboard, we recommend saving the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 
-{{< docs-imagebox img="/img/docs/v73/cloud-monitoring-dashboard-import.png" caption="Cloud Monitoring dashboard import" >}}
+## Curated dashboards
+
+>**Note:** Available in Grafana v7.4 and later versions.
+
+Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. The dashboards are based on similar dashboards in the GCP dashboard samples repository. They are:
+
+
+To import the pre-configured dashboards, go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
+
+1. Click `Import` for the dashboard you would like to use.
+
+To customize the dashboard, we recommend to save the dashboard under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
+

--- a/docs/sources/datasources/cloudmonitoring.md
+++ b/docs/sources/datasources/cloudmonitoring.md
@@ -8,11 +8,9 @@ weight = 200
 
 # Using Google Cloud Monitoring in Grafana
 
-> Officially released in Grafana v6.0.0
-
-> Before Grafana v7.1 this data source was named Google Stackdriver.
-
 Grafana ships with built-in support for Google Cloud Monitoring. Just add it as a data source and you are ready to build dashboards for your Google Cloud Monitoring metrics.
+
+> **Note** Google Cloud Monitoring is supported in Grafana v6.0 and later versions. Before Grafana v7.1, it was referred to as Google Stackdriver.
 
 ## Adding the data source
 

--- a/docs/sources/datasources/cloudmonitoring.md
+++ b/docs/sources/datasources/cloudmonitoring.md
@@ -22,15 +22,15 @@ To access Google Cloud Monitoring settings, hover your mouse over the **Configur
 | `Default`             | Default data source means that it will be pre-selected for new panels.                |
 | `Service Account Key` | Upload or paste in the Service Account Key file for a GCP Project. Refer to [Using a Google Service Account Key File]({{< relref "add-a-data-source.md" >}}) for details.|
 
-## Authentication
+### Authentication
 
 There are two ways to authenticate the Google Cloud Monitoring plugin - either by uploading a Google JWT file, or by automatically retrieving credentials from Google metadata server. The latter option is only available when running Grafana on GCE virtual machine.
 
-### Using a Google Service Account Key File
+#### Using a Google Service Account Key File
 
 To authenticate with the Google Cloud Monitoring API, you need to create a Google Cloud Platform (GCP) Service Account for the Project you want to show data for. A Grafana data source integrates with one GCP Project. If you want to visualize data from multiple GCP Projects then you need to create one data source per GCP Project.
 
-#### Enable APIs
+##### Enable APIs
 
 The following APIs need to be enabled first:
 
@@ -41,7 +41,7 @@ Click on the links above and click the `Enable` button:
 
 {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_enable_api.png" class="docs-image--no-shadow" caption="Enable GCP APIs" >}}
 
-#### Create a GCP Service Account for a Project
+##### Create a GCP Service Account for a Project
 
 1. Navigate to the [APIs and Services Credentials page](https://console.cloud.google.com/apis/credentials).
 1. Click on the `Create credentials` dropdown/button and choose the `Service account key` option.
@@ -371,9 +371,11 @@ In case you want to customize a dashboard, we recommend that you save it under a
 
 Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. The dashboards are based on similar dashboards in the GCP dashboard samples repository.
 
-![Curated dashboards](/img/docs/google-clooud-monitoring/curated-dashboards-7-4.png)
+![Curated dashboards](/img/docs/google-cloud-monitoring/curated-dashboards-7-4.png)
 
-To import the pre-configured dashboards, go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
+To import the pre-configured dashboards
+
+1. Go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
 
 1. Click `Import` for the dashboard you would like to use.
 

--- a/docs/sources/datasources/cloudmonitoring.md
+++ b/docs/sources/datasources/cloudmonitoring.md
@@ -361,20 +361,21 @@ To import the pre-configured dashboards, go to the configuration page of a Cloud
 
 1. Click `Import` for the dashboard you would like to use.
 
-The datasource of the newly created dashboard panels will be the one selected above. The dashboards have a template variable which is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
+The data source of the newly created dashboard panels will be the one selected above. The dashboards have a template variable that is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
 
-To customize the dashboard, we recommend saving the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
+In case you want to customize a dashboard, we recommend that you save it under a different name. Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 
 ## Curated dashboards
 
 >**Note:** Available in Grafana v7.4 and later versions.
 
-Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. The dashboards are based on similar dashboards in the GCP dashboard samples repository. They are:
+Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. The dashboards are based on similar dashboards in the GCP dashboard samples repository.
 
+![Curated dashboards](/img/docs/google-clooud-monitoring/curated-dashboards-7-4.png)
 
 To import the pre-configured dashboards, go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
 
 1. Click `Import` for the dashboard you would like to use.
 
-To customize the dashboard, we recommend to save the dashboard under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
+In case you want to customize a dashboard, we recommend that you save it under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 

--- a/docs/sources/datasources/cloudmonitoring.md
+++ b/docs/sources/datasources/cloudmonitoring.md
@@ -175,7 +175,7 @@ Example Result: `gce_instance - compute.googleapis.com/instance/cpu/usage_time`
 
 ### SLO (Service Level Objective) queries
 
-> Only available in Grafana v7.0+
+>**Note** Available in Grafana v7.0 and later versions.
 
 {{< docs-imagebox img="/img/docs/v70/slo-query-builder.png" max-width= "400px" class="docs-image--right" >}}
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -2,7 +2,7 @@
 title = "Google Cloud Monitoring"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
-aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/latest/features/datasources/cloudmonitoring/"]
+aliases = ["/docs/grafana/latest/features/datasources/stackdriver", “/docs/grafana/latest/datasources/cloudmonitoring/", "/docs/grafana/latest/features/datasources/cloudmonitoring/"]
 weight = 200
 +++
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -30,7 +30,7 @@ There are two ways to authenticate the Google Cloud Monitoring plugin - either b
 
 To authenticate with the Google Cloud Monitoring API, you need to create a Google Cloud Platform (GCP) Service Account for the Project you want to show data for. A Grafana data source integrates with one GCP Project. If you want to visualize data from multiple GCP Projects then you need to create one data source per GCP Project.
 
-##### Enable APIs
+#### Enable APIs
 
 The following APIs need to be enabled first:
 
@@ -41,7 +41,7 @@ Click on the links above and click the `Enable` button:
 
 {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_enable_api.png" max-width="450px" class="docs-image--no-shadow" caption="Enable GCP APIs" >}}
 
-##### Create a GCP Service Account for a Project
+#### Create a GCP Service Account for a Project
 
 1. Navigate to the [APIs and Services Credentials page](https://console.cloud.google.com/apis/credentials).
 1. Click on the `Create credentials` dropdown/button and choose the `Service account key` option.
@@ -175,7 +175,7 @@ Example Result: `gce_instance - compute.googleapis.com/instance/cpu/usage_time`
 
 #### Deep linking from Grafana panels to the Metrics Explorer in Google Cloud Console
 
->**Note:** Available in Grafana v7.1 and later versions.
+> **Note:** Available in Grafana v7.1 and later versions.
 
 {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_deep_linking.png" max-width="500px" class="docs-image--right" caption="Google Cloud Monitoring deep linking" >}}
 
@@ -184,7 +184,7 @@ The link navigates the user first to the Google Account Chooser and after succes
 
 ### SLO (Service Level Objective) queries
 
->**Note** Available in Grafana v7.0 and later versions.
+> **Note:** Available in Grafana v7.0 and later versions.
 
 {{< docs-imagebox img="/img/docs/v70/slo-query-builder.png" max-width= "400px" class="docs-image--right" >}}
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -305,7 +305,7 @@ Example Result: `monitoring.googleapis.com/uptime_check/http_status has this val
 
 ## Configure the data source with provisioning
 
-It's now possible to configure data sources using config files with Grafana's provisioning system. You can read more about how it works and all the settings you can set for data sources on the [provisioning docs page]({{< relref "../../administration/provisioning/#datasources" >}})
+You can configure data sources using config files with Grafana's provisioning system. Read more about how it works and all the settings you can set for data sources on the [provisioning docs page]({{< relref "../../administration/provisioning/#datasources" >}})
 
 Here is a provisioning example using the JWT (Service Account key file) authentication type.
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -2,7 +2,7 @@
 title = "Google Cloud Monitoring"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
-aliases = ["/docs/grafana/latest/features/datasources/stackdriver", “/docs/grafana/latest/datasources/cloudmonitoring/", "/docs/grafana/latest/features/datasources/cloudmonitoring/"]
+aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/latest/datasources/cloudmonitoring/", "/docs/grafana/latest/features/datasources/cloudmonitoring/"]
 weight = 200
 +++
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -305,7 +305,7 @@ Example Result: `monitoring.googleapis.com/uptime_check/http_status has this val
 
 ## Configure the data source with provisioning
 
-It's now possible to configure data sources using config files with Grafana's provisioning system. You can read more about how it works and all the settings you can set for data sources on the [provisioning docs page]({{< relref "../../administration/provisioning/#datasources" >}})
+You can configure data sources using config files with Grafana's provisioning system. Read more about how it works and all the settings you can set for data sources on the [provisioning docs page]({{< relref "../../administration/provisioning/#datasources" >}})
 
 Here is a provisioning example using the JWT (Service Account key file) authentication type.
 
@@ -342,4 +342,3 @@ datasources:
     jsonData:
       authenticationType: gce
 ```
-

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -22,15 +22,15 @@ To access Google Cloud Monitoring settings, hover your mouse over the **Configur
 | `Default`             | Default data source means that it will be pre-selected for new panels.                |
 | `Service Account Key` | Upload or paste in the Service Account Key file for a GCP Project. Refer to [Using a Google Service Account Key File](#using-a-google-service-account-key-file) for details.|
 
-### Authentication
+## Authentication
 
 There are two ways to authenticate the Google Cloud Monitoring plugin - either by uploading a Google JWT file, or by automatically retrieving credentials from Google metadata server. The latter option is only available when running Grafana on GCE virtual machine.
 
-##### Using a Google Service Account Key File
+### Using a Google Service Account Key File
 
 To authenticate with the Google Cloud Monitoring API, you need to create a Google Cloud Platform (GCP) Service Account for the Project you want to show data for. A Grafana data source integrates with one GCP Project. If you want to visualize data from multiple GCP Projects then you need to create one data source per GCP Project.
 
-###### Enable APIs
+##### Enable APIs
 
 The following APIs need to be enabled first:
 
@@ -41,7 +41,7 @@ Click on the links above and click the `Enable` button:
 
 {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_enable_api.png" max-width="450px" class="docs-image--no-shadow" caption="Enable GCP APIs" >}}
 
-###### Create a GCP Service Account for a Project
+##### Create a GCP Service Account for a Project
 
 1. Navigate to the [APIs and Services Credentials page](https://console.cloud.google.com/apis/credentials).
 1. Click on the `Create credentials` dropdown/button and choose the `Service account key` option.
@@ -65,7 +65,7 @@ Click on the links above and click the `Enable` button:
 
    {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_grafana_key_uploaded.png" max-width="600px" class="docs-image--no-shadow" caption="Service key file is uploaded to Grafana" >}}
 
-#### Using GCE Default Service Account
+### Using GCE Default Service Account
 
 If Grafana is running on a Google Compute Engine (GCE) virtual machine, it is possible for Grafana to automatically retrieve default credentials from the metadata server. This has the advantage of not needing to generate a private key file for the service account and also not having to upload the file to Grafana. However for this to work, there are a few preconditions that need to be met.
 

--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Cloud Monitoring"
+title = "Google Cloud Monitoring"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
 aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/latest/features/datasources/cloudmonitoring/"]
@@ -8,9 +8,9 @@ weight = 200
 
 # Using Google Cloud Monitoring in Grafana
 
-Grafana ships with built-in support for Google Cloud Monitoring. Just add it as a data source and you are ready to build dashboards for your Google Cloud Monitoring metrics.  Refer to [Add a data source]({{< relref "add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
+Grafana ships with built-in support for Google Cloud Monitoring. Just add it as a data source and you are ready to build dashboards for your Google Cloud Monitoring metrics.  Refer to [Add a data source]({{< relref "../add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 
-> **Note** Google Cloud Monitoring is supported in Grafana v6.0 and later versions. Before Grafana v7.1, it was referred to as Google Stackdriver.
+> **Note** Before Grafana v7.1, Google Cloud Monitoring was referred to as Google Stackdriver.
 
 ## Google Cloud Monitoring settings
 
@@ -20,17 +20,17 @@ To access Google Cloud Monitoring settings, hover your mouse over the **Configur
 | --------------------- | ------------------------------------------------------------------------------------- |
 | `Name`                | The data source name. This is how you refer to the data source in panels and queries. |
 | `Default`             | Default data source means that it will be pre-selected for new panels.                |
-| `Service Account Key` | Upload or paste in the Service Account Key file for a GCP Project. Refer to [Using a Google Service Account Key File]({{< relref "add-a-data-source.md" >}}) for details.|
+| `Service Account Key` | Upload or paste in the Service Account Key file for a GCP Project. Refer to [Using a Google Service Account Key File](#using-a-google-service-account-key-file) for details.|
 
 ### Authentication
 
 There are two ways to authenticate the Google Cloud Monitoring plugin - either by uploading a Google JWT file, or by automatically retrieving credentials from Google metadata server. The latter option is only available when running Grafana on GCE virtual machine.
 
-#### Using a Google Service Account Key File
+##### Using a Google Service Account Key File
 
 To authenticate with the Google Cloud Monitoring API, you need to create a Google Cloud Platform (GCP) Service Account for the Project you want to show data for. A Grafana data source integrates with one GCP Project. If you want to visualize data from multiple GCP Projects then you need to create one data source per GCP Project.
 
-##### Enable APIs
+###### Enable APIs
 
 The following APIs need to be enabled first:
 
@@ -39,33 +39,33 @@ The following APIs need to be enabled first:
 
 Click on the links above and click the `Enable` button:
 
-{{< docs-imagebox img="/img/docs/v71/cloudmonitoring_enable_api.png" class="docs-image--no-shadow" caption="Enable GCP APIs" >}}
+{{< docs-imagebox img="/img/docs/v71/cloudmonitoring_enable_api.png" max-width="450px" class="docs-image--no-shadow" caption="Enable GCP APIs" >}}
 
-##### Create a GCP Service Account for a Project
+###### Create a GCP Service Account for a Project
 
 1. Navigate to the [APIs and Services Credentials page](https://console.cloud.google.com/apis/credentials).
 1. Click on the `Create credentials` dropdown/button and choose the `Service account key` option.
 
-   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_create_service_account_button.png" class="docs-image--no-shadow" caption="Create service account button" >}}
+   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_create_service_account_button.png" max-width="500px" class="docs-image--no-shadow" caption="Create service account button" >}}
 
 1. On the `Create service account key` page, choose key type `JSON`. Then in the `Service Account` dropdown, choose the `New service account` option:
 
-   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_create_service_account_key.png" class="docs-image--no-shadow" caption="Create service account key" >}}
+   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_create_service_account_key.png" max-width="500px" class="docs-image--no-shadow" caption="Create service account key" >}}
 
 1. Some new fields will appear. Fill in a name for the service account in the `Service account name` field and then choose the `Monitoring Viewer` role from the `Role` dropdown:
 
-   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_service_account_choose_role.png" class="docs-image--no-shadow" caption="Choose role" >}}
+   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_service_account_choose_role.png" max-width="600px" class="docs-image--no-shadow" caption="Choose role" >}}
 
 1. Click the Create button. A JSON key file will be created and downloaded to your computer. Store this file in a secure place as it allows access to your Google Cloud Monitoring data.
 1. Upload it to Grafana on the data source Configuration page. You can either upload the file or paste in the contents of the file.
 
-   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_grafana_upload_key.png" class="docs-image--no-shadow" caption="Upload service key file to Grafana" >}}
+   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_grafana_upload_key.png" max-width="550px" class="docs-image--no-shadow" caption="Upload service key file to Grafana" >}}
 
 1. The file contents will be encrypted and saved in the Grafana database. Don't forget to save after uploading the file!
 
-   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_grafana_key_uploaded.png" class="docs-image--no-shadow" caption="Service key file is uploaded to Grafana" >}}
+   {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_grafana_key_uploaded.png" max-width="600px" class="docs-image--no-shadow" caption="Service key file is uploaded to Grafana" >}}
 
-### Using GCE Default Service Account
+#### Using GCE Default Service Account
 
 If Grafana is running on a Google Compute Engine (GCE) virtual machine, it is possible for Grafana to automatically retrieve default credentials from the metadata server. This has the advantage of not needing to generate a private key file for the service account and also not having to upload the file to Grafana. However for this to work, there are a few preconditions that need to be met.
 
@@ -173,6 +173,15 @@ Example Alias By: `{{resource.type}} - {{metric.type}}`
 
 Example Result: `gce_instance - compute.googleapis.com/instance/cpu/usage_time`
 
+#### Deep linking from Grafana panels to the Metrics Explorer in Google Cloud Console
+
+>**Note:** Available in Grafana v7.1 and later versions.
+
+{{< docs-imagebox img="/img/docs/v71/cloudmonitoring_deep_linking.png" max-width="500px" class="docs-image--right" caption="Google Cloud Monitoring deep linking" >}}
+
+Click on a time series in the panel to see a context menu with a link to View in Metrics Explorer in Google Cloud Console. Clicking that link opens the Metrics Explorer in the Google Cloud Console and runs the query from the Grafana panel there.
+The link navigates the user first to the Google Account Chooser and after successfully selecting an account, the user is redirected to the Metrics Explorer. The provided link is valid for any account, but it only displays the query if your account has access to the GCP project specified in the query.
+
 ### SLO (Service Level Objective) queries
 
 >**Note** Available in Grafana v7.0 and later versions.
@@ -241,7 +250,7 @@ Instead of hard-coding things like server, application and sensor name in your m
 Variables are shown as dropdown select boxes at the top of the dashboard. These dropdowns make it easy to change the data
 being displayed in your dashboard.
 
-Check out the [Templating]({{< relref "../variables/_index.md" >}}) documentation for an introduction to the templating feature and the different
+Check out the [Templating]({{< relref "../../variables/_index.md" >}}) documentation for an introduction to the templating feature and the different
 types of template variables.
 
 ### Query Variable
@@ -274,7 +283,7 @@ Why two ways? The first syntax is easier to read and write but does not allow yo
 
 {{< docs-imagebox img="/img/docs/v71/cloudmonitoring_annotations_query_editor.png" max-width= "400px" class="docs-image--right" >}}
 
-[Annotations]({{< relref "../dashboards/annotations.md" >}}) allow you to overlay rich event information on top of graphs. You add annotation
+[Annotations]({{< relref "../../dashboards/annotations.md" >}}) allow you to overlay rich event information on top of graphs. You add annotation
 queries via the Dashboard menu / Annotations view. Annotation rendering is expensive so it is important to limit the number of rows returned. There is no support for showing Google Cloud Monitoring annotations and events yet but it works well with [custom metrics](https://cloud.google.com/monitoring/custom-metrics/) in Google Cloud Monitoring.
 
 With the query editor for annotations, you can select a metric and filters. The `Title` and `Text` fields support templating and can use data returned from the query. For example, the Title field could have the following text:
@@ -296,7 +305,7 @@ Example Result: `monitoring.googleapis.com/uptime_check/http_status has this val
 
 ## Configure the data source with provisioning
 
-It's now possible to configure data sources using config files with Grafana's provisioning system. You can read more about how it works and all the settings you can set for data sources on the [provisioning docs page]({{< relref "../administration/provisioning/#datasources" >}})
+It's now possible to configure data sources using config files with Grafana's provisioning system. You can read more about how it works and all the settings you can set for data sources on the [provisioning docs page]({{< relref "../../administration/provisioning/#datasources" >}})
 
 Here is a provisioning example using the JWT (Service Account key file) authentication type.
 
@@ -333,51 +342,4 @@ datasources:
     jsonData:
       authenticationType: gce
 ```
-
-## Deep linking from Grafana panels to the Metrics Explorer in Google Cloud Console
-
-This feature is only available for Metric queries.
-
->**Note:** Available in Grafana v7.1 and later versions.
-
-{{< docs-imagebox img="/img/docs/v71/cloudmonitoring_deep_linking.png" max-width="500px" class="docs-image--right" caption="Google Cloud Monitoring deep linking" >}}
-
-Click on a time series in the panel to see a context menu with a link to View in Metrics Explorer in Google Cloud Console. Clicking that link opens the Metrics Explorer in the Google Cloud Console and runs the query from the Grafana panel there.
-The link navigates the user first to the Google Account Chooser and after successfully selecting an account, the user is redirected to the Metrics Explorer. The provided link is valid for any account, but it only displays the query if your account has access to the GCP project specified in the query.
-
-## Out-of-the-box dashboards
-
->**Note:** Available in Grafana v7.3 and later versions.
-
-Google Cloud Monitoring data source ships with pre-configured dashboards for five of the most popular GCP services:
-
-- BigQuery
-- Cloud Load Balancing
-- Cloud SQL
-- Google Compute Engine `GCE`
-- Google Kubernetes Engine `GKE`
-
-To import the pre-configured dashboards, go to the configuration page of a Cloud monitoring data source and click on the `Dashboards` tab.
-
-1. Click `Import` for the dashboard you would like to use.
-
-The data source of the newly created dashboard panels will be the one selected above. The dashboards have a template variable that is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
-
-In case you want to customize a dashboard, we recommend that you save it under a different name. Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
-
-## Curated dashboards
-
->**Note:** Available in Grafana v7.4 and later versions.
-
-Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. The dashboards are based on similar dashboards in the GCP dashboard samples repository.
-
-![Curated dashboards](/img/docs/google-cloud-monitoring/curated-dashboards-7-4.png)
-
-To import the pre-configured dashboards
-
-1. Go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
-
-1. Click `Import` for the dashboard you would like to use.
-
-In case you want to customize a dashboard, we recommend that you save it under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 

--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -15,9 +15,9 @@ The curated dashboards are based on similar dashboards in the GCP dashboard samp
 
 To import the curated dashboards:
 
-1. Go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
+1. On the configuration page of your Cloud Monitoring data source, click the **Dashboards** tab.
 
-2. Click `Import` for the dashboard you would like to use.
+1. Click **Import** for the dashboard you would like to use.
 
 The data source of the newly created dashboard panels will be the one selected above. The dashboards have a template variable that is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
 

--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -1,5 +1,5 @@
 +++
-title = "Preconfigred dashboards"
+title = "Preconfigured dashboards"
 description = "Guide for using Google Cloud Monitoring in Grafana"
 keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
 aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/latest/features/datasources/cloudmonitoring/"]

--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -6,41 +6,20 @@ aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafa
 weight = 10
 +++
 
-# Preconfigured dashboards
+# Preconfigured Cloud Monitoring dashboards
 
-Google Cloud Monitoring data source ships with [out-of-the-box](#out-of-the-box-dashboards) and [curated](#curated-dashboards) dashboards. See also [Using Google Cloud Monitoring in Grafana]({{< relref "./_index.md" >}}) for detailed instructions on how to add and configure the data source.
-
-## Out-of-the-box dashboards
-
-Grafana v7.3 and later versions supports five of the most popular out-of-the-box GCP services. They are:
-
-- BigQuery
-- Cloud Load Balancing
-- Cloud SQL
-- Google Compute Engine `GCE`
-- Google Kubernetes Engine `GKE`
-
-To import the out-of-the-box dashboards:
-
-1. Go to the configuration page of a Cloud monitoring data source and click on the `Dashboards` tab.
-
-2. Click `Import` for the dashboard you would like to use.
-
-The data source of the newly created dashboard panels will be the one selected above. The dashboards have a template variable that is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
-
-In case you want to customize a dashboard, we recommend that you save it under a different name. Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
-
-{{< docs-imagebox img="/img/docs/v73/cloud-monitoring-dashboard-import.png" max-width= "700px" caption="Cloud Monitoring dashboard import" >}}
-
+Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. These curated dashboards are based on similar dashboards in the GCP dashboard samples repository. See also, [Using Google Cloud Monitoring in Grafana]({{< relref "./_index.md" >}}) for detailed instructions on how to add and configure the Google Cloud Monitoring data source.
 ## Curated dashboards
 
-Grafana v7.4 and later versions support some of the most popular GCP services. These curated dashboards are based on similar dashboards in the GCP dashboard samples repository.
+The curated dashboards are based on similar dashboards in the GCP dashboard samples repository.
 
 To import the curated dashboards:
 
 1. Go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
 
 2. Click `Import` for the dashboard you would like to use.
+
+The data source of the newly created dashboard panels will be the one selected above. The dashboards have a template variable that is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
 
 In case you want to customize a dashboard, we recommend that you save it under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 

--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -8,7 +8,7 @@ weight = 10
 
 # Preconfigured dashboards
 
-Google Cloud Monitoring data source ships with [out-of-the-box](#out-of-the-box-dashboards) and [curated](#curated-dashboards) dashboards. See also [Using Google Cloud Monitoring in Grafana]({{< relref "_index.md" >}}) for detailed instructions on how to add and configure the data source.
+Google Cloud Monitoring data source ships with [out-of-the-box](#out-of-the-box-dashboards) and [curated](#curated-dashboards) dashboards. See also [Using Google Cloud Monitoring in Grafana]({{< relref "./_index.md" >}}) for detailed instructions on how to add and configure the data source.
 
 ## Out-of-the-box dashboards
 

--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -1,0 +1,47 @@
++++
+title = "Preconfigred dashboards"
+description = "Guide for using Google Cloud Monitoring in Grafana"
+keywords = ["grafana", "stackdriver", "google", "guide", "cloud", "monitoring"]
+aliases = ["/docs/grafana/latest/features/datasources/stackdriver", "/docs/grafana/latest/features/datasources/cloudmonitoring/"]
+weight = 10
++++
+
+# Preconfigured dashboards
+
+Google Cloud Monitoring data source ships with [out-of-the-box](#out-of-the-box-dashboards) and [curated](#curated-dashboards) dashboards. See also [Using Google Cloud Monitoring in Grafana]({{< relref "_index.md" >}}) for detailed instructions on how to add and configure the data source.
+
+## Out-of-the-box dashboards
+
+Grafana v7.3 and later versions supports five of the most popular out-of-the-box GCP services. They are:
+
+- BigQuery
+- Cloud Load Balancing
+- Cloud SQL
+- Google Compute Engine `GCE`
+- Google Kubernetes Engine `GKE`
+
+To import the out-of-the-box dashboards:
+
+1. Go to the configuration page of a Cloud monitoring data source and click on the `Dashboards` tab.
+
+2. Click `Import` for the dashboard you would like to use.
+
+The data source of the newly created dashboard panels will be the one selected above. The dashboards have a template variable that is populated with the projects accessible by the configured service account every time the dashboard is loaded. After the dashboard is loaded, you can select the project you prefer from the drop-down list.
+
+In case you want to customize a dashboard, we recommend that you save it under a different name. Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
+
+{{< docs-imagebox img="/img/docs/v73/cloud-monitoring-dashboard-import.png" max-width= "700px" caption="Cloud Monitoring dashboard import" >}}
+
+## Curated dashboards
+
+Grafana v7.4 and later versions support some of the most popular GCP services. These curated dashboards are based on similar dashboards in the GCP dashboard samples repository.
+
+To import the curated dashboards:
+
+1. Go to the configuration page of your Cloud Monitoring data source and click on the `Dashboards` tab.
+
+2. Click `Import` for the dashboard you would like to use.
+
+In case you want to customize a dashboard, we recommend that you save it under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released.
+
+{{< docs-imagebox img="/img/docs/google-cloud-monitoring/curated-dashboards-7-4.png" max-width= "650px" >}}

--- a/docs/sources/whatsnew/whats-new-in-v5-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-3.md
@@ -37,7 +37,7 @@ The Grafana Stackdriver plugin comes with support for automatic unit detection. 
 The data source is still in the `beta` phase, meaning it's currently in active development and is still missing one important feature - templating queries.
 Please try it out, but be aware of that it might be subject to changes and possible bugs. We would love to hear your feedback.
 
-Please read [Using Google Stackdriver in Grafana]({{< relref "../datasources/google-cloud-monitoring/_index.md" >}}) for more detailed information on how to get started and use it.
+Refer to [Using Google Stackdriver in Grafana]({{< relref "../datasources/google-cloud-monitoring/_index.md" >}}) for more detailed information on how to get started and use it.
 
 ## TV and Kiosk Mode
 

--- a/docs/sources/whatsnew/whats-new-in-v5-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-3.md
@@ -37,7 +37,7 @@ The Grafana Stackdriver plugin comes with support for automatic unit detection. 
 The data source is still in the `beta` phase, meaning it's currently in active development and is still missing one important feature - templating queries.
 Please try it out, but be aware of that it might be subject to changes and possible bugs. We would love to hear your feedback.
 
-Please read [Using Google Stackdriver in Grafana]({{< relref "../datasources/cloudmonitoring/" >}}) for more detailed information on how to get started and use it.
+Please read [Using Google Stackdriver in Grafana]({{< relref "../datasources/google-cloud-monitoring/_index.md" >}}) for more detailed information on how to get started and use it.
 
 ## TV and Kiosk Mode
 

--- a/docs/sources/whatsnew/whats-new-in-v5-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v5-4.md
@@ -45,9 +45,9 @@ Stackdriver is the first data source which has support for a custom templating q
 create their very own templating query editor.
 
 Additionally, if Grafana is running on a Google Compute Engine (GCE) virtual machine, it is now possible for Grafana to automatically retrieve default credentials from the metadata server.
-This has the advantage of not needing to generate a private key file for the service account and also not having to upload the file to Grafana. [Learn more]({{< relref "../datasources/cloudmonitoring/#using-gce-default-service-account" >}}).
+This has the advantage of not needing to generate a private key file for the service account and also not having to upload the file to Grafana. [Learn more]({{< relref "../datasources/google-cloud-monitoring/_index.md/#using-gce-default-service-account" >}}).
 
-Please read [Using Google Stackdriver in Grafana]({{< relref "../datasources/cloudmonitoring/" >}}) for more detailed information on how to get started and use it.
+Please read [Using Google Stackdriver in Grafana]({{< relref "../datasources/google-cloud-monitoring/_index.md/" >}}) for more detailed information on how to get started and use it.
 
 <div class="clearfix"></div>
 

--- a/docs/sources/whatsnew/whats-new-in-v6-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v6-0.md
@@ -114,7 +114,7 @@ will be shared soon.
 
 Built-in support for [Google Stackdriver](https://cloud.google.com/stackdriver/) is officially released in Grafana 6.0. Beta support was added in Grafana 5.3 and we have added lots of improvements since then.
 
-To get started read the guide: [Using Google Stackdriver in Grafana]({{< relref "../datasources/cloudmonitoring/" >}}).
+To get started read the guide: [Using Google Stackdriver in Grafana]({{< relref "../datasources/google-cloud-monitoring/_index.md/" >}}).
 
 ## Azure Monitor data source
 

--- a/docs/sources/whatsnew/whats-new-in-v7-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-0.md
@@ -179,7 +179,7 @@ It was released as a beta feature in Grafana 6.7. The feedback has been really p
 
 ## Stackdriver data source supports Service Monitoring
 
-[Service monitoring](https://cloud.google.com/service-monitoring) in Google Cloud Platform (GCP) enables you to monitor based on Service Level Objectives (SLOs) for your GCP services. The new SLO query builder in the Stackdriver data source allows you to display SLO data in Grafana. Read more about it in the [Stackdriver data source documentation]({{< relref "../datasources/cloudmonitoring/#slo-service-level-objective-queries" >}}).
+[Service monitoring](https://cloud.google.com/service-monitoring) in Google Cloud Platform (GCP) enables you to monitor based on Service Level Objectives (SLOs) for your GCP services. The new SLO query builder in the Stackdriver data source allows you to display SLO data in Grafana. Read more about it in the [Stackdriver data source documentation]({{< relref "../datasources/google-cloud-monitoring/_index.md/#slo-service-level-objective-queries" >}}).
 
 ## Time zone support
 

--- a/docs/sources/whatsnew/whats-new-in-v7-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-1.md
@@ -83,7 +83,7 @@ Additionally, the Raw Edit mode for Application Insights Analytics has been repl
 
 ## Deep linking for Google Cloud Monitoring (formerly named Google Stackdriver) data source
 
-A new feature in Grafana 7.1 is [deep linking from Grafana panels to the Metrics Explorer in Google Cloud Console]({{<relref "../datasources/cloudmonitoring.md#deep-linking-from-grafana-panels-to-the-metrics-explorer-in-google-cloud-console">}}). Click on a time series in the panel to see a context menu with a link to View in Metrics explorer in Google Cloud Console. Clicking that link opens the Metrics explorer in the Monitoring Google Cloud Console and runs the query from the Grafana panel there.
+A new feature in Grafana 7.1 is [deep linking from Grafana panels to the Metrics Explorer in Google Cloud Console]({{<relref "../datasources/google-cloud-monitoring/_index.md#deep-linking-from-grafana-panels-to-the-metrics-explorer-in-google-cloud-console">}}). Click on a time series in the panel to see a context menu with a link to View in Metrics explorer in Google Cloud Console. Clicking that link opens the Metrics explorer in the Monitoring Google Cloud Console and runs the query from the Grafana panel there.
 
 ## Time range picker update
 

--- a/docs/sources/whatsnew/whats-new-in-v7-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-3.md
@@ -75,7 +75,7 @@ The updated Google Cloud monitoring data source is shipped with pre-configured d
 
 To import the pre-configured dashboards, go to the configuration page of your Google Cloud Monitoring data source and click on the `Dashboards` tab. Click `Import` for the dashboard you would like to use. To customize the dashboard, we recommend to save the dashboard under a different name, because otherwise the dashboard will be overwritten when a new version of the dashboard is released.
 
-For more details, see the [Google Cloud Monitoring docs]({{<relref "../datasources/cloudmonitoring/#out-of-the-box-dashboards">}})
+For more details, see the [Google Cloud Monitoring docs]({{<relref "../datasources/google-cloud-monitoring/_index.md/#out-of-the-box-dashboards">}})
 
 ## Shorten URL for dashboards and Explore
 

--- a/public/app/plugins/datasource/cloud-monitoring/partials/config.html
+++ b/public/app/plugins/datasource/cloud-monitoring/partials/config.html
@@ -2,20 +2,19 @@
   <div class="grafana-info-box">
     <h4>Google Cloud Monitoring Authentication</h4>
     <p>
-      There are two ways to authenticate the Google Cloud Monitoring plugin - either by uploading a Service Account key file, or by
+      There are two ways to authenticate the Google Cloud Monitoring plugin - either by uploading a Service Account key file or by
       automatically retrieving credentials from the Google metadata server. The latter option is only available when
       running Grafana on a GCE virtual machine.
     </p>
 
     <h5>Uploading a Service Account Key File</h5>
     <p>
-      First you need to create a Google Cloud Platform (GCP) Service Account for the Project you want to show data for.
-      A Grafana datasource integrates with one GCP Project. If you want to visualize data from multiple GCP Projects
-      then you need to create one datasource per GCP Project.
+      There are two ways to authenticate the Google Cloud Monitoring plugin. You can upload a Service Account key file or automatically retrieve 
+      credentials from the Google metadata server. The latter option is only available when running Grafana on a GCE virtual machine.
     </p>
     <p>
       The <strong>Monitoring Viewer</strong> role provides all the permissions that Grafana needs. The following API
-      needs to be enabled on GCP for the datasource to work:
+      needs to be enabled on GCP for the data source to work:
       <a
         class="external-link"
         target="_blank"
@@ -34,7 +33,7 @@
 
     <p>
       Detailed instructions on how to create a Service Account can be found
-      <a class="external-link" target="_blank" href="https://grafana.com/docs/grafana/latest/datasources/cloudmonitoring/"
+      <a class="external-link" target="_blank" href="https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/_index.md"
         >in the documentation.</a
       >
     </p>


### PR DESCRIPTION
Some of the changes include:
**Broke down one topic "Using Google Cloud Monitoring in Grafana" into 2.
**New topic is "Preconfigured Cloud Monitoring dashboards".
**Resized the images.
**Removed Add data source section.
**Moved section "Deep linking from Grafana panels to the Metrics Explorer in Google Cloud Console" to Metric queries.

