### PR TITLE
Explore: Set Explore's GraphNG to be connected

### DIFF
--- a/public/app/features/explore/ExploreGraphNGPanel.tsx
+++ b/public/app/features/explore/ExploreGraphNGPanel.tsx
@@ -65,6 +65,7 @@ export function ExploreGraphNGPanel({
         drawStyle: DrawStyle.Line,
         fillOpacity: 0,
         pointSize: 5,
+        spanNulls: true,
       },
     },
     overrides: [],


### PR DESCRIPTION
**What this PR does / why we need it**:
In Explore, before switching to GraphNG, we've used connected graph. This PR implements it. I dicovered it during documenting this issue https://github.com/grafana/grafana/issues/30705 that was mentioned by @wardbekker and as it was tiny fix, I implemeted it right away. 

Before: 
![image](https://user-images.githubusercontent.com/30407135/106138573-9808ae00-616c-11eb-83e7-6688ea8eca73.png)

After: 
![image](https://user-images.githubusercontent.com/30407135/106138657-b40c4f80-616c-11eb-94af-e80b43bd1450.png)


**Which issue(s) this PR fixes**:

Fixes #30705 

**Special notes for your reviewer**:

