### PR TITLE
PanelLibrary: better handling of deleted panels

### DIFF
--- a/devenv/dev-dashboards/panel-library/panel-library.json
+++ b/devenv/dev-dashboards/panel-library/panel-library.json
@@ -142,7 +142,8 @@
       },
       "id": 3,
       "libraryPanel": {
-        "uid": "MAnX2ifMk"
+        "uid": "MAnX2ifMk",
+        "name": "React Table"
       }
     },
     {
@@ -154,7 +155,8 @@
       },
       "id": 2,
       "libraryPanel": {
-        "uid": "g1sNpCaMz"
+        "uid": "g1sNpCaMz",
+        "name": "React Gauge"
       }
     }
   ],

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -71,7 +71,16 @@ func (lps *LibraryPanelService) LoadLibraryPanelsForDashboard(dash *models.Dashb
 
 		libraryPanelInDB, ok := libraryPanels[uid]
 		if !ok {
-			return fmt.Errorf("found connection to library panel %q that isn't in database", uid)
+			name := libraryPanel.Get("name").MustString()
+			elem := dash.Data.Get("panels").GetIndex(i)
+			elem.Set("gridPos", panelAsJSON.Get("gridPos").MustMap())
+			elem.Set("id", panelAsJSON.Get("id").MustInt64())
+			elem.Set("type", fmt.Sprintf("Name: \"%s\", UID: \"%s\"", name, uid))
+			elem.Set("libraryPanel", map[string]interface{}{
+				"uid":  uid,
+				"name": name,
+			})
+			continue
 		}
 
 		// we have a match between what is stored in db and in dashboard json

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -650,7 +650,7 @@ func TestLoadLibraryPanelsForDashboard(t *testing.T) {
 			require.EqualError(t, err, errLibraryPanelHeaderUIDMissing.Error())
 		})
 
-	testScenario(t, "When an admin tries to load a dashboard with a library panel that is not connected, it should fail",
+	testScenario(t, "When an admin tries to load a dashboard with a library panel that is not connected, it should set correct JSON and continue",
 		func(t *testing.T, sc scenarioContext) {
 			command := getCreateCommand(1, "Text - Library Panel1")
 			response := sc.service.createHandler(sc.reqContext, command)
@@ -692,7 +692,38 @@ func TestLoadLibraryPanelsForDashboard(t *testing.T) {
 			}
 
 			err = sc.service.LoadLibraryPanelsForDashboard(&dash)
-			require.EqualError(t, err, fmt.Errorf("found connection to library panel %q that isn't in database", existing.Result.UID).Error())
+			require.NoError(t, err)
+			expectedJSON := map[string]interface{}{
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": int64(1),
+						"gridPos": map[string]interface{}{
+							"h": 6,
+							"w": 6,
+							"x": 0,
+							"y": 0,
+						},
+					},
+					map[string]interface{}{
+						"id": int64(2),
+						"gridPos": map[string]interface{}{
+							"h": 6,
+							"w": 6,
+							"x": 6,
+							"y": 0,
+						},
+						"libraryPanel": map[string]interface{}{
+							"uid":  existing.Result.UID,
+							"name": existing.Result.Name,
+						},
+						"type": fmt.Sprintf("Name: \"%s\", UID: \"%s\"", existing.Result.Name, existing.Result.UID),
+					},
+				},
+			}
+			expected := simplejson.NewFromAny(expectedJSON)
+			if diff := cmp.Diff(expected.Interface(), dash.Data.Interface(), getCompareOptions()...); diff != "" {
+				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
+			}
 		})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does two things:

1. Whenever a library panel is deleted we also clean up any dashboard connections
2. When loading a dashboard that includes a library panel that isn't connected to the dash would previously fail the load. This PR changes this behavior by setting a minimal JSON that ends up showing something like this 
![image](https://user-images.githubusercontent.com/562238/106141689-c25c6a80-6170-11eb-8e9c-4b012bcc3c6e.png)
This should probably be even more refined but this will do for now.
3. Adds name to panels in the test dashboard

**Which issue(s) this PR fixes**:
Relates #29610

**Special notes for your reviewer**:

