### PR TITLE
test: update configurePanel for RefreshPicker changes

### DIFF
--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -189,7 +189,7 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
     }
 
     // Avoid annotations flakiness
-    e2e().get('.refresh-picker-buttons .btn').first().click();
+    e2e.components.RefreshPicker.runButton().should('be.visible').click();
 
     e2e().wait('@chartData');
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, our e2e tests for our enterprise plugins are failing if the flow includes `configurePanel` because of ~~v7.4.0 changes~~ this PR's changes (https://github.com/grafana/grafana/pull/30510) to the refresh button.

**Before**

The expected css classes no longer exist so we can no longer use `.refresh-picker-buttons .btn` to select it.

`v7.3.7`
![Screenshot 2021-02-10 at 13 01 00](https://user-images.githubusercontent.com/36230812/107514521-b2497f80-6ba1-11eb-877c-542d66bb97cf.png)

`v7.4.0`
![Screenshot 2021-02-10 at 13 00 24](https://user-images.githubusercontent.com/36230812/107514512-aeb5f880-6ba1-11eb-9ebd-f2c3f6c17b99.png)

The Cypress tests would fail on selecting the refresh button:

![Screenshot 2021-02-10 at 13 19 12](https://user-images.githubusercontent.com/36230812/107515179-97c3d600-6ba2-11eb-8f0e-b5bf633385b6.png)

**After**

This change was inspired by another e2e tests where it clicks the refresh button: https://github.com/grafana/grafana/blob/master/e2e/suite1/specs/trace-view-scrolling.spec.ts#L22

The tests now pass and we can select the refresh button now:

![Screenshot 2021-02-10 at 13 15 49](https://user-images.githubusercontent.com/36230812/107514904-30a62180-6ba2-11eb-8d07-eea64e02500b.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/integrations-team/issues/113 which encompasses all our plugins (this specific example was discovered with current work on adding e2e tests to the Github plugin)

**Special notes for your reviewer**:

All the current e2e tests are passing locally:

![Screenshot 2021-02-10 at 13 08 42](https://user-images.githubusercontent.com/36230812/107514422-8deda300-6ba1-11eb-89e2-757433cbef23.png)

This was previously not caught with https://github.com/grafana/grafana/pull/31059 because I was running the e2e tests for a different plugin that did not run `configurePanel` 😄 