### PR TITLE
QueryEditor: Fix disabling queries in dashboards

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -80,6 +80,8 @@ export class QueryEditorRow extends PureComponent<Props, State> {
     const panel = new PanelModel({ targets: queries });
     const dashboard = {} as DashboardModel;
 
+    const me = this;
+
     return {
       datasource: datasource,
       target: query,
@@ -89,6 +91,12 @@ export class QueryEditorRow extends PureComponent<Props, State> {
         // Old angular editors modify the query model and just call refresh
         // Important that this use this.props here so that as this fuction is only created on mount and it's
         // important not to capture old prop functions in this closure
+
+        // query.hide can be changed "from the outside", so we have to apply it
+        if (query.hide !== me.props.query.hide) {
+          query.hide = me.props.query.hide;
+        }
+
         this.props.onChange(query);
         this.props.onRunQuery();
       },

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -92,7 +92,9 @@ export class QueryEditorRow extends PureComponent<Props, State> {
         // Important that this use this.props here so that as this fuction is only created on mount and it's
         // important not to capture old prop functions in this closure
 
-        // query.hide can be changed "from the outside", so we have to apply it
+        // the "hide" attribute of the quries can be changed from the "outside",
+        // it will be applied to "this.props.query.hide", but not to "query.hide".
+        // so we have to apply it.
         if (query.hide !== me.props.query.hide) {
           query.hide = me.props.query.hide;
         }


### PR DESCRIPTION
in angular-based datasource-query-editors this happens:
- user disables the editor
- user modifies the content of the editor, then clicks outside the editor
- the editor becomes enabled

the reason is that the angular-based editors operate on the version of the query as it was when the component was mounted at the beginning. later changes to the query gets reflected in the props of react-based components, but not in the data given to angular-based components. this becomes a problem, because later, when an angular-based component applies new changes using "refresh", it overwrites changes that happened to the query "from the outside". this comment describes the scenario in more detail as it applies to the influxql editor: https://github.com/grafana/grafana/issues/31054#issuecomment-781560516

this pull request manually applies the hide-attribute to the "angular copy" of the query.

i'm not sure if this is the best way to fix the problem, so if anyone has another idea, please tell.

this problem was described here https://github.com/grafana/grafana/issues/31054

i verified that it fixes the problem in the influxdb-influxql editor and in the postgres-editor.