### PR TITLE
Panels: Remove value mapping of values that have been formatted #26763

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -164,7 +164,7 @@ describe('Format value', () => {
     expect(instance(value).numeric).toEqual(1);
   });
 
-  it('should not map 1kw to the value for 1w', () => {
+  it('should not map 1kW to the value for 1W', () => {
     const valueMappings: ValueMapping[] = [{ id: 0, text: 'mapped', type: MappingType.ValueToText, value: '1' }];
     const value = '1000';
     const instance = getDisplayProcessorFromConfig({ decimals: 1, mappings: valueMappings, unit: 'watt' });

--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -164,6 +164,16 @@ describe('Format value', () => {
     expect(instance(value).numeric).toEqual(1);
   });
 
+  it('should not map 1kw to the value for 1w', () => {
+    const valueMappings: ValueMapping[] = [{ id: 0, text: 'mapped', type: MappingType.ValueToText, value: '1' }];
+    const value = '1000';
+    const instance = getDisplayProcessorFromConfig({ decimals: 1, mappings: valueMappings, unit: 'watt' });
+
+    const result = instance(value);
+
+    expect(result.text).toEqual('1.0');
+  });
+
   it('With null value and thresholds should use base color', () => {
     const instance = getDisplayProcessorFromConfig({
       thresholds: {

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -90,14 +90,6 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
         text = v.text;
         suffix = v.suffix;
         prefix = v.prefix;
-
-        // Check if the formatted text mapped to a different value
-        if (mappings && mappings.length > 0) {
-          const mappedValue = getMappedValue(mappings, text);
-          if (mappedValue) {
-            text = mappedValue.text;
-          }
-        }
       }
 
       // Return the value along with scale info


### PR DESCRIPTION
**What this PR does / why we need it**:
Value mappings are applied both before and after formatting a value. This leads to issues where a value mapping for the value 1, will also trigger on a value for 1000, if a unit that uses SI prefixes is used ( kilo, mega, giga, etc).

This PR removes the second pass over the value mappings.

However, this removes the ability to use a value mapping for the value 10, and have it match 0.1 with the unit Percent 0.0-1. However this use case is not very user friendly right now anyway as a value mapping with the value 10 will match both the raw value 0.1 and 10.

Other examples are if you use scientific notation you can no longer set the value mapping to 1e-1 and have it match for the raw value 0.1.

There's some hint of why this was added here: https://github.com/grafana/grafana/pull/18580/files/bc264f0c5fa4c2c4555cb76f972f5187052a1e59

**Which issue(s) this PR fixes**:
Fixes #26763 