### PR TITLE
Explore: Do not show non queryable data sources in data source picker 

### DIFF
--- a/packages/grafana-runtime/src/services/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/dataSourceSrv.ts
@@ -28,12 +28,31 @@ export interface DataSourceSrv {
 
 /** @public */
 export interface GetDataSourceListFilters {
+  /** Include mixed deta source by setting this to true */
   mixed?: boolean;
+
+  /** Only return data sources that support metrics response */
   metrics?: boolean;
+
+  /** Only return data sources that support tracing response */
   tracing?: boolean;
+
+  /** Only return data sources that support annotations */
   annotations?: boolean;
+
+  /**
+   * By default only data sources that can be queried will be returned. Meaning they have tracing,
+   * metrics, logs or annotations flag set in plugin.json file
+   * */
+  all?: boolean;
+
+  /** Set to true to return dashboard data source */
   dashboard?: boolean;
+
+  /** Set to true to return data source variables */
   variables?: boolean;
+
+  /** filter list by plugin  */
   pluginId?: string;
 }
 

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -157,6 +157,15 @@ export class DatasourceSrv implements DataSourceService {
       if (filters.pluginId && x.meta.id !== filters.pluginId) {
         return false;
       }
+      if (
+        !filters.all &&
+        x.meta.metrics !== true &&
+        x.meta.annotations !== true &&
+        x.meta.tracing !== true &&
+        x.meta.logs !== true
+      ) {
+        return false;
+      }
       return true;
     });
 

--- a/public/app/features/plugins/specs/datasource_srv.test.ts
+++ b/public/app/features/plugins/specs/datasource_srv.test.ts
@@ -76,6 +76,12 @@ describe('datasource_srv', () => {
       uid: 'uid-code-Jaeger',
       meta: { tracing: true, id: 'jaeger' },
     },
+    CannotBeQueried: {
+      type: 'no-query',
+      name: 'no-query',
+      uid: 'no-query',
+      meta: { id: 'no-query' },
+    },
   };
 
   describe('Given a list of data sources', () => {
@@ -119,6 +125,13 @@ describe('datasource_srv', () => {
         const externalSources = dataSourceSrv.getExternal();
         expect(externalSources.length).toBe(6);
       });
+    });
+
+    it('Should by default filter out data sources that cannot be queried', () => {
+      const list = dataSourceSrv.getList({});
+      expect(list.find((x) => x.name === 'no-query')).toBeUndefined();
+      const all = dataSourceSrv.getList({ all: true });
+      expect(all.find((x) => x.name === 'no-query')).toBeDefined();
     });
 
     it('Can get list of data sources with variables: true', () => {


### PR DESCRIPTION
Fixes #30299

*  DataSourceSrv: Filter out non queryable data sources by default
