### PR TITLE
[v7.4.x] Chore(deps): Add gotest.tools v2.2.0+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	gopkg.in/redis.v5 v5.2.9
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.3.0
+	gotest.tools v2.2.0+incompatible
 	xorm.io/core v0.7.3
 	xorm.io/xorm v0.8.1
 )


### PR DESCRIPTION
Commit c8a7044504 added an import of gotest.tools/assert, but go.mod wasn't updated to also include this dependency, which breaks vendoring when building packages of v7.4.2 for openSUSE on build.opensuse.org (the error message we get is "gotest.tools@v2.2.0+incompatible: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod").

I note that this omission has since been fixed in commit 23621357b0 in master, but I'm not sure if that will be backported to v7.4.x or not, due to that commit also updating other dependencies.  Is that commit *will* eventually be backported to v7.4.x, please feel free to ignore this PR.

Signed-off-by: Tim Serong <tserong@suse.com>