### PR TITLE
BarGauge: Improvements to value sizing and table inner width calculations 

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -10,6 +10,7 @@ import {
   getTitleStyles,
   getValuePercent,
   BarGaugeDisplayMode,
+  calculateBarAndValueDimensions,
 } from './BarGauge';
 import { getTheme } from '../../themes';
 
@@ -209,6 +210,20 @@ describe('BarGauge', () => {
     it('should render', () => {
       const { wrapper } = setup();
       expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe('calculateBarAndValueDimensions', () => {
+    it('valueWidth should including paddings in valueWidth', () => {
+      const result = calculateBarAndValueDimensions(
+        getProps({
+          height: 30,
+          width: 100,
+          value: getValue(1, 'AA'),
+          orientation: VizOrientation.Horizontal,
+        })
+      );
+      expect(result.valueWidth).toBe(21);
     });
   });
 });

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -29,8 +29,8 @@ import { VizOrientation } from '@grafana/data';
 import { Themeable } from '../../types';
 
 const MIN_VALUE_HEIGHT = 18;
-const MAX_VALUE_HEIGHT = 50;
-const MIN_VALUE_WIDTH = 50;
+const MAX_VALUE_HEIGHT = 80;
+const MIN_VALUE_WIDTH = 100;
 const MAX_VALUE_WIDTH = 150;
 const TITLE_LINE_HEIGHT = 1.5;
 const VALUE_LINE_HEIGHT = 1;
@@ -396,12 +396,7 @@ function calculateBarAndValueDimensions(props: Props): BarAndValueDimensions {
     wrapperWidth = width;
     wrapperHeight = height - titleDim.height;
   } else {
-    if (text?.valueSize) {
-      valueHeight = text.valueSize * VALUE_LINE_HEIGHT;
-    } else {
-      valueHeight = height - titleDim.height;
-    }
-
+    valueHeight = height - titleDim.height;
     valueWidth = Math.max(Math.min(width * 0.2, MAX_VALUE_WIDTH), MIN_VALUE_WIDTH);
     maxBarHeight = height - titleDim.height;
     maxBarWidth = width - valueWidth - titleDim.width;

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -29,8 +29,7 @@ import { VizOrientation } from '@grafana/data';
 import { Themeable } from '../../types';
 
 const MIN_VALUE_HEIGHT = 18;
-const MAX_VALUE_HEIGHT = 80;
-const MIN_VALUE_WIDTH = 50;
+const MAX_VALUE_HEIGHT = 50;
 const MAX_VALUE_WIDTH = 150;
 const TITLE_LINE_HEIGHT = 1.5;
 const VALUE_LINE_HEIGHT = 1;

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -372,7 +372,11 @@ interface BarAndValueDimensions {
   wrapperWidth: number;
 }
 
-function calculateBarAndValueDimensions(props: Props): BarAndValueDimensions {
+/**
+ * @internal
+ * Only exported for unit tests
+ **/
+export function calculateBarAndValueDimensions(props: Props): BarAndValueDimensions {
   const { height, width, orientation, text, alignmentFactors } = props;
   const titleDim = calculateTitleDimensions(props);
   const value = alignmentFactors ?? props.value;

--- a/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
+++ b/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
@@ -29,13 +29,13 @@ exports[`BarGauge Render with basic options should render 1`] = `
           "alignItems": "center",
           "color": "#73BF69",
           "display": "flex",
-          "fontSize": 140,
+          "fontSize": 280,
           "height": "300px",
           "justifyContent": "flex-end",
           "lineHeight": 1,
           "paddingLeft": "10px",
           "paddingRight": "10px",
-          "width": "60px",
+          "width": "100px",
         }
       }
       value={
@@ -74,7 +74,7 @@ exports[`BarGauge Render with basic options should render 1`] = `
           "height": "300px",
           "position": "relative",
           "transition": "width 1s",
-          "width": "60px",
+          "width": "50px",
           "zIndex": 1,
         }
       }

--- a/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
+++ b/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
@@ -29,13 +29,13 @@ exports[`BarGauge Render with basic options should render 1`] = `
           "alignItems": "center",
           "color": "#73BF69",
           "display": "flex",
-          "fontSize": 280,
+          "fontSize": 140,
           "height": "300px",
           "justifyContent": "flex-end",
           "lineHeight": 1,
           "paddingLeft": "10px",
           "paddingRight": "10px",
-          "width": "100px",
+          "width": "60px",
         }
       }
       value={
@@ -62,6 +62,7 @@ exports[`BarGauge Render with basic options should render 1`] = `
           "flexGrow": 1,
           "left": "-3px",
           "position": "relative",
+          "width": "180px",
         }
       }
     />
@@ -74,7 +75,7 @@ exports[`BarGauge Render with basic options should render 1`] = `
           "height": "300px",
           "position": "relative",
           "transition": "width 1s",
-          "width": "50px",
+          "width": "60px",
           "zIndex": 1,
         }
       }

--- a/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
@@ -19,7 +19,7 @@ const defaultScale: ThresholdsConfig = {
 };
 
 export const BarGaugeCell: FC<TableCellProps> = (props) => {
-  const { field, column, tableStyles, cell, cellProps } = props;
+  const { field, innerWidth, tableStyles, cell, cellProps } = props;
 
   let config = getFieldConfigWithMinMax(field, false);
   if (!config.thresholds) {
@@ -38,17 +38,10 @@ export const BarGaugeCell: FC<TableCellProps> = (props) => {
     barGaugeMode = BarGaugeDisplayMode.Basic;
   }
 
-  let width;
-  if (column.width) {
-    width = (column.width as number) - tableStyles.cellPadding * 2;
-  } else {
-    width = tableStyles.cellPadding * 2;
-  }
-
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>
       <BarGauge
-        width={width}
+        width={innerWidth}
         height={tableStyles.cellHeightInner}
         field={config}
         display={field.display}

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -178,6 +178,8 @@ export const Table: FC<Props> = memo((props: Props) => {
               tableStyles={tableStyles}
               cell={cell}
               onCellFilterAdded={onCellFilterAdded}
+              columnIndex={index}
+              columnCount={row.cells.length}
             />
           ))}
         </div>

--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -9,9 +9,11 @@ export interface Props {
   field: Field;
   tableStyles: TableStyles;
   onCellFilterAdded?: TableFilterActionCallback;
+  columnIndex: number;
+  columnCount: number;
 }
 
-export const TableCell: FC<Props> = ({ cell, field, tableStyles, onCellFilterAdded }) => {
+export const TableCell: FC<Props> = ({ cell, field, tableStyles, onCellFilterAdded, columnIndex, columnCount }) => {
   const cellProps = cell.getCellProps();
 
   if (!field.display) {
@@ -23,6 +25,13 @@ export const TableCell: FC<Props> = ({ cell, field, tableStyles, onCellFilterAdd
     cellProps.style.justifyContent = (cell.column as any).justifyContent;
   }
 
+  let innerWidth = ((cell.column.width as number) ?? 24) - tableStyles.cellPadding * 2;
+
+  // last child sometimes have extra padding if there is a non overlay scrollbar
+  if (columnIndex === columnCount - 1) {
+    innerWidth -= tableStyles.lastChildExtraPadding;
+  }
+
   return (
     <>
       {cell.render('Cell', {
@@ -30,6 +39,7 @@ export const TableCell: FC<Props> = ({ cell, field, tableStyles, onCellFilterAdd
         tableStyles,
         onCellFilterAdded,
         cellProps,
+        innerWidth,
       })}
     </>
   );

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -13,7 +13,7 @@ export const getTableStyles = stylesFactory((theme: GrafanaTheme) => {
   const bodyFontSize = 14;
   const cellHeight = cellPadding * 2 + bodyFontSize * lineHeight;
   const rowHoverBg = styleMixins.hoverColor(theme.colors.bg1, theme);
-  const scollbarWidth = getScrollbarWidth();
+  const lastChildExtraPadding = Math.max(getScrollbarWidth(), cellPadding);
 
   const buildCellContainerStyle = (color?: string, background?: string) => {
     return css`
@@ -29,10 +29,7 @@ export const getTableStyles = stylesFactory((theme: GrafanaTheme) => {
 
       &:last-child {
         border-right: none;
-
-        > div {
-          padding-right: ${scollbarWidth + cellPadding}px;
-        }
+        padding-right: ${lastChildExtraPadding}px;
       }
 
       &:hover {
@@ -54,6 +51,7 @@ export const getTableStyles = stylesFactory((theme: GrafanaTheme) => {
     cellHeight,
     buildCellContainerStyle,
     cellPadding,
+    lastChildExtraPadding,
     cellHeightInner: bodyFontSize * lineHeight,
     rowHeight: cellHeight + 2,
     table: css`

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -45,6 +45,7 @@ export interface TableCellProps extends CellProps<any> {
   cellProps: CSSProperties;
   field: Field;
   onCellFilterAdded: TableFilterActionCallback;
+  innerWidth: number;
 }
 
 export type CellComponent = FC<TableCellProps>;

--- a/packages/grafana-ui/src/utils/scrollbar.ts
+++ b/packages/grafana-ui/src/utils/scrollbar.ts
@@ -29,5 +29,6 @@ export function getScrollbarWidth() {
   } else {
     scrollbarWidth = 0;
   }
+
   return scrollbarWidth || 0;
 }


### PR DESCRIPTION
Fixes #30965

* [x]  Adds proper measurement of value sizing instead of always taking a fixed percentage of the width for the value. This will improve the gauge a lot for smaller widths making the value more more readable. (so a narrow gauge can still have readable value)
* [x] Adds some heuristic to try to use the title font size as base when measuring the value width, in order to try two match those to sizes 
* [x] Improves the table inner width calculation and moves it to be shared among all cells (Sparkline cell will need it as well). And fixes the logic so correct innerWidth is calculated for the last chid if there is a scrollbar 
* [x] Moves the last child padding from a inner cell div to the cell div itself (that has the default cell padding) 

Before: 
![Screenshot from 2021-02-09 09-31-09](https://user-images.githubusercontent.com/10999/107336604-95d21800-6ab9-11eb-9a86-e659ff50207c.png)

After:
![Screenshot from 2021-02-09 09-30-46](https://user-images.githubusercontent.com/10999/107336615-98cd0880-6ab9-11eb-9fc0-b8a04c6d2636.png)

Before table: 
![Screenshot from 2021-02-09 09-37-46](https://user-images.githubusercontent.com/10999/107337924-4260c980-6abb-11eb-8735-5382b92f1b00.png)

After table:
![Screenshot from 2021-02-09 09-40-00](https://user-images.githubusercontent.com/10999/107337946-47257d80-6abb-11eb-8cfa-ccdad7428788.png)
