### PR TITLE
LogsPanel: Add deduplication option for logs

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -10,7 +10,6 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   data,
   timeZone,
   options: { showLabels, showTime, wrapLogMessage, sortOrder, dedupStrategy },
-  width,
 }) => {
   if (!data) {
     return (

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { LogRows, CustomScrollbar } from '@grafana/ui';
 import { LogsDedupStrategy, PanelProps } from '@grafana/data';
 import { Options } from './types';
-import { dataFrameToLogsModel } from 'app/core/logs_model';
+import { dataFrameToLogsModel, dedupLogRows } from 'app/core/logs_model';
 
 interface LogsPanelProps extends PanelProps<Options> {}
 
 export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   data,
   timeZone,
-  options: { showLabels, showTime, wrapLogMessage, sortOrder },
+  options: { showLabels, showTime, wrapLogMessage, sortOrder, dedupStrategy },
   width,
 }) => {
   if (!data) {
@@ -21,12 +21,15 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   }
 
   const newResults = data ? dataFrameToLogsModel(data.series, data.request?.intervalMs, timeZone) : null;
+  const deduplicatedRows =
+    dedupStrategy === LogsDedupStrategy.none ? undefined : dedupLogRows(newResults?.rows || [], dedupStrategy);
 
   return (
     <CustomScrollbar autoHide>
       <LogRows
         logRows={newResults?.rows || []}
-        dedupStrategy={LogsDedupStrategy.none}
+        deduplicatedRows={deduplicatedRows}
+        dedupStrategy={dedupStrategy}
         highlighterExpressions={[]}
         showLabels={showLabels}
         showTime={showTime}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LogRows, CustomScrollbar } from '@grafana/ui';
-import { LogsDedupStrategy, PanelProps } from '@grafana/data';
+import { PanelProps } from '@grafana/data';
 import { Options } from './types';
 import { dataFrameToLogsModel, dedupLogRows } from 'app/core/logs_model';
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -21,13 +21,13 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   }
 
   const newResults = data ? dataFrameToLogsModel(data.series, data.request?.intervalMs, timeZone) : null;
-  const deduplicatedRows =
-    dedupStrategy === LogsDedupStrategy.none ? undefined : dedupLogRows(newResults?.rows || [], dedupStrategy);
+  const logRows = newResults?.rows || [];
+  const deduplicatedRows = dedupLogRows(logRows, dedupStrategy);
 
   return (
     <CustomScrollbar autoHide>
       <LogRows
-        logRows={newResults?.rows || []}
+        logRows={logRows}
         deduplicatedRows={deduplicatedRows}
         dedupStrategy={dedupStrategy}
         highlighterExpressions={[]}

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -23,18 +23,6 @@ export const plugin = new PanelPlugin<Options>(LogsPanel).setPanelOptions((build
       defaultValue: false,
     })
     .addRadio({
-      path: 'sortOrder',
-      name: 'Order',
-      description: '',
-      settings: {
-        options: [
-          { value: LogsSortOrder.Descending, label: 'Descending' },
-          { value: LogsSortOrder.Ascending, label: 'Ascending' },
-        ],
-      },
-      defaultValue: LogsSortOrder.Descending,
-    })
-    .addRadio({
       path: 'dedupStrategy',
       name: 'Deduplication',
       description: '',
@@ -59,5 +47,17 @@ export const plugin = new PanelPlugin<Options>(LogsPanel).setPanelOptions((build
         ],
       },
       defaultValue: LogsDedupStrategy.none,
+    })
+    .addRadio({
+      path: 'sortOrder',
+      name: 'Order',
+      description: '',
+      settings: {
+        options: [
+          { value: LogsSortOrder.Descending, label: 'Descending' },
+          { value: LogsSortOrder.Ascending, label: 'Ascending' },
+        ],
+      },
+      defaultValue: LogsSortOrder.Descending,
     });
 });

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -1,4 +1,4 @@
-import { PanelPlugin, LogsSortOrder } from '@grafana/data';
+import { PanelPlugin, LogsSortOrder, LogsDedupStrategy, LogsDedupDescription } from '@grafana/data';
 import { Options } from './types';
 import { LogsPanel } from './LogsPanel';
 
@@ -33,5 +33,31 @@ export const plugin = new PanelPlugin<Options>(LogsPanel).setPanelOptions((build
         ],
       },
       defaultValue: LogsSortOrder.Descending,
+    })
+    .addRadio({
+      path: 'dedupStrategy',
+      name: 'Deduplication',
+      description: '',
+      settings: {
+        options: [
+          { value: LogsDedupStrategy.none, label: 'None', description: LogsDedupDescription[LogsDedupStrategy.none] },
+          {
+            value: LogsDedupStrategy.exact,
+            label: 'Exact',
+            description: LogsDedupDescription[LogsDedupStrategy.exact],
+          },
+          {
+            value: LogsDedupStrategy.numbers,
+            label: 'Numbers',
+            description: LogsDedupDescription[LogsDedupStrategy.numbers],
+          },
+          {
+            value: LogsDedupStrategy.signature,
+            label: 'Signature',
+            description: LogsDedupDescription[LogsDedupStrategy.signature],
+          },
+        ],
+      },
+      defaultValue: LogsDedupStrategy.none,
     });
 });

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -1,8 +1,9 @@
-import { LogsSortOrder } from '@grafana/data';
+import { LogsSortOrder, LogsDedupStrategy } from '@grafana/data';
 
 export interface Options {
   showLabels: boolean;
   showTime: boolean;
   wrapLogMessage: boolean;
   sortOrder: LogsSortOrder;
+  dedupStrategy: LogsDedupStrategy;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In Logs Panel, we are currently supporting the same logs view customisation as in Explore, besides deduplication. This PR adds deduplication support in Logs Panel. 

**Explore:**
![image](https://user-images.githubusercontent.com/30407135/107346326-d97e4f00-6ac4-11eb-9b70-85e1b96eb566.png)

**Logs Panel:**
![image](https://user-images.githubusercontent.com/30407135/107346389-ee5ae280-6ac4-11eb-8edc-c40a7256a762.png)

![image](https://user-images.githubusercontent.com/30407135/107346466-029edf80-6ac5-11eb-9a05-d81b6e1c16a1.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/22498

