### PR TITLE
Alerting: Omit empty message in PagerDuty notifier

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -167,7 +167,7 @@ func (pn *PagerdutyNotifier) buildEventPayload(evalContext *alerting.EvalContext
 	}
 
 	var summary string
-	if pn.MessageInDetails {
+	if pn.MessageInDetails || evalContext.Rule.Message == "" {
 		summary = evalContext.Rule.Name
 	} else {
 		summary = evalContext.Rule.Name + " - " + evalContext.Rule.Message

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -171,6 +171,60 @@ func TestPagerdutyNotifier(t *testing.T) {
 				So(diff, ShouldBeEmpty)
 			})
 
+			Convey("should return properly formatted default v2 event payload with empty message", func() {
+				json := `{
+					"integrationKey": "abcdefgh0123456789",
+					"autoResolve": false
+				}`
+
+				settingsJSON, err := simplejson.NewJson([]byte(json))
+				So(err, ShouldBeNil)
+
+				model := &models.AlertNotification{
+					Name:     "pagerduty_testing",
+					Type:     "pagerduty",
+					Settings: settingsJSON,
+				}
+
+				not, err := NewPagerdutyNotifier(model)
+				So(err, ShouldBeNil)
+
+				pagerdutyNotifier := not.(*PagerdutyNotifier)
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:    0,
+					Name:  "someRule",
+					State: models.AlertStateAlerting,
+				}, &validations.OSSPluginRequestValidator{})
+				evalContext.IsTestRun = true
+
+				payloadJSON, err := pagerdutyNotifier.buildEventPayload(evalContext)
+				So(err, ShouldBeNil)
+				payload, err := simplejson.NewJson(payloadJSON)
+				So(err, ShouldBeNil)
+
+				diff := cmp.Diff(map[string]interface{}{
+					"client":       "Grafana",
+					"client_url":   "",
+					"dedup_key":    "alertId-0",
+					"event_action": "trigger",
+					"links": []interface{}{
+						map[string]interface{}{
+							"href": "",
+						},
+					},
+					"payload": map[string]interface{}{
+						"component":      "Grafana",
+						"source":         "<<PRESENCE>>",
+						"custom_details": map[string]interface{}{},
+						"severity":       "critical",
+						"summary":        "someRule",
+						"timestamp":      "<<PRESENCE>>",
+					},
+					"routing_key": "abcdefgh0123456789",
+				}, payload.Interface(), cmp.Comparer(presenceComparer))
+				So(diff, ShouldBeEmpty)
+			})
+
 			Convey("should return properly formatted payload with message moved to details", func() {
 				json := `{
 					"integrationKey": "abcdefgh0123456789",


### PR DESCRIPTION
**What this PR does / why we need it**:

When using the PagerDuty notifier, alerts without messages appear in PagerDuty as `Rule Name - `.

![Screen Shot 2021-02-19 at 8 50 00 AM](https://user-images.githubusercontent.com/5273164/108534933-8f992400-728f-11eb-8aa7-0cc4c81ac6b7.png)

This PR changes the behavior to just use the rule name if the message is empty.

