### PR TITLE
Loki: Remove deprecated and breaking config field in devenv

### DIFF
--- a/devenv/docker/blocks/loki/config.yaml
+++ b/devenv/docker/blocks/loki/config.yaml
@@ -10,7 +10,6 @@ client:
 
 scrape_configs:
 - job_name: system
-  entry_parser: raw
   static_configs:
   - targets:
       - localhost
@@ -18,7 +17,6 @@ scrape_configs:
       job: varlogs
       __path__: /var/log/*log
 - job_name: grafana
-  entry_parser: raw
   static_configs:
   - targets:
       - localhost


### PR DESCRIPTION
**What this PR does / why we need it**:
In [Loki 2.0 release ](https://github.com/grafana/loki/blob/master/CHANGELOG.md#important-notes) the long deprecated `entry_parser` config in Promtail has been removed. That is the reason why our loki devenv block was unusable and was throwing error:

![image](https://user-images.githubusercontent.com/30407135/107972784-a2240c80-6fb4-11eb-9b85-8d1a58b8eb64.png)

Users can now use [pipeline_stages](https://grafana.com/docs/loki/latest/clients/promtail/pipelines/) instead. What pipeline does: 

```
Typical pipelines will start with a parsing stage (such as a regex or json stage) to extract data from the log line. 
Then, a series of action stages will be present to do something with that extracted data. 
The most common action stage will be a labels stage to turn extracted data into a label.
```

This is not something we need for our usecase, therefore we don't need to replace `entry_parser` with `pipeline_stages`. By removing `entry_parser`, we make our loki block usable again 🎉: 

![image](https://user-images.githubusercontent.com/30407135/107972997-f202d380-6fb4-11eb-9cb4-404cd1a72cfc.png)