### PR TITLE
Only update usagestats every 30min

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -55,7 +55,7 @@ func (uss *UsageStatsService) Run(ctx context.Context) error {
 	uss.updateTotalStats()
 
 	onceEveryDayTick := time.NewTicker(time.Hour * 24)
-	everyMinuteTicker := time.NewTicker(time.Minute)
+	everyMinuteTicker := time.NewTicker(time.Minute * 30)
 	defer onceEveryDayTick.Stop()
 	defer everyMinuteTicker.Stop()
 


### PR DESCRIPTION
These queries can be quite hefty. I dont think we need to run them every minute. 

30 min might be a bit height but I dont see why we would need fresh numbers of these stats. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>
