### PR TITLE
Added section "Curated dashboards for Google Cloud Monitoring" for 7.4 What's New

### DIFF
--- a/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
+++ b/docs/sources/datasources/google-cloud-monitoring/preconfig-cloud-monitoring-dashboards.md
@@ -11,8 +11,6 @@ weight = 10
 Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. These curated dashboards are based on similar dashboards in the GCP dashboard samples repository. See also, [Using Google Cloud Monitoring in Grafana]({{< relref "./_index.md" >}}) for detailed instructions on how to add and configure the Google Cloud Monitoring data source.
 ## Curated dashboards
 
-The curated dashboards are based on similar dashboards in the GCP dashboard samples repository.
-
 To import the curated dashboards:
 
 1. On the configuration page of your Cloud Monitoring data source, click the **Dashboards** tab.

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -149,7 +149,8 @@ Google Cloud Monitoring data source ships with pre-configured dashboards for som
 
 {{< docs-imagebox img="/img/docs/google-cloud-monitoring/curated-dashboards-7-4.png" max-width= "650px" >}}
 
-In case you want to customize a dashboard, we recommend that you save it under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released. For more information, refer to the [Google Cloud Monitoring docs]({{<relref "../datasources/google-cloud-monitoring/_index.md/#out-of-the-box-dashboards">}}).
+If you want to customize a dashboard, we recommend that you save it under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released. For more information, refer to the [Google Cloud Monitoring docs]({{<relref "../datasources/google-cloud-monitoring/_index.md/#out-of-the-box-dashboards">}}).
+
 ### Query Editor Help
 
 The feature previously referred to as DataSource Start Pages or Cheat Sheets has been renamed to Query Editor Help, and is now supported in panel query editors (depending on the data source), as well as in Explore.

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -139,10 +139,17 @@ Unlike the visual query builder, MQL allows you to control the time range and pe
 
 MQL uses a set of operations and functions. Operations are linked together using the common pipe mechanism, where the output of one operation becomes the input to the next. Linking operations makes it possible to build up complex queries incrementally.
 
-Once query type Metrics is selected in the Cloud Monitoring query editor, you can toggle between the editor modes for visual query builder and MQL.
+Once query type Metrics is selected in the Cloud Monitoring query editor, you can toggle between the editor modes for visual query builder and MQL. For more information, refer to the [Google Cloud Monitoring docs]({{<relref "../datasources/google-cloud-monitoring/_index.md/#out-of-the-box-dashboards">}}).
 
 Many thanks to [mtanda](https://github.com/mtanda) this contribution!
 
+## Curated dashboards for Google Cloud Monitoring
+
+Google Cloud Monitoring data source ships with pre-configured dashboards for some of the most popular GCP services. These curated dashboards are based on similar dashboards in the GCP dashboard samples repository. In this release, we have expanded the set of pre-configured dashboards.
+
+{{< docs-imagebox img="/img/docs/google-cloud-monitoring/curated-dashboards-7-4.png" max-width= "650px" >}}
+
+In case you want to customize a dashboard, we recommend that you save it under a different name.  Otherwise the dashboard will be overwritten when a new version of the dashboard is released. For more information, refer to the [Google Cloud Monitoring docs]({{<relref "../datasources/google-cloud-monitoring/_index.md/#out-of-the-box-dashboards">}}).
 ### Query Editor Help
 
 The feature previously referred to as DataSource Start Pages or Cheat Sheets has been renamed to Query Editor Help, and is now supported in panel query editors (depending on the data source), as well as in Explore.


### PR DESCRIPTION
-Added new section "Curated dashboards for Google Cloud Monitoring" to 7.4 What's new topic.
-Removed duplicate line from "Preconfigured Cloud Monitoring dashboards" topic.