### PR TITLE
TagsInput: Make placeholder configurable

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -160,7 +160,6 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
                 onChange={(cookies) =>
                   onSettingsChange({ jsonData: { ...dataSourceConfig.jsonData, keepCookies: cookies } })
                 }
-                width={20}
               />
             </div>
           )}

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.mdx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.mdx
@@ -6,3 +6,6 @@ import { TagsInput } from './TagsInput';
 # TagsInput
 
 A set of an input field and a button next to it that allows the user to add new tags. The added tags are previewed under the input and can be removed there by clicking the "X" icon. You can customize the width of the input.
+
+### Props
+<Props of={TagsInput} />

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -6,8 +6,8 @@ import { Input } from '../Forms/Legacy/Input/Input';
 import { TagItem } from './TagItem';
 
 interface Props {
+  placeholder?: string;
   tags?: string[];
-  width?: number;
 
   onChange: (tags: string[]) => void;
 }
@@ -80,6 +80,7 @@ export class TagsInput extends PureComponent<Props, State> {
   };
 
   render() {
+    const { placeholder = 'Add name' } = this.props;
     const { tags, newTag } = this.state;
 
     const getStyles = stylesFactory(() => ({
@@ -104,7 +105,7 @@ export class TagsInput extends PureComponent<Props, State> {
             `
           )}
         >
-          <Input placeholder="Add Name" onChange={this.onNameChange} value={newTag} onKeyUp={this.onKeyboardAdd} />
+          <Input placeholder={placeholder} onChange={this.onNameChange} value={newTag} onKeyUp={this.onKeyboardAdd} />
           <Button className={getStyles().addButtonStyle} onClick={this.onAdd} variant="secondary" size="md">
             Add
           </Button>


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes `placeholder` configurable because it's not necessarily always the case that this is used for a list of names.
For example, in Cloud Alerting, we need it to implement labels matchers as they currently exist in Alertmanager:

![Screenshot from 2021-01-28 19-43-27](https://user-images.githubusercontent.com/16936908/106183903-23039b80-61a1-11eb-8daa-776e9df038f5.png)

**Drive-by fixes**
- `width` prop isn't actually used and thus might give users of this component the wrong idea, so I removed it from the type
- Added storybook props table