### PR TITLE
Prometheus: Fix enabling of disabled queries when editing in dashboard

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -92,7 +92,9 @@ export class PromQueryEditor extends PureComponent<Props, State> {
 
   onRunQuery = () => {
     const { query } = this;
-    this.props.onChange({ ...this.props.query, ...query });
+    // Change of query.hide happes outside of this component and is just passed as prop. We have to update it when running queries.
+    const { hide } = this.props.query;
+    this.props.onChange({ ...query, hide });
     this.props.onRunQuery();
   };
 

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -92,7 +92,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
 
   onRunQuery = () => {
     const { query } = this;
-    // Change of query.hide happes outside of this component and is just passed as prop. We have to update it when running queries.
+    // Change of query.hide happens outside of this component and is just passed as prop. We have to update it when running queries.
     const { hide } = this.props.query;
     this.props.onChange({ ...query, hide });
     this.props.onRunQuery();

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -92,10 +92,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
 
   onRunQuery = () => {
     const { query } = this;
-    // Change of query.hide happes outside of this component and is just passed as prop,
-    // so we have to update it when running queries
-    const { hide } = this.props.query;
-    this.props.onChange({ ...query, hide });
+    this.props.onChange({ ...this.props.query, ...query });
     this.props.onRunQuery();
   };
 

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -92,7 +92,10 @@ export class PromQueryEditor extends PureComponent<Props, State> {
 
   onRunQuery = () => {
     const { query } = this;
-    this.props.onChange(query);
+    // Change of query.hide happes outside of this component and is just passed as prop,
+    // so we have to update it when running queries
+    const { hide } = this.props.query;
+    this.props.onChange({ ...query, hide });
     this.props.onRunQuery();
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/grafana/grafana/issues/31048 for more information on how to recreate & observe the issue. The problem was that we are setting `query.hide` outside of PromQueryEditor, therefore when we are running query, we need to make sure that it has the current up-to-date hide info, but also any other query param that can be set outside of PromQueryEditor. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/31048


