### PR TITLE
NGAlert: Refactoring that handles cleaning up state

### DIFF
--- a/public/app/features/alerting/AlertRuleList.test.tsx
+++ b/public/app/features/alerting/AlertRuleList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { AlertRuleList, Props } from './AlertRuleList';
+import { AlertRuleListUnconnected, Props } from './AlertRuleList';
 import { AlertRule } from '../../types';
 import appEvents from '../../core/app_events';
 import { NavModel } from '@grafana/data';
@@ -24,15 +24,16 @@ const setup = (propOverrides?: object) => {
     stateFilter: '',
     search: '',
     isLoading: false,
+    ngAlertDefinitions: [],
   };
 
   Object.assign(props, propOverrides);
 
-  const wrapper = shallow(<AlertRuleList {...props} />);
+  const wrapper = shallow(<AlertRuleListUnconnected {...props} />);
 
   return {
     wrapper,
-    instance: wrapper.instance() as AlertRuleList,
+    instance: wrapper.instance() as AlertRuleListUnconnected,
   };
 };
 

--- a/public/app/features/alerting/AlertRuleList.tsx
+++ b/public/app/features/alerting/AlertRuleList.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
-import { connect } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 import Page from 'app/core/components/Page/Page';
 import AlertRuleItem from './AlertRuleItem';
 import appEvents from 'app/core/app_events';
@@ -10,25 +10,37 @@ import { AlertDefinition, AlertRule, CoreEvents, StoreState } from 'app/types';
 import { getAlertRulesAsync, togglePauseAlertRule } from './state/actions';
 import { getAlertRuleItems, getSearchQuery } from './state/selectors';
 import { FilterInput } from 'app/core/components/FilterInput/FilterInput';
-import { NavModel, SelectableValue } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { setSearchQuery } from './state/reducers';
 import { Button, LinkButton, Select, VerticalGroup } from '@grafana/ui';
 import { AlertDefinitionItem } from './components/AlertDefinitionItem';
 
-export interface Props {
-  navModel: NavModel;
-  alertRules: Array<AlertRule | AlertDefinition>;
-  updateLocation: typeof updateLocation;
-  getAlertRulesAsync: typeof getAlertRulesAsync;
-  setSearchQuery: typeof setSearchQuery;
-  togglePauseAlertRule: typeof togglePauseAlertRule;
-  stateFilter: string;
-  search: string;
-  isLoading: boolean;
+function mapStateToProps(state: StoreState) {
+  return {
+    navModel: getNavModel(state.navIndex, 'alert-list'),
+    alertRules: getAlertRuleItems(state),
+    stateFilter: state.location.query.state,
+    search: getSearchQuery(state.alertRules),
+    isLoading: state.alertRules.isLoading,
+    ngAlertDefinitions: state.alertDefinition.alertDefinitions,
+  };
 }
 
-export class AlertRuleList extends PureComponent<Props, any> {
+const mapDispatchToProps = {
+  updateLocation,
+  getAlertRulesAsync,
+  setSearchQuery,
+  togglePauseAlertRule,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+interface OwnProps {}
+
+export type Props = OwnProps & ConnectedProps<typeof connector>;
+
+export class AlertRuleListUnconnected extends PureComponent<Props, any> {
   stateFilters = [
     { label: 'All', value: 'all' },
     { label: 'OK', value: 'ok' },
@@ -156,20 +168,4 @@ export class AlertRuleList extends PureComponent<Props, any> {
   }
 }
 
-const mapStateToProps = (state: StoreState) => ({
-  navModel: getNavModel(state.navIndex, 'alert-list'),
-  alertRules: getAlertRuleItems(state),
-  stateFilter: state.location.query.state,
-  search: getSearchQuery(state.alertRules),
-  isLoading: state.alertRules.isLoading,
-  ngAlertDefinitions: state.alertDefinition.alertDefinitions,
-});
-
-const mapDispatchToProps = {
-  updateLocation,
-  getAlertRulesAsync,
-  setSearchQuery,
-  togglePauseAlertRule,
-};
-
-export default hot(module)(connect(mapStateToProps, mapDispatchToProps)(AlertRuleList));
+export default hot(module)(connector(AlertRuleListUnconnected));

--- a/public/app/features/alerting/components/AlertingQueryEditor.tsx
+++ b/public/app/features/alerting/components/AlertingQueryEditor.tsx
@@ -1,28 +1,33 @@
 import React, { PureComponent } from 'react';
-import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
 import { RefreshPicker, stylesFactory } from '@grafana/ui';
+
 import { config } from 'app/core/config';
 import { QueryGroup } from '../../query/components/QueryGroup';
-import { PanelQueryRunner } from '../../query/state/PanelQueryRunner';
 import { onRunQueries, queryOptionsChange } from '../state/actions';
 import { QueryGroupOptions, StoreState } from 'app/types';
 
+function mapStateToProps(state: StoreState) {
+  return {
+    queryOptions: state.alertDefinition.getQueryOptions(),
+    queryRunner: state.alertDefinition.queryRunner,
+  };
+}
+
+const mapDispatchToProps = {
+  queryOptionsChange,
+  onRunQueries,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
 interface OwnProps {}
 
-interface ConnectedProps {
-  queryOptions: QueryGroupOptions;
-  queryRunner?: PanelQueryRunner;
-}
-interface DispatchProps {
-  queryOptionsChange: typeof queryOptionsChange;
-  onRunQueries: typeof onRunQueries;
-}
+type Props = OwnProps & ConnectedProps<typeof connector>;
 
-type Props = ConnectedProps & DispatchProps & OwnProps;
-
-export class AlertingQueryEditor extends PureComponent<Props> {
+class AlertingQueryEditorUnconnected extends PureComponent<Props> {
   onQueryOptionsChange = (queryOptions: QueryGroupOptions) => {
     this.props.queryOptionsChange(queryOptions);
   };
@@ -62,19 +67,7 @@ export class AlertingQueryEditor extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = (state) => {
-  return {
-    queryOptions: state.alertDefinition.getQueryOptions(),
-    queryRunner: state.alertDefinition.queryRunner,
-  };
-};
-
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = {
-  queryOptionsChange,
-  onRunQueries,
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(AlertingQueryEditor);
+export const AlertingQueryEditor = connector(AlertingQueryEditorUnconnected);
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {

--- a/public/app/features/alerting/components/AlertingQueryEditor.tsx
+++ b/public/app/features/alerting/components/AlertingQueryEditor.tsx
@@ -13,7 +13,7 @@ interface OwnProps {}
 
 interface ConnectedProps {
   queryOptions: QueryGroupOptions;
-  queryRunner: PanelQueryRunner;
+  queryRunner?: PanelQueryRunner;
 }
 interface DispatchProps {
   queryOptionsChange: typeof queryOptionsChange;
@@ -51,7 +51,7 @@ export class AlertingQueryEditor extends PureComponent<Props> {
             />
           </div>
           <QueryGroup
-            queryRunner={queryRunner}
+            queryRunner={queryRunner!} // if the queryRunner is undefined here somethings very wrong so it's ok to throw an unhandled error
             options={queryOptions}
             onRunQueries={this.onRunQueries}
             onOptionsChange={this.onQueryOptionsChange}

--- a/public/app/features/alerting/components/AlertingQueryPreview.tsx
+++ b/public/app/features/alerting/components/AlertingQueryPreview.tsx
@@ -2,8 +2,8 @@ import React, { FC, useMemo, useState } from 'react';
 import { useObservable } from 'react-use';
 import { css } from 'emotion';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { DataFrame, DataQuery, GrafanaTheme } from '@grafana/data';
-import { TabsBar, TabContent, Tab, useStyles, Icon, Button } from '@grafana/ui';
+import { DataFrame, DataQuery, GrafanaTheme, PanelData } from '@grafana/data';
+import { Button, Icon, Tab, TabContent, TabsBar, useStyles } from '@grafana/ui';
 import { PanelQueryRunner } from '../../query/state/PanelQueryRunner';
 import { PreviewQueryTab } from './PreviewQueryTab';
 import { PreviewInstancesTab } from './PreviewInstancesTab';
@@ -31,7 +31,7 @@ export const AlertingQueryPreview: FC<Props> = ({ getInstances, onRunQueries, on
   const styles = useStyles(getStyles);
 
   const observable = useMemo(() => queryRunner.getData({ withFieldConfig: true, withTransforms: true }), []);
-  const data = useObservable(observable);
+  const data = useObservable<PanelData>(observable);
   const instances = getInstances();
 
   return (

--- a/public/app/features/alerting/components/PreviewQueryTab.tsx
+++ b/public/app/features/alerting/components/PreviewQueryTab.tsx
@@ -1,10 +1,10 @@
 import React, { FC, useMemo, useState } from 'react';
-import { getFrameDisplayName, GrafanaTheme, PanelData } from '@grafana/data';
+import { getFrameDisplayName, GrafanaTheme, PanelData, SelectableValue, toDataFrame } from '@grafana/data';
 import { Select, stylesFactory, Table, useTheme } from '@grafana/ui';
 import { css } from 'emotion';
 
 interface Props {
-  data: PanelData;
+  data?: PanelData;
   width: number;
   height: number;
 }
@@ -13,13 +13,20 @@ export const PreviewQueryTab: FC<Props> = ({ data, height, width }) => {
   const [currentSeries, setSeries] = useState<number>(0);
   const theme = useTheme();
   const styles = getStyles(theme, height);
-  const series = useMemo(
-    () => data.series.map((frame, index) => ({ value: index, label: getFrameDisplayName(frame) })),
-    [data.series]
-  );
+  const series = useMemo<Array<SelectableValue<number>>>(() => {
+    if (data?.series) {
+      return data.series.map((frame, index) => ({ value: index, label: getFrameDisplayName(frame) }));
+    }
+
+    return [];
+  }, [data]);
 
   // Select padding
   const padding = 16;
+
+  if (!data?.series?.length) {
+    return <Table data={toDataFrame([])} height={height} width={width} />;
+  }
 
   if (data.series.length > 1) {
     return (

--- a/public/app/features/alerting/state/actions.ts
+++ b/public/app/features/alerting/state/actions.ts
@@ -11,27 +11,28 @@ import { appEvents } from 'app/core/core';
 import { updateLocation } from 'app/core/actions';
 import store from 'app/core/store';
 import {
-  notificationChannelLoaded,
+  ALERT_DEFINITION_UI_STATE_STORAGE_KEY,
+  cleanUpState,
   loadAlertRules,
   loadedAlertRules,
-  setNotificationChannels,
-  setUiState,
-  ALERT_DEFINITION_UI_STATE_STORAGE_KEY,
-  updateAlertDefinitionOptions,
-  setQueryOptions,
-  setAlertDefinitions,
+  notificationChannelLoaded,
   setAlertDefinition,
+  setAlertDefinitions,
   setInstanceData,
+  setNotificationChannels,
+  setQueryOptions,
+  setUiState,
+  updateAlertDefinitionOptions,
 } from './reducers';
 import {
   AlertDefinition,
+  AlertDefinitionState,
   AlertDefinitionUiState,
   AlertRuleDTO,
   NotifierDTO,
-  ThunkResult,
-  QueryGroupOptions,
   QueryGroupDataSource,
-  AlertDefinitionState,
+  QueryGroupOptions,
+  ThunkResult,
 } from 'app/types';
 import { ExpressionDatasourceID } from '../../expressions/ExpressionDatasource';
 import { ExpressionQuery } from '../../expressions/types';
@@ -173,7 +174,8 @@ export function onRunQueries(): ThunkResult<void> {
     const timeRange = { from: 'now-1h', to: 'now' };
     const queryOptions = getQueryOptions();
 
-    queryRunner.run({
+    queryRunner!.run({
+      // if the queryRunner is undefined here somethings very wrong so it's ok to throw an unhandled error
       timezone: 'browser',
       timeRange: { from: dateMath.parse(timeRange.from)!, to: dateMath.parse(timeRange.to)!, raw: timeRange },
       maxDataPoints: queryOptions.maxDataPoints ?? 100,
@@ -212,6 +214,12 @@ export function evaluateNotSavedAlertDefinition(): ThunkResult<void> {
     const handledResponse = handleBase64Response(response.instances);
     dispatch(setInstanceData(handledResponse));
     appEvents.emit(AppEvents.alertSuccess, ['Alert definition tested successfully']);
+  };
+}
+
+export function cleanUpDefinitionState(): ThunkResult<void> {
+  return (dispatch) => {
+    dispatch(cleanUpState());
   };
 }
 

--- a/public/app/features/alerting/state/actions.ts
+++ b/public/app/features/alerting/state/actions.ts
@@ -219,7 +219,7 @@ export function evaluateNotSavedAlertDefinition(): ThunkResult<void> {
 
 export function cleanUpDefinitionState(): ThunkResult<void> {
   return (dispatch) => {
-    dispatch(cleanUpState());
+    dispatch(cleanUpState(undefined));
   };
 }
 

--- a/public/app/features/alerting/state/reducers.ts
+++ b/public/app/features/alerting/state/reducers.ts
@@ -165,40 +165,47 @@ const alertDefinitionSlice = createSlice({
     setAlertDefinition: (state: AlertDefinitionState, action: PayloadAction<AlertDefinitionDTO>) => {
       const currentOptions = state.getQueryOptions();
 
-      return {
-        ...state,
-        alertDefinition: {
-          title: action.payload.title,
-          id: action.payload.id,
-          uid: action.payload.uid,
-          condition: action.payload.condition,
-          intervalSeconds: action.payload.intervalSeconds,
-          data: action.payload.data,
-          description: '',
-        },
-        getQueryOptions: () => ({
-          ...currentOptions,
-          queries: action.payload.data.map((q: AlertDefinitionQueryModel) => ({ ...q.model })),
-        }),
-      };
+      state.alertDefinition.title = action.payload.title;
+      state.alertDefinition.id = action.payload.id;
+      state.alertDefinition.uid = action.payload.uid;
+      state.alertDefinition.condition = action.payload.condition;
+      state.alertDefinition.intervalSeconds = action.payload.intervalSeconds;
+      state.alertDefinition.data = action.payload.data;
+      state.alertDefinition.description = action.payload.description;
+      state.getQueryOptions = () => ({
+        ...currentOptions,
+        queries: action.payload.data.map((q: AlertDefinitionQueryModel) => ({ ...q.model })),
+      });
     },
     updateAlertDefinitionOptions: (state: AlertDefinitionState, action: PayloadAction<Partial<AlertDefinition>>) => {
-      return { ...state, alertDefinition: { ...state.alertDefinition, ...action.payload } };
+      state.alertDefinition = { ...state.alertDefinition, ...action.payload };
     },
     setUiState: (state: AlertDefinitionState, action: PayloadAction<AlertDefinitionUiState>) => {
-      return { ...state, uiState: { ...state.uiState, ...action.payload } };
+      state.uiState = { ...state.uiState, ...action.payload };
     },
     setQueryOptions: (state: AlertDefinitionState, action: PayloadAction<QueryGroupOptions>) => {
-      return {
-        ...state,
-        getQueryOptions: () => action.payload,
-      };
+      state.getQueryOptions = () => action.payload;
     },
     setAlertDefinitions: (state: AlertDefinitionState, action: PayloadAction<AlertDefinition[]>) => {
-      return { ...state, alertDefinitions: action.payload };
+      state.alertDefinitions = action.payload;
     },
     setInstanceData: (state: AlertDefinitionState, action: PayloadAction<DataFrame[]>) => {
-      return { ...state, getInstances: () => action.payload };
+      state.getInstances = () => action.payload;
+    },
+    cleanUpState: (state: AlertDefinitionState, action: PayloadAction<undefined>) => {
+      if (state.queryRunner) {
+        state.queryRunner.destroy();
+        state.queryRunner = undefined;
+        delete state.queryRunner;
+        state.queryRunner = new PanelQueryRunner(dataConfig);
+      }
+
+      state.alertDefinitions = initialAlertDefinitionState.alertDefinitions;
+      state.alertDefinition = initialAlertDefinitionState.alertDefinition;
+      state.data = initialAlertDefinitionState.data;
+      state.getInstances = initialAlertDefinitionState.getInstances;
+      state.getQueryOptions = initialAlertDefinitionState.getQueryOptions;
+      state.uiState = initialAlertDefinitionState.uiState;
     },
   },
 });
@@ -218,6 +225,7 @@ export const {
   setAlertDefinitions,
   setAlertDefinition,
   setInstanceData,
+  cleanUpState,
 } = alertDefinitionSlice.actions;
 
 export const alertRulesReducer = alertRulesSlice.reducer;

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -140,7 +140,7 @@ export interface AlertNotification {
 export interface AlertDefinitionState {
   uiState: AlertDefinitionUiState;
   alertDefinition: AlertDefinition;
-  queryRunner: PanelQueryRunner;
+  queryRunner?: PanelQueryRunner;
   data: PanelData[];
   alertDefinitions: AlertDefinition[];
   getInstances: () => DataFrame[];


### PR DESCRIPTION
**What this PR does / why we need it**:
I'll write comments in all the places in the code instead of writing a summary here but basically the connectWithCleanup doesn't work for the QueryRunner in state because you need to call `destroy` on it before deleting it.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

