### PR TITLE
Elasticsearch: Fix impossibility to perform non-logs queries after importing queries from loki or prometheus in explore

### DIFF
--- a/public/app/features/alerting/getAlertingValidationMessage.test.ts
+++ b/public/app/features/alerting/getAlertingValidationMessage.test.ts
@@ -28,8 +28,8 @@ describe('getAlertingValidationMessage', () => {
         getInstanceSettings: (() => {}) as any,
       };
       const targets: ElasticsearchQuery[] = [
-        { refId: 'A', query: '@hostname:$hostname', isLogsQuery: false },
-        { refId: 'B', query: '@instance:instance', isLogsQuery: false },
+        { refId: 'A', query: '@hostname:$hostname' },
+        { refId: 'B', query: '@instance:instance' },
       ];
       const transformations: DataTransformerConfig[] = [];
 
@@ -95,8 +95,8 @@ describe('getAlertingValidationMessage', () => {
         },
       };
       const targets: ElasticsearchQuery[] = [
-        { refId: 'A', query: '@hostname:$hostname', isLogsQuery: false },
-        { refId: 'B', query: '@instance:$instance', isLogsQuery: false },
+        { refId: 'A', query: '@hostname:$hostname' },
+        { refId: 'B', query: '@instance:$instance' },
       ];
       const transformations: DataTransformerConfig[] = [];
 
@@ -124,8 +124,8 @@ describe('getAlertingValidationMessage', () => {
         },
       };
       const targets: ElasticsearchQuery[] = [
-        { refId: 'A', query: '@hostname:hostname', isLogsQuery: false },
-        { refId: 'B', query: '@instance:instance', isLogsQuery: false },
+        { refId: 'A', query: '@hostname:hostname' },
+        { refId: 'B', query: '@instance:instance' },
       ];
       const transformations: DataTransformerConfig[] = [];
 
@@ -153,8 +153,8 @@ describe('getAlertingValidationMessage', () => {
         },
       };
       const targets: ElasticsearchQuery[] = [
-        { refId: 'A', query: '@hostname:hostname', isLogsQuery: false },
-        { refId: 'B', query: '@instance:instance', isLogsQuery: false },
+        { refId: 'A', query: '@hostname:hostname' },
+        { refId: 'B', query: '@instance:instance' },
       ];
       const transformations: DataTransformerConfig[] = [{ id: 'A', options: null }];
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -226,9 +226,8 @@ describe('ElasticDatasource', function (this: any) {
                 id: '2',
               },
             ],
-            metrics: [{ type: 'count', id: '1' }],
+            metrics: [{ type: 'logs', id: '1' }],
             query: 'escape\\:test',
-            isLogsQuery: true,
             timeField: '@timestamp',
           },
         ],
@@ -957,7 +956,6 @@ const createElasticQuery = (): DataQueryRequest<ElasticsearchQuery> => {
     targets: [
       {
         refId: '',
-        isLogsQuery: false,
         bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '2' }],
         metrics: [{ type: 'count', id: '' }],
         query: 'test',

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -530,7 +530,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     let payload = '';
     const targets = this.interpolateVariablesInQueries(_.cloneDeep(options.targets), options.scopedVars);
     const sentTargets: ElasticsearchQuery[] = [];
-    let targetsContainesLogsQuery = targets.some((target) => hasMetricOfType(target, 'logs'));
+    let targetsContainsLogsQuery = targets.some((target) => hasMetricOfType(target, 'logs'));
 
     // add global adhoc filters to timeFilter
     const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
@@ -584,7 +584,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
         const er = new ElasticResponse(sentTargets, res);
 
         // TODO: This needs to be revisited, it seems wroong to process ALL the sent queries as logs if only one of them was a log query
-        if (targetsContainesLogsQuery) {
+        if (targetsContainsLogsQuery) {
           const response = er.getLogs(this.logMessageField, this.logLevelField);
           for (const dataFrame of response.data) {
             enhanceDataFrame(dataFrame, this.dataLinks);

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -497,7 +497,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     const payload = [header, esQuery].join('\n') + '\n';
     const url = this.getMultiSearchUrl();
     const response = await this.post(url, payload).toPromise();
-    const targets: ElasticsearchQuery[] = [{ refId: `${row.dataFrame.refId}`, metrics: [], isLogsQuery: true }];
+    const targets: ElasticsearchQuery[] = [{ refId: `${row.dataFrame.refId}`, metrics: [{ type: 'logs', id: '1' }] }];
     const elasticResponse = new ElasticResponse(targets, transformHitsBasedOnDirection(response, sort));
     const logResponse = elasticResponse.getLogs(this.logMessageField, this.logLevelField);
     const dataFrame = _.first(logResponse.data);
@@ -530,6 +530,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     let payload = '';
     const targets = this.interpolateVariablesInQueries(_.cloneDeep(options.targets), options.scopedVars);
     const sentTargets: ElasticsearchQuery[] = [];
+    let targetsContainesLogsQuery = targets.some((target) => hasMetricOfType(target, 'logs'));
 
     // add global adhoc filters to timeFilter
     const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
@@ -540,11 +541,10 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       }
 
       let queryObj;
-      if (target.isLogsQuery || hasMetricOfType(target, 'logs')) {
+      if (hasMetricOfType(target, 'logs')) {
         target.bucketAggs = [defaultBucketAgg()];
         target.metrics = [];
         // Setting this for metrics queries that are typed as logs
-        target.isLogsQuery = true;
         queryObj = this.queryBuilder.getLogsQuery(target, adhocFilters, target.query);
       } else {
         if (target.alias) {
@@ -583,7 +583,8 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       map((res) => {
         const er = new ElasticResponse(sentTargets, res);
 
-        if (sentTargets.some((target) => target.isLogsQuery)) {
+        // TODO: This needs to be revisited, it seems wroong to process ALL the sent queries as logs if only one of them was a log query
+        if (targetsContainesLogsQuery) {
           const response = er.getLogs(this.logMessageField, this.logLevelField);
           for (const dataFrame of response.data) {
             enhanceDataFrame(dataFrame, this.dataLinks);

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -583,7 +583,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       map((res) => {
         const er = new ElasticResponse(sentTargets, res);
 
-        // TODO: This needs to be revisited, it seems wroong to process ALL the sent queries as logs if only one of them was a log query
+        // TODO: This needs to be revisited, it seems wrong to process ALL the sent queries as logs if only one of them was a log query
         if (targetsContainsLogsQuery) {
           const response = er.getLogs(this.logMessageField, this.logLevelField);
           for (const dataFrame of response.data) {

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -425,7 +425,7 @@ export class ElasticResponse {
   }
 
   getTimeSeries() {
-    if (this.targets.some((target) => target.metrics?.some((metric) => metric.type === 'raw_data'))) {
+    if (this.targets.some((target) => queryDef.hasMetricOfType(target, 'raw_data'))) {
       return this.processResponseToDataFrames(false);
     }
     return this.processResponseToSeries();

--- a/public/app/plugins/datasource/elasticsearch/language_provider.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/language_provider.test.ts
@@ -26,7 +26,6 @@ const dataSource = new ElasticDatasource(
 );
 
 const baseLogsQuery: Partial<ElasticsearchQuery> = {
-  isLogsQuery: true,
   metrics: [{ type: 'logs', id: '1' }],
   bucketAggs: [{ ...defaultBucketAgg('2'), field: dataSource.timeField } as DateHistogram],
 };

--- a/public/app/plugins/datasource/elasticsearch/language_provider.ts
+++ b/public/app/plugins/datasource/elasticsearch/language_provider.ts
@@ -116,7 +116,6 @@ export default class ElasticsearchLanguageProvider extends LanguageProvider {
         let prometheusQuery = query as PromQuery;
         const expr = getElasticsearchQuery(extractPrometheusLabels(prometheusQuery.expr));
         return {
-          isLogsQuery: true,
           metrics: [
             {
               id: '1',

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -6,6 +6,7 @@ import {
   MetricAggregationType,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig, pipelineOptions } from './components/QueryEditor/MetricAggregationsEditor/utils';
+import { ElasticsearchQuery } from './types';
 
 export const extendedStats: ExtendedStat[] = [
   { label: 'Avg', value: 'avg' },
@@ -42,8 +43,8 @@ export function defaultBucketAgg(id = '1'): BucketAggregation {
 export const findMetricById = (metrics: MetricAggregation[], id: MetricAggregation['id']) =>
   metrics.find((metric) => metric.id === id);
 
-export function hasMetricOfType(target: any, type: string): boolean {
-  return target && target.metrics && target.metrics.some((m: any) => m.type === type);
+export function hasMetricOfType(target: ElasticsearchQuery, type: string): boolean {
+  return !!target?.metrics?.some((m) => m.type === type);
 }
 
 // Even if we have type guards when building a query, we currently have no way of getting this information from the response.

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -43,7 +43,7 @@ export function defaultBucketAgg(id = '1'): BucketAggregation {
 export const findMetricById = (metrics: MetricAggregation[], id: MetricAggregation['id']) =>
   metrics.find((metric) => metric.id === id);
 
-export function hasMetricOfType(target: ElasticsearchQuery, type: string): boolean {
+export function hasMetricOfType(target: ElasticsearchQuery, type: MetricAggregationType): boolean {
   return !!target?.metrics?.some((m) => m.type === type);
 }
 

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1208,17 +1208,12 @@ describe('ElasticResponse', () => {
   });
 
   describe('simple logs query and count', () => {
-    const targets: any = [
+    const targets: ElasticsearchQuery[] = [
       {
         refId: 'A',
         metrics: [{ type: 'count', id: '1' }],
         bucketAggs: [{ type: 'date_histogram', settings: { interval: 'auto' }, id: '2' }],
-        context: 'explore',
-        interval: '10s',
-        isLogsQuery: true,
         key: 'Q-1561369883389-0.7611823271062786-0',
-        liveStreaming: false,
-        maxDataPoints: 1620,
         query: 'hello AND message',
         timeField: '@timestamp',
       },

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -59,7 +59,6 @@ export interface ElasticsearchAggregation {
 }
 
 export interface ElasticsearchQuery extends DataQuery {
-  isLogsQuery?: boolean;
   alias?: string;
   query?: string;
   bucketAggs?: BucketAggregation[];


### PR DESCRIPTION
When importing queries in explore we were setting `isLogsQuery: true` which made it impossible to perform non-logs queries in elasticsearch when switching from  a loki/prometheus datasource.

`isLogsQuery` is effectively useless since we can check for the existence of the "virtual" logs aggregation to determine if a query is a logs query.

**Note:** I'm not sure how to better phrase the PR title, feel free to change it if you have a better idea.