### PR TITLE
Chore: Remove gotest.tools dependency (#31391)

### DIFF
--- a/pkg/api/dtos/models_test.go
+++ b/pkg/api/dtos/models_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsHiddenUser(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Manually backport #31391 to v7.4.x

