### PR TITLE
LocationService: Move to runtime and  remove getLocationService and export singleston const instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "@types/sockjs-client": "^1.1.1",
     "@types/uuid": "8.3.0",
     "@welldone-software/why-did-you-render": "4.0.6",
+    "history": "4.10.1",
     "abortcontroller-polyfill": "1.4.0",
     "angular": "1.8.2",
     "angular-bindonce": "0.3.1",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -25,7 +25,8 @@
     "@grafana/data": "7.5.0-pre.0",
     "@grafana/ui": "7.5.0-pre.0",
     "systemjs": "0.20.19",
-    "systemjs-plugin-css": "0.1.37"
+    "systemjs-plugin-css": "0.1.37",
+    "history": "4.10.1"
   },
   "devDependencies": {
     "@grafana/tsconfig": "^1.0.0-rc1",
@@ -34,6 +35,7 @@
     "@types/jest": "26.0.15",
     "@types/rollup-plugin-visualizer": "2.6.0",
     "@types/systemjs": "^0.20.6",
+    "@types/history": "^4.7.8",
     "lodash": "4.17.20",
     "pretty-format": "25.1.0",
     "rollup": "2.33.3",

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -1,4 +1,6 @@
+import { locationUtil } from '@grafana/data';
 import * as H from 'history';
+import { navigationLogger } from '../utils/navUtils';
 import { LocationUpdate } from './LocationSrv';
 
 export interface LocationService {
@@ -13,12 +15,117 @@ export interface LocationService {
   update: (update: LocationUpdate) => void;
 }
 
-let singletonInstance: LocationService;
+class HistoryWrapper implements LocationService {
+  private readonly history: H.History;
+  private fullPageReloadRoutes = ['/logout'];
 
-export function setLocationService(instance: LocationService) {
-  singletonInstance = instance;
+  constructor(history?: H.History) {
+    // If no history passed create an in memory one if being called from test
+    this.history =
+      history || process.env.NODE_ENV === 'test'
+        ? H.createMemoryHistory({ initialEntries: ['/'] })
+        : H.createBrowserHistory();
+
+    this.history.listen((update) => {
+      navigationLogger('LocationService', false, 'history.listen', update);
+      const urlWithoutBase = locationUtil.stripBaseFromUrl(update.pathname);
+
+      if (this.fullPageReloadRoutes.indexOf(urlWithoutBase) > -1) {
+        window.location.href = update.pathname;
+        return;
+      }
+      // const mode = queryStringToJSON(update.search).kiosk as KioskUrlValue;
+      // setViewModeBodyClass(mode);
+    });
+
+    // For debugging purposes the location service is attached to global _debug variable
+    if (process.env.NODE_ENV !== 'production') {
+      // @ts-ignore
+      let debugGlobal = window['_debug'];
+      if (debugGlobal) {
+        debugGlobal = {
+          ...debugGlobal,
+          location: this,
+        };
+      } else {
+        debugGlobal = {
+          location: this,
+        };
+      }
+      // @ts-ignore
+      window['_debug'] = debugGlobal;
+    }
+
+    this.partial = this.partial.bind(this);
+    this.push = this.push.bind(this);
+    this.replace = this.replace.bind(this);
+    this.getSearch = this.getSearch.bind(this);
+    this.getHistory = this.getHistory.bind(this);
+    this.getCurrentLocation = this.getCurrentLocation.bind(this);
+  }
+
+  getHistory() {
+    return this.history;
+  }
+
+  getSearch() {
+    return new URLSearchParams(this.history.location.search);
+  }
+
+  partial(query: Record<string, any>, replace?: boolean) {
+    const currentLocation = this.history.location;
+    const params = this.getSearch();
+
+    for (const key of Object.keys(query)) {
+      if (params.has(key)) {
+        // removing params with null | undefined
+        if (query[key] === null || query[key] === undefined) {
+          params.delete(key);
+        } else {
+          params.set(key, query[key]);
+        }
+      } else {
+        // ignoring params with null | undefined values
+        if (query[key] !== null && query[key] !== undefined) {
+          params.append(key, query[key]);
+        }
+      }
+    }
+
+    const locationUpdate: H.Location = {
+      ...currentLocation,
+      search: params.toString(),
+    };
+
+    if (replace) {
+      this.history.replace(locationUpdate);
+    } else {
+      this.history.push(locationUpdate);
+    }
+  }
+
+  push(location: H.Path | H.LocationDescriptor) {
+    this.history.push(location);
+  }
+
+  replace(location: H.Path) {
+    this.history.replace(location);
+  }
+
+  getCurrentLocation() {
+    return this.history.location;
+  }
+
+  /** @depecreated */
+  update(options: LocationUpdate) {
+    if (options.partial && options.query) {
+      this.partial(options.query, options.replace);
+    }
+    if (options.replace) {
+      this.replace(options.path!);
+    }
+    this.push(options.path!);
+  }
 }
 
-export function getLocationService(): LocationService {
-  return singletonInstance;
-}
+export const locationService: LocationService = new HistoryWrapper();

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -2,6 +2,7 @@ import { locationUtil } from '@grafana/data';
 import * as H from 'history';
 import { navigationLogger } from '../utils/navUtils';
 import { LocationUpdate } from './LocationSrv';
+import createMemoryHistory from 'history/createMemoryHistory';
 
 export interface LocationService {
   partial: (query: Record<string, any>, replace?: boolean) => void;
@@ -23,7 +24,7 @@ class HistoryWrapper implements LocationService {
     // If no history passed create an in memory one if being called from test
     this.history =
       history || process.env.NODE_ENV === 'test'
-        ? H.createMemoryHistory({ initialEntries: ['/'] })
+        ? createMemoryHistory({ initialEntries: ['/'] })
         : H.createBrowserHistory();
 
     this.history.listen((update) => {

--- a/packages/grafana-runtime/src/utils/navUtils.ts
+++ b/packages/grafana-runtime/src/utils/navUtils.ts
@@ -1,0 +1,30 @@
+import { createLogger } from '@grafana/ui';
+
+export const navigationLogger = createLogger('Router');
+
+export function queryStringToJSON(queryString: string) {
+  const params: Array<[string, string | boolean]> = [];
+  new URLSearchParams(queryString).forEach((v, k) => params.push([k, parseValue(v)]));
+  return Object.fromEntries(new Map(params));
+}
+
+export function parseValue(value: string) {
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return value;
+}
+
+export function shouldForceReload(query: string) {
+  const params = new URLSearchParams(query);
+  const forceLoginParam = params.get('forceLogin');
+
+  if (forceLoginParam !== null && parseValue(forceLoginParam)) {
+    return true;
+  }
+
+  return false;
+}

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -22,7 +22,6 @@ import 'vendor/angular-other/angular-strap';
 import config from 'app/core/config';
 // @ts-ignore ignoring this for now, otherwise we would have to extend _ interface with move
 import {
-  AppEvents,
   setLocale,
   setTimeZoneResolver,
   standardEditorsRegistry,
@@ -34,7 +33,7 @@ import { arrayMove } from 'app/core/utils/arrayMove';
 import { importPluginModule } from 'app/features/plugins/plugin_loader';
 import { angularModules } from 'app/core/core_module';
 import { registerAngularDirectives } from 'app/core/core';
-import { getLocationService, registerEchoBackend, setEchoSrv, setLocationService } from '@grafana/runtime';
+import { registerEchoBackend, setEchoSrv } from '@grafana/runtime';
 import { Echo } from './core/services/echo/Echo';
 import { reportPerformance } from './core/services/echo/EchoSrv';
 import { PerformanceBackend } from './core/services/echo/backends/PerformanceBackend';
@@ -51,15 +50,11 @@ import { setVariableQueryRunner, VariableQueryRunner } from './features/variable
 import { configureStore } from './store/configureStore';
 import { DashboardLoaderSrv } from './features/dashboard/services/DashboardLoaderSrv';
 import { AppWrapper } from './core/AppWrapper';
-import { LocationService } from './core/navigation/LocationService';
 
 // Function that patches Angular routing that seems to kick off because of $routeProvider and ng-include usages
 // Ref: https://stackoverflow.com/questions/58146221/is-it-possible-to-tamper-client-side-code-in-angular-app
 import bridgeReactAngularRouting from './core/navigation/bridgeReactAngularRouting';
 import { interceptLinkClicks } from './core/navigation/patch/interceptLinkClicks';
-import appEvents from './core/app_events';
-import { CoreEvents, KioskUrlValue } from './types';
-import { queryStringToJSON, setViewModeBodyClass } from './core/navigation/utils';
 
 // add move to lodash for backward compatabilty with plugins
 // @ts-ignore
@@ -81,8 +76,6 @@ export class GrafanaApp {
   preBootModules: any[] | null;
 
   constructor() {
-    this.initServices();
-    this.registerAppEvents();
     this.preBootModules = [];
     this.registerFunctions = {};
     this.ngModuleDependencies = [];
@@ -101,7 +94,7 @@ export class GrafanaApp {
   init() {
     const app = angular.module('grafana', []);
     addClassIfNoOverlayScrollbar();
-    setViewModeBodyClass(queryStringToJSON(getLocationService().getCurrentLocation().search).kiosk as KioskUrlValue);
+    //setViewModeBodyClass(queryStringToJSON(getLocationService().getCurrentLocation().search).kiosk as KioskUrlValue);
     setLocale(config.bootData.user.locale);
     setTimeZoneResolver(() => config.bootData.user.timezone);
 
@@ -215,40 +208,36 @@ export class GrafanaApp {
     });
   }
 
-  initServices = () => {
-    setLocationService(new LocationService());
-  };
+  // registerAppEvents() {
+  //   appEvents.on(CoreEvents.toggleKioskMode, (options: { exit?: boolean }) => {
+  //     const search: { kiosk?: KioskUrlValue | null } = queryStringToJSON(
+  //       getLocationService().getCurrentLocation().search
+  //     );
 
-  registerAppEvents() {
-    appEvents.on(CoreEvents.toggleKioskMode, (options: { exit?: boolean }) => {
-      const search: { kiosk?: KioskUrlValue | null } = queryStringToJSON(
-        getLocationService().getCurrentLocation().search
-      );
+  //     if (options && options.exit) {
+  //       search.kiosk = '1';
+  //     }
 
-      if (options && options.exit) {
-        search.kiosk = '1';
-      }
+  //     switch (search.kiosk) {
+  //       case 'tv': {
+  //         search.kiosk = true;
+  //         appEvents.emit(AppEvents.alertSuccess, ['Press ESC to exit Kiosk mode']);
+  //         break;
+  //       }
+  //       case '1':
+  //       case true: {
+  //         search.kiosk = null;
+  //         break;
+  //       }
+  //       default: {
+  //         search.kiosk = 'tv';
+  //       }
+  //     }
 
-      switch (search.kiosk) {
-        case 'tv': {
-          search.kiosk = true;
-          appEvents.emit(AppEvents.alertSuccess, ['Press ESC to exit Kiosk mode']);
-          break;
-        }
-        case '1':
-        case true: {
-          search.kiosk = null;
-          break;
-        }
-        default: {
-          search.kiosk = 'tv';
-        }
-      }
-
-      getLocationService().partial(search);
-      setViewModeBodyClass(search.kiosk!);
-    });
-  }
+  //     locationService.partial(search);
+  //     setViewModeBodyClass(search.kiosk!);
+  //   });
+  // }
 
   initEchoSrv() {
     setEchoSrv(new Echo({ debug: process.env.NODE_ENV === 'development' }));

--- a/public/app/core/AppWrapper.tsx
+++ b/public/app/core/AppWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Router, Route, Redirect, Switch } from 'react-router-dom';
 import angular from 'angular';
 import { each, extend } from 'lodash';
-import { config, getLocationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { Provider } from 'react-redux';
 import { store } from 'app/store/store';
 import { ErrorBoundaryAlert, ModalRoot, ModalsProvider } from '@grafana/ui';
@@ -113,7 +113,7 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
               <ModalsProvider>
                 <>
                   <div className="grafana-app">
-                    <Router history={getLocationService().getHistory()}>
+                    <Router history={locationService.getHistory()}>
                       <>
                         <SideMenu />
                         <div className="main-view">

--- a/public/app/core/navigation/bridgeReactAngularRouting.ts
+++ b/public/app/core/navigation/bridgeReactAngularRouting.ts
@@ -1,4 +1,4 @@
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { coreModule } from '../core';
 import { RouteProvider } from './patch/RouteProvider';
 import { RouteParamsProvider } from './patch/RouteParamsProvider';
@@ -18,7 +18,7 @@ const registerInterceptedLinkDirective = () => {
             $event.stopPropagation();
 
             // TODO: refactor to one method insted of chain
-            getLocationService().getHistory().push(elm.attr('href'));
+            locationService.getHistory().push(elm.attr('href'));
             return false;
           }
 
@@ -65,11 +65,11 @@ class AngularLocationWrapper {
     navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: path');
 
     if (pathname) {
-      getLocationService().push(pathname);
+      locationService.push(pathname);
       return this as any;
     }
 
-    return getLocationService().getCurrentLocation().pathname;
+    return locationService.getCurrentLocation().pathname;
   }
 
   port(): number {
@@ -85,6 +85,7 @@ class AngularLocationWrapper {
   }
 
   search(search?: any, paramValue?: any) {
+    navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: search');
     throw new Error('AngularLocationWrapper method not implemented.');
   }
 
@@ -96,10 +97,10 @@ class AngularLocationWrapper {
     navigationLogger('AngularLocationWrapper', false, 'Angular compat layer: url');
 
     if (newUrl) {
-      getLocationService().push(newUrl);
+      locationService.push(newUrl);
     }
 
-    return getLocationService().getCurrentLocation().pathname;
+    return locationService.getCurrentLocation().pathname;
   }
 }
 

--- a/public/app/core/navigation/patch/interceptLinkClicks.ts
+++ b/public/app/core/navigation/patch/interceptLinkClicks.ts
@@ -1,5 +1,5 @@
 import { navigationLogger } from '../utils';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export function interceptLinkClicks(e: MouseEvent) {
   const target = e.target as HTMLElement;
@@ -9,7 +9,7 @@ export function interceptLinkClicks(e: MouseEvent) {
     if (href) {
       navigationLogger('utils', false, 'intercepting link click', e);
       e.preventDefault();
-      getLocationService().push(href);
+      locationService.push(href);
     }
   }
 }

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -15,8 +15,6 @@ import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { SaveDashboardModalProxy } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
 // import { defaultQueryParams } from 'app/features/search/reducers/searchQueryReducer';
 import { ContextSrv } from './context_srv';
-import { getLocationService } from '@grafana/runtime';
-import { queryStringToJSON } from '../navigation/utils';
 
 export class KeybindingSrv {
   modalOpen = false;
@@ -112,7 +110,8 @@ export class KeybindingSrv {
       this.modalOpen = false;
       return;
     }
-    const search = queryStringToJSON(getLocationService().getCurrentLocation().search);
+
+    //const search = queryStringToJSON(getLocationService().getCurrentLocation().search);
     // close settings view
     // const search = this.$location.search();
     // if (search.editview) {
@@ -139,9 +138,9 @@ export class KeybindingSrv {
     //   return;
     // }
 
-    if (search.kiosk) {
-      this.$rootScope.appEvent(CoreEvents.toggleKioskMode, { exit: true });
-    }
+    // if (search.kiosk) {
+    //   this.$rootScope.appEvent(CoreEvents.toggleKioskMode, { exit: true });
+    // }
     //
     // if (search.search) {
     //   this.closeSearch();

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -16,7 +16,7 @@ import { DashboardModel } from '../../state';
 import { CoreEvents, StoreState } from 'app/types';
 import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { SaveDashboardModalProxy } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardModalProxy';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export interface OwnProps {
   dashboard: DashboardModel;
@@ -61,11 +61,11 @@ class DashNav extends PureComponent<Props> {
   }
 
   onFolderNameClick = () => {
-    getLocationService().partial({ search: 'open', folder: 'current' });
+    locationService.partial({ search: 'open', folder: 'current' });
   };
 
   onClose = () => {
-    getLocationService().partial({ viewPanel: null });
+    locationService.partial({ viewPanel: null });
   };
 
   onToggleTVMode = () => {
@@ -73,7 +73,7 @@ class DashNav extends PureComponent<Props> {
   };
 
   onOpenSettings = () => {
-    getLocationService().partial({ editview: 'settings' });
+    locationService.partial({ editview: 'settings' });
   };
 
   onStarDashboard = () => {
@@ -100,7 +100,7 @@ class DashNav extends PureComponent<Props> {
   };
 
   onDashboardNameClick = () => {
-    getLocationService().partial({ search: 'open' });
+    locationService.partial({ search: 'open' });
   };
 
   addCustomContent(actions: DashNavButtonModel[], buttons: ReactNode[]) {

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -15,7 +15,7 @@ import { LinksSettings } from './LinksSettings';
 import { VersionsSettings } from './VersionsSettings';
 import { JsonEditorSettings } from './JsonEditorSettings';
 import { GrafanaTheme } from '@grafana/data';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export interface Props {
   dashboard: DashboardModel;
@@ -31,11 +31,11 @@ export interface SettingsPage {
 
 export class DashboardSettings extends PureComponent<Props> {
   onClose = () => {
-    getLocationService().partial({ editview: null });
+    locationService.partial({ editview: null });
   };
 
   onChangePage = (editview: string) => {
-    getLocationService().partial({ editview });
+    locationService.partial({ editview });
   };
 
   getPages(): SettingsPage[] {

--- a/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { PanelPlugin } from '@grafana/data';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 import { StoreState } from 'app/types';
 import { GetDataOptions } from '../../../query/state/PanelQueryRunner';
@@ -36,7 +36,7 @@ const PanelInspectorUnconnected: React.FC<Props> = ({ panel, dashboard, defaultT
   const metaDs = useDatasourceMetadata(data);
   const tabs = useInspectTabs(plugin, dashboard, error, metaDs);
   const onClose = () => {
-    getLocationService().partial({
+    locationService.partial({
       inspect: null,
       inspectTab: null,
     });

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -47,7 +47,7 @@ import { CoreEvents, StoreState } from 'app/types';
 import { DisplayMode, displayModes, PanelEditorTab } from './types';
 import { DashboardModel, PanelModel } from '../../state';
 import { PanelOptionsChangedEvent } from 'app/types/events';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { UnlinkModal } from '../../../library-panels/components/UnlinkModal/UnlinkModal';
 import { SaveLibraryPanelModal } from 'app/features/library-panels/components/SaveLibraryPanelModal/SaveLibraryPanelModal';
 
@@ -114,14 +114,14 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   onDiscard = () => {
     this.props.setDiscardChanges(true);
 
-    getLocationService().partial({
+    locationService.partial({
       editPanel: null,
       tab: null,
     });
   };
 
   onOpenDashboardSettings = () => {
-    getLocationService().partial({
+    locationService.partial({
       editview: 'settings',
     });
   };

--- a/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
@@ -5,7 +5,7 @@ import { Button, VerticalGroup } from '@grafana/ui';
 
 import { Layout } from '@grafana/ui/src/components/Layout/Layout';
 import { PanelEditorTabId } from './types';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export interface Props {
   message: string;
@@ -15,7 +15,7 @@ export interface Props {
 export const PanelNotSupported: FC<Props> = ({ message, dispatch: propsDispatch }) => {
   const dispatch = propsDispatch ? propsDispatch : useDispatch();
   const onBackToQueries = useCallback(() => {
-    getLocationService().partial({ tab: PanelEditorTabId.Query });
+    locationService.partial({ tab: PanelEditorTabId.Query });
   }, [dispatch]);
 
   return (

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -14,7 +14,7 @@ import store from 'app/core/store';
 import pick from 'lodash/pick';
 import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return (dispatch) => {
@@ -47,7 +47,7 @@ export function exitPanelEditor(): ThunkResult<void> {
     const dashboard = getStore().dashboard.getModel();
     const { getPanel, getSourcePanel, shouldDiscardChanges } = getStore().panelEditor;
 
-    const onConfirm = () => getLocationService().partial({ editPanel: null, tab: null });
+    const onConfirm = () => locationService.partial({ editPanel: null, tab: null });
 
     const modifiedPanel = getPanel();
     const modifiedSaveModel = modifiedPanel.getSaveModel();

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -33,7 +33,7 @@ import { SubMenu } from '../components/SubMenu/SubMenu';
 import { cleanUpDashboardAndVariables } from '../state/actions';
 import { cancelVariables } from '../../variables/state/actions';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export interface Props {
   urlUid?: string;
@@ -183,7 +183,7 @@ export class DashboardPage extends PureComponent<Props, State> {
       // Panel not found
       this.props.notifyApp(createErrorNotification(`Panel with id ${urlPanelId} not found`));
       // Clear url state
-      getLocationService().partial({ editPanel: null, viewPanel: null });
+      locationService.partial({ editPanel: null, viewPanel: null });
       return;
     }
 
@@ -231,7 +231,7 @@ export class DashboardPage extends PureComponent<Props, State> {
   };
 
   cancelVariables = () => {
-    getLocationService().push('/');
+    locationService.push('/');
   };
 
   renderSlowInitState() {

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -4,7 +4,6 @@ import { initDashboard, InitDashboardArgs } from './initDashboard';
 import { DashboardInitPhase, DashboardRouteInfo } from 'app/types';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { dashboardInitCompleted, dashboardInitFetching, dashboardInitServices } from './reducers';
-import { updateLocation } from '../../../core/actions';
 import { locationService, setEchoSrv } from '@grafana/runtime';
 import { Echo } from '../../../core/services/echo/Echo';
 import { variableAdapters } from 'app/features/variables/adapters';

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -5,7 +5,7 @@ import { DashboardInitPhase, DashboardRouteInfo } from 'app/types';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { dashboardInitCompleted, dashboardInitFetching, dashboardInitServices } from './reducers';
 import { updateLocation } from '../../../core/actions';
-import { setEchoSrv } from '@grafana/runtime';
+import { locationService, setEchoSrv } from '@grafana/runtime';
 import { Echo } from '../../../core/services/echo/Echo';
 import { variableAdapters } from 'app/features/variables/adapters';
 import { createConstantVariableAdapter } from 'app/features/variables/constant/adapter';
@@ -179,13 +179,13 @@ describeInitScenario('Initializing new dashboard', (ctx) => {
   });
 
   it('Should update location with orgId query param', () => {
-    expect(ctx.actions[2].type).toBe(updateLocation.type);
-    expect(ctx.actions[2].payload.query.orgId).toBe(12);
+    const search = locationService.getSearch();
+    expect(search.get('orgId')).toBe('12');
   });
 
   it('Should send action dashboardInitCompleted', () => {
-    expect(ctx.actions[8].type).toBe(dashboardInitCompleted.type);
-    expect(ctx.actions[8].payload.title).toBe('New dashboard');
+    expect(ctx.actions[7].type).toBe(dashboardInitCompleted.type);
+    expect(ctx.actions[7].payload.title).toBe('New dashboard');
   });
 
   it('Should initialize services', () => {
@@ -206,8 +206,8 @@ describeInitScenario('Initializing home dashboard', (ctx) => {
   });
 
   it('Should redirect to custom home dashboard', () => {
-    expect(ctx.actions[1].type).toBe(updateLocation.type);
-    expect(ctx.actions[1].payload.path).toBe('/u/123/my-home');
+    const location = locationService.getCurrentLocation();
+    expect(location.pathname).toBe('/u/123/my-home');
   });
 });
 
@@ -252,13 +252,13 @@ describeInitScenario('Initializing existing dashboard', (ctx) => {
   });
 
   it('Should update location with orgId query param', () => {
-    expect(ctx.actions[2].type).toBe(updateLocation.type);
-    expect(ctx.actions[2].payload.query.orgId).toBe(12);
+    const search = locationService.getSearch();
+    expect(search.get('orgId')).toBe('12');
   });
 
   it('Should send action dashboardInitCompleted', () => {
-    expect(ctx.actions[9].type).toBe(dashboardInitCompleted.type);
-    expect(ctx.actions[9].payload.title).toBe('My cool dashboard');
+    expect(ctx.actions[8].type).toBe(dashboardInitCompleted.type);
+    expect(ctx.actions[8].payload.title).toBe('My cool dashboard');
   });
 
   it('Should initialize services', () => {
@@ -270,7 +270,7 @@ describeInitScenario('Initializing existing dashboard', (ctx) => {
   });
 
   it('Should initialize redux variables if newVariables is enabled', () => {
-    expect(ctx.actions[3].type).toBe(variablesInitTransaction.type);
+    expect(ctx.actions[2].type).toBe(variablesInitTransaction.type);
   });
 });
 

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -30,7 +30,7 @@ import { DataQuery, locationUtil } from '@grafana/data';
 import { initVariablesTransaction } from '../../variables/state/actions';
 import { emitDashboardViewEvent } from './analyticsProcessor';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
-import { getLocationService } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export interface InitDashboardArgs {
   $injector: any;
@@ -55,7 +55,7 @@ async function redirectToNewUrl(slug: string, dispatch: ThunkDispatch, currentPa
     }
 
     const url = locationUtil.stripBaseFromUrl(newUrl);
-    getLocationService().replace(url);
+    locationService.replace(url);
   }
 }
 
@@ -73,7 +73,7 @@ async function fetchDashboard(
         // if user specified a custom home dashboard redirect to that
         if (dashDTO.redirectUri) {
           const newUrl = locationUtil.stripBaseFromUrl(dashDTO.redirectUri);
-          getLocationService().replace(newUrl);
+          locationService.replace(newUrl);
           return null;
         }
 
@@ -99,8 +99,7 @@ async function fetchDashboard(
           const currentPath = getState().location.path;
 
           if (dashboardUrl !== currentPath) {
-            // replace url to not create additional history items and then return so that initDashboard below isn't executed multiple times.
-            getLocationService().replace(dashboardUrl);
+            locationService.replace(dashboardUrl);
             return null;
           }
         }
@@ -171,7 +170,7 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
     const storeState = getState();
     if (!storeState.location.query.orgId) {
       // TODO this is currently not possible with the LocationService API
-      getLocationService().partial({ orgId: storeState.user.orgId }, true);
+      locationService.partial({ orgId: storeState.user.orgId }, true);
     }
 
     // init services

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,5 +1,5 @@
 import { store } from 'app/store/store';
-import { AngularComponent, getDataSourceSrv, getLocationService } from '@grafana/runtime';
+import { AngularComponent, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { PanelMenuItem } from '@grafana/data';
 import { copyPanel, duplicatePanel, removePanel, sharePanel } from 'app/features/dashboard/utils/panel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -18,14 +18,14 @@ export function getPanelMenu(
 ): PanelMenuItem[] {
   const onViewPanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
-    getLocationService().partial({
+    locationService.partial({
       viewPanel: panel.id,
     });
   };
 
   const onEditPanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
-    getLocationService().partial({
+    locationService.partial({
       editPanel: panel.id,
     });
   };
@@ -36,7 +36,7 @@ export function getPanelMenu(
   };
 
   const onInspectPanel = (tab?: string) => {
-    getLocationService().partial({
+    locationService.partial({
       inspect: panel.id,
       inspectTab: tab,
     });

--- a/public/app/routes/GrafanaCtrl.ts
+++ b/public/app/routes/GrafanaCtrl.ts
@@ -10,7 +10,7 @@ import {
   setDataSourceSrv,
   setLegacyAngularInjector,
   setLocationSrv,
-  getLocationService,
+  locationService,
 } from '@grafana/runtime';
 import config from 'app/core/config';
 import coreModule from 'app/core/core_module';
@@ -71,7 +71,7 @@ export class GrafanaCtrl {
       buildParamsFromVariables: getTemplateSrv().fillVariableValuesForUrl,
     });
 
-    setLocationSrv(getLocationService());
+    setLocationSrv(locationService);
 
     // Initialize websocket event streaming
     if (config.featureToggles.live) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14802,7 +14802,7 @@ highlight.js@^10.1.1, highlight.js@~10.5.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.5.0.tgz#3f09fede6a865757378f2d9ebdcbc15ba268f98f"
   integrity sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==
 
-history@^4.9.0:
+history@4.10.1, history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==


### PR DESCRIPTION
The getXXService functions are not really needed, we get the exact same thing with a package const  (we can add a function that update's it if we need to). 

This moves the implementation to the runtime so this it becomes a bit easier to use for external plugins as well (in tests etc, without mocking). And this now becomes cleaner to use in components as well, and becomes easily testable as it automatically switches to a in-memory history for tests. 

Comments out the kiosk stuff, think we can solve that without events and outside the LocationSevice (ie the body class stuff) 