### PR TITLE
BarChart: inside-align strokes, upgrade uPlot to 1.6.4.

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -72,7 +72,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.3"
+    "uplot": "1.6.4"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/packages/grafana-ui/src/components/BarChart/BarChart.tsx
+++ b/packages/grafana-ui/src/components/BarChart/BarChart.tsx
@@ -165,8 +165,10 @@ export const BarChart: React.FunctionComponent<Props> = ({
 
       builder.addSeries({
         scaleKey,
+        pxAlign: false,
         lineWidth: customConfig.lineWidth,
         lineColor: seriesColor,
+        //lineStyle: customConfig.lineStyle,
         fillOpacity: customConfig.fillOpacity,
         theme,
         colorMode,
@@ -175,12 +177,6 @@ export const BarChart: React.FunctionComponent<Props> = ({
         show: !customConfig.hideFrom?.graph,
         gradientMode: customConfig.gradientMode,
         thresholds: field.config.thresholds,
-
-        /*
-          lineColor: customConfig.lineColor ?? seriesColor,
-          lineWidth: customConfig.lineWidth,
-          lineStyle: customConfig.lineStyle,
-          */
 
         // The following properties are not used in the uPlot config, but are utilized as transport for legend config
         dataFrameFieldIndex: {

--- a/packages/grafana-ui/src/components/BarChart/bars.ts
+++ b/packages/grafana-ui/src/components/BarChart/bars.ts
@@ -64,6 +64,7 @@ export function getConfig(opts: BarsOptions) {
       sidx,
       (series, dataX, dataY, scaleX, scaleY, valToPosX, valToPosY, xOff, yOff, xDim, yDim, moveTo, lineTo, rect) => {
         const fill = new Path2D();
+        const stroke = new Path2D();
 
         let numGroups = dataX.length;
         let barsPerGroup = u.series.length - 1;
@@ -83,6 +84,12 @@ export function getConfig(opts: BarsOptions) {
             let top = Math.round(Math.min(yPos, y0Pos));
             let barHgt = btm - top;
 
+            let strokeWidth = series.width || 0;
+
+            if (strokeWidth) {
+              rect(stroke, lft + strokeWidth / 2, top + strokeWidth / 2, barWid - strokeWidth, barHgt - strokeWidth);
+            }
+
             rect(fill, lft, top, barWid, barHgt);
 
             let x = ori === 0 ? Math.round(lft - xOff) : Math.round(top - yOff);
@@ -95,7 +102,7 @@ export function getConfig(opts: BarsOptions) {
         });
 
         return {
-          stroke: fill,
+          stroke,
           fill,
         };
       }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -469,6 +469,7 @@ describe('UPlotConfigBuilder', () => {
               "size": 5,
               "stroke": "#00ff00",
             },
+            "pxAlign": undefined,
             "scale": "scale-x",
             "show": true,
             "spanGaps": false,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -17,6 +17,7 @@ import { getHueGradientFn, getOpacityGradientFn, getScaleGradientFn } from './gr
 
 export interface SeriesProps extends LineConfig, BarConfig, FillConfig, PointsConfig {
   scaleKey: string;
+  pxAlign?: boolean;
   gradientMode?: GraphGradientMode;
   /** Used when gradientMode is set to Scheme */
   thresholds?: ThresholdsConfig;
@@ -46,6 +47,7 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
       pointColor,
       pointSize,
       scaleKey,
+      pxAlign,
       spanNulls,
       show = true,
     } = this.props;
@@ -103,6 +105,7 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
     return {
       scale: scaleKey,
       spanGaps: spanNulls,
+      pxAlign,
       show,
       fill: this.getFill(),
       ...lineConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -26041,10 +26041,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.3.tgz#85b21f59b2e9db24976aa688cb267d950dfa45b5"
-  integrity sha512-aSqtBqJRqO7KkuZxRxVGumDi7+293HsBCdzg9HbOYkRZ8lxf2utLpkAu4oljejlwYy1zrn7DXBSvcZ5wnWig9w==
+uplot@1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.4.tgz#016e9f66796d78c187957e710743f7ca405dfb4d"
+  integrity sha512-4d6JixG54HQKFDLAegzwgwf87GtEbp6pt3YlHygyLt+mJ9RHneCXYlZxr1QOhLetoSSHeeDuWP5RFMv8mdltpg==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
prior to this PR, the BarChart stroke was center-aligned to the bar edge, so if it was wide, it would run into neighboring bars and the value text. this aligns the stroke inside (see below). also, the bars would become blurry at odd stroke widths due to the way uPlot tries to align line paths, this adds a new opt-out called `pxAlign`, so we can maintain bar crispness at all stroke widths.

uPlot gets bumped to 1.6.4. nothing too risky in this changelog, but please test all the panels just in case!

https://github.com/leeoniya/uPlot/releases/tag/1.6.4

the bump also fixes a bug that affects fillBelowTo for bars and dominik's stacking PR, where the bar strokes were not clipped to the proper level (the fill was clipped correctly).

![image](https://user-images.githubusercontent.com/43234/106547702-53b24080-64d3-11eb-9a91-203088258611.png)
