### PR TITLE
Docs: Derived fields links in logs detail view

### DIFF
--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -39,7 +39,7 @@ The Derived Fields configuration allows you to:
 - Add fields parsed from the log message.
 - Add a link that uses the value of the field.
 
-You can use this functionality to link to your tracing backend directly from your logs, or link to a user profile page if a userId is present in the log line. These links appear in the [log details](/explore/#labels-and-detected-fields).
+You can use this functionality to link to your tracing backend directly from your logs, or link to a user profile page if a userId is present in the log line. These links appear in the [log details](/explore/logs-integration/#labels-and-detected-fields).
 {{< docs-imagebox img="/img/docs/v65/loki_derived_fields.png" class="docs-image--no-shadow" caption="Screenshot of the derived fields configuration" >}}
 Each derived field consists of:
 

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -82,6 +82,11 @@ You can change the order of received logs from the default descending order (new
 
 Each log row has an extendable area with its labels and detected fields, for more robust interaction. For all labels we have added the ability to filter for (positive filter) and filter out (negative filter) selected labels. Each field or label also has a stats icon to display ad-hoc statistics in relation to all displayed logs.
 
+#### Derived fields links
+
+By using Derived fields, you are able to turn any part of a log message into the internal or external link. Created link will be visible as button next to the Detected field in the Log details view.
+{{< docs-imagebox img="/img/docs/explore/detected-fields-link-7-4.png" max-width="800px" caption="Detected fields link in Explore" >}}
+
 ### Toggle detected fields
 
 > **Note:** Available in Grafana 7.2 and later versions.

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -84,7 +84,7 @@ Each log row has an extendable area with its labels and detected fields, for mor
 
 #### Derived fields links
 
-By using Derived fields, you are able to turn any part of a log message into the internal or external link. Created link will be visible as button next to the Detected field in the Log details view.
+By using Derived fields, you can turn any part of a log message into an internal or external link. The created link is visible as a button next to the Detected field in the Log details view.
 {{< docs-imagebox img="/img/docs/explore/detected-fields-link-7-4.png" max-width="800px" caption="Detected fields link in Explore" >}}
 
 #### Toggle detected fields

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -87,7 +87,7 @@ Each log row has an extendable area with its labels and detected fields, for mor
 By using Derived fields, you are able to turn any part of a log message into the internal or external link. Created link will be visible as button next to the Detected field in the Log details view.
 {{< docs-imagebox img="/img/docs/explore/detected-fields-link-7-4.png" max-width="800px" caption="Detected fields link in Explore" >}}
 
-### Toggle detected fields
+#### Toggle detected fields
 
 > **Note:** Available in Grafana 7.2 and later versions.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds documentation for Derived fields links in logs detail view. 

The PR with image: https://github.com/grafana/website/pull/3587/files

