### PR TITLE
Table: Use local field min & max for bar gauge cells

### DIFF
--- a/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
@@ -21,7 +21,7 @@ const defaultScale: ThresholdsConfig = {
 export const BarGaugeCell: FC<TableCellProps> = (props) => {
   const { field, innerWidth, tableStyles, cell, cellProps } = props;
 
-  let config = getFieldConfigWithMinMax(field, false);
+  let config = getFieldConfigWithMinMax(field, true);
   if (!config.thresholds) {
     config = {
       ...config,


### PR DESCRIPTION
Saldy it is much harder to fix this for colored background cells as they are using a color scale and those are getting color
from the display processor which is then calling the color scale which will use the field.state.range which has global min & max.

Actually this is also a problem for bar gauge cells when they use a gradient by value color scale.
