### PR TITLE
Elasticsearch: Fix alias field value not being shown in query editor

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { SettingsEditor } from '.';
 import { ElasticsearchProvider } from '../../ElasticsearchQueryContext';
-import { ElasticDatasource } from 'app/plugins/datasource/elasticsearch/datasource';
-import { ElasticsearchQuery } from 'app/plugins/datasource/elasticsearch/types';
+import { ElasticDatasource } from '../../../../datasource';
+import { ElasticsearchQuery } from '../../../../types';
 
 describe('Settings Editor', () => {
   describe('Raw Data', () => {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryEditor } from '.';
+import { ElasticDatasource } from '../../datasource';
+import { ElasticsearchQuery } from '../../types';
+
+describe('QueryEditor', () => {
+  describe('Alias Field', () => {
+    it('Should correctly render and trigger changes on blur', () => {
+      const alias = '{{metric}}';
+      const query: ElasticsearchQuery = {
+        refId: 'A',
+        alias,
+        metrics: [
+          {
+            id: '1',
+            type: 'raw_data',
+          },
+        ],
+        bucketAggs: [],
+      };
+
+      const onChange = jest.fn<void, [ElasticsearchQuery]>();
+
+      render(
+        <QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={onChange} onRunQuery={() => {}} />
+      );
+
+      let aliasField = screen.getByLabelText('Alias') as HTMLInputElement;
+
+      // The Query should have an alias field
+      expect(aliasField).toBeInTheDocument();
+
+      // its value should match the one in the query
+      expect(aliasField.value).toBe(alias);
+
+      // We change value and trigger a blur event to trigger an update
+      const newAlias = 'new alias';
+      fireEvent.change(aliasField, { target: { value: newAlias } });
+      fireEvent.blur(aliasField);
+
+      // the onChange handler should have been called correctly, and the resulting
+      // query state should match what expected
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].alias).toBe(newAlias);
+    });
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -46,7 +46,12 @@ const QueryEditorForm: FunctionComponent<Props> = ({ value }) => {
           />
         </InlineField>
         <InlineField label="Alias" labelWidth={15}>
-          <Input placeholder="Alias Pattern" onBlur={(e) => dispatch(changeAliasPattern(e.currentTarget.value))} />
+          <Input
+            id={`ES-query-${value.refId}_alias`}
+            placeholder="Alias Pattern"
+            onBlur={(e) => dispatch(changeAliasPattern(e.currentTarget.value))}
+            defaultValue={value.alias}
+          />
         </InlineField>
       </InlineFieldRow>
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The react migration introduced a bug for which the alias field value wasn't being shown in the UI (although it was correctly set and changes modified the query correctly)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #30946


