### PR TITLE
Library Panels: Don't list current panel in available panels list

### DIFF
--- a/public/app/features/library-panels/components/LibraryPanelsView/LibraryPanelsView.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelsView/LibraryPanelsView.tsx
@@ -13,6 +13,7 @@ interface LibraryPanelViewProps {
   onClickCard?: (panel: LibraryPanelDTO) => void;
   formatDate?: (dateString: DateTimeInput, format?: string) => string;
   showSecondaryActions?: boolean;
+  currentPanelId?: string;
 }
 
 export const LibraryPanelsView: React.FC<LibraryPanelViewProps> = ({
@@ -22,6 +23,7 @@ export const LibraryPanelsView: React.FC<LibraryPanelViewProps> = ({
   onClickCard,
   formatDate,
   showSecondaryActions,
+  currentPanelId: currentPanel,
 }) => {
   const styles = useStyles(getPanelViewStyles);
   const [searchString, setSearchString] = useState('');
@@ -38,10 +40,14 @@ export const LibraryPanelsView: React.FC<LibraryPanelViewProps> = ({
   const [filteredItems, setFilteredItems] = useState(libraryPanels);
   useDebounce(
     () => {
-      setFilteredItems(libraryPanels?.filter((v) => v.name.toLowerCase().includes(searchString.toLowerCase())));
+      setFilteredItems(
+        libraryPanels?.filter(
+          (v) => v.name.toLowerCase().includes(searchString.toLowerCase()) && v.uid !== currentPanel
+        )
+      );
     },
     300,
-    [searchString, libraryPanels]
+    [searchString, libraryPanels, currentPanel]
   );
 
   const onDeletePanel = async (uid: string) => {

--- a/public/app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup.tsx
+++ b/public/app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup.tsx
@@ -59,6 +59,7 @@ export const PanelLibraryOptionsGroup: React.FC<Props> = ({ panel, dashboard }) 
     >
       <LibraryPanelsView
         formatDate={(dateString: string) => dashboard.formatDate(dateString, 'L')}
+        currentPanelId={panel.libraryPanel?.uid}
         showSecondaryActions
       >
         {(panel) => (


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, if the panel being edited was a library panel, it would still be listed as one of the panels available to replace the current panel. This PR changes that behavior so now only other panels will be listed.

See https://github.com/grafana/grafana/issues/31305
