### PR TITLE
Chore: add more docs annotations

### DIFF
--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -1,6 +1,9 @@
 import { MutableVector } from '../types/vector';
 import { FunctionalVector } from './FunctionalVector';
 
+/**
+ * @public
+ */
 export class ArrayVector<T = any> extends FunctionalVector<T> implements MutableVector<T> {
   buffer: T[];
 

--- a/packages/grafana-data/src/vector/AsNumberVector.ts
+++ b/packages/grafana-data/src/vector/AsNumberVector.ts
@@ -1,6 +1,11 @@
 import { Vector } from '../types';
 import { FunctionalVector } from './FunctionalVector';
 
+/**
+ * This will force all values to be numbers
+ *
+ * @public
+ */
 export class AsNumberVector extends FunctionalVector<number> {
   constructor(private field: Vector) {
     super();

--- a/packages/grafana-data/src/vector/BinaryOperationVector.ts
+++ b/packages/grafana-data/src/vector/BinaryOperationVector.ts
@@ -2,6 +2,9 @@ import { Vector } from '../types/vector';
 import { vectorToArray } from './vectorToArray';
 import { BinaryOperation } from '../utils/binaryOperators';
 
+/**
+ * @public
+ */
 export class BinaryOperationVector implements Vector<number> {
   constructor(private left: Vector<number>, private right: Vector<number>, private operation: BinaryOperation) {}
 

--- a/packages/grafana-data/src/vector/CircularVector.ts
+++ b/packages/grafana-data/src/vector/CircularVector.ts
@@ -14,6 +14,8 @@ interface CircularOptions<T> {
  *
  * This supports adding to the 'head' or 'tail' and will grow the buffer
  * to match a configured capacity.
+ *
+ * @public
  */
 export class CircularVector<T = any> extends FunctionalVector<T> implements MutableVector<T> {
   private buffer: T[];

--- a/packages/grafana-data/src/vector/ConstantVector.ts
+++ b/packages/grafana-data/src/vector/ConstantVector.ts
@@ -1,5 +1,8 @@
 import { Vector } from '../types/vector';
 
+/**
+ * @public
+ */
 export class ConstantVector<T = any> implements Vector<T> {
   constructor(private value: T, private len: number) {}
 

--- a/packages/grafana-data/src/vector/FormattedVector.ts
+++ b/packages/grafana-data/src/vector/FormattedVector.ts
@@ -1,10 +1,15 @@
 import { Vector } from '../types/vector';
 import { DisplayProcessor } from '../types';
 import { formattedValueToString } from '../valueFormats';
-import { vectorToArray } from './vectorToArray';
+import { FunctionalVector } from './FunctionalVector';
 
-export class FormattedVector<T = any> implements Vector<string> {
-  constructor(private source: Vector<T>, private formatter: DisplayProcessor) {}
+/**
+ * @public
+ */
+export class FormattedVector<T = any> extends FunctionalVector<string> {
+  constructor(private source: Vector<T>, private formatter: DisplayProcessor) {
+    super();
+  }
 
   get length() {
     return this.source.length;
@@ -13,13 +18,5 @@ export class FormattedVector<T = any> implements Vector<string> {
   get(index: number): string {
     const v = this.source.get(index);
     return formattedValueToString(this.formatter(v));
-  }
-
-  toArray(): string[] {
-    return vectorToArray(this);
-  }
-
-  toJSON(): string[] {
-    return this.toArray();
   }
 }


### PR DESCRIPTION
Master and 7.4x are failing because the docs are missing annotations -- given the commit order, green checks in PRs did not prevent the annotation count regression.

This adds a few simple annotations