### PR TITLE
InfluxDB: Show all datapoints for dynamically windowed flux query

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -27,7 +27,7 @@ func executeQuery(ctx context.Context, query queryModel, runner queryRunner, max
 		glog.Warn("Flux query failed", "err", err, "query", flux)
 		dr.Error = err
 	} else {
-		dr = readDataFrames(tables, int(float64(query.MaxDataPoints)*1.5), maxSeries)
+		dr = readDataFrames(tables, int(float64(query.MaxDataPoints)*2), maxSeries)
 	}
 
 	// Make sure there is at least one frame


### PR DESCRIPTION
Hotfix for #30607 by raising the max point limit during dataframe construction.

