### PR TITLE
Usage stats: Adds source/distributor setting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -162,8 +162,8 @@ send_user_header = false
 # Change this option to false to disable reporting.
 reporting_enabled = true
 
-# The name of the distributor of the Grafana instance. Ex hosted-grafana
-reporting_distributor =
+# The name of the distributor of the Grafana instance. Ex hosted-grafana, grafana-labs
+reporting_distributor = grafana-labs
 
 # Set to false to disable all checks to https://grafana.com
 # for new versions (grafana itself and plugins), check is used

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -162,6 +162,9 @@ send_user_header = false
 # Change this option to false to disable reporting.
 reporting_enabled = true
 
+# The name of the distributor of the Grafana instance. Ex hosted-grafana
+reporting_distributor =
+
 # Set to false to disable all checks to https://grafana.com
 # for new versions (grafana itself and plugins), check is used
 # in some UI views to notify that grafana or plugin update exists

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -168,8 +168,8 @@
 # Change this option to false to disable reporting.
 ;reporting_enabled = true
 
-# The name of the distributor of the Grafana instance. Ex hosted-grafana
-reporting_distributor =
+# The name of the distributor of the Grafana instance. Ex hosted-grafana, grafana-labs
+;reporting_distributor = grafana-labs
 
 # Set to false to disable all checks to https://grafana.net
 # for new versions (grafana itself and plugins), check is used

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -168,6 +168,9 @@
 # Change this option to false to disable reporting.
 ;reporting_enabled = true
 
+# The name of the distributor of the Grafana instance. Ex hosted-grafana
+reporting_distributor =
+
 # Set to false to disable all checks to https://grafana.net
 # for new versions (grafana itself and plugins), check is used
 # in some UI views to notify that grafana or plugin update exists

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -103,6 +103,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.ds.other.count"] = dsOtherCount
 
 	metrics["stats.packaging."+setting.Packaging+".count"] = 1
+	metrics["stats.distributor."+setting.ReportingDistributor+".count"] = 1
 
 	// Alerting stats
 	alertingUsageStats, err := uss.AlertingUsageStats.QueryUsageStats()

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -212,6 +212,7 @@ func TestMetrics(t *testing.T) {
 			setting.LDAPEnabled = true
 			setting.AuthProxyEnabled = true
 			setting.Packaging = "deb"
+			setting.ReportingDistributor = "hosted-grafana"
 
 			wg.Add(1)
 			err := uss.sendUsageStats(context.Background())
@@ -293,6 +294,7 @@ func TestMetrics(t *testing.T) {
 				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_grafana_com.count").MustInt())
 
 				assert.Equal(t, 1, metrics.Get("stats.packaging.deb.count").MustInt())
+				assert.Equal(t, 1, metrics.Get("stats.distributor.hosted-grafana.count").MustInt())
 
 				assert.Equal(t, 1, metrics.Get("stats.auth_token_per_user_le_3").MustInt())
 				assert.Equal(t, 2, metrics.Get("stats.auth_token_per_user_le_6").MustInt())

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -821,9 +821,9 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	GoogleAnalyticsId = analytics.Key("google_analytics_ua_id").String()
 	GoogleTagManagerId = analytics.Key("google_tag_manager_id").String()
 	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
-	reportingDistributor := analytics.Key("reporting_distributor").String()
-	if len(reportingDistributor) >= 100 {
-		ReportingDistributor = reportingDistributor[:100]
+	ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana_labs")
+	if len(ReportingDistributor) >= 100 {
+		ReportingDistributor = ReportingDistributor[:100]
 	}
 
 	if err := readAlertingSettings(iniFile); err != nil {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -141,10 +141,12 @@ var (
 	appliedCommandLineProperties []string
 	appliedEnvOverrides          []string
 
-	ReportingEnabled   bool
-	CheckForUpdates    bool
-	GoogleAnalyticsId  string
-	GoogleTagManagerId string
+	// analytics
+	ReportingEnabled     bool
+	ReportingDistributor string
+	CheckForUpdates      bool
+	GoogleAnalyticsId    string
+	GoogleTagManagerId   string
 
 	// LDAP
 	LDAPEnabled           bool
@@ -815,10 +817,14 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	cfg.MetricsEndpointDisableTotalStats = iniFile.Section("metrics").Key("disable_total_stats").MustBool(false)
 
 	analytics := iniFile.Section("analytics")
-	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
 	CheckForUpdates = analytics.Key("check_for_updates").MustBool(true)
 	GoogleAnalyticsId = analytics.Key("google_analytics_ua_id").String()
 	GoogleTagManagerId = analytics.Key("google_tag_manager_id").String()
+	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
+	reportingDistributor := analytics.Key("reporting_distributor").String()
+	if len(reportingDistributor) >= 100 {
+		ReportingDistributor = reportingDistributor[:100]
+	}
 
 	if err := readAlertingSettings(iniFile); err != nil {
 		return err

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -821,7 +821,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	GoogleAnalyticsId = analytics.Key("google_analytics_ua_id").String()
 	GoogleTagManagerId = analytics.Key("google_tag_manager_id").String()
 	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
-	ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana_labs")
+	ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana-labs")
 	if len(ReportingDistributor) >= 100 {
 		ReportingDistributor = ReportingDistributor[:100]
 	}


### PR DESCRIPTION
This can be useful for filter out usage stats from other providers if they use this flag. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>


