### PR TITLE
Chore: report eslint no-explicit-any errors to metrics

### DIFF
--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 set -e
 
-ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --strict true | grep -oP 'Found \K(\d+)')"
+ERROR_COUNT="$(yarn run tsc --project tsconfig.json --noEmit --strict true | grep -oP 'Found \K(\d+)')"
 DIRECTIVES="$(grep -r -o  directive public/app/ | wc -l)"
 CONTROLLERS="$(grep -r -oP 'class .*Ctrl' public/app/ | wc -l)"
 STORIES_COUNT="$(find ./packages/grafana-ui/src/components -name "*.story.tsx" | wc -l)"
 MDX_COUNT="$(find ./packages/grafana-ui/src/components -name "*.mdx" | wc -l)"
 LEGACY_FORMS="$(grep -r -oP 'LegacyForms;' public/app | wc -l)"
+
+STRICT_LINT_RESULTS="$(yarn run eslint --rule '@typescript-eslint/no-explicit-any: ["error"]' --format unix ./public/ || true)"
+STRICT_LINT_EXPLICIT_ANY="$(echo ${STRICT_LINT_RESULTS} | grep -o "no-explicit-any" | wc -l)"
 
 echo -e "Typescript errors: $ERROR_COUNT"
 echo -e "Directives: $DIRECTIVES"
@@ -14,6 +17,7 @@ echo -e "Controllers: $CONTROLLERS"
 echo -e "Stories: $STORIES_COUNT"
 echo -e "Documented stories: $MDX_COUNT"
 echo -e "Legacy forms: $LEGACY_FORMS"
+echo -e "TS Explicit any: $STRICT_LINT_EXPLICIT_ANY"
 
 echo "Metrics: {
   \"grafana.ci-code.strictErrors\": \"${ERROR_COUNT}\",
@@ -21,5 +25,6 @@ echo "Metrics: {
   \"grafana.ci-code.controllers\": \"${CONTROLLERS}\",
   \"grafana.ci-code.grafana-ui.stories\": \"${STORIES_COUNT}\",
   \"grafana.ci-code.grafana-ui.mdx\": \"${MDX_COUNT}\",
-  \"grafana.ci-code.legacyForms\": \"${LEGACY_FORMS}\"
+  \"grafana.ci-code.legacyForms\": \"${LEGACY_FORMS}\",
+  \"grafana.ci-code.strictLint.noExplicitAny\": \"${STRICT_LINT_EXPLICIT_ANY}\"
 }"

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -9,7 +9,7 @@ MDX_COUNT="$(find ./packages/grafana-ui/src/components -name "*.mdx" | wc -l)"
 LEGACY_FORMS="$(grep -r -oP 'LegacyForms;' public/app | wc -l)"
 
 STRICT_LINT_RESULTS="$(yarn run eslint --rule '@typescript-eslint/no-explicit-any: ["error"]' --format unix ./public/ || true)"
-STRICT_LINT_EXPLICIT_ANY="$(echo ${STRICT_LINT_RESULTS} | grep -o "no-explicit-any" | wc -l)"
+STRICT_LINT_EXPLICIT_ANY="$(echo "${STRICT_LINT_RESULTS}" | grep -o "no-explicit-any" | wc -l)"
 
 echo -e "Typescript errors: $ERROR_COUNT"
 echo -e "Directives: $DIRECTIVES"


### PR DESCRIPTION
**What this PR does / why we need it**:

Reports `any` usage in Typescript files along with the other frontend metrics that are being tracked.

This does run ESLint a second time over the codebase, I'm open to other approaches if we're concerned about the slowdown caused by this...

**Special notes for your reviewer**:

Have a nice day 😄