### PR TITLE
IPv6: Support host address configured with enclosing square brackets

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/grafana/grafana/pkg/services/live"
@@ -103,8 +104,10 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 
 	hs.applyRoutes()
 
+	// Remove any square brackets enclosing IPv6 addresses, a format we support for backwards compatibility
+	host := strings.TrimSuffix(strings.TrimPrefix(setting.HttpAddr, "["), "]")
 	hs.httpSrv = &http.Server{
-		Addr:    net.JoinHostPort(setting.HttpAddr, setting.HttpPort),
+		Addr:    net.JoinHostPort(host, setting.HttpPort),
 		Handler: hs.macaron,
 	}
 	switch hs.Cfg.Protocol {

--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -114,6 +114,8 @@ func (server *Server) Dial() error {
 		}
 	}
 	for _, host := range strings.Split(server.Config.Host, " ") {
+		// Remove any square brackets enclosing IPv6 addresses, a format we support for backwards compatibility
+		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
 		address := net.JoinHostPort(host, strconv.Itoa(server.Config.Port))
 		if server.Config.UseSSL {
 			tlsCfg := &tls.Config{


### PR DESCRIPTION
**What this PR does / why we need it**:
For backwards compatibility reasons, and because the image renderer gets weird (leaks memory?) if Grafana is configured with an IPv6 address not enclosed in square brackets, support Grafana's host address being an IPv6 address enclosed in square brackets (f.ex. `[::1]`).

**Which issue(s) this PR fixes**:

Fixes #30930
Fixes #31136 
