### PR TITLE
GraphNG: improve behavior when switching between solid/dash/dots

### DIFF
--- a/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
+++ b/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
@@ -73,9 +73,16 @@ export const LineStyleEditor: React.FC<FieldOverrideEditorProps<LineStyle, any>>
         value={value?.fill || 'solid'}
         options={lineFillOptions}
         onChange={(v) => {
+          let dash: number[] | undefined = undefined;
+          if (v === 'dot') {
+            dash = parseText(dotOptions[0].value!);
+          } else if (v === 'dash') {
+            dash = parseText(dashOptions[0].value!);
+          }
           onChange({
             ...value,
             fill: v!,
+            dash,
           });
         }}
       />


### PR DESCRIPTION
When switching between dash/dots, we also need to update the spacing -- this PR updates the segment spacing when the mode changes