### PR TITLE
Prometheus: Change default httpMethod for new instances to POST

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.test.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.test.tsx
@@ -1,7 +1,9 @@
-import { getValueFromEventItem, promSettingsValidationEvents } from './PromSettings';
+import React, { SyntheticEvent } from 'react';
+import { render, screen } from '@testing-library/react';
 import { EventsWithValidation } from '@grafana/ui';
-import { SyntheticEvent } from 'react';
 import { SelectableValue } from '@grafana/data';
+import { getValueFromEventItem, promSettingsValidationEvents, PromSettings } from './PromSettings';
+import { createDefaultConfigOptions } from './mocks';
 
 describe('PromSettings', () => {
   describe('getValueFromEventItem', () => {
@@ -82,5 +84,57 @@ describe('PromSettings', () => {
         expect(validationEvents[EventsWithValidation.onBlur][0].rule(value)).toBe(expected);
       }
     );
+  });
+  describe('PromSettings component', () => {
+    const defaultProps = createDefaultConfigOptions();
+
+    it('should show POST httpMethod if no httpMethod and no url', () => {
+      const options = defaultProps;
+      options.url = '';
+      options.jsonData.httpMethod = '';
+
+      render(
+        <div>
+          <PromSettings onOptionsChange={() => {}} options={options} />
+        </div>
+      );
+      expect(screen.getByText('POST')).toBeInTheDocument();
+    });
+    it('should show GET httpMethod if no httpMethod and url', () => {
+      const options = defaultProps;
+      options.url = 'test_url';
+      options.jsonData.httpMethod = '';
+
+      render(
+        <div>
+          <PromSettings onOptionsChange={() => {}} options={options} />
+        </div>
+      );
+      expect(screen.getByText('GET')).toBeInTheDocument();
+    });
+    it('should show POST httpMethod if POST httpMethod is configured', () => {
+      const options = defaultProps;
+      options.url = 'test_url';
+      options.jsonData.httpMethod = 'POST';
+
+      render(
+        <div>
+          <PromSettings onOptionsChange={() => {}} options={options} />
+        </div>
+      );
+      expect(screen.getByText('POST')).toBeInTheDocument();
+    });
+    it('should show GET httpMethod if GET httpMethod is configured', () => {
+      const options = defaultProps;
+      options.url = 'test_url';
+      options.jsonData.httpMethod = 'GET';
+
+      render(
+        <div>
+          <PromSettings onOptionsChange={() => {}} options={options} />
+        </div>
+      );
+      expect(screen.getByText('GET')).toBeInTheDocument();
+    });
   });
 });

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -21,8 +21,8 @@ export const PromSettings = (props: Props) => {
   const { options, onOptionsChange } = props;
 
   /**
-   * We want to change the default httpMethod to POST for all of the Prometheus data sources instances (no url) added in 7.5+.
-   * We are explicitly adding httpMethod as previously it could be undefined and defaulted to 'GET'.
+   * We want to change the default httpMethod to 'POST' for all of the new Prometheus data sources instances (no url) added in 7.5+.
+   * We are explicitly adding httpMethod, as previously it could be undefined and defaulted to 'GET'.
    * Undefined httpMethod is still going to be considered 'GET' for backward compatibility reasons, but if users open data
    * source settings it is going to be set to 'GET' explicitly and it will be selected in httpMethod dropdown as 'GET'.
    * */

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -28,7 +28,7 @@ export const PromSettings = (props: Props) => {
    * */
 
   if (!options.jsonData.httpMethod) {
-    options.url ? (options.jsonData.httpMethod = 'POST') : (options.jsonData.httpMethod = 'GET');
+    options.url ? (options.jsonData.httpMethod = 'GET') : (options.jsonData.httpMethod = 'POST');
   }
 
   return (

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -11,14 +11,25 @@ import { ExemplarsSettings } from './ExemplarsSettings';
 const { Select, Input, FormField, Switch } = LegacyForms;
 
 const httpOptions = [
-  { value: 'GET', label: 'GET' },
   { value: 'POST', label: 'POST' },
+  { value: 'GET', label: 'GET' },
 ];
 
 type Props = Pick<DataSourcePluginOptionsEditorProps<PromOptions>, 'options' | 'onOptionsChange'>;
 
 export const PromSettings = (props: Props) => {
   const { options, onOptionsChange } = props;
+
+  /**
+   * We want to change the default httpMethod to POST for all of the Prometheus data sources instances (no url) added in 7.5+.
+   * We are explicitly adding httpMethod as previously it could be undefined and defaulted to 'GET'.
+   * Undefined httpMethod is still going to be considered 'GET' for backward compatibility reasons, but if users open data
+   * source settings it is going to be set to 'GET' explicitly and it will be selected in httpMethod dropdown as 'GET'.
+   * */
+
+  if (!options.jsonData.httpMethod) {
+    options.url ? (options.jsonData.httpMethod = 'POST') : (options.jsonData.httpMethod = 'GET');
+  }
 
   return (
     <>
@@ -64,7 +75,7 @@ export const PromSettings = (props: Props) => {
         <div className="gf-form">
           <InlineFormLabel
             width={13}
-            tooltip="Specify the HTTP Method to query Prometheus. (POST is only available in Prometheus >= v2.1.0)"
+            tooltip="You can use either POST or GET HTTP method to query your Prometheus data source. The POST method allows you to perform heavy requests, while the GET method will restrict you and return an error if the query is too large. POST is only available in Prometheus v2.1+)"
           >
             HTTP Method
           </InlineFormLabel>

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -75,7 +75,7 @@ export const PromSettings = (props: Props) => {
         <div className="gf-form">
           <InlineFormLabel
             width={13}
-            tooltip="You can use either POST or GET HTTP method to query your Prometheus data source. The POST method allows you to perform heavy requests, while the GET method will restrict you and return an error if the query is too large. POST is only available in Prometheus v2.1+)"
+            tooltip="You can use either POST or GET HTTP method to query your Prometheus data source. POST is the recommended method as it allows bigger queries. Change this to GET if you have a Prometheus version older than 2.1 or if POST requests are restricted in your network."
           >
             HTTP Method
           </InlineFormLabel>

--- a/public/app/plugins/datasource/prometheus/configuration/mocks.ts
+++ b/public/app/plugins/datasource/prometheus/configuration/mocks.ts
@@ -1,0 +1,12 @@
+import { DataSourceSettings } from '@grafana/data';
+import { PromOptions } from '../types';
+import { createDatasourceSettings } from '../../../../features/datasources/mocks';
+
+export function createDefaultConfigOptions(): DataSourceSettings<PromOptions> {
+  return createDatasourceSettings<PromOptions>({
+    timeInterval: '1m',
+    queryTimeout: '1m',
+    httpMethod: 'GET',
+    directUrl: 'url',
+  });
+}

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -106,37 +106,11 @@ describe('PrometheusDatasource', () => {
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
     });
 
-    it('should perform a GET request with the DS HTTP method set to POST for non-POST endpoints', () => {
+    it('should still perform a GET request with the DS HTTP method set to POST', () => {
       const postSettings = _.cloneDeep(instanceSettings);
       postSettings.jsonData.httpMethod = 'POST';
       const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
       promDs.metadataRequest('/foo');
-      expect(fetchMock.mock.calls.length).toBe(1);
-      expect(fetchMock.mock.calls[0][0].method).toBe('GET');
-    });
-    it('should perform a GET request with no DS version, DS HTTP method set to POST for POST endpoints', () => {
-      const postSettings = _.cloneDeep(instanceSettings);
-      postSettings.jsonData.httpMethod = 'POST';
-      const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
-      promDs.metadataRequest('/api/v1/series');
-      expect(fetchMock.mock.calls.length).toBe(1);
-      expect(fetchMock.mock.calls[0][0].method).toBe('GET');
-    });
-    it('should perform a POST request with the DS version, DS HTTP method set to POST and with POST endpoints', () => {
-      const postSettings = _.cloneDeep(instanceSettings);
-      postSettings.jsonData.httpMethod = 'POST';
-      const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
-      promDs.version = '2.14.0';
-      promDs.metadataRequest('/api/v1/series');
-      expect(fetchMock.mock.calls.length).toBe(1);
-      expect(fetchMock.mock.calls[0][0].method).toBe('POST');
-    });
-    it('should perform a GET request with the DS version, DS HTTP method set to GET and with POST endpoints', () => {
-      const postSettings = _.cloneDeep(instanceSettings);
-      postSettings.jsonData.httpMethod = 'GET';
-      const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
-      promDs.version = '2.14.0';
-      promDs.metadataRequest('/api/v1/series');
       expect(fetchMock.mock.calls.length).toBe(1);
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
     });

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -106,11 +106,37 @@ describe('PrometheusDatasource', () => {
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
     });
 
-    it('should still perform a GET request with the DS HTTP method set to POST', () => {
+    it('should perform a GET request with the DS HTTP method set to POST for non-POST endpoints', () => {
       const postSettings = _.cloneDeep(instanceSettings);
       postSettings.jsonData.httpMethod = 'POST';
       const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
       promDs.metadataRequest('/foo');
+      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(fetchMock.mock.calls[0][0].method).toBe('GET');
+    });
+    it('should perform a GET request with no DS version, DS HTTP method set to POST for POST endpoints', () => {
+      const postSettings = _.cloneDeep(instanceSettings);
+      postSettings.jsonData.httpMethod = 'POST';
+      const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
+      promDs.metadataRequest('/api/v1/series');
+      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(fetchMock.mock.calls[0][0].method).toBe('GET');
+    });
+    it('should perform a POST request with the DS version, DS HTTP method set to POST and with POST endpoints', () => {
+      const postSettings = _.cloneDeep(instanceSettings);
+      postSettings.jsonData.httpMethod = 'POST';
+      const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
+      promDs.version = '2.14.0';
+      promDs.metadataRequest('/api/v1/series');
+      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(fetchMock.mock.calls[0][0].method).toBe('POST');
+    });
+    it('should perform a GET request with the DS version, DS HTTP method set to GET and with POST endpoints', () => {
+      const postSettings = _.cloneDeep(instanceSettings);
+      postSettings.jsonData.httpMethod = 'GET';
+      const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
+      promDs.version = '2.14.0';
+      promDs.metadataRequest('/api/v1/series');
       expect(fetchMock.mock.calls.length).toBe(1);
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
     });

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -44,6 +44,7 @@ import { PrometheusVariableSupport } from './variables';
 import PrometheusMetricFindQuery from './metric_find_query';
 
 export const ANNOTATION_QUERY_STEP_DEFAULT = '60s';
+const GET_AND_POST_MEDATADATA_ENDPOINTS = ['api/v1/query', 'api/v1/query_range', 'api/v1/series', 'api/v1/labels'];
 
 export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> {
   type: string;
@@ -61,6 +62,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
   exemplarTraceIdDestinations: ExemplarTraceIdDestination[] | undefined;
   lookupsDisabled: boolean;
   customQueryParameters: any;
+  version: string | undefined;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<PromOptions>,
@@ -83,12 +85,13 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.languageProvider = new PrometheusLanguageProvider(this);
     this.lookupsDisabled = instanceSettings.jsonData.disableMetricsLookup ?? false;
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
-
     this.variables = new PrometheusVariableSupport(this, this.templateSrv, this.timeSrv);
+    this.version = undefined;
   }
 
   init = () => {
     this.loadRules();
+    this.setVersion();
   };
 
   getQueryDisplayText(query: PromQuery) {
@@ -144,7 +147,14 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
         data[key] = value;
       }
     }
-    return this._request<T>(url, data, { method: 'GET', hideFromInspector: true }).toPromise(); // toPromise until we change getTagValues, getTagKeys to Observable
+    // If we have version (endpoint added in 2.14), we know that Prometheus instance supports POST method for /series and /labels
+    const supportsGetAndPostMethods =
+      this.version && GET_AND_POST_MEDATADATA_ENDPOINTS.some((endpoint) => url.includes(endpoint));
+
+    return this._request<T>(url, data, {
+      method: supportsGetAndPostMethods ? this.httpMethod : 'GET',
+      hideFromInspector: true,
+    }).toPromise(); // toPromise until we change getTagValues, getTagKeys to Observable
   }
 
   interpolateQueryExpr(value: string | string[] = [], variable: any) {
@@ -719,6 +729,19 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       }
     } catch (e) {
       console.log('Rules API is experimental. Ignore next error.');
+      console.error(e);
+    }
+  }
+
+  async setVersion() {
+    try {
+      const res = await this.metadataRequest('/api/v1/status/buildinfo');
+      const version = res.data?.data?.version;
+      if (version) {
+        this.version = version;
+      }
+    } catch (e) {
+      console.error(`Wasn't able to retrieve Prometheus version`);
       console.error(e);
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes default http method for all of the newly added Prometheus data sources to 'POST'. (more in the comment directly in the code).

**Which issue(s) this PR fixes**:

Fixes: https://github.com/grafana/grafana/issues/30837

