### PR TITLE
Elasticsearch: Show Size setting for raw_data metric

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SettingsEditor } from '.';
+import { ElasticsearchProvider } from '../../ElasticsearchQueryContext';
+import { ElasticDatasource } from 'app/plugins/datasource/elasticsearch/datasource';
+import { ElasticsearchQuery } from 'app/plugins/datasource/elasticsearch/types';
+
+describe('Settings Editor', () => {
+  describe('Raw Data', () => {
+    it('Should correctly render the settings editor and trigger correct state changes', () => {
+      const metricId = '1';
+      const initialSize = '500';
+      const query: ElasticsearchQuery = {
+        refId: 'A',
+        metrics: [
+          {
+            id: metricId,
+            type: 'raw_data',
+            settings: {
+              size: initialSize,
+            },
+          },
+        ],
+      };
+
+      const onChange = jest.fn();
+
+      const { rerender } = render(
+        <ElasticsearchProvider
+          query={query}
+          datasource={{} as ElasticDatasource}
+          onChange={onChange}
+          onRunQuery={() => {}}
+        >
+          <SettingsEditor metric={query.metrics![0]} previousMetrics={[]} />
+        </ElasticsearchProvider>
+      );
+
+      let settingsButtonEl = screen.getByRole('button', {
+        name: /Size: \d+$/i,
+      });
+
+      // The metric row should have a settings button
+      expect(settingsButtonEl).toBeInTheDocument();
+      expect(settingsButtonEl.textContent).toBe(`Size: ${initialSize}`);
+
+      // Open the settings editor
+      fireEvent.click(settingsButtonEl);
+
+      // The settings editor should have a Size input
+      const sizeInputEl = screen.getByLabelText('Size');
+      expect(sizeInputEl).toBeInTheDocument();
+
+      // We change value and trigger a blur event to trigger an update
+      const newSizeValue = '23';
+      fireEvent.change(sizeInputEl, { target: { value: newSizeValue } });
+      fireEvent.blur(sizeInputEl);
+
+      // the onChange handler should have been called correctly, and the resulting
+      // query state should match what expected
+      expect(onChange).toHaveBeenCalledTimes(1);
+      rerender(
+        <ElasticsearchProvider
+          query={onChange.mock.calls[0][0]}
+          datasource={{} as ElasticDatasource}
+          onChange={onChange}
+          onRunQuery={() => {}}
+        >
+          <SettingsEditor metric={onChange.mock.calls[0][0].metrics![0]} previousMetrics={[]} />
+        </ElasticsearchProvider>
+      );
+
+      settingsButtonEl = screen.getByRole('button', {
+        name: /Size: \d+$/i,
+      });
+      expect(settingsButtonEl).toBeInTheDocument();
+      expect(settingsButtonEl.textContent).toBe(`Size: ${newSizeValue}`);
+    });
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
@@ -16,6 +16,7 @@ import { useDescription } from './useDescription';
 import { MovingAverageSettingsEditor } from './MovingAverageSettingsEditor';
 import { uniqueId } from 'lodash';
 import { metricAggregationConfig } from '../utils';
+import { useQuery } from '../../ElasticsearchQueryContext';
 
 // TODO: Move this somewhere and share it with BucketsAggregation Editor
 const inlineFieldProps: Partial<ComponentProps<typeof InlineField>> = {
@@ -30,6 +31,7 @@ interface Props {
 export const SettingsEditor: FunctionComponent<Props> = ({ metric, previousMetrics }) => {
   const dispatch = useDispatch();
   const description = useDescription(metric);
+  const query = useQuery();
 
   return (
     <SettingsEditorContainer label={description} hidden={metric.hide}>
@@ -63,6 +65,7 @@ export const SettingsEditor: FunctionComponent<Props> = ({ metric, previousMetri
       {(metric.type === 'raw_data' || metric.type === 'raw_document') && (
         <InlineField label="Size" {...inlineFieldProps}>
           <Input
+            id={`ES-query-${query.refId}_metric-${metric.id}-size`}
             onBlur={(e) => dispatch(changeMetricSetting(metric, 'size', e.target.value))}
             defaultValue={metric.settings?.size ?? metricAggregationConfig['raw_data'].defaults.settings?.size}
           />

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -208,7 +208,7 @@ export const metricAggregationConfig: MetricsConfiguration = {
     isPipelineAgg: false,
     supportsMissing: false,
     supportsMultipleBucketPaths: false,
-    hasSettings: false,
+    hasSettings: true,
     supportsInlineScript: false,
     hasMeta: false,
     defaults: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The React migration introduced a tiny bug for which we are not showing the settings editor when selecting a `raw_data` metric in the ES query editor, this PR brings back the settings editor for that metric type.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #30964

**Special notes for your reviewer**:

