### PR TITLE
LibraryPanels: Disconnect before connect during dashboard save

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -149,7 +149,7 @@ func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
 
 	if hs.Cfg.IsPanelLibraryEnabled() {
 		// load library panels JSON for this dashboard
-		err = hs.LibraryPanelService.LoadLibraryPanelsForDashboard(dash)
+		err = hs.LibraryPanelService.LoadLibraryPanelsForDashboard(c, dash)
 		if err != nil {
 			return response.Error(500, "Error while loading library panels", err)
 		}
@@ -220,7 +220,7 @@ func (hs *HTTPServer) deleteDashboard(c *models.ReqContext) response.Response {
 
 	if hs.Cfg.IsPanelLibraryEnabled() {
 		// disconnect all library panels for this dashboard
-		err := hs.LibraryPanelService.DisconnectLibraryPanelsForDashboard(dash)
+		err := hs.LibraryPanelService.DisconnectLibraryPanelsForDashboard(c, dash)
 		if err != nil {
 			hs.log.Error("Failed to disconnect library panels", "dashboard", dash.Id, "user", c.SignedInUser.UserId, "error", err)
 		}

--- a/pkg/services/librarypanels/database.go
+++ b/pkg/services/librarypanels/database.go
@@ -67,12 +67,12 @@ func (lps *LibraryPanelService) createLibraryPanel(c *models.ReqContext, cmd cre
 			CreatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.CreatedBy,
 				Name:      c.SignedInUser.Login,
-				AvatarUrl: dtos.GetGravatarUrl(c.SignedInUser.Email),
+				AvatarURL: dtos.GetGravatarUrl(c.SignedInUser.Email),
 			},
 			UpdatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.UpdatedBy,
 				Name:      c.SignedInUser.Login,
-				AvatarUrl: dtos.GetGravatarUrl(c.SignedInUser.Email),
+				AvatarURL: dtos.GetGravatarUrl(c.SignedInUser.Email),
 			},
 		},
 	}
@@ -115,6 +115,10 @@ func (lps *LibraryPanelService) connectDashboard(c *models.ReqContext, uid strin
 // connectLibraryPanelsForDashboard adds connections for all Library Panels in a Dashboard.
 func (lps *LibraryPanelService) connectLibraryPanelsForDashboard(c *models.ReqContext, uids []string, dashboardID int64) error {
 	err := lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+		_, err := session.Exec("DELETE FROM library_panel_dashboard WHERE dashboard_id=?", dashboardID)
+		if err != nil {
+			return err
+		}
 		for _, uid := range uids {
 			err := connectDashboard(session, lps.SQLStore.Dialect, c.SignedInUser, uid, dashboardID)
 			if err != nil {
@@ -235,12 +239,12 @@ func (lps *LibraryPanelService) getLibraryPanel(c *models.ReqContext, uid string
 			CreatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.CreatedBy,
 				Name:      libraryPanel.CreatedByName,
-				AvatarUrl: dtos.GetGravatarUrl(libraryPanel.CreatedByEmail),
+				AvatarURL: dtos.GetGravatarUrl(libraryPanel.CreatedByEmail),
 			},
 			UpdatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.UpdatedBy,
 				Name:      libraryPanel.UpdatedByName,
-				AvatarUrl: dtos.GetGravatarUrl(libraryPanel.UpdatedByEmail),
+				AvatarURL: dtos.GetGravatarUrl(libraryPanel.UpdatedByEmail),
 			},
 		},
 	}
@@ -280,12 +284,12 @@ func (lps *LibraryPanelService) getAllLibraryPanels(c *models.ReqContext) ([]Lib
 				CreatedBy: LibraryPanelDTOMetaUser{
 					ID:        panel.CreatedBy,
 					Name:      panel.CreatedByName,
-					AvatarUrl: dtos.GetGravatarUrl(panel.CreatedByEmail),
+					AvatarURL: dtos.GetGravatarUrl(panel.CreatedByEmail),
 				},
 				UpdatedBy: LibraryPanelDTOMetaUser{
 					ID:        panel.UpdatedBy,
 					Name:      panel.UpdatedByName,
-					AvatarUrl: dtos.GetGravatarUrl(panel.UpdatedByEmail),
+					AvatarURL: dtos.GetGravatarUrl(panel.UpdatedByEmail),
 				},
 			},
 		})
@@ -348,12 +352,12 @@ func (lps *LibraryPanelService) getLibraryPanelsForDashboardID(dashboardID int64
 					CreatedBy: LibraryPanelDTOMetaUser{
 						ID:        panel.CreatedBy,
 						Name:      panel.CreatedByName,
-						AvatarUrl: dtos.GetGravatarUrl(panel.CreatedByEmail),
+						AvatarURL: dtos.GetGravatarUrl(panel.CreatedByEmail),
 					},
 					UpdatedBy: LibraryPanelDTOMetaUser{
 						ID:        panel.UpdatedBy,
 						Name:      panel.UpdatedByName,
-						AvatarUrl: dtos.GetGravatarUrl(panel.UpdatedByEmail),
+						AvatarURL: dtos.GetGravatarUrl(panel.UpdatedByEmail),
 					},
 				},
 			}
@@ -421,12 +425,12 @@ func (lps *LibraryPanelService) patchLibraryPanel(c *models.ReqContext, cmd patc
 				CreatedBy: LibraryPanelDTOMetaUser{
 					ID:        panelInDB.CreatedBy,
 					Name:      panelInDB.CreatedByName,
-					AvatarUrl: dtos.GetGravatarUrl(panelInDB.CreatedByEmail),
+					AvatarURL: dtos.GetGravatarUrl(panelInDB.CreatedByEmail),
 				},
 				UpdatedBy: LibraryPanelDTOMetaUser{
 					ID:        libraryPanel.UpdatedBy,
 					Name:      c.SignedInUser.Login,
-					AvatarUrl: dtos.GetGravatarUrl(c.SignedInUser.Email),
+					AvatarURL: dtos.GetGravatarUrl(c.SignedInUser.Email),
 				},
 			},
 		}

--- a/pkg/services/librarypanels/database.go
+++ b/pkg/services/librarypanels/database.go
@@ -1,7 +1,6 @@
 package librarypanels
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -42,7 +41,7 @@ func (lps *LibraryPanelService) createLibraryPanel(c *models.ReqContext, cmd cre
 		CreatedBy: c.SignedInUser.UserId,
 		UpdatedBy: c.SignedInUser.UserId,
 	}
-	err := lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithTransactionalDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		if _, err := session.Insert(&libraryPanel); err != nil {
 			if lps.SQLStore.Dialect.IsUniqueConstraintViolation(err) {
 				return errLibraryPanelAlreadyExists
@@ -105,7 +104,7 @@ func connectDashboard(session *sqlstore.DBSession, dialect migrator.Dialect, use
 
 // connectDashboard adds a connection between a Library Panel and a Dashboard.
 func (lps *LibraryPanelService) connectDashboard(c *models.ReqContext, uid string, dashboardID int64) error {
-	err := lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithTransactionalDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		return connectDashboard(session, lps.SQLStore.Dialect, c.SignedInUser, uid, dashboardID)
 	})
 
@@ -114,7 +113,7 @@ func (lps *LibraryPanelService) connectDashboard(c *models.ReqContext, uid strin
 
 // connectLibraryPanelsForDashboard adds connections for all Library Panels in a Dashboard.
 func (lps *LibraryPanelService) connectLibraryPanelsForDashboard(c *models.ReqContext, uids []string, dashboardID int64) error {
-	err := lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithTransactionalDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		_, err := session.Exec("DELETE FROM library_panel_dashboard WHERE dashboard_id=?", dashboardID)
 		if err != nil {
 			return err
@@ -133,7 +132,7 @@ func (lps *LibraryPanelService) connectLibraryPanelsForDashboard(c *models.ReqCo
 
 // deleteLibraryPanel deletes a Library Panel.
 func (lps *LibraryPanelService) deleteLibraryPanel(c *models.ReqContext, uid string) error {
-	return lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	return lps.SQLStore.WithTransactionalDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		panel, err := getLibraryPanel(session, uid, c.SignedInUser.OrgId)
 		if err != nil {
 			return err
@@ -159,7 +158,7 @@ func (lps *LibraryPanelService) deleteLibraryPanel(c *models.ReqContext, uid str
 
 // disconnectDashboard deletes a connection between a Library Panel and a Dashboard.
 func (lps *LibraryPanelService) disconnectDashboard(c *models.ReqContext, uid string, dashboardID int64) error {
-	return lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	return lps.SQLStore.WithTransactionalDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		panel, err := getLibraryPanel(session, uid, c.SignedInUser.OrgId)
 		if err != nil {
 			return err
@@ -181,8 +180,8 @@ func (lps *LibraryPanelService) disconnectDashboard(c *models.ReqContext, uid st
 }
 
 // disconnectLibraryPanelsForDashboard deletes connections for all Library Panels in a Dashboard.
-func (lps *LibraryPanelService) disconnectLibraryPanelsForDashboard(dashboardID int64, panelCount int64) error {
-	return lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+func (lps *LibraryPanelService) disconnectLibraryPanelsForDashboard(c *models.ReqContext, dashboardID int64, panelCount int64) error {
+	return lps.SQLStore.WithTransactionalDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		result, err := session.Exec("DELETE FROM library_panel_dashboard WHERE dashboard_id=?", dashboardID)
 		if err != nil {
 			return err
@@ -218,7 +217,7 @@ func getLibraryPanel(session *sqlstore.DBSession, uid string, orgID int64) (Libr
 // getLibraryPanel gets a Library Panel.
 func (lps *LibraryPanelService) getLibraryPanel(c *models.ReqContext, uid string) (LibraryPanelDTO, error) {
 	var libraryPanel LibraryPanelWithMeta
-	err := lps.SQLStore.WithDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		var err error
 		libraryPanel, err = getLibraryPanel(session, uid, c.SignedInUser.OrgId)
 		return err
@@ -256,7 +255,7 @@ func (lps *LibraryPanelService) getLibraryPanel(c *models.ReqContext, uid string
 func (lps *LibraryPanelService) getAllLibraryPanels(c *models.ReqContext) ([]LibraryPanelDTO, error) {
 	orgID := c.SignedInUser.OrgId
 	libraryPanels := make([]LibraryPanelWithMeta, 0)
-	err := lps.SQLStore.WithDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		sql := sqlStatmentLibrayPanelDTOWithMeta + "WHERE lp.org_id=?"
 		sess := session.SQL(sql, orgID)
 		err := sess.Find(&libraryPanels)
@@ -301,7 +300,7 @@ func (lps *LibraryPanelService) getAllLibraryPanels(c *models.ReqContext) ([]Lib
 // getConnectedDashboards gets all dashboards connected to a Library Panel.
 func (lps *LibraryPanelService) getConnectedDashboards(c *models.ReqContext, uid string) ([]int64, error) {
 	connectedDashboardIDs := make([]int64, 0)
-	err := lps.SQLStore.WithDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		panel, err := getLibraryPanel(session, uid, c.SignedInUser.OrgId)
 		if err != nil {
 			return err
@@ -325,9 +324,9 @@ func (lps *LibraryPanelService) getConnectedDashboards(c *models.ReqContext, uid
 	return connectedDashboardIDs, err
 }
 
-func (lps *LibraryPanelService) getLibraryPanelsForDashboardID(dashboardID int64) (map[string]LibraryPanelDTO, error) {
+func (lps *LibraryPanelService) getLibraryPanelsForDashboardID(c *models.ReqContext, dashboardID int64) (map[string]LibraryPanelDTO, error) {
 	libraryPanelMap := make(map[string]LibraryPanelDTO)
-	err := lps.SQLStore.WithDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		var libraryPanels []LibraryPanelWithMeta
 		sql := sqlStatmentLibrayPanelDTOWithMeta + "INNER JOIN library_panel_dashboard AS lpd ON lpd.librarypanel_id = lp.id AND lpd.dashboard_id=?"
 		sess := session.SQL(sql, dashboardID)
@@ -372,7 +371,7 @@ func (lps *LibraryPanelService) getLibraryPanelsForDashboardID(dashboardID int64
 // patchLibraryPanel updates a Library Panel.
 func (lps *LibraryPanelService) patchLibraryPanel(c *models.ReqContext, cmd patchLibraryPanelCommand, uid string) (LibraryPanelDTO, error) {
 	var dto LibraryPanelDTO
-	err := lps.SQLStore.WithTransactionalDbSession(context.Background(), func(session *sqlstore.DBSession) error {
+	err := lps.SQLStore.WithTransactionalDbSession(c.Context.Req.Context(), func(session *sqlstore.DBSession) error {
 		panelInDB, err := getLibraryPanel(session, uid, c.SignedInUser.OrgId)
 		if err != nil {
 			return err

--- a/pkg/services/librarypanels/database.go
+++ b/pkg/services/librarypanels/database.go
@@ -67,12 +67,12 @@ func (lps *LibraryPanelService) createLibraryPanel(c *models.ReqContext, cmd cre
 			CreatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.CreatedBy,
 				Name:      c.SignedInUser.Login,
-				AvatarURL: dtos.GetGravatarUrl(c.SignedInUser.Email),
+				AvatarUrl: dtos.GetGravatarUrl(c.SignedInUser.Email),
 			},
 			UpdatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.UpdatedBy,
 				Name:      c.SignedInUser.Login,
-				AvatarURL: dtos.GetGravatarUrl(c.SignedInUser.Email),
+				AvatarUrl: dtos.GetGravatarUrl(c.SignedInUser.Email),
 			},
 		},
 	}
@@ -239,12 +239,12 @@ func (lps *LibraryPanelService) getLibraryPanel(c *models.ReqContext, uid string
 			CreatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.CreatedBy,
 				Name:      libraryPanel.CreatedByName,
-				AvatarURL: dtos.GetGravatarUrl(libraryPanel.CreatedByEmail),
+				AvatarUrl: dtos.GetGravatarUrl(libraryPanel.CreatedByEmail),
 			},
 			UpdatedBy: LibraryPanelDTOMetaUser{
 				ID:        libraryPanel.UpdatedBy,
 				Name:      libraryPanel.UpdatedByName,
-				AvatarURL: dtos.GetGravatarUrl(libraryPanel.UpdatedByEmail),
+				AvatarUrl: dtos.GetGravatarUrl(libraryPanel.UpdatedByEmail),
 			},
 		},
 	}
@@ -284,12 +284,12 @@ func (lps *LibraryPanelService) getAllLibraryPanels(c *models.ReqContext) ([]Lib
 				CreatedBy: LibraryPanelDTOMetaUser{
 					ID:        panel.CreatedBy,
 					Name:      panel.CreatedByName,
-					AvatarURL: dtos.GetGravatarUrl(panel.CreatedByEmail),
+					AvatarUrl: dtos.GetGravatarUrl(panel.CreatedByEmail),
 				},
 				UpdatedBy: LibraryPanelDTOMetaUser{
 					ID:        panel.UpdatedBy,
 					Name:      panel.UpdatedByName,
-					AvatarURL: dtos.GetGravatarUrl(panel.UpdatedByEmail),
+					AvatarUrl: dtos.GetGravatarUrl(panel.UpdatedByEmail),
 				},
 			},
 		})
@@ -352,12 +352,12 @@ func (lps *LibraryPanelService) getLibraryPanelsForDashboardID(dashboardID int64
 					CreatedBy: LibraryPanelDTOMetaUser{
 						ID:        panel.CreatedBy,
 						Name:      panel.CreatedByName,
-						AvatarURL: dtos.GetGravatarUrl(panel.CreatedByEmail),
+						AvatarUrl: dtos.GetGravatarUrl(panel.CreatedByEmail),
 					},
 					UpdatedBy: LibraryPanelDTOMetaUser{
 						ID:        panel.UpdatedBy,
 						Name:      panel.UpdatedByName,
-						AvatarURL: dtos.GetGravatarUrl(panel.UpdatedByEmail),
+						AvatarUrl: dtos.GetGravatarUrl(panel.UpdatedByEmail),
 					},
 				},
 			}
@@ -425,12 +425,12 @@ func (lps *LibraryPanelService) patchLibraryPanel(c *models.ReqContext, cmd patc
 				CreatedBy: LibraryPanelDTOMetaUser{
 					ID:        panelInDB.CreatedBy,
 					Name:      panelInDB.CreatedByName,
-					AvatarURL: dtos.GetGravatarUrl(panelInDB.CreatedByEmail),
+					AvatarUrl: dtos.GetGravatarUrl(panelInDB.CreatedByEmail),
 				},
 				UpdatedBy: LibraryPanelDTOMetaUser{
 					ID:        libraryPanel.UpdatedBy,
 					Name:      c.SignedInUser.Login,
-					AvatarURL: dtos.GetGravatarUrl(c.SignedInUser.Email),
+					AvatarUrl: dtos.GetGravatarUrl(c.SignedInUser.Email),
 				},
 			},
 		}

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -45,12 +45,12 @@ func (lps *LibraryPanelService) IsEnabled() bool {
 
 // LoadLibraryPanelsForDashboard loops through all panels in dashboard JSON and replaces any library panel JSON
 // with JSON stored for library panel in db.
-func (lps *LibraryPanelService) LoadLibraryPanelsForDashboard(dash *models.Dashboard) error {
+func (lps *LibraryPanelService) LoadLibraryPanelsForDashboard(c *models.ReqContext, dash *models.Dashboard) error {
 	if !lps.IsEnabled() {
 		return nil
 	}
 
-	libraryPanels, err := lps.getLibraryPanelsForDashboardID(dash.Id)
+	libraryPanels, err := lps.getLibraryPanelsForDashboardID(c, dash.Id)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func (lps *LibraryPanelService) ConnectLibraryPanelsForDashboard(c *models.ReqCo
 }
 
 // DisconnectLibraryPanelsForDashboard loops through all panels in dashboard JSON and disconnects any library panels from the dashboard.
-func (lps *LibraryPanelService) DisconnectLibraryPanelsForDashboard(dash *models.Dashboard) error {
+func (lps *LibraryPanelService) DisconnectLibraryPanelsForDashboard(c *models.ReqContext, dash *models.Dashboard) error {
 	if !lps.IsEnabled() {
 		return nil
 	}
@@ -216,7 +216,7 @@ func (lps *LibraryPanelService) DisconnectLibraryPanelsForDashboard(dash *models
 		panelCount++
 	}
 
-	return lps.disconnectLibraryPanelsForDashboard(dash.Id, panelCount)
+	return lps.disconnectLibraryPanelsForDashboard(c, dash.Id, panelCount)
 }
 
 // AddMigration defines database migrations.

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -112,12 +112,12 @@ func (lps *LibraryPanelService) LoadLibraryPanelsForDashboard(dash *models.Dashb
 				"createdBy": map[string]interface{}{
 					"id":        libraryPanelInDB.Meta.CreatedBy.ID,
 					"name":      libraryPanelInDB.Meta.CreatedBy.Name,
-					"avatarUrl": libraryPanelInDB.Meta.CreatedBy.AvatarURL,
+					"avatarUrl": libraryPanelInDB.Meta.CreatedBy.AvatarUrl,
 				},
 				"updatedBy": map[string]interface{}{
 					"id":        libraryPanelInDB.Meta.UpdatedBy.ID,
 					"name":      libraryPanelInDB.Meta.UpdatedBy.Name,
-					"avatarUrl": libraryPanelInDB.Meta.UpdatedBy.AvatarURL,
+					"avatarUrl": libraryPanelInDB.Meta.UpdatedBy.AvatarUrl,
 				},
 			},
 		})

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -112,12 +112,12 @@ func (lps *LibraryPanelService) LoadLibraryPanelsForDashboard(dash *models.Dashb
 				"createdBy": map[string]interface{}{
 					"id":        libraryPanelInDB.Meta.CreatedBy.ID,
 					"name":      libraryPanelInDB.Meta.CreatedBy.Name,
-					"avatarUrl": libraryPanelInDB.Meta.CreatedBy.AvatarUrl,
+					"avatarUrl": libraryPanelInDB.Meta.CreatedBy.AvatarURL,
 				},
 				"updatedBy": map[string]interface{}{
 					"id":        libraryPanelInDB.Meta.UpdatedBy.ID,
 					"name":      libraryPanelInDB.Meta.UpdatedBy.Name,
-					"avatarUrl": libraryPanelInDB.Meta.UpdatedBy.AvatarUrl,
+					"avatarUrl": libraryPanelInDB.Meta.UpdatedBy.AvatarURL,
 				},
 			},
 		})

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -1530,7 +1530,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		t.Cleanup(registry.ClearOverrides)
 
 		ctx := macaron.Context{
-			Req: macaron.Request{&http.Request{}},
+			Req: macaron.Request{Request: &http.Request{}},
 		}
 		orgID := int64(1)
 		role := models.ROLE_ADMIN

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -801,7 +802,7 @@ func TestLoadLibraryPanelsForDashboard(t *testing.T) {
 				Data: simplejson.NewFromAny(dashJSON),
 			}
 
-			err = sc.service.LoadLibraryPanelsForDashboard(&dash)
+			err = sc.service.LoadLibraryPanelsForDashboard(sc.reqContext, &dash)
 			require.NoError(t, err)
 			expectedJSON := map[string]interface{}{
 				"panels": []interface{}{
@@ -898,7 +899,7 @@ func TestLoadLibraryPanelsForDashboard(t *testing.T) {
 				Data: simplejson.NewFromAny(dashJSON),
 			}
 
-			err = sc.service.LoadLibraryPanelsForDashboard(&dash)
+			err = sc.service.LoadLibraryPanelsForDashboard(sc.reqContext, &dash)
 			require.EqualError(t, err, errLibraryPanelHeaderUIDMissing.Error())
 		})
 
@@ -943,7 +944,7 @@ func TestLoadLibraryPanelsForDashboard(t *testing.T) {
 				Data: simplejson.NewFromAny(dashJSON),
 			}
 
-			err = sc.service.LoadLibraryPanelsForDashboard(&dash)
+			err = sc.service.LoadLibraryPanelsForDashboard(sc.reqContext, &dash)
 			require.NoError(t, err)
 			expectedJSON := map[string]interface{}{
 				"panels": []interface{}{
@@ -1388,7 +1389,7 @@ func TestDisconnectLibraryPanelsForDashboard(t *testing.T) {
 				Data: simplejson.NewFromAny(dashJSON),
 			}
 
-			err = sc.service.DisconnectLibraryPanelsForDashboard(&dash)
+			err = sc.service.DisconnectLibraryPanelsForDashboard(sc.reqContext, &dash)
 			require.NoError(t, err)
 
 			sc.reqContext.ReplaceAllParams(map[string]string{":uid": existing.Result.UID})
@@ -1448,7 +1449,7 @@ func TestDisconnectLibraryPanelsForDashboard(t *testing.T) {
 				Data: simplejson.NewFromAny(dashJSON),
 			}
 
-			err = sc.service.DisconnectLibraryPanelsForDashboard(&dash)
+			err = sc.service.DisconnectLibraryPanelsForDashboard(sc.reqContext, &dash)
 			require.EqualError(t, err, errLibraryPanelHeaderUIDMissing.Error())
 		})
 }
@@ -1528,7 +1529,9 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 	t.Run(desc, func(t *testing.T) {
 		t.Cleanup(registry.ClearOverrides)
 
-		ctx := macaron.Context{}
+		ctx := macaron.Context{
+			Req: macaron.Request{&http.Request{}},
+		}
 		orgID := int64(1)
 		role := models.ROLE_ADMIN
 

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -59,12 +59,12 @@ func TestCreateLibraryPanel(t *testing.T) {
 						CreatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "signed_in_user",
-							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
 						},
 						UpdatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "signed_in_user",
-							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
 						},
 					},
 				},
@@ -227,12 +227,12 @@ func TestGetLibraryPanel(t *testing.T) {
 						CreatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "user_in_db",
-							AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
+							AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
 						},
 						UpdatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "user_in_db",
-							AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
+							AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
 						},
 					},
 				},
@@ -336,12 +336,12 @@ func TestGetAllLibraryPanels(t *testing.T) {
 							CreatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 							UpdatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 						},
 					},
@@ -365,12 +365,12 @@ func TestGetAllLibraryPanels(t *testing.T) {
 							CreatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 							UpdatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 						},
 					},
@@ -566,12 +566,12 @@ func TestPatchLibraryPanel(t *testing.T) {
 						CreatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "user_in_db",
-							AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
+							AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
 						},
 						UpdatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "signed_in_user",
-							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
 						},
 					},
 				},
@@ -603,7 +603,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 			require.NoError(t, err)
 			existing.Result.FolderID = int64(100)
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -630,7 +630,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 			require.NoError(t, err)
 			existing.Result.Name = "New Name"
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -659,7 +659,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 				"name": "New Model Name",
 			}
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -685,7 +685,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 			require.NoError(t, err)
 			existing.Result.Meta.UpdatedBy.ID = int64(2)
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -1335,7 +1335,7 @@ func TestConnectLibraryPanelsForDashboard(t *testing.T) {
 			var unusedResult libraryPanelDashboardsResult
 			err = json.Unmarshal(response.Body(), &unusedResult)
 			require.NoError(t, err)
-			require.Len(t, unusedResult.Result, 1)
+			require.Len(t, unusedResult.Result, 0)
 		})
 }
 

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -59,12 +59,12 @@ func TestCreateLibraryPanel(t *testing.T) {
 						CreatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
 						},
 						UpdatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
 						},
 					},
 				},
@@ -227,12 +227,12 @@ func TestGetLibraryPanel(t *testing.T) {
 						CreatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "user_in_db",
-							AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
+							AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
 						},
 						UpdatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "user_in_db",
-							AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
+							AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
 						},
 					},
 				},
@@ -336,12 +336,12 @@ func TestGetAllLibraryPanels(t *testing.T) {
 							CreatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 							UpdatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 						},
 					},
@@ -365,12 +365,12 @@ func TestGetAllLibraryPanels(t *testing.T) {
 							CreatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 							UpdatedBy: LibraryPanelDTOMetaUser{
 								ID:        1,
 								Name:      "user_in_db",
-								AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
+								AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
 							},
 						},
 					},
@@ -566,12 +566,12 @@ func TestPatchLibraryPanel(t *testing.T) {
 						CreatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "user_in_db",
-							AvatarUrl: "/avatar/402d08de060496d6b6874495fe20f5ad",
+							AvatarURL: "/avatar/402d08de060496d6b6874495fe20f5ad",
 						},
 						UpdatedBy: LibraryPanelDTOMetaUser{
 							ID:        1,
 							Name:      "signed_in_user",
-							AvatarUrl: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
 						},
 					},
 				},
@@ -603,7 +603,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 			require.NoError(t, err)
 			existing.Result.FolderID = int64(100)
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -630,7 +630,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 			require.NoError(t, err)
 			existing.Result.Name = "New Name"
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -659,7 +659,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 				"name": "New Model Name",
 			}
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -685,7 +685,7 @@ func TestPatchLibraryPanel(t *testing.T) {
 			require.NoError(t, err)
 			existing.Result.Meta.UpdatedBy.ID = int64(2)
 			existing.Result.Meta.CreatedBy.Name = "user_in_db"
-			existing.Result.Meta.CreatedBy.AvatarUrl = "/avatar/402d08de060496d6b6874495fe20f5ad"
+			existing.Result.Meta.CreatedBy.AvatarURL = "/avatar/402d08de060496d6b6874495fe20f5ad"
 			if diff := cmp.Diff(existing.Result, result.Result, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
@@ -1257,6 +1257,85 @@ func TestConnectLibraryPanelsForDashboard(t *testing.T) {
 
 			err = sc.service.ConnectLibraryPanelsForDashboard(sc.reqContext, &dash)
 			require.EqualError(t, err, errLibraryPanelHeaderUIDMissing.Error())
+		})
+
+	testScenario(t, "When an admin tries to store a dashboard with unusused/removed library panels, it should disconnect unusused/removed library panels",
+		func(t *testing.T, sc scenarioContext) {
+			command := getCreateCommand(1, "Unused Libray Panel")
+			response := sc.service.createHandler(sc.reqContext, command)
+			require.Equal(t, 200, response.Status())
+
+			var unused libraryPanelResult
+			err := json.Unmarshal(response.Body(), &unused)
+			require.NoError(t, err)
+
+			sc.reqContext.ReplaceAllParams(map[string]string{":uid": unused.Result.UID, ":dashboardId": "1"})
+			response = sc.service.connectHandler(sc.reqContext)
+			require.Equal(t, 200, response.Status())
+
+			command = getCreateCommand(1, "Text - Library Panel1")
+			response = sc.service.createHandler(sc.reqContext, command)
+			require.Equal(t, 200, response.Status())
+
+			var existing libraryPanelResult
+			err = json.Unmarshal(response.Body(), &existing)
+			require.NoError(t, err)
+
+			dashJSON := map[string]interface{}{
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": int64(1),
+						"gridPos": map[string]interface{}{
+							"h": 6,
+							"w": 6,
+							"x": 0,
+							"y": 0,
+						},
+					},
+					map[string]interface{}{
+						"id": int64(2),
+						"gridPos": map[string]interface{}{
+							"h": 6,
+							"w": 6,
+							"x": 6,
+							"y": 0,
+						},
+						"datasource": "${DS_GDEV-TESTDATA}",
+						"libraryPanel": map[string]interface{}{
+							"uid":  existing.Result.UID,
+							"name": existing.Result.Name,
+						},
+						"title": "Text - Library Panel",
+						"type":  "text",
+					},
+				},
+			}
+			dash := models.Dashboard{
+				Id:   int64(1),
+				Data: simplejson.NewFromAny(dashJSON),
+			}
+
+			err = sc.service.ConnectLibraryPanelsForDashboard(sc.reqContext, &dash)
+			require.NoError(t, err)
+
+			sc.reqContext.ReplaceAllParams(map[string]string{":uid": existing.Result.UID})
+			response = sc.service.getConnectedDashboardsHandler(sc.reqContext)
+			require.Equal(t, 200, response.Status())
+
+			var existingResult libraryPanelDashboardsResult
+			err = json.Unmarshal(response.Body(), &existingResult)
+			require.NoError(t, err)
+			require.Len(t, existingResult.Result, 1)
+			require.Equal(t, int64(1), existingResult.Result[0])
+
+			sc.reqContext.ReplaceAllParams(map[string]string{":uid": unused.Result.UID})
+			response = sc.service.getConnectedDashboardsHandler(sc.reqContext)
+			require.Equal(t, 200, response.Status())
+
+			var unusedResult libraryPanelDashboardsResult
+			err = json.Unmarshal(response.Body(), &unusedResult)
+			require.NoError(t, err)
+			require.Len(t, unusedResult.Result, 1)
 		})
 }
 

--- a/pkg/services/librarypanels/models.go
+++ b/pkg/services/librarypanels/models.go
@@ -71,7 +71,7 @@ type LibraryPanelDTOMeta struct {
 type LibraryPanelDTOMetaUser struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`
-	AvatarURL string `json:"avatarUrl"`
+	AvatarUrl string `json:"avatarUrl"`
 }
 
 // libraryPanelDashboard is the model for library panel connections.

--- a/pkg/services/librarypanels/models.go
+++ b/pkg/services/librarypanels/models.go
@@ -71,7 +71,7 @@ type LibraryPanelDTOMeta struct {
 type LibraryPanelDTOMetaUser struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`
-	AvatarUrl string `json:"avatarUrl"`
+	AvatarURL string `json:"avatarUrl"`
 }
 
 // libraryPanelDashboard is the model for library panel connections.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that only the current added libarary panels are connected to the dashboard.

Scenario: A user removes a library panel from a dashboard and saves the dashboard. We want to make sure that the removed libarary panel is disconnected. This PR takes care of this. This approach means that the last saved dashboard will win if there are several users trying to update the same dashboard. If we need a more complex solution let me know.

**Which issue(s) this PR fixes**:
Relates #29610

**Special notes for your reviewer**:
I also renamed `AvatarUrl` to `AvatarURL`.

