### PR TITLE
Datasource: Use json-iterator configuration compatible with standard library

### DIFF
--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -102,7 +102,12 @@ func (r StreamingResponse) WriteTo(ctx *models.ReqContext) {
 		header[k] = v
 	}
 	ctx.Resp.WriteHeader(r.status)
-	enc := jsoniter.ConfigCompatibleWithStandardLibrary.NewEncoder(ctx.Resp)
+
+	// Use a configuration that's compatible with the standard library
+	// to minimize the risk of introducing bugs. This will make sure
+	// that map keys is ordered.
+	jsonCfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	enc := jsonCfg.NewEncoder(ctx.Resp)
 	if err := enc.Encode(r.body); err != nil {
 		ctx.Logger.Error("Error writing to response", "err", err)
 	}

--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -102,7 +102,7 @@ func (r StreamingResponse) WriteTo(ctx *models.ReqContext) {
 		header[k] = v
 	}
 	ctx.Resp.WriteHeader(r.status)
-	enc := jsoniter.NewEncoder(ctx.Resp)
+	enc := jsoniter.ConfigCompatibleWithStandardLibrary.NewEncoder(ctx.Resp)
 	if err := enc.Encode(r.body); err != nil {
 		ctx.Logger.Error("Error writing to response", "err", err)
 	}

--- a/pkg/tsdb/models.go
+++ b/pkg/tsdb/models.go
@@ -264,5 +264,9 @@ func (df *dataFrames) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	return jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(encoded)
+	// Use a configuration that's compatible with the standard library
+	// to minimize the risk of introducing bugs. This will make sure
+	// that map keys is ordered.
+	jsonCfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	return jsonCfg.Marshal(encoded)
 }

--- a/pkg/tsdb/models.go
+++ b/pkg/tsdb/models.go
@@ -264,5 +264,5 @@ func (df *dataFrames) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	return jsoniter.Marshal(encoded)
+	return jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(encoded)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This will make sure that any map keys in JSON is ordered.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Seems like #30250 removed ordering of map keys in /api/ds/query responses. Using the standard lib JSON encoder per defaults order the map keys for you. With ordered map keys in responses we would have a stable order of the results.

First fixed in #29916, but opened this to include in 7.4 stable.
