### PR TITLE
Chore: Remove logging of unhashed user tokens

### DIFF
--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -108,10 +108,6 @@ func (s *UserAuthTokenService) CreateToken(ctx context.Context, user *models.Use
 
 func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken string) (*models.UserToken, error) {
 	hashedToken := hashToken(unhashedToken)
-	if setting.Env == setting.Dev {
-		s.log.Debug("looking up token", "unhashed", unhashedToken, "hashed", hashedToken)
-	}
-
 	var model userAuthToken
 	var exists bool
 	var err error


### PR DESCRIPTION
We should not log unhashed user tokens even in dev mode IMO. While it might be ok in development mode we dont want ppl to log this by mistake. 