### PR TITLE
GrafanaUI: Add a way to persistently close InfoBox

### DIFF
--- a/packages/grafana-ui/src/components/InfoBox/DismissableFeatureInfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/DismissableFeatureInfoBox.tsx
@@ -10,6 +10,7 @@ interface DismissableFeatureInfoBoxProps extends FeatureInfoBoxProps {
 }
 
 /**
+  @internal
   Wraps FeatureInfoBox and perists if a user has dismissed the box in local storage.
  */
 export const DismissableFeatureInfoBox = React.memo(

--- a/packages/grafana-ui/src/components/InfoBox/DismissableFeatureInfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/DismissableFeatureInfoBox.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useLocalStorage } from 'react-use';
+import { FeatureInfoBox, FeatureInfoBoxProps } from './FeatureInfoBox';
+
+export const FEATUREINFOBOX_PERSISTENCE_ID_PREFIX = 'grafana-ui.components.InfoBox.FeatureInfoBox';
+
+interface DismissableFeatureInfoBoxProps extends FeatureInfoBoxProps {
+  /** Unique id under which this instance will be persisted. */
+  persistenceId: string;
+}
+
+/**
+  Wraps FeatureInfoBox and perists if a user has dismissed the box in local storage.
+ */
+export const DismissableFeatureInfoBox = React.memo(
+  React.forwardRef<HTMLDivElement, DismissableFeatureInfoBoxProps>(
+    ({ persistenceId, onDismiss, ...otherProps }, ref) => {
+      const localStorageKey = FEATUREINFOBOX_PERSISTENCE_ID_PREFIX.concat(persistenceId);
+
+      const [dismissed, setDismissed] = useLocalStorage(localStorageKey, { isDismissed: false });
+
+      const dismiss = () => {
+        setDismissed({ isDismissed: true });
+        if (onDismiss) {
+          onDismiss();
+        }
+      };
+
+      if (dismissed.isDismissed) {
+        return null;
+      }
+      return <FeatureInfoBox onDismiss={dismiss} ref={ref} {...otherProps}></FeatureInfoBox>;
+    }
+  )
+);
+DismissableFeatureInfoBox.displayName = 'DismissableFeatureInfoBox';

--- a/packages/grafana-ui/src/components/InfoBox/DismissableFeatureInfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/DismissableFeatureInfoBox.tsx
@@ -4,7 +4,7 @@ import { FeatureInfoBox, FeatureInfoBoxProps } from './FeatureInfoBox';
 
 export const FEATUREINFOBOX_PERSISTENCE_ID_PREFIX = 'grafana-ui.components.InfoBox.FeatureInfoBox';
 
-interface DismissableFeatureInfoBoxProps extends FeatureInfoBoxProps {
+export interface DismissableFeatureInfoBoxProps extends FeatureInfoBoxProps {
   /** Unique id under which this instance will be persisted. */
   persistenceId: string;
 }

--- a/packages/grafana-ui/src/components/InfoBox/FeatureInfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/FeatureInfoBox.tsx
@@ -5,7 +5,7 @@ import { stylesFactory, useStyles } from '../../themes';
 import { Badge, BadgeProps } from '../Badge/Badge';
 import { css } from 'emotion';
 
-interface FeatureInfoBoxProps extends Omit<InfoBoxProps, 'branded' | 'title' | 'urlTitle'> {
+export interface FeatureInfoBoxProps extends Omit<InfoBoxProps, 'branded' | 'title' | 'urlTitle'> {
   title: string;
   featureState?: FeatureState;
 }

--- a/packages/grafana-ui/src/components/InfoBox/FeatureInfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/FeatureInfoBox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { InfoBox, InfoBoxProps } from './InfoBox';
 import { FeatureState, GrafanaTheme } from '@grafana/data';
-import { stylesFactory, useTheme } from '../../themes';
+import { stylesFactory, useStyles } from '../../themes';
 import { Badge, BadgeProps } from '../Badge/Badge';
 import { css } from 'emotion';
 
@@ -12,8 +12,7 @@ interface FeatureInfoBoxProps extends Omit<InfoBoxProps, 'branded' | 'title' | '
 
 export const FeatureInfoBox = React.memo(
   React.forwardRef<HTMLDivElement, FeatureInfoBoxProps>(({ title, featureState, ...otherProps }, ref) => {
-    const theme = useTheme();
-    const styles = getFeatureInfoBoxStyles(theme);
+    const styles = useStyles(getFeatureInfoBoxStyles);
 
     const titleEl = featureState ? (
       <>
@@ -25,7 +24,7 @@ export const FeatureInfoBox = React.memo(
     ) : (
       <h3>{title}</h3>
     );
-    return <InfoBox branded title={titleEl} urlTitle="Read documentation" {...otherProps} />;
+    return <InfoBox branded title={titleEl} urlTitle="Read documentation" ref={ref} {...otherProps} />;
   })
 );
 FeatureInfoBox.displayName = 'FeatureInfoBox';

--- a/packages/grafana-ui/src/components/InfoBox/InfoBox.story.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/InfoBox.story.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { number, select, text } from '@storybook/addon-knobs';
 import { FeatureState } from '@grafana/data';
 import { InfoBox, FeatureInfoBox } from '@grafana/ui';
 import mdx from './InfoBox.mdx';
-import { DismissableFeatureInfoBox, FEATUREINFOBOX_PERSISTENCE_ID_PREFIX } from './DismissableFeatureInfoBox';
+import {
+  DismissableFeatureInfoBox,
+  DismissableFeatureInfoBoxProps,
+  FEATUREINFOBOX_PERSISTENCE_ID_PREFIX,
+} from './DismissableFeatureInfoBox';
 import { Button } from '../Button';
 import { css } from 'emotion';
+import { Story } from '@storybook/react';
+import { FeatureInfoBoxProps } from './FeatureInfoBox';
+import { InfoBoxProps } from './InfoBox';
 
 export default {
   title: 'Layout/InfoBox',
@@ -16,108 +22,63 @@ export default {
       page: mdx,
     },
   },
+  argTypes: {
+    onDismiss: { action: 'Dismissed' },
+    featureState: {
+      control: { type: 'select', options: ['alpha', 'beta', undefined] },
+    },
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
-const getKnobs = () => {
-  const containerWidth = number('Container width', 800, {
-    range: true,
-    min: 100,
-    max: 1500,
-    step: 100,
-  });
+const defaultProps: DismissableFeatureInfoBoxProps = {
+  title: 'A title',
+  severity: 'info',
+  url: 'http://www.grafana.com',
+  persistenceId: 'storybook-feature-info-box-persist',
+  featureState: FeatureState.beta,
 
-  const title = text('Title', 'User permission');
-  const url = text('Url', 'http://docs.grafana.org/features/datasources/mysql/');
-  const severity = select('Severity', ['success', 'warning', 'error', 'info'], 'info');
-
-  return { containerWidth, severity, title, url };
+  children: (
+    <p>
+      The database user should only be granted SELECT permissions on the specified database &amp; tables you want to
+      query. Grafana does not validate that queries are safe so queries can contain any SQL statement. For example,
+      statements like <code>USE otherdb;</code> and <code>DROP TABLE user;</code> would be executed. To protect against
+      this we <strong>Highly</strong> recommend you create a specific MySQL user with restricted permissions.
+    </p>
+  ),
 };
 
-export const basic = () => {
-  const { containerWidth, severity, title, url } = getKnobs();
+const InfoBoxTemplate: Story<InfoBoxProps> = (args) => <InfoBox {...args} />;
+export const infoBox = InfoBoxTemplate.bind({});
+infoBox.args = defaultProps;
 
-  return (
-    <div style={{ width: containerWidth }}>
-      <InfoBox
-        title={title}
-        url={url}
-        severity={severity}
-        onDismiss={() => {
-          alert('onDismiss clicked');
-        }}
-      >
-        <p>
-          The database user should only be granted SELECT permissions on the specified database &amp; tables you want to
-          query. Grafana does not validate that queries are safe so queries can contain any SQL statement. For example,
-          statements like <code>USE otherdb;</code> and <code>DROP TABLE user;</code> would be executed. To protect
-          against this we <strong>Highly</strong> recommend you create a specific MySQL user with restricted
-          permissions.
-        </p>
-      </InfoBox>
-    </div>
-  );
-};
+const FeatureInfoBoxTemplate: Story<FeatureInfoBoxProps> = (args) => <FeatureInfoBox {...args}></FeatureInfoBox>;
+export const featureInfoBox = FeatureInfoBoxTemplate.bind({});
+featureInfoBox.args = defaultProps;
 
-export const featureInfoBox = () => {
-  const { containerWidth } = getKnobs();
-
-  return (
-    <div style={{ width: containerWidth }}>
-      <FeatureInfoBox
-        title="Transformations"
-        url={'http://www.grafana.com'}
-        featureState={FeatureState.beta}
-        onDismiss={() => {
-          alert('onDismiss clicked');
-        }}
-      >
-        Transformations allow you to join, calculate, re-order, hide and rename your query results before being
-        visualized. <br />
-        Many transforms are not suitable if you&apos;re using the Graph visualisation as it currently only supports time
-        series. <br />
-        It can help to switch to Table visualisation to understand what a transformation is doing.
-      </FeatureInfoBox>
-    </div>
-  );
-};
-
-export const dismissableFeatureInfoBox = () => {
-  const { containerWidth, severity, title, url } = getKnobs();
-
-  const id = 'storybook-example-id';
-
+const DismissableTemplate: Story<DismissableFeatureInfoBoxProps> = (args) => {
   const onResetClick = () => {
-    localStorage.removeItem(FEATUREINFOBOX_PERSISTENCE_ID_PREFIX.concat(id));
+    localStorage.removeItem(FEATUREINFOBOX_PERSISTENCE_ID_PREFIX.concat(args.persistenceId));
     location.reload();
   };
 
   return (
     <div>
-      <div style={{ width: containerWidth }}>
-        <DismissableFeatureInfoBox
-          persistenceId={id}
-          title={title}
-          severity={severity}
-          url={url}
-          featureState={FeatureState.beta}
-          onDismiss={() => {
-            alert('onDismiss clicked');
-          }}
-        >
-          Transformations allow you to join, calculate, re-order, hide and rename your query results before being
-          visualized. <br />
-          Many transforms are not suitable if you&apos;re using the Graph visualisation as it currently only supports
-          time series. <br />
-          It can help to switch to Table visualisation to understand what a transformation is doing.
-        </DismissableFeatureInfoBox>
+      <div>
+        <DismissableFeatureInfoBox {...args} />
       </div>
       <div
         className={css`
           margin-top: 24px;
         `}
-      >
-        <Button onClick={onResetClick}>Reset DismissableFeatureInfoBox</Button>
-      </div>
+      ></div>
+      <Button onClick={onResetClick}>Reset DismissableFeatureInfoBox</Button>
     </div>
   );
 };
+export const dismissableFeatureInfoBox = DismissableTemplate.bind({});
+dismissableFeatureInfoBox.args = defaultProps;

--- a/packages/grafana-ui/src/components/InfoBox/InfoBox.story.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/InfoBox.story.tsx
@@ -75,8 +75,9 @@ const DismissableTemplate: Story<DismissableFeatureInfoBoxProps> = (args) => {
         className={css`
           margin-top: 24px;
         `}
-      ></div>
-      <Button onClick={onResetClick}>Reset DismissableFeatureInfoBox</Button>
+      >
+        <Button onClick={onResetClick}>Reset DismissableFeatureInfoBox</Button>
+      </div>
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/InfoBox/InfoBox.story.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/InfoBox.story.tsx
@@ -3,6 +3,9 @@ import { number, select, text } from '@storybook/addon-knobs';
 import { FeatureState } from '@grafana/data';
 import { InfoBox, FeatureInfoBox } from '@grafana/ui';
 import mdx from './InfoBox.mdx';
+import { DismissableFeatureInfoBox, FEATUREINFOBOX_PERSISTENCE_ID_PREFIX } from './DismissableFeatureInfoBox';
+import { Button } from '../Button';
+import { css } from 'emotion';
 
 export default {
   title: 'Layout/InfoBox',
@@ -74,6 +77,47 @@ export const featureInfoBox = () => {
         series. <br />
         It can help to switch to Table visualisation to understand what a transformation is doing.
       </FeatureInfoBox>
+    </div>
+  );
+};
+
+export const dismissableFeatureInfoBox = () => {
+  const { containerWidth, severity, title, url } = getKnobs();
+
+  const id = 'storybook-example-id';
+
+  const onResetClick = () => {
+    localStorage.removeItem(FEATUREINFOBOX_PERSISTENCE_ID_PREFIX.concat(id));
+    location.reload();
+  };
+
+  return (
+    <div>
+      <div style={{ width: containerWidth }}>
+        <DismissableFeatureInfoBox
+          persistenceId={id}
+          title={title}
+          severity={severity}
+          url={url}
+          featureState={FeatureState.beta}
+          onDismiss={() => {
+            alert('onDismiss clicked');
+          }}
+        >
+          Transformations allow you to join, calculate, re-order, hide and rename your query results before being
+          visualized. <br />
+          Many transforms are not suitable if you&apos;re using the Graph visualisation as it currently only supports
+          time series. <br />
+          It can help to switch to Table visualisation to understand what a transformation is doing.
+        </DismissableFeatureInfoBox>
+      </div>
+      <div
+        className={css`
+          margin-top: 24px;
+        `}
+      >
+        <Button onClick={onResetClick}>Reset DismissableFeatureInfoBox</Button>
+      </div>
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/InfoBox/InfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/InfoBox.tsx
@@ -9,9 +9,6 @@ import panelArtDark from './panelArt_dark.svg';
 import panelArtLight from './panelArt_light.svg';
 import { stylesFactory, useTheme } from '../../themes';
 import { getColorsFromSeverity } from '../../utils/colors';
-import { useLocalStorage } from 'react-use';
-
-const FEATUREINFOBOX_PERSISTENCE_ID_PREFIX = 'grafana-ui.components.InfoBox.';
 
 export interface InfoBoxProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   children: React.ReactNode;
@@ -27,8 +24,6 @@ export interface InfoBoxProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
   severity?: AlertVariant;
   /** Call back to be performed when box is dismissed */
   onDismiss?: () => void;
-  /** If dismissPersistenceId is set, the info box will be peristently dismissed when the user dismisses the infobox.*/
-  dismissPersistenceId?: string;
 }
 
 /**
@@ -36,52 +31,17 @@ export interface InfoBoxProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
  */
 export const InfoBox = React.memo(
   React.forwardRef<HTMLDivElement, InfoBoxProps>(
-    (
-      {
-        title,
-        className,
-        children,
-        branded,
-        url,
-        urlTitle,
-        onDismiss,
-        dismissPersistenceId,
-        severity = 'info',
-        ...otherProps
-      },
-      ref
-    ) => {
+    ({ title, className, children, branded, url, urlTitle, onDismiss, severity = 'info', ...otherProps }, ref) => {
       const theme = useTheme();
       const styles = getInfoBoxStyles(theme, severity);
-      const wrapperClassName = branded ? cx(styles.wrapperBranded, className) : cx(styles.wrapper, className);
-
-      let dismiss;
-
-      if (dismissPersistenceId) {
-        const persistanceId = FEATUREINFOBOX_PERSISTENCE_ID_PREFIX.concat(dismissPersistenceId);
-
-        const [dismissed, setDismissed] = useLocalStorage(persistanceId, { isDismissed: false });
-
-        dismiss = () => {
-          setDismissed({ isDismissed: true });
-          if (onDismiss) {
-            onDismiss();
-          }
-        };
-
-        if (dismissed.isDismissed) {
-          return null;
-        }
-      } else {
-        dismiss = onDismiss;
-      }
+      const wrapperClassName = cx(branded ? styles.wrapperBranded : styles.wrapper, className);
 
       return (
         <div className={wrapperClassName} {...otherProps} ref={ref}>
           <div>
             <HorizontalGroup justify={'space-between'} align={'flex-start'}>
               <div>{typeof title === 'string' ? <h4>{title}</h4> : title}</div>
-              {dismiss && <IconButton name={'times'} onClick={dismiss} />}
+              {onDismiss && <IconButton name={'times'} onClick={onDismiss} />}
             </HorizontalGroup>
           </div>
           <div>{children}</div>

--- a/packages/grafana-ui/src/components/InfoBox/InfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/InfoBox.tsx
@@ -9,6 +9,9 @@ import panelArtDark from './panelArt_dark.svg';
 import panelArtLight from './panelArt_light.svg';
 import { stylesFactory, useTheme } from '../../themes';
 import { getColorsFromSeverity } from '../../utils/colors';
+import { useLocalStorage } from 'react-use';
+
+const FEATUREINFOBOX_PERSISTENCE_ID_PREFIX = 'grafana-ui.components.InfoBox.';
 
 export interface InfoBoxProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   children: React.ReactNode;
@@ -24,6 +27,8 @@ export interface InfoBoxProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
   severity?: AlertVariant;
   /** Call back to be performed when box is dismissed */
   onDismiss?: () => void;
+  /** If dismissPersistenceId is set, the info box will be peristently dismissed when the user dismisses the infobox.*/
+  dismissPersistenceId?: string;
 }
 
 /**
@@ -31,17 +36,52 @@ export interface InfoBoxProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
  */
 export const InfoBox = React.memo(
   React.forwardRef<HTMLDivElement, InfoBoxProps>(
-    ({ title, className, children, branded, url, urlTitle, onDismiss, severity = 'info', ...otherProps }, ref) => {
+    (
+      {
+        title,
+        className,
+        children,
+        branded,
+        url,
+        urlTitle,
+        onDismiss,
+        dismissPersistenceId,
+        severity = 'info',
+        ...otherProps
+      },
+      ref
+    ) => {
       const theme = useTheme();
       const styles = getInfoBoxStyles(theme, severity);
       const wrapperClassName = branded ? cx(styles.wrapperBranded, className) : cx(styles.wrapper, className);
+
+      let dismiss;
+
+      if (dismissPersistenceId) {
+        const persistanceId = FEATUREINFOBOX_PERSISTENCE_ID_PREFIX.concat(dismissPersistenceId);
+
+        const [dismissed, setDismissed] = useLocalStorage(persistanceId, { isDismissed: false });
+
+        dismiss = () => {
+          setDismissed({ isDismissed: true });
+          if (onDismiss) {
+            onDismiss();
+          }
+        };
+
+        if (dismissed.isDismissed) {
+          return null;
+        }
+      } else {
+        dismiss = onDismiss;
+      }
 
       return (
         <div className={wrapperClassName} {...otherProps} ref={ref}>
           <div>
             <HorizontalGroup justify={'space-between'} align={'flex-start'}>
               <div>{typeof title === 'string' ? <h4>{title}</h4> : title}</div>
-              {onDismiss && <IconButton name={'times'} onClick={onDismiss} />}
+              {dismiss && <IconButton name={'times'} onClick={dismiss} />}
             </HorizontalGroup>
           </div>
           <div>{children}</div>

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -103,6 +103,7 @@ export { DataLinksContextMenu } from './DataLinks/DataLinksContextMenu';
 export { SeriesIcon } from './VizLegend/SeriesIcon';
 export { InfoBox } from './InfoBox/InfoBox';
 export { FeatureBadge, FeatureInfoBox } from './InfoBox/FeatureInfoBox';
+export { DismissableFeatureInfoBox } from './InfoBox/DismissableFeatureInfoBox';
 
 export { JSONFormatter } from './JSONFormatter/JSONFormatter';
 export { JsonExplorer } from './JSONFormatter/json_explorer/json_explorer';

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Container,
   CustomScrollbar,
-  FeatureInfoBox,
   stylesFactory,
   Themeable,
   useTheme,
@@ -32,7 +31,7 @@ import { TransformationOperationRows } from './TransformationOperationRows';
 import { TransformationsEditorTransformation } from './types';
 import { PanelNotSupported } from '../PanelEditor/PanelNotSupported';
 import { AppNotificationSeverity } from '../../../../types';
-import theme from '@grafana/ui/src/themes/default';
+import { DismissableFeatureInfoBox } from '@grafana/ui/src/components/InfoBox/DismissableFeatureInfoBox';
 
 interface TransformationsEditorProps extends Themeable {
   panel: PanelModel;
@@ -213,12 +212,12 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
     return (
       <>
         <Container grow={1}>
-          <FeatureInfoBox
+          <DismissableFeatureInfoBox
             title="Transformations"
             className={css`
-              margin-bottom: ${theme.spacing.lg};
+              margin-bottom: ${this.props.theme.spacing.lg};
             `}
-            dismissPersistenceId="transformationsFeaturesInfoBox"
+            persistenceId="transformationsFeaturesInfoBox"
             url={getDocsLink(DocsId.Transformations)}
           >
             <p>
@@ -228,7 +227,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
               supports time series. <br />
               It can help to switch to Table visualization to understand what a transformation is doing. <br />
             </p>
-          </FeatureInfoBox>
+          </DismissableFeatureInfoBox>
         </Container>
         <VerticalGroup>
           {standardTransformersRegistry.list().map((t) => {

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -6,6 +6,7 @@ import {
   CustomScrollbar,
   stylesFactory,
   Themeable,
+  DismissableFeatureInfoBox,
   useTheme,
   ValuePicker,
   VerticalGroup,
@@ -31,7 +32,6 @@ import { TransformationOperationRows } from './TransformationOperationRows';
 import { TransformationsEditorTransformation } from './types';
 import { PanelNotSupported } from '../PanelEditor/PanelNotSupported';
 import { AppNotificationSeverity } from '../../../../types';
-import { DismissableFeatureInfoBox } from '@grafana/ui/src/components/InfoBox/DismissableFeatureInfoBox';
 
 interface TransformationsEditorProps extends Themeable {
   panel: PanelModel;

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -6,9 +6,11 @@ import {
   CustomScrollbar,
   FeatureInfoBox,
   stylesFactory,
+  Themeable,
   useTheme,
   ValuePicker,
   VerticalGroup,
+  withTheme,
 } from '@grafana/ui';
 import {
   DataFrame,
@@ -30,8 +32,9 @@ import { TransformationOperationRows } from './TransformationOperationRows';
 import { TransformationsEditorTransformation } from './types';
 import { PanelNotSupported } from '../PanelEditor/PanelNotSupported';
 import { AppNotificationSeverity } from '../../../../types';
+import theme from '@grafana/ui/src/themes/default';
 
-interface TransformationsEditorProps {
+interface TransformationsEditorProps extends Themeable {
   panel: PanelModel;
 }
 
@@ -40,7 +43,7 @@ interface State {
   transformations: TransformationsEditorTransformation[];
 }
 
-export class TransformationsEditor extends React.PureComponent<TransformationsEditorProps, State> {
+class UnThemedTransformationsEditor extends React.PureComponent<TransformationsEditorProps, State> {
   subscription?: Unsubscribable;
 
   constructor(props: TransformationsEditorProps) {
@@ -208,9 +211,16 @@ export class TransformationsEditor extends React.PureComponent<TransformationsEd
 
   renderNoAddedTransformsState() {
     return (
-      <VerticalGroup spacing={'lg'}>
+      <>
         <Container grow={1}>
-          <FeatureInfoBox title="Transformations" url={getDocsLink(DocsId.Transformations)}>
+          <FeatureInfoBox
+            title="Transformations"
+            className={css`
+              margin-bottom: ${theme.spacing.lg};
+            `}
+            dismissPersistenceId="transformationsFeaturesInfoBox"
+            url={getDocsLink(DocsId.Transformations)}
+          >
             <p>
               Transformations allow you to join, calculate, re-order, hide and rename your query results before being
               visualized. <br />
@@ -236,7 +246,7 @@ export class TransformationsEditor extends React.PureComponent<TransformationsEd
             );
           })}
         </VerticalGroup>
-      </VerticalGroup>
+      </>
     );
   }
 
@@ -299,3 +309,5 @@ const getTransformationCardStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
   };
 });
+
+export const TransformationsEditor = withTheme(UnThemedTransformationsEditor);


### PR DESCRIPTION
**What this PR does / why we need it**:
InfoBox and FeatureInfoBox can take up a lot of screen real estate. This makes it easy to let the user close the boxes and not have them come back. It also enables this feature on the TransformationsEditor.

**Which issue(s) this PR fixes**:
Fixes #24664

