### PR TITLE
Chore: remove debug csp logging line

### DIFF
--- a/pkg/middleware/csp.go
+++ b/pkg/middleware/csp.go
@@ -18,7 +18,6 @@ import (
 func AddCSPHeader(cfg *setting.Cfg, logger log.Logger) macaron.Handler {
 	return func(w http.ResponseWriter, req *http.Request, c *macaron.Context) {
 		if !cfg.CSPEnabled {
-			logger.Debug("Not adding CSP header to response since it's disabled")
 			return
 		}
 


### PR DESCRIPTION
While under development it was useful to have verbose logging on CSP headers.  Now that it is stable, lets remove the message.