### PR TITLE
Grafana-UI: Update tooltip type in SecretFormField

### DIFF
--- a/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
+++ b/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
@@ -3,6 +3,7 @@ import React, { InputHTMLAttributes, FunctionComponent } from 'react';
 import { FormField } from '../FormField/FormField';
 import { Button } from '../Button/Button';
 import { css, cx } from 'emotion';
+import { PopoverContent } from '../Tooltip/Tooltip';
 
 export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onReset'> {
   // Function to use when reset is clicked. Means you have to reset the input value yourself as this is  uncontrolled
@@ -11,7 +12,7 @@ export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onRe
   isConfigured: boolean;
 
   label?: string;
-  tooltip?: string;
+  tooltip?: PopoverContent;
   labelWidth?: number;
   inputWidth?: number;
   // Placeholder of the input field when in non configured state.
@@ -50,7 +51,7 @@ export const SecretFormField: FunctionComponent<Props> = ({
   return (
     <FormField
       label={label!}
-      tooltip={tooltip!}
+      tooltip={tooltip}
       labelWidth={labelWidth}
       inputEl={
         isConfigured ? (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
`SecretFormField` has a tooltip type as a string, even though the underlying FormField component uses more broad `PopoverContent`. Changing it to `PopoverContent` would allow to pass components (e.g. links) to the tooltip. 

