### PR TITLE
PageHeader: Add alt text to header logos 

### DIFF
--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -121,7 +121,7 @@ export default class PageHeader extends React.Component<Props, any> {
       <div className="page-header__inner">
         <span className="page-header__logo">
           {main.icon && <Icon name={main.icon as IconName} size="xxxl" className={iconClassName} />}
-          {main.img && <img className="page-header__img" src={main.img} />}
+          {main.img && <img className="page-header__img" src={main.img} alt={`logo of ${main.text}`} />}
         </span>
 
         <div className="page-header__info-block">


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR simply adds an alt text to the images used as logos, which fixes an accessibility issue we have at the plugins side as well.

![Screen Shot 2021-01-28 at 14 32 04](https://user-images.githubusercontent.com/7255779/106145345-ba52f980-6175-11eb-95d3-46d617949a86.png)


