### PR TITLE
DataFrameDTO: accept a `replacements` parameter to fill in missing JSON features

### DIFF
--- a/packages/grafana-data/src/dataframe/ArrayDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/ArrayDataFrame.test.ts
@@ -1,6 +1,6 @@
 import { ArrayDataFrame } from './ArrayDataFrame';
-import { toDataFrameDTO } from './processDataFrame';
 import { FieldType, DataFrame } from '../types';
+import { toDataFrameDTO } from './DataFrameDTO';
 
 describe('Array DataFrame', () => {
   const input = [

--- a/packages/grafana-data/src/dataframe/ArrayDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/ArrayDataFrame.ts
@@ -1,8 +1,9 @@
 import { Field, FieldType, DataFrame } from '../types/dataFrame';
 import { vectorToArray } from '../vector/vectorToArray';
 import { Vector, QueryResultMeta } from '../types';
-import { guessFieldTypeFromNameAndValue, toDataFrameDTO } from './processDataFrame';
+import { guessFieldTypeFromNameAndValue } from './processDataFrame';
 import { FunctionalVector } from '../vector/FunctionalVector';
+import { toDataFrameDTO } from './DataFrameDTO';
 
 export type ValueConverter<T = any> = (val: any) => T;
 

--- a/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
@@ -1,63 +1,18 @@
 import { FieldType } from '../types/dataFrame';
-import { DataFrameDTO, dataFrameFromDTO, DataFrameReplacementValue, toDataFrameDTO } from './DataFrameDTO';
+import { DataFrameDTO, dataFrameFromDTO, toDataFrameDTO } from './DataFrameDTO';
 
 describe('dataFrameView', () => {
   const dto: DataFrameDTO = {
     name: 'hello',
     fields: [
       { name: 'time', type: FieldType.time, values: [100, 200, 300] },
-      { name: 'name', type: FieldType.string, values: ['a', 'b', null] },
-      { name: 'value', type: FieldType.number, values: [1, 2, null] },
-    ],
-    replace: [
-      { field: 1, value: DataFrameReplacementValue.Undefined, index: [2] },
-      { field: 2, value: DataFrameReplacementValue.NaN, index: [2] },
+      { name: 'name', type: FieldType.string, values: ['a', 'b', null], replaced: { NaN: [2] } },
+      { name: 'value', type: FieldType.number, values: [1, 2, null], replaced: { Inf: [2] } },
     ],
   };
   const frame = dataFrameFromDTO(dto);
 
   it('back to DTO', () => {
-    expect(toDataFrameDTO(frame)).toMatchInlineSnapshot(`
-      Object {
-        "fields": Array [
-          Object {
-            "config": Object {},
-            "labels": undefined,
-            "name": "time",
-            "type": "time",
-            "values": Array [
-              100,
-              200,
-              300,
-            ],
-          },
-          Object {
-            "config": Object {},
-            "labels": undefined,
-            "name": "name",
-            "type": "string",
-            "values": Array [
-              "a",
-              "b",
-              undefined,
-            ],
-          },
-          Object {
-            "config": Object {},
-            "labels": undefined,
-            "name": "value",
-            "type": "number",
-            "values": Array [
-              1,
-              2,
-              NaN,
-            ],
-          },
-        ],
-        "meta": undefined,
-        "name": undefined,
-        "refId": undefined,
-      }
-    `);
+    expect(toDataFrameDTO(frame)).toMatchInlineSnapshot();
   });
 });

--- a/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
@@ -1,18 +1,73 @@
 import { FieldType } from '../types/dataFrame';
 import { DataFrameDTO, dataFrameFromDTO, toDataFrameDTO } from './DataFrameDTO';
 
-describe('dataFrameView', () => {
-  const dto: DataFrameDTO = {
-    name: 'hello',
-    fields: [
-      { name: 'time', type: FieldType.time, values: [100, 200, 300] },
-      { name: 'name', type: FieldType.string, values: ['a', 'b', null], replaced: { NaN: [2] } },
-      { name: 'value', type: FieldType.number, values: [1, 2, null], replaced: { Inf: [2] } },
-    ],
-  };
-  const frame = dataFrameFromDTO(dto);
+describe('dataFrameDTO', () => {
+  it('converts nan and inf', () => {
+    const dto: DataFrameDTO = {
+      name: 'hello',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+        { name: 'name', type: FieldType.string, values: ['a', 'b', null], replaced: { NaN: [2] } },
+        { name: 'value', type: FieldType.number, values: [1, 2, null], replaced: { Inf: [2] } },
+      ],
+    };
+    const frame = dataFrameFromDTO(dto);
+    expect(toDataFrameDTO(frame)).toMatchInlineSnapshot(`
+      Object {
+        "fields": Array [
+          Object {
+            "config": Object {},
+            "labels": undefined,
+            "name": "time",
+            "type": "time",
+            "values": Array [
+              100,
+              200,
+              300,
+            ],
+          },
+          Object {
+            "config": Object {},
+            "labels": undefined,
+            "name": "name",
+            "type": "string",
+            "values": Array [
+              "a",
+              "b",
+              NaN,
+            ],
+          },
+          Object {
+            "config": Object {},
+            "labels": undefined,
+            "name": "value",
+            "type": "number",
+            "values": Array [
+              1,
+              2,
+              Infinity,
+            ],
+          },
+        ],
+        "meta": undefined,
+        "name": undefined,
+        "refId": undefined,
+      }
+    `);
+  });
 
-  it('back to DTO', () => {
-    expect(toDataFrameDTO(frame)).toMatchInlineSnapshot();
+  it('makes everything the same length', () => {
+    const dto: DataFrameDTO = {
+      name: 'hello',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+        { name: 'name', type: FieldType.string, values: ['a', 'b'] },
+        { name: 'value', type: FieldType.number, values: [1] },
+      ],
+    };
+    const frame = dataFrameFromDTO(dto);
+    expect(frame.fields[0].values.length).toEqual(3);
+    expect(frame.fields[1].values.length).toEqual(3);
+    expect(frame.fields[2].values.length).toEqual(3);
   });
 });

--- a/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
@@ -1,0 +1,63 @@
+import { FieldType } from '../types/dataFrame';
+import { DataFrameDTO, dataFrameFromDTO, DataFrameReplacementValue, toDataFrameDTO } from './DataFrameDTO';
+
+describe('dataFrameView', () => {
+  const dto: DataFrameDTO = {
+    name: 'hello',
+    fields: [
+      { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+      { name: 'name', type: FieldType.string, values: ['a', 'b', null] },
+      { name: 'value', type: FieldType.number, values: [1, 2, null] },
+    ],
+    replace: [
+      { field: 1, value: DataFrameReplacementValue.Undefined, rows: [2] },
+      { field: 2, value: DataFrameReplacementValue.NaN, rows: [2] },
+    ],
+  };
+  const frame = dataFrameFromDTO(dto);
+
+  it('back to DTO', () => {
+    expect(toDataFrameDTO(frame)).toMatchInlineSnapshot(`
+      Object {
+        "fields": Array [
+          Object {
+            "config": Object {},
+            "labels": undefined,
+            "name": "time",
+            "type": "time",
+            "values": Array [
+              100,
+              200,
+              300,
+            ],
+          },
+          Object {
+            "config": Object {},
+            "labels": undefined,
+            "name": "name",
+            "type": "string",
+            "values": Array [
+              "a",
+              "b",
+              undefined,
+            ],
+          },
+          Object {
+            "config": Object {},
+            "labels": undefined,
+            "name": "value",
+            "type": "number",
+            "values": Array [
+              1,
+              2,
+              NaN,
+            ],
+          },
+        ],
+        "meta": undefined,
+        "name": undefined,
+        "refId": undefined,
+      }
+    `);
+  });
+});

--- a/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameDTO.test.ts
@@ -10,8 +10,8 @@ describe('dataFrameView', () => {
       { name: 'value', type: FieldType.number, values: [1, 2, null] },
     ],
     replace: [
-      { field: 1, value: DataFrameReplacementValue.Undefined, rows: [2] },
-      { field: 2, value: DataFrameReplacementValue.NaN, rows: [2] },
+      { field: 1, value: DataFrameReplacementValue.Undefined, index: [2] },
+      { field: 2, value: DataFrameReplacementValue.NaN, index: [2] },
     ],
   };
   const frame = dataFrameFromDTO(dto);

--- a/packages/grafana-data/src/dataframe/DataFrameDTO.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameDTO.ts
@@ -4,37 +4,40 @@ import { vectorToArray } from '../vector/vectorToArray';
 import { guessFieldTypeFromNameAndValue } from './processDataFrame';
 
 /**
- * JSON does not support these value types
+ * Since JSON does not support encoding some numeric types, we need to replace them on load.
+ * While some system solve this by encoding everythign as strings, this approach lets is
+ * efficiently communicate which values needed special encoding.
  *
  * @alpha
  */
-export enum DataFrameReplacementValue {
-  NaN = 'NaN',
-  Undefined = 'Undef',
-  Infinity = 'Inf',
-  NegInf = 'NegInf',
+export interface DataFrameReplacements {
+  NaN?: number[];
+  Undef?: number[]; // Missing because of absense or join
+  Inf?: number[];
+  NegInf?: number[];
 }
 
 /**
+ * Field object passed over JSON
+ *
  * @alpha
- */
-export interface DataFrameReplacement {
-  value: DataFrameReplacementValue;
-  field: number;
-  index: number[];
-}
-
-/**
- * Like a field, but properties are optional and values may be a simple array
  */
 export interface FieldDTO {
   name: string; // The column name
   type?: FieldType;
   config?: FieldConfig;
   labels?: Labels;
-  values: any[]; // Converted to vector in real DataFrame
+  values: any[]; // Converted to a vector
+
+  // These values were replaced with nulls while encoding and need to be converted on load
+  replaced?: DataFrameReplacements;
 }
 
+/**
+ * The JSON transfer object for DataFrames.  Values are stored in simple JSON
+ *
+ * @alpha
+ */
 export interface DataFrameDTO {
   /**
    * Matches the query target refId
@@ -55,57 +58,50 @@ export interface DataFrameDTO {
    * Field definition without any metadata
    */
   fields: FieldDTO[];
-
-  /**
-   * replacement functions for the incoming data (fixes json limitations)
-   */
-  replace?: DataFrameReplacement[];
 }
 
-export function getReplacementValue(v: DataFrameReplacementValue): any {
+export function getReplacementValue(v: keyof DataFrameReplacements): any {
   switch (v) {
-    case DataFrameReplacementValue.Infinity:
+    case 'Inf':
       return Number.POSITIVE_INFINITY;
-    case DataFrameReplacementValue.NegInf:
+    case 'NegInf':
       return Number.NEGATIVE_INFINITY;
-    case DataFrameReplacementValue.Undefined:
+    case 'Undef':
       return undefined;
-    case DataFrameReplacementValue.NaN:
+    case 'NaN':
       return NaN;
   }
   return undefined; // should not be possible
 }
 
-function applyReplacements(msg: DataFrameDTO) {
-  if (!msg.replace?.length) {
+function applyReplacements(field: FieldDTO) {
+  if (!field.replaced) {
     return;
   }
 
-  for (const r of msg.replace) {
-    const val = getReplacementValue(r.value);
-    const col = msg.fields[r.field].values;
-    for (const idx of r.index) {
-      col[idx] = val;
+  for (const key of Object.keys(field.replaced)) {
+    const val = getReplacementValue(key as keyof DataFrameReplacements);
+    for (const idx of field.replaced[key as keyof DataFrameReplacements]!) {
+      field.values[idx] = val;
     }
   }
 }
 
-function guessFieldType(idx: number, dto: DataFrameDTO): FieldType {
-  const name = dto.fields[idx].name;
-  for (const v of dto.fields[idx].values) {
+function guessFieldType(field: FieldDTO): FieldType {
+  for (const v of field.values) {
     if (v != null) {
-      return guessFieldTypeFromNameAndValue(name, v);
+      return guessFieldTypeFromNameAndValue(field.name, v);
     }
   }
-
   return FieldType.other;
 }
 
 /**
- * NOTE: the data array may be mutated applying any replacement funciton defined
+ * NOTE: data in the original array will be replaced with values from the DataFrameReplacements property
+ *
+ * @alpha
  */
 export function dataFrameFromDTO(dto: DataFrameDTO): DataFrame {
-  applyReplacements(dto);
   let length = 0;
   for (const f of dto.fields) {
     let flen = f.values?.length;
@@ -114,12 +110,19 @@ export function dataFrameFromDTO(dto: DataFrameDTO): DataFrame {
     }
   }
 
-  const fields = dto.fields.map((f, index) => ({
-    ...f,
-    type: f.type ?? guessFieldType(index, dto),
-    config: f.config ?? {},
-    values: new ArrayVector(dto.fields[index].values).setLength(length),
-  }));
+  const fields = dto.fields.map((f, index) => {
+    if (f.replaced) {
+      applyReplacements(f);
+    }
+    f.values.length = length; // will pad with undefined
+    return {
+      ...f,
+      replaced: f.replaced ?? {},
+      type: f.type ?? guessFieldType(f),
+      config: f.config ?? {},
+      values: new ArrayVector(f.values),
+    };
+  });
   return {
     refId: dto.refId,
     meta: dto.meta,

--- a/packages/grafana-data/src/dataframe/DataFrameDTO.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameDTO.ts
@@ -1,0 +1,149 @@
+import { DataFrame, FieldType, FieldConfig, Labels, QueryResultMeta } from '../types';
+import { ArrayVector } from '../vector';
+import { vectorToArray } from '../vector/vectorToArray';
+import { guessFieldTypeFromNameAndValue } from './processDataFrame';
+
+/**
+ * JSON does not support these value types
+ *
+ * @alpha
+ */
+export enum DataFrameReplacementValue {
+  NaN = 'NaN',
+  Undefined = 'Undef',
+  Infinity = 'Inf',
+  NegInf = 'NegInf',
+}
+
+/**
+ * @alpha
+ */
+export interface DataFrameReplacement {
+  value: DataFrameReplacementValue;
+  field: number;
+  rows: number[];
+}
+
+/**
+ * Like a field, but properties are optional and values may be a simple array
+ */
+export interface FieldDTO {
+  name: string; // The column name
+  type?: FieldType;
+  config?: FieldConfig;
+  labels?: Labels;
+  values: any[]; // Converted to vector in real DataFrame
+}
+
+export interface DataFrameDTO {
+  /**
+   * Matches the query target refId
+   */
+  refId?: string;
+
+  /**
+   * Initial response global metadata
+   */
+  meta?: QueryResultMeta;
+
+  /**
+   * Frame name
+   */
+  name?: string;
+
+  /**
+   * Field definition without any metadata
+   */
+  fields: FieldDTO[];
+
+  /**
+   * replacement functions for the incoming data (fixes json limitations)
+   */
+  replace?: DataFrameReplacement[];
+}
+
+export function getReplacementValue(v: DataFrameReplacementValue): any {
+  switch (v) {
+    case DataFrameReplacementValue.Infinity:
+      return Number.POSITIVE_INFINITY;
+    case DataFrameReplacementValue.NegInf:
+      return Number.NEGATIVE_INFINITY;
+    case DataFrameReplacementValue.Undefined:
+      return undefined;
+    case DataFrameReplacementValue.NaN:
+      return NaN;
+  }
+  return undefined; // should not be possible
+}
+
+function applyReplacements(msg: DataFrameDTO) {
+  if (!msg.replace?.length) {
+    return;
+  }
+
+  for (const r of msg.replace) {
+    const val = getReplacementValue(r.value);
+    const col = msg.fields[r.field].values;
+    for (const idx of r.rows) {
+      col[idx] = val;
+    }
+  }
+}
+
+function guessFieldType(idx: number, dto: DataFrameDTO): FieldType {
+  const name = dto.fields[idx].name;
+  for (const v of dto.fields[idx].values) {
+    if (v != null) {
+      return guessFieldTypeFromNameAndValue(name, v);
+    }
+  }
+
+  return FieldType.other;
+}
+
+/**
+ * NOTE: the data array may be mutated applying any replacement funciton defined
+ */
+export function dataFrameFromDTO(dto: DataFrameDTO): DataFrame {
+  applyReplacements(dto);
+
+  const fields = dto.fields.map((f, index) => ({
+    ...f,
+    type: f.type ?? guessFieldType(index, dto),
+    config: f.config ?? {},
+    values: new ArrayVector(dto.fields[index].values),
+  }));
+  return {
+    refId: dto.refId,
+    meta: dto.meta,
+    fields,
+    length: fields[0].values.length,
+  };
+}
+
+/**
+ * Returns a copy that does not include functions
+ */
+export function toDataFrameDTO(data: DataFrame): DataFrameDTO {
+  const fields: FieldDTO[] = data.fields.map((f) => {
+    let values = f.values.toArray();
+    // The byte buffers serialize like objects
+    if (values instanceof Float64Array) {
+      values = vectorToArray(f.values);
+    }
+    return {
+      name: f.name,
+      type: f.type,
+      config: f.config,
+      values,
+      labels: f.labels,
+    };
+  });
+
+  return {
+    fields,
+    refId: data.refId,
+    meta: data.meta,
+    name: data.name,
+  };
+}

--- a/packages/grafana-data/src/dataframe/MutableDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/MutableDataFrame.ts
@@ -1,6 +1,7 @@
-import { Field, DataFrame, DataFrameDTO, FieldDTO, FieldType } from '../types/dataFrame';
+import { Field, DataFrame, FieldType } from '../types/dataFrame';
 import { QueryResultMeta } from '../types/data';
-import { guessFieldTypeFromValue, guessFieldTypeForField, toDataFrameDTO } from './processDataFrame';
+import { guessFieldTypeFromValue, guessFieldTypeForField } from './processDataFrame';
+import { DataFrameDTO, FieldDTO, toDataFrameDTO } from './DataFrameDTO';
 import isString from 'lodash/isString';
 import { makeFieldParser } from '../utils/fieldParser';
 import { MutableVector, Vector } from '../types/vector';
@@ -69,7 +70,7 @@ export class MutableDataFrame<T = any> extends FunctionalVector<T> implements Da
     return this.addField({
       name: name || '', // Will be filled in
       type: guessFieldTypeFromValue(value),
-    });
+    } as any);
   }
 
   addField(f: Field | FieldDTO, startLength?: number): MutableField {
@@ -164,7 +165,7 @@ export class MutableDataFrame<T = any> extends FunctionalVector<T> implements Da
       this.addField({
         name: `Field ${i + 1}`,
         type: guessFieldTypeFromValue(row[i]),
-      });
+      } as any);
     }
 
     // The first line may change the field types

--- a/packages/grafana-data/src/dataframe/MutableDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/MutableDataFrame.ts
@@ -73,7 +73,7 @@ export class MutableDataFrame<T = any> extends FunctionalVector<T> implements Da
     } as any);
   }
 
-  addField(f: Field | FieldDTO, startLength?: number): MutableField {
+  addField(f: Field | Partial<FieldDTO>, startLength?: number): MutableField {
     let buffer: any[] | undefined = undefined;
 
     if (f.values) {

--- a/packages/grafana-data/src/dataframe/MutableDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/MutableDataFrame.ts
@@ -70,7 +70,7 @@ export class MutableDataFrame<T = any> extends FunctionalVector<T> implements Da
     return this.addField({
       name: name || '', // Will be filled in
       type: guessFieldTypeFromValue(value),
-    } as any);
+    });
   }
 
   addField(f: Field | Partial<FieldDTO>, startLength?: number): MutableField {
@@ -165,7 +165,7 @@ export class MutableDataFrame<T = any> extends FunctionalVector<T> implements Da
       this.addField({
         name: `Field ${i + 1}`,
         type: guessFieldTypeFromValue(row[i]),
-      } as any);
+      });
     }
 
     // The first line may change the field types

--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -7,3 +7,4 @@ export * from './dimensions';
 export * from './ArrowDataFrame';
 export * from './ArrayDataFrame';
 export * from './frameComparisons';
+export * from './DataFrameDTO';

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -12,19 +12,17 @@ import {
   Column,
   GraphSeriesXY,
   TimeSeriesValue,
-  FieldDTO,
-  DataFrameDTO,
   TIME_SERIES_VALUE_FIELD_NAME,
   TIME_SERIES_TIME_FIELD_NAME,
 } from '../types/index';
 import { isDateTime } from '../datetime/moment_wrapper';
 import { ArrayVector } from '../vector/ArrayVector';
-import { MutableDataFrame } from './MutableDataFrame';
 import { SortedVector } from '../vector/SortedVector';
 import { ArrayDataFrame } from './ArrayDataFrame';
 import { getFieldDisplayName } from '../field/fieldState';
 import { fieldIndexComparer } from '../field/fieldComparers';
 import { vectorToArray } from '../vector/vectorToArray';
+import { dataFrameFromDTO, DataFrameDTO } from './DataFrameDTO';
 
 function convertTableToDataFrame(table: TableData): DataFrame {
   const fields = table.columns.map((c) => {
@@ -289,7 +287,7 @@ export function toDataFrame(data: any): DataFrame {
     }
 
     // This will convert the array values into Vectors
-    return new MutableDataFrame(data as DataFrameDTO);
+    return dataFrameFromDTO(data as DataFrameDTO);
   }
 
   // Handle legacy docs/json type
@@ -437,33 +435,6 @@ export function getDataFrameRow(data: DataFrame, row: number): any[] {
     values.push(field.values.get(row));
   }
   return values;
-}
-
-/**
- * Returns a copy that does not include functions
- */
-export function toDataFrameDTO(data: DataFrame): DataFrameDTO {
-  const fields: FieldDTO[] = data.fields.map((f) => {
-    let values = f.values.toArray();
-    // The byte buffers serialize like objects
-    if (values instanceof Float64Array) {
-      values = vectorToArray(f.values);
-    }
-    return {
-      name: f.name,
-      type: f.type,
-      config: f.config,
-      values,
-      labels: f.labels,
-    };
-  });
-
-  return {
-    fields,
-    refId: data.refId,
-    meta: data.meta,
-    name: data.name,
-  };
 }
 
 export const getTimeField = (series: DataFrame): { timeField?: Field; timeIndex?: number } => {

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -21,7 +21,6 @@ import { SortedVector } from '../vector/SortedVector';
 import { ArrayDataFrame } from './ArrayDataFrame';
 import { getFieldDisplayName } from '../field/fieldState';
 import { fieldIndexComparer } from '../field/fieldComparers';
-import { vectorToArray } from '../vector/vectorToArray';
 import { dataFrameFromDTO, DataFrameDTO } from './DataFrameDTO';
 
 function convertTableToDataFrame(table: TableData): DataFrame {

--- a/packages/grafana-data/src/transformations/transformers/labelsToFields.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/labelsToFields.test.ts
@@ -1,8 +1,8 @@
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
 import { LabelsToFieldsOptions, labelsToFieldsTransformer } from './labelsToFields';
-import { DataTransformerConfig, FieldDTO, FieldType } from '../../types';
+import { DataTransformerConfig, FieldType } from '../../types';
 import { DataTransformerID } from './ids';
-import { toDataFrame, toDataFrameDTO } from '../../dataframe';
+import { toDataFrame, toDataFrameDTO, FieldDTO } from '../../dataframe';
 import { transformDataFrame } from '../transformDataFrame';
 
 describe('Labels as Columns', () => {

--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -185,25 +185,6 @@ export interface DataFrame extends QueryResultBase {
   length: number;
 }
 
-/**
- * Like a field, but properties are optional and values may be a simple array
- */
-export interface FieldDTO<T = any> {
-  name: string; // The column name
-  type?: FieldType;
-  config?: FieldConfig;
-  values?: Vector<T> | T[]; // toJSON will always be T[], input could be either
-  labels?: Labels;
-}
-
-/**
- * Like a DataFrame, but fields may be a FieldDTO
- */
-export interface DataFrameDTO extends QueryResultBase {
-  name?: string;
-  fields: Array<FieldDTO | Field>;
-}
-
 export interface FieldCalcs extends Record<string, any> {}
 
 export const TIME_SERIES_VALUE_FIELD_NAME = 'Value';

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -5,12 +5,13 @@ import { PanelData } from './panel';
 import { LogRowModel } from './logs';
 import { AnnotationEvent, AnnotationSupport } from './annotations';
 import { DataTopic, KeyValue, LoadingState, TableData, TimeSeries } from './data';
-import { DataFrame, DataFrameDTO } from './dataFrame';
+import { DataFrame } from './dataFrame';
 import { RawTimeRange, TimeRange } from './time';
 import { ScopedVars } from './ScopedVars';
 import { CoreApp } from './app';
 import { LiveChannelSupport } from './live';
 import { CustomVariableSupport, DataSourceVariableSupport, StandardVariableSupport } from './variables';
+import { DataFrameDTO } from '../dataframe';
 
 export interface DataSourcePluginOptionsEditorProps<JSONData = DataSourceJsonData, SecureJSONData = {}> {
   options: DataSourceSettings<JSONData, SecureJSONData>;

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -16,11 +16,6 @@ export class ArrayVector<T = any> extends FunctionalVector<T> implements Mutable
     return this.buffer.length;
   }
 
-  setLength(len: number): ArrayVector<T> {
-    this.buffer.length = len;
-    return this;
-  }
-
   add(value: T) {
     this.buffer.push(value);
   }

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -16,6 +16,11 @@ export class ArrayVector<T = any> extends FunctionalVector<T> implements Mutable
     return this.buffer.length;
   }
 
+  setLength(len: number): ArrayVector<T> {
+    this.buffer.length = len;
+    return this;
+  }
+
   add(value: T) {
     this.buffer.push(value);
   }

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { Observable, of, throwError } from 'rxjs';
 import {
-  ArrayVector,
   CoreApp,
   DataQueryRequest,
   DataSourceInstanceSettings,
@@ -900,11 +899,11 @@ describe('enhanceDataFrame', () => {
       fields: [
         {
           name: 'urlField',
-          values: new ArrayVector([]),
+          values: [],
         },
         {
           name: 'traceField',
-          values: new ArrayVector([]),
+          values: [],
         },
       ],
     });


### PR DESCRIPTION
We are currently using `json(base64(arrow))` to pass data from backend to the frontend -- needless to say, this is less efficient that it could be :)

@leeoniya and I have explored various options to improve this.  TLDR, all signs point towards json with native browser compression.  One big drawback to JSON is that it does not support: `undefined`, `NaN`, `Infinity`, `-Infinity` -- this PR adds a replacements section to the existing DataFrameDTO so that it can represent the same data as arrow.  (excluding the stuff we don't really support in the frontend anyway -- like binary etc)

For Grafana 8, we will also evaluate removing the `Vector<T>` abstraction and forcing field values to be a simple array.  That is out-of-scope for this PR, but this puts us on a path to greatly simplify the DataFrame.

EDIT (leon):

the back->front sandwich we have: `arrow -> gzip(json(base64(arrow)))`
the back->front sandwich we want: `arrow -> brotli(json)`