### PR TITLE
Graph: Make axes unit option work even when field option unit is set

### DIFF
--- a/public/app/plugins/panel/graph/axes_editor.ts
+++ b/public/app/plugins/panel/graph/axes_editor.ts
@@ -51,7 +51,13 @@ export class AxesEditorCtrl {
   setUnitFormat(axis: { format: any }) {
     return (unit: string) => {
       axis.format = unit;
-      this.panelCtrl.render();
+      // if already set via field config we need to update that as well
+      if (this.panel.fieldConfig.defaults.unit) {
+        this.panel.fieldConfig.defaults.unit = unit;
+        this.panelCtrl.refresh();
+      } else {
+        this.panelCtrl.render();
+      }
     };
   }
 

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -156,6 +156,7 @@ export class GraphCtrl extends MetricsPanelCtrl {
     this.useDataFrames = true;
     this.processor = new DataProcessor(this.panel);
     this.contextMenuCtrl = new GraphContextMenuCtrl($scope);
+    this.annotationsPromise = Promise.resolve({ annotations: [] });
 
     this.events.on(PanelEvents.render, this.onRender.bind(this));
     this.events.on(PanelEvents.dataFramesReceived, this.onDataFramesReceived.bind(this));
@@ -163,7 +164,11 @@ export class GraphCtrl extends MetricsPanelCtrl {
     this.events.on(PanelEvents.editModeInitialized, this.onInitEditMode.bind(this));
     this.events.on(PanelEvents.initPanelActions, this.onInitPanelActions.bind(this));
 
-    this.annotationsPromise = Promise.resolve({ annotations: [] });
+    // set axes format from field config
+    const fieldConfigUnit = this.panel.fieldConfig.defaults.unit;
+    if (fieldConfigUnit) {
+      this.panel.yaxes[0].format = fieldConfigUnit;
+    }
   }
 
   onInitEditMode() {

--- a/public/app/plugins/panel/graph/specs/graph.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph.test.ts
@@ -78,6 +78,9 @@ describe('grafanaGraph', () => {
         tooltip: {
           shared: true,
         },
+        fieldConfig: {
+          defaults: {},
+        },
       },
       renderingCompleted: jest.fn(),
       hiddenSeries: {},

--- a/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
+++ b/public/app/plugins/panel/graph/specs/graph_ctrl.test.ts
@@ -30,6 +30,9 @@ describe('GraphCtrl', () => {
     gridPos: {
       w: 100,
     },
+    fieldConfig: {
+      defaults: {},
+    },
   };
 
   const ctx = {} as any;


### PR DESCRIPTION
Fixes #31141
