### PR TITLE
Annotations: Make the annotation clean up batch size configurable

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -682,6 +682,9 @@ max_annotation_age =
 max_annotations_to_keep =
 
 #################################### Annotations #########################
+[annotations]
+# configures the batch size for the annotation clean up job. This setting is used for dashboard, api and alert annotations
+cleanupjob_batchsize = 100
 
 [annotations.dashboard]
 # Dashboard annotations means that annotations are associated with the dashboard they are created on.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -683,7 +683,7 @@ max_annotations_to_keep =
 
 #################################### Annotations #########################
 [annotations]
-# configures the batch size for the annotation clean up job. This setting is used for dashboard, api and alert annotations
+# Configures the batch size for the annotation clean-up job. This setting is used for dashboard, API, and alert annotations.
 cleanupjob_batchsize = 100
 
 [annotations.dashboard]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -675,6 +675,9 @@
 ;max_annotations_to_keep =
 
 #################################### Annotations #########################
+[annotations]
+# configures the batch size for the annotation clean up job. This setting is used for dashboard, api and alert annotations
+;cleanupjob_batchsize = 100
 
 [annotations.dashboard]
 # Dashboard annotations means that annotations are associated with the dashboard they are created on.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -676,7 +676,7 @@
 
 #################################### Annotations #########################
 [annotations]
-# configures the batch size for the annotation clean up job. This setting is used for dashboard, api and alert annotations
+# Configures the batch size for the annotation clean-up job. This setting is used for dashboard, API, and alert annotations.
 ;cleanupjob_batchsize = 100
 
 [annotations.dashboard]

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1086,7 +1086,7 @@ Configures max number of alert annotations that Grafana stores. Default value is
 
 ### cleanupjob_batchsize
 
-Configures the batch size for the annotation clean up job. This setting is used for dashboard, api and alert annotations
+Configures the batch size for the annotation clean-up job. This setting is used for dashboard, API, and alert annotations.
 
 ## [annotations.dashboard]
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1082,6 +1082,12 @@ Configures max number of alert annotations that Grafana stores. Default value is
 
 <hr>
 
+## [annotations]
+
+### cleanupjob_batchsize
+
+Configures the batch size for the annotation clean up job. This setting is used for dashboard, api and alert annotations
+
 ## [annotations.dashboard]
 
 Dashboard annotations means that annotations are associated with the dashboard they are created on.

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -105,7 +105,7 @@ func (ss *SQLStore) Init() error {
 
 	// Init repo instances
 	annotations.SetRepository(&SQLAnnotationRepo{})
-	annotations.SetAnnotationCleaner(&AnnotationCleanupService{batchSize: 100, log: log.New("annotationcleaner")})
+	annotations.SetAnnotationCleaner(&AnnotationCleanupService{batchSize: ss.Cfg.AnnotationCleanupJobBatchSize, log: log.New("annotationcleaner")})
 	ss.Bus.SetTransactionManager(ss)
 
 	// Register handlers

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -472,11 +472,12 @@ func (cfg *Cfg) readGrafanaEnvironmentMetrics() error {
 }
 
 func (cfg *Cfg) readAnnotationSettings() {
+	section := cfg.Raw.Section("annotations")
+	cfg.AnnotationCleanupJobBatchSize = section.Key("cleanupjob_batchsize").MustInt64(100)
+
 	dashboardAnnotation := cfg.Raw.Section("annotations.dashboard")
 	apiIAnnotation := cfg.Raw.Section("annotations.api")
 	alertingSection := cfg.Raw.Section("alerting")
-	section := cfg.Raw.Section("annotations")
-	cleanupJobBatchSize := section.Key("cleanupjob_batchsize").MustInt64(100)
 
 	var newAnnotationCleanupSettings = func(section *ini.Section, maxAgeField string) AnnotationCleanupSettings {
 		maxAge, err := gtime.ParseDuration(section.Key(maxAgeField).MustString(""))
@@ -493,7 +494,6 @@ func (cfg *Cfg) readAnnotationSettings() {
 	cfg.AlertingAnnotationCleanupSetting = newAnnotationCleanupSettings(alertingSection, "max_annotation_age")
 	cfg.DashboardAnnotationCleanupSettings = newAnnotationCleanupSettings(dashboardAnnotation, "max_age")
 	cfg.APIAnnotationCleanupSettings = newAnnotationCleanupSettings(apiIAnnotation, "max_age")
-	cfg.AnnotationCleanupJobBatchSize = cleanupJobBatchSize
 }
 
 func (cfg *Cfg) readExpressionsSettings() {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -318,6 +318,7 @@ type Cfg struct {
 	HiddenUsers           map[string]struct{}
 
 	// Annotations
+	AnnotationCleanupJobBatchSize      int64
 	AlertingAnnotationCleanupSetting   AnnotationCleanupSettings
 	DashboardAnnotationCleanupSettings AnnotationCleanupSettings
 	APIAnnotationCleanupSettings       AnnotationCleanupSettings
@@ -474,6 +475,8 @@ func (cfg *Cfg) readAnnotationSettings() {
 	dashboardAnnotation := cfg.Raw.Section("annotations.dashboard")
 	apiIAnnotation := cfg.Raw.Section("annotations.api")
 	alertingSection := cfg.Raw.Section("alerting")
+	section := cfg.Raw.Section("annotations")
+	cleanupJobBatchSize := section.Key("cleanupjob_batchsize").MustInt64(100)
 
 	var newAnnotationCleanupSettings = func(section *ini.Section, maxAgeField string) AnnotationCleanupSettings {
 		maxAge, err := gtime.ParseDuration(section.Key(maxAgeField).MustString(""))
@@ -490,6 +493,7 @@ func (cfg *Cfg) readAnnotationSettings() {
 	cfg.AlertingAnnotationCleanupSetting = newAnnotationCleanupSettings(alertingSection, "max_annotation_age")
 	cfg.DashboardAnnotationCleanupSettings = newAnnotationCleanupSettings(dashboardAnnotation, "max_age")
 	cfg.APIAnnotationCleanupSettings = newAnnotationCleanupSettings(apiIAnnotation, "max_age")
+	cfg.AnnotationCleanupJobBatchSize = cleanupJobBatchSize
 }
 
 func (cfg *Cfg) readExpressionsSettings() {


### PR DESCRIPTION
Some of our instances have an insane amount of annotations. The query to find the annotations to delete takes long enough that the instances barely purge any annotations at all. By increase the batch job size it should be quicker. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>
