### PR TITLE
Prometheus: Fix issues with ad-hoc filters

### DIFF
--- a/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
@@ -96,6 +96,17 @@ describe('addLabelToQuery()', () => {
       'avg(rate((my_metric{bar="baz",instance="foo"} > 0)[3h:])) by (device)'
     );
   });
+  it('should not add ad-hoc filter to labels in label list provided with the group modifier', () => {
+    expect(
+      addLabelToQuery(
+        'max by (org_id, org_name, id, name, type) (grafanacloud_instance_info{type=~"prometheus|graphite|graphite-shared"}) * on(id) group_right(org_id, org_name, type, name) sum by (id) (grafanacloud_instance_created_date) * 1000',
+        'bar',
+        'baz'
+      )
+    ).toBe(
+      'max by (org_id, org_name, id, name, type) (grafanacloud_instance_info{bar="baz",type=~"prometheus|graphite|graphite-shared"}) * on(id) group_right(org_id, org_name, type, name) sum by (id) (grafanacloud_instance_created_date{bar="baz"}) * 1000'
+    );
+  });
 });
 
 describe('addLabelToSelector()', () => {

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
@@ -107,6 +107,11 @@ describe('addLabelToQuery()', () => {
       'max by (org_id, org_name, id, name, type) (grafanacloud_instance_info{bar="baz",type=~"prometheus|graphite|graphite-shared"}) * on(id) group_right(org_id, org_name, type, name) sum by (id) (grafanacloud_instance_created_date{bar="baz"}) * 1000'
     );
   });
+  it('should not add ad-hoc filter to labels in label list provided with the group modifier', () => {
+    expect(addLabelToQuery('rate(http_server_requests_seconds_count[${__range_s}s])', 'bar', 'baz')).toBe(
+      'rate(http_server_requests_seconds_count{bar="baz"}[${__range_s}s])'
+    );
+  });
 });
 
 describe('addLabelToSelector()', () => {

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.test.ts
@@ -74,8 +74,26 @@ describe('addLabelToQuery()', () => {
     expect(addLabelToQuery('{job="grafana"} |= "foo-bar"', 'filename', 'test.txt', undefined, true)).toBe(
       '{filename="test.txt",job="grafana"} |= "foo-bar"'
     );
-    expect(addLabelToQuery('{job="grafana"} |= "foo-bar"', 'filename', 'test.txt')).toBe(
-      '{filename="test.txt",job="grafana"} |= "foo{filename="test.txt"}-bar"'
+  });
+
+  it('should add labels to metrics with logical operators', () => {
+    expect(addLabelToQuery('go_info or grafana_info', 'bar', 'baz')).toBe(
+      'go_info{bar="baz"} or grafana_info{bar="baz"}'
+    );
+    expect(addLabelToQuery('go_info and grafana_info', 'bar', 'baz')).toBe(
+      'go_info{bar="baz"} and grafana_info{bar="baz"}'
+    );
+  });
+
+  it('should not add ad-hoc filter to template variables', () => {
+    expect(addLabelToQuery('sum(rate({job="grafana"}[2m])) by (valueName $variable)', 'bar', 'baz')).toBe(
+      'sum(rate({bar="baz",job="grafana"}[2m])) by (valueName $variable)'
+    );
+  });
+
+  it('should not add ad-hoc filter to range', () => {
+    expect(addLabelToQuery('avg(rate((my_metric{instance="foo"} > 0)[3h:])) by (device)', 'bar', 'baz')).toBe(
+      'avg(rate((my_metric{bar="baz",instance="foo"} > 0)[3h:])) by (device)'
     );
   });
 });

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-const keywords = 'by|without|on|ignoring|group_left|group_right|bool';
+const keywords = 'by|without|on|ignoring|group_left|group_right|bool|offset';
 const logicalOperators = 'or|and|unless';
 
 // Duplicate from mode-prometheus.js, which can't be used in tests due to global ace not being loaded.
@@ -17,7 +17,8 @@ const builtInWords = [
   .join('|')
   .split('|');
 
-const metricNameRegexp = /([A-Za-z:][\w:]*)\b(?![\(\]{=!",])/g;
+// We want to extract metrics names and all possible keywods
+const metricsAndKeywordsRegexp = /([A-Za-z:][\w:]*)\b(?![\]{=!",])/g;
 const selectorRegexp = /{([^{]*)}/g;
 
 export function addLabelToQuery(
@@ -36,7 +37,7 @@ export function addLabelToQuery(
 
   // Add empty selectors to bare metric names
   let previousWord: string;
-  query = query.replace(metricNameRegexp, (match, word, offset) => {
+  query = query.replace(metricsAndKeywordsRegexp, (match, word, offset) => {
     const insideSelector = isPositionInsideChars(query, offset, '{', '}');
     // Handle "sum by (key) (metric)"
     const previousWordIsKeyWord = previousWord && keywords.split('|').indexOf(previousWord) > -1;

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -38,9 +38,10 @@ export function addLabelToQuery(
     const insideSelector = isPositionInsideChars(query, offset, '{', '}');
     // Handle "sum by (key) (metric)"
     const previousWordIsKeyWord = previousWord && keywords.split('|').indexOf(previousWord) > -1;
-
-    // check for colon as as "word boundary" symbol
+    // Check for colon as as "word boundary" symbol
     const isColonBounded = word.endsWith(':');
+    // Check for words that startt with " which means that they are not metrics
+    const startsWithQuote = query[offset - 1] === '"';
 
     previousWord = word;
 
@@ -52,6 +53,7 @@ export function addLabelToQuery(
       !insideSelector &&
       !isColonBounded &&
       !previousWordIsKeyWord &&
+      !startsWithQuote &&
       builtInWords.indexOf(word) === -1
     ) {
       return `${word}{}`;

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -40,8 +40,9 @@ export function addLabelToQuery(
     const previousWordIsKeyWord = previousWord && keywords.split('|').indexOf(previousWord) > -1;
     // Check for colon as as "word boundary" symbol
     const isColonBounded = word.endsWith(':');
-    // Check for words that startt with " which means that they are not metrics
+    // Check for words that start with " which means that they are not metrics
     const startsWithQuote = query[offset - 1] === '"';
+    const isTemplateVariable = query[offset - 1] === '$';
 
     previousWord = word;
 
@@ -54,6 +55,7 @@ export function addLabelToQuery(
       !isColonBounded &&
       !previousWordIsKeyWord &&
       !startsWithQuote &&
+      !isTemplateVariable &&
       builtInWords.indexOf(word) === -1
     ) {
       return `${word}{}`;

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -17,7 +17,7 @@ const builtInWords = [
   .join('|')
   .split('|');
 
-// We want to extract all keywods and
+// We want to extract all possible metrics and also keywords
 const metricsAndKeywordsRegexp = /([A-Za-z:][\w:]*)\b(?![\]{=!",])/g;
 // Safari currently doesn't support negative lookbehind. When it does, we should refactor this.
 // We are creating 2 matching groups. (\$) is for the Grafana's variables such as ${__rate_s}. We want to ignore
@@ -40,35 +40,12 @@ export function addLabelToQuery(
 
   // Add empty selectors to bare metric names
   let previousWord: string;
-  query = query.replace(metricsAndKeywordsRegexp, (match, word, offset) => {
-    const insideSelector = isPositionInsideChars(query, offset, '{', '}');
-    // Handle "sum by (key) (metric)"
-    const previousWordIsKeyWord = previousWord && keywords.split('|').indexOf(previousWord) > -1;
-    // Check for colon as as "word boundary" symbol
-    const isColonBounded = word.endsWith(':');
-    // Check for words that start with " which means that they are not metrics
-    const startsWithQuote = query[offset - 1] === '"';
-    const isTemplateVariable = query[offset - 1] === '$';
-    const isTimeUnit = ['s', 'm', 'h', 'd', 'w'].includes(word) && Boolean(Number(query[offset - 1]));
 
+  query = query.replace(metricsAndKeywordsRegexp, (match, word, offset) => {
+    const isMetric = isWordMetric(query, word, offset, previousWord, hasNoMetrics);
     previousWord = word;
 
-    // with Prometheus datasource, adds an empty selector to a bare metric name
-    // but doesn't add it with Loki datasource so there are no unnecessary labels
-    // e.g. when the filter contains a dash (-) character inside
-    if (
-      !hasNoMetrics &&
-      !insideSelector &&
-      !isColonBounded &&
-      !previousWordIsKeyWord &&
-      !startsWithQuote &&
-      !isTemplateVariable &&
-      !isTimeUnit &&
-      builtInWords.indexOf(word) === -1
-    ) {
-      return `${word}{}`;
-    }
-    return word;
+    return isMetric ? `${word}{}` : word;
   });
 
   // Adding label to existing selectors
@@ -133,6 +110,34 @@ function isPositionInsideChars(text: string, position: number, openChar: string,
   const nextSelectorStart = text.slice(position).indexOf(openChar);
   const nextSelectorEnd = text.slice(position).indexOf(closeChar);
   return nextSelectorEnd > -1 && (nextSelectorStart === -1 || nextSelectorStart > nextSelectorEnd);
+}
+
+function isWordMetric(query: string, word: string, offset: number, previousWord: string, hasNoMetrics?: boolean) {
+  const insideSelector = isPositionInsideChars(query, offset, '{', '}');
+  // Handle "sum by (key) (metric)"
+  const previousWordIsKeyWord = previousWord && keywords.split('|').indexOf(previousWord) > -1;
+  // Check for colon as as "word boundary" symbol
+  const isColonBounded = word.endsWith(':');
+  // Check for words that start with " which means that they are not metrics
+  const startsWithQuote = query[offset - 1] === '"';
+  // Check for template variables
+  const isTemplateVariable = query[offset - 1] === '$';
+  // Check for time units
+  const isTimeUnit = ['s', 'm', 'h', 'd', 'w'].includes(word) && Boolean(Number(query[offset - 1]));
+
+  if (
+    !hasNoMetrics &&
+    !insideSelector &&
+    !isColonBounded &&
+    !previousWordIsKeyWord &&
+    !startsWithQuote &&
+    !isTemplateVariable &&
+    !isTimeUnit &&
+    builtInWords.indexOf(word) === -1
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export default addLabelToQuery;

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 
-const keywords = 'by|without|on|ignoring|group_left|group_right|bool|or|and|unless';
+const keywords = 'by|without|on|ignoring|group_left|group_right|bool';
+const logicalOperators = 'or|and|unless';
 
 // Duplicate from mode-prometheus.js, which can't be used in tests due to global ace not being loaded.
 const builtInWords = [
   keywords,
+  logicalOperators,
   'count|count_values|min|max|avg|sum|stddev|stdvar|bottomk|topk|quantile',
   'true|false|null|__name__|job',
   'abs|absent|ceil|changes|clamp_max|clamp_min|count_scalar|day_of_month|day_of_week|days_in_month|delta|deriv',
@@ -43,6 +45,7 @@ export function addLabelToQuery(
     // Check for words that start with " which means that they are not metrics
     const startsWithQuote = query[offset - 1] === '"';
     const isTemplateVariable = query[offset - 1] === '$';
+    const isTimeUnit = ['s', 'm', 'h', 'd', 'w'].includes(word) && Boolean(Number(query[offset - 1]));
 
     previousWord = word;
 
@@ -56,6 +59,7 @@ export function addLabelToQuery(
       !previousWordIsKeyWord &&
       !startsWithQuote &&
       !isTemplateVariable &&
+      !isTimeUnit &&
       builtInWords.indexOf(word) === -1
     ) {
       return `${word}{}`;


### PR DESCRIPTION
**What this PR does / why we need it**:
I have added a test scenario for each of this queries. 

**Issues:** 

✅  https://github.com/grafana/grafana/issues/29857 **Problem**: When using template variables, we consider variable to be metric
**Query:** `sum(rate({__name__=~"some_metric_name_.*"}[2m])) by (valueName $grouping)` 
**Correct:** `sum(rate({**name**=~"some*metric_name*.\*",kubernetes_namespace="some-namespace",name="some-name"}[2m])) by (valueName )`
**Incorrect:** `sum(rate({__name__=~"some_metric_name_.*",kubernetes_namespace="some-namespace",name="some-name"}[2m])) by (valueName {kubernetes_namespace="some-namespace",name="some-name"})`

✅ https://github.com/grafana/grafana/issues/16486 **Problem:** Filter is not applied to metrics after **or**
**Query:** `go_info or grafana_info`
**Correct:** `go_info{job="grafana"} or grafana_info{job="grafana"}`
**Incorrect:** `go_info{job="grafana"} or grafana_info`

✅ #14802 **Problem:** Filter added to range vector that is ending with **:**
Query: `avg(rate((my_metric{instance="foo"} > 0)[3h:])) by (device)`
Correct: `avg(rate((my_metric{goversion="go1.13.8",instance="foo"} > 0)[3h:])) by (device)`
Incorrect: `avg(rate((my_metric{goversion="go1.13.8",instance="foo"} > 0)[3h{goversion="go1.13.8"}:])) by (device)`

✅ https://github.com/grafana/grafana/issues/14802 **Problem:** Filter was inserted to the last label, as it considered last label to be metric
**Query:** `max by (org_id, org_name, id, name, type) (grafanacloud_instance_info{type=~"prometheus|graphite|graphite-shared"}) * on(id) group_right(org_id, org_name, type, name) sum by (id) (grafanacloud_instance_created_date) * 1000`
**Correct:** `max by (org_id, org_name, id, name, type) (grafanacloud_instance_info{type=~"prometheus|graphite|graphite-shared", type="prometheus"}) * on(id) group_right(org_id, org_name, type, name) sum by (id) (grafanacloud_instance_created_date{type="prometheus"}) * 1000`
**Incorrect:** `max by (org_id, org_name, id, name, type) (grafanacloud_instance_info{type=~"prometheus|graphite|graphite-shared",type="prometheus"}) * on(id{type="prometheus"}) group_right(org_id, org_name, type, name{type="prometheus"}) sum by (id) (grafanacloud_instance_created_date{type="prometheus"}) * 1000`

✅ https://github.com/grafana/grafana/issues/19008 **Problem:** Filter with broke the simple query with regex
**Query:** `ALERTS{severity=~".*",alertstate=~"firing"}`
**Correct:** `ALERTS{severity=~".*",alertstate=~"firing",alertname!="DeploymentInProgress"}`
**Incorrect:** `ALERTS{severity=~"${alertname!="DeploymentInProgress"}",alertstate=~"${alertname!="DeploymentInProgress"}`

✅ https://github.com/grafana/grafana/issues/19008 **Problem:** Filters get inserted into  **${__range_s}**
**Query:** `sum(rate(http_server_requests_seconds_count{}[${__range_s}s]))`
**Correct:** `query= sum(rate(http_server_requests_seconds_count{status="200", method="GET"}[3600s]))`
**Incorrect:** `query= sum(rate(http_server_requests_seconds_count{status="200", method="GET"}[${status="200", method="GET"}s]))`

✅ https://github.com/grafana/grafana/issues/26029 **Problem:** Filters get inserted into mathematical operations
**Query:** `count(node_filesystem_avail_bytes{fstype!="rootfs",mountpoint="/"} < (5*1024*1024*1024) or vector(0)) - 1`
**Correct:** `count(node_filesystem_avail_bytes{fstype!="rootfs",mountpoint="/",probe!="icmp"} < (5*1024*1024*1024) or vector(0)) - 1`
**Incorrect:** `count(node_filesystem_avail_bytes{fstype!="rootfs",mountpoint="/",probe!="icmp"} < (5{probe!="icmp"}*1024*1024*1024) or vector(0)) - 1`

Fixes #26029
Fixes #19008
Fixes #14802
Fixes #16486
Fixes #29857
Fixes #14556
Fixes #29857

**Special notes for your reviewer**:
In the nest PR, I'll try to tackle these issues, but I need to do some research first on what is desired behaviour:

LABEL_REPLACE: 2. #26526 **Problem:** Filter is inserted to regex
**Query:** `sum by (cluster, nodepool) (label_replace(kube_node_info, "nodepool", "$1", "node", "(.*-.{8})-.*"))`
**Correct:** `sum{cluster="some-12345678-cluster"} by (cluster, nodepool) (label_replace(kube_node_info, "nodepool", "$1", "node", "(.*-.{8})-.*"))`
**Incorrect:** `sum{cluster="some-12345678-cluster"} by (cluster, nodepool) (label_replace(kube_node_info, "nodepool", "$1", "node", "(.*-.{cluster="some-12345678-cluster"})-.*"`

LABEL_REPLACE: 8. #14556 **Problem:** Filters are added to regex and multiple times
**Query:** `sum by (status) (label_replace(label_replace(rate(http_requests_total{}[1m]), "status", "${1}xx", "code", "([0-9]).."), "status", "${1}", "code", "([a-z]+)"))`
**Correct:** `sum by (status) (label_replace(label_replace(rate(http_requests_total{status="4xx"}[1m]), "status", "${1}xx", "code", "([0-9]).."), "status", "${1}", "code", "([a-z]+)"))`
**Incorrect:** `sum by (status) (label_replace(label_replace(rate(http_requests_total{status="4xx"}{status="4xx"}[1m]), "status", "${status="4xx"}xx", "code", "([0-9]).."), "status", "${status="4xx"}", "code", "([a{status="4xx"}-z]+)"))`
