### PR TITLE
Permissions: Fix team and role permissions on folders/dashboards not displayed for non Grafana Admin users

### DIFF
--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -32,7 +32,7 @@ func (hs *HTTPServer) GetDashboardPermissionList(c *models.ReqContext) response.
 
 	filteredAcls := make([]*models.DashboardAclInfoDTO, 0, len(acl))
 	for _, perm := range acl {
-		if dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
+		if perm.UserId > 0 && dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
 			continue
 		}
 

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -77,7 +77,7 @@ func GetGravatarUrlWithDefault(text string, defaultText string) string {
 }
 
 func IsHiddenUser(userLogin string, signedInUser *models.SignedInUser, cfg *setting.Cfg) bool {
-	if signedInUser.IsGrafanaAdmin || userLogin == signedInUser.Login {
+	if userLogin == "" || signedInUser.IsGrafanaAdmin || userLogin == signedInUser.Login {
 		return false
 	}
 

--- a/pkg/api/dtos/models_test.go
+++ b/pkg/api/dtos/models_test.go
@@ -1,0 +1,86 @@
+package dtos
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
+	"gotest.tools/assert"
+)
+
+func TestIsHiddenUser(t *testing.T) {
+	emptyHiddenUsers := map[string]struct{}{}
+	hiddenUser := map[string]struct{}{
+		"user": {},
+	}
+
+	testcases := []struct {
+		desc         string
+		userLogin    string
+		signedInUser *models.SignedInUser
+		hiddenUsers  map[string]struct{}
+		expected     bool
+	}{
+		{
+			desc:      "non-server admin user should see non-hidden user",
+			userLogin: "user",
+			signedInUser: &models.SignedInUser{
+				IsGrafanaAdmin: false,
+				Login:          "admin",
+			},
+			hiddenUsers: emptyHiddenUsers,
+			expected:    false,
+		},
+		{
+			desc:      "non-server admin user should not see hidden user",
+			userLogin: "user",
+			signedInUser: &models.SignedInUser{
+				IsGrafanaAdmin: false,
+				Login:          "admin",
+			},
+			hiddenUsers: hiddenUser,
+			expected:    true,
+		},
+		{
+			desc:      "non-server admin user should see himself, even if he's hidden",
+			userLogin: "admin",
+			signedInUser: &models.SignedInUser{
+				IsGrafanaAdmin: false,
+				Login:          "admin",
+			},
+			hiddenUsers: map[string]struct{}{
+				"admin": {},
+			},
+			expected: false,
+		},
+		{
+			desc:      "server admin user should see hidden user",
+			userLogin: "user",
+			signedInUser: &models.SignedInUser{
+				IsGrafanaAdmin: true,
+				Login:          "admin",
+			},
+			hiddenUsers: hiddenUser,
+			expected:    false,
+		},
+		{
+			desc:      "server admin user should see non-hidden user",
+			userLogin: "user",
+			signedInUser: &models.SignedInUser{
+				IsGrafanaAdmin: true,
+				Login:          "admin",
+			},
+			hiddenUsers: emptyHiddenUsers,
+			expected:    false,
+		},
+	}
+
+	for _, c := range testcases {
+		t.Run(c.desc, func(t *testing.T) {
+			isHidden := IsHiddenUser(c.userLogin, c.signedInUser, &setting.Cfg{
+				HiddenUsers: c.hiddenUsers,
+			})
+			assert.Equal(t, c.expected, isHidden)
+		})
+	}
+}

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -34,7 +34,7 @@ func (hs *HTTPServer) GetFolderPermissionList(c *models.ReqContext) response.Res
 
 	filteredAcls := make([]*models.DashboardAclInfoDTO, 0, len(acl))
 	for _, perm := range acl {
-		if dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
+		if perm.UserId > 0 && dtos.IsHiddenUser(perm.UserLogin, c.SignedInUser, hs.Cfg) {
 			continue
 		}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1196,7 +1196,9 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	hiddenUsers := users.Key("hidden_users").MustString("")
 	for _, user := range strings.Split(hiddenUsers, ",") {
 		user = strings.TrimSpace(user)
-		cfg.HiddenUsers[user] = struct{}{}
+		if user != "" {
+			cfg.HiddenUsers[user] = struct{}{}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix team and role permissions not displayed for folder and dashboard permissions. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/31134

**Special notes for your reviewer**:
There are two fixes in this PR:
- The first one is to initialize the `cfg.HiddenUsers` field as empty when the config field is empty.
- The second one is to not even use this config field if the `userLogin` field is empty which is the case for team and role permissions. This isn't necessary but it was my first fix and I think it makes senses anyway.

Also, this issue wasn't catched in the dashboard permissions tests because settings are not initialized in the same way than for a real Grafana instance. E2E tests for dashboard permissions would be great but I don't have the knowledge to include them in this PR.
