### PR TITLE
StatPanel: Fixes issue formatting date values using unit option

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -27,9 +27,10 @@ interface DisplayProcessorOptions {
 // Reasonable units for time
 const timeFormats: KeyValue<boolean> = {
   dateTimeAsIso: true,
-  dateTimeAsIsoSmart: true,
+  dateTimeAsIsoNoDateIfToday: true,
   dateTimeAsUS: true,
-  dateTimeAsUSSmart: true,
+  dateTimeAsUSNoDateIfToday: true,
+  dateTimeAsLocal: true,
   dateTimeFromNow: true,
 };
 

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -77,7 +77,7 @@ export const getStandardFieldConfigs = () => {
       placeholder: 'none',
     },
 
-    shouldApply: (field) => field.type === FieldType.number,
+    shouldApply: () => true,
     category,
   };
 


### PR DESCRIPTION
Fixes #30938

Not sure what is best here the shouldApply function on field option is constantly causing issues. Makes it so that you have to use overrides in some cases to
apply units that should act on time or string fields.

Wonder if we can remove this for unit? Some things could break?
