### PR TITLE
Table: Fix an issue regarding the fixed min and auto max values in bar gauge cell

### DIFF
--- a/packages/grafana-data/src/field/scale.ts
+++ b/packages/grafana-data/src/field/scale.ts
@@ -65,14 +65,20 @@ function getMinMaxAndDelta(field: Field): NumericRange {
   };
 }
 
+/**
+ * @internal
+ */
 export function getFieldConfigWithMinMax(field: Field, local?: boolean): FieldConfig {
   const { config } = field;
   let { min, max } = config;
-  if (isNumber(min) && !isNumber(max)) {
-    return config; // noop
+
+  if (isNumber(min) && isNumber(max)) {
+    return config;
   }
+
   if (local || !field.state?.range) {
     return { ...config, ...getMinMaxAndDelta(field) };
   }
+
   return { ...config, ...field.state.range };
 }


### PR DESCRIPTION
Fixes #31314

Normally I would add unit test for this but getFieldConfigWithMinMax should go away soon. Want to introduce a different way to control dynamic min/max on the panel level.
