### PR TITLE
Explore: Show ANSI colored logs in logs context

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -64,7 +64,7 @@ export class LogMessageAnsi extends PureComponent<Props, State> {
 
     return chunks.map((chunk, index) =>
       chunk.style ? (
-        <span key={index} style={chunk.style}>
+        <span key={index} style={chunk.style} data-testid="ansiLogLine">
           {chunk.text}
         </span>
       ) : (

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { LogRowModel } from '@grafana/data';
+import { render, screen } from '@testing-library/react';
+import { LogRowContextGroup } from './LogRowContext';
+
+describe('LogRowContextGroup component', () => {
+  it('should correctly render logs with ANSI', () => {
+    const defaultProps = {
+      rows: ['Log 1 with \u001B[31mANSI\u001B[0m code', 'Log 2', 'Log 3 with \u001B[31mANSI\u001B[0m code'],
+      onLoadMoreContext: () => {},
+      canLoadMoreRows: false,
+      row: {} as LogRowModel,
+      className: '',
+    };
+
+    render(
+      <div>
+        <LogRowContextGroup {...defaultProps} />
+      </div>
+    );
+    expect(screen.getAllByTestId('ansiLogLine')).toHaveLength(2);
+  });
+});

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -96,7 +96,7 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
   );
 };
 
-const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps> = ({
+export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps> = ({
   row,
   rows,
   error,

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -134,10 +134,8 @@ const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps> = ({
               <List
                 items={rows}
                 renderItem={(item) => {
-                  if (typeof item === 'string') {
-                    if (textUtil.hasAnsiCodes(item)) {
-                      return <LogMessageAnsi value={item} />;
-                    }
+                  if (typeof item === 'string' && textUtil.hasAnsiCodes(item)) {
+                    return <LogMessageAnsi value={item} />;
                   }
                   return (
                     <div

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useRef, useState, useLayoutEffect, useEffect } from 'react';
-import { GrafanaTheme, DataQueryError, LogRowModel } from '@grafana/data';
+import { GrafanaTheme, DataQueryError, LogRowModel, textUtil } from '@grafana/data';
 import { css, cx } from 'emotion';
 
 import { Alert } from '../Alert/Alert';
@@ -8,6 +8,7 @@ import { ThemeContext } from '../../themes/ThemeContext';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
 import { List } from '../List/List';
 import { ClickOutsideWrapper } from '../ClickOutsideWrapper/ClickOutsideWrapper';
+import { LogMessageAnsi } from './LogMessageAnsi';
 
 interface LogRowContextProps {
   row: LogRowModel;
@@ -133,6 +134,11 @@ const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps> = ({
               <List
                 items={rows}
                 renderItem={(item) => {
+                  if (typeof item === 'string') {
+                    if (textUtil.hasAnsiCodes(item)) {
+                      return <LogMessageAnsi value={item} />;
+                    }
+                  }
                   return (
                     <div
                       className={css`

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -134,16 +134,13 @@ const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps> = ({
               <List
                 items={rows}
                 renderItem={(item) => {
-                  if (typeof item === 'string' && textUtil.hasAnsiCodes(item)) {
-                    return <LogMessageAnsi value={item} />;
-                  }
                   return (
                     <div
                       className={css`
                         padding: 5px 0;
                       `}
                     >
-                      {item}
+                      {typeof item === 'string' && textUtil.hasAnsiCodes(item) ? <LogMessageAnsi value={item} /> : item}
                     </div>
                   );
                 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR shows logs with ANSI trough <LogMessageAnsi /> component that is used in LogRows and in LiveTailing. 

![image](https://user-images.githubusercontent.com/30407135/109299601-a4e4f400-7835-11eb-91b9-486c15a906a1.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/20799

