### PR TITLE
StoryBook: Introduces Grafana Controls

### DIFF
--- a/packages/grafana-ui/.storybook/main.ts
+++ b/packages/grafana-ui/.storybook/main.ts
@@ -14,6 +14,7 @@ module.exports = {
   addons: [
     '@storybook/addon-docs',
     '@storybook/addon-controls',
+    '../src/addons/grafana-controls/preset.ts',
     '@storybook/addon-knobs',
     '@storybook/addon-actions',
     'storybook-dark-mode/register',

--- a/packages/grafana-ui/src/addons/grafana-controls/preset.ts
+++ b/packages/grafana-ui/src/addons/grafana-controls/preset.ts
@@ -1,0 +1,5 @@
+module.exports = {
+  managerEntries(entry = []) {
+    return [...entry, require.resolve('./register')];
+  },
+};

--- a/packages/grafana-ui/src/addons/grafana-controls/register.tsx
+++ b/packages/grafana-ui/src/addons/grafana-controls/register.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ArgTypes } from '@storybook/react';
+import { addons, types } from '@storybook/addons';
+import { AddonPanel, ArgsTable } from '@storybook/components';
+import { useArgs, useArgTypes, useParameter } from '@storybook/api';
+
+const ADDON_ID = 'storybook/grafana-controls';
+const PANEL_ID = `${ADDON_ID}/controls`;
+const PARAM_KEY = 'grafanaControls';
+
+const GrafanaControlsPanel = () => {
+  const [args, updateArgs, resetArgs] = useArgs();
+  const rows = useArgTypes();
+  const argTypes = useParameter<ArgTypes>(PARAM_KEY, {});
+  const newRows: ArgTypes = {};
+
+  for (const key in argTypes) {
+    if (!Object.hasOwnProperty.call(argTypes, key)) {
+      continue;
+    }
+
+    if (Object.hasOwnProperty.call(rows, key)) {
+      newRows[key] = { ...rows[key], ...argTypes[key] };
+    }
+  }
+
+  return (
+    <ArgsTable rows={newRows} args={args} updateArgs={updateArgs} resetArgs={resetArgs as any} inAddonPanel compact />
+  );
+};
+
+addons.register(ADDON_ID, (api) => {
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title: 'Grafana Controls',
+    // eslint-disable-next-line react/display-name
+    render: ({ active, key }) => (
+      <AddonPanel active={Boolean(active)} key={key}>
+        <GrafanaControlsPanel />
+      </AddonPanel>
+    ),
+  });
+});

--- a/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
@@ -11,7 +11,6 @@ import {
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import mdx from './BigValue.mdx';
 import { useTheme } from '../../themes';
-import { NOOP_CONTROL } from '@grafana/ui/.storybook/preview';
 import { ArrayVector, FieldSparkline, FieldType } from '@grafana/data';
 
 export default {
@@ -23,36 +22,31 @@ export default {
       page: mdx,
     },
     knobs: {
-      disabled: true,
+      disable: true,
     },
-  },
-  argTypes: {
-    width: { control: { type: 'range', min: 200, max: 800 } },
-    height: { control: { type: 'range', min: 200, max: 800 } },
-    colorMode: { control: { type: 'select', options: [BigValueColorMode.Value, BigValueColorMode.Background] } },
-    graphMode: { control: { type: 'select', options: [BigValueGraphMode.Area, BigValueGraphMode.None] } },
-    justifyMode: { control: { type: 'select', options: [BigValueJustifyMode.Auto, BigValueJustifyMode.Center] } },
-    textMode: {
-      control: {
-        type: 'radio',
-        options: [
-          BigValueTextMode.Auto,
-          BigValueTextMode.Name,
-          BigValueTextMode.ValueAndName,
-          BigValueTextMode.None,
-          BigValueTextMode.Value,
-        ],
+    controls: {
+      disable: true,
+    },
+    grafanaControls: {
+      width: { control: { type: 'range', min: 200, max: 800 } },
+      height: { control: { type: 'range', min: 200, max: 800 } },
+      colorMode: { control: { type: 'select', options: [BigValueColorMode.Value, BigValueColorMode.Background] } },
+      graphMode: { control: { type: 'select', options: [BigValueGraphMode.Area, BigValueGraphMode.None] } },
+      justifyMode: { control: { type: 'select', options: [BigValueJustifyMode.Auto, BigValueJustifyMode.Center] } },
+      textMode: {
+        control: {
+          type: 'radio',
+          options: [
+            BigValueTextMode.Auto,
+            BigValueTextMode.Name,
+            BigValueTextMode.ValueAndName,
+            BigValueTextMode.None,
+            BigValueTextMode.Value,
+          ],
+        },
       },
+      color: { control: { type: 'color' } },
     },
-    color: { control: 'color' },
-    value: NOOP_CONTROL,
-    sparkline: NOOP_CONTROL,
-    onClick: NOOP_CONTROL,
-    className: NOOP_CONTROL,
-    alignmentFactors: NOOP_CONTROL,
-    text: NOOP_CONTROL,
-    count: NOOP_CONTROL,
-    theme: NOOP_CONTROL,
   },
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We are currently in the process of migrating all our StoryBook stories from using `knobs` to using `controls`. 

During this process we've come across a sort of anti-pattern where we need to opt out properties that we don't want to show up in the controls section of a story. I did even suggest to create a `NOOP_CONTROL` [constant that we could reuse in all our stories](https://github.com/grafana/grafana/pull/31240#discussion_r577337621).
```ts
argTypes: {
  width: { control: { type: 'range', min: 200, max: 800 } },
  height: { control: { type: 'range', min: 200, max: 800 } },
  colorMode: { control: { type: 'select', options: [BigValueColorMode.Value, BigValueColorMode.Background] } },
  graphMode: { control: { type: 'select', options: [BigValueGraphMode.Area, BigValueGraphMode.None] } },
  justifyMode: { control: { type: 'select', options: [BigValueJustifyMode.Auto, BigValueJustifyMode.Center] } },
  textMode: {
    control: {
      type: 'radio',
      options: [
        BigValueTextMode.Auto,
        BigValueTextMode.Name,
        BigValueTextMode.ValueAndName,
        BigValueTextMode.None,
        BigValueTextMode.Value,
      ],
    },
  },
  color: { control: 'color' },
  value: NOOP_CONTROL,
  sparkline: NOOP_CONTROL,
  onClick: NOOP_CONTROL,
  className: NOOP_CONTROL,
  alignmentFactors: NOOP_CONTROL,
  text: NOOP_CONTROL,
  count: NOOP_CONTROL,
  theme: NOOP_CONTROL,
},
```

But the `NOOP_CONTROL` pattern isn't something that will scale or be easy to maintain as the components continue to evolve, so this PR is my contribution to our internal Hack Day VII!

Instead of opting out controls, this PR forces you to opt in instead. How?

1. First of all, disable the built-in Controls tab:
```ts
parameters: {
  ...
  controls: {
    disable: true,
  },
  ...
```
2. Second, move any previously defined `argTypes` into a parameter named `grafanaControls`:
```ts
parameters: {
  ...
  grafanaControls: {
    width: { control: { type: 'range', min: 200, max: 800 } },
    height: { control: { type: 'range', min: 200, max: 800 } },
    colorMode: { control: { type: 'select', options: [BigValueColorMode.Value, BigValueColorMode.Background] } },
    graphMode: { control: { type: 'select', options: [BigValueGraphMode.Area, BigValueGraphMode.None] } },
    justifyMode: { control: { type: 'select', options: [BigValueJustifyMode.Auto, BigValueJustifyMode.Center] } },
    textMode: {
      control: {
        type: 'radio',
        options: [
          BigValueTextMode.Auto,
          BigValueTextMode.Name,
          BigValueTextMode.ValueAndName,
          BigValueTextMode.None,
          BigValueTextMode.Value,
        ],
      },
    },
    color: { control: { type: 'color' } },
  },
  ...
```
![storybook](https://user-images.githubusercontent.com/562238/108507258-57f3a180-72ba-11eb-878d-d8372426b806.gif)

**Which issue(s) this PR fixes**:
Relates #30182

**Special notes for your reviewer**:
This PR uses StoryBook's own `ArgsTable` component and hooks. Unfortunately, the ArgTypes api is still experimental so things might change 😞 

## Hack Day VII Log
- 06:00 - 08:00 Initial hypothesis (very naïve), build a utility function that could extract argTypes from a React Component in Typescript during runtime. Then we could use this utility function and assign to argTypes in stories.
   - Browsed the code in https://github.com/styleguidist/react-docgen-typescript to see how they solved this
   - Also looked at https://github.com/diegohaz/parse-prop-types 
   - Gave up this idea
- 08:00 - 09:30 Reading through Storybook docs and browsing code for alternatives, decorator or addon
- 09:30 - 11:00 Initial POC using a StoryBook decorator, as the decorator receives both the story and the context.
  - Changing the context within the decorator didn't affect the Controls panel context 😞 
  - Tried emitting updates via channels, failed
  - Tried using hooks, failed. I learned later that I could only use client-api hooks and useArgTypes was not part of that (or rather I couldn't find it)
- 11:00 - 11:30 Lunch
- 11:30 - 13:30 Next POC try to create a custom addon (feeling the time running out now)
  - Struggling to create the addon within grafana-ui but failed
  - Decided to create an addon in a completely separate folder/repo following the steps here https://storybook.js.org/docs/react/addons/writing-addons
    - The example for `preset.js` under https://storybook.js.org/docs/react/addons/writing-addons#build-system was wrong
    ![image](https://user-images.githubusercontent.com/562238/108511591-6ba20680-72c0-11eb-8153-30f5fe7e72e9.png)    
    should be
    ![image](https://user-images.githubusercontent.com/562238/108511682-87a5a800-72c0-11eb-9789-687fdd147f6f.png)
  - Got the custom panel working at 13:30:ish
- 13:30 - 14:00 Move everything from my separate folder into grafana-ui and make it work, push code and open PR!
- Done!

  



