### PR TITLE
Chore: Fix typo in TransformerRegistyItem

### DIFF
--- a/packages/grafana-data/src/transformations/index.ts
+++ b/packages/grafana-data/src/transformations/index.ts
@@ -5,7 +5,7 @@ export { standardTransformers } from './transformers';
 export * from './fieldReducer';
 export { transformDataFrame } from './transformDataFrame';
 export {
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
   standardTransformersRegistry,
 } from './standardTransformersRegistry';

--- a/packages/grafana-data/src/transformations/standardTransformersRegistry.ts
+++ b/packages/grafana-data/src/transformations/standardTransformersRegistry.ts
@@ -14,7 +14,7 @@ export interface TransformerUIProps<T> {
   onChange: (options: T) => void;
 }
 
-export interface TransformerRegistyItem<TOptions> extends RegistryItem {
+export interface TransformerRegistryItem<TOptions> extends RegistryItem {
   /**
    * Object describing transformer configuration
    */
@@ -29,4 +29,4 @@ export interface TransformerRegistyItem<TOptions> extends RegistryItem {
  * Registry of transformation options that can be driven by
  * stored configuration files.
  */
-export const standardTransformersRegistry = new Registry<TransformerRegistyItem<any>>();
+export const standardTransformersRegistry = new Registry<TransformerRegistryItem<any>>();

--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -2,7 +2,7 @@ import { MonoTypeOperatorFunction, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
 import { DataFrame, DataTransformerConfig } from '../types';
-import { standardTransformersRegistry, TransformerRegistyItem } from './standardTransformersRegistry';
+import { standardTransformersRegistry, TransformerRegistryItem } from './standardTransformersRegistry';
 
 const getOperator = (config: DataTransformerConfig): MonoTypeOperatorFunction<DataFrame[]> => (source) => {
   const info = standardTransformersRegistry.get(config.id);
@@ -21,7 +21,7 @@ const getOperator = (config: DataTransformerConfig): MonoTypeOperatorFunction<Da
 
 const postProcessTransform = (
   before: DataFrame[],
-  info: TransformerRegistyItem<any>
+  info: TransformerRegistryItem<any>
 ): MonoTypeOperatorFunction<DataFrame[]> => (source) =>
   source.pipe(
     map((after) => {

--- a/public/app/core/components/TransformersUI/CalculateFieldTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/CalculateFieldTransformerEditor.tsx
@@ -12,7 +12,7 @@ import {
   ReducerID,
   SelectableValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
 import { FilterPill, HorizontalGroup, Input, LegacyForms, Select, StatsPicker } from '@grafana/ui';
@@ -374,7 +374,7 @@ export class CalculateFieldTransformerEditor extends React.PureComponent<
   }
 }
 
-export const calculateFieldTransformRegistryItem: TransformerRegistyItem<CalculateFieldTransformerOptions> = {
+export const calculateFieldTransformRegistryItem: TransformerRegistryItem<CalculateFieldTransformerOptions> = {
   id: DataTransformerID.calculateField,
   editor: CalculateFieldTransformerEditor,
   transformation: standardTransformers.calculateFieldTransformer,

--- a/public/app/core/components/TransformersUI/ConcatenateTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/ConcatenateTransformerEditor.tsx
@@ -3,7 +3,7 @@ import {
   DataTransformerID,
   SelectableValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
 import { Input, Select } from '@grafana/ui';
@@ -82,7 +82,7 @@ export class ConcatenateTransformerEditor extends React.PureComponent<Concatenat
   }
 }
 
-export const concatenateTransformRegistryItem: TransformerRegistyItem<ConcatenateTransformerOptions> = {
+export const concatenateTransformRegistryItem: TransformerRegistryItem<ConcatenateTransformerOptions> = {
   id: DataTransformerID.concatenate,
   editor: ConcatenateTransformerEditor,
   transformation: standardTransformers.concatenateTransformer,

--- a/public/app/core/components/TransformersUI/FilterByNameTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/FilterByNameTransformerEditor.tsx
@@ -3,7 +3,7 @@ import {
   DataTransformerID,
   KeyValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
   getFieldDisplayName,
   stringToJsRegex,
@@ -202,7 +202,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
   }
 }
 
-export const filterFieldsByNameTransformRegistryItem: TransformerRegistyItem<FilterFieldsByNameTransformerOptions> = {
+export const filterFieldsByNameTransformRegistryItem: TransformerRegistryItem<FilterFieldsByNameTransformerOptions> = {
   id: DataTransformerID.filterFieldsByName,
   editor: FilterByNameTransformerEditor,
   transformation: standardTransformers.filterFieldsByNameTransformer,

--- a/public/app/core/components/TransformersUI/FilterByRefIdTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/FilterByRefIdTransformerEditor.tsx
@@ -3,7 +3,7 @@ import {
   DataTransformerID,
   KeyValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
 import { HorizontalGroup, FilterPill } from '@grafana/ui';
@@ -129,7 +129,7 @@ export class FilterByRefIdTransformerEditor extends React.PureComponent<
   }
 }
 
-export const filterFramesByRefIdTransformRegistryItem: TransformerRegistyItem<FilterFramesByRefIdTransformerOptions> = {
+export const filterFramesByRefIdTransformRegistryItem: TransformerRegistryItem<FilterFramesByRefIdTransformerOptions> = {
   id: DataTransformerID.filterByRefId,
   editor: FilterByRefIdTransformerEditor,
   transformation: standardTransformers.filterFramesByRefIdTransformer,

--- a/public/app/core/components/TransformersUI/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import {
   DataTransformerID,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
   getFieldDisplayName,
   DataFrame,
@@ -133,7 +133,7 @@ export const FilterByValueTransformerEditor: React.FC<TransformerUIProps<FilterB
   );
 };
 
-export const filterByValueTransformRegistryItem: TransformerRegistyItem<FilterByValueTransformerOptions> = {
+export const filterByValueTransformRegistryItem: TransformerRegistryItem<FilterByValueTransformerOptions> = {
   id: DataTransformerID.filterByValue,
   editor: FilterByValueTransformerEditor,
   transformation: standardTransformers.filterByValueTransformer,

--- a/public/app/core/components/TransformersUI/GroupByTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/GroupByTransformerEditor.tsx
@@ -5,7 +5,7 @@ import {
   ReducerID,
   SelectableValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
 import { getAllFieldNamesFromDataFrames } from './OrganizeFieldsTransformerEditor';
@@ -136,7 +136,7 @@ const getStyling = stylesFactory(() => {
   };
 });
 
-export const groupByTransformRegistryItem: TransformerRegistyItem<GroupByTransformerOptions> = {
+export const groupByTransformRegistryItem: TransformerRegistryItem<GroupByTransformerOptions> = {
   id: DataTransformerID.groupBy,
   editor: GroupByTransformerEditor,
   transformation: standardTransformers.groupByTransformer,

--- a/public/app/core/components/TransformersUI/LabelsToFieldsTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/LabelsToFieldsTransformerEditor.tsx
@@ -3,7 +3,7 @@ import {
   DataTransformerID,
   SelectableValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
 import { Select } from '@grafana/ui';
@@ -55,7 +55,7 @@ export const LabelsAsFieldsTransformerEditor: React.FC<TransformerUIProps<Labels
   );
 };
 
-export const labelsToFieldsTransformerRegistryItem: TransformerRegistyItem<LabelsToFieldsOptions> = {
+export const labelsToFieldsTransformerRegistryItem: TransformerRegistryItem<LabelsToFieldsOptions> = {
   id: DataTransformerID.labelsToFields,
   editor: LabelsAsFieldsTransformerEditor,
   transformation: standardTransformers.labelsToFieldsTransformer,

--- a/public/app/core/components/TransformersUI/MergeTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/MergeTransformerEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataTransformerID, standardTransformers, TransformerRegistyItem, TransformerUIProps } from '@grafana/data';
+import { DataTransformerID, standardTransformers, TransformerRegistryItem, TransformerUIProps } from '@grafana/data';
 import { MergeTransformerOptions } from '@grafana/data/src/transformations/transformers/merge';
 
 export const MergeTransformerEditor: React.FC<TransformerUIProps<MergeTransformerOptions>> = ({
@@ -10,11 +10,11 @@ export const MergeTransformerEditor: React.FC<TransformerUIProps<MergeTransforme
   return null;
 };
 
-export const mergeTransformerRegistryItem: TransformerRegistyItem<MergeTransformerOptions> = {
+export const mergeTransformerRegistryItem: TransformerRegistryItem<MergeTransformerOptions> = {
   id: DataTransformerID.merge,
   editor: MergeTransformerEditor,
   transformation: standardTransformers.mergeTransformer,
   name: 'Merge',
-  description: `Merge many series/tables and return a single table where mergeable values will be combined into the same row. 
+  description: `Merge many series/tables and return a single table where mergeable values will be combined into the same row.
                 Useful for showing multiple series, tables or a combination of both visualized in a table.`,
 };

--- a/public/app/core/components/TransformersUI/OrganizeFieldsTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/OrganizeFieldsTransformerEditor.tsx
@@ -6,7 +6,7 @@ import {
   DataTransformerID,
   GrafanaTheme,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
   getFieldDisplayName,
 } from '@grafana/data';
@@ -221,7 +221,7 @@ export const getAllFieldNamesFromDataFrames = (input: DataFrame[]): string[] => 
   );
 };
 
-export const organizeFieldsTransformRegistryItem: TransformerRegistyItem<OrganizeFieldsTransformerOptions> = {
+export const organizeFieldsTransformRegistryItem: TransformerRegistryItem<OrganizeFieldsTransformerOptions> = {
   id: DataTransformerID.organize,
   editor: OrganizeFieldsTransformerEditor,
   transformation: standardTransformers.organizeFieldsTransformer,

--- a/public/app/core/components/TransformersUI/ReduceTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/ReduceTransformerEditor.tsx
@@ -5,7 +5,7 @@ import {
   ReducerID,
   SelectableValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
 
@@ -99,7 +99,7 @@ export const ReduceTransformerEditor: React.FC<TransformerUIProps<ReduceTransfor
   );
 };
 
-export const reduceTransformRegistryItem: TransformerRegistyItem<ReduceTransformerOptions> = {
+export const reduceTransformRegistryItem: TransformerRegistryItem<ReduceTransformerOptions> = {
   id: DataTransformerID.reduce,
   editor: ReduceTransformerEditor,
   transformation: standardTransformers.reduceTransformer,

--- a/public/app/core/components/TransformersUI/RenameByRegexTransformer.tsx
+++ b/public/app/core/components/TransformersUI/RenameByRegexTransformer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   DataTransformerID,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
   stringToJsRegex,
 } from '@grafana/data';
@@ -122,7 +122,7 @@ export class RenameByRegexTransformerEditor extends React.PureComponent<
   }
 }
 
-export const renameByRegexTransformRegistryItem: TransformerRegistyItem<RenameByRegexTransformerOptions> = {
+export const renameByRegexTransformRegistryItem: TransformerRegistryItem<RenameByRegexTransformerOptions> = {
   id: DataTransformerID.renameByRegex,
   editor: RenameByRegexTransformerEditor,
   transformation: standardTransformers.renameByRegexTransformer,

--- a/public/app/core/components/TransformersUI/SeriesToFieldsTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/SeriesToFieldsTransformerEditor.tsx
@@ -3,7 +3,7 @@ import {
   DataTransformerID,
   SelectableValue,
   standardTransformers,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
 import { getAllFieldNamesFromDataFrames } from './OrganizeFieldsTransformerEditor';
@@ -39,7 +39,7 @@ export const SeriesToFieldsTransformerEditor: React.FC<TransformerUIProps<Series
   );
 };
 
-export const seriesToFieldsTransformerRegistryItem: TransformerRegistyItem<SeriesToColumnsOptions> = {
+export const seriesToFieldsTransformerRegistryItem: TransformerRegistryItem<SeriesToColumnsOptions> = {
   id: DataTransformerID.seriesToColumns,
   editor: SeriesToFieldsTransformerEditor,
   transformation: standardTransformers.seriesToColumnsTransformer,

--- a/public/app/core/components/TransformersUI/SeriesToRowsTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/SeriesToRowsTransformerEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataTransformerID, standardTransformers, TransformerRegistyItem, TransformerUIProps } from '@grafana/data';
+import { DataTransformerID, standardTransformers, TransformerRegistryItem, TransformerUIProps } from '@grafana/data';
 import { SeriesToRowsTransformerOptions } from '@grafana/data/src/transformations/transformers/seriesToRows';
 
 export const SeriesToRowsTransformerEditor: React.FC<TransformerUIProps<SeriesToRowsTransformerOptions>> = ({
@@ -10,11 +10,11 @@ export const SeriesToRowsTransformerEditor: React.FC<TransformerUIProps<SeriesTo
   return null;
 };
 
-export const seriesToRowsTransformerRegistryItem: TransformerRegistyItem<SeriesToRowsTransformerOptions> = {
+export const seriesToRowsTransformerRegistryItem: TransformerRegistryItem<SeriesToRowsTransformerOptions> = {
   id: DataTransformerID.seriesToRows,
   editor: SeriesToRowsTransformerEditor,
   transformation: standardTransformers.seriesToRowsTransformer,
   name: 'Series to rows',
-  description: `Merge many series and return a single series with time, metric and value as columns. 
+  description: `Merge many series and return a single series with time, metric and value as columns.
                 Useful for showing multiple time series visualized in a table.`,
 };

--- a/public/app/core/components/TransformersUI/SortByTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/SortByTransformerEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { DataTransformerID, standardTransformers, TransformerRegistyItem, TransformerUIProps } from '@grafana/data';
+import { DataTransformerID, standardTransformers, TransformerRegistryItem, TransformerUIProps } from '@grafana/data';
 import { getAllFieldNamesFromDataFrames } from './OrganizeFieldsTransformerEditor';
 import { InlineField, InlineSwitch, InlineFieldRow, Select } from '@grafana/ui';
 
@@ -59,7 +59,7 @@ export const SortByTransformerEditor: React.FC<TransformerUIProps<SortByTransfor
   );
 };
 
-export const sortByTransformRegistryItem: TransformerRegistyItem<SortByTransformerOptions> = {
+export const sortByTransformRegistryItem: TransformerRegistryItem<SortByTransformerOptions> = {
   id: DataTransformerID.sortBy,
   editor: SortByTransformerEditor,
   transformation: standardTransformers.sortByTransformer,

--- a/public/app/core/utils/standardTransformers.ts
+++ b/public/app/core/utils/standardTransformers.ts
@@ -1,4 +1,4 @@
-import { TransformerRegistyItem } from '@grafana/data';
+import { TransformerRegistryItem } from '@grafana/data';
 import { reduceTransformRegistryItem } from '../components/TransformersUI/ReduceTransformerEditor';
 import { filterFieldsByNameTransformRegistryItem } from '../components/TransformersUI/FilterByNameTransformerEditor';
 import { filterFramesByRefIdTransformRegistryItem } from '../components/TransformersUI/FilterByRefIdTransformerEditor';
@@ -14,7 +14,7 @@ import { seriesToRowsTransformerRegistryItem } from '../components/TransformersU
 import { concatenateTransformRegistryItem } from '../components/TransformersUI/ConcatenateTransformerEditor';
 import { renameByRegexTransformRegistryItem } from '../components/TransformersUI/RenameByRegexTransformer';
 
-export const getStandardTransformers = (): Array<TransformerRegistyItem<any>> => {
+export const getStandardTransformers = (): Array<TransformerRegistryItem<any>> => {
   return [
     reduceTransformRegistryItem,
     filterFieldsByNameTransformRegistryItem,

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
@@ -7,7 +7,7 @@ import {
   DataTransformerConfig,
   GrafanaTheme,
   transformDataFrame,
-  TransformerRegistyItem,
+  TransformerRegistryItem,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
@@ -17,7 +17,7 @@ interface TransformationEditorProps {
   debugMode?: boolean;
   index: number;
   data: DataFrame[];
-  uiConfig: TransformerRegistyItem<any>;
+  uiConfig: TransformerRegistryItem<any>;
   configs: TransformationsEditorTransformation[];
   onChange: (index: number, config: DataTransformerConfig) => void;
 }

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { DataFrame, DataTransformerConfig, TransformerRegistyItem } from '@grafana/data';
+import { DataFrame, DataTransformerConfig, TransformerRegistryItem } from '@grafana/data';
 import { HorizontalGroup } from '@grafana/ui';
 
 import { TransformationEditor } from './TransformationEditor';
@@ -14,7 +14,7 @@ interface TransformationOperationRowProps {
   id: string;
   index: number;
   data: DataFrame[];
-  uiConfig: TransformerRegistyItem<any>;
+  uiConfig: TransformerRegistryItem<any>;
   configs: TransformationsEditorTransformation[];
   onRemove: (index: number) => void;
   onChange: (index: number, config: DataTransformerConfig) => void;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the typo in `TransformerRegistyItem`.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

Building and running works fine, `yarn test` has a bunch of seemingly unrelated flakes/errors.
