### PR TITLE
Variables: Fixes error with: cannot read property length of undefined

### DIFF
--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -19,7 +19,7 @@ import { getTemplatedRegex } from '../utils';
 import { v4 as uuidv4 } from 'uuid';
 import { getTimeSrv } from '../../dashboard/services/TimeSrv';
 import { QueryRunners } from './queryRunners';
-import { preProcessPanelData, runRequest } from '../../query/state/runRequest';
+import { runRequest } from '../../query/state/runRequest';
 import {
   runUpdateTagsRequest,
   toMetricFindValues,
@@ -129,7 +129,7 @@ export class VariableQueryRunner {
               return throwError(data.error);
             }
 
-            return of(preProcessPanelData(data));
+            return of(data);
           }),
           toMetricFindValues(),
           updateOptionsState({ variable, dispatch, getTemplatedRegexFunc }),

--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -19,7 +19,7 @@ import { getTemplatedRegex } from '../utils';
 import { v4 as uuidv4 } from 'uuid';
 import { getTimeSrv } from '../../dashboard/services/TimeSrv';
 import { QueryRunners } from './queryRunners';
-import { runRequest } from '../../query/state/runRequest';
+import { preProcessPanelData, runRequest } from '../../query/state/runRequest';
 import {
   runUpdateTagsRequest,
   toMetricFindValues,
@@ -129,7 +129,7 @@ export class VariableQueryRunner {
               return throwError(data.error);
             }
 
-            return of(data);
+            return of(preProcessPanelData(data));
           }),
           toMetricFindValues(),
           updateOptionsState({ variable, dispatch, getTemplatedRegexFunc }),

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -9,6 +9,7 @@ import { DataSourceApi, FieldType, getFieldDisplayName, isDataFrame, MetricFindV
 import { updateVariableOptions, updateVariableTags } from './reducer';
 import { getTimeSrv, TimeSrv } from '../../dashboard/services/TimeSrv';
 import { getLegacyQueryOptions, getTemplatedRegex } from '../utils';
+import { getProcessedDataFrames } from 'app/features/query/state/runRequest';
 
 export function toMetricFindValues(): OperatorFunction<PanelData, MetricFindValue[]> {
   return (source) =>
@@ -23,6 +24,7 @@ export function toMetricFindValues(): OperatorFunction<PanelData, MetricFindValu
           return frames;
         }
 
+        const processedDataFrames = getProcessedDataFrames(frames);
         const metrics: MetricFindValue[] = [];
 
         let valueIndex = -1;
@@ -30,7 +32,7 @@ export function toMetricFindValues(): OperatorFunction<PanelData, MetricFindValu
         let stringIndex = -1;
         let expandableIndex = -1;
 
-        for (const frame of frames) {
+        for (const frame of processedDataFrames) {
           for (let index = 0; index < frame.fields.length; index++) {
             const field = frame.fields[index];
             const fieldName = getFieldDisplayName(field, frame, frames).toLowerCase();
@@ -181,6 +183,7 @@ export function areMetricFindValues(data: any[]): data is MetricFindValue[] {
   }
 
   const firstValue: any = data[0];
+
   if (isDataFrame(firstValue)) {
     return false;
   }


### PR DESCRIPTION
Fixes #31445

I think the error reported there is due to not passing the result through preProcessPanelData which translates legacy formats. This function should really be part of runRequest,
only potential reason to leave it outside is that explore has a throttling that adds after runRequest and then this pre-processing can be skipped.
