### PR TITLE
DeployImage: Switch base images to Debian

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -433,7 +433,7 @@ steps:
   - package
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
@@ -527,7 +527,7 @@ steps:
   - end-to-end-tests
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -638,7 +638,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages-oss
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json --build-id ${DRONE_BUILD_NUMBER}
@@ -935,7 +935,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -948,7 +948,7 @@ steps:
   - postgres-integration-tests
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
@@ -1324,7 +1324,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition enterprise
   environment:
@@ -1377,7 +1377,7 @@ steps:
   - end-to-end-tests-server-enterprise2
 
 - name: upload-packages-enterprise2
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket grafana-downloads-enterprise2
   environment:
@@ -1506,7 +1506,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages-oss
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
@@ -1525,7 +1525,7 @@ steps:
   - initialize
 
 - name: publish-packages-enterprise
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
@@ -1816,7 +1816,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads-test
   environment:
@@ -1829,7 +1829,7 @@ steps:
   - postgres-integration-tests
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - echo Testing release
   environment:
@@ -2194,7 +2194,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition enterprise --packages-bucket grafana-downloads-test
   environment:
@@ -2247,7 +2247,7 @@ steps:
   - end-to-end-tests-server-enterprise2
 
 - name: upload-packages-enterprise2
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket grafana-downloads-test
   environment:
@@ -2376,7 +2376,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages-oss
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json --deb-db-bucket grafana-testing-aptly-db --deb-repo-bucket grafana-testing-repo --packages-bucket grafana-downloads-test --rpm-repo-bucket grafana-testing-repo --simulate-release v7.3.0-test
@@ -2395,7 +2395,7 @@ steps:
   - initialize
 
 - name: publish-packages-enterprise
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition enterprise --gcp-key /tmp/gcpkey.json --deb-db-bucket grafana-testing-aptly-db --deb-repo-bucket grafana-testing-repo --packages-bucket grafana-downloads-test --rpm-repo-bucket grafana-testing-repo --simulate-release v7.3.0-test
@@ -2682,7 +2682,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -3040,7 +3040,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition enterprise
   environment:
@@ -3093,7 +3093,7 @@ steps:
   - end-to-end-tests-server-enterprise2
 
 - name: upload-packages-enterprise2
-  image: grafana/grafana-ci-deploy:1.2.7
+  image: grafana/grafana-ci-deploy:1.3.0
   commands:
   - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket grafana-downloads-enterprise2
   environment:

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,4 +1,12 @@
-FROM cimg/go:1.15.5
+FROM debian:testing-20210111-slim
+
+ARG GOVERSION=1.15.7
+
+ENV PATH=/usr/local/go/bin:$PATH \
+    GOPATH=/go
+
+RUN apt update && apt install -yq curl git make
+RUN curl -fL https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz | tar -xz -C /usr/local
 
 RUN git clone https://github.com/aptly-dev/aptly $GOPATH/src/github.com/aptly-dev/aptly
 RUN cd $GOPATH/src/github.com/aptly-dev/aptly && \
@@ -6,27 +14,23 @@ RUN cd $GOPATH/src/github.com/aptly-dev/aptly && \
     git reset --hard a64807efdaf5e380bfa878c71bc88eae10d62be1 && \
     make install
 
-FROM circleci/python:2.7-stretch-node
+FROM debian:testing-20210111-slim
 
-USER root
+ARG GOOGLE_SDK_VERSION=325.0.0
+ARG GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7
 
-ARG GOOGLE_SDK_VERSION=319.0.0
-ARG GOOGLE_SDK_CHECKSUM=28048af8fe83a1c80a37258d4e6c00edf22bc93edf570fb9bb6a42cca726d4c5
-
-RUN apt-get install -yq python3-pip && pip3 install -U awscli crcmod && \
+RUN apt update && apt install -yq curl python3-pip && pip3 install -U awscli crcmod && \
     curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     echo "${GOOGLE_SDK_CHECKSUM} google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
     tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \
     rm google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     apt update && \
-    apt install -y createrepo expect && \
+    apt install -y createrepo-c expect && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /opt/google-cloud-sdk/bin/gsutil /usr/bin/gsutil && \
     ln -s /opt/google-cloud-sdk/bin/gcloud /usr/bin/gcloud && \
     mkdir -p /deb-repo /rpm-repo && \
-    chown circleci:circleci /deb-repo /rpm-repo
+    ln -s /usr/bin/createrepo_c /usr/bin/createrepo
 
-COPY --from=0 /home/circleci/go/bin/aptly /usr/local/bin/aptly
-
-USER circleci
+COPY --from=0 /go/bin/aptly /usr/local/bin/aptly

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,12 +1,17 @@
 FROM debian:testing-20210111-slim
 
-ARG GOVERSION=1.15.7
+# Use ARG so as not to persist environment variable in image
+ARG GOVERSION=1.15.7 \
+  GO_CHECKSUM=0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3 \
+  DEBIAN_FRONTEND=noninteractive
 
 ENV PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go
 
 RUN apt update && apt install -yq curl git make
-RUN curl -fL https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz | tar -xz -C /usr/local
+RUN curl -fLO https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz && \
+      echo "${GO_CHECKSUM} go${GOVERSION}.linux-amd64.tar.gz" | sha256sum --check --strict --status && \
+      tar -xzf go${GOVERSION}.linux-amd64.tar.gz -C /usr/local
 
 RUN git clone https://github.com/aptly-dev/aptly $GOPATH/src/github.com/aptly-dev/aptly
 RUN cd $GOPATH/src/github.com/aptly-dev/aptly && \
@@ -16,8 +21,10 @@ RUN cd $GOPATH/src/github.com/aptly-dev/aptly && \
 
 FROM debian:testing-20210111-slim
 
-ARG GOOGLE_SDK_VERSION=325.0.0
-ARG GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7
+# Use ARG so as not to persist environment variable in image
+ARG DEBIAN_FRONTEND=noninteractive \
+  GOOGLE_SDK_VERSION=325.0.0 \
+  GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7
 
 RUN apt update && apt install -yq curl python3-pip && pip3 install -U awscli crcmod && \
     curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.2.7"
+_version="1.3.0"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,6 +1,6 @@
 grabpl_version = '0.5.35'
 build_image = 'grafana/build-container:1.3.1'
-publish_image = 'grafana/grafana-ci-deploy:1.2.7'
+publish_image = 'grafana/grafana-ci-deploy:1.3.0'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 alpine_image = 'alpine:3.12'
 windows_image = 'mcr.microsoft.com/windows:1809'


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch the base images of our grafana/grafana-ci-deploy image to Debian, to get rid of sudo among other things.


