### PR TITLE
test: add support for timeout to be passed in for addDatasource

### DIFF
--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -77,12 +77,13 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
   form();
 
   e2e.pages.DataSource.saveAndTest().click();
-  e2e.pages.DataSource.alert().should('exist');
 
   // use the timeout passed in if it exists, otherwise, continue to use the default
-  e2e.pages.DataSource.alert().contains(expectedAlertMessage, {
-    timeout: timeout ?? e2e.config().defaultCommandTimeout,
-  });
+  e2e.pages.DataSource.alert()
+    .should('exist')
+    .contains(expectedAlertMessage, {
+      timeout: timeout ?? e2e.config().defaultCommandTimeout,
+    });
   e2e().logToConsole('Added data source with name:', name);
 
   return e2e()

--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -13,6 +13,7 @@ export interface AddDataSourceConfig {
   name: string;
   skipTlsVerify: boolean;
   type: string;
+  timeout?: number;
 }
 
 // @todo this actually returns type `Cypress.Chainable<AddDaaSourceConfig>`
@@ -40,6 +41,7 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
     name,
     skipTlsVerify,
     type,
+    timeout,
   } = fullConfig;
 
   e2e().logToConsole('Adding data source with name:', name);
@@ -75,8 +77,12 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
   form();
 
   e2e.pages.DataSource.saveAndTest().click();
-  e2e.pages.DataSource.alert().should('exist').contains(expectedAlertMessage); // assertion
+  e2e.pages.DataSource.alert().should('exist');
 
+  // use the timeout passed in if it exists, otherwise, continue to use the default
+  e2e.pages.DataSource.alert().contains(expectedAlertMessage, {
+    timeout: timeout ?? e2e.config().defaultCommandTimeout,
+  });
   e2e().logToConsole('Added data source with name:', name);
 
   return e2e()


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, our e2e tests for ServiceNow plugin are failing because the alert message check when adding a new datasource needs a bit more time for the plugin health check to complete.

Added support for timeouts to be passed in for the alert message check.

While this is specific example of how it fixes our problem currently, it can also help other plugins in the future with APIs that are slower and requires more time for the assertion check.

- Added optional `timeout` to `AddDataSourceConfig`
- Pass in either the `timeout` passed in if it exists or default command timeout into the alert message assertion 

Example usage of this with our ServiceNow plugin is then:

```
e2e.flows.addDataSource({
    basicAuth: true,
    basicAuthPassword: password,
    basicAuthUser: username,
    checkHealth: true,
    expectedAlertMessage: 'Plugin health check successful',
    form: () => fillUrl(),
    skipTlsVerify: true,
    type: 'ServiceNow',
    timeout: 6000,
});
```

**Before**

If we are unable to change the timeout and it uses the default of 4000, it does not have sufficient time to check the plugin health and update the alert message:

![Screenshot 2021-01-29 at 11 25 33](https://user-images.githubusercontent.com/36230812/106271182-04e07e80-6227-11eb-831b-682b2804e86e.png)

**After**

Passing in the timeout of 6000 now gives it enough time to check the plugin health and update the alert message:

![Screenshot 2021-01-29 at 11 24 51](https://user-images.githubusercontent.com/36230812/106271192-090c9c00-6227-11eb-98ff-50026e5117de.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/plugins-private/issues/601

**Special notes for your reviewer**:

Cypress docs for the `timeout` option: https://docs.cypress.io/api/commands/contains.html#Usage

E2E tests are still passing locally after this change:

![Screenshot 2021-01-29 at 11 39 17](https://user-images.githubusercontent.com/36230812/106271927-1f672780-6228-11eb-8f09-343e0c537042.png)

~~I have another [PR up](https://github.com/grafana/grafana/pull/30644) for updating Cypress to v6 - do we need to wait for that to be merged in before this? This is more of a blocker for our team than the v6 update.~~ This has now been merged.

Thanks! 🙏