### PR TITLE
Docs: Clarifies custom date formats for variables

### DIFF
--- a/docs/sources/variables/variable-types/global-variables.md
+++ b/docs/sources/variables/variable-types/global-variables.md
@@ -27,7 +27,7 @@ Grafana has two built in time range variables: `$__from` and `$__to`. They are c
 | `${__from:date}`         | 2020-07-13T20:19:09.254Z | No args, defaults to ISO 8601/RFC 3339 |
 | `${__from:date:iso}`     | 2020-07-13T20:19:09.254Z | ISO 8601/RFC 3339 |
 | `${__from:date:seconds}` | 1594671549               | Unix seconds epoch |
-| `${__from:date:YYYY-MM}` | 2020-07                  | Any custom [date format](https://momentjs.com/docs/#/displaying/) |
+| `${__from:date:YYYY-MM}` | 2020-07                  | Any custom [date format](https://momentjs.com/docs/#/displaying/) that does not include the `:` character |
 
 The above syntax works with `${__to}` as well.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently don't support the `:` character in the custom date formatting of variables because the `:` character is used as the delimiter. This PR tries to clarifies this in the docs.

**Which issue(s) this PR fixes**:
Relates #31265

**Special notes for your reviewer**:

