### PR TITLE
Elasticsearch: move fields query to BE

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -345,6 +345,13 @@ func (c *baseClientImpl) GetIndexMapping() (*IndexMappingResponse, error) {
 	}
 
 	res, err := c.executeRequest(http.MethodGet, index+"/_mapping", "", nil)
+
+	defer func() {
+		if err := res.httpResponse.Body.Close(); err != nil {
+			clientLog.Warn("Failed to close response body", "err", err)
+		}
+	}()
+
 	if err != nil {
 		return nil, err
 	}
@@ -353,12 +360,6 @@ func (c *baseClientImpl) GetIndexMapping() (*IndexMappingResponse, error) {
 
 	start := time.Now()
 	clientLog.Debug("Decoding index mapping json response")
-
-	defer func() {
-		if err := res.httpResponse.Body.Close(); err != nil {
-			clientLog.Warn("Failed to close response body", "err", err)
-		}
-	}()
 
 	var objmap map[string]interface{}
 	dec := json.NewDecoder(res.httpResponse.Body)

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -354,13 +354,16 @@ func (c *baseClientImpl) GetIndexMapping() (*IndexMappingResponse, error) {
 	start := time.Now()
 	clientLog.Debug("Decoding index mapping json response")
 
+	defer func() {
+		if err := res.httpResponse.Body.Close(); err != nil {
+			clientLog.Warn("Failed to close response body", "err", err)
+		}
+	}()
+
 	var objmap map[string]interface{}
-	defer res.httpResponse.Body.Close()
 	dec := json.NewDecoder(res.httpResponse.Body)
 	err = dec.Decode(&objmap)
 	if err != nil {
-		responseBuffer := bytes.Buffer{}
-		responseBuffer.ReadFrom(res.httpResponse.Body)
 		return nil, err
 	}
 
@@ -374,7 +377,7 @@ func (c *baseClientImpl) GetIndexMapping() (*IndexMappingResponse, error) {
 		imr.Mappings = objmap
 	}
 
-	elapsed := time.Now().Sub(start)
+	elapsed := time.Since(start)
 	clientLog.Debug("Decoded index mapping json response", "took", elapsed)
 
 	return &imr, nil

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -18,8 +18,13 @@ const (
 	intervalYearly  = "yearly"
 )
 
+var timeNowUtc = func() time.Time {
+	return time.Now().UTC()
+}
+
 type indexPattern interface {
 	GetIndices(timeRange plugins.DataTimeRange) ([]string, error)
+	GetIndexForToday() (string, error)
 }
 
 var newIndexPattern = func(interval string, pattern string) (indexPattern, error) {
@@ -36,6 +41,14 @@ type staticIndexPattern struct {
 
 func (ip *staticIndexPattern) GetIndices(timeRange plugins.DataTimeRange) ([]string, error) {
 	return []string{ip.indexName}, nil
+}
+
+func (ip *staticIndexPattern) GetIndexForToday() (string, error) {
+	return ip.indexName, nil
+}
+
+func (ip *dynamicIndexPattern) GetIndexForToday() (string, error) {
+	return formatDate(timeNowUtc(), ip.pattern), nil
 }
 
 type intervalGenerator interface {

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -313,3 +313,9 @@ func (a *PipelineAggregation) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(root)
 }
+
+type IndexMappingResponse struct {
+	StatusCode int
+	Error      map[string]interface{}
+	Mappings   map[string]interface{}
+}

--- a/pkg/tsdb/elasticsearch/fields_query.go
+++ b/pkg/tsdb/elasticsearch/fields_query.go
@@ -114,7 +114,6 @@ func transform(indexMapping *es.IndexMappingResponse, fieldTypeFilter, refID str
 	// from extractedFields we get only those fields that match the provided type alias
 	filteredFields := fieldsMap{}
 	for fieldName := range extractedFields {
-		// FIXME: geo_point doesn't work
 		if fieldTypeMatchesAlias(extractedFields[fieldName], fieldTypeFilter) {
 			filteredFields[fieldName] = extractedFields[fieldName]
 		}
@@ -170,7 +169,7 @@ func isMetadataField(fieldName string) bool {
 }
 
 // Given a `fieldType` and a `typeAlias`, returns true if the field type matches the given alias, false otherwise
-// eg. a "string" type alias will return `true` for fields of type "text" and "sring"
+// eg. a "string" type alias will return `true` for fields of type "text" and "string"
 func fieldTypeMatchesAlias(fieldType string, typeAlias string) bool {
 	typeMap := map[string]string{
 		"float":        "number",
@@ -179,12 +178,10 @@ func fieldTypeMatchesAlias(fieldType string, typeAlias string) bool {
 		"long":         "number",
 		"scaled_float": "number",
 		"histogram":    "number",
-		"date":         "date",
 		"date_nanos":   "date",
-		"string":       "string",
 		"text":         "string",
 		"nested":       "nested",
 	}
 
-	return typeMap[fieldType] == typeAlias
+	return typeMap[fieldType] == typeAlias || fieldType == typeAlias
 }

--- a/pkg/tsdb/elasticsearch/fields_query.go
+++ b/pkg/tsdb/elasticsearch/fields_query.go
@@ -147,7 +147,6 @@ func transform(indexMapping *es.IndexMappingResponse, fieldTypeFilter, refID str
 
 // Given a field name `fieldName` returns `true` if `fieldName` is a known metadata field according to https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html#_identity_metadata_fields, `false` otherwise
 func isMetadataField(fieldName string) bool {
-
 	// The following are metadata fields as defined in https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html#_identity_metadata_fields.
 	// custom fields can start with underscores, therefore is not safe to exclude anything that starts with one.
 	elasticsearchMetaFields := []string{

--- a/pkg/tsdb/elasticsearch/fields_query.go
+++ b/pkg/tsdb/elasticsearch/fields_query.go
@@ -1,0 +1,192 @@
+package elasticsearch
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
+)
+
+type fieldsQuery struct {
+	client    es.Client
+	tsdbQuery plugins.DataQuery
+}
+
+
+var newFieldsQuery = func(client es.Client, dataQuery plugins.DataQuery) *fieldsQuery {
+	return &fieldsQuery{
+		client:    client,
+		tsdbQuery: dataQuery,
+	}
+}
+
+func (e *fieldsQuery) execute() (plugins.DataResponse, error) {
+	query := e.tsdbQuery.Queries[0]
+
+	indexMapping, err := e.client.GetIndexMapping()
+	if err != nil {
+		return plugins.DataResponse{}, err
+	}
+
+	var fieldTypeFilter string
+	if typeProp, ok := query.Model.CheckGet("fieldTypeFilter"); ok {
+		fieldTypeFilter = typeProp.MustString()
+	}
+
+	return transform(indexMapping, fieldTypeFilter, query.RefID)
+}
+
+type fieldsMap map[string]string
+
+func extractFields(fieldMap map[string]interface{}, path []string) fieldsMap {
+	// TODO: Old js implementation had this:
+	// if (configuredEsVersion < 70) {
+	// 		for (const typeName in mappings) {
+	// 	  		const properties = mappings[typeName].properties;
+	// 	  		getFieldsRecursively(properties);
+	// 		}
+	// } else {
+	// 		const properties = mappings.properties;
+	// 		getFieldsRecursively(properties);
+	// }
+	properties := fieldMap["properties"].(map[string]interface{})
+	fields := fieldsMap{}
+
+	for key, v := range properties {
+		// We skip adding the field if it's a known metadata field.
+		if isMetadataField(key) {
+			continue
+		}
+
+		vv := v.(map[string]interface{})
+
+		if vv["type"] != nil {
+			fields[strings.Join(append(path, key), ".")] = vv["type"].(string)
+		}
+
+		if vv["properties"] != nil {
+			f := extractFields(vv, append(path, key))
+
+			for k, v := range f {
+				fields[k] = v
+			}
+		}
+	}
+
+	return fields
+}
+
+// Here we transform a raw ES `/_mappings` response to a table structure to return to the frontend.
+// The table has the following structure:
+//
+// |-----------|-----------|
+// | name      | type      |
+// |-----------|-----------|
+// | fieldName | fieldType |
+// |-----------|-----------|
+func transform(indexMapping *es.IndexMappingResponse, fieldTypeFilter, refID string) (plugins.DataResponse, error) {
+	if indexMapping.Error != nil {
+		return plugins.DataResponse{
+			Results: map[string]plugins.DataQueryResult{
+				// TODO: This
+				// refID: getErrorFromElasticResponse(indexMapping.Error),
+			},
+		}, nil
+	}
+
+	// We create the table structure for the response
+	table := plugins.DataTable{
+		Columns: make([]plugins.DataTableColumn, 0),
+		Rows:    make([]plugins.DataRowValues, 0),
+	}
+	table.Columns = append(table.Columns, plugins.DataTableColumn{Text: "name"})
+	table.Columns = append(table.Columns, plugins.DataTableColumn{Text: "type"})
+
+	// fieds contains data in the form of { [filedName]: type }
+	extractedFields := fieldsMap{}
+	for indexName := range indexMapping.Mappings {
+		index := indexMapping.Mappings[indexName].(map[string]interface{})
+		mappings := index["mappings"].(map[string]interface{})
+
+		extractedFields = extractFields(mappings, nil)
+	}
+
+	// from extractedFields we get only those fields that match the provided type alias
+	filteredFields := fieldsMap{}
+	for fieldName := range extractedFields {
+		// FIXME: geo_point doesn't work
+		if fieldTypeMatchesAlias(extractedFields[fieldName], fieldTypeFilter) {
+			filteredFields[fieldName] = extractedFields[fieldName]
+		}
+	}
+
+	// We alphabetically sort the field names in a new slice
+	fieldNames := []string{}
+	for fieldName := range filteredFields {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Strings(fieldNames)
+
+	// We iterate over the sorted slice, adding a row ro the response table for each field
+	for _, fieldName := range fieldNames {
+		table.Rows = append(table.Rows, plugins.DataRowValues{fieldName, filteredFields[fieldName]})
+	}
+
+	result := plugins.DataResponse{
+		Results: map[string]plugins.DataQueryResult{
+			refID: {
+				RefID:  refID,
+				Tables: []plugins.DataTable{table},
+			},
+		},
+	}
+
+	return result, nil
+}
+
+// Given a field name `fieldName` returns `true` if `fieldName` is a known metadata field according to https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html#_identity_metadata_fields, `false` otherwise
+func isMetadataField(fieldName string) bool {
+
+	// The following are metadata fields as defined in https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html#_identity_metadata_fields.
+	// custom fields can start with underscores, therefore is not safe to exclude anything that starts with one.
+	elasticsearchMetaFields := []string{
+		"_index",
+		"_type",
+		"_id",
+		"_source",
+		"_size",
+		"_field_names",
+		"_ignored",
+		"_routing",
+		"_meta",
+	}
+
+	for _, metaField := range elasticsearchMetaFields {
+		if metaField == fieldName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Given a `fieldType` and a `typeAlias`, returns true if the field type matches the given alias, false otherwise
+// eg. a "string" type alias will return `true` for fields of type "text" and "sring"
+func fieldTypeMatchesAlias(fieldType string, typeAlias string) bool {
+	typeMap := map[string]string{
+		"float":		"number",
+		"double":		"number",
+		"integer":		"number",
+		"long":			"number",
+		"scaled_float":	"number",
+		"histogram":	"number",
+		"date":			"date",
+		"date_nanos":	"date",
+		"string":		"string",
+		"text":			"string",
+		"nested":		"nested",
+	}
+
+	return typeMap[fieldType] == typeAlias
+}

--- a/pkg/tsdb/elasticsearch/fields_query.go
+++ b/pkg/tsdb/elasticsearch/fields_query.go
@@ -13,7 +13,6 @@ type fieldsQuery struct {
 	tsdbQuery plugins.DataQuery
 }
 
-
 var newFieldsQuery = func(client es.Client, dataQuery plugins.DataQuery) *fieldsQuery {
 	return &fieldsQuery{
 		client:    client,
@@ -174,17 +173,17 @@ func isMetadataField(fieldName string) bool {
 // eg. a "string" type alias will return `true` for fields of type "text" and "sring"
 func fieldTypeMatchesAlias(fieldType string, typeAlias string) bool {
 	typeMap := map[string]string{
-		"float":		"number",
-		"double":		"number",
-		"integer":		"number",
-		"long":			"number",
-		"scaled_float":	"number",
-		"histogram":	"number",
-		"date":			"date",
-		"date_nanos":	"date",
-		"string":		"string",
-		"text":			"string",
-		"nested":		"nested",
+		"float":        "number",
+		"double":       "number",
+		"integer":      "number",
+		"long":         "number",
+		"scaled_float": "number",
+		"histogram":    "number",
+		"date":         "date",
+		"date_nanos":   "date",
+		"string":       "string",
+		"text":         "string",
+		"nested":       "nested",
 	}
 
 	return typeMap[fieldType] == typeAlias

--- a/pkg/tsdb/elasticsearch/models.go
+++ b/pkg/tsdb/elasticsearch/models.go
@@ -2,7 +2,12 @@ package elasticsearch
 
 import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/plugins"
 )
+
+type queryEndpoint interface {
+	execute() (plugins.DataResponse, error)
+}
 
 // Query represents the time series query model of the datasource
 type Query struct {

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -888,6 +888,13 @@ func (c *fakeClient) GetMinInterval(queryInterval string) (time.Duration, error)
 	return 15 * time.Second, nil
 }
 
+// TODO: properly mock this
+func (c *fakeClient) GetIndexMapping() (*es.IndexMappingResponse, error) {
+	return &es.IndexMappingResponse{
+		StatusCode: 200,
+	}, nil
+}
+
 func (c *fakeClient) ExecuteMultisearch(r *es.MultiSearchRequest) (*es.MultiSearchResponse, error) {
 	c.multisearchRequests = append(c.multisearchRequests, r)
 	return c.multiSearchResponse, c.multiSearchError

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/BucketAggregationEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/BucketAggregationEditor.tsx
@@ -1,8 +1,8 @@
-import { MetricFindValue, SelectableValue } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { InlineSegmentGroup, Segment, SegmentAsync } from '@grafana/ui';
 import React, { FunctionComponent } from 'react';
+import { useFields } from '../../../hooks/useFields';
 import { useDispatch } from '../../../hooks/useStatelessReducer';
-import { useDatasource } from '../ElasticsearchQueryContext';
 import { segmentStyles } from '../styles';
 import { BucketAggregation, BucketAggregationType, isBucketAggregationWithField } from './aggregations';
 import { SettingsEditor } from './SettingsEditor';
@@ -17,11 +17,6 @@ const bucketAggOptions: Array<SelectableValue<BucketAggregationType>> = Object.e
   })
 );
 
-const toSelectableValue = ({ value, text }: MetricFindValue): SelectableValue<string> => ({
-  label: text,
-  value: `${value || text}`,
-});
-
 const toOption = (bucketAgg: BucketAggregation) => ({
   label: bucketAggregationConfig[bucketAgg.type].label,
   value: bucketAgg.type,
@@ -32,24 +27,8 @@ interface QueryMetricEditorProps {
 }
 
 export const BucketAggregationEditor: FunctionComponent<QueryMetricEditorProps> = ({ value }) => {
-  const datasource = useDatasource();
   const dispatch = useDispatch<BucketAggregationAction>();
-
-  // TODO: Move this in a separate hook (and simplify)
-  const getFields = async () => {
-    const get = () => {
-      switch (value.type) {
-        case 'date_histogram':
-          return datasource.getFields('date');
-        case 'geohash_grid':
-          return datasource.getFields('geo_point');
-        default:
-          return datasource.getFields();
-      }
-    };
-
-    return (await get().toPromise()).map(toSelectableValue);
-  };
+  const getFields = useFields(value.type);
 
   return (
     <>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import { ElasticsearchProvider, useDatasource, useQuery } from './ElasticsearchQueryContext';
 import { ElasticsearchQuery } from '../../types';
 import { ElasticDatasource } from '../../datasource';
+import { getDefaultTimeRange } from '@grafana/data';
 
 const query: ElasticsearchQuery = {
   refId: 'A',
@@ -20,6 +21,7 @@ describe('ElasticsearchQueryContext', () => {
 
     render(
       <ElasticsearchProvider
+        range={getDefaultTimeRange()}
         query={{ refId: 'A' }}
         onChange={onChange}
         datasource={datasource}
@@ -49,6 +51,7 @@ describe('ElasticsearchQueryContext', () => {
     it('Should return the current query object', () => {
       const wrapper: FunctionComponent = ({ children }) => (
         <ElasticsearchProvider
+          range={getDefaultTimeRange()}
           datasource={{} as ElasticDatasource}
           query={query}
           onChange={() => {}}
@@ -77,7 +80,13 @@ describe('ElasticsearchQueryContext', () => {
       const datasource = {} as ElasticDatasource;
 
       const wrapper: FunctionComponent = ({ children }) => (
-        <ElasticsearchProvider datasource={datasource} query={query} onChange={() => {}} onRunQuery={() => {}}>
+        <ElasticsearchProvider
+          range={getDefaultTimeRange()}
+          datasource={datasource}
+          query={query}
+          onChange={() => {}}
+          onRunQuery={() => {}}
+        >
           {children}
         </ElasticsearchProvider>
       );

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -6,15 +6,18 @@ import { ElasticsearchQuery } from '../../types';
 import { reducer as metricsReducer } from './MetricAggregationsEditor/state/reducer';
 import { reducer as bucketAggsReducer } from './BucketAggregationsEditor/state/reducer';
 import { aliasPatternReducer, queryReducer, initQuery } from './state';
+import { TimeRange } from '@grafana/data';
 
 const DatasourceContext = createContext<ElasticDatasource | undefined>(undefined);
 const QueryContext = createContext<ElasticsearchQuery | undefined>(undefined);
+const RangeContext = createContext<TimeRange | undefined>(undefined);
 
 interface Props {
   query: ElasticsearchQuery;
   onChange: (query: ElasticsearchQuery) => void;
   onRunQuery: () => void;
   datasource: ElasticDatasource;
+  range: TimeRange;
 }
 
 export const ElasticsearchProvider: FunctionComponent<Props> = ({
@@ -23,6 +26,7 @@ export const ElasticsearchProvider: FunctionComponent<Props> = ({
   onRunQuery,
   query,
   datasource,
+  range,
 }) => {
   const onStateChange = useCallback(
     (query: ElasticsearchQuery) => {
@@ -57,7 +61,9 @@ export const ElasticsearchProvider: FunctionComponent<Props> = ({
   return (
     <DatasourceContext.Provider value={datasource}>
       <QueryContext.Provider value={query}>
-        <DispatchContext.Provider value={dispatch}>{children}</DispatchContext.Provider>
+        <RangeContext.Provider value={range}>
+          <DispatchContext.Provider value={dispatch}>{children}</DispatchContext.Provider>
+        </RangeContext.Provider>
       </QueryContext.Provider>
     </DatasourceContext.Provider>
   );
@@ -80,4 +86,13 @@ export const useDatasource = () => {
   }
 
   return datasource;
+};
+
+export const useRange = () => {
+  const range = useContext(RangeContext);
+  if (!range) {
+    throw new Error('use ElasticsearchProvider first.');
+  }
+
+  return range;
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx
@@ -1,4 +1,4 @@
-import { MetricFindValue, SelectableValue } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { InlineSegmentGroup, Segment, SegmentAsync, useTheme } from '@grafana/ui';
 import { cx } from 'emotion';
 import React, { FunctionComponent } from 'react';
@@ -19,15 +19,11 @@ import {
   MetricAggregation,
   MetricAggregationType,
 } from './aggregations';
+import { useFields } from '../../../hooks/useFields';
 
 const toOption = (metric: MetricAggregation) => ({
   label: metricAggregationConfig[metric.type].label,
   value: metric.type,
-});
-
-const toSelectableValue = ({ value, text }: MetricFindValue): SelectableValue<string> => ({
-  label: text,
-  value: `${value || text}`,
 });
 
 interface Props {
@@ -67,24 +63,13 @@ export const MetricEditor: FunctionComponent<Props> = ({ value }) => {
   const styles = getStyles(useTheme(), !!value.hide);
   const datasource = useDatasource();
   const query = useQuery();
+  const getFields = useFields(value.type);
   const dispatch = useDispatch<MetricAggregationAction>();
 
   const previousMetrics = query.metrics!.slice(
     0,
     query.metrics!.findIndex((m) => m.id === value.id)
   );
-
-  // TODO: This could be common with the one in BucketAggregationEditor
-  const getFields = async () => {
-    const get = () => {
-      if (value.type === 'cardinality') {
-        return datasource.getFields();
-      }
-      return datasource.getFields('number');
-    };
-
-    return (await get().toPromise()).map(toSelectableValue);
-  };
 
   return (
     <>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.test.tsx
@@ -4,6 +4,7 @@ import { SettingsEditor } from '.';
 import { ElasticsearchProvider } from '../../ElasticsearchQueryContext';
 import { ElasticDatasource } from '../../../../datasource';
 import { ElasticsearchQuery } from '../../../../types';
+import { getDefaultTimeRange } from '@grafana/data';
 
 describe('Settings Editor', () => {
   describe('Raw Data', () => {
@@ -29,6 +30,7 @@ describe('Settings Editor', () => {
 
       const { rerender } = render(
         <ElasticsearchProvider
+          range={getDefaultTimeRange()}
           query={query}
           datasource={{} as ElasticDatasource}
           onChange={onChange}
@@ -63,6 +65,7 @@ describe('Settings Editor', () => {
       expect(onChange).toHaveBeenCalledTimes(1);
       rerender(
         <ElasticsearchProvider
+          range={getDefaultTimeRange()}
           query={onChange.mock.calls[0][0]}
           datasource={{} as ElasticDatasource}
           onChange={onChange}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { QueryEditorProps } from '@grafana/data';
+import { getDefaultTimeRange, QueryEditorProps } from '@grafana/data';
 import { ElasticDatasource } from '../../datasource';
 import { ElasticsearchOptions, ElasticsearchQuery } from '../../types';
 import { ElasticsearchProvider } from './ElasticsearchQueryContext';
@@ -17,8 +17,15 @@ export const QueryEditor: FunctionComponent<ElasticQueryEditorProps> = ({
   onChange,
   onRunQuery,
   datasource,
+  range,
 }) => (
-  <ElasticsearchProvider datasource={datasource} onChange={onChange} onRunQuery={onRunQuery} query={query}>
+  <ElasticsearchProvider
+    datasource={datasource}
+    onChange={onChange}
+    onRunQuery={onRunQuery}
+    query={query}
+    range={range || getDefaultTimeRange()}
+  >
     <QueryEditorForm value={query} />
   </ElasticsearchProvider>
 );

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -455,7 +455,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return nested fields', async () => {
       const { ds } = getTestContext({ data, jsonData: { esVersion: 50 }, database: 'metricbeat' });
 
-      await expect(ds.getFields()).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields(null)).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         const fieldObjects = received[0];
         const fields = _.map(fieldObjects, 'text');
@@ -478,7 +478,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return number fields', async () => {
       const { ds } = getTestContext({ data, jsonData: { esVersion: 50 }, database: 'metricbeat' });
 
-      await expect(ds.getFields('number')).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields('number')).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         const fieldObjects = received[0];
         const fields = _.map(fieldObjects, 'text');
@@ -490,7 +490,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return date fields', async () => {
       const { ds } = getTestContext({ data, jsonData: { esVersion: 50 }, database: 'metricbeat' });
 
-      await expect(ds.getFields('date')).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields('date')).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         const fieldObjects = received[0];
         const fields = _.map(fieldObjects, 'text');
@@ -553,7 +553,7 @@ describe('ElasticDatasource', function (this: any) {
 
       const range = timeSrv.timeRange();
 
-      await expect(ds.getFields(undefined, range)).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields(null, range)).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         const fieldObjects = received[0];
         const fields = _.map(fieldObjects, 'text');
@@ -577,7 +577,7 @@ describe('ElasticDatasource', function (this: any) {
 
       const range = timeSrv.timeRange();
 
-      await expect(ds.getFields(undefined, range)).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields(null, range)).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         expect(received[0]).toStrictEqual({ status: 500 });
         expect(fetchMock).toBeCalledTimes(1);
@@ -594,7 +594,7 @@ describe('ElasticDatasource', function (this: any) {
       });
       const range = timeSrv.timeRange();
 
-      await expect(ds.getFields(undefined, range)).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields(null, range)).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
         expect(received[0]).toStrictEqual('Could not find an available index for this time range.');
         expect(fetchMock).toBeCalledTimes(7);
@@ -689,7 +689,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return nested fields', async () => {
       const { ds } = getTestContext({ data, database: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
 
-      await expect(ds.getFields()).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields(null)).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
 
         const fieldObjects = received[0];
@@ -716,7 +716,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return number fields', async () => {
       const { ds } = getTestContext({ data, database: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
 
-      await expect(ds.getFields('number')).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields('number')).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
 
         const fieldObjects = received[0];
@@ -735,7 +735,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should return date fields', async () => {
       const { ds } = getTestContext({ data, database: 'genuine.es7._mapping.response', jsonData: { esVersion: 70 } });
 
-      await expect(ds.getFields('date')).toEmitValuesWith((received) => {
+      await expect(ds.legacy_getFields('date')).toEmitValuesWith((received) => {
         expect(received.length).toBe(1);
 
         const fieldObjects = received[0];
@@ -851,7 +851,7 @@ describe('ElasticDatasource', function (this: any) {
     it('should replace range as integer not string', async () => {
       const { ds } = getTestContext({ jsonData: { interval: 'Daily', esVersion: 2, timeField: '@time' } });
       const postMock = jest.fn((url: string, data: any) => of(createFetchResponse({ responses: [] })));
-      ds['post'] = postMock;
+      ds['legacy_post'] = postMock;
 
       await expect(ds.query(createElasticQuery())).toEmitValuesWith((received) => {
         expect(postMock).toHaveBeenCalledTimes(1);

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -659,7 +659,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     }).pipe(map((data) => transformFieldsQueryResponse('A', data)));
   }
 
-  private legacy_getFields(
+  legacy_getFields(
     type: 'number' | 'date' | 'string' | 'nested' | 'geo_point' | null,
     range?: TimeRange
   ): Observable<MetricFindValue[]> {

--- a/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
@@ -1,0 +1,43 @@
+import { MetricFindValue, SelectableValue } from '@grafana/data';
+import { BucketAggregationType } from '../components/QueryEditor/BucketAggregationsEditor/aggregations';
+import { useDatasource, useRange } from '../components/QueryEditor/ElasticsearchQueryContext';
+import {
+  isMetricAggregationType,
+  MetricAggregationType,
+} from '../components/QueryEditor/MetricAggregationsEditor/aggregations';
+
+const toSelectableValue = ({ value, text }: MetricFindValue): SelectableValue<string> => ({
+  label: text,
+  value: `${value || text}`,
+});
+
+const getFilter = (aggregationType: BucketAggregationType | MetricAggregationType) => {
+  // For all metric types we want only numbers, except for cardinality
+  if (isMetricAggregationType(aggregationType)) {
+    if (aggregationType === 'cardinality') {
+      return null;
+    }
+    return 'number';
+  }
+
+  switch (aggregationType) {
+    case 'date_histogram':
+      return 'date';
+    case 'geohash_grid':
+      return 'geo_point';
+    default:
+      return null;
+  }
+};
+
+export const useFields = (aggregationType: BucketAggregationType | MetricAggregationType) => {
+  const datasource = useDatasource();
+  const range = useRange();
+  const filter = getFilter(aggregationType);
+  console.log(filter);
+
+  return async () => {
+    const rawFields = await datasource.getFields(range, filter).toPromise();
+    return rawFields.map(toSelectableValue);
+  };
+};

--- a/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
@@ -34,7 +34,6 @@ export const useFields = (aggregationType: BucketAggregationType | MetricAggrega
   const datasource = useDatasource();
   const range = useRange();
   const filter = getFilter(aggregationType);
-  console.log(filter);
 
   return async () => {
     const rawFields = await datasource.getFields(range, filter).toPromise();

--- a/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { ElasticsearchProvider } from '../components/QueryEditor/ElasticsearchQueryContext';
 import { useNextId } from './useNextId';
 import { ElasticsearchQuery } from '../types';
+import { getDefaultTimeRange } from '@grafana/data';
 
 describe('useNextId', () => {
   it('Should return the next available id', () => {
@@ -14,7 +15,13 @@ describe('useNextId', () => {
     };
     const wrapper: FunctionComponent = ({ children }) => {
       return (
-        <ElasticsearchProvider query={query} datasource={{} as any} onChange={() => {}} onRunQuery={() => {}}>
+        <ElasticsearchProvider
+          range={getDefaultTimeRange()}
+          query={query}
+          datasource={{} as any}
+          onChange={() => {}}
+          onRunQuery={() => {}}
+        >
           {children}
         </ElasticsearchProvider>
       );

--- a/public/app/plugins/datasource/elasticsearch/responseTransformers/index.ts
+++ b/public/app/plugins/datasource/elasticsearch/responseTransformers/index.ts
@@ -1,0 +1,10 @@
+export const transformFieldsQueryResponse = (refId: string, res: any) => {
+  if (!res.results?.[refId]?.tables) {
+    return [];
+  }
+
+  return res.results[refId].tables[0].rows.map((row: any) => ({
+    text: row[0],
+    type: row[1],
+  }));
+};

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -50,13 +50,7 @@ export type BucketsConfiguration = {
   [P in BucketAggregationType]: BucketConfiguration<P>;
 };
 
-export interface ElasticsearchAggregation {
-  id: string;
-  type: MetricAggregationType | BucketAggregationType;
-  settings?: unknown;
-  field?: string;
-  hide: boolean;
-}
+export type ElasticsearchAggregation = BucketAggregation | MetricAggregation;
 
 export interface ElasticsearchQuery extends DataQuery {
   alias?: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes fields query use the new BE implementation.


# TODO: 

- [ ] Test with authentication
- [ ] Write tests for new FE code
- [ ] Write tests for BE code
- [ ] Think of a better structure/handling for multiple queries within the same request in the BE
- [ ] Check if `this.url` when serving grafana from a subpath


**Special notes for your reviewer**:

To allow us to merge this without breaking anything, I created some `lecacy_*` methods in `datasource.ts` so that the frontend will still be able to issue "FE queries" when browser access is set. once we migrate everything to the BE we can simply remove all the `legacy_` prefixed methods and everything should work as all the logic is going to be in the BE.


superseds https://github.com/grafana/grafana/pull/31289 (partially) as I'm trying to implement it in smaller chunks
