### PR TITLE
QueryEditors: Fix an issue that happens after moving queries then editing would update other queries

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -75,7 +75,7 @@ export class QueryEditorRow extends PureComponent<Props, State> {
   }
 
   getAngularQueryComponentScope(): AngularQueryComponentScope {
-    const { query, onChange, onRunQuery, queries } = this.props;
+    const { query, queries } = this.props;
     const { datasource } = this.state;
     const panel = new PanelModel({ targets: queries });
     const dashboard = {} as DashboardModel;
@@ -87,8 +87,10 @@ export class QueryEditorRow extends PureComponent<Props, State> {
       dashboard: dashboard,
       refresh: () => {
         // Old angular editors modify the query model and just call refresh
-        onChange(query);
-        onRunQuery();
+        // Important that this use this.props here so that as this fuction is only created on mount and it's
+        // important not to capture old prop functions in this closure
+        this.props.onChange(query);
+        this.props.onRunQuery();
       },
       render: () => () => console.log('legacy render function called, it does nothing'),
       events: new EventBusSrv(),


### PR DESCRIPTION
Fixes #31184

Moving queries changes the onChange callback (as it is created on every render in QueryEditorRows) and the index of the query is captured in the callback. But the angular refresh function
used a onChange callback that was frozen in the outer scope so would call an old onChange with the old index.


