### PR TITLE
InfluxDB: In flux query editor, do not run query when disabled

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -73,7 +73,14 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
 
   query(request: DataQueryRequest<InfluxQuery>): Observable<DataQueryResponse> {
     if (this.isFlux) {
-      return super.query(request);
+      // for not-flux queries we call `this.classicQuery`, and that
+      // handles the is-hidden situation.
+      // for the flux-case, we do the filtering here
+      const filteredRequest = {
+        ...request,
+        targets: request.targets.filter((t) => t.hide !== true),
+      };
+      return super.query(filteredRequest);
     }
 
     // Fallback to classic query support


### PR DESCRIPTION
inspired by the issue https://github.com/grafana/grafana/issues/31054 i looked into the situation with the flux-mode in influxdb data-source, and it always returns query-data, even when the query is disabled. this pull-requests fixes the problem.

i'm not 100% sure if this is the best place to put the check,  if anyone has a better idea, please tell.