### PR TITLE
Plugins: Fix plugin signature validation for manifest v2 on Windows

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -533,7 +533,7 @@ func collectPluginFilesWithin(rootDir string) ([]string, error) {
 			if err != nil {
 				return err
 			}
-			files = append(files, file)
+			files = append(files, filepath.ToSlash(file))
 		}
 		return nil
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Forces POSIX style file paths when tracking plugin files

Fixes an issue where plugin manifest validation fails on Windows due to inconsistent checking of strings (`path/to/file`) vs (`path\to\file`)

Have manually tested on Windows
