### PR TITLE
Prometheus: Add documentation for ad-hoc filters

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -143,7 +143,7 @@ options are enabled, Grafana converts the labels from plain text to a regex comp
 
 ### Ad hoc filters variable
 
-Prometheus supports the special `ad hoc filters` variable type. It allows you to specify any number of label/value filters on the fly. These filters are automatically
+Prometheus supports the special [ad hoc filters](https://grafana.com/docs/grafana/latest/variables/variable-types/add-ad-hoc-filters/) variable type. It allows you to specify any number of label/value filters on the fly. These filters are automatically
 applied to all your Prometheus queries.
 
 ## Annotations

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -143,7 +143,7 @@ options are enabled, Grafana converts the labels from plain text to a regex comp
 
 ### Ad hoc filters variable
 
-Prometheus supports the special `Ad hoc filters` variable type. This variable allows you to specify any number of label/value filters on the fly. These filters will automatically
+Prometheus supports the special `ad hoc filters` variable type. It allows you to specify any number of label/value filters on the fly. These filters are automatically
 applied to all your Prometheus queries.
 
 ## Annotations

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -141,6 +141,11 @@ There are two syntaxes:
 Why two ways? The first syntax is easier to read and write but does not allow you to use a variable in the middle of a word. When the _Multi-value_ or _Include all value_
 options are enabled, Grafana converts the labels from plain text to a regex compatible string. Which means you have to use `=~` instead of `=`.
 
+### Ad hoc filters variable
+
+Prometheus supports the special `Ad hoc filters` variable type. This variable allows you to specify any number of label/value filters on the fly. These filters will automatically
+be applied to all your Prometheus queries.
+
 ## Annotations
 
 [Annotations]({{< relref "../dashboards/annotations.md" >}}) allow you to overlay rich event information on top of graphs. You add annotation

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -143,7 +143,7 @@ options are enabled, Grafana converts the labels from plain text to a regex comp
 
 ### Ad hoc filters variable
 
-Prometheus supports the special [ad hoc filters](https://grafana.com/docs/grafana/latest/variables/variable-types/add-ad-hoc-filters/) variable type. It allows you to specify any number of label/value filters on the fly. These filters are automatically
+Prometheus supports the special [ad hoc filters]({{< relref "../variables/variable-types/add-ad-hoc-filters.md" >}}) variable type. It allows you to specify any number of label/value filters on the fly. These filters are automatically
 applied to all your Prometheus queries.
 
 ## Annotations

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -144,7 +144,7 @@ options are enabled, Grafana converts the labels from plain text to a regex comp
 ### Ad hoc filters variable
 
 Prometheus supports the special `Ad hoc filters` variable type. This variable allows you to specify any number of label/value filters on the fly. These filters will automatically
-be applied to all your Prometheus queries.
+applied to all your Prometheus queries.
 
 ## Annotations
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Documents ad-hoc filters in Prometheus documentation in the same way how it is in other data sources (e.g. [Influx](https://grafana.com/docs/grafana/latest/datasources/influxdb/#ad-hoc-filters-variable))

