### PR TITLE
Add info to docs about concurrent session limits

### DIFF
--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -25,7 +25,7 @@ Restrictions are applied separately for viewers and editors.
 
 When the number of maximum active viewers or editors is reached, Grafana displays a warning banner.
 
-Sometimes it is useful to log in to an account from multiple locations concurrently. With Grafana Enterprise accounts are limited to three concurrent sessions.
+Sometimes it is useful to log in to an account from multiple locations concurrently. With Grafana Enterprise, accounts are limited to three concurrent sessions.
 
 ## Expiration date
 

--- a/docs/sources/enterprise/license-restrictions.md
+++ b/docs/sources/enterprise/license-restrictions.md
@@ -25,6 +25,8 @@ Restrictions are applied separately for viewers and editors.
 
 When the number of maximum active viewers or editors is reached, Grafana displays a warning banner.
 
+Sometimes it is useful to log in to an account from multiple locations concurrently. With Grafana Enterprise accounts are limited to three concurrent sessions.
+
 ## Expiration date
 
 The license expiration date is the date when a license is no longer active. As the license expiration date approaches, Grafana Enterprise displays a banner.


### PR DESCRIPTION
This parallels a [change in the Grafana Cloud docs](https://github.com/grafana/website/pull/3504) which was based on a kind and appreciated message from support. The limit does not apply to Grafana OSS, just to Enterprise and Cloud, as far as any of us know.

Tagging both @osg-grafana and @achatterjee-grafana as reviewers as I'm not certain who owns these docs, @oddlittlebird is out, and I don't want to step on toes. I'm just trying to help out with a quick change. :)