### PR TITLE
test: update addDashboard flow for v7.4.0 changes

### DIFF
--- a/packages/grafana-e2e/src/flows/addDashboard.ts
+++ b/packages/grafana-e2e/src/flows/addDashboard.ts
@@ -37,7 +37,6 @@ interface AddVariableRequired {
 export type PartialAddVariableConfig = Partial<AddVariableDefault> & AddVariableOptional & AddVariableRequired;
 export type AddVariableConfig = AddVariableDefault & AddVariableOptional & AddVariableRequired;
 
-// @todo this actually returns type `Cypress.Chainable<AddDashboardConfig>`
 export const addDashboard = (config?: Partial<AddDashboardConfig>) => {
   const fullConfig: AddDashboardConfig = {
     annotations: [],
@@ -64,10 +63,12 @@ export const addDashboard = (config?: Partial<AddDashboardConfig>) => {
 
     fullConfig.variables = addVariables(variables);
 
-    e2e.components.BackButton.backArrow().click();
+    e2e.components.BackButton.backArrow().should('be.visible').click({ force: true });
   }
 
-  setDashboardTimeRange(timeRange);
+  if (timeRange) {
+    setDashboardTimeRange(timeRange);
+  }
 
   e2e.components.PageToolbar.item('Save dashboard').click();
   e2e.pages.SaveDashboardAsModal.newName().clear().type(title);
@@ -156,25 +157,38 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
 
   // This field is key to many reactive changes
   if (type !== VARIABLE_TYPE_QUERY) {
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect().select(type);
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect()
+      .should('be.visible')
+      .within(() => {
+        e2e.components.Select.singleValue().should('have.text', 'Query').click().type(`${type}{enter}`);
+      });
   }
 
-  // Avoid '', which is an accepted value
-  if (hide !== undefined) {
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalHideSelect().select(hide);
+  // Hide only does not show up for VARIABLE_TYPE_CONSTANT
+  // Hide can be '', so we are explicitly checking for undefined
+  if (type !== VARIABLE_TYPE_CONSTANT && hide !== undefined) {
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalHideSelect()
+      .should('be.visible')
+      .within(() => {
+        e2e.components.Select.input().should('have.text', '').type(`${hide}{enter}`);
+      });
   }
 
   if (label) {
     e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput().type(label);
   }
 
-  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput().type(name);
+  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput().clear().type(name);
 
   if (
     dataSource &&
     (type === VARIABLE_TYPE_AD_HOC_FILTERS || type === VARIABLE_TYPE_DATASOURCE || type === VARIABLE_TYPE_QUERY)
   ) {
-    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsDataSourceSelect().select(dataSource);
+    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsDataSourceSelect()
+      .should('be.visible')
+      .within(() => {
+        e2e.components.Select.input().should('be.visible').type(`${dataSource}{enter}`);
+      });
   }
 
   if (constantValue && type === VARIABLE_TYPE_CONSTANT) {
@@ -193,13 +207,12 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
 
   // Avoid flakiness
   e2e().focused().blur();
-  e2e()
-    .contains('.gf-form-group', 'Preview of values')
-    .within(() => {
+
+  e2e.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption()
+    .should('exist')
+    .within((previewOfValues) => {
       if (type === VARIABLE_TYPE_CONSTANT) {
-        e2e()
-          .root()
-          .contains(constantValue as string);
+        expect(previewOfValues.text()).equals(constantValue);
       }
     });
 

--- a/packages/grafana-e2e/src/flows/addDashboard.ts
+++ b/packages/grafana-e2e/src/flows/addDashboard.ts
@@ -66,9 +66,7 @@ export const addDashboard = (config?: Partial<AddDashboardConfig>) => {
     e2e.components.BackButton.backArrow().should('be.visible').click({ force: true });
   }
 
-  if (timeRange) {
-    setDashboardTimeRange(timeRange);
-  }
+  setDashboardTimeRange(timeRange);
 
   e2e.components.PageToolbar.item('Save dashboard').click();
   e2e.pages.SaveDashboardAsModal.newName().clear().type(title);
@@ -153,7 +151,7 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
     e2e.pages.Dashboard.Settings.Variables.List.newButton().click();
   }
 
-  const { constantValue, dataSource, hide, label, name, query, regex, type } = fullConfig;
+  const { constantValue, dataSource, label, name, query, regex, type } = fullConfig;
 
   // This field is key to many reactive changes
   if (type !== VARIABLE_TYPE_QUERY) {
@@ -161,16 +159,6 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
       .should('be.visible')
       .within(() => {
         e2e.components.Select.singleValue().should('have.text', 'Query').click().type(`${type}{enter}`);
-      });
-  }
-
-  // Hide only does not show up for VARIABLE_TYPE_CONSTANT
-  // Hide can be '', so we are explicitly checking for undefined
-  if (type !== VARIABLE_TYPE_CONSTANT && hide !== undefined) {
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalHideSelect()
-      .should('be.visible')
-      .within(() => {
-        e2e.components.Select.input().should('have.text', '').type(`${hide}{enter}`);
       });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, our e2e tests for our enterprise plugins are failing because our build runs them against latest stable Grafana (`v7.4.0`) which has introduced some changes to the `Variables` editor, in particular. The flows we use for our e2e tests (`addDashboard`, `addAnnotation` and `addVariable`: https://github.com/grafana/grafana/blob/master/packages/grafana-e2e/src/flows/addDashboard.ts) are currently only being exported by Grafana and not used in existing e2e tests in the package, so relevant updates from the changes were not applied to these flows.

The changes that affected this:
- We are no longer using `select` but `div` here so we are unable to continue using our cypress select

`v7.3.7`:
![Screenshot 2021-02-09 at 13 06 04](https://user-images.githubusercontent.com/36230812/107415936-cc388300-6b0b-11eb-8897-169cb3b1428d.png)

`v7.4.0`:
![Screenshot 2021-02-09 at 13 05 55](https://user-images.githubusercontent.com/36230812/107415955-d2c6fa80-6b0b-11eb-83e4-318a4c430f70.png)

- The previously expected CSS class name for `Preview of values` no longer exists

`v7.3.7`:
![Screenshot 2021-02-09 at 19 22 30](https://user-images.githubusercontent.com/36230812/107416300-3b15dc00-6b0c-11eb-9d99-8732d8e9394f.png)

`v7.4.0`:
![Screenshot 2021-02-09 at 19 22 39](https://user-images.githubusercontent.com/36230812/107416326-41a45380-6b0c-11eb-9bc3-9dd65ef351bf.png)

I've updated the flows so they coincide with the `v7.4.0` changes so our e2e tests now pass:

**Before**

We get an error in Cypress:
![Screenshot 2021-02-09 at 13 06 58](https://user-images.githubusercontent.com/36230812/107415930-c80c6580-6b0b-11eb-8805-81b95ca458e9.png)

**After**

Testing the flow for `Type = "Constant"` to make sure the following change works:

```
e2e.components.Select.singleValue().should('have.text', 'Query').click().type(`${type}{enter}`);
```

![Screenshot 2021-02-09 at 19 09 11](https://user-images.githubusercontent.com/36230812/107416467-6e586b00-6b0c-11eb-88b2-b4ae174d9b23.png)

Testing the flow for `Type = "Query"` to make sure the following changes works:

```
e2e.components.Select.input().should('have.text', '').type(`${hide}{enter}`);
e2e.components.Select.input().should('be.visible').type(`${dataSource}{enter}`);
```

![Screenshot 2021-02-09 at 19 07 17](https://user-images.githubusercontent.com/36230812/107416487-744e4c00-6b0c-11eb-938d-452e3be94b0a.png)

- Added `.clear()` because it looks like without this, Cypress no longer removes what is in the textbox and just types so it adds to the default `query0` text.
- Added `.click({ force: true })` to fix flakiness
- Slight refactoring of existing code

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/integrations-team/issues/113, which is a ticket that encompasses all our enterprise plugins.

**Special notes for your reviewer**:

Ran the e2e tests for this PR locally and they have all passed:

![Screenshot 2021-02-09 at 19 20 58](https://user-images.githubusercontent.com/36230812/107416063-f9853100-6b0b-11eb-8ae4-11e1955c9ca2.png)

There is an issue open for potentially adding the missing flows in to our core tests to mitigate against something like this happening in the future: https://github.com/grafana/grafana/issues/31035