### PR TITLE
Docs feedback: /sources/http_api/user.md

### DIFF
--- a/docs/sources/http_api/user.md
+++ b/docs/sources/http_api/user.md
@@ -298,8 +298,10 @@ Content-Type: application/json
 GET /api/user HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+Authorization: Basic YWRtaW46YWRtaW4=
 ```
+
+Requires basic authentication.
 
 **Example Response**:
 
@@ -328,7 +330,7 @@ Content-Type: application/json
 
 `PUT /api/user/password`
 
-Changes the password for the user
+Changes the password for the user. Requires basic authentication.
 
 **Example Request**:
 
@@ -336,7 +338,7 @@ Changes the password for the user
 PUT /api/user/password HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+Authorization: Basic YWRtaW46YWRtaW4=
 
 {
   "oldPassword": "old_password",
@@ -415,7 +417,7 @@ Content-Type: application/json
 
 `GET /api/user/orgs`
 
-Return a list of all organizations of the current user.
+Return a list of all organizations of the current user. Requires basic authentication.
 
 **Example Request**:
 
@@ -423,7 +425,7 @@ Return a list of all organizations of the current user.
 GET /api/user/orgs HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+Authorization: Basic YWRtaW46YWRtaW4=
 ```
 
 **Example Response**:


### PR DESCRIPTION
I believe it's a mistake in the docs, since http requests against those endpoints are not supposed to be authenticated with API keys:

- `GET /api/user`
- `GET /api/user/orgs`
- `PUT /api/user/password`

If I correctly understand Grafana's auth design, the API key is not issued/tied to a user, therefore there is no mechanism to detect who the user is when the request is authenticated with an API key.

Please note there may be other endpoints like this...
