### PR TITLE
Loki: Add line limit for annotations

### DIFF
--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -160,7 +160,7 @@ export function registerAngularDirectives() {
   ]);
 
   react2AngularDirective('lokiAnnotationsQueryEditor', LokiAnnotationsQueryEditor, [
-    'expr',
+    'query',
     'onChange',
     ['datasource', { watchDepth: 'reference' }],
   ]);

--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -160,7 +160,9 @@ export function registerAngularDirectives() {
   ]);
 
   react2AngularDirective('lokiAnnotationsQueryEditor', LokiAnnotationsQueryEditor, [
-    'query',
+    'expr',
+    'maxLines',
+    'instant',
     'onChange',
     ['datasource', { watchDepth: 'reference' }],
   ]);

--- a/public/app/plugins/datasource/loki/LokiAnnotationsQueryCtrl.tsx
+++ b/public/app/plugins/datasource/loki/LokiAnnotationsQueryCtrl.tsx
@@ -1,3 +1,4 @@
+import { LokiQuery } from './types';
 /**
  * Just a simple wrapper for a react component that is actually implementing the query editor.
  */
@@ -8,10 +9,11 @@ export class LokiAnnotationsQueryCtrl {
   /** @ngInject */
   constructor() {
     this.annotation.target = this.annotation.target || {};
+    this.annotation.query = this.annotation.query || {};
     this.onQueryChange = this.onQueryChange.bind(this);
   }
 
-  onQueryChange(expr: string) {
-    this.annotation.expr = expr;
+  onQueryChange(query: LokiQuery) {
+    this.annotation.query = query;
   }
 }

--- a/public/app/plugins/datasource/loki/LokiAnnotationsQueryCtrl.tsx
+++ b/public/app/plugins/datasource/loki/LokiAnnotationsQueryCtrl.tsx
@@ -9,11 +9,12 @@ export class LokiAnnotationsQueryCtrl {
   /** @ngInject */
   constructor() {
     this.annotation.target = this.annotation.target || {};
-    this.annotation.query = this.annotation.query || {};
     this.onQueryChange = this.onQueryChange.bind(this);
   }
 
   onQueryChange(query: LokiQuery) {
-    this.annotation.query = query;
+    this.annotation.expr = query.expr;
+    this.annotation.maxLines = query.maxLines;
+    this.annotation.instant = query.instant;
   }
 }

--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -8,13 +8,13 @@ import { LokiQueryFieldForm } from './LokiQueryFieldForm';
 import LokiDatasource from '../datasource';
 
 interface Props {
-  expr: string;
+  query: LokiQuery;
   datasource: LokiDatasource;
-  onChange: (expr: string) => void;
+  onChange: (query: LokiQuery) => void;
 }
 
 export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEditor(props: Props) {
-  const { expr, datasource, onChange } = props;
+  const { query, datasource, onChange } = props;
 
   // Timerange to get existing labels from. Hard coding like this seems to be good enough right now.
   const absolute = {
@@ -27,17 +27,16 @@ export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEdito
     absolute
   );
 
-  const query: LokiQuery = {
+  const queryWithRefId: LokiQuery = {
+    ...query,
     refId: '',
-    expr,
   };
-
   return (
     <div className="gf-form-group">
       <LokiQueryFieldForm
         datasource={datasource}
-        query={query}
-        onChange={(query: LokiQuery) => onChange(query.expr)}
+        query={queryWithRefId}
+        onChange={onChange}
         onRunQuery={() => {}}
         history={[]}
         onLoadOptions={setActiveOption}

--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -8,13 +8,15 @@ import { LokiQueryFieldForm } from './LokiQueryFieldForm';
 import LokiDatasource from '../datasource';
 
 interface Props {
-  query: LokiQuery;
+  expr: string;
+  maxLines?: number;
+  instant?: boolean;
   datasource: LokiDatasource;
   onChange: (query: LokiQuery) => void;
 }
 
 export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEditor(props: Props) {
-  const { query, datasource, onChange } = props;
+  const { expr, maxLines, instant, datasource, onChange } = props;
 
   // Timerange to get existing labels from. Hard coding like this seems to be good enough right now.
   const absolute = {
@@ -28,8 +30,10 @@ export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEdito
   );
 
   const queryWithRefId: LokiQuery = {
-    ...query,
     refId: '',
+    expr,
+    maxLines,
+    instant,
   };
   return (
     <div className="gf-form-group">

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -490,22 +490,17 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   }
 
   async annotationQuery(options: AnnotationQueryRequest<LokiQuery>): Promise<AnnotationEvent[]> {
-    const annotation = options.annotation;
-    // In LokiAnnotationEditor we are using query object insted of listing every property separately (maxLines, instant, range,...)
-    // This way, if we add a new query property to the core editor, we don't have to update it again
-    const query = (annotation.query as unknown) as LokiQuery;
+    const { expr, maxLines, instant } = options.annotation;
 
-    if (!query.expr) {
+    if (!expr) {
       return [];
     }
 
-    const interpolatedExpr = this.templateSrv.replace(query.expr, {}, this.interpolateQueryExpr);
-    const annotationQuery = { ...query, refId: `annotation-${options.annotation.name}`, expr: interpolatedExpr };
-    console.log('annotationQuery', annotationQuery);
-    console.log('options', options);
-    const { data } = query.instant
-      ? await this.runInstantQuery(annotationQuery, options as any).toPromise()
-      : await this.runRangeQuery(annotationQuery, options as any).toPromise();
+    const interpolatedExpr = this.templateSrv.replace(expr, {}, this.interpolateQueryExpr);
+    const query = { refId: `annotation-${options.annotation.name}`, expr: interpolatedExpr, maxLines, instant };
+    const { data } = instant
+      ? await this.runInstantQuery(query, options as any).toPromise()
+      : await this.runRangeQuery(query, options as any).toPromise();
 
     const annotations: AnnotationEvent[] = [];
 

--- a/public/app/plugins/datasource/loki/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/loki/partials/annotations.editor.html
@@ -1,5 +1,7 @@
 <loki-annotations-query-editor
-  query="ctrl.annotation.query"
+  expr="ctrl.annotation.expr"
+  max-lines="ctrl.annotation.maxLines"
+  instant="ctrl.annotation.instant"
   on-change="ctrl.onQueryChange"
   datasource="ctrl.datasource"
 />

--- a/public/app/plugins/datasource/loki/partials/annotations.editor.html
+++ b/public/app/plugins/datasource/loki/partials/annotations.editor.html
@@ -1,5 +1,5 @@
 <loki-annotations-query-editor
-    expr="ctrl.annotation.expr"
-    on-change="ctrl.onQueryChange"
-    datasource="ctrl.datasource"
+  query="ctrl.annotation.query"
+  on-change="ctrl.onQueryChange"
+  datasource="ctrl.datasource"
 />


### PR DESCRIPTION
**What this PR does / why we need it**:

We already had line limit and query type fields in Annotation Loki editor since implementing it in dashboard https://github.com/grafana/grafana/pull/29356. But unfortunately, these new fields weren't working (you couldn't input the number and couldn't switch query type). This PR fixes it and implements logic to limit number of logs in annotation queries and choose query type. 

https://user-images.githubusercontent.com/30407135/107802450-a0163f80-6d61-11eb-8b18-0f55238e276c.mov

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/21308

