### PR TITLE
Modals: Fix closing of modals with escape key

### DIFF
--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -40,7 +40,7 @@ export function Modal(props: PropsWithChildren<Props>): ReturnType<FC<Props>> {
     }
   }, [propsOnDismiss]);
 
-  const onEscKey = (ev: KeyboardEvent): void => {
+  const onEscKey = (ev: KeyboardEvent) => {
     if (ev.key === 'Esc' || ev.key === 'Escape') {
       onDismiss();
     }

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -14,6 +14,7 @@ export interface Props {
   title: string | JSX.Element;
   className?: string;
   contentClassName?: string;
+  closeOnEscape?: boolean;
 
   isOpen?: boolean;
   onDismiss?: () => void;
@@ -27,6 +28,7 @@ export function Modal(props: PropsWithChildren<Props>): ReturnType<FC<Props>> {
     title,
     children,
     isOpen = false,
+    closeOnEscape = true,
     className,
     contentClassName,
     onDismiss: propsOnDismiss,
@@ -47,7 +49,7 @@ export function Modal(props: PropsWithChildren<Props>): ReturnType<FC<Props>> {
   };
 
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && closeOnEscape) {
       document.addEventListener('keydown', onEscKey, false);
     } else {
       document.removeEventListener('keydown', onEscKey, false);
@@ -55,7 +57,7 @@ export function Modal(props: PropsWithChildren<Props>): ReturnType<FC<Props>> {
     return () => {
       document.removeEventListener('keydown', onEscKey, false);
     };
-  }, [isOpen]);
+  }, [closeOnEscape, isOpen]);
 
   if (!isOpen) {
     return null;

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, useCallback } from 'react';
+import React, { FC, PropsWithChildren, useCallback, useEffect } from 'react';
 import { Portal } from '../Portal/Portal';
 import { cx } from 'emotion';
 import { useTheme } from '../../themes';
@@ -39,6 +39,23 @@ export function Modal(props: PropsWithChildren<Props>): ReturnType<FC<Props>> {
       propsOnDismiss();
     }
   }, [propsOnDismiss]);
+
+  const onEscKey = (ev: KeyboardEvent): void => {
+    if (ev.key === 'Esc' || ev.key === 'Escape') {
+      onDismiss();
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', onEscKey, false);
+    } else {
+      document.removeEventListener('keydown', onEscKey, false);
+    }
+    return () => {
+      document.removeEventListener('keydown', onEscKey, false);
+    };
+  }, [isOpen]);
 
   if (!isOpen) {
     return null;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a listener to the grafana ui modal to handle closing by pressing the Esc key. 
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #30592

**Special notes for your reviewer**:
Initial testing suggests this works but I'm not sure if this is the right direction or if we should be making use of the `KeybindingSrv` class to handle this within the Grafana app.
