### PR TITLE
test: pass Cypress options objects into selector wrappers

### DIFF
--- a/packages/grafana-e2e/src/support/types.ts
+++ b/packages/grafana-e2e/src/support/types.ts
@@ -69,21 +69,38 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
 
     if (typeof value === 'function') {
       // @ts-ignore
-      e2eObjects[key] = (textOrOptions?: string | CypressOptions, options?: CypressOptions) => {
-        // set the selector to default if we are seeing () => or (options) =>
-        let selector = value((undefined as unknown) as string);
+      e2eObjects[key] = function (textOrOptions?: string | CypressOptions, options?: CypressOptions) {
+        // the input can only be ()
+        if (arguments.length === 0) {
+          const selector = value((undefined as unknown) as string);
 
-        // if (text) => or (text, options) => then we want to update the selector
-        if (typeof textOrOptions === 'string') {
-          const ariaText = value(textOrOptions);
-          selector = Selector.fromAriaLabel(ariaText);
-        } else {
-          // textOrOptions is the options passed in so overwrite the options param
-          options = textOrOptions;
+          logOutput(selector);
+          return e2e().get(selector);
         }
 
-        logOutput(selector);
-        return e2e().get(selector, options);
+        // the input can be (text) or (options)
+        if (arguments.length === 1) {
+          if (typeof textOrOptions === 'string') {
+            const ariaText = value(textOrOptions);
+            const selector = Selector.fromAriaLabel(ariaText);
+
+            logOutput(selector);
+            return e2e().get(selector);
+          }
+          const selector = value((undefined as unknown) as string);
+
+          logOutput(selector);
+          return e2e().get(selector, textOrOptions);
+        }
+
+        // the input can only be (text, options)
+        if (arguments.length === 2) {
+          const ariaText = value(textOrOptions as string);
+          const selector = Selector.fromAriaLabel(ariaText);
+
+          logOutput(selector);
+          return e2e().get(selector, options);
+        }
       };
 
       continue;


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we have wrappers for our selectors for our e2e tests which wrap around Cypress's `.get()`: https://docs.cypress.io/api/commands/get.html#Syntax

However, our wrappers do not pass down any options we may want (which Cypress's `.get()` supports) - e.g. if we want to increase the timeout for one individual select - see discussion regarding this in a [previous PR](https://github.com/grafana/grafana/pull/30644#discussion_r566269322).

If we want to pass in options at the moment, we would need to do this without the wrappers e.g.

```
e2e().get(selector, options)
```

in our tests, but it would be nice to be able to use our wrappers for consistency.

**Proposed example usages:**

For selectors where they are functions which accept text inputs:
```
// Definition
item: (tooltip: string) => `Page toolbar button ${tooltip}`

// Usage
e2e.components.PageToolbar.item('Add panel', { timeout: 6000 }).click();
```

For selectors where they are functions which accept no inputs:
```
// Definition
input: () => 'input[id*="react-select-"]'

// Usage
e2e.components.Select.input({ timeout: 6000 }).should('be.visible').click();
```

For selectors where they are just strings (for aria-labels)
```
// Definition:
legendSection: 'Legend section',

// Usage:
e2e.components.Panels.Visualization.Graph.VisualizationTab.legendSection({ timeout: 6000 }).click()
```

Passing in `{ timeout: 10000 }` increases the individual timeout from its default of 4000:
(I chose a failing example because if I chose a selector that actually exists/is found then I won't be able to demonstrate that the timeout overrides the default)

<img width="528" alt="Screenshot 2021-03-01 at 19 15 04" src="https://user-images.githubusercontent.com/36230812/109546763-83e50300-7ac2-11eb-9573-53e253cfb648.png">

vs

<img width="528" alt="Screenshot 2021-03-01 at 19 04 11" src="https://user-images.githubusercontent.com/36230812/109545683-12588500-7ac1-11eb-816b-5adedca407b0.png">

**Types before changes**

In Grafana: `e2e/shared/smokeTestScenario.ts`:

```
item: (tooltip: string) => `Page toolbar button ${tooltip}`
```
<img width="958" alt="Screenshot 2021-03-01 at 18 53 27" src="https://user-images.githubusercontent.com/36230812/109544479-842fcf00-7abf-11eb-966f-b26925e21160.png">

```
input: () => 'input[id*="react-select-"]'
```
<img width="644" alt="Screenshot 2021-03-01 at 18 53 38" src="https://user-images.githubusercontent.com/36230812/109544493-8a25b000-7abf-11eb-9af5-13b5d970c44f.png">

```
legendSection: 'Legend section'
```
<img width="936" alt="Screenshot 2021-03-01 at 18 53 46" src="https://user-images.githubusercontent.com/36230812/109544509-8e51cd80-7abf-11eb-80a2-00bfd13a99c8.png">

**Types after changes**

In Grafana: `e2e/shared/smokeTestScenario.ts`:

```
item: (tooltip: string) => `Page toolbar button ${tooltip}`
```
<img width="969" alt="Screenshot 2021-03-01 at 18 49 06" src="https://user-images.githubusercontent.com/36230812/109543954-dde3c980-7abe-11eb-9519-edf215c78c52.png">

```
input: () => 'input[id*="react-select-"]'
```
<img width="824" alt="Screenshot 2021-03-01 at 18 48 42" src="https://user-images.githubusercontent.com/36230812/109544075-05d32d00-7abf-11eb-9788-648411c7e065.png">

```
legendSection: 'Legend section'
```
<img width="1093" alt="Screenshot 2021-03-01 at 18 48 50" src="https://user-images.githubusercontent.com/36230812/109544044-f9e76b00-7abe-11eb-95af-2d9a260f1dd1.png">

Opening a draft PR because I wasn't sure if the typing changes I've made are correct (I _think_ this is what we would want and it looks like it works?).

Took the options type from the `cypress.d.ts` file for `.get()`:
```
get<E extends Node = HTMLElement>(selector: string, options?: Partial<Loggable & Timeoutable & Withinable & Shadow>): Chainable<JQuery<E>>
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/integrations-team/issues/117

**Special notes for your reviewer**:

All existing e2e tests are still passing locally:

<img width="545" alt="Screenshot 2021-03-01 at 18 14 50" src="https://user-images.githubusercontent.com/36230812/109541076-45981580-7abb-11eb-9a9b-688cbdc5944b.png">