### PR TITLE
CDN: Adds support for serving assets over a CDN

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -66,6 +66,9 @@ cert_key =
 # Unix socket path
 socket = /tmp/grafana.sock
 
+# CDN Url
+cdn_url =
+
 #################################### Database ############################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -67,6 +67,9 @@
 # Unix socket path
 ;socket =
 
+# CDN Path
+;cdn_url =
+
 #################################### Database ####################################
 [database]
 # You can configure the database connection by specifying type, host, name, user and password

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -67,7 +67,7 @@
 # Unix socket path
 ;socket =
 
-# CDN Path
+# CDN Url
 ;cdn_url =
 
 #################################### Database ####################################

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -263,7 +263,7 @@ Path where the socket should be created when `protocol=socket`. Make sure that G
 
 > **Note**: Only available in v7.4+
 
-Specify a full http url address to the root of your Grafana CDN assets. Grafana will add edition and version paths.
+Specify a full HTTP URL address to the root of your Grafana CDN assets. Grafana will add edition and version paths.
 
 For example, given a cdn url like `https://cdn.myserver.com` grafana will try to load a javascript file from
 `http://cdn.myserver.com/oss/v7.4.0/public/build/app.<hash>.js`.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -261,7 +261,7 @@ Path where the socket should be created when `protocol=socket`. Make sure that G
 
 ### cdn_url
 
-> **Note**: Only available in v7.4+
+> **Note**: Available in Grafana v7.4 and later versions.
 
 Specify a full HTTP URL address to the root of your Grafana CDN assets. Grafana will add edition and version paths.
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -266,7 +266,7 @@ Path where the socket should be created when `protocol=socket`. Make sure that G
 Specify a full HTTP URL address to the root of your Grafana CDN assets. Grafana will add edition and version paths.
 
 For example, given a cdn url like `https://cdn.myserver.com` grafana will try to load a javascript file from
-`http://cdn.myserver.com/oss/v7.4.0/public/build/app.<hash>.js`.
+`http://cdn.myserver.com/grafana-oss/v7.4.0/public/build/app.<hash>.js`.
 
 <hr />
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -259,6 +259,15 @@ Path to the certificate key file (if `protocol` is set to `https` or `h2`).
 
 Path where the socket should be created when `protocol=socket`. Make sure that Grafana has appropriate permissions before you change this setting.
 
+### cdn_url
+
+> **Note**: Only available in v7.4+
+
+Specify a full http url address to the root of your Grafana CDN assets. Grafana will add edition and version paths.
+
+For example, given a cdn url like `https://cdn.myserver.com` grafana will try to load a javascript file from
+`http://cdn.myserver.com/oss/v7.4.0/public/build/app.<hash>.js`.
+
 <hr />
 
 ## [database]

--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -25,7 +25,7 @@ type IndexViewData struct {
 	AppleTouchIcon          template.URL
 	AppTitle                string
 	Sentry                  *setting.Sentry
-	CDNPath                 string
+	ContentDeliveryURL      string
 	// Nonce is a cryptographic identifier for use with Content Security Policy.
 	Nonce string
 }

--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -25,6 +25,7 @@ type IndexViewData struct {
 	AppleTouchIcon          template.URL
 	AppTitle                string
 	Sentry                  *setting.Sentry
+	CDNPath                 string
 	// Nonce is a cryptographic identifier for use with Content Security Policy.
 	Nonce string
 }

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -428,7 +428,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		NavTree:                 navTree,
 		Sentry:                  &hs.Cfg.Sentry,
 		Nonce:                   c.RequestNonce,
-		CDNPath:                 hs.Cfg.GetFullCDNPath((hs.License.Edition())),
+		CDNPath:                 hs.Cfg.GetFullCDNURL((hs.License.Edition())),
 	}
 
 	if setting.DisableGravatar {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -428,7 +428,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		NavTree:                 navTree,
 		Sentry:                  &hs.Cfg.Sentry,
 		Nonce:                   c.RequestNonce,
-		CDNPath:                 hs.Cfg.CDNPath,
+		CDNPath:                 hs.Cfg.GetFullCDNPath((hs.License.Edition())),
 	}
 
 	if setting.DisableGravatar {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -428,7 +428,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		NavTree:                 navTree,
 		Sentry:                  &hs.Cfg.Sentry,
 		Nonce:                   c.RequestNonce,
-		CDNPath:                 hs.Cfg.GetFullCDNURL((hs.License.Edition())),
+		ContentDeliveryURL:      hs.Cfg.GetContentDeliveryURL((hs.License.Edition())),
 	}
 
 	if setting.DisableGravatar {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -428,6 +428,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		NavTree:                 navTree,
 		Sentry:                  &hs.Cfg.Sentry,
 		Nonce:                   c.RequestNonce,
+		CDNPath:                 hs.Cfg.CDNPath,
 	}
 
 	if setting.DisableGravatar {

--- a/pkg/models/licensing.go
+++ b/pkg/models/licensing.go
@@ -13,6 +13,9 @@ type Licensing interface {
 	// Return edition
 	Edition() string
 
+	// Used to build content delivery URL
+	ContentDeliveryPrefix() string
+
 	LicenseURL(user *SignedInUser) string
 
 	StateInfo() string

--- a/pkg/plugins/backendplugin/manager_test.go
+++ b/pkg/plugins/backendplugin/manager_test.go
@@ -403,6 +403,10 @@ func (t *testLicensingService) StateInfo() string {
 	return ""
 }
 
+func (t *testLicensingService) ContentDeliveryPrefix() string {
+	return ""
+}
+
 func (t *testLicensingService) LicenseURL(user *models.SignedInUser) string {
 	return ""
 }

--- a/pkg/services/licensing/oss.go
+++ b/pkg/services/licensing/oss.go
@@ -32,6 +32,10 @@ func (*OSSLicensingService) StateInfo() string {
 	return ""
 }
 
+func (*OSSLicensingService) ContentDeliveryPrefix() string {
+	return "grafana-oss"
+}
+
 func (l *OSSLicensingService) LicenseURL(user *models.SignedInUser) string {
 	if user.IsGrafanaAdmin {
 		return l.Cfg.AppSubURL + "/admin/upgrading"

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1309,8 +1309,8 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	return nil
 }
 
-// Returns full CDN Path with BuildVersion and edition added
-func (cfg *Cfg) GetFullCDNURL(edition string) string {
+// GetContentDeliveryURL returns full content delivery URL with /<edition>/<version> added to URL
+func (cfg *Cfg) GetContentDeliveryURL(edition string) string {
 	if cfg.CDNRootURL != nil {
 		url := *cfg.CDNRootURL
 		preReleaseFolder := ""

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1307,7 +1307,11 @@ func (cfg *Cfg) GetFullCDNPath(edition string) string {
 	if cfg.CDNPath != "" {
 		cdnUrl, err := url.Parse(cfg.CDNPath)
 		if err == nil {
-			cdnUrl.Path = path.Join(cdnUrl.Path, strings.ToLower(edition), cfg.BuildVersion)
+			preReleaseFolder := ""
+			if strings.Contains(cfg.BuildVersion, "pre") || strings.Contains(cfg.BuildVersion, "alpha") {
+				preReleaseFolder = "master"
+			}
+			cdnUrl.Path = path.Join(cdnUrl.Path, strings.ToLower(edition), preReleaseFolder, cfg.BuildVersion)
 			return cdnUrl.String()
 		}
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1319,7 +1319,6 @@ func (cfg *Cfg) GetContentDeliveryURL(edition string) string {
 		}
 		url.Path = path.Join(url.Path, strings.ToLower(edition), preReleaseFolder, cfg.BuildVersion)
 		return url.String()
-
 	}
 
 	return ""

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1310,14 +1310,16 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 }
 
 // GetContentDeliveryURL returns full content delivery URL with /<edition>/<version> added to URL
-func (cfg *Cfg) GetContentDeliveryURL(edition string) string {
+func (cfg *Cfg) GetContentDeliveryURL(prefix string) string {
 	if cfg.CDNRootURL != nil {
 		url := *cfg.CDNRootURL
 		preReleaseFolder := ""
+
 		if strings.Contains(cfg.BuildVersion, "pre") || strings.Contains(cfg.BuildVersion, "alpha") {
-			preReleaseFolder = "master"
+			preReleaseFolder = "pre-releases"
 		}
-		url.Path = path.Join(url.Path, strings.ToLower(edition), preReleaseFolder, cfg.BuildVersion)
+
+		url.Path = path.Join(url.Path, prefix, preReleaseFolder, cfg.BuildVersion)
 		return url.String()
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1298,14 +1298,21 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 		return err
 	}
 
-	cdnPath := valueAsString(server, "cdn_path", "")
-	if cdnPath != "" {
-		cdnUrl, _ := url.Parse(cdnPath)
-		cdnUrl.Path = path.Join(cdnUrl.Path, cfg.BuildVersion)
-		cfg.CDNPath = cdnUrl.String()
+	cfg.CDNPath = valueAsString(server, "cdn_path", "")
+	return nil
+}
+
+// Returns full CDN Path with BuildVersion and edition added
+func (cfg *Cfg) GetFullCDNPath(edition string) string {
+	if cfg.CDNPath != "" {
+		cdnUrl, err := url.Parse(cfg.CDNPath)
+		if err == nil {
+			cdnUrl.Path = path.Join(cdnUrl.Path, strings.ToLower(edition), cfg.BuildVersion)
+			return cdnUrl.String()
+		}
 	}
 
-	return nil
+	return ""
 }
 
 func (cfg *Cfg) readDataSourcesSettings() {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -768,7 +768,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	provisioning := valueAsString(iniFile.Section("paths"), "provisioning", "")
 	cfg.ProvisioningPath = makeAbsolute(provisioning, HomePath)
 
-	if err := readServerSettings(iniFile, cfg); err != nil {
+	if err := cfg.readServerSettings(iniFile); err != nil {
 		return err
 	}
 
@@ -1252,7 +1252,7 @@ func readSnapshotsSettings(cfg *Cfg, iniFile *ini.File) error {
 	return nil
 }
 
-func readServerSettings(iniFile *ini.File, cfg *Cfg) error {
+func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	server := iniFile.Section("server")
 	var err error
 	AppUrl, AppSubUrl, err = parseAppUrlAndSubUrl(server)
@@ -1298,7 +1298,13 @@ func readServerSettings(iniFile *ini.File, cfg *Cfg) error {
 		return err
 	}
 
-	cfg.CDNPath = valueAsString(server, "cdn_path", "")
+	cdnPath := valueAsString(server, "cdn_path", "")
+	if cdnPath != "" {
+		cdnUrl, _ := url.Parse(cdnPath)
+		cdnUrl.Path = path.Join(cdnUrl.Path, cfg.BuildVersion)
+		cfg.CDNPath = cdnUrl.String()
+	}
+
 	return nil
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -197,6 +197,7 @@ type Cfg struct {
 	SocketPath       string
 	RouterLogging    bool
 	Domain           string
+	CDNPath          string
 
 	// build
 	BuildVersion string
@@ -1263,8 +1264,8 @@ func readServerSettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.AppURL = AppUrl
 	cfg.AppSubURL = AppSubUrl
 	cfg.ServeFromSubPath = ServeFromSubPath
-
 	cfg.Protocol = HTTPScheme
+
 	protocolStr := valueAsString(server, "protocol", "http")
 
 	if protocolStr == "https" {
@@ -1297,6 +1298,7 @@ func readServerSettings(iniFile *ini.File, cfg *Cfg) error {
 		return err
 	}
 
+	cfg.CDNPath = valueAsString(server, "cdn_path", "")
 	return nil
 }
 

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -390,10 +390,27 @@ func TestAuthDurationSettings(t *testing.T) {
 	require.Equal(t, maxLifetimeDurationTest, cfg.LoginMaxLifetime)
 }
 
-func TestServiceSettings(t *testing.T) {
+func TestGetCDNPath(t *testing.T) {
+	cfg := NewCfg()
+	cfg.BuildVersion = "v7.5.0-11124"
+	cfg.CDNPath = "http://cdn.grafana.com"
+	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124", cfg.GetFullCDNPath("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124", cfg.GetFullCDNPath("Enterprise"))
+}
+
+func TestGetCDNPathWithPreReleaseVersion(t *testing.T) {
 	cfg := NewCfg()
 	cfg.BuildVersion = "v7.5.0-11124pre"
 	cfg.CDNPath = "http://cdn.grafana.com"
-	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124pre", cfg.GetFullCDNPath("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124pre", cfg.GetFullCDNPath("Enterprise"))
+	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-11124pre", cfg.GetFullCDNPath("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-11124pre", cfg.GetFullCDNPath("Enterprise"))
+}
+
+// Adding a case for this in case we switch to proper semver version strings
+func TestGetCDNPathWithAlphaVersion(t *testing.T) {
+	cfg := NewCfg()
+	cfg.BuildVersion = "v7.5.0-alpha.11124"
+	cfg.CDNPath = "http://cdn.grafana.com"
+	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-alpha.11124", cfg.GetFullCDNPath("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-alpha.11124", cfg.GetFullCDNPath("Enterprise"))
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -391,13 +391,9 @@ func TestAuthDurationSettings(t *testing.T) {
 }
 
 func TestServiceSettings(t *testing.T) {
-	f := ini.Empty()
 	cfg := NewCfg()
 	cfg.BuildVersion = "v7.5.0-11124pre"
-	sec, err := f.NewSection("server")
-	require.NoError(t, err)
-	sec.NewKey("cdn_path", "http://cdn.grafana.com")
-	err = cfg.readServerSettings(f)
-	require.NoError(t, err)
-	require.Equal(t, cfg.CDNPath, "http://cdn.grafana.com/v7.5.0-11124pre")
+	cfg.CDNPath = "http://cdn.grafana.com"
+	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124pre", cfg.GetFullCDNPath("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124pre", cfg.GetFullCDNPath("Enterprise"))
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -394,9 +394,10 @@ func TestServiceSettings(t *testing.T) {
 	f := ini.Empty()
 	cfg := NewCfg()
 	cfg.BuildVersion = "v7.5.0-11124pre"
-	sec, _ := f.NewSection("server")
+	sec, err := f.NewSection("server")
+	require.NoError(t, err)
 	sec.NewKey("cdn_path", "http://cdn.grafana.com")
-	err := cfg.readServerSettings(f)
+	err = cfg.readServerSettings(f)
 	require.NoError(t, err)
 	require.Equal(t, cfg.CDNPath, "http://cdn.grafana.com/v7.5.0-11124pre")
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -398,8 +398,8 @@ func TestGetCDNPath(t *testing.T) {
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
 	require.NoError(t, err)
 
-	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124", cfg.GetContentDeliveryURL("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124", cfg.GetContentDeliveryURL("Enterprise"))
+	require.Equal(t, "http://cdn.grafana.com/grafana-oss/v7.5.0-11124", cfg.GetContentDeliveryURL("grafana-oss"))
+	require.Equal(t, "http://cdn.grafana.com/grafana/v7.5.0-11124", cfg.GetContentDeliveryURL("grafana"))
 }
 
 func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
@@ -408,8 +408,8 @@ func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
 	cfg.BuildVersion = "v7.5.0-11124pre"
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com/sub")
 	require.NoError(t, err)
-	require.Equal(t, "http://cdn.grafana.com/sub/oss/master/v7.5.0-11124pre", cfg.GetContentDeliveryURL("oss"))
-	require.Equal(t, "http://cdn.grafana.com/sub/enterprise/master/v7.5.0-11124pre", cfg.GetContentDeliveryURL("Enterprise"))
+	require.Equal(t, "http://cdn.grafana.com/sub/grafana-oss/pre-releases/v7.5.0-11124pre", cfg.GetContentDeliveryURL("grafana-oss"))
+	require.Equal(t, "http://cdn.grafana.com/sub/grafana/pre-releases/v7.5.0-11124pre", cfg.GetContentDeliveryURL("grafana"))
 }
 
 // Adding a case for this in case we switch to proper semver version strings
@@ -419,6 +419,6 @@ func TestGetCDNPathWithAlphaVersion(t *testing.T) {
 	cfg.BuildVersion = "v7.5.0-alpha.11124"
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
 	require.NoError(t, err)
-	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-alpha.11124", cfg.GetContentDeliveryURL("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-alpha.11124", cfg.GetContentDeliveryURL("Enterprise"))
+	require.Equal(t, "http://cdn.grafana.com/grafana-oss/pre-releases/v7.5.0-alpha.11124", cfg.GetContentDeliveryURL("grafana-oss"))
+	require.Equal(t, "http://cdn.grafana.com/grafana/pre-releases/v7.5.0-alpha.11124", cfg.GetContentDeliveryURL("grafana"))
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"bufio"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -391,26 +392,33 @@ func TestAuthDurationSettings(t *testing.T) {
 }
 
 func TestGetCDNPath(t *testing.T) {
+	var err error
 	cfg := NewCfg()
 	cfg.BuildVersion = "v7.5.0-11124"
-	cfg.CDNPath = "http://cdn.grafana.com"
-	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124", cfg.GetFullCDNPath("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124", cfg.GetFullCDNPath("Enterprise"))
+	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
+	require.NoError(t, err)
+
+	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124", cfg.GetFullCDNURL("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124", cfg.GetFullCDNURL("Enterprise"))
 }
 
-func TestGetCDNPathWithPreReleaseVersion(t *testing.T) {
+func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
+	var err error
 	cfg := NewCfg()
 	cfg.BuildVersion = "v7.5.0-11124pre"
-	cfg.CDNPath = "http://cdn.grafana.com"
-	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-11124pre", cfg.GetFullCDNPath("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-11124pre", cfg.GetFullCDNPath("Enterprise"))
+	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com/sub")
+	require.NoError(t, err)
+	require.Equal(t, "http://cdn.grafana.com/sub/oss/master/v7.5.0-11124pre", cfg.GetFullCDNURL("oss"))
+	require.Equal(t, "http://cdn.grafana.com/sub/enterprise/master/v7.5.0-11124pre", cfg.GetFullCDNURL("Enterprise"))
 }
 
 // Adding a case for this in case we switch to proper semver version strings
 func TestGetCDNPathWithAlphaVersion(t *testing.T) {
+	var err error
 	cfg := NewCfg()
 	cfg.BuildVersion = "v7.5.0-alpha.11124"
-	cfg.CDNPath = "http://cdn.grafana.com"
-	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-alpha.11124", cfg.GetFullCDNPath("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-alpha.11124", cfg.GetFullCDNPath("Enterprise"))
+	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
+	require.NoError(t, err)
+	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-alpha.11124", cfg.GetFullCDNURL("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-alpha.11124", cfg.GetFullCDNURL("Enterprise"))
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -398,8 +398,8 @@ func TestGetCDNPath(t *testing.T) {
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
 	require.NoError(t, err)
 
-	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124", cfg.GetFullCDNURL("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124", cfg.GetFullCDNURL("Enterprise"))
+	require.Equal(t, "http://cdn.grafana.com/oss/v7.5.0-11124", cfg.GetContentDeliveryURL("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/v7.5.0-11124", cfg.GetContentDeliveryURL("Enterprise"))
 }
 
 func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
@@ -408,8 +408,8 @@ func TestGetCDNPathWithPreReleaseVersionAndSubPath(t *testing.T) {
 	cfg.BuildVersion = "v7.5.0-11124pre"
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com/sub")
 	require.NoError(t, err)
-	require.Equal(t, "http://cdn.grafana.com/sub/oss/master/v7.5.0-11124pre", cfg.GetFullCDNURL("oss"))
-	require.Equal(t, "http://cdn.grafana.com/sub/enterprise/master/v7.5.0-11124pre", cfg.GetFullCDNURL("Enterprise"))
+	require.Equal(t, "http://cdn.grafana.com/sub/oss/master/v7.5.0-11124pre", cfg.GetContentDeliveryURL("oss"))
+	require.Equal(t, "http://cdn.grafana.com/sub/enterprise/master/v7.5.0-11124pre", cfg.GetContentDeliveryURL("Enterprise"))
 }
 
 // Adding a case for this in case we switch to proper semver version strings
@@ -419,6 +419,6 @@ func TestGetCDNPathWithAlphaVersion(t *testing.T) {
 	cfg.BuildVersion = "v7.5.0-alpha.11124"
 	cfg.CDNRootURL, err = url.Parse("http://cdn.grafana.com")
 	require.NoError(t, err)
-	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-alpha.11124", cfg.GetFullCDNURL("oss"))
-	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-alpha.11124", cfg.GetFullCDNURL("Enterprise"))
+	require.Equal(t, "http://cdn.grafana.com/oss/master/v7.5.0-alpha.11124", cfg.GetContentDeliveryURL("oss"))
+	require.Equal(t, "http://cdn.grafana.com/enterprise/master/v7.5.0-alpha.11124", cfg.GetContentDeliveryURL("Enterprise"))
 }

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -389,3 +389,14 @@ func TestAuthDurationSettings(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, maxLifetimeDurationTest, cfg.LoginMaxLifetime)
 }
+
+func TestServiceSettings(t *testing.T) {
+	f := ini.Empty()
+	cfg := NewCfg()
+	cfg.BuildVersion = "v7.5.0-11124pre"
+	sec, _ := f.NewSection("server")
+	sec.NewKey("cdn_path", "http://cdn.grafana.com")
+	err := cfg.readServerSettings(f)
+	require.NoError(t, err)
+	require.Equal(t, cfg.CDNPath, "http://cdn.grafana.com/v7.5.0-11124pre")
+}

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,5 +1,11 @@
 declare let __webpack_public_path__: string;
-__webpack_public_path__ = window.public_cdn_path;
+
+/**
+ * Check if we are hosting files on cdn and set webpack public path
+ */
+if ((window as any).public_cdn_path) {
+  __webpack_public_path__ = (window as any).public_cdn_path;
+}
 
 import app from './app';
 app.initEchoSrv();

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,4 +1,6 @@
-import app from './app';
+declare let __webpack_public_path__: string;
+__webpack_public_path__ = window.public_cdn_path;
 
+import app from './app';
 app.initEchoSrv();
 app.init();

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -24,7 +24,7 @@
 
     <link
       rel="preload"
-      href="public/fonts/roboto/RxZJdnzeo3R5zSexge8UUVtXRa8TVwTICgirnJhmVJw.woff2"
+      href="[[.ContentDeliveryURL]]/public/fonts/roboto/RxZJdnzeo3R5zSexge8UUVtXRa8TVwTICgirnJhmVJw.woff2"
       as="font"
       crossorigin
     />
@@ -32,7 +32,6 @@
     <link rel="icon" type="image/png" href="[[.FavIcon]]" />
     <link rel="apple-touch-icon" sizes="180x180" href="[[.AppleTouchIcon]]" />
     <link rel="mask-icon" href="[[.ContentDeliveryURL]]/public/img/grafana_mask_icon.svg" color="#F05A28" />
-
     <link rel="stylesheet" href="[[.ContentDeliveryURL]]/public/build/grafana.[[ .Theme ]].<%= webpack.hash %>.css" />
 
     <script nonce="[[.Nonce]]">
@@ -243,55 +242,59 @@
     </script>
 
     [[if .GoogleTagManagerId]]
-    <!-- Google Tag Manager -->
-    <script nonce="[[.Nonce]]">
-      dataLayer = [
-        {
-          IsSignedIn: '[[.User.IsSignedIn]]',
-          Email: '[[.User.Email]]',
-          Name: '[[.User.Name]]',
-          UserId: '[[.User.Id]]',
-          OrgId: '[[.User.OrgId]]',
-          OrgName: '[[.User.OrgName]]',
-        },
-      ];
-    </script>
-    <noscript>
-      <iframe
-        src="//www.googletagmanager.com/ns.html?id=[[.GoogleTagManagerId]]"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe>
-    </noscript>
-    <script nonce="[[.Nonce]]">
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', '[[.GoogleTagManagerId]]');
-    </script>
-    <!-- End Google Tag Manager -->
-    [[end]] <% for (key in htmlWebpackPlugin.files.chunks) { %><% if (htmlWebpackPlugin.files.jsIntegrity) { %>
-    <script
-      nonce="[[.Nonce]]"
-      src="[[.ContentDeliveryURL]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
-      type="text/javascript"
-      integrity="<%= htmlWebpackPlugin.files.jsIntegrity[htmlWebpackPlugin.files.js.indexOf(htmlWebpackPlugin.files.chunks[key].entry)] %>"
-      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
-    ></script>
-    <% } else { %>
-    <script
-      nonce="[[.Nonce]]"
-      src="[[.ContentDeliveryURL]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
-      type="text/javascript"
-    ></script>
-    <% } %><% } %>
+      <!-- Google Tag Manager -->
+      <script nonce="[[.Nonce]]">
+        dataLayer = [
+          {
+            IsSignedIn: '[[.User.IsSignedIn]]',
+            Email: '[[.User.Email]]',
+            Name: '[[.User.Name]]',
+            UserId: '[[.User.Id]]',
+            OrgId: '[[.User.OrgId]]',
+            OrgName: '[[.User.OrgName]]',
+          },
+        ];
+      </script>
+      <noscript>
+        <iframe
+          src="//www.googletagmanager.com/ns.html?id=[[.GoogleTagManagerId]]"
+          height="0"
+          width="0"
+          style="display: none; visibility: hidden"
+        ></iframe>
+      </noscript>
+      <script nonce="[[.Nonce]]">
+        (function (w, d, s, l, i) {
+          w[l] = w[l] || [];
+          w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+          var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != 'dataLayer' ? '&l=' + l : '';
+          j.async = true;
+          j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
+          f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', '[[.GoogleTagManagerId]]');
+      </script>
+      <!-- End Google Tag Manager -->
+    [[end]] 
+
+    <% for (key in htmlWebpackPlugin.files.chunks) { %>
+      <% if (htmlWebpackPlugin.files.jsIntegrity) { %>
+        <script
+          nonce="[[.Nonce]]"
+          src="[[.ContentDeliveryURL]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
+          type="text/javascript"
+          integrity="<%= htmlWebpackPlugin.files.jsIntegrity[htmlWebpackPlugin.files.js.indexOf(htmlWebpackPlugin.files.chunks[key].entry)] %>"
+          crossorigin="<%= webpackConfig.output.crossOriginLoading %>">
+        </script>
+      <% } else { %>
+        <script
+          nonce="[[.Nonce]]"
+          src="[[.ContentDeliveryURL]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
+          type="text/javascript">
+        </script>
+      <% } %>
+    <% } %>
     <script nonce="[[.Nonce]]">
       performance.mark('js done blocking');
     </script>

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -31,9 +31,9 @@
 
     <link rel="icon" type="image/png" href="[[.FavIcon]]" />
     <link rel="apple-touch-icon" sizes="180x180" href="[[.AppleTouchIcon]]" />
-    <link rel="mask-icon" href="[[.CDNPath]]/public/img/grafana_mask_icon.svg" color="#F05A28" />
+    <link rel="mask-icon" href="[[.ContentDeliveryURL]]/public/img/grafana_mask_icon.svg" color="#F05A28" />
 
-    <link rel="stylesheet" href="[[.CDNPath]]/public/build/grafana.[[ .Theme ]].<%= webpack.hash %>.css" />
+    <link rel="stylesheet" href="[[.ContentDeliveryURL]]/public/build/grafana.[[ .Theme ]].<%= webpack.hash %>.css" />
 
     <script nonce="[[.Nonce]]">
       performance.mark('css done blocking');
@@ -239,7 +239,7 @@
           }
         };
 
-        window.public_cdn_path = '[[.CDNPath]]/public/build/';
+        window.public_cdn_path = '[[.ContentDeliveryURL]]/public/build/';
     </script>
 
     [[if .GoogleTagManagerId]]
@@ -280,7 +280,7 @@
     [[end]] <% for (key in htmlWebpackPlugin.files.chunks) { %><% if (htmlWebpackPlugin.files.jsIntegrity) { %>
     <script
       nonce="[[.Nonce]]"
-      src="[[.CDNPath]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
+      src="[[.ContentDeliveryURL]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
       type="text/javascript"
       integrity="<%= htmlWebpackPlugin.files.jsIntegrity[htmlWebpackPlugin.files.js.indexOf(htmlWebpackPlugin.files.chunks[key].entry)] %>"
       crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
@@ -288,7 +288,7 @@
     <% } else { %>
     <script
       nonce="[[.Nonce]]"
-      src="[[.CDNPath]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
+      src="[[.ContentDeliveryURL]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
       type="text/javascript"
     ></script>
     <% } %><% } %>

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -205,10 +205,9 @@
           <br />
           4. Sometimes restarting grafana-server can help<br />
           <br />
-          5. You might be using a non-supported browser. To make sure read the documentation on
-          <a href="https://grafana.com/docs/grafana/latest/installation/requirements/#supported-web-browsers"
-            >supported browsers</a
-          >.
+          5. Check if you are using a non-supported browser. For more information, refer to the list of <a 
+            href="https://grafana.com/docs/grafana/latest/installation/requirements/#supported-web-browsers">
+            supported browsers</a>.
         </p>
       </div>
     </div>

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -3,16 +3,15 @@
   <head>
     <script nonce="[[.Nonce]]">
       // https://github.com/GoogleChromeLabs/tti-polyfill
-      !(function() {
+      !(function () {
         if ('PerformanceLongTaskTiming' in window) {
           var g = (window.__tti = { e: [] });
-          g.o = new PerformanceObserver(function(l) {
+          g.o = new PerformanceObserver(function (l) {
             g.e = g.e.concat(l.getEntries());
           });
           g.o.observe({ entryTypes: ['longtask'] });
         }
       })();
-
     </script>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
@@ -32,9 +31,9 @@
 
     <link rel="icon" type="image/png" href="[[.FavIcon]]" />
     <link rel="apple-touch-icon" sizes="180x180" href="[[.AppleTouchIcon]]" />
-    <link rel="mask-icon" href="public/img/grafana_mask_icon.svg" color="#F05A28" />
+    <link rel="mask-icon" href="[[.CDNPath]]/public/img/grafana_mask_icon.svg" color="#F05A28" />
 
-    <link rel="stylesheet" href="public/build/grafana.[[ .Theme ]].<%= webpack.hash %>.css" />
+    <link rel="stylesheet" href="[[.CDNPath]]/public/build/grafana.[[ .Theme ]].<%= webpack.hash %>.css" />
 
     <script nonce="[[.Nonce]]">
       performance.mark('css done blocking');
@@ -199,14 +198,18 @@
         </p>
         <p>
           1. This could be caused by your reverse proxy settings.<br /><br />
-          2. If you host grafana under subpath make sure your grafana.ini root_url setting includes subpath. If not using a reverse proxy make sure to set serve_from_sub_path to true.<br />
+          2. If you host grafana under subpath make sure your grafana.ini root_url setting includes subpath. If not
+          using a reverse proxy make sure to set serve_from_sub_path to true.<br />
           <br />
           3. If you have a local dev build make sure you build frontend using: yarn start, yarn start:hot, or yarn
           build<br />
           <br />
           4. Sometimes restarting grafana-server can help<br />
           <br />
-          5. You might be using a non-supported browser. To make sure read the documentation on <a href="https://grafana.com/docs/grafana/latest/installation/requirements/#supported-web-browsers">supported browsers</a>.
+          5. You might be using a non-supported browser. To make sure read the documentation on
+          <a href="https://grafana.com/docs/grafana/latest/installation/requirements/#supported-web-browsers"
+            >supported browsers</a
+          >.
         </p>
       </div>
     </div>
@@ -217,7 +220,7 @@
       <search-wrapper></search-wrapper>
 
       <div class="main-view">
-				<div ng-view class="scroll-canvas"></div>
+        <div ng-view class="scroll-canvas"></div>
       </div>
     </grafana-app>
 
@@ -235,6 +238,8 @@
             preloader[0].className = "preloader preloader--done";
           }
         };
+
+        window.public_cdn_path = '[[.CDNPath]]/public/build/';
     </script>
 
     [[if .GoogleTagManagerId]]
@@ -256,11 +261,11 @@
         src="//www.googletagmanager.com/ns.html?id=[[.GoogleTagManagerId]]"
         height="0"
         width="0"
-        style="display:none;visibility:hidden"
+        style="display: none; visibility: hidden"
       ></iframe>
     </noscript>
     <script nonce="[[.Nonce]]">
-      (function(w, d, s, l, i) {
+      (function (w, d, s, l, i) {
         w[l] = w[l] || [];
         w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
         var f = d.getElementsByTagName(s)[0],
@@ -272,20 +277,21 @@
       })(window, document, 'script', 'dataLayer', '[[.GoogleTagManagerId]]');
     </script>
     <!-- End Google Tag Manager -->
-    [[end]]
-
-    <%
-    for (key in htmlWebpackPlugin.files.chunks) { %><%
-      if (htmlWebpackPlugin.files.jsIntegrity) { %>
-    <script nonce="[[.Nonce]]"
-      src="<%= htmlWebpackPlugin.files.chunks[key].entry %>"
+    [[end]] <% for (key in htmlWebpackPlugin.files.chunks) { %><% if (htmlWebpackPlugin.files.jsIntegrity) { %>
+    <script
+      nonce="[[.Nonce]]"
+      src="[[.CDNPath]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
       type="text/javascript"
       integrity="<%= htmlWebpackPlugin.files.jsIntegrity[htmlWebpackPlugin.files.js.indexOf(htmlWebpackPlugin.files.chunks[key].entry)] %>"
-      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script><%
-      } else { %>
-    <script nonce="[[.Nonce]]" src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script><%
-      } %><%
-    } %>
+      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
+    ></script>
+    <% } else { %>
+    <script
+      nonce="[[.Nonce]]"
+      src="[[.CDNPath]]/<%= htmlWebpackPlugin.files.chunks[key].entry %>"
+      type="text/javascript"
+    ></script>
+    <% } %><% } %>
     <script nonce="[[.Nonce]]">
       performance.mark('js done blocking');
     </script>


### PR DESCRIPTION
Closes #6844

Adds option to load js & css from cdn path. Tested by starting a local nginx with a custom hostname and copying everything under public to it.

This does not currently impact loading plugins, they are still loaded from instance.

It does impact the content_security_policy, if enabled it needs to be modified allow the cdn. Not sure how exactly.

TODO
* [ ] How to make it apply to all images 

![Screenshot from 2021-01-27 22-39-34](https://user-images.githubusercontent.com/10999/106058266-4cfd8500-60f1-11eb-8ce9-1366cfe0618c.png)



