### PR TITLE
UsageStats: Purpose named variables

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -54,18 +54,18 @@ func (uss *UsageStatsService) Init() error {
 func (uss *UsageStatsService) Run(ctx context.Context) error {
 	uss.updateTotalStats()
 
-	onceEveryDayTick := time.NewTicker(time.Hour * 24)
-	everyMinuteTicker := time.NewTicker(time.Minute * 30)
-	defer onceEveryDayTick.Stop()
-	defer everyMinuteTicker.Stop()
+	sendReportTicker := time.NewTicker(time.Hour * 24)
+	updateStatsTicker := time.NewTicker(time.Minute * 30)
+	defer sendReportTicker.Stop()
+	defer updateStatsTicker.Stop()
 
 	for {
 		select {
-		case <-onceEveryDayTick.C:
+		case <-sendReportTicker.C:
 			if err := uss.sendUsageStats(ctx); err != nil {
 				metricsLogger.Warn("Failed to send usage stats", "err", err)
 			}
-		case <-everyMinuteTicker.C:
+		case <-updateStatsTicker.C:
 			uss.updateTotalStats()
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
**What this PR does / why we need it**:

#31131 changed `everyMinuteTicker` to run every 30 minutes without updating the name, leaving the variable name outdated/confused.
I don't think updating the ticker should require updating the name, esp. considering that the ticker isn't some global thing but rather a hyperlocal ticker, so I propose changing the names to be accurate but describe what the ticker's purpose is rather than describing how the ticker was defined.