### PR TITLE
Remove last synchronisation field from LDAP debug view

### DIFF
--- a/public/app/features/admin/UserLdapSyncInfo.tsx
+++ b/public/app/features/admin/UserLdapSyncInfo.tsx
@@ -21,10 +21,8 @@ export class UserLdapSyncInfo extends PureComponent<Props, State> {
 
   render() {
     const { ldapSyncInfo, user } = this.props;
-    const prevSyncSuccessful = ldapSyncInfo && ldapSyncInfo.prevSync;
     const nextSyncSuccessful = ldapSyncInfo && ldapSyncInfo.nextSync;
     const nextSyncTime = nextSyncSuccessful ? dateTimeFormat(ldapSyncInfo.nextSync, { format }) : '';
-    const prevSyncTime = prevSyncSuccessful ? dateTimeFormat(ldapSyncInfo.prevSync!.started, { format }) : '';
     const debugLDAPMappingURL = `${debugLDAPMappingBaseURL}?user=${user && user.login}`;
 
     return (
@@ -52,17 +50,6 @@ export class UserLdapSyncInfo extends PureComponent<Props, State> {
                       <td>Next scheduled synchronisation</td>
                       <td colSpan={2}>Not enabled</td>
                     </>
-                  )}
-                </tr>
-                <tr>
-                  {prevSyncSuccessful ? (
-                    <>
-                      <td>Last synchronisation</td>
-                      <td>{prevSyncTime}</td>
-                      <td>Successful</td>
-                    </>
-                  ) : (
-                    <td colSpan={3}>Last synchronisation</td>
                   )}
                 </tr>
               </tbody>

--- a/public/app/features/admin/ldap/LdapSyncInfo.tsx
+++ b/public/app/features/admin/ldap/LdapSyncInfo.tsx
@@ -26,8 +26,6 @@ export class LdapSyncInfo extends PureComponent<Props, State> {
     const { ldapSyncInfo } = this.props;
     const { isSyncing } = this.state;
     const nextSyncTime = dateTimeFormat(ldapSyncInfo.nextSync, { format });
-    const prevSyncSuccessful = ldapSyncInfo && ldapSyncInfo.prevSync;
-    const prevSyncTime = prevSyncSuccessful ? dateTimeFormat(ldapSyncInfo.prevSync!.started, { format }) : '';
 
     return (
       <>
@@ -53,15 +51,6 @@ export class LdapSyncInfo extends PureComponent<Props, State> {
                 <tr>
                   <td>Next scheduled synchronisation</td>
                   <td>{nextSyncTime}</td>
-                </tr>
-                <tr>
-                  <td>Last synchronisation</td>
-                  {prevSyncSuccessful && (
-                    <>
-                      <td>{prevSyncTime}</td>
-                      <td>Successful</td>
-                    </>
-                  )}
                 </tr>
               </tbody>
             </table>

--- a/public/app/types/ldap.ts
+++ b/public/app/types/ldap.ts
@@ -12,21 +12,12 @@ export interface SyncInfo {
   enabled: boolean;
   schedule: string;
   nextSync: string;
-  prevSync?: SyncResult;
 }
 
 export interface LdapUserSyncInfo {
   nextSync?: string;
   prevSync?: string;
   status?: string;
-}
-
-export interface SyncResult {
-  started: string;
-  elapsed: string;
-  UpdatedUserIds: number[];
-  MissingUserIds: number[];
-  FailedUsers?: FailedUser[];
 }
 
 export interface FailedUser {


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes last sync field from LDAP debug view and solves [this Enterprise issue](https://github.com/grafana/grafana-enterprise/issues/314 ) 
