### PR TITLE
type/build-packaging: Clean upgrades for Windows Installations

### DIFF
--- a/scripts/build/ci-msi-build/Dockerfile
+++ b/scripts/build/ci-msi-build/Dockerfile
@@ -2,7 +2,7 @@ FROM grafana/wix-toolset-ci:v3
 
 RUN mkdir -p /tmp/dist /tmp/cache && \
     cd /tmp/dist && \
-    wget https://dl.grafana.com/enterprise/master/grafana-enterprise-6.6.0-ca61af52pre.windows-amd64.zip && \
+    wget https://dl.grafana.com/oss/release/grafana-7.3.7.windows-amd64.zip && \
     unzip -l *.zip
 
 COPY . /package-grafana

--- a/scripts/build/ci-msi-build/msigenerator/generator/build.py
+++ b/scripts/build/ci-msi-build/msigenerator/generator/build.py
@@ -49,9 +49,9 @@ MSI_GENERATOR_VERSION = '1.0.0'
 #############################
 WIX_HOME = '/home/xclient/wix'
 WINE_CMD = '/usr/bin/wine64'  # or just wine for 32bit
-CANDLE = '{} {}/candle.exe'.format(WINE_CMD, WIX_HOME)
-LIGHT = '{} {}/light.exe'.format(WINE_CMD, WIX_HOME)
-HEAT = '{} {}/heat.exe'.format(WINE_CMD, WIX_HOME)
+CANDLE = '{}/candle.exe'.format(WIX_HOME)
+LIGHT = '{}/light.exe'.format(WIX_HOME)
+HEAT = '{}/heat.exe'.format(WIX_HOME)
 NSSM_VERSION = '2.24'
 DIST_LOCATION = '/tmp/dist'
 #############################
@@ -149,19 +149,27 @@ def build_msi(zip_file, extracted_name, PRODUCT_VERSION, grafana_hash, config, f
     # -cg - component group to be referenced in main wxs file
     # -fr - directory ref to be used in main wxs file
     try:
-        cmd = '''
-          {} dir {} \
-          -platform x64 \
-          -sw5150 \
-          -srd \
-          -cg {} \
-          -gg \
-          -sfrag \
-          -dr {} \
-          -template fragment \
-          -out {}'''.strip().format(HEAT, target_dir_name, cgname, cgdir, outfile)
-        print(cmd)
-        os.system(cmd)
+        result = subprocess.run([
+            WINE_CMD,
+            HEAT,
+            'dir',
+            target_dir_name,
+            '-platform', 
+            'x64',
+            '-sw5150',
+            '-srd',
+            '-cg',
+            cgname,
+            '-gg',
+            '-sfrag',
+            '-dr',
+            cgdir,
+            '-template',
+            'fragment',
+            '-out',
+            outfile
+        ], stdout=subprocess.PIPE)
+        print(result.stdout)
     except Exception as ex:
         print(ex)
 
@@ -186,34 +194,63 @@ def build_msi(zip_file, extracted_name, PRODUCT_VERSION, grafana_hash, config, f
     os.chdir('/tmp/scratch')
     try:
         filename = 'grafana-service.wxs'
-        cmd = '{} -ext WixFirewallExtension -ext WixUtilExtension -v -arch x64 {}'.format(
-            CANDLE, filename)
-        print(cmd)
-        os.system(cmd)
+        result = subprocess.run([
+            WINE_CMD,
+            CANDLE,
+            '-ext',
+            'WixFirewallExtension',
+            '-ext',
+            'WixUtilExtension',
+            '-v',
+            '-arch x64',
+            filename
+        ], stdout=subprocess.PIPE)
+        print(result.stdout)
         shutil.copy2('grafana-service.wixobj', target_dir_name)
         #
         filename = 'grafana-firewall.wxs'
-        cmd = '{} -ext WixFirewallExtension -ext WixUtilExtension -v -arch x64 {}'.format(
+        result = subprocess.run([
+            WINE_CMD,
             CANDLE,
-            filename)
-        print(cmd)
-        os.system(cmd)
+            '-ext',
+            'WixFirewallExtension',
+            '-ext',
+            'WixUtilExtension',
+            '-v',
+            '-arch x64',
+            filename
+        ], stdout=subprocess.PIPE)
+        print(result.stdout)
         shutil.copy2('grafana-firewall.wixobj', target_dir_name)
         #
         filename = 'grafana-oss.wxs'
-        cmd = '{} -ext WixFirewallExtension -ext WixUtilExtension -v -arch x64 {}'.format(
+        result = subprocess.run([
+            WINE_CMD,
             CANDLE,
-            filename)
-        print(cmd)
-        os.system(cmd)
+            '-ext',
+            'WixFirewallExtension',
+            '-ext',
+            'WixUtilExtension',
+            '-v',
+            '-arch x64',
+            filename
+        ], stdout=subprocess.PIPE)
+        print(result.stdout)
         shutil.copy2('grafana-oss.wixobj', target_dir_name)
         #
         filename = 'product.wxs'
-        cmd = '{} -ext WixFirewallExtension -ext WixUtilExtension -v -arch x64 {}'.format(
+        result = subprocess.run([
+            WINE_CMD,
             CANDLE,
-            filename)
-        print(cmd)
-        os.system(cmd)
+            '-ext',
+            'WixFirewallExtension',
+            '-ext',
+            'WixUtilExtension',
+            '-v',
+            '-arch x64',
+            filename
+        ], stdout=subprocess.PIPE)
+        print(result.stdout)
         shutil.copy2('product.wixobj', target_dir_name)
     except Exception as ex:
         print(ex)
@@ -225,8 +262,8 @@ def build_msi(zip_file, extracted_name, PRODUCT_VERSION, grafana_hash, config, f
     os.system('cp -pr nssm/nssm-2.24 .')
     try:
         result = subprocess.run([
-            '/usr/bin/wine64',
-            '/home/xclient/wix/light.exe',
+            WINE_CMD,
+            LIGHT,
             '-cultures:en-US',
             '-ext',
             'WixUIExtension.dll',

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/grafana-service.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/grafana-service.wxs.j2
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
-     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
   <Fragment>
     <ComponentGroup Id="GrafanaServiceX64">
-      <Component Id="nssm_component" Guid="*" Directory="INSTALLDIR">
-        <File Id="nssm" KeyPath="yes" Source="SourceDir\nssm-{{ nssm_version }}\win64\nssm.exe" />
+      <Component Id="nssm_component" Guid="*" Permanent="yes" Directory="INSTALLDIR">
+        <File Id="nssm" KeyPath="yes" Source="SourceDir\nssm-{{ nssm_version }}\win64\nssm.exe"/>
 
         <ServiceInstall Id="ServiceInstall"
           Account="LocalSystem"
@@ -36,7 +36,7 @@
             <RegistryValue Name="AppEnvironmentExtra" Type="multiString">
               <MultiStringValue>LOG_LEVEL=DEBUG</MultiStringValue>
             </RegistryValue>
-         
+
             <RegistryValue Name="AppStdout" Value="[LOGDIR]grafana-service.log" Type="expandable" />
             <RegistryValue Name="AppStderr" Value="[LOGDIR]grafana-service.log" Type="expandable" />
             <RegistryValue Name="AppRotateFiles" Value="1" Type="integer" />

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/grafana-service.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/grafana-service.wxs.j2
@@ -3,8 +3,8 @@
   xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
   <Fragment>
-    <ComponentGroup Id="GrafanaServiceX64">
-      <Component Id="nssm_component" Guid="*" Directory="INSTALLDIR">
+    <ComponentGroup Id="GrafanaServiceX64" Directory="GrafanaServiceX64Dir">
+      <Component Id="nssm_component" Guid="*">
         <File Id="nssm" KeyPath="yes" Source="SourceDir\nssm-{{ nssm_version }}\win64\nssm.exe"/>
 
         <ServiceInstall Id="ServiceInstall"

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/grafana-service.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/grafana-service.wxs.j2
@@ -4,7 +4,7 @@
 
   <Fragment>
     <ComponentGroup Id="GrafanaServiceX64">
-      <Component Id="nssm_component" Guid="*" Permanent="yes" Directory="INSTALLDIR">
+      <Component Id="nssm_component" Guid="*" Directory="INSTALLDIR">
         <File Id="nssm" KeyPath="yes" Source="SourceDir\nssm-{{ nssm_version }}\win64\nssm.exe"/>
 
         <ServiceInstall Id="ServiceInstall"

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
@@ -18,10 +18,6 @@
     <MajorUpgrade
       DowngradeErrorMessage="A newer version of Grafana is already installed. Uninstall the current version to install this older version. Setup will now exit."/>
 
-    <InstallExecuteSequence>
-      <DeleteServices>REMOVE ~= "ALL" AND (NOT UPGRADINGPRODUCTCODE)</DeleteServices>
-    </InstallExecuteSequence>
-
     <Icon Id="icon.ico" SourceFile="grafana_icon.ico"/>
 
     <WixVariable Id="WixUILicenseRtf" Value="{{config.license}}" />
@@ -40,7 +36,10 @@
         <Directory Id="INSTALLDIR" Name="GrafanaLabs">
           {% for feature in features %}
             {% for component_group in feature.component_groups %}
-              <Directory Id="{{component_group.directory}}"/>
+              <Directory
+                Id="{{component_group.directory}}"
+                {% if component_group.dirname|length %} Name="{{component_group.dirname}}-{{config.grafana_version}}" {% endif %}
+                />
             {% endfor %}
           {% endfor %}
         </Directory>

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
@@ -28,7 +28,7 @@
     <Property Id="ARPURLINFOABOUT" Value="https://www.grafana.com" />
 
     <SetProperty Id="ARPINSTALLLOCATION" Value="[ApplicationFolder]"
-          After="CostFinalize" />
+      After="CostFinalize" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder">

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
@@ -12,6 +12,8 @@
       InstallerVersion="200"
       Compressed="yes"
       Comments="Windows Installer Package"/>
+    <MajorUpgrade
+      DowngradeErrorMessage="A newer version of Grafana is already installed. Uninstall the current version to install this older version. Setup will now exit."/>
 
     <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
@@ -24,6 +26,9 @@
     <Property Id="ARPPRODUCTICON" Value="icon.ico" />
     <Property Id="ARPHELPLINK" Value="https://www.grafana.com" />
     <Property Id="ARPURLINFOABOUT" Value="https://www.grafana.com" />
+
+    <SetProperty Id="ARPINSTALLLOCATION" Value="[ApplicationFolder]"
+          After="CostFinalize" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder">
@@ -50,7 +55,5 @@
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
 		<UIRef Id="WixUI_FeatureTree"/>
 
-    <MajorUpgrade
-      DowngradeErrorMessage="A newer version of Grafana is already installed. Uninstall the current version to install this older version. Setup will now exit."/>
   </Product>
 </Wix>

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
@@ -12,10 +12,11 @@
       InstallerVersion="200"
       Compressed="yes"
       Comments="Windows Installer Package"/>
+
+    <MediaTemplate EmbedCab="yes" />
+
     <MajorUpgrade
       DowngradeErrorMessage="A newer version of Grafana is already installed. Uninstall the current version to install this older version. Setup will now exit."/>
-
-    <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
 
     <Icon Id="icon.ico" SourceFile="grafana_icon.ico"/>
 

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
@@ -50,5 +50,7 @@
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
 		<UIRef Id="WixUI_FeatureTree"/>
 
-   </Product>
+    <MajorUpgrade
+      DowngradeErrorMessage="A newer version of Grafana is already installed. Uninstall the current version to install this older version. Setup will now exit."/>
+  </Product>
 </Wix>

--- a/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
+++ b/scripts/build/ci-msi-build/msigenerator/templates/common/product.wxs.j2
@@ -18,6 +18,10 @@
     <MajorUpgrade
       DowngradeErrorMessage="A newer version of Grafana is already installed. Uninstall the current version to install this older version. Setup will now exit."/>
 
+    <InstallExecuteSequence>
+      <DeleteServices>REMOVE ~= "ALL" AND (NOT UPGRADINGPRODUCTCODE)</DeleteServices>
+    </InstallExecuteSequence>
+
     <Icon Id="icon.ico" SourceFile="grafana_icon.ico"/>
 
     <WixVariable Id="WixUILicenseRtf" Value="{{config.license}}" />


### PR DESCRIPTION
**What this PR does / why we need it**:

Current MSI will leave remnants of old versions in the installation log, and can allow old versions to remove the current version.

* This change implements a "major upgrade" which leaves just one item in Add/Remove Programs
* Also separates the nssm service into a unique component per version which will upgraded  and uninstalled cleanly.
* converted wix calls to subprocess for easier debugging

**Which issue(s) this PR fixes**:

Fixes #26423

**Special notes for your reviewer**:

There is still an issue with 2 files being too long during testing, but did not show up in CI builds.

```
public/build/default~DataSourceDashboards~DataSourceSettingsPage~DataSourcesListPage~NewDataSourcePage.ddf7518003180e1ca7bc.js
public/build/default~DataSourceDashboards~DataSourceSettingsPage~DataSourcesListPage~NewDataSourcePage.ddf7518003180e1ca7bc.js.map
```
