### PR TITLE
grafana-ui: added storybook link to readme

### DIFF
--- a/packages/grafana-ui/README.md
+++ b/packages/grafana-ui/README.md
@@ -6,6 +6,8 @@
 
 Our goal is to deliver Grafana's common UI elements for plugins developers and contributors.
 
+Browse the [Storybook catalog of the components](http://developers.grafana.com/).
+
 See [package source](https://github.com/grafana/grafana/tree/master/packages/grafana-ui) for more details.
 
 ## Installation


### PR DESCRIPTION
i added a link to the online available grafana-ui storybook collection, this way when someone finds this package on npm/yarn, they can easily check it out. i'm not 100% happy with the sentence, but it's better than nothing. i'm open to ideas how to rewrite it.