### PR TITLE
FolderPicker: Remove useNewForms from FolderPicker

### DIFF
--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -18,7 +18,6 @@ export interface Props {
   dashboardId?: any;
   initialTitle?: string;
   initialFolderId?: number;
-  useNewForms?: boolean;
 }
 
 interface State {
@@ -46,7 +45,6 @@ export class FolderPicker extends PureComponent<Props, State> {
     enableReset: false,
     initialTitle: '',
     enableCreateNew: false,
-    useNewForms: false,
   };
 
   componentDidMount = async () => {
@@ -148,41 +146,21 @@ export class FolderPicker extends PureComponent<Props, State> {
 
   render() {
     const { folder } = this.state;
-    const { enableCreateNew, useNewForms } = this.props;
+    const { enableCreateNew } = this.props;
 
     return (
       <div aria-label={selectors.components.FolderPicker.container}>
-        {useNewForms && (
-          <AsyncSelect
-            loadingMessage="Loading folders..."
-            defaultOptions
-            defaultValue={folder}
-            value={folder}
-            allowCustomValue={enableCreateNew}
-            loadOptions={this.debouncedSearch}
-            onChange={this.onFolderChange}
-            onCreateOption={this.createNewFolder}
-            menuPosition="fixed"
-          />
-        )}
-        {!useNewForms && (
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <label className="gf-form-label width-7">Folder</label>
-              <AsyncSelect
-                loadingMessage="Loading folders..."
-                defaultOptions
-                defaultValue={folder}
-                value={folder}
-                className={'width-20'}
-                allowCustomValue={enableCreateNew}
-                loadOptions={this.debouncedSearch}
-                onChange={this.onFolderChange}
-                onCreateOption={this.createNewFolder}
-              />
-            </div>
-          </div>
-        )}
+        <AsyncSelect
+          loadingMessage="Loading folders..."
+          defaultOptions
+          defaultValue={folder}
+          value={folder}
+          allowCustomValue={enableCreateNew}
+          loadOptions={this.debouncedSearch}
+          onChange={this.onFolderChange}
+          onCreateOption={this.createNewFolder}
+          menuPosition="fixed"
+        />
       </div>
     );
   }

--- a/public/app/core/components/Select/__snapshots__/FolderPicker.test.tsx.snap
+++ b/public/app/core/components/Select/__snapshots__/FolderPicker.test.tsx.snap
@@ -4,29 +4,16 @@ exports[`FolderPicker should render 1`] = `
 <div
   aria-label="Folder picker select container"
 >
-  <div
-    className="gf-form-inline"
-  >
-    <div
-      className="gf-form"
-    >
-      <label
-        className="gf-form-label width-7"
-      >
-        Folder
-      </label>
-      <AsyncSelect
-        allowCustomValue={false}
-        className="width-20"
-        defaultOptions={true}
-        defaultValue={Object {}}
-        loadOptions={[Function]}
-        loadingMessage="Loading folders..."
-        onChange={[Function]}
-        onCreateOption={[Function]}
-        value={Object {}}
-      />
-    </div>
-  </div>
+  <AsyncSelect
+    allowCustomValue={false}
+    defaultOptions={true}
+    defaultValue={Object {}}
+    loadOptions={[Function]}
+    loadingMessage="Loading folders..."
+    menuPosition="fixed"
+    onChange={[Function]}
+    onCreateOption={[Function]}
+    value={Object {}}
+  />
 </div>
 `;

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -84,7 +84,6 @@ export const GeneralSettings: React.FC<Props> = ({ dashboard }) => {
         </Field>
         <Field label="Folder">
           <FolderPicker
-            useNewForms={true}
             initialTitle={dashboard.meta.folderTitle}
             initialFolderId={dashboard.meta.folderId}
             onChange={onFolderChange}

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -109,7 +109,6 @@ export const SaveDashboardAsForm: React.FC<SaveDashboardFormProps & { isNew?: bo
               initialFolderId={dashboard.meta.folderId}
               initialTitle={dashboard.meta.folderTitle}
               enableCreateNew
-              useNewForms
             />
           </Field>
           <Field label="Copy tags">

--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -68,7 +68,6 @@ export const ImportDashboardForm: FC<Props> = ({
         <InputControl
           as={FolderPicker}
           name="folder"
-          useNewForms
           enableCreateNew
           initialFolderId={initialFolderId}
           control={control}

--- a/public/app/features/search/components/MoveToFolderModal.tsx
+++ b/public/app/features/search/components/MoveToFolderModal.tsx
@@ -59,7 +59,7 @@ export const MoveToFolderModal: FC<Props> = ({ results, onMoveItems, isOpen, onD
             Move the {selectedDashboards.length} selected dashboard{selectedDashboards.length === 1 ? '' : 's'} to the
             following folder:
           </p>
-          <FolderPicker onChange={(f) => setFolder(f as FolderInfo)} useNewForms />
+          <FolderPicker onChange={(f) => setFolder(f as FolderInfo)} />
         </div>
 
         <HorizontalGroup justify="center">

--- a/public/app/plugins/panel/dashlist/module.tsx
+++ b/public/app/plugins/panel/dashlist/module.tsx
@@ -48,7 +48,6 @@ export const plugin = new PanelPlugin<DashListOptions>(DashList)
           return (
             <FolderPicker
               initialFolderId={props.value}
-              useNewForms
               initialTitle="All"
               enableReset={true}
               onChange={({ id }) => props.onChange(id)}


### PR DESCRIPTION
Noticed that the Folder picker in the add library panel modal was using
the old form styles and realised this option is no longer needed we do
not use the FolderPicker in any legacy forms any more so can remove it
and default to new forms
