### PR TITLE
Docs: add 7.4.1 relese notes link

### DIFF
--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,6 +8,7 @@ weight = 10000
 Here you can find detailed release notes that list everything that is included in every release as well as notices
 about deprecations, breaking changes as well as changes that relate to plugin development.
 
+- [Release notes for 7.4.1]({{< relref "release-notes-7-4-1" >}})
 - [Release notes for 7.4.0]({{< relref "release-notes-7-4-0" >}})
 - [Release notes for 7.3.7]({{< relref "release-notes-7-3-7" >}})
 - [Release notes for 7.3.6]({{< relref "release-notes-7-3-6" >}})


### PR DESCRIPTION
I noticed that grot didn't update the index with the patch release notes link. Was it supposed to be automatic?