### PR TITLE
TSDB: Use non-global config

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -128,7 +128,7 @@ func GetAlerts(c *models.ReqContext) response.Response {
 }
 
 // POST /api/alerts/test
-func AlertTest(c *models.ReqContext, dto dtos.AlertTestCommand) response.Response {
+func (hs *HTTPServer) AlertTest(c *models.ReqContext, dto dtos.AlertTestCommand) response.Response {
 	if _, idErr := dto.Dashboard.Get("id").Int64(); idErr != nil {
 		return response.Error(400, "The dashboard needs to be saved at least once before you can test an alert rule", nil)
 	}
@@ -138,6 +138,7 @@ func AlertTest(c *models.ReqContext, dto dtos.AlertTestCommand) response.Respons
 		Dashboard: dto.Dashboard,
 		PanelID:   dto.PanelId,
 		User:      c.SignedInUser,
+		Cfg:       hs.Cfg,
 	}
 
 	if err := bus.Dispatch(&backendCmd); err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -314,7 +314,7 @@ func (hs *HTTPServer) registerRoutes() {
 			dashboardRoute.Post("/db", bind(models.SaveDashboardCommand{}), routing.Wrap(hs.PostDashboard))
 			dashboardRoute.Get("/home", routing.Wrap(hs.GetHomeDashboard))
 			dashboardRoute.Get("/tags", GetDashboardTags)
-			dashboardRoute.Post("/import", bind(dtos.ImportDashboardCommand{}), routing.Wrap(ImportDashboard))
+			dashboardRoute.Post("/import", bind(dtos.ImportDashboardCommand{}), routing.Wrap(hs.ImportDashboard))
 
 			dashboardRoute.Group("/id/:dashboardId", func(dashIdRoute routing.RouteRegister) {
 				dashIdRoute.Get("/versions", routing.Wrap(GetDashboardVersions))
@@ -352,13 +352,13 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Post("/tsdb/query", bind(dtos.MetricRequest{}), routing.Wrap(hs.QueryMetrics))
 		apiRoute.Get("/tsdb/testdata/scenarios", routing.Wrap(GetTestDataScenarios))
 		apiRoute.Get("/tsdb/testdata/gensql", reqGrafanaAdmin, routing.Wrap(GenerateSQLTestData))
-		apiRoute.Get("/tsdb/testdata/random-walk", routing.Wrap(GetTestDataRandomWalk))
+		apiRoute.Get("/tsdb/testdata/random-walk", routing.Wrap(hs.GetTestDataRandomWalk))
 
 		// DataSource w/ expressions
 		apiRoute.Post("/ds/query", bind(dtos.MetricRequest{}), routing.Wrap(hs.QueryMetricsV2))
 
 		apiRoute.Group("/alerts", func(alertsRoute routing.RouteRegister) {
-			alertsRoute.Post("/test", bind(dtos.AlertTestCommand{}), routing.Wrap(AlertTest))
+			alertsRoute.Post("/test", bind(dtos.AlertTestCommand{}), routing.Wrap(hs.AlertTest))
 			alertsRoute.Post("/:alertId/pause", reqEditorRole, bind(dtos.PauseAlertCommand{}), routing.Wrap(PauseAlert))
 			alertsRoute.Get("/:alertId", ValidateOrgAlert, routing.Wrap(GetAlert))
 			alertsRoute.Get("/", routing.Wrap(GetAlerts))

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -122,7 +122,7 @@ func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
 		meta.FolderUrl = query.Result.GetUrl()
 	}
 
-	provisioningData, err := dashboards.NewProvisioningService().GetProvisionedDashboardDataByDashboardID(dash.Id)
+	provisioningData, err := dashboards.NewProvisioningService(hs.Cfg).GetProvisionedDashboardDataByDashboardID(dash.Id)
 	if err != nil {
 		return response.Error(500, "Error while checking if dashboard is provisioned", err)
 	}
@@ -226,7 +226,7 @@ func (hs *HTTPServer) deleteDashboard(c *models.ReqContext) response.Response {
 		}
 	}
 
-	err := dashboards.NewService().DeleteDashboard(dash.Id, c.OrgId)
+	err := dashboards.NewService(hs.Cfg).DeleteDashboard(dash.Id, c.OrgId)
 	if err != nil {
 		var dashboardErr models.DashboardErr
 		if ok := errors.As(err, &dashboardErr); ok {
@@ -262,7 +262,7 @@ func (hs *HTTPServer) PostDashboard(c *models.ReqContext, cmd models.SaveDashboa
 		}
 	}
 
-	provisioningData, err := dashboards.NewProvisioningService().GetProvisionedDashboardDataByDashboardID(dash.Id)
+	provisioningData, err := dashboards.NewProvisioningService(hs.Cfg).GetProvisionedDashboardDataByDashboardID(dash.Id)
 	if err != nil {
 		return response.Error(500, "Error while checking if dashboard is provisioned", err)
 	}
@@ -288,7 +288,7 @@ func (hs *HTTPServer) PostDashboard(c *models.ReqContext, cmd models.SaveDashboa
 		Overwrite: cmd.Overwrite,
 	}
 
-	dashboard, err := dashboards.NewService().SaveDashboard(dashItem, allowUiUpdate)
+	dashboard, err := dashboards.NewService(hs.Cfg).SaveDashboard(dashItem, allowUiUpdate)
 	if err != nil {
 		return dashboardSaveErrorToApiResponse(err)
 	}

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1205,7 +1205,7 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 		dashboards.MockDashboardService(mock)
 
 		origProvisioningService := dashboards.NewProvisioningService
-		dashboards.NewProvisioningService = func() dashboards.DashboardProvisioningService {
+		dashboards.NewProvisioningService = func(*setting.Cfg) dashboards.DashboardProvisioningService {
 			return mockDashboardProvisioningService{}
 		}
 
@@ -1269,7 +1269,7 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 		})
 
 		origProvisioningService := dashboards.NewProvisioningService
-		dashboards.NewProvisioningService = func() dashboards.DashboardProvisioningService {
+		dashboards.NewProvisioningService = func(*setting.Cfg) dashboards.DashboardProvisioningService {
 			return mockDashboardProvisioningService{}
 		}
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -68,7 +68,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricReq
 		})
 	}
 
-	resp, err := tsdb.HandleRequest(c.Req.Context(), ds, request)
+	resp, err := tsdb.HandleRequest(c.Req.Context(), ds, request, hs.Cfg)
 	if err != nil {
 		return response.Error(500, "Metric request error", err)
 	}
@@ -185,7 +185,7 @@ func (hs *HTTPServer) QueryMetrics(c *models.ReqContext, reqDto dtos.MetricReque
 		})
 	}
 
-	resp, err := tsdb.HandleRequest(c.Req.Context(), ds, request)
+	resp, err := tsdb.HandleRequest(c.Req.Context(), ds, request, hs.Cfg)
 	if err != nil {
 		return response.Error(500, "Metric request error", err)
 	}
@@ -242,7 +242,7 @@ func GenerateSQLTestData(c *models.ReqContext) response.Response {
 }
 
 // GET /api/tsdb/testdata/random-walk
-func GetTestDataRandomWalk(c *models.ReqContext) response.Response {
+func (hs *HTTPServer) GetTestDataRandomWalk(c *models.ReqContext) response.Response {
 	from := c.Query("from")
 	to := c.Query("to")
 	intervalMs := c.QueryInt64("intervalMs")
@@ -260,7 +260,7 @@ func GetTestDataRandomWalk(c *models.ReqContext) response.Response {
 		DataSource: dsInfo,
 	})
 
-	resp, err := tsdb.HandleRequest(context.Background(), dsInfo, request)
+	resp, err := tsdb.HandleRequest(context.Background(), dsInfo, request, hs.Cfg)
 	if err != nil {
 		return response.Error(500, "Metric request error", err)
 	}

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -243,7 +243,7 @@ func GetPluginMarkdown(c *models.ReqContext) response.Response {
 	return resp
 }
 
-func ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDashboardCommand) response.Response {
+func (hs *HTTPServer) ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDashboardCommand) response.Response {
 	if apiCmd.PluginId == "" && apiCmd.Dashboard == nil {
 		return response.Error(422, "Dashboard must be set", nil)
 	}
@@ -257,6 +257,7 @@ func ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDashboardCommand) r
 		Overwrite: apiCmd.Overwrite,
 		FolderId:  apiCmd.FolderId,
 		Dashboard: apiCmd.Dashboard,
+		Cfg:       hs.Cfg,
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -33,7 +33,7 @@ func (s *Service) isDisabled() bool {
 
 // BuildPipeline builds a pipeline from a request.
 func (s *Service) BuildPipeline(req *backend.QueryDataRequest) (DataPipeline, error) {
-	return buildPipeline(req)
+	return buildPipeline(req, s.Cfg)
 }
 
 // ExecutePipeline executes an expression pipeline and returns all the results.

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/stretchr/testify/require"
 )
@@ -101,11 +102,11 @@ func registerEndPoint(df ...*data.Frame) {
 	me := &mockEndpoint{
 		Frames: df,
 	}
-	endpoint := func(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+	endpoint := func(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 		return me, nil
 	}
 
-	tsdb.RegisterTsdbQueryEndpoint("test", endpoint)
+	tsdb.RegisterTSDBQueryEndpoint("test", endpoint)
 	bus.AddHandler("test", func(query *models.GetDataSourceQuery) error {
 		query.Result = &models.DataSource{Id: 1, OrgId: 1, Type: "test"}
 		return nil

--- a/pkg/models/alert.go
+++ b/pkg/models/alert.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type AlertStateType string
@@ -216,6 +217,7 @@ type UpdateDashboardAlertsCommand struct {
 	OrgId     int64
 	Dashboard *Dashboard
 	User      *SignedInUser
+	Cfg       *setting.Cfg
 }
 
 type ValidateDashboardAlertsCommand struct {
@@ -223,4 +225,5 @@ type ValidateDashboardAlertsCommand struct {
 	OrgId     int64
 	Dashboard *Dashboard
 	User      *SignedInUser
+	Cfg       *setting.Cfg
 }

--- a/pkg/plugins/backendplugin/coreplugin/core_plugin.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
@@ -43,7 +44,7 @@ func (cp *corePlugin) Logger() log.Logger {
 
 func (cp *corePlugin) Start(ctx context.Context) error {
 	if cp.QueryDataHandler != nil {
-		tsdb.RegisterTsdbQueryEndpoint(cp.pluginID, func(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+		tsdb.RegisterTSDBQueryEndpoint(cp.pluginID, func(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 			return newQueryEndpointAdapter(cp.pluginID, cp.logger, backendplugin.InstrumentQueryDataHandler(cp.QueryDataHandler)), nil
 		})
 	}

--- a/pkg/plugins/dashboard_importer.go
+++ b/pkg/plugins/dashboard_importer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var varRegex = regexp.MustCompile(`(\$\{.+?\})`)
@@ -19,11 +20,11 @@ type ImportDashboardCommand struct {
 	Inputs    []ImportDashboardInput
 	Overwrite bool
 	FolderId  int64
-
-	OrgId    int64
-	User     *models.SignedInUser
-	PluginId string
-	Result   *PluginDashboardInfoDTO
+	Cfg       *setting.Cfg
+	OrgId     int64
+	User      *models.SignedInUser
+	PluginId  string
+	Result    *PluginDashboardInfoDTO
 }
 
 type ImportDashboardInput struct {
@@ -83,8 +84,7 @@ func ImportDashboard(cmd *ImportDashboardCommand) error {
 		User:      cmd.User,
 	}
 
-	savedDash, err := dashboards.NewService().ImportDashboard(dto)
-
+	savedDash, err := dashboards.NewService(cmd.Cfg).ImportDashboard(dto)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/datasource_plugin.go
+++ b/pkg/plugins/datasource_plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/grpcplugin"
 	"github.com/grafana/grafana/pkg/plugins/datasource/wrapper"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
@@ -60,7 +61,7 @@ func (p *DataSourcePlugin) Load(decoder *json.Decoder, base *PluginBase, backend
 }
 
 func (p *DataSourcePlugin) onLegacyPluginStart(pluginID string, client *grpcplugin.LegacyClient, logger log.Logger) error {
-	tsdb.RegisterTsdbQueryEndpoint(pluginID, func(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+	tsdb.RegisterTSDBQueryEndpoint(pluginID, func(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 		return wrapper.NewDatasourcePluginWrapper(logger, client.DatasourcePlugin), nil
 	})
 
@@ -69,7 +70,7 @@ func (p *DataSourcePlugin) onLegacyPluginStart(pluginID string, client *grpcplug
 
 func (p *DataSourcePlugin) onPluginStart(pluginID string, client *grpcplugin.Client, logger log.Logger) error {
 	if client.DataPlugin != nil {
-		tsdb.RegisterTsdbQueryEndpoint(pluginID, func(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+		tsdb.RegisterTSDBQueryEndpoint(pluginID, func(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 			return wrapper.NewDatasourcePluginWrapperV2(logger, p.Id, p.Type, client.DataPlugin), nil
 		})
 	}

--- a/pkg/services/alerting/commands.go
+++ b/pkg/services/alerting/commands.go
@@ -11,7 +11,7 @@ func init() {
 }
 
 func validateDashboardAlerts(cmd *models.ValidateDashboardAlertsCommand) error {
-	extractor := NewDashAlertExtractor(cmd.Dashboard, cmd.OrgId, cmd.User)
+	extractor := NewDashAlertExtractor(cmd.Dashboard, cmd.OrgId, cmd.User, cmd.Cfg)
 
 	return extractor.ValidateAlerts()
 }
@@ -23,7 +23,7 @@ func updateDashboardAlerts(cmd *models.UpdateDashboardAlertsCommand) error {
 		DashboardId: cmd.Dashboard.Id,
 	}
 
-	extractor := NewDashAlertExtractor(cmd.Dashboard, cmd.OrgId, cmd.User)
+	extractor := NewDashAlertExtractor(cmd.Dashboard, cmd.OrgId, cmd.User, cmd.Cfg)
 
 	alerts, err := extractor.GetAlerts()
 	if err != nil {

--- a/pkg/services/alerting/engine.go
+++ b/pkg/services/alerting/engine.go
@@ -25,6 +25,7 @@ import (
 type AlertEngine struct {
 	RenderService rendering.Service `inject:""`
 	Bus           bus.Bus           `inject:""`
+	Cfg           *setting.Cfg      `inject:""`
 
 	execQueue     chan *Job
 	ticker        *Ticker
@@ -50,7 +51,7 @@ func (e *AlertEngine) Init() error {
 	e.execQueue = make(chan *Job, 1000)
 	e.scheduler = newScheduler()
 	e.evalHandler = NewEvalHandler()
-	e.ruleReader = newRuleReader()
+	e.ruleReader = newRuleReader(e.Cfg)
 	e.log = log.New("alerting.engine")
 	e.resultHandler = newResultHandler(e.RenderService)
 	return nil

--- a/pkg/services/alerting/extractor_test.go
+++ b/pkg/services/alerting/extractor_test.go
@@ -9,12 +9,15 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestAlertRuleExtraction(t *testing.T) {
+	cfg := setting.NewCfg()
+
 	Convey("Parsing alert rules  from dashboard json", t, func() {
-		RegisterCondition("query", func(model *simplejson.Json, index int) (Condition, error) {
+		RegisterCondition("query", func(model *simplejson.Json, index int, cfg *setting.Cfg) (Condition, error) {
 			return &FakeCondition{}, nil
 		})
 
@@ -69,7 +72,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 				So(getTarget(dashJSON), ShouldEqual, "")
 			})
 
-			extractor := NewDashAlertExtractor(dash, 1, nil)
+			extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 			_, _ = extractor.GetAlerts()
 
 			Convey("Dashboard json should not be updated after extracting rules", func() {
@@ -82,7 +85,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			dash := models.NewDashboardFromJson(dashJSON)
-			extractor := NewDashAlertExtractor(dash, 1, nil)
+			extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 			alerts, err := extractor.GetAlerts()
 
@@ -150,7 +153,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 			dashJSON, err := simplejson.NewJson(panelWithoutID)
 			So(err, ShouldBeNil)
 			dash := models.NewDashboardFromJson(dashJSON)
-			extractor := NewDashAlertExtractor(dash, 1, nil)
+			extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 			_, err = extractor.GetAlerts()
 
@@ -166,7 +169,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 			dashJSON, err := simplejson.NewJson(panelWithIDZero)
 			So(err, ShouldBeNil)
 			dash := models.NewDashboardFromJson(dashJSON)
-			extractor := NewDashAlertExtractor(dash, 1, nil)
+			extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 			_, err = extractor.GetAlerts()
 
@@ -182,7 +185,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 			dashJSON, err := simplejson.NewJson(panelWithoutSpecifiedDatasource)
 			So(err, ShouldBeNil)
 			dash := models.NewDashboardFromJson(dashJSON)
-			extractor := NewDashAlertExtractor(dash, 1, nil)
+			extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 			alerts, err := extractor.GetAlerts()
 
@@ -204,7 +207,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 			dashJSON, err := simplejson.NewJson(json)
 			So(err, ShouldBeNil)
 			dash := models.NewDashboardFromJson(dashJSON)
-			extractor := NewDashAlertExtractor(dash, 1, nil)
+			extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 			alerts, err := extractor.GetAlerts()
 
@@ -233,7 +236,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 				dashJSON, err := simplejson.NewJson(json)
 				So(err, ShouldBeNil)
 				dash := models.NewDashboardFromJson(dashJSON)
-				extractor := NewDashAlertExtractor(dash, 1, nil)
+				extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 				alerts, err := extractor.GetAlerts()
 
@@ -263,7 +266,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				dash := models.NewDashboardFromJson(dashJSON)
-				extractor := NewDashAlertExtractor(dash, 1, nil)
+				extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 				alerts, err := extractor.GetAlerts()
 
@@ -283,7 +286,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 				dashJSON, err := simplejson.NewJson(json)
 				So(err, ShouldBeNil)
 				dash := models.NewDashboardFromJson(dashJSON)
-				extractor := NewDashAlertExtractor(dash, 1, nil)
+				extractor := NewDashAlertExtractor(dash, 1, nil, cfg)
 
 				err = extractor.ValidateAlerts()
 

--- a/pkg/services/alerting/reader.go
+++ b/pkg/services/alerting/reader.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type ruleReader interface {
@@ -16,11 +17,13 @@ type ruleReader interface {
 type defaultRuleReader struct {
 	sync.RWMutex
 	log log.Logger
+	cfg *setting.Cfg
 }
 
-func newRuleReader() *defaultRuleReader {
+func newRuleReader(cfg *setting.Cfg) *defaultRuleReader {
 	ruleReader := &defaultRuleReader{
 		log: log.New("alerting.ruleReader"),
+		cfg: cfg,
 	}
 
 	return ruleReader
@@ -36,7 +39,7 @@ func (arr *defaultRuleReader) fetch() []*Rule {
 
 	res := make([]*Rule, 0)
 	for _, ruleDef := range cmd.Result {
-		if model, err := NewRuleFromDBAlert(ruleDef, false); err != nil {
+		if model, err := NewRuleFromDBAlert(ruleDef, false, arr.cfg); err != nil {
 			arr.log.Error("Could not build alert model for rule", "ruleId", ruleDef.Id, "error", err)
 		} else {
 			res = append(res, model)

--- a/pkg/services/alerting/rule_test.go
+++ b/pkg/services/alerting/rule_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,8 +51,11 @@ func TestAlertRuleFrequencyParsing(t *testing.T) {
 
 func TestAlertRuleModel(t *testing.T) {
 	sqlstore.InitTestDB(t)
+
+	cfg := setting.NewCfg()
+
 	Convey("Testing alert rule", t, func() {
-		RegisterCondition("test", func(model *simplejson.Json, index int) (Condition, error) {
+		RegisterCondition("test", func(model *simplejson.Json, index int, cfg *setting.Cfg) (Condition, error) {
 			return &FakeCondition{}, nil
 		})
 
@@ -102,7 +106,7 @@ func TestAlertRuleModel(t *testing.T) {
 					Settings: alertJSON,
 				}
 
-				alertRule, err := NewRuleFromDBAlert(alert, false)
+				alertRule, err := NewRuleFromDBAlert(alert, false, cfg)
 				So(err, ShouldBeNil)
 
 				So(len(alertRule.Conditions), ShouldEqual, 1)
@@ -144,7 +148,7 @@ func TestAlertRuleModel(t *testing.T) {
 				Settings: alertJSON,
 			}
 
-			alertRule, err := NewRuleFromDBAlert(alert, false)
+			alertRule, err := NewRuleFromDBAlert(alert, false, cfg)
 			Convey("swallows the error", func() {
 				So(err, ShouldBeNil)
 				So(alertRule.Notifications, ShouldNotContain, "999")
@@ -177,7 +181,7 @@ func TestAlertRuleModel(t *testing.T) {
 				Settings: alertJSON,
 			}
 
-			alertRule, err := NewRuleFromDBAlert(alert, false)
+			alertRule, err := NewRuleFromDBAlert(alert, false, cfg)
 			So(err, ShouldBeNil)
 			So(alertRule.Frequency, ShouldEqual, 60)
 		})
@@ -215,7 +219,7 @@ func TestAlertRuleModel(t *testing.T) {
 				Settings: alertJSON,
 			}
 
-			_, err := NewRuleFromDBAlert(alert, false)
+			_, err := NewRuleFromDBAlert(alert, false, cfg)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "alert validation error: Neither id nor uid is specified in 'notifications' block, type assertion to string failed AlertId: 1 PanelId: 1 DashboardId: 1")
 		})

--- a/pkg/services/alerting/test_rule.go
+++ b/pkg/services/alerting/test_rule.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // AlertTestCommand initiates an test evaluation
@@ -16,6 +17,7 @@ type AlertTestCommand struct {
 	PanelID   int64
 	OrgID     int64
 	User      *models.SignedInUser
+	Cfg       *setting.Cfg
 
 	Result *EvalContext
 }
@@ -27,7 +29,7 @@ func init() {
 func handleAlertTestCommand(cmd *AlertTestCommand) error {
 	dash := models.NewDashboardFromJson(cmd.Dashboard)
 
-	extractor := NewDashAlertExtractor(dash, cmd.OrgID, cmd.User)
+	extractor := NewDashAlertExtractor(dash, cmd.OrgID, cmd.User, cmd.Cfg)
 	alerts, err := extractor.GetAlerts()
 	if err != nil {
 		return err
@@ -35,7 +37,7 @@ func handleAlertTestCommand(cmd *AlertTestCommand) error {
 
 	for _, alert := range alerts {
 		if alert.PanelId == cmd.PanelID {
-			rule, err := NewRuleFromDBAlert(alert, true)
+			rule, err := NewRuleFromDBAlert(alert, true, cmd.Cfg)
 			if err != nil {
 				return err
 			}

--- a/pkg/services/dashboards/dashboard_service.go
+++ b/pkg/services/dashboards/dashboard_service.go
@@ -33,16 +33,18 @@ type DashboardProvisioningService interface {
 }
 
 // NewService factory for creating a new dashboard service
-var NewService = func() DashboardService {
+var NewService = func(cfg *setting.Cfg) DashboardService {
 	return &dashboardServiceImpl{
 		log: log.New("dashboard-service"),
+		cfg: cfg,
 	}
 }
 
 // NewProvisioningService factory for creating a new dashboard provisioning service
-var NewProvisioningService = func() DashboardProvisioningService {
+var NewProvisioningService = func(cfg *setting.Cfg) DashboardProvisioningService {
 	return &dashboardServiceImpl{
 		log: log.New("dashboard-provisioning-service"),
+		cfg: cfg,
 	}
 }
 
@@ -59,6 +61,7 @@ type dashboardServiceImpl struct {
 	orgId int64
 	user  *models.SignedInUser
 	log   log.Logger
+	cfg   *setting.Cfg
 }
 
 func (dr *dashboardServiceImpl) GetProvisionedDashboardData(name string) ([]*models.DashboardProvisioning, error) {
@@ -116,6 +119,7 @@ func (dr *dashboardServiceImpl) buildSaveDashboardCommand(dto *SaveDashboardDTO,
 			OrgId:     dto.OrgId,
 			Dashboard: dash,
 			User:      dto.User,
+			Cfg:       dr.cfg,
 		}
 
 		if err := bus.Dispatch(&validateAlertsCmd); err != nil {
@@ -212,6 +216,7 @@ func (dr *dashboardServiceImpl) updateAlerting(cmd *models.SaveDashboardCommand,
 		OrgId:     dto.OrgId,
 		Dashboard: cmd.Result,
 		User:      dto.User,
+		Cfg:       dr.cfg,
 	}
 
 	return bus.Dispatch(&alertCmd)
@@ -386,7 +391,7 @@ func (s *FakeDashboardService) DeleteDashboard(dashboardId int64, orgId int64) e
 }
 
 func MockDashboardService(mock *FakeDashboardService) {
-	NewService = func() DashboardService {
+	NewService = func(cfg *setting.Cfg) DashboardService {
 		return mock
 	}
 }

--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
@@ -21,8 +22,8 @@ type DashboardProvisioner interface {
 	CleanUpOrphanedDashboards()
 }
 
-// DashboardProvisionerFactory creates DashboardProvisioners based on input
-type DashboardProvisionerFactory func(string) (DashboardProvisioner, error)
+// DashboardProvisionerFactory creates DashboardProvisioners based on input.
+type DashboardProvisionerFactory func(string, *setting.Cfg) (DashboardProvisioner, error)
 
 // Provisioner is responsible for syncing dashboard from disk to Grafana's database.
 type Provisioner struct {
@@ -32,10 +33,10 @@ type Provisioner struct {
 }
 
 // New returns a new DashboardProvisioner
-func New(configDirectory string) (*Provisioner, error) {
+func New(configDirectory string, cfg *setting.Cfg) (*Provisioner, error) {
 	logger := log.New("provisioning.dashboard")
 	cfgReader := &configReader{path: configDirectory, log: logger}
-	configs, err := cfgReader.readConfig()
+	configs, err := cfgReader.readConfig(cfg)
 
 	if err != nil {
 		return nil, errutil.Wrap("Failed to read dashboards config", err)

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -56,7 +56,7 @@ func NewDashboardFileReader(cfg *config, log log.Logger) (*FileReader, error) {
 		Cfg:                          cfg,
 		Path:                         path,
 		log:                          log,
-		dashboardProvisioningService: dashboards.NewProvisioningService(),
+		dashboardProvisioningService: dashboards.NewProvisioningService(cfg.Cfg),
 		FoldersFromFilesStructure:    foldersFromFilesStructure,
 	}, nil
 }

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -396,7 +397,7 @@ func mockDashboardProvisioningService() *fakeDashboardProvisioningService {
 	mock := fakeDashboardProvisioningService{
 		provisioned: map[string][]*models.DashboardProvisioning{},
 	}
-	dashboards.NewProvisioningService = func() dashboards.DashboardProvisioningService {
+	dashboards.NewProvisioningService = func(*setting.Cfg) dashboards.DashboardProvisioningService {
 		return &mock
 	}
 	return &mock

--- a/pkg/services/provisioning/dashboards/types.go
+++ b/pkg/services/provisioning/dashboards/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/provisioning/values"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type config struct {
@@ -21,6 +22,7 @@ type config struct {
 	DisableDeletion       bool
 	UpdateIntervalSeconds int64
 	AllowUIUpdates        bool
+	Cfg                   *setting.Cfg
 }
 
 type configV0 struct {
@@ -73,7 +75,7 @@ func createDashboardJSON(data *simplejson.Json, lastModified time.Time, cfg *con
 	return dash, nil
 }
 
-func mapV0ToDashboardsAsConfig(v0 []*configV0) ([]*config, error) {
+func mapV0ToDashboardsAsConfig(v0 []*configV0, cfg *setting.Cfg) ([]*config, error) {
 	var r []*config
 	seen := make(map[string]bool)
 
@@ -94,13 +96,14 @@ func mapV0ToDashboardsAsConfig(v0 []*configV0) ([]*config, error) {
 			DisableDeletion:       v.DisableDeletion,
 			UpdateIntervalSeconds: v.UpdateIntervalSeconds,
 			AllowUIUpdates:        v.AllowUIUpdates,
+			Cfg:                   cfg,
 		})
 	}
 
 	return r, nil
 }
 
-func (dc *configV1) mapToDashboardsAsConfig() ([]*config, error) {
+func (dc *configV1) mapToDashboardsAsConfig(cfg *setting.Cfg) ([]*config, error) {
 	var r []*config
 	seen := make(map[string]bool)
 
@@ -121,6 +124,7 @@ func (dc *configV1) mapToDashboardsAsConfig() ([]*config, error) {
 			DisableDeletion:       v.DisableDeletion.Value(),
 			UpdateIntervalSeconds: v.UpdateIntervalSeconds.Value(),
 			AllowUIUpdates:        v.AllowUIUpdates.Value(),
+			Cfg:                   cfg,
 		})
 	}
 

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -28,8 +28,8 @@ func init() {
 	registry.Register(&registry.Descriptor{
 		Name: "ProvisioningService",
 		Instance: NewProvisioningServiceImpl(
-			func(path string) (dashboards.DashboardProvisioner, error) {
-				return dashboards.New(path)
+			func(path string, cfg *setting.Cfg) (dashboards.DashboardProvisioner, error) {
+				return dashboards.New(path, cfg)
 			},
 			notifiers.Provision,
 			datasources.Provision,
@@ -134,9 +134,9 @@ func (ps *provisioningServiceImpl) ProvisionNotifications() error {
 
 func (ps *provisioningServiceImpl) ProvisionDashboards() error {
 	dashboardPath := filepath.Join(ps.Cfg.ProvisioningPath, "dashboards")
-	dashProvisioner, err := ps.newDashboardProvisioner(dashboardPath)
+	dashProvisioner, err := ps.newDashboardProvisioner(dashboardPath, ps.Cfg)
 	if err != nil {
-		return errutil.Wrap("Failed to create provisioner", err)
+		return errutil.Wrap("failed to create provisioner", err)
 	}
 
 	ps.mutex.Lock()

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -91,7 +91,7 @@ func setup() *serviceTestStruct {
 	}
 
 	serviceTest.service = NewProvisioningServiceImpl(
-		func(path string) (dashboards.DashboardProvisioner, error) {
+		func(path string, cfg *setting.Cfg) (dashboards.DashboardProvisioner, error) {
 			return serviceTest.mock, nil
 		},
 		nil,

--- a/pkg/services/sqlstore/dashboard_service_integration_test.go
+++ b/pkg/services/sqlstore/dashboard_service_integration_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
@@ -16,6 +18,8 @@ import (
 )
 
 func TestIntegratedDashboardService(t *testing.T) {
+	cfg := setting.NewCfg()
+
 	Convey("Dashboard service integration tests", t, func() {
 		InitTestDB(t)
 		var testOrgId int64 = 1
@@ -34,11 +38,11 @@ func TestIntegratedDashboardService(t *testing.T) {
 				return nil
 			})
 
-			savedFolder := saveTestFolder("Saved folder", testOrgId)
-			savedDashInFolder := saveTestDashboard("Saved dash in folder", testOrgId, savedFolder.Id)
-			saveTestDashboard("Other saved dash in folder", testOrgId, savedFolder.Id)
-			savedDashInGeneralFolder := saveTestDashboard("Saved dashboard in general folder", testOrgId, 0)
-			otherSavedFolder := saveTestFolder("Other saved folder", testOrgId)
+			savedFolder := saveTestFolder(t, "Saved folder", testOrgId, cfg)
+			savedDashInFolder := saveTestDashboard(t, "Saved dash in folder", testOrgId, savedFolder.Id, cfg)
+			saveTestDashboard(t, "Other saved dash in folder", testOrgId, savedFolder.Id, cfg)
+			savedDashInGeneralFolder := saveTestDashboard(t, "Saved dashboard in general folder", testOrgId, 0, cfg)
+			otherSavedFolder := saveTestFolder(t, "Other saved folder", testOrgId, cfg)
 
 			Convey("Should return dashboard model", func() {
 				So(savedFolder.Title, ShouldEqual, "Saved folder")
@@ -67,7 +71,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 					}),
 				}
 
-				err := callSaveWithError(cmd)
+				err := callSaveWithError(t, cmd, cfg)
 
 				Convey("It should result in not found error", func() {
 					So(err, ShouldNotBeNil)
@@ -90,7 +94,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: false,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should result in not found error", func() {
 						So(err, ShouldNotBeNil)
@@ -110,7 +114,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: false,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 
 						Convey("It should create a new dashboard in organization B", func() {
 							So(res, ShouldNotBeNil)
@@ -141,7 +145,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for General Folder with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -164,7 +168,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for other folder with correct arguments and rsult in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -187,7 +191,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for folder with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -211,7 +215,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for folder with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -235,7 +239,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for dashboard with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -259,7 +263,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for dashboard with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -283,7 +287,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for other folder with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -307,7 +311,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for General folder with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -331,7 +335,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for other folder with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -355,7 +359,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 						Overwrite: true,
 					}
 
-					err := callSaveWithError(cmd)
+					err := callSaveWithError(t, cmd, cfg)
 
 					Convey("It should create dashboard guardian for General folder with correct arguments and result in access denied error", func() {
 						So(err, ShouldNotBeNil)
@@ -385,7 +389,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should create a new dashboard", func() {
@@ -409,7 +413,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should create a new dashboard", func() {
@@ -434,7 +438,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should create a new folder", func() {
@@ -459,7 +463,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should create a new dashboard", func() {
@@ -484,7 +488,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should create a new dashboard", func() {
@@ -506,7 +510,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in folder not found error", func() {
 							So(err, ShouldNotBeNil)
@@ -525,7 +529,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in version mismatch error", func() {
 							So(err, ShouldNotBeNil)
@@ -545,7 +549,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should update dashboard", func() {
@@ -570,7 +574,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in version mismatch error", func() {
 							So(err, ShouldNotBeNil)
@@ -590,7 +594,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should update dashboard", func() {
@@ -615,7 +619,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in dashboard with same name in folder error", func() {
 							So(err, ShouldNotBeNil)
@@ -634,7 +638,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in dashboard with same name in folder error", func() {
 							So(err, ShouldNotBeNil)
@@ -653,7 +657,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in dashboard with same name in folder error", func() {
 							So(err, ShouldNotBeNil)
@@ -676,7 +680,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should update dashboard", func() {
@@ -701,7 +705,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 						So(res, ShouldNotBeNil)
 
 						Convey("It should update dashboard", func() {
@@ -726,7 +730,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 
 						Convey("It should update dashboard", func() {
 							So(res, ShouldNotBeNil)
@@ -753,7 +757,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in same uid exists error", func() {
 							So(err, ShouldNotBeNil)
@@ -772,7 +776,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 
 						Convey("It should overwrite existing dashboard", func() {
 							So(res, ShouldNotBeNil)
@@ -799,7 +803,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						res := callSaveWithResult(cmd)
+						res := callSaveWithResult(t, cmd, cfg)
 
 						Convey("It should overwrite existing dashboard", func() {
 							So(res, ShouldNotBeNil)
@@ -826,7 +830,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in type mismatch error", func() {
 							So(err, ShouldNotBeNil)
@@ -845,7 +849,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in type mismatch error", func() {
 							So(err, ShouldNotBeNil)
@@ -864,7 +868,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in type mismatch error", func() {
 							So(err, ShouldNotBeNil)
@@ -883,7 +887,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in type mismatch error", func() {
 							So(err, ShouldNotBeNil)
@@ -901,7 +905,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in dashboard with same name as folder error", func() {
 							So(err, ShouldNotBeNil)
@@ -919,7 +923,7 @@ func TestIntegratedDashboardService(t *testing.T) {
 							Overwrite: shouldOverwrite,
 						}
 
-						err := callSaveWithError(cmd)
+						err := callSaveWithError(t, cmd, cfg)
 
 						Convey("It should result in folder with same name as dashboard error", func() {
 							So(err, ShouldNotBeNil)
@@ -962,19 +966,25 @@ func permissionScenario(desc string, canSave bool, fn dashboardPermissionScenari
 	dashboardPermissionScenario(desc, mock, fn)
 }
 
-func callSaveWithResult(cmd models.SaveDashboardCommand) *models.Dashboard {
+func callSaveWithResult(t *testing.T, cmd models.SaveDashboardCommand, cfg *setting.Cfg) *models.Dashboard {
+	t.Helper()
 	dto := toSaveDashboardDto(cmd)
-	res, _ := dashboards.NewService().SaveDashboard(&dto, false)
+	res, err := dashboards.NewService(cfg).SaveDashboard(&dto, false)
+	require.NoError(t, err)
 	return res
 }
 
-func callSaveWithError(cmd models.SaveDashboardCommand) error {
+func callSaveWithError(t *testing.T, cmd models.SaveDashboardCommand, cfg *setting.Cfg) error {
+	t.Helper()
+
 	dto := toSaveDashboardDto(cmd)
-	_, err := dashboards.NewService().SaveDashboard(&dto, false)
+	_, err := dashboards.NewService(cfg).SaveDashboard(&dto, false)
 	return err
 }
 
-func saveTestDashboard(title string, orgId int64, folderId int64) *models.Dashboard {
+func saveTestDashboard(t *testing.T, title string, orgId int64, folderId int64, cfg *setting.Cfg) *models.Dashboard {
+	t.Helper()
+
 	cmd := models.SaveDashboardCommand{
 		OrgId:    orgId,
 		FolderId: folderId,
@@ -994,13 +1004,15 @@ func saveTestDashboard(title string, orgId int64, folderId int64) *models.Dashbo
 		},
 	}
 
-	res, err := dashboards.NewService().SaveDashboard(&dto, false)
-	So(err, ShouldBeNil)
+	res, err := dashboards.NewService(cfg).SaveDashboard(&dto, false)
+	require.NoError(t, err)
 
 	return res
 }
 
-func saveTestFolder(title string, orgId int64) *models.Dashboard {
+func saveTestFolder(t *testing.T, title string, orgId int64, cfg *setting.Cfg) *models.Dashboard {
+	t.Helper()
+
 	cmd := models.SaveDashboardCommand{
 		OrgId:    orgId,
 		FolderId: 0,
@@ -1020,8 +1032,8 @@ func saveTestFolder(title string, orgId int64) *models.Dashboard {
 		},
 	}
 
-	res, err := dashboards.NewService().SaveDashboard(&dto, false)
-	So(err, ShouldBeNil)
+	res, err := dashboards.NewService(cfg).SaveDashboard(&dto, false)
+	require.NoError(t, err)
 
 	return res
 }

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
@@ -16,20 +17,20 @@ var (
 	legendKeyFormat *regexp.Regexp
 )
 
-// AzureMonitorExecutor executes queries for the Azure Monitor datasource - all four services
-type AzureMonitorExecutor struct {
+// azureMonitorExecutor executes queries for the Azure Monitor datasource - all four services
+type azureMonitorExecutor struct {
 	httpClient *http.Client
 	dsInfo     *models.DataSource
 }
 
-// NewAzureMonitorExecutor initializes a http client
-func NewAzureMonitorExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+// newAzureMonitorExecutor initializes a http client
+func newAzureMonitorExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	httpClient, err := dsInfo.GetHttpClient()
 	if err != nil {
 		return nil, err
 	}
 
-	return &AzureMonitorExecutor{
+	return &azureMonitorExecutor{
 		httpClient: httpClient,
 		dsInfo:     dsInfo,
 	}, nil
@@ -37,7 +38,7 @@ func NewAzureMonitorExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint,
 
 func init() {
 	azlog = log.New("tsdb.azuremonitor")
-	tsdb.RegisterTsdbQueryEndpoint("grafana-azure-monitor-datasource", NewAzureMonitorExecutor)
+	tsdb.RegisterTSDBQueryEndpoint("grafana-azure-monitor-datasource", newAzureMonitorExecutor)
 	legendKeyFormat = regexp.MustCompile(`\{\{\s*(.+?)\s*\}\}`)
 }
 
@@ -45,7 +46,7 @@ func init() {
 // expected by chosen Azure Monitor service (Azure Monitor, App Insights etc.)
 // executes the queries against the API and parses the response into
 // the right format
-func (e *AzureMonitorExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
+func (e *azureMonitorExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
 	var err error
 
 	var azureMonitorQueries []*tsdb.Query

--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -68,8 +68,8 @@ type CloudMonitoringExecutor struct {
 	dsInfo     *models.DataSource
 }
 
-// NewCloudMonitoringExecutor initializes a http client
-func NewCloudMonitoringExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+// newCloudMonitoringExecutor initializes a http client
+func newCloudMonitoringExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	httpClient, err := dsInfo.GetHttpClient()
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func NewCloudMonitoringExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoi
 
 func init() {
 	slog = log.New("tsdb.cloudMonitoring")
-	tsdb.RegisterTsdbQueryEndpoint("stackdriver", NewCloudMonitoringExecutor)
+	tsdb.RegisterTSDBQueryEndpoint("stackdriver", newCloudMonitoringExecutor)
 }
 
 // Query takes in the frontend queries, parses them into the CloudMonitoring query format

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -68,7 +68,7 @@ type CloudWatchService struct {
 func (s *CloudWatchService) Init() error {
 	plog.Debug("initing")
 
-	tsdb.RegisterTsdbQueryEndpoint("cloudwatch", func(ds *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+	tsdb.RegisterTSDBQueryEndpoint("cloudwatch", func(ds *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 		return newExecutor(s.LogsService), nil
 	})
 

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )
@@ -17,13 +18,13 @@ var (
 )
 
 // NewElasticsearchExecutor creates a new elasticsearch executor
-func NewElasticsearchExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewElasticsearchExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &ElasticsearchExecutor{}, nil
 }
 
 func init() {
 	intervalCalculator = tsdb.NewIntervalCalculator(nil)
-	tsdb.RegisterTsdbQueryEndpoint("elasticsearch", NewElasticsearchExecutor)
+	tsdb.RegisterTSDBQueryEndpoint("elasticsearch", NewElasticsearchExecutor)
 }
 
 // Query handles an elasticsearch datasource request

--- a/pkg/tsdb/fake_test.go
+++ b/pkg/tsdb/fake_test.go
@@ -6,21 +6,14 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 )
 
-type FakeExecutor struct {
+type fakeExecutor struct {
 	results   map[string]*QueryResult
 	resultsFn map[string]ResultsFn
 }
 
 type ResultsFn func(context *TsdbQuery) *QueryResult
 
-func NewFakeExecutor(dsInfo *models.DataSource) (*FakeExecutor, error) {
-	return &FakeExecutor{
-		results:   make(map[string]*QueryResult),
-		resultsFn: make(map[string]ResultsFn),
-	}, nil
-}
-
-func (e *FakeExecutor) Query(ctx context.Context, dsInfo *models.DataSource, context *TsdbQuery) (*Response, error) {
+func (e *fakeExecutor) Query(ctx context.Context, dsInfo *models.DataSource, context *TsdbQuery) (*Response, error) {
 	result := &Response{Results: make(map[string]*QueryResult)}
 	for _, query := range context.Queries {
 		if results, has := e.results[query.RefId]; has {
@@ -34,12 +27,12 @@ func (e *FakeExecutor) Query(ctx context.Context, dsInfo *models.DataSource, con
 	return result, nil
 }
 
-func (e *FakeExecutor) Return(refId string, series TimeSeriesSlice) {
+func (e *fakeExecutor) Return(refId string, series TimeSeriesSlice) {
 	e.results[refId] = &QueryResult{
 		RefId: refId, Series: series,
 	}
 }
 
-func (e *FakeExecutor) HandleQuery(refId string, fn ResultsFn) {
+func (e *fakeExecutor) HandleQuery(refId string, fn ResultsFn) {
 	e.resultsFn[refId] = fn
 }

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -25,14 +25,14 @@ type GraphiteExecutor struct {
 	HttpClient *http.Client
 }
 
-func NewGraphiteExecutor(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewGraphiteExecutor(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &GraphiteExecutor{}, nil
 }
 
 var glog = log.New("tsdb.graphite")
 
 func init() {
-	tsdb.RegisterTsdbQueryEndpoint("graphite", NewGraphiteExecutor)
+	tsdb.RegisterTSDBQueryEndpoint("graphite", NewGraphiteExecutor)
 }
 
 func (e *GraphiteExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -17,14 +17,14 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/flux"
 )
 
-type InfluxDBExecutor struct {
+type influxDBExecutor struct {
 	// *models.DataSource
 	QueryParser    *InfluxdbQueryParser
 	ResponseParser *ResponseParser
 }
 
-func NewInfluxDBExecutor(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
-	return &InfluxDBExecutor{
+func NewInfluxDBExecutor(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
+	return &influxDBExecutor{
 		QueryParser:    &InfluxdbQueryParser{},
 		ResponseParser: &ResponseParser{},
 	}, nil
@@ -38,10 +38,10 @@ var ErrInvalidHttpMode error = errors.New("'httpMode' should be either 'GET' or 
 
 func init() {
 	glog = log.New("tsdb.influxdb")
-	tsdb.RegisterTsdbQueryEndpoint("influxdb", NewInfluxDBExecutor)
+	tsdb.RegisterTSDBQueryEndpoint("influxdb", NewInfluxDBExecutor)
 }
 
-func (e *InfluxDBExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
+func (e *influxDBExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
 	glog.Debug("Received a query request", "numQueries", len(tsdbQuery.Queries))
 
 	version := dsInfo.JsonData.Get("version").MustString("")
@@ -108,7 +108,7 @@ func (e *InfluxDBExecutor) Query(ctx context.Context, dsInfo *models.DataSource,
 	return result, nil
 }
 
-func (e *InfluxDBExecutor) getQuery(dsInfo *models.DataSource, queries []*tsdb.Query, context *tsdb.TsdbQuery) (*Query, error) {
+func (e *influxDBExecutor) getQuery(dsInfo *models.DataSource, queries []*tsdb.Query, context *tsdb.TsdbQuery) (*Query, error) {
 	if len(queries) == 0 {
 		return nil, fmt.Errorf("query request contains no queries")
 	}
@@ -122,7 +122,7 @@ func (e *InfluxDBExecutor) getQuery(dsInfo *models.DataSource, queries []*tsdb.Q
 	return query, nil
 }
 
-func (e *InfluxDBExecutor) createRequest(ctx context.Context, dsInfo *models.DataSource, query string) (*http.Request, error) {
+func (e *influxDBExecutor) createRequest(ctx context.Context, dsInfo *models.DataSource, query string) (*http.Request, error) {
 	u, err := url.Parse(dsInfo.Url)
 	if err != nil {
 		return nil, err

--- a/pkg/tsdb/influxdb/influxdb_test.go
+++ b/pkg/tsdb/influxdb/influxdb_test.go
@@ -19,7 +19,7 @@ func TestInfluxDBExecutor_createRequest(t *testing.T) {
 		JsonData: simplejson.New(),
 	}
 	query := "SELECT awesomeness FROM somewhere"
-	e := &InfluxDBExecutor{
+	e := &influxDBExecutor{
 		QueryParser:    &InfluxdbQueryParser{},
 		ResponseParser: &ResponseParser{},
 	}

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -19,12 +19,12 @@ import (
 )
 
 func init() {
-	tsdb.RegisterTsdbQueryEndpoint("mssql", newMssqlQueryEndpoint)
+	tsdb.RegisterTSDBQueryEndpoint("mssql", newMSSQLQueryEndpoint)
 }
 
 var logger = log.New("tsdb.mssql")
 
-func newMssqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func newMSSQLQueryEndpoint(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	cnnstr, err := generateConnectionString(datasource)
 	if err != nil {
 		return nil, err

--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	. "github.com/smartystreets/goconvey/convey"
@@ -29,6 +30,8 @@ import (
 var serverIP = "localhost"
 
 func TestMSSQL(t *testing.T) {
+	cfg := setting.NewCfg()
+
 	SkipConvey("MSSQL", t, func() {
 		x := InitMSSQLTestDB(t)
 
@@ -42,10 +45,10 @@ func TestMSSQL(t *testing.T) {
 			return sql, nil
 		}
 
-		endpoint, err := newMssqlQueryEndpoint(&models.DataSource{
+		endpoint, err := newMSSQLQueryEndpoint(&models.DataSource{
 			JsonData:       simplejson.New(),
 			SecureJsonData: securejsondata.SecureJsonData{},
-		})
+		}, cfg)
 		So(err, ShouldBeNil)
 
 		sess := x.NewSession()

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -21,14 +21,14 @@ import (
 )
 
 func init() {
-	tsdb.RegisterTsdbQueryEndpoint("mysql", newMysqlQueryEndpoint)
+	tsdb.RegisterTSDBQueryEndpoint("mysql", newMysqlQueryEndpoint)
 }
 
 func characterEscape(s string, escapeChar string) string {
 	return strings.ReplaceAll(s, escapeChar, url.QueryEscape(escapeChar))
 }
 
-func newMysqlQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func newMysqlQueryEndpoint(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	logger := log.New("tsdb.mysql")
 
 	protocol := "tcp"

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	"xorm.io/xorm"
@@ -31,6 +32,8 @@ import (
 // use to verify that the generated data are visualized as expected, see
 // devenv/README.md for setup instructions.
 func TestMySQL(t *testing.T) {
+	cfg := setting.NewCfg()
+
 	// change to true to run the MySQL tests
 	runMySQLTests := false
 	// runMySqlTests := true
@@ -55,7 +58,7 @@ func TestMySQL(t *testing.T) {
 		endpoint, err := newMysqlQueryEndpoint(&models.DataSource{
 			JsonData:       simplejson.New(),
 			SecureJsonData: securejsondata.SecureJsonData{},
-		})
+		}, cfg)
 		So(err, ShouldBeNil)
 
 		sess := x.NewSession()

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -24,7 +24,7 @@ import (
 type OpenTsdbExecutor struct {
 }
 
-func NewOpenTsdbExecutor(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func NewOpenTSDBExecutor(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	return &OpenTsdbExecutor{}, nil
 }
 
@@ -34,7 +34,7 @@ var (
 
 func init() {
 	plog = log.New("tsdb.opentsdb")
-	tsdb.RegisterTsdbQueryEndpoint("opentsdb", NewOpenTsdbExecutor)
+	tsdb.RegisterTSDBQueryEndpoint("opentsdb", NewOpenTSDBExecutor)
 }
 
 func (e *OpenTsdbExecutor) Query(ctx context.Context, dsInfo *models.DataSource, queryContext *tsdb.TsdbQuery) (*tsdb.Response, error) {

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -17,10 +17,10 @@ import (
 )
 
 func init() {
-	tsdb.RegisterTsdbQueryEndpoint("postgres", newPostgresQueryEndpoint)
+	tsdb.RegisterTSDBQueryEndpoint("postgres", newPostgresQueryEndpoint)
 }
 
-func newPostgresQueryEndpoint(datasource *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
+func newPostgresQueryEndpoint(datasource *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
 	logger := log.New("tsdb.postgres")
 	logger.Debug("Creating Postgres query endpoint")
 

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
 	"github.com/stretchr/testify/assert"
@@ -123,6 +124,8 @@ func TestGenerateConnectionString(t *testing.T) {
 // use to verify that the generated data are visualized as expected, see
 // devenv/README.md for setup instructions.
 func TestPostgres(t *testing.T) {
+	cfg := setting.NewCfg()
+
 	// change to true to run the PostgreSQL tests
 	runPostgresTests := false
 	// runPostgresTests := true
@@ -149,7 +152,7 @@ func TestPostgres(t *testing.T) {
 	endpoint, err := newPostgresQueryEndpoint(&models.DataSource{
 		JsonData:       simplejson.New(),
 		SecureJsonData: securejsondata.SecureJsonData{},
-	})
+	}, cfg)
 	require.NoError(t, err)
 
 	sess := x.NewSession()

--- a/pkg/tsdb/query_endpoint.go
+++ b/pkg/tsdb/query_endpoint.go
@@ -4,20 +4,21 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type TsdbQueryEndpoint interface {
 	Query(ctx context.Context, ds *models.DataSource, query *TsdbQuery) (*Response, error)
 }
 
-var registry map[string]GetTsdbQueryEndpointFn
+var registry map[string]GetTSDBQueryEndpointFn
 
-type GetTsdbQueryEndpointFn func(dsInfo *models.DataSource) (TsdbQueryEndpoint, error)
+type GetTSDBQueryEndpointFn func(dsInfo *models.DataSource, cfg *setting.Cfg) (TsdbQueryEndpoint, error)
 
 func init() {
-	registry = make(map[string]GetTsdbQueryEndpointFn)
+	registry = make(map[string]GetTSDBQueryEndpointFn)
 }
 
-func RegisterTsdbQueryEndpoint(pluginId string, fn GetTsdbQueryEndpointFn) {
+func RegisterTSDBQueryEndpoint(pluginId string, fn GetTSDBQueryEndpointFn) {
 	registry[pluginId] = fn
 }

--- a/pkg/tsdb/request.go
+++ b/pkg/tsdb/request.go
@@ -5,19 +5,18 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
-type HandleRequestFunc func(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery) (*Response, error)
+type HandleRequestFunc func(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery, cfg *setting.Cfg) (*Response, error)
 
-func HandleRequest(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery) (*Response, error) {
-	var endpoint TsdbQueryEndpoint
+func HandleRequest(ctx context.Context, dsInfo *models.DataSource, req *TsdbQuery, cfg *setting.Cfg) (*Response, error) {
 	fn, exists := registry[dsInfo.Type]
 	if !exists {
 		return nil, fmt.Errorf("could not find executor for data source type: %s", dsInfo.Type)
 	}
 
-	var err error
-	endpoint, err = fn(dsInfo)
+	endpoint, err := fn(dsInfo, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/testdatasource/testdata.go
+++ b/pkg/tsdb/testdatasource/testdata.go
@@ -5,26 +5,27 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
 
-type TestDataExecutor struct {
+type testDataExecutor struct {
 	*models.DataSource
 	log log.Logger
 }
 
-func NewTestDataExecutor(dsInfo *models.DataSource) (tsdb.TsdbQueryEndpoint, error) {
-	return &TestDataExecutor{
+func newTestDataExecutor(dsInfo *models.DataSource, cfg *setting.Cfg) (tsdb.TsdbQueryEndpoint, error) {
+	return &testDataExecutor{
 		DataSource: dsInfo,
 		log:        log.New("tsdb.testdata"),
 	}, nil
 }
 
 func init() {
-	tsdb.RegisterTsdbQueryEndpoint("testdata", NewTestDataExecutor)
+	tsdb.RegisterTSDBQueryEndpoint("testdata", newTestDataExecutor)
 }
 
-func (e *TestDataExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
+func (e *testDataExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
 	result := &tsdb.Response{}
 	result.Results = make(map[string]*tsdb.QueryResult)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor the TSDB backend code to use non-global configuration (no functionality changes!). This is necessary for #30353, unless we want to keep the approach of injecting the Postgres data source as a service (which I don't think we should) since it requires access to config in the Postgres data source.

Sorry for the huge PR, but it was a domino effect.o

Also performing some minor cleanup, such as renaming symbols to follow standard Go style.