### PR TITLE
Instrumentation: Make the first database histogram bucket smaller

### DIFF
--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -27,7 +27,7 @@ func init() {
 		Namespace: "grafana",
 		Name:      "database_queries_duration_seconds",
 		Help:      "Database query histogram",
-		Buckets:   prometheus.ExponentialBuckets(0.0001, 4, 9),
+		Buckets:   prometheus.ExponentialBuckets(0.00001, 4, 10),
 	}, []string{"status"})
 
 	prometheus.MustRegister(databaseQueryHistogram)


### PR DESCRIPTION
Currently, lots of queries on HG are faster then the lowest bucket.



Signed-off-by: bergquist <carl.bergquist@gmail.com>

before:
```
# HELP grafana_database_queries_duration_seconds Database query histogram
# TYPE grafana_database_queries_duration_seconds histogram
grafana_database_queries_duration_seconds_bucket{status="success",le="0.0001"} 71
grafana_database_queries_duration_seconds_bucket{status="success",le="0.0004"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="0.0016"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="0.0064"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="0.0256"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="0.1024"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="0.4096"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="1.6384"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="6.5536"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="+Inf"} 103
grafana_database_queries_duration_seconds_sum{status="success"} 0.006981633000000002
grafana_database_queries_duration_seconds_count{status="success"} 103
```

after:
```
# HELP grafana_database_queries_duration_seconds Database query histogram
# TYPE grafana_database_queries_duration_seconds histogram
grafana_database_queries_duration_seconds_bucket{status="success",le="1e-05"} 0
grafana_database_queries_duration_seconds_bucket{status="success",le="4e-05"} 67
grafana_database_queries_duration_seconds_bucket{status="success",le="0.00016"} 103
grafana_database_queries_duration_seconds_bucket{status="success",le="0.00064"} 108
grafana_database_queries_duration_seconds_bucket{status="success",le="0.00256"} 108
grafana_database_queries_duration_seconds_bucket{status="success",le="0.01024"} 108
grafana_database_queries_duration_seconds_bucket{status="success",le="0.04096"} 108
grafana_database_queries_duration_seconds_bucket{status="success",le="0.16384"} 108
grafana_database_queries_duration_seconds_bucket{status="success",le="0.65536"} 108
grafana_database_queries_duration_seconds_bucket{status="success",le="2.62144"} 108
grafana_database_queries_duration_seconds_bucket{status="success",le="+Inf"} 108
grafana_database_queries_duration_seconds_sum{status="success"} 0.006905398999999997
grafana_database_queries_duration_seconds_count{status="success"} 108
```