### PR TITLE
Grafana-UI: Fix setting default value for MultiSelect

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -4,7 +4,6 @@ import { SelectCommonProps, MultiSelectCommonProps, SelectAsyncProps } from './t
 import { SelectBase } from './SelectBase';
 
 export function Select<T>(props: SelectCommonProps<T>) {
-  console.log('pp', props);
   return <SelectBase {...props} />;
 }
 

--- a/packages/grafana-ui/src/components/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.tsx
@@ -4,6 +4,7 @@ import { SelectCommonProps, MultiSelectCommonProps, SelectAsyncProps } from './t
 import { SelectBase } from './SelectBase';
 
 export function Select<T>(props: SelectCommonProps<T>) {
+  console.log('pp', props);
   return <SelectBase {...props} />;
 }
 

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -150,7 +150,7 @@ export function SelectBase<T>({
   let ReactSelectComponent: ReactSelect | Creatable = ReactSelect;
   const creatableProps: any = {};
   let asyncSelectProps: any = {};
-  let selectedValue = [];
+  let selectedValue;
   if (isMulti && loadOptions) {
     selectedValue = value as any;
   } else {
@@ -207,7 +207,7 @@ export function SelectBase<T>({
     renderControl,
     showAllSelectedWhenOpen,
     tabSelectsValue,
-    value: isMulti ? selectedValue : selectedValue[0],
+    value: isMulti ? selectedValue : selectedValue?.[0],
   };
 
   if (allowCustomValue) {

--- a/packages/grafana-ui/src/components/Select/utils.test.ts
+++ b/packages/grafana-ui/src/components/Select/utils.test.ts
@@ -74,11 +74,11 @@ describe('Select utils', () => {
       expect(cleanValue('test1', optGroup)).toEqual([{ label: 'Group 4 - Option 1', value: 'test1' }]);
       expect(cleanValue(3, options)).toEqual([{ label: 'Option 3', value: 3 }]);
     });
-    it('should return empty array for null/undefined/empty values', () => {
-      expect(cleanValue([undefined], options)).toEqual([]);
-      expect(cleanValue(undefined, options)).toEqual([]);
-      expect(cleanValue(null, options)).toEqual([]);
-      expect(cleanValue('', options)).toEqual([]);
+    it('should return undefined for null/undefined/empty values', () => {
+      expect(cleanValue([undefined], options)).toEqual(undefined);
+      expect(cleanValue(undefined, options)).toEqual(undefined);
+      expect(cleanValue(null, options)).toEqual(undefined);
+      expect(cleanValue('', options)).toEqual(undefined);
     });
   });
 });

--- a/packages/grafana-ui/src/components/Select/utils.ts
+++ b/packages/grafana-ui/src/components/Select/utils.ts
@@ -4,10 +4,7 @@ import { SelectableOptGroup } from './types';
 /**
  * Normalize the value format to SelectableValue[] | []. Only used for single select
  */
-export const cleanValue = (
-  value: any,
-  options: Array<SelectableValue | SelectableOptGroup | SelectableOptGroup[]>
-): SelectableValue[] | [] => {
+export const cleanValue = (value: any, options: Array<SelectableValue | SelectableOptGroup | SelectableOptGroup[]>) => {
   if (Array.isArray(value)) {
     return value.filter(Boolean);
   }
@@ -20,7 +17,7 @@ export const cleanValue = (
       return [selectedValue];
     }
   }
-  return [];
+  return undefined;
 };
 
 /**

--- a/packages/grafana-ui/src/components/Select/utils.ts
+++ b/packages/grafana-ui/src/components/Select/utils.ts
@@ -6,7 +6,8 @@ import { SelectableOptGroup } from './types';
  */
 export const cleanValue = (value: any, options: Array<SelectableValue | SelectableOptGroup | SelectableOptGroup[]>) => {
   if (Array.isArray(value)) {
-    return value.filter(Boolean);
+    const filtered = value.filter(Boolean);
+    return filtered?.length ? filtered : undefined;
   }
   if (typeof value === 'object' && value !== null) {
     return [value];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Default to `undefined` instead of an empty array for Select's `value`, to enable `defaultValue` to be set. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/30649

**Special notes for your reviewer**:

