### PR TITLE
DashboardLinks: Fix the links that always cause a full page to reload

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -46,7 +46,7 @@ export const DashboardLinks: FC<Props> = ({ dashboard, links }) => {
           <a
             className="gf-form-label gf-form-label--dashlink"
             href={sanitizeUrl(linkInfo.href)}
-            target={link.targetBlank ? '_blank' : '_self'}
+            target={link.targetBlank ? '_blank' : undefined}
             aria-label={selectors.components.DashboardLinks.link}
           >
             <Icon name={iconMap[link.icon] as IconName} style={{ marginRight: '4px' }} />


### PR DESCRIPTION
Noticed that clicking a dashboard link to another dashboard caused full page reload
