### PR TITLE
CloudMonitoring: Show service and SLO display name in SLO Query editor

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/SLOQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLOQueryEditor.tsx
@@ -21,7 +21,9 @@ export const defaultQuery: (dataSource: CloudMonitoringDatasource) => SLOQuery =
   aliasBy: '',
   selectorName: 'select_slo_health',
   serviceId: '',
+  serviceName: '',
   sloId: '',
+  sloName: '',
 });
 
 export function SLOQueryEditor({
@@ -42,7 +44,7 @@ export function SLOQueryEditor({
       <QueryInlineField label="Service">
         <SegmentAsync
           allowCustomValue
-          value={query?.serviceId}
+          value={{ value: query?.serviceId, label: query?.serviceName || query?.serviceId }}
           placeholder="Select service"
           loadOptions={() =>
             datasource.getSLOServices(query.projectName).then((services) => [
@@ -53,14 +55,16 @@ export function SLOQueryEditor({
               ...services,
             ])
           }
-          onChange={({ value: serviceId = '' }) => onChange({ ...query, serviceId, sloId: '' })}
+          onChange={({ value: serviceId = '', label: serviceName = '' }) =>
+            onChange({ ...query, serviceId, serviceName, sloId: '' })
+          }
         />
       </QueryInlineField>
 
       <QueryInlineField label="SLO">
         <SegmentAsync
           allowCustomValue
-          value={query?.sloId}
+          value={{ value: query?.sloId, label: query?.sloName || query?.sloId }}
           placeholder="Select SLO"
           loadOptions={() =>
             datasource.getServiceLevelObjectives(query.projectName, query.serviceId).then((sloIds) => [
@@ -71,10 +75,10 @@ export function SLOQueryEditor({
               ...sloIds,
             ])
           }
-          onChange={async ({ value: sloId = '' }) => {
+          onChange={async ({ value: sloId = '', label: sloName = '' }) => {
             const slos = await datasource.getServiceLevelObjectives(query.projectName, query.serviceId);
             const slo = slos.find(({ value }) => value === datasource.templateSrv.replace(sloId));
-            onChange({ ...query, sloId, goal: slo?.goal });
+            onChange({ ...query, sloId, sloName, goal: slo?.goal });
           }}
         />
       </QueryInlineField>

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -257,9 +257,9 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
 
   async getSLOServices(projectName: string): Promise<Array<SelectableValue<string>>> {
     return this.api.get(`${this.templateSrv.replace(projectName)}/services?pageSize=1000`, {
-      responseMap: ({ name }: { name: string }) => ({
+      responseMap: ({ name, displayName }: { name: string; displayName: string }) => ({
         value: name.match(/([^\/]*)\/*$/)![1],
-        label: name.match(/([^\/]*)\/*$/)![1],
+        label: displayName || name.match(/([^\/]*)\/*$/)![1],
       }),
     });
   }

--- a/public/app/plugins/datasource/cloud-monitoring/types.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/types.ts
@@ -92,7 +92,9 @@ export interface SLOQuery {
   aliasBy?: string;
   selectorName: string;
   serviceId: string;
+  serviceName: string;
   sloId: string;
+  sloName: string;
   goal?: number;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In the SLO Query editor in Cloud Monitoring, the Service field and the SLO field only showed the id in the segment dropdown. This was fine in some scenarios when the id was a human readable value, like `prometheus-service`, but that's not always the case so this PR makes sure SLO/Service display name is being used in the field dropdown in the editor. 

Please note that the display name needs to be loaded from the api before they can be properly displayed, so for existing SLO queries it won't work until SLO/Service field has been clicked and re-selected. 

**Which issue(s) this PR fixes**:
Fixes #29611