### PR TITLE
Implement version sort for variables

### DIFF
--- a/public/app/features/variables/query/QueryVariableSortSelect.tsx
+++ b/public/app/features/variables/query/QueryVariableSortSelect.tsx
@@ -17,6 +17,8 @@ const SORT_OPTIONS = [
   { label: 'Numerical (desc)', value: VariableSort.numericalDesc },
   { label: 'Alphabetical (case-insensitive, asc)', value: VariableSort.alphabeticalCaseInsensitiveAsc },
   { label: 'Alphabetical (case-insensitive, desc)', value: VariableSort.alphabeticalCaseInsensitiveDesc },
+  { label: 'Version (asc)', value: VariableSort.versionAsc },
+  { label: 'Version (desc)', value: VariableSort.versionDesc },
 ];
 
 export function QueryVariableSortSelect({ onChange, sort }: PropsWithChildren<Props>) {

--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -288,14 +288,16 @@ describe('queryVariableReducer', () => {
 describe('sortVariableValues', () => {
   describe('when using any sortOrder with an option with null as text', () => {
     it.each`
-      options                                           | sortOrder                                       | expected
-      ${[{ text: '1' }, { text: null }, { text: '2' }]} | ${VariableSort.disabled}                        | ${[{ text: '1' }, { text: null }, { text: '2' }]}
-      ${[{ text: 'a' }, { text: null }, { text: 'b' }]} | ${VariableSort.alphabeticalAsc}                 | ${[{ text: 'a' }, { text: 'b' }, { text: null }]}
-      ${[{ text: 'a' }, { text: null }, { text: 'b' }]} | ${VariableSort.alphabeticalDesc}                | ${[{ text: null }, { text: 'b' }, { text: 'a' }]}
-      ${[{ text: '1' }, { text: null }, { text: '2' }]} | ${VariableSort.numericalAsc}                    | ${[{ text: null }, { text: '1' }, { text: '2' }]}
-      ${[{ text: '1' }, { text: null }, { text: '2' }]} | ${VariableSort.numericalDesc}                   | ${[{ text: '2' }, { text: '1' }, { text: null }]}
-      ${[{ text: 'a' }, { text: null }, { text: 'b' }]} | ${VariableSort.alphabeticalCaseInsensitiveAsc}  | ${[{ text: null }, { text: 'a' }, { text: 'b' }]}
-      ${[{ text: 'a' }, { text: null }, { text: 'b' }]} | ${VariableSort.alphabeticalCaseInsensitiveDesc} | ${[{ text: 'b' }, { text: 'a' }, { text: null }]}
+      options                                            | sortOrder                                       | expected
+      ${[{ text: '1' }, { text: null }, { text: '2' }]}  | ${VariableSort.disabled}                        | ${[{ text: '1' }, { text: null }, { text: '2' }]}
+      ${[{ text: 'a' }, { text: null }, { text: 'b' }]}  | ${VariableSort.alphabeticalAsc}                 | ${[{ text: 'a' }, { text: 'b' }, { text: null }]}
+      ${[{ text: 'a' }, { text: null }, { text: 'b' }]}  | ${VariableSort.alphabeticalDesc}                | ${[{ text: null }, { text: 'b' }, { text: 'a' }]}
+      ${[{ text: '1' }, { text: null }, { text: '2' }]}  | ${VariableSort.numericalAsc}                    | ${[{ text: null }, { text: '1' }, { text: '2' }]}
+      ${[{ text: '1' }, { text: null }, { text: '2' }]}  | ${VariableSort.numericalDesc}                   | ${[{ text: '2' }, { text: '1' }, { text: null }]}
+      ${[{ text: 'a' }, { text: null }, { text: 'b' }]}  | ${VariableSort.alphabeticalCaseInsensitiveAsc}  | ${[{ text: null }, { text: 'a' }, { text: 'b' }]}
+      ${[{ text: 'a' }, { text: null }, { text: 'b' }]}  | ${VariableSort.alphabeticalCaseInsensitiveDesc} | ${[{ text: 'b' }, { text: 'a' }, { text: null }]}
+      ${[{ text: '10' }, { text: null }, { text: '2' }]} | ${VariableSort.versionAsc}                      | ${[{ text: null }, { text: '2' }, { text: '10' }]}
+      ${[{ text: '10' }, { text: null }, { text: '2' }]} | ${VariableSort.versionDesc}                     | ${[{ text: '10' }, { text: '2' }, { text: null }]}
     `(
       'then it should sort the options correctly without throwing (sortOrder:$sortOrder)',
       ({ options, sortOrder, expected }) => {

--- a/public/app/features/variables/query/reducer.ts
+++ b/public/app/features/variables/query/reducer.ts
@@ -79,6 +79,14 @@ export const sortVariableValues = (options: any[], sortOrder: VariableSort) => {
     options = _.sortBy(options, (opt) => {
       return _.toLower(opt.text);
     });
+  } else if (sortType === 4) {
+    options = _.sortBy(options, (opt) => {
+      if (!opt.text) {
+        return -1;
+      }
+
+      return opt.text.replace(/\d{1,15}/g, (n: number) => +n + Math.pow(10, 15));
+    });
   }
 
   if (reverseSort) {

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -31,6 +31,8 @@ export enum VariableSort {
   numericalDesc,
   alphabeticalCaseInsensitiveAsc,
   alphabeticalCaseInsensitiveDesc,
+  versionAsc,
+  versionDesc,
 }
 
 export interface VariableTag {


### PR DESCRIPTION
This implements the sorting algorithm for variables known as version sort as it's commonly used to sort version numbers. It's also very helpful if sorting network interface names, hostnames if IP addresses are used in them etc.

Fixes #7307