### PR TITLE
Added section Query a time series database by id

### DIFF
--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -498,7 +498,7 @@ Content-Type: application/json
 
 Proxies all calls to the actual data source.
 
-## Query a time series database by id
+## Query a time series data source by id
 
 Queries a time series data source having backend implementation.
 

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -498,7 +498,7 @@ Content-Type: application/json
 
 Proxies all calls to the actual data source.
 
-## Query a data source by id
+## Query a data source by ID
 
 Queries a data source having backend implementation.
 
@@ -533,12 +533,12 @@ Content-Type: application/json
 JSON Body schema:
 
 - **from/to** – Should be either absolute in epoch timestamps in milliseconds or relative using Grafana time units. For example, `now-1h`.
-- **queries.refId** – Specifies an identifier of the query. Is optional and default to `"A".
+- **queries.refId** – Specifies an identifier of the query. Is optional and default to "A".
 - **queries.datasourceId** – Specifies the data source to be queried. Each `query` in the request must have an unique `datasourceId`.
 - **queries.maxDataPoints** - Species maximum amount of data points that dashboard panel can render. Is optional and default to 100.
 - **queries.intervalMs** - Specifies the time interval in milliseconds of time series. Is optional and defaults to 1000.
 
-In addition, each data source has its own specific properties that should be added in a request. 
+In addition, each data source has its own specific properties that should be added in a request.
 
 **Example request for the MySQL data source:**
 

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -498,9 +498,9 @@ Content-Type: application/json
 
 Proxies all calls to the actual data source.
 
-## Query a time series data source by id
+## Query a data source by id
 
-Queries a time series data source having backend implementation.
+Queries a data source having backend implementation.
 
 `POST /api/tsdb/query`
 

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -500,9 +500,9 @@ Proxies all calls to the actual data source.
 
 ## Query a time series database by id
 
-`POST /api/tsdb/query`
-
 Queries a time series data source having backend implementation.
+
+`POST /api/tsdb/query`
 
 > **Note:** Most of our builtin data sources have backend implementation.
 

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -504,7 +504,7 @@ Queries a time series data source having backend implementation.
 
 `POST /api/tsdb/query`
 
-> **Note:** Most of our builtin data sources have backend implementation.
+> **Note:** Most of Grafana's builtin data sources have backend implementation.
 
 **Example Request**:
 

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -540,7 +540,7 @@ JSON Body schema:
 
 In addition, each data source has its own specific properties that should be added in a request. 
 
-**Example Request for the MySQL data source:**
+**Example request for the MySQL data source:**
 
 ```http
 POST /api/tsdb/query HTTP/1.1

--- a/docs/sources/http_api/data_source.md
+++ b/docs/sources/http_api/data_source.md
@@ -533,12 +533,12 @@ Content-Type: application/json
 JSON Body schema:
 
 - **from/to** – Should be either absolute in epoch timestamps in milliseconds or relative using Grafana time units. For example, `now-1h`.
-- **query.refId** – Specifies an identifier of the query. Is optional and default to `"A".
-- **query.datasourceId** – Specifies the data source to be queried. Each `query` in the request must have an unique `datasourceId`.
-- **query.maxDataPoints** - Species maximum amount of data points that dashboard panel can render. Is optional and default to 100.
-- **query.intervalMs** - Specifies the time interval in milliseconds of time series. Is optional and defaults to 1000.
+- **queries.refId** – Specifies an identifier of the query. Is optional and default to `"A".
+- **queries.datasourceId** – Specifies the data source to be queried. Each `query` in the request must have an unique `datasourceId`.
+- **queries.maxDataPoints** - Species maximum amount of data points that dashboard panel can render. Is optional and default to 100.
+- **queries.intervalMs** - Specifies the time interval in milliseconds of time series. Is optional and defaults to 1000.
 
-In addition, each data source have their own specific properties that should be added in a request. 
+In addition, each data source has its own specific properties that should be added in a request. 
 
 **Example Request for the MySQL data source:**
 


### PR DESCRIPTION
Doc work for the issue [https://github.com/grafana/grafana/issues/21046](21046).

Note to reviewer: 

Data source API is a very long topic and the section "/docs/grafana/latest/http_api/data_source/#query-a-time-series-database-by-id" is getting lost. Can we add this content as an independent subtopic instead of adding it at the end?

Like this:

>Data source API
>>Query a time series data source by id