### PR TITLE
Grafana-data: bump markedjs to v2.x to resolve vulnerability

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -27,7 +27,7 @@
     "apache-arrow": "0.16.0",
     "eventemitter3": "4.0.7",
     "lodash": "4.17.20",
-    "marked": "1.2.2",
+    "marked": "2.0.0",
     "rxjs": "6.6.3",
     "xss": "1.0.6"
   },

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -27,7 +27,7 @@
     "apache-arrow": "0.16.0",
     "eventemitter3": "4.0.7",
     "lodash": "4.17.20",
-    "marked": "2.0.0",
+    "marked": "2.0.1",
     "rxjs": "6.6.3",
     "xss": "1.0.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17867,10 +17867,10 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-marked@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.2.tgz#5d77ffb789c4cb0ae828bfe76250f7140b123f70"
-  integrity sha512-5jjKHVl/FPo0Z6ocP3zYhKiJLzkwJAw4CZoLjv57FkvbUuwOX4LIBBGGcXjAY6ATcd1q9B8UTj5T9Umauj0QYQ==
+marked@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.0.tgz#9662bbcb77ebbded0662a7be66ff929a8611cee5"
+  integrity sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==
 
 material-colors@^1.2.1:
   version "1.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17867,10 +17867,10 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-marked@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.0.tgz#9662bbcb77ebbded0662a7be66ff929a8611cee5"
-  integrity sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==
+marked@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.1.tgz#5e7ed7009bfa5c95182e4eb696f85e948cefcee3"
+  integrity sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
 
 material-colors@^1.2.1:
   version "1.2.6"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
A [vulnerability](https://github.com/markedjs/marked/security/advisories/GHSA-4r62-v4vq-hr96) has been discovered in markedjs. This PR addresses it by bumping marked to v2.0.0.


**Special notes for your reviewer**:
Having tested the text panel everything seems to work however it's worth noting the following breaking changes were introduced in marked v2.x:

**BREAKING CHANGES**
- em and strong tokenizers have been merged into one emStrong tokenizer.
- code and text tokenizers do not get passed all tokens as a second parameter.
- No longer supporting IE 11. IE 11 may still work but we are not committed to making sure it works with every update. We still provide an es5 version in lib/marked.js but some pollyfills may be needed for IE 11 in the future.
