### PR TITLE
Prometheus: Fix showing of wrong label values in table

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -1,4 +1,4 @@
-import { DataFrame } from '@grafana/data';
+import { DataFrame, FieldType } from '@grafana/data';
 import { transform } from './result_transformer';
 
 jest.mock('@grafana/runtime', () => ({
@@ -101,15 +101,20 @@ describe('Prometheus Result Transformer', () => {
         1443454531000,
       ]);
       expect(result[0].fields[0].name).toBe('Time');
+      expect(result[0].fields[0].type).toBe(FieldType.time);
       expect(result[0].fields[1].values.toArray()).toEqual(['test', 'test', 'test2', 'test2']);
       expect(result[0].fields[1].name).toBe('__name__');
       expect(result[0].fields[1].config.filterable).toBe(true);
+      expect(result[0].fields[1].type).toBe(FieldType.string);
       expect(result[0].fields[2].values.toArray()).toEqual(['', '', 'localhost:8080', 'localhost:8080']);
       expect(result[0].fields[2].name).toBe('instance');
+      expect(result[0].fields[2].type).toBe(FieldType.string);
       expect(result[0].fields[3].values.toArray()).toEqual(['testjob', 'testjob', 'otherjob', 'otherjob']);
       expect(result[0].fields[3].name).toBe('job');
+      expect(result[0].fields[3].type).toBe(FieldType.string);
       expect(result[0].fields[4].values.toArray()).toEqual([3846, 3848, 3847, 3849]);
       expect(result[0].fields[4].name).toEqual('Value');
+      expect(result[0].fields[4].type).toBe(FieldType.number);
       expect(result[0].refId).toBe('A');
     });
 
@@ -168,6 +173,7 @@ describe('Prometheus Result Transformer', () => {
       };
       const result = transform({ data: response } as any, { ...options, target: { format: 'table' } });
       expect(result[0].fields[1].values.toArray()).toEqual([102]);
+      expect(result[0].fields[1].type).toEqual(FieldType.number);
     });
   });
 

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -299,10 +299,13 @@ function transformMetricDataToTable(md: MatrixOrVectorResult[], options: Transfo
   const metricFields = Object.keys(md.reduce((acc, series) => ({ ...acc, ...series.metric }), {}))
     .sort()
     .map((label) => {
+      // Labels have string field type, otherwise table tries to figure out the type which can result in unexpected results
+      // Only "le" label has a number field type
+      const numberField = label === 'le';
       return {
         name: label,
         config: { filterable: true },
-        type: FieldType.other,
+        type: numberField ? FieldType.number : FieldType.string,
         values: new ArrayVector(),
       };
     });


### PR DESCRIPTION
**What this PR does / why we need it**:
In current implementation, we are setting the type of field to `other` and then use `guessFieldTypeForField` to figure out the type from values. This resulted in a lot of unexpected results - see the issues below.  

This PR fixes it by setting the field type to be string, as we know that labels are basically strings.  The only exception is the `le` label, so the implementation is considering this. I have also added tests.

Current master - see wrong results in **number** column (shouldn't be NaN) and in the **boolean** column (job=prometheus3 doesn't have boolean label):
![image](https://user-images.githubusercontent.com/30407135/106618318-9aee0f00-656f-11eb-88e7-64168688bbf6.png)

With the fix - showing correct label values:
![image](https://user-images.githubusercontent.com/30407135/106618124-785bf600-656f-11eb-8f6d-684f1fb77743.png)

**Which issue(s) this PR fixes**:

Fixes: 
https://github.com/grafana/grafana/issues/29598
https://github.com/grafana/grafana/issues/29342

**Special notes for your reviewer**:

