### PR TITLE
Drone: Fix deployment image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -433,7 +433,7 @@ steps:
   - package
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
@@ -527,7 +527,7 @@ steps:
   - end-to-end-tests
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -638,7 +638,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages-oss
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json --build-id ${DRONE_BUILD_NUMBER}
@@ -935,7 +935,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -948,7 +948,7 @@ steps:
   - postgres-integration-tests
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - gcloud auth activate-service-account --key-file=/tmp/gcpkey.json
@@ -1326,7 +1326,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition enterprise
   environment:
@@ -1379,7 +1379,7 @@ steps:
   - end-to-end-tests-server-enterprise2
 
 - name: upload-packages-enterprise2
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket grafana-downloads-enterprise2
   environment:
@@ -1508,7 +1508,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages-oss
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
@@ -1527,7 +1527,7 @@ steps:
   - initialize
 
 - name: publish-packages-enterprise
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
@@ -1818,7 +1818,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads-test
   environment:
@@ -1831,7 +1831,7 @@ steps:
   - postgres-integration-tests
 
 - name: publish-storybook
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - echo Testing release
   environment:
@@ -2198,7 +2198,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition enterprise --packages-bucket grafana-downloads-test
   environment:
@@ -2251,7 +2251,7 @@ steps:
   - end-to-end-tests-server-enterprise2
 
 - name: upload-packages-enterprise2
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket grafana-downloads-test
   environment:
@@ -2380,7 +2380,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: publish-packages-oss
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition oss --gcp-key /tmp/gcpkey.json --deb-db-bucket grafana-testing-aptly-db --deb-repo-bucket grafana-testing-repo --packages-bucket grafana-downloads-test --rpm-repo-bucket grafana-testing-repo --simulate-release v7.3.0-test
@@ -2399,7 +2399,7 @@ steps:
   - initialize
 
 - name: publish-packages-enterprise
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
   - ./bin/grabpl publish-packages --edition enterprise --gcp-key /tmp/gcpkey.json --deb-db-bucket grafana-testing-aptly-db --deb-repo-bucket grafana-testing-repo --packages-bucket grafana-downloads-test --rpm-repo-bucket grafana-testing-repo --simulate-release v7.3.0-test
@@ -2686,7 +2686,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition oss
   environment:
@@ -3044,7 +3044,7 @@ steps:
   - test-frontend
 
 - name: upload-packages
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition enterprise
   environment:
@@ -3097,7 +3097,7 @@ steps:
   - end-to-end-tests-server-enterprise2
 
 - name: upload-packages-enterprise2
-  image: grafana/grafana-ci-deploy:1.3.0
+  image: grafana/grafana-ci-deploy:1.3.1
   commands:
   - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket grafana-downloads-enterprise2
   environment:

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
-ARG GOVERSION=1.15.7 \
-  GO_CHECKSUM=0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3 \
+ARG GOVERSION=1.15.8 \
+  GO_CHECKSUM=d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b \
   DEBIAN_FRONTEND=noninteractive
 
 ENV PATH=/usr/local/go/bin:$PATH \
@@ -26,7 +26,8 @@ ARG DEBIAN_FRONTEND=noninteractive \
   GOOGLE_SDK_VERSION=325.0.0 \
   GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7
 
-RUN apt update && apt install -yq curl python3-pip && pip3 install -U awscli crcmod && \
+# Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent
+RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U awscli crcmod && \
     curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     echo "${GOOGLE_SDK_CHECKSUM} google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
     tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.3.0"
+_version="1.3.1"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,6 +1,6 @@
 grabpl_version = '0.5.36'
 build_image = 'grafana/build-container:1.3.2'
-publish_image = 'grafana/grafana-ci-deploy:1.3.0'
+publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 alpine_image = 'alpine:3.12'
 windows_image = 'mcr.microsoft.com/windows:1809'


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Drone release logic by installing pkill (via procps package) in deployment Docker image.

I tested this BTW by dry-running package publishing in a grafana-ci-deploy Docker image, and I hit the issue of `pkill` not being installed.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #31023.
