### PR TITLE
Exemplars: change api to reflect latest changes

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -492,13 +492,9 @@ describe('Prometheus Result Transformer', () => {
         seriesLabels: { __name__: 'test' },
         exemplars: [
           {
-            scrapeTimestamp: 1610449069957,
-            exemplar: {
-              labels: { traceID: '5020b5bc45117f07' },
-              value: 0.002074123,
-              timestamp: 1610449054960,
-              hasTimestamp: true,
-            },
+            timestamp: 1610449069957,
+            labels: { traceID: '5020b5bc45117f07' },
+            value: 0.002074123,
           },
         ],
       },
@@ -521,28 +517,20 @@ describe('Prometheus Result Transformer', () => {
           {
             exemplars: [
               {
-                scrapeTimestamp: 1610449070000,
-                exemplar: {
-                  value: 5,
-                },
+                timestamp: 1610449070000,
+                value: 5,
               },
               {
-                scrapeTimestamp: 1610449070000,
-                exemplar: {
-                  value: 1,
-                },
+                timestamp: 1610449070000,
+                value: 1,
               },
               {
-                scrapeTimestamp: 1610449070500,
-                exemplar: {
-                  value: 13,
-                },
+                timestamp: 1610449070500,
+                value: 13,
               },
               {
-                scrapeTimestamp: 1610449070300,
-                exemplar: {
-                  value: 20,
-                },
+                timestamp: 1610449070300,
+                value: 20,
               },
             ],
           },

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -78,9 +78,9 @@ export function transform(
     prometheusResult.forEach((exemplarData) => {
       const data = exemplarData.exemplars.map((exemplar) => {
         return {
-          [TIME_SERIES_TIME_FIELD_NAME]: exemplar.scrapeTimestamp,
-          [TIME_SERIES_VALUE_FIELD_NAME]: exemplar.exemplar.value,
-          ...exemplar.exemplar.labels,
+          [TIME_SERIES_TIME_FIELD_NAME]: exemplar.timestamp,
+          [TIME_SERIES_VALUE_FIELD_NAME]: exemplar.value,
+          ...exemplar.labels,
           ...exemplarData.seriesLabels,
         };
       });

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -69,21 +69,15 @@ export interface Labels {
   [index: string]: any;
 }
 
-export interface ScrapeExemplar {
-  exemplar: Exemplar;
-  scrapeTimestamp: number;
-}
-
 export interface Exemplar {
   labels: Labels;
   value: number;
   timestamp: number;
-  hasTimestamp: boolean;
 }
 
 export interface PromExemplarData {
   seriesLabels: PromMetric;
-  exemplars: ScrapeExemplar[];
+  exemplars: Exemplar[];
 }
 
 export interface PromVectorData {


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the exemplars api to reflect the latest changes.

**Special notes for your reviewer**:

You can try it out with Tom's exemplars-demo branch. https://github.com/grafana/tns/pull/39
Don't forget to stop the grafana that starts in the docker compose.



## TODO
~The exemplars endpoint return 500 for time range lower than 1 hour.~
~1. We should probably show an error message and show the graph without exemplars.~ Going to open another issue for this
~1. Check with Callum if thats something that is an intended change.~ Fixed in cstyan/prometheus:exemplars-b165c3 docker image