### PR TITLE
AWS: Expose AWS config in grafana-runtime

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -70,6 +70,8 @@ export class GrafanaBootConfig implements GrafanaConfig {
   marketplaceUrl?: string;
   expressionsEnabled = false;
   customTheme?: any;
+  awsAllowedAuthProviders: string[] = [];
+  awsAssumeRoleEnabled = false;
 
   constructor(options: GrafanaBootConfig) {
     this.theme = options.bootData.user.lightTheme ? getTheme(GrafanaThemeType.Light) : getTheme(GrafanaThemeType.Dark);


### PR DESCRIPTION
In #31312, the AWS configurations were not exposed by the grafana/runtime package, making it impossible to use conf by external packages. [Here's](https://github.com/grafana/grafana/blob/master/pkg/api/frontendsettings.go#L246-L247) the magic that sets the variables.