### PR TITLE
Units: Fixes formatting of duration units

### DIFF
--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -227,7 +227,7 @@ export function toDuration(size: number, decimals: DecimalCount, timeScale: Inte
   let decrementDecimals = false;
   let decimalsCount = 0;
 
-  if (decimals !== null || decimals !== undefined) {
+  if (decimals !== null && decimals !== undefined) {
     decimalsCount = decimals as number;
   }
 

--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -12,87 +12,69 @@ interface ValueFormatTest {
   result: string;
 }
 
-const formatTests: ValueFormatTest[] = [
-  // Currency
-  { id: 'currencyUSD', decimals: 2, value: 1532.82, result: '$1.53K' },
-  { id: 'currencyKRW', decimals: 2, value: 1532.82, result: '₩1.53K' },
-  { id: 'currencyIDR', decimals: 2, value: 1532.82, result: 'Rp1.53K' },
-  // no unit
-  { id: 'none', decimals: null, value: 3.23, result: '3.23' },
-  { id: 'none', decimals: null, value: 0.0245, result: '0.0245' },
-  { id: 'none', decimals: null, value: 1 / 3, result: '0.333' },
-
-  // Standard
-  { id: 'ms', decimals: 4, value: 0.0024, result: '0.0024 ms' },
-  { id: 'ms', decimals: 0, value: 100, result: '100 ms' },
-  { id: 'ms', decimals: 2, value: 1250, result: '1.25 s' },
-  { id: 'ms', decimals: 1, value: 10000086.123, result: '2.8 hour' },
-  { id: 'ms', decimals: 0, value: 1200, result: '1 s' },
-  { id: 'short', decimals: null, value: 1000, result: '1 K' },
-  { id: 'short', decimals: null, value: 1200, result: '1.20 K' },
-  { id: 'short', decimals: null, value: 1250, result: '1.25 K' },
-  { id: 'short', decimals: null, value: 1000000, result: '1 Mil' },
-  { id: 'short', decimals: null, value: 1500000, result: '1.50 Mil' },
-  { id: 'short', decimals: null, value: 1000120, result: '1.00 Mil' },
-  { id: 'short', decimals: null, value: 98765, result: '98.8 K' },
-  { id: 'short', decimals: null, value: 9876543, result: '9.88 Mil' },
-  { id: 'short', decimals: null, value: 9876543, result: '9.88 Mil' },
-  { id: 'kbytes', decimals: null, value: 10000000, result: '9.54 GiB' },
-  { id: 'deckbytes', decimals: null, value: 10000000, result: '10 GB' },
-  { id: 'megwatt', decimals: 3, value: 1000, result: '1.000 GW' },
-  { id: 'kohm', decimals: 3, value: 1000, result: '1.000 MΩ' },
-  { id: 'Mohm', decimals: 3, value: 1000, result: '1.000 GΩ' },
-
-  { id: 'farad', decimals: 3, value: 1000, result: '1.000 kF' },
-  { id: 'µfarad', decimals: 3, value: 1000, result: '1.000 mF' },
-  { id: 'nfarad', decimals: 3, value: 1000, result: '1.000 µF' },
-  { id: 'pfarad', decimals: 3, value: 1000, result: '1.000 nF' },
-  { id: 'ffarad', decimals: 3, value: 1000, result: '1.000 pF' },
-
-  { id: 'henry', decimals: 3, value: 1000, result: '1.000 kH' },
-  { id: 'mhenry', decimals: 3, value: 1000, result: '1.000 H' },
-  { id: 'µhenry', decimals: 3, value: 1000, result: '1.000 mH' },
-
-  // Suffix (unknown units append to the end)
-  { id: 'a', decimals: 0, value: 1532.82, result: '1533 a' },
-  { id: 'b', decimals: 0, value: 1532.82, result: '1533 b' },
-
-  // Prefix (unknown units append to the end)
-  { id: 'prefix:b', value: 1532.82, result: 'b1533' },
-  { id: 'suffix:d', value: 1532.82, result: '1533 d' },
-
-  // SI Units
-  { id: 'si:µF', value: 1234, decimals: 2, result: '1.23 mF' },
-  { id: 'si:µF', value: 1234000000, decimals: 2, result: '1.23 kF' },
-  { id: 'si:µF', value: 1234000000000000, decimals: 2, result: '1.23 GF' },
-
-  // Counts (suffix)
-  { id: 'count:xpm', value: 1234567, decimals: 2, result: '1.23M xpm' },
-  { id: 'count:x/min', value: 1234, decimals: 2, result: '1.23K x/min' },
-
-  // Currency (prefix)
-  { id: 'currency:@', value: 1234567, decimals: 2, result: '@1.23M' },
-  { id: 'currency:@', value: 1234, decimals: 2, result: '@1.23K' },
-
-  // Time format
-  { id: 'time:YYYY', decimals: 0, value: dateTime(new Date(1999, 6, 2)).valueOf(), result: '1999' },
-  { id: 'time:YYYY.MM', decimals: 0, value: dateTime(new Date(2010, 6, 2)).valueOf(), result: '2010.07' },
-  { id: 'dateTimeAsIso', decimals: 0, value: dateTime(new Date(2010, 6, 2)).valueOf(), result: '2010-07-02 00:00:00' },
-  {
-    id: 'dateTimeAsUS',
-    decimals: 0,
-    value: dateTime(new Date(2010, 6, 2)).valueOf(),
-    result: '07/02/2010 12:00:00 am',
-  },
-  {
-    id: 'dateTimeAsSystem',
-    decimals: 0,
-    value: dateTime(new Date(2010, 6, 2)).valueOf(),
-    result: '2010-07-02 00:00:00',
-  },
-];
-
 describe('valueFormats', () => {
+  it.each`
+    format                | decimals     | value                                       | expected
+    ${'currencyUSD'}      | ${2}         | ${1532.82}                                  | ${'$1.53K'}
+    ${'currencyKRW'}      | ${2}         | ${1532.82}                                  | ${'₩1.53K'}
+    ${'currencyIDR'}      | ${2}         | ${1532.82}                                  | ${'Rp1.53K'}
+    ${'none'}             | ${undefined} | ${3.23}                                     | ${'3.23'}
+    ${'none'}             | ${undefined} | ${0.0245}                                   | ${'0.0245'}
+    ${'none'}             | ${undefined} | ${1 / 3}                                    | ${'0.333'}
+    ${'ms'}               | ${4}         | ${0.0024}                                   | ${'0.0024 ms'}
+    ${'ms'}               | ${0}         | ${100}                                      | ${'100 ms'}
+    ${'ms'}               | ${2}         | ${1250}                                     | ${'1.25 s'}
+    ${'ms'}               | ${1}         | ${10000086.123}                             | ${'2.8 hour'}
+    ${'ms'}               | ${undefined} | ${1000}                                     | ${'1 s'}
+    ${'ms'}               | ${0}         | ${1200}                                     | ${'1 s'}
+    ${'short'}            | ${undefined} | ${1000}                                     | ${'1 K'}
+    ${'short'}            | ${undefined} | ${1200}                                     | ${'1.20 K'}
+    ${'short'}            | ${undefined} | ${1250}                                     | ${'1.25 K'}
+    ${'short'}            | ${undefined} | ${1000000}                                  | ${'1 Mil'}
+    ${'short'}            | ${undefined} | ${1500000}                                  | ${'1.50 Mil'}
+    ${'short'}            | ${undefined} | ${1000120}                                  | ${'1.00 Mil'}
+    ${'short'}            | ${undefined} | ${98765}                                    | ${'98.8 K'}
+    ${'short'}            | ${undefined} | ${9876543}                                  | ${'9.88 Mil'}
+    ${'short'}            | ${undefined} | ${9876543}                                  | ${'9.88 Mil'}
+    ${'kbytes'}           | ${undefined} | ${10000000}                                 | ${'9.54 GiB'}
+    ${'deckbytes'}        | ${undefined} | ${10000000}                                 | ${'10 GB'}
+    ${'megwatt'}          | ${3}         | ${1000}                                     | ${'1.000 GW'}
+    ${'kohm'}             | ${3}         | ${1000}                                     | ${'1.000 MΩ'}
+    ${'Mohm'}             | ${3}         | ${1000}                                     | ${'1.000 GΩ'}
+    ${'farad'}            | ${3}         | ${1000}                                     | ${'1.000 kF'}
+    ${'µfarad'}           | ${3}         | ${1000}                                     | ${'1.000 mF'}
+    ${'nfarad'}           | ${3}         | ${1000}                                     | ${'1.000 µF'}
+    ${'pfarad'}           | ${3}         | ${1000}                                     | ${'1.000 nF'}
+    ${'ffarad'}           | ${3}         | ${1000}                                     | ${'1.000 pF'}
+    ${'henry'}            | ${3}         | ${1000}                                     | ${'1.000 kH'}
+    ${'mhenry'}           | ${3}         | ${1000}                                     | ${'1.000 H'}
+    ${'µhenry'}           | ${3}         | ${1000}                                     | ${'1.000 mH'}
+    ${'a'}                | ${0}         | ${1532.82}                                  | ${'1533 a'}
+    ${'b'}                | ${0}         | ${1532.82}                                  | ${'1533 b'}
+    ${'prefix:b'}         | ${undefined} | ${1532.82}                                  | ${'b1533'}
+    ${'suffix:d'}         | ${undefined} | ${1532.82}                                  | ${'1533 d'}
+    ${'si:µF'}            | ${2}         | ${1234}                                     | ${'1.23 mF'}
+    ${'si:µF'}            | ${2}         | ${1234000000}                               | ${'1.23 kF'}
+    ${'si:µF'}            | ${2}         | ${1234000000000000}                         | ${'1.23 GF'}
+    ${'count:xpm'}        | ${2}         | ${1234567}                                  | ${'1.23M xpm'}
+    ${'count:x/min'}      | ${2}         | ${1234}                                     | ${'1.23K x/min'}
+    ${'currency:@'}       | ${2}         | ${1234567}                                  | ${'@1.23M'}
+    ${'currency:@'}       | ${2}         | ${1234}                                     | ${'@1.23K'}
+    ${'time:YYYY'}        | ${0}         | ${dateTime(new Date(1999, 6, 2)).valueOf()} | ${'1999'}
+    ${'time:YYYY.MM'}     | ${0}         | ${dateTime(new Date(2010, 6, 2)).valueOf()} | ${'2010.07'}
+    ${'dateTimeAsIso'}    | ${0}         | ${dateTime(new Date(2010, 6, 2)).valueOf()} | ${'2010-07-02 00:00:00'}
+    ${'dateTimeAsUS'}     | ${0}         | ${dateTime(new Date(2010, 6, 2)).valueOf()} | ${'07/02/2010 12:00:00 am'}
+    ${'dateTimeAsSystem'} | ${0}         | ${dateTime(new Date(2010, 6, 2)).valueOf()} | ${'2010-07-02 00:00:00'}
+    ${'dtdurationms'}     | ${undefined} | ${100000}                                   | ${'1 minute'}
+  `(
+    'With format=$format decimals=$decimals and value=$value then result shoudl be = $expected',
+    async ({ format, value, decimals, expected }) => {
+      const result = getValueFormat(format)(value, decimals, undefined, undefined);
+      const full = formattedValueToString(result);
+      expect(full).toBe(expected);
+    }
+  );
+
   it('Manually check a format', () => {
     // helpful for adding tests one at a time with the debugger
     const tests: ValueFormatTest[] = [
@@ -103,16 +85,6 @@ describe('valueFormats', () => {
     const full = formattedValueToString(result);
     expect(full).toBe(test.result);
   });
-
-  for (const test of formatTests) {
-    describe(`value format: ${test.id}`, () => {
-      it(`should translate ${test.value} as ${test.result}`, () => {
-        const result = getValueFormat(test.id)(test.value, test.decimals, test.scaledDecimals);
-        const full = formattedValueToString(result);
-        expect(full).toBe(test.result);
-      });
-    });
-  }
 
   describe('normal cases', () => {
     it('toFixed should handle number correctly if decimal is null', () => {


### PR DESCRIPTION
Fixes #30940

Also rewrite unit tests to use jest table tests (creates much better test error messages)
