### PR TITLE
Alerting: Fixes so notification channels are properly deleted

### DIFF
--- a/public/app/features/alerting/AlertTabCtrl.test.ts
+++ b/public/app/features/alerting/AlertTabCtrl.test.ts
@@ -1,0 +1,81 @@
+import { AlertTabCtrl } from './AlertTabCtrl';
+
+interface Args {
+  notifications?: Array<{ uid?: string; id?: number; isDefault: boolean }>;
+}
+
+function setupTestContext({ notifications = [] }: Args = {}) {
+  const panel = {
+    alert: { notifications },
+    options: [],
+    title: 'Testing Alerts',
+  };
+  const $scope = {
+    ctrl: {
+      panel,
+      render: jest.fn(),
+    },
+  };
+  const dashboardSrv: any = {};
+  const uiSegmentSrv: any = {};
+  const datasourceSrv: any = {};
+
+  const controller = new AlertTabCtrl($scope, dashboardSrv, uiSegmentSrv, datasourceSrv);
+  controller.notifications = notifications;
+  controller.alertNotifications = [];
+  controller.initModel();
+
+  return { controller };
+}
+
+describe('AlertTabCtrl', () => {
+  describe('when removeNotification is called with an uid', () => {
+    it('then the correct notifier should be removed', () => {
+      const { controller } = setupTestContext({
+        notifications: [
+          { id: 1, uid: 'one', isDefault: true },
+          { id: 2, uid: 'two', isDefault: false },
+        ],
+      });
+
+      expect(controller.alert.notifications).toEqual([
+        { id: 1, uid: 'one', isDefault: true, iconClass: 'bell' },
+        { id: 2, uid: 'two', isDefault: false, iconClass: 'bell' },
+      ]);
+      expect(controller.alertNotifications).toEqual([
+        { id: 2, uid: 'two', isDefault: false, iconClass: 'bell' },
+        { id: 1, uid: 'one', isDefault: true, iconClass: 'bell' },
+      ]);
+
+      controller.removeNotification({ uid: 'one' });
+
+      expect(controller.alert.notifications).toEqual([{ id: 2, uid: 'two', isDefault: false, iconClass: 'bell' }]);
+      expect(controller.alertNotifications).toEqual([{ id: 2, uid: 'two', isDefault: false, iconClass: 'bell' }]);
+    });
+  });
+
+  describe('when removeNotification is called with an id', () => {
+    it('then the correct notifier should be removed', () => {
+      const { controller } = setupTestContext({
+        notifications: [
+          { id: 1, uid: 'one', isDefault: true },
+          { id: 2, uid: 'two', isDefault: false },
+        ],
+      });
+
+      expect(controller.alert.notifications).toEqual([
+        { id: 1, uid: 'one', isDefault: true, iconClass: 'bell' },
+        { id: 2, uid: 'two', isDefault: false, iconClass: 'bell' },
+      ]);
+      expect(controller.alertNotifications).toEqual([
+        { id: 2, uid: 'two', isDefault: false, iconClass: 'bell' },
+        { id: 1, uid: 'one', isDefault: true, iconClass: 'bell' },
+      ]);
+
+      controller.removeNotification({ id: 2 });
+
+      expect(controller.alert.notifications).toEqual([{ id: 1, uid: 'one', isDefault: true, iconClass: 'bell' }]);
+      expect(controller.alertNotifications).toEqual([{ id: 1, uid: 'one', isDefault: true, iconClass: 'bell' }]);
+    });
+  });
+});

--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -165,10 +165,10 @@ export class AlertTabCtrl {
   }
 
   removeNotification(an: any) {
-    // remove notifiers refeered to by id and uid to support notifiers added
+    // remove notifiers referred to by id and uid to support notifiers added
     // before and after we added support for uid
-    _.remove(this.alert.notifications, (n: any) => n.uid === an.uid);
-    _.remove(this.alertNotifications, (n: any) => n.uid === an.uid);
+    _.remove(this.alert.notifications, (n: any) => n.uid === an.uid || n.id === an.id);
+    _.remove(this.alertNotifications, (n: any) => n.uid === an.uid || n.id === an.id);
   }
 
   addAlertRuleTag() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure we delete notifications even when using the "old" id property.

**Which issue(s) this PR fixes**:
Fixes #29856

**Special notes for your reviewer**:

