### PR TITLE
Alerting: Dedupe alerts so the same alert message won't repeat

### DIFF
--- a/public/app/core/reducers/appNotification.test.ts
+++ b/public/app/core/reducers/appNotification.test.ts
@@ -116,4 +116,46 @@ describe('notify', () => {
 
     expect(result).toEqual(expectedResult);
   });
+
+  it('Dedupe identical alerts', () => {
+    const initialState = {
+      appNotifications: [
+        {
+          id: 'id1',
+          severity: AppNotificationSeverity.Success,
+          icon: 'success',
+          title: 'test',
+          text: 'test alert',
+          timeout: AppNotificationTimeout.Success,
+        },
+      ],
+    };
+
+    const result = appNotificationsReducer(
+      initialState,
+      notifyApp({
+        id: 'id2',
+        severity: AppNotificationSeverity.Success,
+        icon: 'success',
+        title: 'test',
+        text: 'test alert',
+        timeout: AppNotificationTimeout.Success,
+      })
+    );
+
+    const expectedResult = {
+      appNotifications: [
+        {
+          id: 'id1',
+          severity: AppNotificationSeverity.Success,
+          icon: 'success',
+          title: 'test',
+          text: 'test alert',
+          timeout: AppNotificationTimeout.Success,
+        },
+      ],
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
 });

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -15,10 +15,23 @@ const appNotificationsSlice = createSlice({
   name: 'appNotifications',
   initialState,
   reducers: {
-    notifyApp: (state, action: PayloadAction<AppNotification>): AppNotificationsState => ({
-      ...state,
-      appNotifications: state.appNotifications.concat([action.payload]),
-    }),
+    notifyApp: (state, action: PayloadAction<AppNotification>) => {
+      const newAlert = action.payload;
+
+      for (const existingAlert of state.appNotifications) {
+        if (
+          newAlert.icon === existingAlert.icon &&
+          newAlert.severity === existingAlert.severity &&
+          newAlert.text === existingAlert.text &&
+          newAlert.title === existingAlert.title &&
+          newAlert.component === existingAlert.component
+        ) {
+          return;
+        }
+      }
+
+      state.appNotifications.push(newAlert);
+    },
     clearAppNotification: (state, action: PayloadAction<string>): AppNotificationsState => ({
       ...state,
       appNotifications: state.appNotifications.filter((appNotification) => appNotification.id !== action.payload),


### PR DESCRIPTION
Tired of seeing the below (which we should improve further by auto reloading or something) 

![Screenshot from 2021-02-05 15-06-06](https://user-images.githubusercontent.com/10999/107043788-c1a48380-67c3-11eb-9b29-368f0f135c2d.png)
