### PR TITLE
Chore: Add Hosted Grafana team as migrations code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,9 @@ go.sum @grafana/backend-platform
 /pkg/tsdb/azuremonitor @grafana/cloud-datasources
 /pkg/tsdb/cloudmonitoring @grafana/cloud-datasources
 
+# Database migrations
+/pkg/services/sqlstore/migrations @grafana/backend-platform @grafana/hosted-grafana-team
+*_mig.go @grafana/backend-platform @grafana/hosted-grafana-team
 
 # Backend code docs
 /contribute/style-guides/backend.md @grafana/backend-platform


### PR DESCRIPTION
To make sure we are aware of database migrations and can give feedback before they are merged. 