### PR TITLE
PieChart: Update text color and minor changes

### DIFF
--- a/devenv/dev-dashboards/panel-piechart/panel_test_piechart.json
+++ b/devenv/dev-dashboards/panel-piechart/panel_test_piechart.json
@@ -55,14 +55,9 @@
       "options": {
         "displayLabels": [
           "name"
-        ],
-        "labelOptions": {
-          "showName": true,
-          "showPercent": false,
-          "showValue": false
-        },
+        ],        
         "legend": {
-          "displayColumns": [],
+          "values": [],
           "displayMode": "list",
           "placement": "right"
         },
@@ -130,14 +125,9 @@
         "displayLabels": [
           "name",
           "percent"
-        ],
-        "labelOptions": {
-          "showName": true,
-          "showPercent": true,
-          "showValue": false
-        },
+        ],        
         "legend": {
-          "displayColumns": [
+          "values": [
             "percent"
           ],
           "displayMode": "list",
@@ -204,14 +194,9 @@
       "options": {
         "displayLabels": [
           "name"
-        ],
-        "labelOptions": {
-          "showName": true,
-          "showPercent": false,
-          "showValue": false
-        },
+        ],        
         "legend": {
-          "displayColumns": [],
+          "values": [],
           "displayMode": "hidden",
           "placement": "right"
         },
@@ -276,14 +261,9 @@
       "options": {
         "displayLabels": [
           "percent"
-        ],
-        "labelOptions": {
-          "showName": false,
-          "showPercent": true,
-          "showValue": false
-        },
+        ],      
         "legend": {
-          "displayColumns": [
+          "values": [
             "percent"
           ],
           "displayMode": "table",
@@ -350,14 +330,9 @@
       "options": {
         "displayLabels": [
           "value"
-        ],
-        "labelOptions": {
-          "showName": false,
-          "showPercent": false,
-          "showValue": true
-        },
+        ],        
         "legend": {
-          "displayColumns": [
+          "values": [
             "value"
           ],
           "displayMode": "table",
@@ -424,14 +399,9 @@
       "options": {
         "displayLabels": [
           "name"
-        ],
-        "labelOptions": {
-          "showName": true,
-          "showPercent": false,
-          "showValue": false
-        },
+        ],        
         "legend": {
-          "displayColumns": [],
+          "values": [],
           "displayMode": "list",
           "placement": "bottom"
         },
@@ -494,14 +464,9 @@
       },
       "id": 10,
       "options": {
-        "displayLabels": [],
-        "labelOptions": {
-          "showName": true,
-          "showPercent": false,
-          "showValue": false
-        },
+        "displayLabels": [],        
         "legend": {
-          "displayColumns": ["percent", "value"],
+          "values": ["percent", "value"],
           "displayMode": "table",
           "placement": "bottom"
         },

--- a/packages/grafana-ui/src/components/PieChart/PieChart.tsx
+++ b/packages/grafana-ui/src/components/PieChart/PieChart.tsx
@@ -19,7 +19,7 @@ export enum PieChartLabels {
   Percent = 'percent',
 }
 
-export enum LegendColumns {
+export enum PieChartLegendValues {
   Value = 'value',
   Percent = 'percent',
 }
@@ -42,14 +42,14 @@ export enum PieChartType {
 }
 
 export interface PieChartLegendOptions extends VizLegendOptions {
-  displayColumns: LegendColumns[];
+  values: PieChartLegendValues[];
 }
 
 const defaultLegendOptions: PieChartLegendOptions = {
   displayMode: LegendDisplayMode.List,
   placement: 'right',
   calcs: [],
-  displayColumns: [LegendColumns.Percent],
+  values: [PieChartLegendValues.Percent],
 };
 
 export const PieChart: FC<Props> = ({ values, legendOptions = defaultLegendOptions, width, height, ...restProps }) => {
@@ -65,20 +65,22 @@ export const PieChart: FC<Props> = ({ values, legendOptions = defaultLegendOptio
         color: value.color ?? FALLBACK_COLOR,
         yAxis: 1,
         getDisplayValues: () => {
+          const valuesToShow = legendOptions.values;
           let displayValues = [];
 
-          if (legendOptions.displayColumns.includes(LegendColumns.Value)) {
+          if (valuesToShow.includes(PieChartLegendValues.Value)) {
             displayValues.push({ numeric: value.numeric, text: formattedValueToString(value), title: 'Value' });
           }
 
-          if (legendOptions.displayColumns.includes(LegendColumns.Percent)) {
+          if (valuesToShow.includes(PieChartLegendValues.Percent)) {
             const fractionOfTotal = value.numeric / total;
             const percentOfTotal = fractionOfTotal * 100;
+
             displayValues.push({
               numeric: fractionOfTotal,
               percent: percentOfTotal,
               text: percentOfTotal.toFixed(0) + '%',
-              title: 'Percent',
+              title: valuesToShow.length > 1 ? 'Percent' : undefined,
             });
           }
 
@@ -192,6 +194,7 @@ export const PieChartSvg: FC<SvgProps> = ({
                         innerRadius={layout.innerRadius}
                         displayLabels={displayLabels}
                         total={total}
+                        color={theme.colors.text}
                       />
                     )}
                   </g>
@@ -216,7 +219,8 @@ const PieLabel: FC<{
   innerRadius: number;
   displayLabels: PieChartLabels[];
   total: number;
-}> = ({ arc, outerRadius, innerRadius, displayLabels, total }) => {
+  color: string;
+}> = ({ arc, outerRadius, innerRadius, displayLabels, total, color }) => {
   const labelRadius = innerRadius === 0 ? outerRadius / 6 : innerRadius;
   const [labelX, labelY] = getLabelPos(arc, outerRadius, labelRadius);
   const hasSpaceForLabel = arc.endAngle - arc.startAngle >= 0.3;
@@ -232,7 +236,7 @@ const PieLabel: FC<{
   return (
     <g>
       <text
-        fill="white"
+        fill={color}
         x={labelX}
         y={labelY}
         dy=".33em"

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -17,7 +17,13 @@ export { LoadingPlaceholder, LoadingPlaceholderProps } from './LoadingPlaceholde
 export { ColorPicker, SeriesColorPicker } from './ColorPicker/ColorPicker';
 export { SeriesColorPickerPopover, SeriesColorPickerPopoverWithTheme } from './ColorPicker/SeriesColorPickerPopover';
 export { EmptySearchResult } from './EmptySearchResult/EmptySearchResult';
-export { PieChart, PieChartType, PieChartLabels, PieChartLegendOptions } from './PieChart/PieChart';
+export {
+  PieChart,
+  PieChartType,
+  PieChartLabels,
+  PieChartLegendOptions,
+  PieChartLegendValues,
+} from './PieChart/PieChart';
 export { UnitPicker } from './UnitPicker/UnitPicker';
 export { StatsPicker } from './StatsPicker/StatsPicker';
 export { RefreshPicker, defaultIntervals } from './RefreshPicker/RefreshPicker';

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -2,8 +2,7 @@ import { FieldColorModeId, FieldConfigProperty, PanelPlugin } from '@grafana/dat
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions } from './types';
 import { addStandardDataReduceOptions } from '../stat/types';
-import { LegendDisplayMode, PieChartType } from '@grafana/ui';
-import { LegendColumns, PieChartLabels } from '@grafana/ui/src/components/PieChart/PieChart';
+import { LegendDisplayMode, PieChartType, PieChartLabels, PieChartLegendValues } from '@grafana/ui';
 
 export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
   .useFieldConfig({
@@ -76,11 +75,11 @@ export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
       })
       .addMultiSelect({
         name: 'Legend values',
-        path: 'legend.displayColumns',
+        path: 'legend.values',
         settings: {
           options: [
-            { value: LegendColumns.Percent, label: 'Percent' },
-            { value: LegendColumns.Value, label: 'Value' },
+            { value: PieChartLegendValues.Percent, label: 'Percent' },
+            { value: PieChartLegendValues.Value, label: 'Value' },
           ],
         },
         showIf: (c) => c.legend.displayMode !== LegendDisplayMode.Hidden,


### PR DESCRIPTION
* Updates text color to use theme text color (was a bit to light backgrounds for white text on white theme)
* Renamed persisted option model legend.displayColumns to just legend.values
* Changed legend generation so when only Percent is shown no value title is rendered (cleaner legend when only showing percent)
