### PR TITLE
Variables: Fix missing empty elements from regex filters

### DIFF
--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -346,7 +346,6 @@ describe('metricNamesToVariableValues', () => {
     { value: 'demo.robustperception.io:9100', text: 'demo.robustperception.io:9100', selected: false },
   ];
 
-  ///.*_(\w+)\{/
   it.each`
     variableRegEx                                          | expected
     ${''}                                                  | ${metricsNames}

--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -1,6 +1,7 @@
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
 import {
   getAllMatches,
+  metricNamesToVariableValues,
   queryVariableReducer,
   sortVariableValues,
   updateVariableOptions,
@@ -12,7 +13,7 @@ import { VariablesState } from '../state/variablesReducer';
 import { getVariableTestContext } from '../state/helpers';
 import { toVariablePayload } from '../state/types';
 import { createQueryVariableAdapter } from './adapter';
-import { MetricFindValue, stringToJsRegex } from '@grafana/data';
+import { MetricFindValue } from '@grafana/data';
 
 describe('queryVariableReducer', () => {
   const adapter = createQueryVariableAdapter();
@@ -307,37 +308,80 @@ describe('sortVariableValues', () => {
   });
 });
 
-describe('getAllMatches', () => {
-  it.each`
-    str                                          | regex               | expected
-    ${'A{somelabel="atext",somevalue="avalue"}'} | ${'/unknown/gi'}    | ${{}}
-    ${'A{somelabel="atext",somevalue="avalue"}'} | ${'/unknown/i'}     | ${{}}
-    ${'A{somelabel="atext",somevalue="avalue"}'} | ${'/some(\\w+)/gi'} | ${{ 0: 'somevalue', 1: 'value', index: 20, input: 'A{somelabel="atext",somevalue="avalue"}' }}
-    ${'A{somelabel="atext",somevalue="avalue"}'} | ${'/some(\\w+)/i'}  | ${{ 0: 'somelabel', 1: 'label', index: 2, input: 'A{somelabel="atext",somevalue="avalue"}' }}
-    ${'A{somelabel="atext",somevalue="avalue"}'} | ${'/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/gi'} | ${{
-  0: 'somevalue="avalue',
-  1: 'avalue',
-  2: 'atext',
-  groups: {
-    text: 'atext',
-    value: 'avalue',
-  },
-  index: 20,
-  input: 'A{somelabel="atext",somevalue="avalue"}',
-}}
-    ${'A{somelabel="atext",somevalue="avalue"}'} | ${'/somevalue="(?<value>[^"]+)|somelabel="(?<text>[^"]+)/i'} | ${{
-  0: 'somelabel="atext',
-  1: undefined,
-  2: 'atext',
-  groups: {
-    text: 'atext',
-  },
-  index: 2,
-  input: 'A{somelabel="atext",somevalue="avalue"}',
-}}
-  `('when called with str:{$str}, regex:{$regex} then it should return correct matches', ({ str, regex, expected }) => {
-    const result = getAllMatches(str, stringToJsRegex(regex));
+describe('metricNamesToVariableValues', () => {
+  const item = (str: string) => ({ text: str, value: str, selected: false });
+  const metricsNames = [
+    item('go_info{instance="demo.robustperception.io:9090",job="prometheus",version="go1.15.6"} 1 1613047998000'),
+    item('go_info{instance="demo.robustperception.io:9091",job="pushgateway",version="go1.15.6"} 1 1613047998000'),
+    item('go_info{instance="demo.robustperception.io:9093",job="alertmanager",version="go1.14.4"} 1 1613047998000'),
+    item('go_info{instance="demo.robustperception.io:9100",job="node",version="go1.14.4"} 1 1613047998000'),
+  ];
 
+  const expected1 = [
+    { value: 'demo.robustperception.io:9090', text: 'demo.robustperception.io:9090', selected: false },
+    { value: 'demo.robustperception.io:9091', text: 'demo.robustperception.io:9091', selected: false },
+    { value: 'demo.robustperception.io:9093', text: 'demo.robustperception.io:9093', selected: false },
+    { value: 'demo.robustperception.io:9100', text: 'demo.robustperception.io:9100', selected: false },
+  ];
+
+  const expected2 = [
+    { value: 'prometheus', text: 'prometheus', selected: false },
+    { value: 'pushgateway', text: 'pushgateway', selected: false },
+    { value: 'alertmanager', text: 'alertmanager', selected: false },
+    { value: 'node', text: 'node', selected: false },
+  ];
+
+  const expected3 = [
+    { value: 'demo.robustperception.io:9090', text: 'prometheus', selected: false },
+    { value: 'demo.robustperception.io:9091', text: 'pushgateway', selected: false },
+    { value: 'demo.robustperception.io:9093', text: 'alertmanager', selected: false },
+    { value: 'demo.robustperception.io:9100', text: 'node', selected: false },
+  ];
+
+  const expected4 = [
+    { value: 'demo.robustperception.io:9090', text: 'demo.robustperception.io:9090', selected: false },
+    { value: undefined, text: undefined, selected: false },
+    { value: 'demo.robustperception.io:9091', text: 'demo.robustperception.io:9091', selected: false },
+    { value: 'demo.robustperception.io:9093', text: 'demo.robustperception.io:9093', selected: false },
+    { value: 'demo.robustperception.io:9100', text: 'demo.robustperception.io:9100', selected: false },
+  ];
+
+  ///.*_(\w+)\{/
+  it.each`
+    variableRegEx                                          | expected
+    ${''}                                                  | ${metricsNames}
+    ${'/unknown/'}                                         | ${[]}
+    ${'/unknown/g'}                                        | ${[]}
+    ${'/go/'}                                              | ${metricsNames}
+    ${'/go/g'}                                             | ${metricsNames}
+    ${'/(go)/'}                                            | ${[{ value: 'go', text: 'go', selected: false }]}
+    ${'/(go)/g'}                                           | ${[{ value: 'go', text: 'go', selected: false }]}
+    ${'/(go)?/'}                                           | ${[{ value: 'go', text: 'go', selected: false }]}
+    ${'/(go)?/g'}                                          | ${[{ value: 'go', text: 'go', selected: false }, { value: undefined, text: undefined, selected: false }]}
+    ${'/go(\\w+)/'}                                        | ${[{ value: '_info', text: '_info', selected: false }]}
+    ${'/go(\\w+)/g'}                                       | ${[{ value: '_info', text: '_info', selected: false }, { value: '1', text: '1', selected: false }]}
+    ${'/.*_(\\w+)\\{/'}                                    | ${[{ value: 'info', text: 'info', selected: false }]}
+    ${'/.*_(\\w+)\\{/g'}                                   | ${[{ value: 'info', text: 'info', selected: false }]}
+    ${'/instance="(?<value>[^"]+)/'}                       | ${expected1}
+    ${'/instance="(?<value>[^"]+)/g'}                      | ${expected1}
+    ${'/instance="(?<grp1>[^"]+)/'}                        | ${expected1}
+    ${'/instance="(?<grp1>[^"]+)/g'}                       | ${expected1}
+    ${'/instancee="(?<value>[^"]+)/'}                      | ${[]}
+    ${'/job="(?<text>[^"]+)/'}                             | ${expected2}
+    ${'/job="(?<text>[^"]+)/g'}                            | ${expected2}
+    ${'/job="(?<grp2>[^"]+)/'}                             | ${expected2}
+    ${'/job="(?<grp2>[^"]+)/g'}                            | ${expected2}
+    ${'/jobb="(?<text>[^"]+)/g'}                           | ${[]}
+    ${'/instance="(?<value>[^"]+)|job="(?<text>[^"]+)/'}   | ${expected1}
+    ${'/instance="(?<value>[^"]+)|job="(?<text>[^"]+)/g'}  | ${expected3}
+    ${'/instance="(?<grp1>[^"]+)|job="(?<grp2>[^"]+)/'}    | ${expected1}
+    ${'/instance="(?<grp1>[^"]+)|job="(?<grp2>[^"]+)/g'}   | ${expected4}
+    ${'/instance="(?<value>[^"]+).*job="(?<text>[^"]+)/'}  | ${expected3}
+    ${'/instance="(?<value>[^"]+).*job="(?<text>[^"]+)/g'} | ${expected3}
+    ${'/instance="(?<grp1>[^"]+).*job="(?<grp2>[^"]+)/'}   | ${expected1}
+    ${'/instance="(?<grp1>[^"]+).*job="(?<grp2>[^"]+)/g'}  | ${expected1}
+  `('when called with variableRegEx:$variableRegEx then it return correct options', ({ variableRegEx, expected }) => {
+    const result = metricNamesToVariableValues(variableRegEx, VariableSort.disabled, metricsNames);
     expect(result).toEqual(expected);
   });
 });

--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -1,6 +1,5 @@
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
 import {
-  getAllMatches,
   metricNamesToVariableValues,
   queryVariableReducer,
   sortVariableValues,


### PR DESCRIPTION
**What this PR does / why we need it**:
This fix for #31011 was straight down the regex rabbit's hole but in the end I think we now have feature parity with Grafana 7.3.7 again. I'll try to explain what has happened, bare with me.

In 7.4.0 I approved this PR #28625 because I thought it was a substantial addition to the Variable system. I think this was one of my first approvals of the Variable system and to be honest; I didn't do a superb job testing the PR.

I spent the entire day yesterday looking into the difference before and after #28625 and this is what I found:

Before #28625 we implicitly add all matches as options because if you enter the global flag `/g` in the regex field of a query variable we would implicitly reuse the `regex` object without resetting the `lastIndex`

Initialized once and never reset:
https://github.com/grafana/grafana/blob/1e261642f4bff28093de2c30093198fcd231c8a6/public/app/features/variables/query/reducer.ts#L93-L95
https://github.com/grafana/grafana/blob/1e261642f4bff28093de2c30093198fcd231c8a6/public/app/features/variables/query/reducer.ts#L112

This implicit reuse of `regex` works great as long as you don't use `/g` in your regex. And in some edge cases this implicit reuse actually leads to a bug in Grafana < 7.3.7 and rows were excluded because `lastIndex` was not reset and therefore the next match will not match. See this issue in Grafana 7.3.7 in movie below:
![variables](https://user-images.githubusercontent.com/562238/107735850-f56e3480-6d00-11eb-9ca6-ded50c8ea7ef.gif)

So this PR tries to reuse the good parts from 7.3.7, i.e. the implicit finding of all matches with `/g`, but not include the issue where items are excluded as described above. 

This is the reason I introduced the extra loop here:
https://github.com/grafana/grafana/blob/hugoh/issue-variables-regex/public/app/features/variables/query/reducer.ts#L143-L147

I also removed the lodash merging and just pushed results to an array instead, this made the code a ~10x faster for 100000 items:
https://github.com/grafana/grafana/blob/8d339a279bedaa1fad8ab7257d852fdc32942314/public/app/features/variables/query/reducer.ts#L97

If you have any questions, please ping me and I'll try to explain.

Enjoy the review 🐰 

**Which issue(s) this PR fixes**:
Fixes #31011

**Special notes for your reviewer**:
I also moved the tests from getAllMatches and added tests for metricNamesToVariableValues instead, because they seemed more valuable.

