### PR TITLE
Postgres: Fix timeGroup macro converts long intervals to invalid numbers when TimescaleDB is enabled

### DIFF
--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -107,7 +107,7 @@ func (m *postgresMacroEngine) evaluateMacro(name string, args []string) (string,
 		}
 
 		if m.timescaledb {
-			return fmt.Sprintf("time_bucket('%vs',%s)", interval.Seconds(), args[0]), nil
+			return fmt.Sprintf("time_bucket('%.0fs',%s)", interval.Seconds(), args[0]), nil
 		}
 
 		return fmt.Sprintf(

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -104,7 +104,7 @@ func TestMacroEngine(t *testing.T) {
 				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
 			})
 
-			Convey("interpolate __timeGroup function with large number args and TimescaleDB enabled", func() {
+			Convey("interpolate __timeGroup function with large time range as an argument and TimescaleDB enabled", func() {
 				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column , '12d')")
 				So(err, ShouldBeNil)
 

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -104,6 +104,13 @@ func TestMacroEngine(t *testing.T) {
 				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
 			})
 
+			Convey("interpolate __timeGroup function with large number args and TimescaleDB enabled", func() {
+				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column , '12d')")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, "GROUP BY time_bucket('1036800s',time_column)")
+			})
+
 			Convey("interpolate __unixEpochFilter function", func() {
 				sql, err := engine.Interpolate(query, timeRange, "select $__unixEpochFilter(time)")
 				So(err, ShouldBeNil)


### PR DESCRIPTION
**What this PR does / why we need it**: This bug occurs when we passed more (or equals) than 12d as an argument for timeGroup inside TimescaleDB/Postgres query

**Which issue(s) this PR fixes**: #27253 

**Special notes for your reviewer**: