### PR TITLE
Loki: Refactor line limit to use grafana/ui component

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -4,7 +4,7 @@ import { css, cx } from 'emotion';
 import { LokiQuery } from '../types';
 
 // Types
-import { InlineFormLabel, RadioButtonGroup } from '@grafana/ui';
+import { InlineFormLabel, RadioButtonGroup, InlineField, Input } from '@grafana/ui';
 
 export interface LokiOptionFieldsProps {
   lineLimitValue: string;
@@ -108,21 +108,22 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
         )}
         aria-label="Line limit field"
       >
-        <InlineFormLabel width={5}>Line limit</InlineFormLabel>
-        <input
-          type="number"
-          className="gf-form-input width-4"
-          placeholder={'auto'}
-          min={0}
-          onChange={onMaxLinesChange}
-          onKeyDown={onReturnKeyDown}
-          value={lineLimitValue}
-          onBlur={() => {
-            if (runOnBlur) {
-              onRunQuery();
-            }
-          }}
-        />
+        <InlineField label="Line limit">
+          <Input
+            className="width-4"
+            placeholder="auto"
+            type="number"
+            min={0}
+            onChange={onMaxLinesChange}
+            onKeyDown={onReturnKeyDown}
+            value={lineLimitValue}
+            onBlur={() => {
+              if (runOnBlur) {
+                onRunQuery();
+              }
+            }}
+          />
+        </InlineField>
       </div>
     </div>
   );

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -25,8 +25,8 @@ const queryTypeOptions = [
 export function LokiOptionFields(props: LokiOptionFieldsProps) {
   const { lineLimitValue, queryType, query, onRunQuery, runOnBlur, onChange } = props;
 
-  function onChangeQueryLimit(value: string) {
-    const nextQuery = { ...query, maxLines: preprocessMaxLines(value) };
+  function onChangeQueryLimit(maxLines: number) {
+    const nextQuery = { ...query, maxLines };
     onChange(nextQuery);
   }
 
@@ -40,23 +40,12 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
     onChange(nextQuery);
   }
 
-  function preprocessMaxLines(value: string): number {
-    if (value.length === 0) {
-      // empty input - falls back to dataSource.maxLines limit
-      return NaN;
-    } else if (value.length > 0 && (isNaN(+value) || +value < 0)) {
-      // input with at least 1 character and that is either incorrect (value in the input field is not a number) or negative
-      // falls back to the limit of 0 lines
-      return 0;
-    } else {
-      // default case - correct input
-      return +value;
-    }
-  }
-
   function onMaxLinesChange(e: React.SyntheticEvent<HTMLInputElement>) {
-    if (query.maxLines !== preprocessMaxLines(e.currentTarget.value)) {
-      onChangeQueryLimit(e.currentTarget.value);
+    //If value is lower than 0, or if it can't be converted into number, we want to return 0
+    const limit = Math.max(Number(e.currentTarget.value), 0);
+    //Run change only if limit changes
+    if (query.maxLines !== limit) {
+      onChangeQueryLimit(limit);
     }
   }
 

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -25,8 +25,8 @@ const queryTypeOptions = [
 export function LokiOptionFields(props: LokiOptionFieldsProps) {
   const { lineLimitValue, queryType, query, onRunQuery, runOnBlur, onChange } = props;
 
-  function onChangeQueryLimit(maxLines: number) {
-    const nextQuery = { ...query, maxLines };
+  function onChangeQueryLimit(value: string) {
+    const nextQuery = { ...query, maxLines: preprocessMaxLines(value) };
     onChange(nextQuery);
   }
 
@@ -40,12 +40,23 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
     onChange(nextQuery);
   }
 
+  function preprocessMaxLines(value: string): number {
+    if (value.length === 0) {
+      // empty input - falls back to dataSource.maxLines limit
+      return NaN;
+    } else if (value.length > 0 && (isNaN(+value) || +value < 0)) {
+      // input with at least 1 character and that is either incorrect (value in the input field is not a number) or negative
+      // falls back to the limit of 0 lines
+      return 0;
+    } else {
+      // default case - correct input
+      return +value;
+    }
+  }
+
   function onMaxLinesChange(e: React.SyntheticEvent<HTMLInputElement>) {
-    //If value is lower than 0, or if it can't be converted into number, we want to return 0
-    const limit = Math.max(Number(e.currentTarget.value), 0);
-    //Run change only if limit changes
-    if (query.maxLines !== limit) {
-      onChangeQueryLimit(limit);
+    if (query.maxLines !== preprocessMaxLines(e.currentTarget.value)) {
+      onChangeQueryLimit(e.currentTarget.value);
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors **Line limit** to use components from component library. I hope that this might fix https://github.com/grafana/grafana/issues/23225. 

Unfortunately, I was never able to reproduce this issue (I have tried a lot of time over the past couple of months as I am active Loki user). Error in it is thrown is here in [Typeahead component](https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx#L141), but for line limit isn't even using it. After this refactor, we are using only component from the component library and therefore I hope this issue will be fixed.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/23225

**Special notes for your reviewer**:

