### PR TITLE
Prometheus: Multiply exemplars timestamp to follow api change

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -492,7 +492,7 @@ describe('Prometheus Result Transformer', () => {
         seriesLabels: { __name__: 'test' },
         exemplars: [
           {
-            timestamp: 1610449069957,
+            timestamp: 1610449069.957,
             labels: { traceID: '5020b5bc45117f07' },
             value: 0.002074123,
           },
@@ -517,19 +517,19 @@ describe('Prometheus Result Transformer', () => {
           {
             exemplars: [
               {
-                timestamp: 1610449070000,
+                timestamp: 1610449070.0,
                 value: 5,
               },
               {
-                timestamp: 1610449070000,
+                timestamp: 1610449070.0,
                 value: 1,
               },
               {
-                timestamp: 1610449070500,
+                timestamp: 1610449070.5,
                 value: 13,
               },
               {
-                timestamp: 1610449070300,
+                timestamp: 1610449070.3,
                 value: 20,
               },
             ],

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -78,7 +78,7 @@ export function transform(
     prometheusResult.forEach((exemplarData) => {
       const data = exemplarData.exemplars.map((exemplar) => {
         return {
-          [TIME_SERIES_TIME_FIELD_NAME]: exemplar.timestamp,
+          [TIME_SERIES_TIME_FIELD_NAME]: exemplar.timestamp * 1000,
           [TIME_SERIES_VALUE_FIELD_NAME]: exemplar.value,
           ...exemplar.labels,
           ...exemplarData.seriesLabels,


### PR DESCRIPTION
**What this PR does / why we need it**:

With the latest changes in Prometheus for exemplars the timestamp changed from milliseconds to seconds so this pr multiplies the timestamp to be milliseconds again.


