### PR TITLE
DashboardLinks: Fix an issue where the dashboard links were causing a full page reload

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
@@ -40,7 +40,7 @@ export const DashboardLinksDashboard: React.FC<Props> = (props) => {
                   <li key={`dashlinks-dropdown-item-${resolvedLink.id}-${index}`}>
                     <a
                       href={resolvedLink.url}
-                      target={link.targetBlank ? '_blank' : '_self'}
+                      target={link.targetBlank ? '_blank' : undefined}
                       aria-label={selectors.components.DashboardLinks.link}
                     >
                       {resolvedLink.title}
@@ -67,7 +67,7 @@ export const DashboardLinksDashboard: React.FC<Props> = (props) => {
               <a
                 className="gf-form-label gf-form-label--dashlink"
                 href={resolvedLink.url}
-                target={link.targetBlank ? '_blank' : '_self'}
+                target={link.targetBlank ? '_blank' : undefined}
                 aria-label={selectors.components.DashboardLinks.link}
               >
                 <Icon name="apps" style={{ marginRight: '4px' }} />


### PR DESCRIPTION
Thought I fixed this in https://github.com/grafana/grafana/pull/31178 but found that there were more self links for dashboard links as dropdown 