### PR TITLE
Chore: Move NOOP_CONTROL to storybook utils directory

### DIFF
--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -59,5 +59,3 @@ export const parameters = {
     escapeHTML: false,
   },
 };
-
-export const NOOP_CONTROL = { control: { disable: true } };

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.story.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { BarGauge, BarGaugeDisplayMode } from '@grafana/ui';
-import { NOOP_CONTROL } from '@grafana/ui/.storybook/preview';
+import { NOOP_CONTROL } from '../../utils/storybook/noopControl';
 import { VizOrientation, ThresholdsMode, Field, FieldType, getDisplayProcessor } from '@grafana/data';
 import { Props } from './BarGauge';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';

--- a/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
@@ -11,7 +11,7 @@ import {
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import mdx from './BigValue.mdx';
 import { useTheme } from '../../themes';
-import { NOOP_CONTROL } from '@grafana/ui/.storybook/preview';
+import { NOOP_CONTROL } from '../../utils/storybook/noopControl';
 import { ArrayVector, FieldSparkline, FieldType } from '@grafana/data';
 
 export default {

--- a/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.story.tsx
+++ b/packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.story.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Story } from '@storybook/react';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { ButtonCascader } from '@grafana/ui';
-import { NOOP_CONTROL } from '@grafana/ui/.storybook/preview';
+import { NOOP_CONTROL } from '../../utils/storybook/noopControl';
 import { ButtonCascaderProps } from './ButtonCascader';
 
 export default {

--- a/packages/grafana-ui/src/components/CallToActionCard/CallToActionCard.story.internal.tsx
+++ b/packages/grafana-ui/src/components/CallToActionCard/CallToActionCard.story.internal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderComponentWithTheme } from '../../utils/storybook/withTheme';
 import { CallToActionCard, CallToActionCardProps } from './CallToActionCard';
-import { NOOP_CONTROL } from '../../../.storybook/preview';
+import { NOOP_CONTROL } from '../../utils/storybook/noopControl';
 import { Story } from '@storybook/react';
 import { Button } from '../Button/Button';
 import { action } from '@storybook/addon-actions';

--- a/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
@@ -1,6 +1,6 @@
 import { Story } from '@storybook/react';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
-import { NOOP_CONTROL } from '../../../.storybook/preview';
+import { NOOP_CONTROL } from '../../utils/storybook/noopControl';
 import { Cascader } from '@grafana/ui';
 import { CascaderProps } from './Cascader';
 import mdx from './Cascader.mdx';

--- a/packages/grafana-ui/src/utils/storybook/noopControl.tsx
+++ b/packages/grafana-ui/src/utils/storybook/noopControl.tsx
@@ -1,0 +1,1 @@
+export const NOOP_CONTROL = { control: { disable: true } };

--- a/packages/grafana-ui/tsconfig.build.json
+++ b/packages/grafana-ui/tsconfig.build.json
@@ -1,12 +1,4 @@
 {
-  "exclude": [
-    "**/*.story.tsx",
-    "**/*.story.internal.tsx",
-    "**/*.test.ts*",
-    "**/*.tmpl.ts",
-    "dist",
-    "node_modules",
-    "src/utils/storybook"
-  ],
+  "exclude": ["**/*.story.tsx", "**/*.test.ts*", "**/*.tmpl.ts", "dist", "node_modules", "src/utils/storybook"],
   "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR moves NOOP_CONTROL to storybook utils since storybook's preview.ts should only export StoryBook related things.


