### PR TITLE
Alerting: Fix case when Alertmanager notifier fails if a URL is not working

### DIFF
--- a/pkg/services/alerting/notifiers/alertmanager.go
+++ b/pkg/services/alerting/notifiers/alertmanager.go
@@ -2,6 +2,7 @@ package notifiers
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -170,6 +171,7 @@ func (am *AlertmanagerNotifier) Notify(evalContext *alerting.EvalContext) error 
 
 	bodyJSON := simplejson.NewFromAny(alerts)
 	body, _ := bodyJSON.MarshalJSON()
+	errCnt := 0
 
 	for _, url := range am.URL {
 		cmd := &models.SendWebhookSync{
@@ -182,8 +184,14 @@ func (am *AlertmanagerNotifier) Notify(evalContext *alerting.EvalContext) error 
 
 		if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 			am.log.Error("Failed to send alertmanager", "error", err, "alertmanager", am.Name, "url", url)
-			return err
+			errCnt++
 		}
+	}
+
+	// This happens when every dispatch return error
+	if errCnt == len(am.URL) {
+		am.log.Error("Failed to send alert for all urls")
+		return fmt.Errorf("failed to send alert for all urls")
 	}
 
 	return nil

--- a/pkg/services/alerting/notifiers/alertmanager.go
+++ b/pkg/services/alerting/notifiers/alertmanager.go
@@ -190,8 +190,7 @@ func (am *AlertmanagerNotifier) Notify(evalContext *alerting.EvalContext) error 
 
 	// This happens when every dispatch return error
 	if errCnt == len(am.URL) {
-		am.log.Error("Failed to send alert for all urls")
-		return fmt.Errorf("failed to send alert for all urls")
+		return fmt.Errorf("failed to send alert to alertmanager")
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes behaviour of Notify that returns error when one of the dispatch event return error, to maintain high availability, we should return error when all dispatched events return error instead.

**Which issue(s) this PR fixes**: #30509 

**Special notes for your reviewer**: