### PR TITLE
GraphNG: Fix Tooltip mode 'All' for XYChart

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -82,8 +82,8 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({ mode = 'single', t
           for (let i = 0; i < otherProps.data.length; i++) {
             series = series.concat(
               otherProps.data[i].fields.reduce<SeriesTableRowProps[]>((agg, f, j) => {
-                // skipping time field and non-numeric fields
-                if (f.type === FieldType.time || f.type !== FieldType.number) {
+                // skipping xField, time fields, and non-numeric fields
+                if (f === xField || f.type === FieldType.time || f.type !== FieldType.number) {
                   return agg;
                 }
 


### PR DESCRIPTION
What this PR does / why we need it:
Adds an additional check to the uPlot Tooltip plugin to ensure that it doesn't display the x-axis if the mode 'All' is selected for the tooltip.
This is needed for the XYChart, as it may have an x-axis that is not a Time type.
The x-axis does not have the color attribute needed by the tooltip container and would throw an exception otherwise.

Fixes #30921