### PR TITLE
Usage Stats: Report usage for all signed plugins

### DIFF
--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -94,7 +94,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	// as sending that name could be sensitive information
 	dsOtherCount := 0
 	for _, dsStat := range dsStats.Result {
-		if models.IsKnownDataSourcePlugin(dsStat.Type) {
+		if uss.shouldBeReported(dsStat.Type) {
 			metrics["stats.ds."+dsStat.Type+".count"] = dsStat.Count
 		} else {
 			dsOtherCount += dsStat.Count
@@ -118,7 +118,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 
 	alertingOtherCount := 0
 	for dsType, usageCount := range alertingUsageStats.DatasourceUsage {
-		if models.IsKnownDataSourcePlugin(dsType) {
+		if uss.shouldBeReported(dsType) {
 			addAlertingUsageStats(dsType, usageCount)
 		} else {
 			alertingOtherCount += usageCount
@@ -145,7 +145,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 
 		access := strings.ToLower(dsAccessStat.Access)
 
-		if models.IsKnownDataSourcePlugin(dsAccessStat.Type) {
+		if uss.shouldBeReported(dsAccessStat.Type) {
 			metrics["stats.ds_access."+dsAccessStat.Type+"."+access+".count"] = dsAccessStat.Count
 		} else {
 			old := dsAccessOtherCount[access]
@@ -288,6 +288,15 @@ func (uss *UsageStatsService) updateTotalStats() {
 	for _, dsStat := range dsStats.Result {
 		metrics.StatsTotalDataSources.WithLabelValues(dsStat.Type).Set(float64(dsStat.Count))
 	}
+}
+
+func (uss *UsageStatsService) shouldBeReported(dsType string) bool {
+	ds, ok := plugins.DataSources[dsType]
+	if !ok {
+		return false
+	}
+
+	return ds.Signature.IsValid() || ds.Signature.IsInternal()
 }
 
 func getEdition() string {

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -39,6 +39,8 @@ func Test_InterfaceContractValidity(t *testing.T) {
 
 func TestMetrics(t *testing.T) {
 	t.Run("When sending usage stats", func(t *testing.T) {
+		setupSomeDataSourcePlugins(t)
+
 		uss := &UsageStatsService{
 			Bus:      bus.New(),
 			SQLStore: sqlstore.InitTestDB(t),
@@ -525,4 +527,41 @@ func (aum *alertingUsageMock) QueryUsageStats() (*alerting.UsageStats, error) {
 			"unknown-datasource": 90,
 		},
 	}, nil
+}
+
+func setupSomeDataSourcePlugins(t *testing.T) {
+	plugins.DataSources = make(map[string]*plugins.DataSourcePlugin)
+
+	plugins.DataSources[models.DS_ES] = &plugins.DataSourcePlugin{
+		FrontendPluginBase: plugins.FrontendPluginBase{
+			PluginBase: plugins.PluginBase{
+				Signature: "internal",
+			},
+		},
+	}
+	plugins.DataSources[models.DS_PROMETHEUS] = &plugins.DataSourcePlugin{
+		FrontendPluginBase: plugins.FrontendPluginBase{
+			PluginBase: plugins.PluginBase{
+				Signature: "internal",
+			},
+		},
+	}
+
+	plugins.DataSources[models.DS_GRAPHITE] = &plugins.DataSourcePlugin{
+		FrontendPluginBase: plugins.FrontendPluginBase{
+			PluginBase: plugins.PluginBase{
+				Signature: "internal",
+			},
+		},
+	}
+
+	plugins.DataSources[models.DS_MYSQL] = &plugins.DataSourcePlugin{
+		FrontendPluginBase: plugins.FrontendPluginBase{
+			PluginBase: plugins.PluginBase{
+				Signature: "internal",
+			},
+		},
+	}
+
+	t.Cleanup(func() { plugins.DataSources = nil })
 }

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -530,6 +530,9 @@ func (aum *alertingUsageMock) QueryUsageStats() (*alerting.UsageStats, error) {
 }
 
 func setupSomeDataSourcePlugins(t *testing.T) {
+	originalDataSources := plugins.DataSources
+	t.Cleanup(func() { plugins.DataSources = originalDataSources })
+
 	plugins.DataSources = make(map[string]*plugins.DataSourcePlugin)
 
 	plugins.DataSources[models.DS_ES] = &plugins.DataSourcePlugin{
@@ -562,6 +565,4 @@ func setupSomeDataSourcePlugins(t *testing.T) {
 			},
 		},
 	}
-
-	t.Cleanup(func() { plugins.DataSources = nil })
 }

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -14,6 +14,7 @@ const (
 	DS_INFLUXDB_08    = "influxdb_08"
 	DS_ES             = "elasticsearch"
 	DS_PROMETHEUS     = "prometheus"
+	DS_MYSQL          = "mysql"
 	DS_ACCESS_DIRECT  = "direct"
 	DS_ACCESS_PROXY   = "proxy"
 	DS_ES_OPEN_DISTRO = "grafana-es-open-distro-datasource"

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -9,25 +9,14 @@ import (
 )
 
 const (
-	DS_GRAPHITE      = "graphite"
-	DS_INFLUXDB      = "influxdb"
-	DS_INFLUXDB_08   = "influxdb_08"
-	DS_ES            = "elasticsearch"
-	DS_OPENTSDB      = "opentsdb"
-	DS_CLOUDWATCH    = "cloudwatch"
-	DS_KAIROSDB      = "kairosdb"
-	DS_PROMETHEUS    = "prometheus"
-	DS_POSTGRES      = "postgres"
-	DS_MYSQL         = "mysql"
-	DS_MSSQL         = "mssql"
-	DS_ACCESS_DIRECT = "direct"
-	DS_ACCESS_PROXY  = "proxy"
-	// Stackdriver was renamed Google Cloud monitoring 2020-05 but we keep
-	// "stackdriver" to avoid breaking changes in reporting.
-	DS_CLOUD_MONITORING = "stackdriver"
-	DS_AZURE_MONITOR    = "grafana-azure-monitor-datasource"
-	DS_LOKI             = "loki"
-	DS_ES_OPEN_DISTRO   = "grafana-es-open-distro-datasource"
+	DS_GRAPHITE       = "graphite"
+	DS_INFLUXDB       = "influxdb"
+	DS_INFLUXDB_08    = "influxdb_08"
+	DS_ES             = "elasticsearch"
+	DS_PROMETHEUS     = "prometheus"
+	DS_ACCESS_DIRECT  = "direct"
+	DS_ACCESS_PROXY   = "proxy"
+	DS_ES_OPEN_DISTRO = "grafana-es-open-distro-datasource"
 )
 
 var (
@@ -87,50 +76,6 @@ func (ds *DataSource) decryptedValue(field string, fallback string) string {
 		return value
 	}
 	return fallback
-}
-
-var knownDatasourcePlugins = map[string]bool{
-	DS_ES:                                    true,
-	DS_GRAPHITE:                              true,
-	DS_INFLUXDB:                              true,
-	DS_INFLUXDB_08:                           true,
-	DS_KAIROSDB:                              true,
-	DS_CLOUDWATCH:                            true,
-	DS_PROMETHEUS:                            true,
-	DS_OPENTSDB:                              true,
-	DS_POSTGRES:                              true,
-	DS_MYSQL:                                 true,
-	DS_MSSQL:                                 true,
-	DS_CLOUD_MONITORING:                      true,
-	DS_AZURE_MONITOR:                         true,
-	DS_LOKI:                                  true,
-	"opennms":                                true,
-	"abhisant-druid-datasource":              true,
-	"dalmatinerdb-datasource":                true,
-	"gnocci":                                 true,
-	"zabbix":                                 true,
-	"newrelic-app":                           true,
-	"grafana-datadog-datasource":             true,
-	"grafana-simple-json":                    true,
-	"grafana-splunk-datasource":              true,
-	"udoprog-heroic-datasource":              true,
-	"grafana-openfalcon-datasource":          true,
-	"opennms-datasource":                     true,
-	"rackerlabs-blueflood-datasource":        true,
-	"crate-datasource":                       true,
-	"ayoungprogrammer-finance-datasource":    true,
-	"monasca-datasource":                     true,
-	"vertamedia-clickhouse-datasource":       true,
-	"alexanderzobnin-zabbix-datasource":      true,
-	"grafana-influxdb-flux-datasource":       true,
-	"doitintl-bigquery-datasource":           true,
-	"grafana-azure-data-explorer-datasource": true,
-	"tempo":                                  true,
-}
-
-func IsKnownDataSourcePlugin(dsType string) bool {
-	_, exists := knownDatasourcePlugins[dsType]
-	return exists
 }
 
 // ----------------------

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -29,6 +29,14 @@ type PluginSignatureState struct {
 
 type PluginSignatureStatus string
 
+func (pss PluginSignatureStatus) IsValid() bool {
+	return pss == pluginSignatureValid
+}
+
+func (pss PluginSignatureStatus) IsInternal() bool {
+	return pss == pluginSignatureInternal
+}
+
 const (
 	pluginSignatureInternal PluginSignatureStatus = "internal" // core plugin, no signature
 	pluginSignatureValid    PluginSignatureStatus = "valid"    // signed and accurate MANIFEST


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to no longer have to maintain a static map of "known" data sources (for which their usage is being reported), we decided to just check whether the plugin is signed or not because we can assume we "know" every signed plugin.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related with https://github.com/grafana/grafana-enterprise/issues/1113

**Special notes for your reviewer**:

- Replaced the `IsKnownDataSourcePlugin` by `shouldBeReported` as the condition to determine if we send specific usage stats for a given data source.
- So, instead of maintaining a static map of "known" data sources, now we only check whether the data source is signed or not.
- Is `"we decided to just check whether the plugin is signed or not because we can assume we "know" every signed plugin."` correct? Or am I missing something? 🤔 
- I left some comments inline. So, can you please take a look and leave some feedback? Thanks! 🙏🏻 