### PR TITLE
Explore: Remove emotion error when displaying logs

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -117,7 +117,7 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
             )}
           </span>
           {showContextToggle?.(row) && (
-            <span onClick={this.onContextToggle} className={cx(style.context)}>
+            <span onClick={this.onContextToggle} className={cx('log-row-context', style.context)}>
               {contextIsOpen ? 'Hide' : 'Show'} context
             </span>
           )}

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -7,13 +7,6 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
   let logColor = theme.isLight ? theme.palette.gray5 : theme.palette.gray2;
   const hoverBgColor = styleMixins.hoverColor(theme.colors.panelBg, theme);
 
-  const context = css`
-    label: context;
-    visibility: hidden;
-    white-space: nowrap;
-    position: relative;
-  `;
-
   switch (logLevel) {
     case LogLevel.crit:
     case LogLevel.critical:
@@ -61,7 +54,12 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       label: logs-rows__horizontal-scroll;
       overflow: auto;
     `,
-    context: context,
+    context: css`
+      label: context;
+      visibility: hidden;
+      white-space: nowrap;
+      position: relative;
+    `,
     logsRow: css`
       label: logs-row;
       width: 100%;

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -69,7 +69,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       vertical-align: top;
 
       &:hover {
-        .${context} {
+        .log-row-context {
           visibility: visible;
           z-index: 1;
           margin-left: 10px;


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes `Interpolating a className from css`` is not recommended` error. We were interpolating a className `context`, but this isn't necessary as we can just use the non-interpolated-classname and not have this error behaviour. 
![image](https://user-images.githubusercontent.com/30407135/107360043-b740fd00-6ad5-11eb-8990-f75424ad7294.png)

Before: 
![image](https://user-images.githubusercontent.com/30407135/107361137-2f5bf280-6ad7-11eb-8a20-d85cbce62ef1.png)

After (still works the same):
![image](https://user-images.githubusercontent.com/30407135/107361234-574b5600-6ad7-11eb-888f-0e35d12187d3.png)

Fixes: https://github.com/grafana/grafana/issues/22645