### PR TITLE
Fix documentation for streaming data sources

### DIFF
--- a/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
@@ -76,12 +76,17 @@ Grafana uses [RxJS](https://rxjs.dev/) to continuously send data from a data sou
 1. Use `subscriber.next()` to send the updated data frame whenever you receive new updates.
 
    ```ts
+   import { LoadingState } from '@grafana/data';
+   ```
+
+   ```ts
    const intervalId = setInterval(() => {
      frame.add({ time: Date.now(), value: Math.random() });
 
      subscriber.next({
        data: [frame],
        key: query.refId,
+       state: LoadingState.Streaming,
      });
    }, 500);
 


### PR DESCRIPTION
The added code is now mandatory since 7.4.x
See https://github.com/grafana/grafana/issues/30686