### PR TITLE
Graph: Fixes so graph is shown for non numeric time values

### DIFF
--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -1,13 +1,14 @@
 import _ from 'lodash';
 import { colors } from '@grafana/ui';
 import {
-  TimeRange,
-  FieldType,
-  Field,
   DataFrame,
-  getTimeField,
-  getFieldDisplayName,
+  dateTime,
+  Field,
+  FieldType,
   getColorForTheme,
+  getFieldDisplayName,
+  getTimeField,
+  TimeRange,
 } from '@grafana/data';
 import TimeSeries from 'app/core/time_series2';
 import config from 'app/core/config';
@@ -46,7 +47,7 @@ export class DataProcessor {
         const datapoints = [];
 
         for (let r = 0; r < series.length; r++) {
-          datapoints.push([field.values.get(r), timeField.values.get(r)]);
+          datapoints.push([field.values.get(r), dateTime(timeField.values.get(r)).valueOf()]);
         }
 
         list.push(this.toTimeSeries(field, name, i, j, datapoints, list.length, range));

--- a/public/app/plugins/panel/graph/specs/__snapshots__/data_processor.test.ts.snap
+++ b/public/app/plugins/panel/graph/specs/__snapshots__/data_processor.test.ts.snap
@@ -157,6 +157,37 @@ Array [
     "unit": undefined,
     "valueFormater": [Function],
   },
+  TimeSeries {
+    "alias": "series with time as strings v1",
+    "aliasEscaped": "series with time as strings v1",
+    "bars": Object {
+      "fillColor": "#1F78C1",
+    },
+    "color": "#1F78C1",
+    "dataFrameIndex": 3,
+    "datapoints": Array [
+      Array [
+        0.1,
+        1609477200000,
+      ],
+      Array [
+        0.2,
+        1609563600000,
+      ],
+      Array [
+        0.3,
+        1609650000000,
+      ],
+    ],
+    "fieldIndex": 0,
+    "hasMsResolution": false,
+    "id": "series with time as strings v1",
+    "label": "series with time as strings v1",
+    "legend": true,
+    "stats": Object {},
+    "unit": undefined,
+    "valueFormater": [Function],
+  },
 ]
 `;
 
@@ -230,6 +261,18 @@ Array [
       Array [
         3.3,
         1003,
+      ],
+      Array [
+        0.1,
+        1609477200000,
+      ],
+      Array [
+        0.2,
+        1609563600000,
+      ],
+      Array [
+        0.3,
+        1609650000000,
       ],
     ],
     "fieldIndex": 1,

--- a/public/app/plugins/panel/graph/specs/__snapshots__/data_processor.test.ts.snap
+++ b/public/app/plugins/panel/graph/specs/__snapshots__/data_processor.test.ts.snap
@@ -168,19 +168,19 @@ Array [
     "datapoints": Array [
       Array [
         0.1,
-        1609477200000,
+        1609462800000,
       ],
       Array [
         0.2,
-        1609563600000,
+        1609462800000,
       ],
       Array [
         0.3,
-        1609650000000,
+        1612769338132,
       ],
     ],
     "fieldIndex": 0,
-    "hasMsResolution": false,
+    "hasMsResolution": true,
     "id": "series with time as strings v1",
     "label": "series with time as strings v1",
     "legend": true,
@@ -264,15 +264,15 @@ Array [
       ],
       Array [
         0.1,
-        1609477200000,
+        1609462800000,
       ],
       Array [
         0.2,
-        1609563600000,
+        1609462800000,
       ],
       Array [
         0.3,
-        1609650000000,
+        1612769338139,
       ],
     ],
     "fieldIndex": 1,

--- a/public/app/plugins/panel/graph/specs/__snapshots__/data_processor.test.ts.snap
+++ b/public/app/plugins/panel/graph/specs/__snapshots__/data_processor.test.ts.snap
@@ -176,11 +176,11 @@ Array [
       ],
       Array [
         0.3,
-        1612769338132,
+        1609466400000,
       ],
     ],
     "fieldIndex": 0,
-    "hasMsResolution": true,
+    "hasMsResolution": false,
     "id": "series with time as strings v1",
     "label": "series with time as strings v1",
     "legend": true,
@@ -272,7 +272,7 @@ Array [
       ],
       Array [
         0.3,
-        1612769338139,
+        1609466400000,
       ],
     ],
     "fieldIndex": 1,

--- a/public/app/plugins/panel/graph/specs/data_processor.test.ts
+++ b/public/app/plugins/panel/graph/specs/data_processor.test.ts
@@ -48,7 +48,10 @@ describe('Graph DataProcessor', () => {
         name: 'series with time as strings',
         fields: [
           { name: 'v1', values: [0.1, 0.2, 0.3] }, // first
-          { name: 'time', values: ['2021-01-01', '2021-01-02', '2021-01-03'] }, // Time is last column
+          {
+            name: 'time',
+            values: ['2021-01-01T01:00:00.000Z', 'Fri, 01 Jan 2021 01:00:00 GMT'],
+          }, // Time is last column
         ],
       },
     ]);

--- a/public/app/plugins/panel/graph/specs/data_processor.test.ts
+++ b/public/app/plugins/panel/graph/specs/data_processor.test.ts
@@ -50,8 +50,8 @@ describe('Graph DataProcessor', () => {
           { name: 'v1', values: [0.1, 0.2, 0.3] }, // first
           {
             name: 'time',
-            values: ['2021-01-01T01:00:00.000Z', 'Fri, 01 Jan 2021 01:00:00 GMT'],
-          }, // Time is last column
+            values: ['2021-01-01T01:00:00.000Z', 'Fri, 01 Jan 2021 01:00:00 GMT', '2021-01-01T02:00:00.000Z'], // Time is last column
+          },
         ],
       },
     ]);

--- a/public/app/plugins/panel/graph/specs/data_processor.test.ts
+++ b/public/app/plugins/panel/graph/specs/data_processor.test.ts
@@ -44,12 +44,19 @@ describe('Graph DataProcessor', () => {
           { name: 'time', values: [1001, 1002, 1003] }, // Time is last column
         ],
       },
+      {
+        name: 'series with time as strings',
+        fields: [
+          { name: 'v1', values: [0.1, 0.2, 0.3] }, // first
+          { name: 'time', values: ['2021-01-01', '2021-01-02', '2021-01-03'] }, // Time is last column
+        ],
+      },
     ]);
 
     it('Should return a new series for each field', () => {
       panel.xaxis.mode = 'series';
       const series = processor.getSeriesList({ dataList });
-      expect(series.length).toEqual(5);
+      expect(series.length).toEqual(6);
 
       expect(series).toMatchSnapshot();
     });


### PR DESCRIPTION
**What this PR does / why we need it**:
When time column includes non numeric time values, i.e. strings like `2021-01-01 00:00:00` then the values where just passed through without conversion to numbers. This results in the graph not being drawn.

**Which issue(s) this PR fixes**:
Fixes #30929

**Special notes for your reviewer**:

