### PR TITLE
AdHocVariables: Fix an issue where adhoc filter values stored as integer was causing Grafana to crash

### DIFF
--- a/public/app/features/variables/adhoc/urlParser.test.ts
+++ b/public/app/features/variables/adhoc/urlParser.test.ts
@@ -78,6 +78,42 @@ describe('urlParser', () => {
     });
   });
 
+  describe('parsing toUrl with filters with number values', () => {
+    it('then url params should be correct', () => {
+      const a = ({
+        value: 1974,
+        key: 'key',
+        operator: '=',
+        condition: '',
+      } as unknown) as AdHocVariableFilter;
+
+      const filters: AdHocVariableFilter[] = [a];
+
+      const expectedA = `key|=|1974`;
+      const expected: string[] = [expectedA];
+
+      expect(toUrl(filters)).toEqual(expected);
+    });
+  });
+
+  describe('parsing toUrl with filters with boolean values', () => {
+    it('then url params should be correct', () => {
+      const a = ({
+        value: false,
+        key: 'key',
+        operator: '=',
+        condition: '',
+      } as unknown) as AdHocVariableFilter;
+
+      const filters: AdHocVariableFilter[] = [a];
+
+      const expectedA = `key|=|false`;
+      const expected: string[] = [expectedA];
+
+      expect(toUrl(filters)).toEqual(expected);
+    });
+  });
+
   describe('parsing toFilters with url containing no filters as string', () => {
     it('then url params should be correct', () => {
       const url: UrlQueryValue = '';

--- a/public/app/features/variables/adhoc/urlParser.ts
+++ b/public/app/features/variables/adhoc/urlParser.ts
@@ -17,11 +17,19 @@ export const toFilters = (value: UrlQueryValue): AdHocVariableFilter[] => {
 };
 
 function escapeDelimiter(value: string | undefined): string {
-  return value?.replace(/\|/g, '__gfp__') ?? '';
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return /\|/g[Symbol.replace](value, '__gfp__');
 }
 
 function unescapeDelimiter(value: string | undefined): string {
-  return value?.replace(/__gfp__/g, '|') ?? '';
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return /__gfp__/g[Symbol.replace](value, '|');
 }
 
 function toArray(filter: AdHocVariableFilter): string[] {


### PR DESCRIPTION
**What this PR does / why we need it**:
Looked into storing everything as strings but that could probably have other effects so I ended up just fixing the issue and adding some tests.

**Which issue(s) this PR fixes**:
Fixes #31335

**Special notes for your reviewer**:

