### PR TITLE
Graphite/SSE: update graphite to work with server side expressions

### DIFF
--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -39,10 +39,12 @@ func init() {
 func (e *GraphiteExecutor) Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery *tsdb.TsdbQuery) (*tsdb.Response, error) {
 	result := &tsdb.Response{}
 
+	// This logic is used when called from Dashboard Alerting.
 	from := "-" + formatTimeRange(tsdbQuery.TimeRange.From)
 	until := formatTimeRange(tsdbQuery.TimeRange.To)
 
-	if timeRangeIsDigit(tsdbQuery.TimeRange) {
+	// This logic is used when called through server side expressions.
+	if isTimeRangeNumeric(tsdbQuery.TimeRange) {
 		var err error
 		from, until, err = epochMStoGraphiteTime(tsdbQuery.TimeRange)
 		if err != nil {
@@ -213,7 +215,7 @@ func fixIntervalFormat(target string) string {
 	return target
 }
 
-func timeRangeIsDigit(tr *tsdb.TimeRange) bool {
+func isTimeRangeNumeric(tr *tsdb.TimeRange) bool {
 	if _, err := strconv.ParseInt(tr.From, 10, 64); err != nil {
 		return false
 	}

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -40,6 +41,15 @@ func (e *GraphiteExecutor) Query(ctx context.Context, dsInfo *models.DataSource,
 
 	from := "-" + formatTimeRange(tsdbQuery.TimeRange.From)
 	until := formatTimeRange(tsdbQuery.TimeRange.To)
+
+	if timeRangeIsDigit(tsdbQuery.TimeRange) {
+		var err error
+		from, until, err = epochMStoGraphiteTime(tsdbQuery.TimeRange)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var target string
 
 	formData := url.Values{
@@ -154,6 +164,12 @@ func (e *GraphiteExecutor) parseResponse(res *http.Response) ([]TargetResponseDT
 		return nil, err
 	}
 
+	for si := range data {
+		// Convert Response to timestamps MS
+		for pi, point := range data[si].DataPoints {
+			data[si].DataPoints[pi][1].Float64 = point[1].Float64 * 1000
+		}
+	}
 	return data, nil
 }
 
@@ -195,4 +211,28 @@ func fixIntervalFormat(target string) string {
 		return strings.ReplaceAll(M, "M", "mon")
 	})
 	return target
+}
+
+func timeRangeIsDigit(tr *tsdb.TimeRange) bool {
+	if _, err := strconv.ParseInt(tr.From, 10, 64); err != nil {
+		return false
+	}
+	if _, err := strconv.ParseInt(tr.To, 10, 64); err != nil {
+		return false
+	}
+	return true
+}
+
+func epochMStoGraphiteTime(tr *tsdb.TimeRange) (string, string, error) {
+	from, err := strconv.ParseInt(tr.From, 10, 64)
+	if err != nil {
+		return "", "", err
+	}
+
+	to, err := strconv.ParseInt(tr.To, 10, 64)
+	if err != nil {
+		return "", "", err
+	}
+
+	return fmt.Sprintf("%d", from/1000), fmt.Sprintf("%d", to/1000), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the time value of the response to be milliseconds, which I think is like the other data sources I have seen.

Also if it sees the timerange values as numbers, assumes they are unixMS (and come from expressions, or our new backend.TimeRange type). When this timerange is used, the request is sent to graphite with from and until as epoch timestamps (which seems to correspond to https://github.com/grafana/grafana/commit/c925014bb5bba30330b616d8cdfe344e3543c621). 

**Special notes for your reviewer**:
Graphite timerange, and values for the time in the tsdb time slice seem different from the other data sources.