### PR TITLE
InfluxDB: Fix width of variable query editor 

### DIFF
--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, PureComponent } from 'react';
+import { css } from 'emotion';
 import { MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { InlineField, InlineFieldRow, VerticalGroup } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
@@ -197,7 +198,14 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
               </InlineField>
               <QueryVariableRefreshSelect onChange={this.onRefreshChange} refresh={this.props.variable.refresh} />
             </InlineFieldRow>
-            <div style={{ flexDirection: 'column' }}>{this.renderQueryEditor()}</div>
+            <div
+              className={css`
+                flex-direction: column;
+                width: 100%;
+              `}
+            >
+              {this.renderQueryEditor()}
+            </div>
             <VariableTextField
               value={this.state.regex ?? this.props.variable.regex}
               name="Regex"


### PR DESCRIPTION
**What this PR does / why we need it**:
In 7.3.7 Flux variables query editor has full width:
![image](https://user-images.githubusercontent.com/30407135/106465508-52b0ed00-649a-11eb-8c77-c264d33fc8c1.png)

In 7.4-beta, Flux and Influx variables query editor don't have full width :
![image](https://user-images.githubusercontent.com/30407135/106465716-a3c0e100-649a-11eb-83e7-bf997920b3c0.png)
![image](https://user-images.githubusercontent.com/30407135/106468158-dae4c180-649d-11eb-8c53-272d433aaa31.png)

This is probably related to https://github.com/grafana/grafana/pull/29542 refactor. 

This PR fixes this by setting the width of `<div>` that is wrapping variables query editor to 100%. I have tested if this doesn't break other variable editors and there wasn't any problem. Moreover, I have found that this was not just a problem with Flux, but with all of the custom variable query editors (e.g. Influx). Most of the other internal data sources (prometheus, loki, elastic, graphite,...) use **LegacyVariableQueryEditor** that wasn't affected by this change.

Fixed:
![image](https://user-images.githubusercontent.com/30407135/106468231-f354dc00-649d-11eb-8322-f1ccfd3e142b.png)
![image](https://user-images.githubusercontent.com/30407135/106468267-fe0f7100-649d-11eb-9c7a-5370a44794df.png)
![image](https://user-images.githubusercontent.com/30407135/106468294-05367f00-649e-11eb-9a66-8776ff73721b.png)
![image](https://user-images.githubusercontent.com/30407135/106468324-0f587d80-649e-11eb-9944-be3344014af6.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/30622

**Special notes for your reviewer**:

