### PR TITLE
Influx: Make max series limit configurable and show the limiting message if applied

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -85,7 +85,9 @@ func readDataFrames(result *api.QueryTableResult, maxPoints int, maxSeries int) 
 		}
 	}
 
-	// Attach any errors (may be null)
-	dr.Error = result.Err()
+	// Pass result error only if not nil so we do not overwrite any other errors
+	if result.Err() != nil {
+		dr.Error = result.Err()
+	}
 	return dr
 }

--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -85,7 +85,7 @@ func readDataFrames(result *api.QueryTableResult, maxPoints int, maxSeries int) 
 		}
 	}
 
-	// Pass result error only if not nil so we do not overwrite any other errors
+	// result.Err() is probably more important then the other errors
 	if result.Err() != nil {
 		dr.Error = result.Err()
 	}

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -3,6 +3,7 @@ package flux
 import (
 	"context"
 	"fmt"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -3,8 +3,6 @@ package flux
 import (
 	"context"
 	"fmt"
-	"strconv"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -40,12 +38,8 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 			continue
 		}
 
-		// Same default should be set in the frontend but we are not doing migration so old DS may have this undefined
-		maxSeries, err := strconv.Atoi(dsInfo.JsonData.Get("maxSeries").MustString())
-		if err != nil {
-			maxSeries = 1000
-		}
-		glog.Debug("Max series", "val", maxSeries)
+		// If the default changes also update labels/placeholder in config page.
+		maxSeries := dsInfo.JsonData.Get("maxSeries").MustInt(1000)
 		res := executeQuery(ctx, *qm, r, maxSeries)
 
 		tRes.Results[query.RefId] = backendDataResponseToTSDBResponse(&res, query.RefId)

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -3,6 +3,7 @@ package flux
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -39,7 +40,13 @@ func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQ
 			continue
 		}
 
-		res := executeQuery(ctx, *qm, r, 50)
+		// Same default should be set in the frontend but we are not doing migration so old DS may have this undefined
+		maxSeries, err := strconv.Atoi(dsInfo.JsonData.Get("maxSeries").MustString())
+		if err != nil {
+			maxSeries = 1000
+		}
+		glog.Debug("Max series", "val", maxSeries)
+		res := executeQuery(ctx, *qm, r, maxSeries)
 
 		tRes.Results[query.RefId] = backendDataResponseToTSDBResponse(&res, query.RefId)
 	}

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -4,15 +4,27 @@ import {
   cancelQueriesAction,
   queryReducer,
   removeQueryRowAction,
+  runQueries,
   scanStartAction,
   scanStopAction,
 } from './query';
 import { ExploreId, ExploreItemState } from 'app/types';
-import { interval } from 'rxjs';
-import { RawTimeRange, toUtc } from '@grafana/data';
+import { interval, of } from 'rxjs';
+import {
+  ArrayVector,
+  DataQueryResponse,
+  DefaultTimeZone,
+  EventBusExtended,
+  MutableDataFrame,
+  RawTimeRange,
+  toUtc,
+} from '@grafana/data';
 import { thunkTester } from 'test/core/thunk/thunkTester';
 import { makeExplorePaneState } from './utils';
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
+import { configureStore } from '../../../store/configureStore';
+import { setTimeSrv } from '../../dashboard/services/TimeSrv';
+import Mock = jest.Mock;
 
 const QUERY_KEY_REGEX = /Q-(?:[a-z0-9]+-){5}(?:[0-9]+)/;
 const t = toUtc();
@@ -24,6 +36,58 @@ const testRange = {
     to: t,
   },
 };
+const defaultInitialState = {
+  user: {
+    orgId: '1',
+    timeZone: DefaultTimeZone,
+  },
+  explore: {
+    [ExploreId.left]: {
+      datasourceInstance: {
+        query: jest.fn(),
+        meta: {
+          id: 'something',
+        },
+      },
+      initialized: true,
+      containerWidth: 1920,
+      eventBridge: { emit: () => {} } as any,
+      queries: [{ expr: 'test' }] as any[],
+      range: testRange,
+      refreshInterval: {
+        label: 'Off',
+        value: 0,
+      },
+    },
+  },
+};
+
+describe('runQueries', () => {
+  it('should pass dataFrames to state even if there is error in response', async () => {
+    setTimeSrv({
+      init() {},
+    } as any);
+    const store = configureStore({
+      ...(defaultInitialState as any),
+    });
+    (store.getState().explore[ExploreId.left].datasourceInstance?.query as Mock).mockReturnValueOnce(
+      of({
+        error: { message: 'test error' },
+        data: [
+          new MutableDataFrame({
+            fields: [{ name: 'test', values: new ArrayVector() }],
+            meta: {
+              preferredVisualisationType: 'graph',
+            },
+          }),
+        ],
+      } as DataQueryResponse)
+    );
+    await store.dispatch(runQueries(ExploreId.left));
+    expect(store.getState().explore[ExploreId.left].showMetrics).toBeTruthy();
+    expect(store.getState().explore[ExploreId.left].graphResult).toBeDefined();
+  });
+});
 
 describe('running queries', () => {
   it('should cancel running query when cancelQueries is dispatched', async () => {

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -10,15 +10,7 @@ import {
 } from './query';
 import { ExploreId, ExploreItemState } from 'app/types';
 import { interval, of } from 'rxjs';
-import {
-  ArrayVector,
-  DataQueryResponse,
-  DefaultTimeZone,
-  EventBusExtended,
-  MutableDataFrame,
-  RawTimeRange,
-  toUtc,
-} from '@grafana/data';
+import { ArrayVector, DataQueryResponse, DefaultTimeZone, MutableDataFrame, RawTimeRange, toUtc } from '@grafana/data';
 import { thunkTester } from 'test/core/thunk/thunkTester';
 import { makeExplorePaneState } from './utils';
 import { reducerTester } from '../../../../test/core/redux/reducerTester';

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -664,16 +664,6 @@ export const processQueryResponse = (
 
     // For Angular editors
     state.eventBridge.emit(PanelEvents.dataError, error);
-
-    return {
-      ...state,
-      loading: loadingState === LoadingState.Loading || loadingState === LoadingState.Streaming,
-      queryResponse: response,
-      graphResult: null,
-      tableResult: null,
-      logsResult: null,
-      update: makeInitialUpdateState(),
-    };
   }
 
   if (!request) {

--- a/public/app/features/explore/utils/decorators.test.ts
+++ b/public/app/features/explore/utils/decorators.test.ts
@@ -132,7 +132,7 @@ describe('decorateWithGraphLogsTraceAndTable', () => {
     });
   });
 
-  it('should handle query error', () => {
+  it('should return frames even if there is an error', () => {
     const { timeSeries, logs, table } = getTestContext();
     const series: DataFrame[] = [timeSeries, logs, table];
     const panelData: PanelData = {
@@ -147,9 +147,9 @@ describe('decorateWithGraphLogsTraceAndTable', () => {
       error: {},
       state: LoadingState.Error,
       timeRange: {},
-      graphFrames: [],
-      tableFrames: [],
-      logsFrames: [],
+      graphFrames: [timeSeries],
+      tableFrames: [table],
+      logsFrames: [logs],
       traceFrames: [],
       nodeGraphFrames: [],
       graphResult: null,
@@ -171,10 +171,10 @@ describe('decorateWithGraphResult', () => {
     expect(decorateWithGraphResult(panelData).graphResult).toBeNull();
   });
 
-  it('returns null if panelData has error', () => {
+  it('returns data if panelData has error', () => {
     const { timeSeries } = getTestContext();
     const panelData = createExplorePanelData({ error: {}, graphFrames: [timeSeries] });
-    expect(decorateWithGraphResult(panelData).graphResult).toBeNull();
+    expect(decorateWithGraphResult(panelData).graphResult).toMatchObject([timeSeries]);
   });
 });
 
@@ -272,11 +272,11 @@ describe('decorateWithTableResult', () => {
     expect(panelResult.tableResult).toBeNull();
   });
 
-  it('returns null if panelData has error', async () => {
+  it('returns data if panelData has error', async () => {
     const { table, emptyTable } = getTestContext();
     const panelData = createExplorePanelData({ error: {}, tableFrames: [table, emptyTable] });
     const panelResult = await decorateWithTableResult(panelData).toPromise();
-    expect(panelResult.tableResult).toBeNull();
+    expect(panelResult.tableResult).not.toBeNull();
   });
 });
 
@@ -386,9 +386,9 @@ describe('decorateWithLogsResult', () => {
     expect(decorateWithLogsResult()(panelData).logsResult).toBeNull();
   });
 
-  it('returns null if panelData has error', () => {
+  it('returns data if panelData has error', () => {
     const { logs } = getTestContext();
     const panelData = createExplorePanelData({ error: {}, logsFrames: [logs] });
-    expect(decorateWithLogsResult()(panelData).logsResult).toBeNull();
+    expect(decorateWithLogsResult()(panelData).logsResult).not.toBeNull();
   });
 });

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -21,20 +21,6 @@ import { ExplorePanelData } from '../../../types';
  * Observable pipeline, it decorates the existing panelData to pass the results to later processing stages.
  */
 export const decorateWithFrameTypeMetadata = (data: PanelData): ExplorePanelData => {
-  if (data.error) {
-    return {
-      ...data,
-      graphFrames: [],
-      tableFrames: [],
-      logsFrames: [],
-      traceFrames: [],
-      nodeGraphFrames: [],
-      graphResult: null,
-      tableResult: null,
-      logsResult: null,
-    };
-  }
-
   const graphFrames: DataFrame[] = [];
   const tableFrames: DataFrame[] = [];
   const logsFrames: DataFrame[] = [];
@@ -83,7 +69,7 @@ export const decorateWithFrameTypeMetadata = (data: PanelData): ExplorePanelData
 };
 
 export const decorateWithGraphResult = (data: ExplorePanelData): ExplorePanelData => {
-  if (data.error || !data.graphFrames.length) {
+  if (!data.graphFrames.length) {
     return { ...data, graphResult: null };
   }
 
@@ -96,10 +82,6 @@ export const decorateWithGraphResult = (data: ExplorePanelData): ExplorePanelDat
  * multiple results and so this should be used with mergeMap or similar to unbox the internal observable.
  */
 export const decorateWithTableResult = (data: ExplorePanelData): Observable<ExplorePanelData> => {
-  if (data.error) {
-    return of({ ...data, tableResult: null });
-  }
-
   if (data.tableFrames.length === 0) {
     return of({ ...data, tableResult: null });
   }
@@ -149,10 +131,6 @@ export const decorateWithTableResult = (data: ExplorePanelData): Observable<Expl
 export const decorateWithLogsResult = (
   options: { absoluteRange?: AbsoluteTimeRange; refreshInterval?: string } = {}
 ) => (data: ExplorePanelData): ExplorePanelData => {
-  if (data.error) {
-    return { ...data, logsResult: null };
-  }
-
   if (data.logsFrames.length === 0) {
     return { ...data, logsResult: null };
   }

--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -7,6 +7,7 @@ import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceJsonDataOptionSelect,
   onUpdateDatasourceSecureJsonDataOption,
+  updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
 import { DataSourceHttpSettings, InfoBox, InlineFormLabel, LegacyForms } from '@grafana/ui';
 const { Select, Input, SecretFormField } = LegacyForms;
@@ -31,15 +32,18 @@ const versions = [
 ] as Array<SelectableValue<InfluxVersion>>;
 
 export type Props = DataSourcePluginOptionsEditorProps<InfluxOptions>;
+type State = {
+  maxSeries: string | undefined;
+};
 
-export class ConfigEditor extends PureComponent<Props> {
+export class ConfigEditor extends PureComponent<Props, State> {
   state = {
-    maxSeries: 0,
+    maxSeries: '',
   };
 
   constructor(props: Props) {
     super(props);
-    this.state.maxSeries = props.options.jsonData.maxSeries || 1000;
+    this.state.maxSeries = props.options.jsonData.maxSeries?.toString() || '';
   }
 
   // 1x
@@ -290,13 +294,14 @@ export class ConfigEditor extends PureComponent<Props> {
           <div className="gf-form-inline">
             <div className="gf-form">
               <InlineFormLabel
-                tooltip="Max number of series that will be returned from the data source query."
+                tooltip="Max number of series that will be returned from the data source query. Defaults to 1000."
                 className="width-10"
               >
                 Max series
               </InlineFormLabel>
               <div className="width-20">
                 <Input
+                  placeholder="1000"
                   type="number"
                   className="width-20"
                   value={this.state.maxSeries}
@@ -305,9 +310,11 @@ export class ConfigEditor extends PureComponent<Props> {
                     // any influence over saving so this seems to be only way to do this.
                     this.setState({ maxSeries: event.currentTarget.value });
                     const val = parseInt(event.currentTarget.value, 10);
-                    if (Number.isFinite(val)) {
-                      onUpdateDatasourceJsonDataOption(this.props, 'maxSeries');
-                    }
+                    updateDatasourcePluginJsonDataOption(
+                      this.props,
+                      'maxSeries',
+                      Number.isFinite(val) ? val : undefined
+                    );
                   }}
                 />
               </div>

--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -9,7 +9,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { DataSourceHttpSettings, InfoBox, InlineFormLabel, LegacyForms } from '@grafana/ui';
+import { DataSourceHttpSettings, InfoBox, InlineField, InlineFormLabel, LegacyForms } from '@grafana/ui';
 const { Select, Input, SecretFormField } = LegacyForms;
 import { InfluxOptions, InfluxSecureJsonData, InfluxVersion } from '../types';
 
@@ -292,33 +292,25 @@ export class ConfigEditor extends PureComponent<Props, State> {
           </div>
           {options.jsonData.version === InfluxVersion.Flux ? this.renderInflux2x() : this.renderInflux1x()}
           <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel
-                tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
+            <InlineField
+              labelWidth={20}
+              label="Max series"
+              tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
+            >
+              <Input
+                placeholder="1000"
+                type="number"
                 className="width-10"
-              >
-                Max series
-              </InlineFormLabel>
-              <div className="width-20">
-                <Input
-                  placeholder="1000"
-                  type="number"
-                  className="width-20"
-                  value={this.state.maxSeries}
-                  onChange={(event) => {
-                    // We duplicate this state so that we allow to write freely inside the input. We don't have
-                    // any influence over saving so this seems to be only way to do this.
-                    this.setState({ maxSeries: event.currentTarget.value });
-                    const val = parseInt(event.currentTarget.value, 10);
-                    updateDatasourcePluginJsonDataOption(
-                      this.props,
-                      'maxSeries',
-                      Number.isFinite(val) ? val : undefined
-                    );
-                  }}
-                />
-              </div>
-            </div>
+                value={this.state.maxSeries}
+                onChange={(event) => {
+                  // We duplicate this state so that we allow to write freely inside the input. We don't have
+                  // any influence over saving so this seems to be only way to do this.
+                  this.setState({ maxSeries: event.currentTarget.value });
+                  const val = parseInt(event.currentTarget.value, 10);
+                  updateDatasourcePluginJsonDataOption(this.props, 'maxSeries', Number.isFinite(val) ? val : undefined);
+                }}
+              />
+            </InlineField>
           </div>
         </div>
       </>

--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -269,7 +269,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
 
         {options.jsonData.version === InfluxVersion.Flux && (
           <InfoBox>
-            <h5>Support for flux in Grafana is currently in beta</h5>
+            <h5>Support for Flux in Grafana is currently in beta</h5>
             <p>
               Please report any issues to: <br />
               <a href="https://github.com/grafana/grafana/issues/new/choose">

--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -294,7 +294,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
           <div className="gf-form-inline">
             <div className="gf-form">
               <InlineFormLabel
-                tooltip="Max number of series that will be returned from the data source query. Defaults to 1000."
+                tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
                 className="width-10"
               >
                 Max series

--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -289,7 +289,12 @@ export class ConfigEditor extends PureComponent<Props> {
           {options.jsonData.version === InfluxVersion.Flux ? this.renderInflux2x() : this.renderInflux1x()}
           <div className="gf-form-inline">
             <div className="gf-form">
-              <InlineFormLabel className="width-10">Max series</InlineFormLabel>
+              <InlineFormLabel
+                tooltip="Max number of series that will be returned from the data source query."
+                className="width-10"
+              >
+                Max series
+              </InlineFormLabel>
               <div className="width-20">
                 <Input
                   type="number"

--- a/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -71,214 +71,230 @@ exports[`Render should disable basic auth password input 1`] = `
       </div>
     </div>
   </div>
-  <div>
-    <DataSourceHttpSettings
-      dataSourceConfig={
-        Object {
-          "access": "proxy",
-          "basicAuth": false,
-          "basicAuthPassword": "",
-          "basicAuthUser": "",
-          "database": "",
-          "id": 21,
-          "isDefault": false,
-          "jsonData": Object {
-            "httpMode": "POST",
-            "timeInterval": "4",
-          },
-          "name": "InfluxDB-3",
-          "orgId": 1,
-          "password": "",
-          "readOnly": false,
-          "secureJsonFields": Object {},
-          "type": "influxdb",
-          "typeLogoUrl": "",
-          "url": "",
-          "user": "",
-          "version": 1,
-          "withCredentials": false,
-        }
+  <DataSourceHttpSettings
+    dataSourceConfig={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 21,
+        "isDefault": false,
+        "jsonData": Object {
+          "httpMode": "POST",
+          "timeInterval": "4",
+        },
+        "name": "InfluxDB-3",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonFields": Object {},
+        "type": "influxdb",
+        "typeLogoUrl": "",
+        "url": "",
+        "user": "",
+        "version": 1,
+        "withCredentials": false,
       }
-      defaultUrl="http://localhost:8086"
-      onChange={[MockFunction]}
-      showAccessOptions={true}
-    />
-    <h3
-      className="page-heading"
-    >
-      InfluxDB Details
-    </h3>
+    }
+    defaultUrl="http://localhost:8086"
+    onChange={[MockFunction]}
+    showAccessOptions={true}
+  />
+  <div
+    className="gf-form-group"
+  >
+    <div>
+      <h3
+        className="page-heading"
+      >
+        InfluxDB Details
+      </h3>
+    </div>
+    <InfoBox>
+      <h5>
+        Database Access
+      </h5>
+      <p>
+        Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
+        <code>
+          SHOW MEASUREMENTS ON _internal
+        </code>
+         or
+        <code>
+          SELECT * FROM "_internal".."database" LIMIT 10
+        </code>
+        <br />
+        <br />
+        To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
+      </p>
+    </InfoBox>
     <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-          >
-            Database
-          </FormLabel>
-          <div
+          Database
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
             className="width-20"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-10"
-          >
-            User
-          </FormLabel>
-          <div
-            className="width-10"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <SecretFormField
-            inputWidth={20}
-            label="Password"
-            labelWidth={10}
             onChange={[Function]}
-            onReset={[Function]}
             value=""
           />
         </div>
       </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-            tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
-          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
-          will restrict you and return an error if the query is too large."
-          >
-            HTTP Method
-          </FormLabel>
-          <Select
-            allowCustomValue={false}
-            autoFocus={false}
-            backspaceRemovesValue={true}
-            className="width-10"
-            components={
-              Object {
-                "Group": [Function],
-                "IndicatorsContainer": [Function],
-                "MenuList": [Function],
-                "Option": [Function],
-                "SingleValue": [Function],
-              }
-            }
-            defaultValue="POST"
-            isClearable={false}
-            isDisabled={false}
-            isLoading={false}
-            isMulti={false}
-            isSearchable={true}
-            maxMenuHeight={300}
+          User
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
+            className="width-20"
             onChange={[Function]}
-            openMenuOnFocus={false}
-            options={
-              Array [
-                Object {
-                  "label": "GET",
-                  "value": "GET",
-                },
-                Object {
-                  "label": "POST",
-                  "value": "POST",
-                },
-              ]
-            }
-            tabSelectsValue={true}
-            value={
-              Object {
-                "label": "POST",
-                "value": "POST",
-              }
-            }
+            value=""
           />
         </div>
       </div>
     </div>
     <div
-      className="gf-form-group"
-    >
-      <InfoBox>
-        <h5>
-          Database Access
-        </h5>
-        <p>
-          Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
-          <code>
-            SHOW MEASUREMENTS ON _internal
-          </code>
-           or
-          <code>
-            SELECT * FROM "_internal".."database" LIMIT 10
-          </code>
-          <br />
-          <br />
-          To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
-        </p>
-      </InfoBox>
-    </div>
-    <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <SecretFormField
+          inputWidth={20}
+          label="Password"
+          labelWidth={10}
+          onChange={[Function]}
+          onReset={[Function]}
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
+          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
+          will restrict you and return an error if the query is too large."
         >
-          <FormLabel
-            className="width-10"
-            tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
+          HTTP Method
+        </FormLabel>
+        <Select
+          allowCustomValue={false}
+          autoFocus={false}
+          backspaceRemovesValue={true}
+          className="width-10"
+          components={
+            Object {
+              "Group": [Function],
+              "IndicatorsContainer": [Function],
+              "MenuList": [Function],
+              "Option": [Function],
+              "SingleValue": [Function],
+            }
+          }
+          defaultValue="POST"
+          isClearable={false}
+          isDisabled={false}
+          isLoading={false}
+          isMulti={false}
+          isSearchable={true}
+          maxMenuHeight={300}
+          onChange={[Function]}
+          openMenuOnFocus={false}
+          options={
+            Array [
+              Object {
+                "label": "GET",
+                "value": "GET",
+              },
+              Object {
+                "label": "POST",
+                "value": "POST",
+              },
+            ]
+          }
+          tabSelectsValue={true}
+          value={
+            Object {
+              "label": "POST",
+              "value": "POST",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example 1m if your data is written every minute."
-          >
-            Min time interval
-          </FormLabel>
-          <div
+        >
+          Min time interval
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
             className="width-10"
-          >
-            <Input
-              className="width-10"
-              onChange={[Function]}
-              placeholder="10s"
-              value="4"
-            />
-          </div>
+            onChange={[Function]}
+            placeholder="10s"
+            value="4"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="Max number of series that will be returned from the data source query."
+        >
+          Max series
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
+            className="width-20"
+            onChange={[Function]}
+            type="number"
+            value={1000}
+          />
         </div>
       </div>
     </div>
@@ -357,214 +373,230 @@ exports[`Render should hide basic auth fields when switch off 1`] = `
       </div>
     </div>
   </div>
-  <div>
-    <DataSourceHttpSettings
-      dataSourceConfig={
-        Object {
-          "access": "proxy",
-          "basicAuth": false,
-          "basicAuthPassword": "",
-          "basicAuthUser": "",
-          "database": "",
-          "id": 21,
-          "isDefault": false,
-          "jsonData": Object {
-            "httpMode": "POST",
-            "timeInterval": "4",
-          },
-          "name": "InfluxDB-3",
-          "orgId": 1,
-          "password": "",
-          "readOnly": false,
-          "secureJsonFields": Object {},
-          "type": "influxdb",
-          "typeLogoUrl": "",
-          "url": "",
-          "user": "",
-          "version": 1,
-          "withCredentials": false,
-        }
+  <DataSourceHttpSettings
+    dataSourceConfig={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 21,
+        "isDefault": false,
+        "jsonData": Object {
+          "httpMode": "POST",
+          "timeInterval": "4",
+        },
+        "name": "InfluxDB-3",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonFields": Object {},
+        "type": "influxdb",
+        "typeLogoUrl": "",
+        "url": "",
+        "user": "",
+        "version": 1,
+        "withCredentials": false,
       }
-      defaultUrl="http://localhost:8086"
-      onChange={[MockFunction]}
-      showAccessOptions={true}
-    />
-    <h3
-      className="page-heading"
-    >
-      InfluxDB Details
-    </h3>
+    }
+    defaultUrl="http://localhost:8086"
+    onChange={[MockFunction]}
+    showAccessOptions={true}
+  />
+  <div
+    className="gf-form-group"
+  >
+    <div>
+      <h3
+        className="page-heading"
+      >
+        InfluxDB Details
+      </h3>
+    </div>
+    <InfoBox>
+      <h5>
+        Database Access
+      </h5>
+      <p>
+        Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
+        <code>
+          SHOW MEASUREMENTS ON _internal
+        </code>
+         or
+        <code>
+          SELECT * FROM "_internal".."database" LIMIT 10
+        </code>
+        <br />
+        <br />
+        To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
+      </p>
+    </InfoBox>
     <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-          >
-            Database
-          </FormLabel>
-          <div
+          Database
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
             className="width-20"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-10"
-          >
-            User
-          </FormLabel>
-          <div
-            className="width-10"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <SecretFormField
-            inputWidth={20}
-            label="Password"
-            labelWidth={10}
             onChange={[Function]}
-            onReset={[Function]}
             value=""
           />
         </div>
       </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-            tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
-          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
-          will restrict you and return an error if the query is too large."
-          >
-            HTTP Method
-          </FormLabel>
-          <Select
-            allowCustomValue={false}
-            autoFocus={false}
-            backspaceRemovesValue={true}
-            className="width-10"
-            components={
-              Object {
-                "Group": [Function],
-                "IndicatorsContainer": [Function],
-                "MenuList": [Function],
-                "Option": [Function],
-                "SingleValue": [Function],
-              }
-            }
-            defaultValue="POST"
-            isClearable={false}
-            isDisabled={false}
-            isLoading={false}
-            isMulti={false}
-            isSearchable={true}
-            maxMenuHeight={300}
+          User
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
+            className="width-20"
             onChange={[Function]}
-            openMenuOnFocus={false}
-            options={
-              Array [
-                Object {
-                  "label": "GET",
-                  "value": "GET",
-                },
-                Object {
-                  "label": "POST",
-                  "value": "POST",
-                },
-              ]
-            }
-            tabSelectsValue={true}
-            value={
-              Object {
-                "label": "POST",
-                "value": "POST",
-              }
-            }
+            value=""
           />
         </div>
       </div>
     </div>
     <div
-      className="gf-form-group"
-    >
-      <InfoBox>
-        <h5>
-          Database Access
-        </h5>
-        <p>
-          Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
-          <code>
-            SHOW MEASUREMENTS ON _internal
-          </code>
-           or
-          <code>
-            SELECT * FROM "_internal".."database" LIMIT 10
-          </code>
-          <br />
-          <br />
-          To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
-        </p>
-      </InfoBox>
-    </div>
-    <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <SecretFormField
+          inputWidth={20}
+          label="Password"
+          labelWidth={10}
+          onChange={[Function]}
+          onReset={[Function]}
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
+          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
+          will restrict you and return an error if the query is too large."
         >
-          <FormLabel
-            className="width-10"
-            tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
+          HTTP Method
+        </FormLabel>
+        <Select
+          allowCustomValue={false}
+          autoFocus={false}
+          backspaceRemovesValue={true}
+          className="width-10"
+          components={
+            Object {
+              "Group": [Function],
+              "IndicatorsContainer": [Function],
+              "MenuList": [Function],
+              "Option": [Function],
+              "SingleValue": [Function],
+            }
+          }
+          defaultValue="POST"
+          isClearable={false}
+          isDisabled={false}
+          isLoading={false}
+          isMulti={false}
+          isSearchable={true}
+          maxMenuHeight={300}
+          onChange={[Function]}
+          openMenuOnFocus={false}
+          options={
+            Array [
+              Object {
+                "label": "GET",
+                "value": "GET",
+              },
+              Object {
+                "label": "POST",
+                "value": "POST",
+              },
+            ]
+          }
+          tabSelectsValue={true}
+          value={
+            Object {
+              "label": "POST",
+              "value": "POST",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example 1m if your data is written every minute."
-          >
-            Min time interval
-          </FormLabel>
-          <div
+        >
+          Min time interval
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
             className="width-10"
-          >
-            <Input
-              className="width-10"
-              onChange={[Function]}
-              placeholder="10s"
-              value="4"
-            />
-          </div>
+            onChange={[Function]}
+            placeholder="10s"
+            value="4"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="Max number of series that will be returned from the data source query."
+        >
+          Max series
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
+            className="width-20"
+            onChange={[Function]}
+            type="number"
+            value={1000}
+          />
         </div>
       </div>
     </div>
@@ -643,214 +675,230 @@ exports[`Render should hide white listed cookies input when browser access chose
       </div>
     </div>
   </div>
-  <div>
-    <DataSourceHttpSettings
-      dataSourceConfig={
-        Object {
-          "access": "proxy",
-          "basicAuth": false,
-          "basicAuthPassword": "",
-          "basicAuthUser": "",
-          "database": "",
-          "id": 21,
-          "isDefault": false,
-          "jsonData": Object {
-            "httpMode": "POST",
-            "timeInterval": "4",
-          },
-          "name": "InfluxDB-3",
-          "orgId": 1,
-          "password": "",
-          "readOnly": false,
-          "secureJsonFields": Object {},
-          "type": "influxdb",
-          "typeLogoUrl": "",
-          "url": "",
-          "user": "",
-          "version": 1,
-          "withCredentials": false,
-        }
+  <DataSourceHttpSettings
+    dataSourceConfig={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 21,
+        "isDefault": false,
+        "jsonData": Object {
+          "httpMode": "POST",
+          "timeInterval": "4",
+        },
+        "name": "InfluxDB-3",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonFields": Object {},
+        "type": "influxdb",
+        "typeLogoUrl": "",
+        "url": "",
+        "user": "",
+        "version": 1,
+        "withCredentials": false,
       }
-      defaultUrl="http://localhost:8086"
-      onChange={[MockFunction]}
-      showAccessOptions={true}
-    />
-    <h3
-      className="page-heading"
-    >
-      InfluxDB Details
-    </h3>
+    }
+    defaultUrl="http://localhost:8086"
+    onChange={[MockFunction]}
+    showAccessOptions={true}
+  />
+  <div
+    className="gf-form-group"
+  >
+    <div>
+      <h3
+        className="page-heading"
+      >
+        InfluxDB Details
+      </h3>
+    </div>
+    <InfoBox>
+      <h5>
+        Database Access
+      </h5>
+      <p>
+        Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
+        <code>
+          SHOW MEASUREMENTS ON _internal
+        </code>
+         or
+        <code>
+          SELECT * FROM "_internal".."database" LIMIT 10
+        </code>
+        <br />
+        <br />
+        To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
+      </p>
+    </InfoBox>
     <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-          >
-            Database
-          </FormLabel>
-          <div
+          Database
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
             className="width-20"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-10"
-          >
-            User
-          </FormLabel>
-          <div
-            className="width-10"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <SecretFormField
-            inputWidth={20}
-            label="Password"
-            labelWidth={10}
             onChange={[Function]}
-            onReset={[Function]}
             value=""
           />
         </div>
       </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-            tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
-          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
-          will restrict you and return an error if the query is too large."
-          >
-            HTTP Method
-          </FormLabel>
-          <Select
-            allowCustomValue={false}
-            autoFocus={false}
-            backspaceRemovesValue={true}
-            className="width-10"
-            components={
-              Object {
-                "Group": [Function],
-                "IndicatorsContainer": [Function],
-                "MenuList": [Function],
-                "Option": [Function],
-                "SingleValue": [Function],
-              }
-            }
-            defaultValue="POST"
-            isClearable={false}
-            isDisabled={false}
-            isLoading={false}
-            isMulti={false}
-            isSearchable={true}
-            maxMenuHeight={300}
+          User
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
+            className="width-20"
             onChange={[Function]}
-            openMenuOnFocus={false}
-            options={
-              Array [
-                Object {
-                  "label": "GET",
-                  "value": "GET",
-                },
-                Object {
-                  "label": "POST",
-                  "value": "POST",
-                },
-              ]
-            }
-            tabSelectsValue={true}
-            value={
-              Object {
-                "label": "POST",
-                "value": "POST",
-              }
-            }
+            value=""
           />
         </div>
       </div>
     </div>
     <div
-      className="gf-form-group"
-    >
-      <InfoBox>
-        <h5>
-          Database Access
-        </h5>
-        <p>
-          Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
-          <code>
-            SHOW MEASUREMENTS ON _internal
-          </code>
-           or
-          <code>
-            SELECT * FROM "_internal".."database" LIMIT 10
-          </code>
-          <br />
-          <br />
-          To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
-        </p>
-      </InfoBox>
-    </div>
-    <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <SecretFormField
+          inputWidth={20}
+          label="Password"
+          labelWidth={10}
+          onChange={[Function]}
+          onReset={[Function]}
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
+          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
+          will restrict you and return an error if the query is too large."
         >
-          <FormLabel
-            className="width-10"
-            tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
+          HTTP Method
+        </FormLabel>
+        <Select
+          allowCustomValue={false}
+          autoFocus={false}
+          backspaceRemovesValue={true}
+          className="width-10"
+          components={
+            Object {
+              "Group": [Function],
+              "IndicatorsContainer": [Function],
+              "MenuList": [Function],
+              "Option": [Function],
+              "SingleValue": [Function],
+            }
+          }
+          defaultValue="POST"
+          isClearable={false}
+          isDisabled={false}
+          isLoading={false}
+          isMulti={false}
+          isSearchable={true}
+          maxMenuHeight={300}
+          onChange={[Function]}
+          openMenuOnFocus={false}
+          options={
+            Array [
+              Object {
+                "label": "GET",
+                "value": "GET",
+              },
+              Object {
+                "label": "POST",
+                "value": "POST",
+              },
+            ]
+          }
+          tabSelectsValue={true}
+          value={
+            Object {
+              "label": "POST",
+              "value": "POST",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example 1m if your data is written every minute."
-          >
-            Min time interval
-          </FormLabel>
-          <div
+        >
+          Min time interval
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
             className="width-10"
-          >
-            <Input
-              className="width-10"
-              onChange={[Function]}
-              placeholder="10s"
-              value="4"
-            />
-          </div>
+            onChange={[Function]}
+            placeholder="10s"
+            value="4"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="Max number of series that will be returned from the data source query."
+        >
+          Max series
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
+            className="width-20"
+            onChange={[Function]}
+            type="number"
+            value={1000}
+          />
         </div>
       </div>
     </div>
@@ -929,214 +977,230 @@ exports[`Render should render component 1`] = `
       </div>
     </div>
   </div>
-  <div>
-    <DataSourceHttpSettings
-      dataSourceConfig={
-        Object {
-          "access": "proxy",
-          "basicAuth": false,
-          "basicAuthPassword": "",
-          "basicAuthUser": "",
-          "database": "",
-          "id": 21,
-          "isDefault": false,
-          "jsonData": Object {
-            "httpMode": "POST",
-            "timeInterval": "4",
-          },
-          "name": "InfluxDB-3",
-          "orgId": 1,
-          "password": "",
-          "readOnly": false,
-          "secureJsonFields": Object {},
-          "type": "influxdb",
-          "typeLogoUrl": "",
-          "url": "",
-          "user": "",
-          "version": 1,
-          "withCredentials": false,
-        }
+  <DataSourceHttpSettings
+    dataSourceConfig={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 21,
+        "isDefault": false,
+        "jsonData": Object {
+          "httpMode": "POST",
+          "timeInterval": "4",
+        },
+        "name": "InfluxDB-3",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonFields": Object {},
+        "type": "influxdb",
+        "typeLogoUrl": "",
+        "url": "",
+        "user": "",
+        "version": 1,
+        "withCredentials": false,
       }
-      defaultUrl="http://localhost:8086"
-      onChange={[MockFunction]}
-      showAccessOptions={true}
-    />
-    <h3
-      className="page-heading"
-    >
-      InfluxDB Details
-    </h3>
+    }
+    defaultUrl="http://localhost:8086"
+    onChange={[MockFunction]}
+    showAccessOptions={true}
+  />
+  <div
+    className="gf-form-group"
+  >
+    <div>
+      <h3
+        className="page-heading"
+      >
+        InfluxDB Details
+      </h3>
+    </div>
+    <InfoBox>
+      <h5>
+        Database Access
+      </h5>
+      <p>
+        Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
+        <code>
+          SHOW MEASUREMENTS ON _internal
+        </code>
+         or
+        <code>
+          SELECT * FROM "_internal".."database" LIMIT 10
+        </code>
+        <br />
+        <br />
+        To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
+      </p>
+    </InfoBox>
     <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-          >
-            Database
-          </FormLabel>
-          <div
+          Database
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
             className="width-20"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-10"
-          >
-            User
-          </FormLabel>
-          <div
-            className="width-10"
-          >
-            <Input
-              className="width-20"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <SecretFormField
-            inputWidth={20}
-            label="Password"
-            labelWidth={10}
             onChange={[Function]}
-            onReset={[Function]}
             value=""
           />
         </div>
       </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <FormLabel
+          className="width-10"
         >
-          <FormLabel
-            className="width-10"
-            tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
-          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
-          will restrict you and return an error if the query is too large."
-          >
-            HTTP Method
-          </FormLabel>
-          <Select
-            allowCustomValue={false}
-            autoFocus={false}
-            backspaceRemovesValue={true}
-            className="width-10"
-            components={
-              Object {
-                "Group": [Function],
-                "IndicatorsContainer": [Function],
-                "MenuList": [Function],
-                "Option": [Function],
-                "SingleValue": [Function],
-              }
-            }
-            defaultValue="POST"
-            isClearable={false}
-            isDisabled={false}
-            isLoading={false}
-            isMulti={false}
-            isSearchable={true}
-            maxMenuHeight={300}
+          User
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
+            className="width-20"
             onChange={[Function]}
-            openMenuOnFocus={false}
-            options={
-              Array [
-                Object {
-                  "label": "GET",
-                  "value": "GET",
-                },
-                Object {
-                  "label": "POST",
-                  "value": "POST",
-                },
-              ]
-            }
-            tabSelectsValue={true}
-            value={
-              Object {
-                "label": "POST",
-                "value": "POST",
-              }
-            }
+            value=""
           />
         </div>
       </div>
     </div>
     <div
-      className="gf-form-group"
-    >
-      <InfoBox>
-        <h5>
-          Database Access
-        </h5>
-        <p>
-          Setting the database for this datasource does not deny access to other databases. The InfluxDB query syntax allows switching the database in the query. For example:
-          <code>
-            SHOW MEASUREMENTS ON _internal
-          </code>
-           or
-          <code>
-            SELECT * FROM "_internal".."database" LIMIT 10
-          </code>
-          <br />
-          <br />
-          To support data isolation and security, make sure appropriate permissions are configured in InfluxDB.
-        </p>
-      </InfoBox>
-    </div>
-    <div
-      className="gf-form-group"
+      className="gf-form-inline"
     >
       <div
-        className="gf-form-inline"
+        className="gf-form"
       >
-        <div
-          className="gf-form"
+        <SecretFormField
+          inputWidth={20}
+          label="Password"
+          labelWidth={10}
+          onChange={[Function]}
+          onReset={[Function]}
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="You can use either GET or POST HTTP method to query your InfluxDB database. The POST
+          method allows you to perform heavy requests (with a lots of WHERE clause) while the GET method
+          will restrict you and return an error if the query is too large."
         >
-          <FormLabel
-            className="width-10"
-            tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
+          HTTP Method
+        </FormLabel>
+        <Select
+          allowCustomValue={false}
+          autoFocus={false}
+          backspaceRemovesValue={true}
+          className="width-10"
+          components={
+            Object {
+              "Group": [Function],
+              "IndicatorsContainer": [Function],
+              "MenuList": [Function],
+              "Option": [Function],
+              "SingleValue": [Function],
+            }
+          }
+          defaultValue="POST"
+          isClearable={false}
+          isDisabled={false}
+          isLoading={false}
+          isMulti={false}
+          isSearchable={true}
+          maxMenuHeight={300}
+          onChange={[Function]}
+          openMenuOnFocus={false}
+          options={
+            Array [
+              Object {
+                "label": "GET",
+                "value": "GET",
+              },
+              Object {
+                "label": "POST",
+                "value": "POST",
+              },
+            ]
+          }
+          tabSelectsValue={true}
+          value={
+            Object {
+              "label": "POST",
+              "value": "POST",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="A lower limit for the auto group by time interval. Recommended to be set to write frequency,
 				for example 1m if your data is written every minute."
-          >
-            Min time interval
-          </FormLabel>
-          <div
+        >
+          Min time interval
+        </FormLabel>
+        <div
+          className="width-10"
+        >
+          <Input
             className="width-10"
-          >
-            <Input
-              className="width-10"
-              onChange={[Function]}
-              placeholder="10s"
-              value="4"
-            />
-          </div>
+            onChange={[Function]}
+            placeholder="10s"
+            value="4"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="gf-form-inline"
+    >
+      <div
+        className="gf-form"
+      >
+        <FormLabel
+          className="width-10"
+          tooltip="Max number of series that will be returned from the data source query."
+        >
+          Max series
+        </FormLabel>
+        <div
+          className="width-20"
+        >
+          <Input
+            className="width-20"
+            onChange={[Function]}
+            type="number"
+            value={1000}
+          />
         </div>
       </div>
     </div>

--- a/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -277,26 +277,19 @@ exports[`Render should disable basic auth password input 1`] = `
     <div
       className="gf-form-inline"
     >
-      <div
-        className="gf-form"
+      <InlineField
+        label="Max series"
+        labelWidth={20}
+        tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
       >
-        <FormLabel
+        <Input
           className="width-10"
-          tooltip="Max number of series that will be returned from the data source query."
-        >
-          Max series
-        </FormLabel>
-        <div
-          className="width-20"
-        >
-          <Input
-            className="width-20"
-            onChange={[Function]}
-            type="number"
-            value={1000}
-          />
-        </div>
-      </div>
+          onChange={[Function]}
+          placeholder="1000"
+          type="number"
+          value=""
+        />
+      </InlineField>
     </div>
   </div>
 </Fragment>
@@ -579,26 +572,19 @@ exports[`Render should hide basic auth fields when switch off 1`] = `
     <div
       className="gf-form-inline"
     >
-      <div
-        className="gf-form"
+      <InlineField
+        label="Max series"
+        labelWidth={20}
+        tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
       >
-        <FormLabel
+        <Input
           className="width-10"
-          tooltip="Max number of series that will be returned from the data source query."
-        >
-          Max series
-        </FormLabel>
-        <div
-          className="width-20"
-        >
-          <Input
-            className="width-20"
-            onChange={[Function]}
-            type="number"
-            value={1000}
-          />
-        </div>
-      </div>
+          onChange={[Function]}
+          placeholder="1000"
+          type="number"
+          value=""
+        />
+      </InlineField>
     </div>
   </div>
 </Fragment>
@@ -881,26 +867,19 @@ exports[`Render should hide white listed cookies input when browser access chose
     <div
       className="gf-form-inline"
     >
-      <div
-        className="gf-form"
+      <InlineField
+        label="Max series"
+        labelWidth={20}
+        tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
       >
-        <FormLabel
+        <Input
           className="width-10"
-          tooltip="Max number of series that will be returned from the data source query."
-        >
-          Max series
-        </FormLabel>
-        <div
-          className="width-20"
-        >
-          <Input
-            className="width-20"
-            onChange={[Function]}
-            type="number"
-            value={1000}
-          />
-        </div>
-      </div>
+          onChange={[Function]}
+          placeholder="1000"
+          type="number"
+          value=""
+        />
+      </InlineField>
     </div>
   </div>
 </Fragment>
@@ -1183,26 +1162,19 @@ exports[`Render should render component 1`] = `
     <div
       className="gf-form-inline"
     >
-      <div
-        className="gf-form"
+      <InlineField
+        label="Max series"
+        labelWidth={20}
+        tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
       >
-        <FormLabel
+        <Input
           className="width-10"
-          tooltip="Max number of series that will be returned from the data source query."
-        >
-          Max series
-        </FormLabel>
-        <div
-          className="width-20"
-        >
-          <Input
-            className="width-20"
-            onChange={[Function]}
-            type="number"
-            value={1000}
-          />
-        </div>
-      </div>
+          onChange={[Function]}
+          placeholder="1000"
+          type="number"
+          value=""
+        />
+      </InlineField>
     </div>
   </div>
 </Fragment>

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -35,7 +35,7 @@ export function configureStore(initialState?: Partial<StoreState>) {
     devTools: process.env.NODE_ENV !== 'production',
     preloadedState: {
       navIndex: buildInitialState(),
-      ...(initialState || {}),
+      ...initialState,
     },
   });
 

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -14,7 +14,7 @@ export function addRootReducer(reducers: any) {
   addReducer(reducers);
 }
 
-export function configureStore() {
+export function configureStore(initialState?: Partial<StoreState>) {
   const logger = createLogger({
     predicate: (getState) => {
       return getState().application.logActions;
@@ -35,6 +35,7 @@ export function configureStore() {
     devTools: process.env.NODE_ENV !== 'production',
     preloadedState: {
       navIndex: buildInitialState(),
+      ...(initialState || {}),
     },
   });
 
@@ -42,7 +43,7 @@ export function configureStore() {
   return store;
 }
 
-/* 
+/*
 function getActionsToIgnoreSerializableCheckOn() {
   return [
     'dashboard/setPanelAngularComponent',
@@ -58,7 +59,7 @@ function getActionsToIgnoreSerializableCheckOn() {
 }
 
 function getPathsToIgnoreMutationAndSerializableCheckOn() {
-  return [    
+  return [
     'plugins.panels',
     'dashboard.panels',
     'dashboard.getModel',
@@ -75,7 +76,7 @@ function getPathsToIgnoreMutationAndSerializableCheckOn() {
     'explore.right.eventBridge',
     'explore.right.range',
     'explore.left.querySubscription',
-    'explore.right.querySubscription',    
+    'explore.right.querySubscription',
   ];
 }
 */


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/26758

There are 2 things in this fix:
- make the max series configurable with default set on 1000. Users can set it in config page 
![Screenshot from 2021-02-09 12-42-20](https://user-images.githubusercontent.com/1014802/107358928-51a04100-6ad4-11eb-9444-8e0d7618acd8.png)
- In explore if there is both error and data in the response we show both instead of showing just the error.
![Screenshot from 2021-02-09 12-42-33](https://user-images.githubusercontent.com/1014802/107359009-709ed300-6ad4-11eb-800c-23a69d95c76c.png)

TODO:
- update tests