### PR TITLE
e2e: extends selector factory to plugins

### DIFF
--- a/packages/grafana-e2e/src/index.ts
+++ b/packages/grafana-e2e/src/index.ts
@@ -6,7 +6,7 @@
 import { e2eScenario, ScenarioArguments } from './support/scenario';
 import { getScenarioContext, setScenarioContext } from './support/scenarioContext';
 import { e2eFactory } from './support';
-import { selectors } from '@grafana/e2e-selectors';
+import { E2ESelectors, Selectors, selectors } from '@grafana/e2e-selectors';
 import * as flows from './flows';
 import * as typings from './typings';
 
@@ -22,6 +22,7 @@ const e2eObject = {
   flows,
   getScenarioContext,
   setScenarioContext,
+  getSelectors: <T extends Selectors>(selectors: E2ESelectors<T>) => e2eFactory({ selectors }),
 };
 
 export const e2e: (() => Cypress.cy) & typeof e2eObject = Object.assign(() => cy, e2eObject);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables plugin authors to use the `e2eFactory` to use the same ease of use e2e selectors as in Grafana.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

