### PR TITLE
Prometheus: Use configured HTTP method for /series and /labels endpoints

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -245,8 +245,8 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if proxy.ctx.Req.Request.Method == "PUT" {
 			return errors.New("puts not allowed on proxied Prometheus datasource")
 		}
-		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range") {
-			return errors.New("posts not allowed on proxied Prometheus datasource except on /query and /query_range")
+		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range" || proxy.proxyPath == "api/v1/series" || proxy.proxyPath == "api/v1/labels") {
+			return errors.New("posts not allowed on proxied Prometheus datasource except on /query, /query_range, /series and /labels")
 		}
 	}
 

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -105,14 +105,21 @@ describe('PrometheusDatasource', () => {
       expect(fetchMock.mock.calls.length).toBe(1);
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
     });
-
-    it('should still perform a GET request with the DS HTTP method set to POST', () => {
+    it('should still perform a GET request with the DS HTTP method set to POST and not POST-friendly endpoint', () => {
       const postSettings = _.cloneDeep(instanceSettings);
       postSettings.jsonData.httpMethod = 'POST';
       const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
       promDs.metadataRequest('/foo');
       expect(fetchMock.mock.calls.length).toBe(1);
       expect(fetchMock.mock.calls[0][0].method).toBe('GET');
+    });
+    it('should try to perform a POST request with the DS HTTP method set to POST and POST-friendly endpoint', () => {
+      const postSettings = _.cloneDeep(instanceSettings);
+      postSettings.jsonData.httpMethod = 'POST';
+      const promDs = new PrometheusDatasource(postSettings, templateSrvStub as any, timeSrvStub as any);
+      promDs.metadataRequest('api/v1/series');
+      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(fetchMock.mock.calls[0][0].method).toBe('POST');
     });
   });
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -149,7 +149,14 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       try {
         return await this._request<T>(url, data, { method: this.httpMethod, hideFromInspector: true }).toPromise();
       } catch (err) {
-        console.warn(`Couldn't use configured HTTP method for this request. Trying to use GET method instead.`);
+        const hasStatusCodesToRetry = [401, 403, 404, 405].some((statusCode) => err.status === statusCode);
+        const hasPostHttpMethod = this.httpMethod === 'POST';
+
+        if (hasPostHttpMethod && hasStatusCodesToRetry) {
+          console.warn(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
+        } else {
+          throw err;
+        }
       }
     }
 

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -150,11 +150,8 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       try {
         return await this._request<T>(url, data, { method: this.httpMethod, hideFromInspector: true }).toPromise();
       } catch (err) {
-        // Theoretically we should retry only on 405, but various status codes have been obsereved - so we've added more possible options
-        const hasStatusCodesToRetry = [401, 403, 404, 405].some((statusCode) => err.status === statusCode);
-        const hasPostHttpMethod = this.httpMethod === 'POST';
-        // If error, check method and status code and either console.warn + retry with GET, or throw error
-        if (hasPostHttpMethod && hasStatusCodesToRetry) {
+        // If status code of error is Method Not Allowed (405) and HTTP method is POST, retry with GET
+        if (this.httpMethod === 'POST' && err.status === 405) {
           console.warn(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
         } else {
           throw err;

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -145,7 +145,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
       }
     }
 
-    // If URL includes endpoint that supports POST method, try to use configures method
+    // If URL includes endpoint that supports POST and GET method, try to use configured method. This might fail as POST is supported only in v2.10+.
     if (GET_AND_POST_MEDATADATA_ENDPOINTS.some((endpoint) => url.includes(endpoint))) {
       try {
         return await this._request<T>(url, data, { method: this.httpMethod, hideFromInspector: true }).toPromise();


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated Prometheus metadata requests to use configured  http method for endpoints that supports that - `'api/v1/query', 'api/v1/query_range', 'api/v1/series', 'api/v1/labels'`. As the support for POST was added in version 2.10+, we decided to use configured method first, and if we gets **Bad Method** error when trying POST method, then retry with GET.
**Request to `/series` with HTTP method set to POST and Prometheus (v2.7.2) NOT supporting POST to that endpoint:**
https://user-images.githubusercontent.com/30407135/108738397-db6bf780-7533-11eb-99a0-128f134afe0d.mov

**Request to `/series` with HTTP method set to POST and Prometheus (:latest) supporting POST to that endpoint:**
https://user-images.githubusercontent.com/30407135/108738413-deff7e80-7533-11eb-812c-fcb0ad7feba1.mov

**Endpoints supporting POST and GET:**
![image](https://user-images.githubusercontent.com/30407135/108371434-07b70980-71fe-11eb-8ba2-83227dc157bb.png)
![image](https://user-images.githubusercontent.com/30407135/108371466-11407180-71fe-11eb-8c41-52adc7064826.png)
![image](https://user-images.githubusercontent.com/30407135/108371511-1dc4ca00-71fe-11eb-9a01-dde04d36a58a.png)
![image](https://user-images.githubusercontent.com/30407135/108371558-287f5f00-71fe-11eb-9b0a-970cebeb59c8.png)


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/17342

