### PR TITLE
Display global options when help is invoked for sub-commands

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -12,7 +12,49 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/urfave/cli/v2"
+	"runtime"
 )
+
+var AppFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "pluginsDir",
+		Usage:   "Path to the Grafana plugin directory",
+		Value:   utils.GetGrafanaPluginDir(runtime.GOOS),
+		EnvVars: []string{"GF_PLUGIN_DIR"},
+	},
+	&cli.StringFlag{
+		Name:    "repo",
+		Usage:   "URL to the plugin repository",
+		Value:   "https://grafana.com/api/plugins",
+		EnvVars: []string{"GF_PLUGIN_REPO"},
+	},
+	&cli.StringFlag{
+		Name:    "pluginUrl",
+		Usage:   "Full url to the plugin zip file instead of downloading the plugin from grafana.com/api",
+		Value:   "",
+		EnvVars: []string{"GF_PLUGIN_URL"},
+	},
+	&cli.BoolFlag{
+		Name:  "insecure",
+		Usage: "Skip TLS verification (insecure)",
+	},
+	&cli.BoolFlag{
+		Name:  "debug, d",
+		Usage: "Enable debug logging",
+	},
+	&cli.StringFlag{
+		Name:  "configOverrides",
+		Usage: "Configuration options to override defaults as a string. e.g. cfg:default.paths.log=/dev/null",
+	},
+	&cli.StringFlag{
+		Name:  "homepath",
+		Usage: "Path to Grafana install/home path, defaults to working directory",
+	},
+	&cli.StringFlag{
+		Name:  "config",
+		Usage: "Path to config file",
+	},
+}
 
 func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore.SQLStore) error) func(context *cli.Context) error {
 	return func(context *cli.Context) error {
@@ -137,10 +179,12 @@ var Commands = []*cli.Command{
 		Name:        "plugins",
 		Usage:       "Manage plugins for grafana",
 		Subcommands: pluginCommands,
+		Flags:       AppFlags,
 	},
 	{
 		Name:        "admin",
 		Usage:       "Grafana admin commands",
 		Subcommands: adminCommands,
+		Flags:       AppFlags,
 	},
 }

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"runtime"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/bus"
@@ -12,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/urfave/cli/v2"
-	"runtime"
 )
 
 var AppFlags = []cli.Flag{

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/commands"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 var version = "master"

--- a/pkg/cmd/grafana-cli/main.go
+++ b/pkg/cmd/grafana-cli/main.go
@@ -2,15 +2,12 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"runtime"
-
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/commands"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
 	"github.com/urfave/cli/v2"
+	"os"
 )
 
 var version = "master"
@@ -26,47 +23,8 @@ func main() {
 				Email: "hello@grafana.com",
 			},
 		},
-		Version: version,
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "pluginsDir",
-				Usage:   "Path to the Grafana plugin directory",
-				Value:   utils.GetGrafanaPluginDir(runtime.GOOS),
-				EnvVars: []string{"GF_PLUGIN_DIR"},
-			},
-			&cli.StringFlag{
-				Name:    "repo",
-				Usage:   "URL to the plugin repository",
-				Value:   "https://grafana.com/api/plugins",
-				EnvVars: []string{"GF_PLUGIN_REPO"},
-			},
-			&cli.StringFlag{
-				Name:    "pluginUrl",
-				Usage:   "Full url to the plugin zip file instead of downloading the plugin from grafana.com/api",
-				Value:   "",
-				EnvVars: []string{"GF_PLUGIN_URL"},
-			},
-			&cli.BoolFlag{
-				Name:  "insecure",
-				Usage: "Skip TLS verification (insecure)",
-			},
-			&cli.BoolFlag{
-				Name:  "debug, d",
-				Usage: "Enable debug logging",
-			},
-			&cli.StringFlag{
-				Name:  "configOverrides",
-				Usage: "Configuration options to override defaults as a string. e.g. cfg:default.paths.log=/dev/null",
-			},
-			&cli.StringFlag{
-				Name:  "homepath",
-				Usage: "Path to Grafana install/home path, defaults to working directory",
-			},
-			&cli.StringFlag{
-				Name:  "config",
-				Usage: "Path to config file",
-			},
-		},
+		Version:         version,
+		Flags:           commands.AppFlags,
 		Commands:        commands.Commands,
 		CommandNotFound: cmdNotFound,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is responsible for adding the feature to display global options, when dealing with a subcommand. Up until now, by running:

`$ grafana-cli plugins -h`, we had:

```
NAME:
   Grafana cli plugins - Manage plugins for grafana

USAGE:
   Grafana cli plugins command [command options] [arguments...]

COMMANDS:
     install                  install <plugin id> <plugin version (optional)>
     list-remote              list remote available plugins
     list-versions            list-versions <plugin id>
     update, upgrade          update <plugin id>
     update-all, upgrade-all  update all your installed plugins
     ls                       list all installed plugins
     uninstall, remove        uninstall <plugin id>

OPTIONS:
   --help, -h  show help
```

After this PR, running the same command, produces:


```
NAME:
   Grafana CLI plugins - Manage plugins for grafana

USAGE:
   Grafana CLI plugins command [command options] [arguments...]

COMMANDS:
   install                  install <plugin id> <plugin version (optional)>
   list-remote              list remote available plugins
   list-versions            list-versions <plugin id>
   update, upgrade          update <plugin id>
   update-all, upgrade-all  update all your installed plugins
   ls                       list all installed plugins
   uninstall, remove        uninstall <plugin id>
   help, h                  Shows a list of commands or help for one command

OPTIONS:
   --pluginsDir value       Path to the Grafana plugin directory (default: "/usr/local/var/lib/grafana/plugins") [$GF_PLUGIN_DIR]
   --repo value             URL to the plugin repository (default: "https://grafana.com/api/plugins") [$GF_PLUGIN_REPO]
   --pluginUrl value        Full url to the plugin zip file instead of downloading the plugin from grafana.com/api [$GF_PLUGIN_URL]
   --insecure               Skip TLS verification (insecure) (default: false)
   --debug                  Enable debug logging (default: false)
   --configOverrides value  Configuration options to override defaults as a string. e.g. cfg:default.paths.log=/dev/null
   --homepath value         Path to Grafana install/home path, defaults to working directory
   --config value           Path to config file
   --help, -h               show help (default: false)
```


**Which issue(s) this PR fixes**:

Fixes #21726

**Special notes for your reviewer**:

* One thing to point, is that when running sub-commands, the `GLOBAL OPTIONS` field is described as `OPTIONS`.