### PR TITLE
Add min time interval in opentsdb plugin

### DIFF
--- a/docs/sources/datasources/opentsdb.md
+++ b/docs/sources/datasources/opentsdb.md
@@ -28,7 +28,7 @@ To access OpenTSDB settings, hover your mouse over the **Configuration** (gear) 
 - Min time interval
 
 A lower limit for the auto group by time interval. Recommended to be set to write frequency, for example `1m` if your data is written every minute.
-This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value **needs** to be formatted as a
+This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value _must_ be formatted as a
 number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 seconds). The following time identifiers are supported:
 
 | Identifier | Description |

--- a/docs/sources/datasources/opentsdb.md
+++ b/docs/sources/datasources/opentsdb.md
@@ -25,7 +25,6 @@ To access OpenTSDB settings, hover your mouse over the **Configuration** (gear) 
 | `Lookup Limit`| Default is 1000.                                                                                                                     |
 | `Min time interval`| Explained below.                                                                                                                     |
 
-- Min time interval
 
 A lower limit for the auto group by time interval. Recommended to be set to write frequency, for example `1m` if your data is written every minute.
 This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value _must_ be formatted as a

--- a/docs/sources/datasources/opentsdb.md
+++ b/docs/sources/datasources/opentsdb.md
@@ -23,23 +23,22 @@ To access OpenTSDB settings, hover your mouse over the **Configuration** (gear) 
 | `Version`    | Version = opentsdb version, either <=2.1 or 2.2                                                                                       |
 | `Resolution` | Metrics from opentsdb may have datapoints with either second or millisecond resolution.                                               |
 | `Lookup Limit`| Default is 1000.                                                                                                                     |
-| `Min time interval`| Explained below.                                                                                                                     |
+| `Min time interval`| A lower limit for the auto group by time interval. Recommended to be set to write frequency, for example `1m` if your data is written every minute. This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value _must_ be formatted as a number followed by a [valid time identifier](#Supported min time identifiers), e.g. `1m` (1 minute) or `30s` (30 seconds). |
 
+### Supported min time identifiers
 
-A lower limit for the auto group by time interval. Recommended to be set to write frequency, for example `1m` if your data is written every minute.
-This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value _must_ be formatted as a
-number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 seconds). The following time identifiers are supported:
+The following time identifiers are supported:
 
 | Identifier | Description |
 | ---------- | ----------- |
-| `y`        | year        |
-| `M`        | month       |
-| `w`        | week        |
-| `d`        | day         |
-| `h`        | hour        |
-| `m`        | minute      |
-| `s`        | second      |
-| `ms`       | millisecond |
+| `y`        | Years (365 days)|
+| `n`        | Months (30 days)|
+| `w`        | Weeks (7 days)|
+| `d`        | Days (24 hours)|
+| `h`        | Hours        |
+| `m`        | Minutes      |
+| `s`        | Seconds      |
+| `ms`       | Milliseconds |
 
 ## Query editor
 

--- a/docs/sources/datasources/opentsdb.md
+++ b/docs/sources/datasources/opentsdb.md
@@ -23,6 +23,24 @@ To access OpenTSDB settings, hover your mouse over the **Configuration** (gear) 
 | `Version`    | Version = opentsdb version, either <=2.1 or 2.2                                                                                       |
 | `Resolution` | Metrics from opentsdb may have datapoints with either second or millisecond resolution.                                               |
 | `Lookup Limit`| Default is 1000.                                                                                                                     |
+| `Min time interval`| Explained below.                                                                                                                     |
+
+- Min time interval
+
+A lower limit for the auto group by time interval. Recommended to be set to write frequency, for example `1m` if your data is written every minute.
+This option can also be overridden/configured in a dashboard panel under data source options. It's important to note that this value **needs** to be formatted as a
+number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 seconds). The following time identifiers are supported:
+
+| Identifier | Description |
+| ---------- | ----------- |
+| `y`        | year        |
+| `M`        | month       |
+| `w`        | week        |
+| `d`        | day         |
+| `h`        | hour        |
+| `m`        | minute      |
+| `s`        | second      |
+| `ms`       | millisecond |
 
 ## Query editor
 

--- a/public/app/plugins/datasource/opentsdb/components/OpenTsdbDetails.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/OpenTsdbDetails.tsx
@@ -1,6 +1,6 @@
 import React, { SyntheticEvent } from 'react';
-import { InlineFormLabel, LegacyForms } from '@grafana/ui';
-const { Select, Input } = LegacyForms;
+import { EventsWithValidation, regexValidation, InlineFormLabel, LegacyForms } from '@grafana/ui';
+const { Select, Input, FormField } = LegacyForms;
 import { DataSourceSettings, SelectableValue } from '@grafana/data';
 import { OpenTsdbOptions } from '../types';
 
@@ -52,6 +52,30 @@ export const OpenTsdbDetails = (props: Props) => {
           value={value.jsonData.lookupLimit ?? 1000}
           onChange={onInputChangeHandler('lookupLimit', value, onChange)}
         />
+      </div>
+      <div className="gf-form-inline">
+        <div className="gf-form">
+          <FormField
+            labelWidth={7}
+            label="Min time interval"
+            inputEl={
+              <Input
+                className={'width-6'}
+                value={value.jsonData.interval || ''}
+                onChange={onInputChangeHandler('interval', value, onChange)}
+                placeholder="1m"
+                validationEvents={{
+                  [EventsWithValidation.onBlur]: [
+                    regexValidation(
+                      /^\d+(ms|[Mwdhmsy])$/,
+                      'Value is not valid, you can use number with time unit specifier: y, M, w, d, h, m, s'
+                    ),
+                  ],
+                }}
+              />
+            }
+          />
+        </div>
       </div>
     </>
   );

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -24,6 +24,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
   tsdbVersion: any;
   tsdbResolution: any;
   lookupLimit: any;
+  interval: any;
   tagKeys: any;
 
   aggregatorsPromise: any;
@@ -40,6 +41,7 @@ export default class OpenTsDatasource extends DataSourceApi<OpenTsdbQuery, OpenT
     this.tsdbVersion = instanceSettings.jsonData.tsdbVersion || 1;
     this.tsdbResolution = instanceSettings.jsonData.tsdbResolution || 1;
     this.lookupLimit = instanceSettings.jsonData.lookupLimit || 1000;
+    this.interval = instanceSettings.jsonData.interval || '30s';
     this.tagKeys = {};
 
     this.aggregatorsPromise = null;

--- a/public/app/plugins/datasource/opentsdb/types.ts
+++ b/public/app/plugins/datasource/opentsdb/types.ts
@@ -8,4 +8,5 @@ export interface OpenTsdbOptions extends DataSourceJsonData {
   tsdbVersion: number;
   tsdbResolution: number;
   lookupLimit: number;
+  interval: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add min time interval in Opentsdb plugin. It will make it easy to set the min time interval in the opentsdb dashBoard rather than set the min time interval in every panel.

**Which issue(s) this PR fixes**:

Fixes #31533 

**Special notes for your reviewer**:

