### PR TITLE
Explore: keep enabled/disabled state in angular based QueryEditors correctly

### DIFF
--- a/public/app/features/explore/QueryEditor.tsx
+++ b/public/app/features/explore/QueryEditor.tsx
@@ -34,9 +34,6 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
     const loader = getAngularLoader();
     const template = '<plugin-component type="query-ctrl"> </plugin-component>';
     const target = { datasource: datasource.name, ...initialQuery };
-
-    const me = this;
-
     const scopeProps = {
       ctrl: {
         datasource,
@@ -46,8 +43,8 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
             // the "hide" attribute of the quries can be changed from the "outside",
             // it will be applied to "this.props.initialQuery.hide", but not to "target.hide".
             // so we have to apply it.
-            if (target.hide !== me.props.initialQuery.hide) {
-              target.hide = me.props.initialQuery.hide;
+            if (target.hide !== this.props.initialQuery.hide) {
+              target.hide = this.props.initialQuery.hide;
             }
             this.props.onQueryChange?.(target);
             this.props.onExecuteQuery?.();

--- a/public/app/features/explore/QueryEditor.tsx
+++ b/public/app/features/explore/QueryEditor.tsx
@@ -34,12 +34,21 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
     const loader = getAngularLoader();
     const template = '<plugin-component type="query-ctrl"> </plugin-component>';
     const target = { datasource: datasource.name, ...initialQuery };
+
+    const me = this;
+
     const scopeProps = {
       ctrl: {
         datasource,
         target,
         refresh: () => {
           setTimeout(() => {
+            // the "hide" attribute of the quries can be changed from the "outside",
+            // it will be applied to "this.props.initialQuery.hide", but not to "target.hide".
+            // so we have to apply it.
+            if (target.hide !== me.props.initialQuery.hide) {
+              target.hide = me.props.initialQuery.hide;
+            }
             this.props.onQueryChange?.(target);
             this.props.onExecuteQuery?.();
           }, 1);


### PR DESCRIPTION
try this in an angular-based query-editor in explore, like influxdb or postgres:

- disable the editor
- adjust a value in the editor

suddenly the editor becomes enabled again.

the reason is that the angular-based editors operate on the version of the query as it was when the component was mounted at the beginning. later changes to the query gets reflected in the props of react-based components, but not in the data given to angular-based components. this becomes a problem, because later, when an angular-based component applies new changes using "refresh", it overwrites changes that happened to the query "from the outside". 

i fixed the same problem in dashboards in https://github.com/grafana/grafana/pull/31336 , it seems there is some duplicated code when the angular-query-editors are handled.

tested with influxdb1 and postgres.