### PR TITLE
Dashboard: Ignore changes to dashboard when the user session expires

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -39,6 +39,7 @@ export class BackendSrv implements BackendService {
     appEvents: appEvents,
     contextSrv: contextSrv,
     logout: () => {
+      contextSrv.setLoggedOut();
       window.location.reload();
     },
   };

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -49,6 +49,14 @@ export class ContextSrv {
     this.minRefreshInterval = config.minRefreshInterval;
   }
 
+  /**
+   * Indicate the user has been logged out
+   */
+  setLoggedOut() {
+    this.user.isSignedIn = false;
+    this.isSignedIn = false;
+  }
+
   hasRole(role: string) {
     return this.user.orgRole === role;
   }

--- a/public/app/features/dashboard/services/ChangeTracker.ts
+++ b/public/app/features/dashboard/services/ChangeTracker.ts
@@ -93,6 +93,11 @@ export class ChangeTracker {
       return true;
     }
 
+    //Ignore changes if the user has been signed out
+    if (!this.contextSrv.isSignedIn) {
+      return true;
+    }
+
     const meta = this.current.meta;
     return !meta.canSave || meta.fromScript || meta.fromFile;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
When the user session expires, and the 401 triggers a page reload to get the user to the login page, ChangeTracker will interfer. By setting the user as logged out in the context when the session is timed out, we can ignore the changes in ChangeTracker.

**Which issue(s) this PR fixes**:
Fixes #30120


**Special notes for your reviewer**:
I'm not 100% sure poking around in contextSrv is kosher. If it isn't I'll find some other way to detect that the user session has expired.
