### PR TITLE
test: Allow check for Table as well as Graph for Explore e2e flow

### DIFF
--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -34,7 +34,7 @@ interface ConfigurePanelOptional {
   panelTitle?: string;
   timeRange?: TimeRangeConfig;
   visualizationName?: string;
-  matchExploreGraph?: boolean;
+  matchExploreTable?: boolean;
 }
 
 interface ConfigurePanelRequired {

--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -76,7 +76,7 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
       dataSourceName,
       isEdit,
       isExplore,
-      matchExploreGraph,
+      matchExploreTable,
       matchScreenshot,
       panelTitle,
       queriesForm,
@@ -202,7 +202,7 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
       let visualization;
 
       if (isExplore) {
-        visualization = matchExploreGraph ? e2e.pages.Explore.General.graph() : e2e.pages.Explore.General.table();
+        visualization = matchExploreTable ? e2e.pages.Explore.General.table() : e2e.pages.Explore.General.graph();
       } else {
         visualization = e2e.components.Panels.Panel.containerByTitle(panelTitle).find('.panel-content');
       }

--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -34,6 +34,7 @@ interface ConfigurePanelOptional {
   panelTitle?: string;
   timeRange?: TimeRangeConfig;
   visualizationName?: string;
+  matchExploreGraph?: boolean;
 }
 
 interface ConfigurePanelRequired {
@@ -75,6 +76,7 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
       dataSourceName,
       isEdit,
       isExplore,
+      matchExploreGraph,
       matchScreenshot,
       panelTitle,
       queriesForm,
@@ -200,7 +202,7 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
       let visualization;
 
       if (isExplore) {
-        visualization = e2e.pages.Explore.General.graph();
+        visualization = matchExploreGraph ? e2e.pages.Explore.General.graph() : e2e.pages.Explore.General.table();
       } else {
         visualization = e2e.components.Panels.Panel.containerByTitle(panelTitle).find('.panel-content');
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we are not able to use the Explore flow from `@grafana/e2e` in some of our e2e tests for our enterprise plugins because the flow specifically checks for a graph to be rendered (and uses that for our screenshots). However, for some of our plugins, we only render a table because it doesn't make sense for us to show a graph if the format of the data is only in tabular format.

While the existing flows are a bit complicated and it makes sense for the some of these flows to be split out into smaller, and more specific flows, this is planned to be done later (because there is a lot more work required for this).
Creating this PR so we are able to add in the flexibility of supporting this first.

Using Github plugin as an example.

**Before**

Usage:
```
e2e.flows.explore({
    matchScreenshot: true,
    timeRange: {
      from: '2020-12-01 00:00:00',
      to: '2020-12-31 23:59:59',
    },
    queriesForm: () => {
      fillQueryEditor();
    },
  });
```

The e2e test fails because there is no graph rendered for the Explore view.

![Screenshot 2021-02-17 at 15 00 44](https://user-images.githubusercontent.com/36230812/108234719-fb1eac80-713c-11eb-81ff-18ec1581d298.png)

**After**

Usage where we can pass in `matchExploreTable` to get the table instead of the graph:
```
e2e.flows.explore({
    matchScreenshot: true,
    matchExploreTable: true,
    timeRange: {
      from: '2020-12-01 00:00:00',
      to: '2020-12-31 23:59:59',
    },
    queriesForm: () => {
      fillQueryEditor();
    },
  });
```

The e2e test is able to pass by checking for the table render instead for the Explore view.

![Screenshot 2021-02-17 at 15 02 47](https://user-images.githubusercontent.com/36230812/108234807-125d9a00-713d-11eb-88ea-b0c693c4a743.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/integrations-team/issues/115.

**Special notes for your reviewer**:

All e2e tests pass locally:

![Screenshot 2021-02-17 at 16 36 00](https://user-images.githubusercontent.com/36230812/108235926-42596d00-713e-11eb-9bb1-d2b35beb655b.png)