### PR TITLE
Chore: Remove gotest.tools dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,6 @@ require (
 	gopkg.in/redis.v5 v5.2.9
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
-	gotest.tools v2.2.0+incompatible
 	xorm.io/core v0.7.3
 	xorm.io/xorm v0.8.2
 )

--- a/pkg/api/dtos/models_test.go
+++ b/pkg/api/dtos/models_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsHiddenUser(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks as if gotest.tools was accidentally introduced as a dependency in our Go test suite in 7f1f5599299. This PR replaces it with stretchr/testify, without any functional changes.