### PR TITLE
Chore: Remove pkill gpg-agent from release pipeline

### DIFF
--- a/scripts/build/update_repo/load-signing-key.sh
+++ b/scripts/build/update_repo/load-signing-key.sh
@@ -3,4 +3,3 @@
 set -e
 
 gpg --batch --allow-secret-key-import --import ~/private-repo/signing/private.key
-pkill gpg-agent

--- a/scripts/build/update_repo/update-deb.sh
+++ b/scripts/build/update_repo/update-deb.sh
@@ -44,7 +44,6 @@ aptly repo add "$REPO" /deb-repo/tmp #adds too many packages in enterprise
 echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
 echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
 
-pkill gpg-agent || true
 touch /tmp/sign-this
 rm /tmp/sign-this.asc || true
 ./scripts/build/update_repo/unlock-gpg-key.sh "$GPG_PASS"

--- a/scripts/build/update_repo/update-rpm.sh
+++ b/scripts/build/update_repo/update-rpm.sh
@@ -43,7 +43,6 @@ echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
 echo "pinentry-mode loopback" > ~/.gnupg/gpg.conf
 
 rm /rpm-repo/repodata/repomd.xml.asc || true
-pkill gpg-agent || true
 ./scripts/build/update_repo/sign-rpm-repo.sh "$GPG_PASS"
 
 # usage:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is responsible for removing `pkill gpg-agent` from the scripts, which essentially restarts the agent. According to @xlson this was a failsafe method that it shouldn't be needed anymore.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/build-pipeline/issues/184