### PR TITLE
Added "Restart Grafana" topic.

### DIFF
--- a/docs/sources/enterprise/activate-license.md
+++ b/docs/sources/enterprise/activate-license.md
@@ -80,7 +80,6 @@ GF_SERVER_ROOT_URL=https://grafana.blah.com/
 ## Step 4. Restart Grafana
 
 To finalize the installation of Grafana Enterprise, restart Grafana to
-enable all Grafana Enterprise features.
+enable all Grafana Enterprise features. Refer to [restart Grafana]({{< relref "../installation/restart-grafana.md" >}})
+topic for more information.
 
-On Linux, when installed as a Systemd service you can restart Grafana
-by running `sudo systemctl restart grafana-server.service`.

--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -17,5 +17,5 @@ This section discusses the hardware and software requirements as well as the pro
 - [Install on Windows]({{< relref "windows" >}})
 - [Run Docker image]({{< relref "docker" >}})
 
-Refer to [Upgrade Grafana]({{< relref "upgrading.md" >}}) topic. If you need to restart Grafana, refer to the [restart Grafana]({{< relref "Restart-grafana.md" >}})
+Refer to [Upgrade Grafana]({{< relref "upgrading.md" >}}) topic. If you need to restart Grafana, refer to the [Restart Grafana]({{< relref "Restart-grafana.md" >}})
 topic for detailed information.

--- a/docs/sources/installation/_index.md
+++ b/docs/sources/installation/_index.md
@@ -17,3 +17,5 @@ This section discusses the hardware and software requirements as well as the pro
 - [Install on Windows]({{< relref "windows" >}})
 - [Run Docker image]({{< relref "docker" >}})
 
+Refer to [Upgrade Grafana]({{< relref "upgrading.md" >}}) topic. If you need to restart Grafana, refer to the [restart Grafana]({{< relref "Restart-grafana.md" >}})
+topic for detailed information.

--- a/docs/sources/installation/restart-grafana.md
+++ b/docs/sources/installation/restart-grafana.md
@@ -7,7 +7,7 @@ weight = 750
 
 # Restart Grafana
 
-Users often need to restart the Grafana service after they have made configuration changes. This topic provides detailed instructions on how to restart the service on supported operating systems.
+Users often need to restart Grafana after they have made configuration changes. This topic provides detailed instructions on how to restart Grafana supported operating systems.
 
 - [Windows](#windows)
 - [MacOS](#macos)
@@ -24,18 +24,25 @@ To restart Grafana:
 
 ## macOS
 
-To restart Grafana that was installed using standalone macOS binaries:
+Restart methods differ depending on whether you installed Grafana using Homebrew or as standalone macOS binaries.
 
-1. Open a terminal and go to the directory where you copied the install setup files. 
+### Restart Grafana using Homebrew
+
+Use the [Homebrew](http://brew.sh/) restart command:
+
+```bash
+brew services restart grafana`
+```
+### Restart standalone macOS binaries
+
+To restart Grafana:
+
+1. Open a terminal and go to the directory where you copied the install setup files.
 1. Run the command:
 
 ```bash
 ./bin/grafana-server web
 ```
-
-If you installed Grafana using [Homebrew](http://brew.sh/), use rge restart command:
-
-`brew services restart grafana`
 ## Linux
 
 Restart methods differ depending on whether your Linux system uses `systemd` or `init.d`.
@@ -82,7 +89,7 @@ sudo update-rc.d grafana-server defaults
 ```
 ## Docker
 
-To restart the Grafana service, use the `docker restart` command. For example:
+To restart the Grafana service, use the `docker restart` command.
 
 `docker restart grafana`
 
@@ -101,7 +108,8 @@ grafana:
     - TERM=linux
     - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-piechart-panel,grafana-polystat-panel
 ```
-Start the server using this command:
+
+Start the Grafana server:
 
 `docker-compose up`
 

--- a/docs/sources/installation/restart-grafana.md
+++ b/docs/sources/installation/restart-grafana.md
@@ -1,6 +1,6 @@
 +++
 title = "Restart Grafana"
-description = "Installation guide for Grafana"
+description = "Instructions for restarting Grafana"
 keywords = ["grafana", "restart", "documentation"]
 weight = 750
 +++
@@ -11,7 +11,7 @@ Users often need to restart the Grafana service after they have made configurati
 
 - [Windows](#windows)
 - [MacOS](#macos)
-- [Linux](linux)
+- [Linux](#linux)
 - [Docker](#docker)
 
 ## Windows
@@ -19,21 +19,26 @@ Users often need to restart the Grafana service after they have made configurati
 To restart Grafana:
 
 1. Open the Services app.
-2. Right-click on the **Grafana** service.
-3. In the context menu, click **Restart**.
+1. Right-click on the **Grafana** service.
+1. In the context menu, click **Restart**.
 
 ## macOS
 
-To restart Grafana, go to the directory where you copied the install setup files. Then run the command:
+To restart Grafana that was installed using standalone macOS binaries:
+
+1. Open a terminal and go to the directory where you copied the install setup files. 
+1. Run the command:
 
 ```bash
 ./bin/grafana-server web
 ```
 
+If you installed Grafana using [Homebrew](http://brew.sh/), use rge restart command:
 
+`brew services restart grafana`
 ## Linux
 
-These instructions are applicable for restarting Grafana installed on Debian or Ubuntu, as well as on the RPM-based Linux systems (CentOS, Fedora, OpenSuse, Red Hat).
+Restart methods differ depending on whether your Linux system uses `systemd` or `init.d`.
 
 ### Restart the server with systemd
 
@@ -77,15 +82,13 @@ sudo update-rc.d grafana-server defaults
 ```
 ## Docker
 
-To restart the Grafana service, use the `docker run` command. For example:
+To restart the Grafana service, use the `docker restart` command. For example:
 
-`docker run -d -p 3000:3000 --name grafana grafana/grafana:latest`
+`docker restart grafana`
 
-This will restart the Grafana service and run it in the background.
+Alternately, you can use the `docker compose restart` command to restart Grafana. For more information, refer to [docker compose documentation](https://docs.docker.com/compose/).
 
-Alternately, you can use the `docker compose` command to restart Grafana. For more information, refer to [docker compose documentation](https://docs.docker.com/compose/).
-
-### An example of using docker compose
+### Docker compose example
 
 Configure your `docker-compose.yml` file. For example:
 
@@ -98,9 +101,12 @@ grafana:
     - TERM=linux
     - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-piechart-panel,grafana-polystat-panel
 ```
-Run the command:
+Start the server using this command:
 
 `docker-compose up`
 
-Grafana along with the three plugins specified in the YAML file are up and running.
+This starts the Grafana server along with the three plugins specified in the YAML file.
 
+To restart the running container, use this command:
+
+`docker-compose restart grafana`

--- a/docs/sources/installation/restart-grafana.md
+++ b/docs/sources/installation/restart-grafana.md
@@ -2,64 +2,105 @@
 title = "Restart Grafana"
 description = "Installation guide for Grafana"
 keywords = ["grafana", "restart", "documentation"]
-weight = 30
+weight = 750
 +++
 
 # Restart Grafana
 
-This topic will help you the restart Grafana. The process of restarting Grafana on different operating systems are . This section has the following topics:
+Users often need to restart the Grafana service after they have made configuration changes. This topic provides detailed instructions on how to restart the service on supported operating systems.
 
-- [Requirements]({{< relref "requirements" >}})
-- [Install on Debian or Ubuntu]({{< relref "debian" >}})
-- [Install on RPM-based Linux (CentOS, Fedora, OpenSuse, RedHat)]({{< relref "rpm" >}})
-- [Install on macOS]({{< relref "mac" >}})
-- [Install on Windows]({{< relref "windows" >}})
-- [Run Docker image]({{< relref "docker" >}})
+- [Windows](#windows)
+- [MacOS](#macos)
+- [Linux](linux)
+- [Docker](#docker)
 
-## On Linux (Debian or Ubuntu)
+## Windows
 
-### Start the server with init.d
+To restart Grafana:
 
-To restart the service and verify that it has started:
+1. Open the Services app.
+2. Right-click on the **Grafana** service.
+3. In the context menu, click **Restart**.
+
+## macOS
+
+To restart Grafana, go to the directory where you copied the install setup files. Then run the command:
 
 ```bash
-    sudo service grafana-server start
-    sudo service grafana-server status
+./bin/grafana-server web
 ```
 
-Alternately, you can configure the Grafana server to restart at boot:
+
+## Linux
+
+These instructions are applicable for restarting Grafana installed on Debian or Ubuntu, as well as on the RPM-based Linux systems (CentOS, Fedora, OpenSuse, Red Hat).
+
+### Restart the server with systemd
+
+To restart the service and verify that the service has started, run the following commands:
 
 ```bash
-sudo update-rc.d grafana-server defaults
-```
-
-### Start the server with systemd
-
-To start the service and verify that the service has started:
-
-```bash
-sudo systemctl start grafana-server
+sudo systemctl restart grafana-server
 sudo systemctl status grafana-server
 ```
 
-Configure the Grafana server to start at boot:
+Alternately, you can configure the Grafana server to restart at boot:
 
 ```bash
 sudo systemctl enable grafana-server.service
 ```
 
+> **Note:** SUSE or OpenSUSE users may need to start the server with the systemd method, then use the init.d method to configure Grafana to start at boot.
+
+### Restart the server with init.d
+
+To restart the service, run the following command:
+
+`sudo service grafana-server restart`
+
+or
+
+`sudo /etc/init.d/grafana-server restart`
+
+Verify the status:
+
+`sudo service grafana-server status`
+
+or
+
+`sudo /etc/init.d/grafana-server status`
+
 Alternately, you can configure the Grafana server to restart at boot:
 
 ```bash
 sudo update-rc.d grafana-server defaults
 ```
+## Docker
 
-## On macOS
+To restart the Grafana service, use the `docker run` command. For example:
 
-To restart Grafana, , go to the directory and run the command: 
+`docker run -d -p 3000:3000 --name grafana grafana/grafana:latest`
+
+This will restart the Grafana service and run it in the background.
+
+Alternately, you can use the `docker compose` command to restart Grafana. For more information, refer to [docker compose documentation](https://docs.docker.com/compose/).
+
+### An example of using docker compose
+
+Configure your `docker-compose.yml` file. For example:
 
 ```bash
-    ./bin/grafana-server web
+grafana:
+  image: grafana/grafana:latest
+  ports:
+    - "3000:3000"
+  environment:
+    - TERM=linux
+    - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-piechart-panel,grafana-polystat-panel
 ```
+Run the command:
 
+`docker-compose up`
+
+Grafana along with the three plugins specified in the YAML file are up and running.
 

--- a/docs/sources/installation/restart-grafana.md
+++ b/docs/sources/installation/restart-grafana.md
@@ -1,0 +1,65 @@
++++
+title = "Restart Grafana"
+description = "Installation guide for Grafana"
+keywords = ["grafana", "restart", "documentation"]
+weight = 30
++++
+
+# Restart Grafana
+
+This topic will help you the restart Grafana. The process of restarting Grafana on different operating systems are . This section has the following topics:
+
+- [Requirements]({{< relref "requirements" >}})
+- [Install on Debian or Ubuntu]({{< relref "debian" >}})
+- [Install on RPM-based Linux (CentOS, Fedora, OpenSuse, RedHat)]({{< relref "rpm" >}})
+- [Install on macOS]({{< relref "mac" >}})
+- [Install on Windows]({{< relref "windows" >}})
+- [Run Docker image]({{< relref "docker" >}})
+
+## On Linux (Debian or Ubuntu)
+
+### Start the server with init.d
+
+To restart the service and verify that it has started:
+
+```bash
+    sudo service grafana-server start
+    sudo service grafana-server status
+```
+
+Alternately, you can configure the Grafana server to restart at boot:
+
+```bash
+sudo update-rc.d grafana-server defaults
+```
+
+### Start the server with systemd
+
+To start the service and verify that the service has started:
+
+```bash
+sudo systemctl start grafana-server
+sudo systemctl status grafana-server
+```
+
+Configure the Grafana server to start at boot:
+
+```bash
+sudo systemctl enable grafana-server.service
+```
+
+Alternately, you can configure the Grafana server to restart at boot:
+
+```bash
+sudo update-rc.d grafana-server defaults
+```
+
+## On macOS
+
+To restart Grafana, , go to the directory and run the command: 
+
+```bash
+    ./bin/grafana-server web
+```
+
+

--- a/docs/sources/installation/restart-grafana.md
+++ b/docs/sources/installation/restart-grafana.md
@@ -31,7 +31,7 @@ Restart methods differ depending on whether you installed Grafana using Homebrew
 Use the [Homebrew](http://brew.sh/) restart command:
 
 ```bash
-brew services restart grafana`
+brew services restart grafana
 ```
 ### Restart standalone macOS binaries
 
@@ -68,19 +68,27 @@ sudo systemctl enable grafana-server.service
 
 To restart the service, run the following command:
 
-`sudo service grafana-server restart`
+```bash
+sudo service grafana-server restart
+```
 
 or
 
-`sudo /etc/init.d/grafana-server restart`
+```bash
+sudo /etc/init.d/grafana-server restart
+```
 
 Verify the status:
 
-`sudo service grafana-server status`
+```bash
+sudo service grafana-server status
+```
 
 or
 
-`sudo /etc/init.d/grafana-server status`
+```bash
+sudo /etc/init.d/grafana-server status
+```
 
 Alternately, you can configure the Grafana server to restart at boot:
 


### PR DESCRIPTION
New topic has separate sections on how to restart Grafana on Windows, macOS, Linux, and Docker.

Also, updated "Activate an Enterprise license" topic to refer to the new restart Grafana topic.

Fixed and added relrefs.

I referred to these pages: https://phoenixnap.com/kb/ubuntu-start-stop-restart-apache and https://www.geeksforgeeks.org/what-is-init-d-in-linux-service-management/.