### PR TITLE
Variables: Adds queryparam formatting option

### DIFF
--- a/devenv/dev-dashboards/feature-templating/global-variables-and-interpolation.json
+++ b/devenv/dev-dashboards/feature-templating/global-variables-and-interpolation.json
@@ -27,14 +27,14 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 16,
+        "h": 18,
         "w": 24,
         "x": 0,
         "y": 0
       },
       "id": 11,
       "options": {
-        "content": "## Global variables\n\n* `__dashboard` = `${__dashboard}`\n* `__dashboard.name` = `${__dashboard.name}`\n* `__dashboard.uid` = `${__dashboard.uid}`\n* `__org.name` = `${__org.name}`\n* `__org.id` = `${__org.id}`\n* `__user.id` = `${__user.id}`\n* `__user.login` = `${__user.login}`\n* `__user.email` = `${__user.email}`\n         \n## Formats\n\n* `Server:raw` = `${Server:raw}`\n* `Server:regex` = `${Server:regex}`\n* `Server:lucene` = `${Server:lucene}`\n* `Server:glob` = `${Server:glob}`\n* `Server:pipe` = `${Server:pipe}`\n* `Server:distributed` = `${Server:distributed}`\n* `Server:csv` = `${Server:csv}`\n* `Server:html` = `${Server:html}`\n* `Server:json` = `${Server:json}`\n* `Server:percentencode` = `${Server:percentencode}`\n* `Server:singlequote` = `${Server:singlequote}`\n* `Server:doublequote` = `${Server:doublequote}`\n* `Server:sqlstring` = `${Server:sqlstring}`\n* `Server:date` = `${Server:date}`\n* `Server:text` = `${Server:text}`\n\n",
+        "content": "## Global variables\n\n* `__dashboard` = `${__dashboard}`\n* `__dashboard.name` = `${__dashboard.name}`\n* `__dashboard.uid` = `${__dashboard.uid}`\n* `__org.name` = `${__org.name}`\n* `__org.id` = `${__org.id}`\n* `__user.id` = `${__user.id}`\n* `__user.login` = `${__user.login}`\n* `__user.email` = `${__user.email}`\n         \n## Formats\n\n* `Server:raw` = `${Server:raw}`\n* `Server:regex` = `${Server:regex}`\n* `Server:lucene` = `${Server:lucene}`\n* `Server:glob` = `${Server:glob}`\n* `Server:pipe` = `${Server:pipe}`\n* `Server:distributed` = `${Server:distributed}`\n* `Server:csv` = `${Server:csv}`\n* `Server:html` = `${Server:html}`\n* `Server:json` = `${Server:json}`\n* `Server:percentencode` = `${Server:percentencode}`\n* `Server:singlequote` = `${Server:singlequote}`\n* `Server:doublequote` = `${Server:doublequote}`\n* `Server:sqlstring` = `${Server:sqlstring}`\n* `Server:date` = `${Server:date}`\n* `Server:text` = `${Server:text}`\n* `Server:queryparam` = `${Server:queryparam}`\n\n",
         "mode": "markdown"
       },
       "pluginVersion": "7.1.0",

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -49,6 +49,6 @@ Value-specific variables are available under ``__value`` namespace:
 
 When linking to another dashboard that uses template variables, select variable values for whoever clicks the link.
 
-``var-myvar=${myvar}`` - where ``myvar`` is a name of the template variable that matches one in the current dashboard that you want to use.
+``${myvar:queryparams}`` - where ``myvar`` is a name of the template variable that matches one in the current dashboard that you want to use.
 
 If you want to add all of the current dashboard's variables to the URL, then use  ``__all_variables``.

--- a/docs/sources/variables/advanced-variable-format-options.md
+++ b/docs/sources/variables/advanced-variable-format-options.md
@@ -150,9 +150,9 @@ String to interpolate: '${servers:text}'
 Interpolation result: "test1 + test2"
 ```
 
-## Query Parameters
+## Query parameters
 
-Formats single- and multi-valued variables into their query parameter representation like `var-foo=value1&var-foo=value2`.
+Formats single- and multi-valued variables into their query parameter representation. Example: `var-foo=value1&var-foo=value2`
 
 ```bash
 servers = ["test1", "test2"]

--- a/docs/sources/variables/advanced-variable-format-options.md
+++ b/docs/sources/variables/advanced-variable-format-options.md
@@ -149,3 +149,13 @@ servers = ["test1", "test2"]
 String to interpolate: '${servers:text}'
 Interpolation result: "test1 + test2"
 ```
+
+## Query Parameters
+
+Formats single- and multi-valued variables into their query parameter representation like `var-foo=value1&var-foo=value2`.
+
+```bash
+servers = ["test1", "test2"]
+String to interpolate: '${servers:queryparam}'
+Interpolation result: "var-servers=test1&var-servers=test2"
+```

--- a/e2e/suite1/specs/dashboard-templating.spec.ts
+++ b/e2e/suite1/specs/dashboard-templating.spec.ts
@@ -35,11 +35,12 @@ e2e.scenario({
       `Server:sqlstring = 'A''A"A','BB\\\B','CCC'`,
       `Server:date = null`,
       `Server:text = All`,
+      `Server:queryparam = var-Server=All`,
     ];
 
     e2e()
       .get('.markdown-html li')
-      .should('have.length', 23)
+      .should('have.length', 24)
       .each((element) => {
         items.push(element.text());
       })

--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useMemo, useContext, useRef, RefObject, memo, useEffect } from 'react';
+import React, { memo, RefObject, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import usePrevious from 'react-use/lib/usePrevious';
 import { DataLinkSuggestions } from './DataLinkSuggestions';
-import { ThemeContext, makeValue } from '../../index';
+import { makeValue, ThemeContext } from '../../index';
 import { SelectionReference } from './SelectionReference';
-import { Portal, getFormStyles } from '../index';
+import { getFormStyles, Portal } from '../index';
 
 // @ts-ignore
 import Prism, { Grammar, LanguageMap } from 'prismjs';
@@ -16,7 +16,7 @@ import { css, cx } from 'emotion';
 import { SlatePrism } from '../../slate-plugins';
 import { SCHEMA } from '../../utils/slate';
 import { stylesFactory } from '../../themes';
-import { GrafanaTheme, VariableSuggestion, VariableOrigin, DataLinkBuiltInVars } from '@grafana/data';
+import { DataLinkBuiltInVars, GrafanaTheme, VariableOrigin, VariableSuggestion } from '@grafana/data';
 
 const modulo = (a: number, n: number) => a - n * Math.floor(a / n);
 
@@ -130,7 +130,7 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
       if (item.origin !== VariableOrigin.Template || item.value === DataLinkBuiltInVars.includeVars) {
         editor.insertText(`${includeDollarSign ? '$' : ''}\{${item.value}}`);
       } else {
-        editor.insertText(`var-${item.value}=$\{${item.value}}`);
+        editor.insertText(`\${${item.value}:queryparam}`);
       }
 
       setLinkUrl(editor.value);

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -1,6 +1,11 @@
 import { dateTime, TimeRange } from '@grafana/data';
 import { initTemplateSrv } from '../../../test/helpers/initTemplateSrv';
 import { silenceConsoleOutput } from '../../../test/core/utils/silenceConsoleOutput';
+import { variableAdapters } from '../variables/adapters';
+import { createQueryVariableAdapter } from '../variables/query/adapter';
+import { createAdHocVariableAdapter } from '../variables/adhoc/adapter';
+
+variableAdapters.setInit(() => [createQueryVariableAdapter(), createAdHocVariableAdapter()]);
 
 describe('templateSrv', () => {
   silenceConsoleOutput();
@@ -225,6 +230,11 @@ describe('templateSrv', () => {
       const target = _templateSrv.replace('${test:pipe},$test', {}, 'glob');
       expect(target).toBe('value1|value2,{value1,value2}');
     });
+
+    it('should replace ${test:queryparam} with correct query parameter', () => {
+      const target = _templateSrv.replace('${test:queryparam}', {});
+      expect(target).toBe('var-test=All');
+    });
   });
 
   describe('variable with all option and custom value', () => {
@@ -263,6 +273,11 @@ describe('templateSrv', () => {
     it('should not escape custom all value', () => {
       const target = _templateSrv.replace('this.$test', {}, 'regex');
       expect(target).toBe('this.*');
+    });
+
+    it('should replace ${test:queryparam} with correct query parameter', () => {
+      const target = _templateSrv.replace('${test:queryparam}', {});
+      expect(target).toBe('var-test=All');
     });
   });
 
@@ -638,6 +653,45 @@ describe('templateSrv', () => {
       });
 
       expect(passedValue).toBe('hello');
+    });
+  });
+
+  describe('queryparam', () => {
+    beforeEach(() => {
+      _templateSrv = initTemplateSrv([
+        {
+          type: 'query',
+          name: 'single',
+          current: { value: 'value1' },
+          options: [{ value: 'value1' }, { value: 'value2' }],
+        },
+        {
+          type: 'query',
+          name: 'multi',
+          current: { value: ['value1', 'value2'] },
+          options: [{ value: 'value1' }, { value: 'value2' }],
+        },
+      ]);
+    });
+
+    it('query variable with single value with queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace('${single:queryparam}', {});
+      expect(target).toBe('var-single=value1');
+    });
+
+    it('query variable with single value and queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace('${single}', {}, 'queryparam');
+      expect(target).toBe('var-single=value1');
+    });
+
+    it('query variable with multi value with queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace('${multi:queryparam}', {});
+      expect(target).toBe('var-multi=value1&var-multi=value2');
+    });
+
+    it('query variable with multi value and queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace('${multi}', {}, 'queryparam');
+      expect(target).toBe('var-multi=value1&var-multi=value2');
     });
   });
 });

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -1,11 +1,15 @@
 import { dateTime, TimeRange } from '@grafana/data';
 import { initTemplateSrv } from '../../../test/helpers/initTemplateSrv';
 import { silenceConsoleOutput } from '../../../test/core/utils/silenceConsoleOutput';
-import { variableAdapters } from '../variables/adapters';
+import { VariableAdapter, variableAdapters } from '../variables/adapters';
 import { createQueryVariableAdapter } from '../variables/query/adapter';
 import { createAdHocVariableAdapter } from '../variables/adhoc/adapter';
+import { VariableModel } from '../variables/types';
 
-variableAdapters.setInit(() => [createQueryVariableAdapter(), createAdHocVariableAdapter()]);
+variableAdapters.setInit(() => [
+  (createQueryVariableAdapter() as unknown) as VariableAdapter<VariableModel>,
+  (createAdHocVariableAdapter() as unknown) as VariableAdapter<VariableModel>,
+]);
 
 describe('templateSrv', () => {
   silenceConsoleOutput();

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -282,7 +282,7 @@ export class TemplateSrv implements BaseTemplateSrv {
         value = this.getAllValue(variable);
         text = ALL_VARIABLE_TEXT;
         // skip formatting of custom all values
-        if (variable.allValue && fmt !== 'text') {
+        if (variable.allValue && fmt !== 'text' && fmt !== 'queryparam') {
           return this.replace(value);
         }
       }

--- a/public/app/features/variables/guard.ts
+++ b/public/app/features/variables/guard.ts
@@ -11,6 +11,7 @@ import {
   QueryEditorProps,
   StandardVariableQuery,
   StandardVariableSupport,
+  VariableModel,
   VariableSupportType,
 } from '@grafana/data';
 
@@ -18,7 +19,6 @@ import {
   AdHocVariableModel,
   ConstantVariableModel,
   QueryVariableModel,
-  VariableModel,
   VariableQueryEditorType,
   VariableWithMultiSupport,
   VariableWithOptions,

--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -3,23 +3,42 @@ import { VariableRefresh } from './types';
 
 describe('isAllVariable', () => {
   it.each`
-    variable                                    | expected
-    ${null}                                     | ${false}
-    ${undefined}                                | ${false}
-    ${{}}                                       | ${false}
-    ${{ current: {} }}                          | ${false}
-    ${{ current: { text: '' } }}                | ${false}
-    ${{ current: { text: null } }}              | ${false}
-    ${{ current: { text: undefined } }}         | ${false}
-    ${{ current: { text: 'Alll' } }}            | ${false}
-    ${{ current: { text: 'All' } }}             | ${true}
-    ${{ current: { text: [] } }}                | ${false}
-    ${{ current: { text: [null] } }}            | ${false}
-    ${{ current: { text: [undefined] } }}       | ${false}
-    ${{ current: { text: ['Alll'] } }}          | ${false}
-    ${{ current: { text: ['Alll', 'All'] } }}   | ${false}
-    ${{ current: { text: ['All'] } }}           | ${true}
-    ${{ current: { text: { prop1: 'test' } } }} | ${false}
+    variable                                         | expected
+    ${null}                                          | ${false}
+    ${undefined}                                     | ${false}
+    ${{}}                                            | ${false}
+    ${{ current: {} }}                               | ${false}
+    ${{ current: { text: '' } }}                     | ${false}
+    ${{ current: { text: null } }}                   | ${false}
+    ${{ current: { text: undefined } }}              | ${false}
+    ${{ current: { text: 'Alll' } }}                 | ${false}
+    ${{ current: { text: 'All' } }}                  | ${true}
+    ${{ current: { text: [] } }}                     | ${false}
+    ${{ current: { text: [null] } }}                 | ${false}
+    ${{ current: { text: [undefined] } }}            | ${false}
+    ${{ current: { text: ['Alll'] } }}               | ${false}
+    ${{ current: { text: ['Alll', 'All'] } }}        | ${false}
+    ${{ current: { text: ['All'] } }}                | ${true}
+    ${{ current: { text: ['All', 'Alll'] } }}        | ${true}
+    ${{ current: { text: { prop1: 'test' } } }}      | ${false}
+    ${{ current: { value: '' } }}                    | ${false}
+    ${{ current: { value: null } }}                  | ${false}
+    ${{ current: { value: undefined } }}             | ${false}
+    ${{ current: { value: '$__alll' } }}             | ${false}
+    ${{ current: { value: '$__all' } }}              | ${true}
+    ${{ current: { value: [] } }}                    | ${false}
+    ${{ current: { value: [null] } }}                | ${false}
+    ${{ current: { value: [undefined] } }}           | ${false}
+    ${{ current: { value: ['$__alll'] } }}           | ${false}
+    ${{ current: { value: ['$__alll', '$__all'] } }} | ${false}
+    ${{ current: { value: ['$__all'] } }}            | ${true}
+    ${{ current: { value: ['$__all', '$__alll'] } }} | ${true}
+    ${{ current: { value: { prop1: 'test' } } }}     | ${false}
+    ${{ current: { value: '', text: '' } }}          | ${false}
+    ${{ current: { value: '', text: 'All' } }}       | ${true}
+    ${{ current: { value: '$__all', text: '' } }}    | ${true}
+    ${{ current: { value: '', text: ['All'] } }}     | ${true}
+    ${{ current: { value: ['$__all'], text: '' } }}  | ${true}
   `("when called with params: 'variable': '$variable' then result should be '$expected'", ({ variable, expected }) => {
     expect(isAllVariable(variable)).toEqual(expected);
   });

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -2,7 +2,7 @@ import isString from 'lodash/isString';
 import { ScopedVars, VariableType } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
-import { ALL_VARIABLE_TEXT } from './state/types';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from './state/types';
 import { QueryVariableModel, VariableModel, VariableRefresh } from './types';
 import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { variableAdapters } from './adapters';
@@ -74,15 +74,29 @@ export const isAllVariable = (variable: any): boolean => {
     return false;
   }
 
-  if (!variable.current.text) {
-    return false;
+  if (variable.current.value) {
+    const isArray = Array.isArray(variable.current.value);
+    if (isArray && variable.current.value.length && variable.current.value[0] === ALL_VARIABLE_VALUE) {
+      return true;
+    }
+
+    if (!isArray && variable.current.value === ALL_VARIABLE_VALUE) {
+      return true;
+    }
   }
 
-  if (Array.isArray(variable.current.text)) {
-    return variable.current.text.length ? variable.current.text[0] === ALL_VARIABLE_TEXT : false;
+  if (variable.current.text) {
+    const isArray = Array.isArray(variable.current.text);
+    if (isArray && variable.current.text.length && variable.current.text[0] === ALL_VARIABLE_TEXT) {
+      return true;
+    }
+
+    if (!isArray && variable.current.text === ALL_VARIABLE_TEXT) {
+      return true;
+    }
   }
 
-  return variable.current.text === ALL_VARIABLE_TEXT;
+  return false;
 };
 
 export const getCurrentText = (variable: any): string => {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `queryparam` formatting options for variables as `${foo:queryparam}`. 
This PR also changes the default suggested variable inserted text in Data Links from `var-${name}=${value}` to `${name:queryparam}` 

**Example**
| Variable Name | Current Variable Value | Result
| --- | --- | --- |
| foo | All | var-foo=All
| foo | A | var-foo=A
| foo | B | var-foo=B
| foo | A + B | var-foo=A&var-foo=B

**Which issue(s) this PR fixes**:
Fixes #21459

**Special notes for your reviewer**:

