### PR TITLE
CloudWatch: Ensure empty query row errors are not passed to the panel

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -552,9 +552,7 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
 
         return {
           data: dataframes,
-          error: Object.values(res.results).reduce((acc, curr) => {
-            return curr.error ? { message: curr.error } : acc;
-          }, null),
+          error: Object.values(res.results).reduce((acc, curr) => (curr.error ? { message: curr.error } : acc), null),
         };
       }),
       catchError((err) => {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -552,13 +552,9 @@ export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWa
 
         return {
           data: dataframes,
-          error: Object.values(res.results)
-            .map((o) => ({
-              message: o.error,
-            }))
-            .reduce((err, error) => {
-              return err || error;
-            }, null),
+          error: Object.values(res.results).reduce((acc, curr) => {
+            return curr.error ? { message: curr.error } : acc;
+          }, null),
         };
       }),
       catchError((err) => {


### PR DESCRIPTION
Accidentally, empty error messages were passed to the panel. This was not a problem in dashboard edit mode, but it caused and empty error message to be displayed in Explore. 

Fixes #31085