### PR TITLE
Library Panels: Choosing library panel now updates plugin type

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelOptionsTab.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelOptionsTab.tsx
@@ -31,6 +31,7 @@ export const PanelOptionsTab: FC<Props> = ({
   onPanelOptionsChanged,
 }) => {
   const visTabInputRef = useRef<HTMLInputElement>(null);
+  const makeDummyEdit = useCallback(() => onPanelConfigChange('isEditing', true), []);
   const linkVariablesSuggestions = useMemo(() => getPanelLinksVariableSuggestions(), []);
   const onRepeatRowSelectChange = useCallback((value: string | null) => onPanelConfigChange('repeat', value), [
     onPanelConfigChange,
@@ -169,12 +170,7 @@ export const PanelOptionsTab: FC<Props> = ({
 
   if (config.featureToggles.panelLibrary) {
     elements.push(
-      <PanelLibraryOptionsGroup
-        panel={panel}
-        dashboard={dashboard}
-        onChange={() => onPanelConfigChange('isEditing', true)}
-        key="Panel Library"
-      />
+      <PanelLibraryOptionsGroup panel={panel} dashboard={dashboard} onChange={makeDummyEdit} key="Panel Library" />
     );
   }
 

--- a/public/app/features/dashboard/components/PanelEditor/PanelOptionsTab.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelOptionsTab.tsx
@@ -168,7 +168,14 @@ export const PanelOptionsTab: FC<Props> = ({
   );
 
   if (config.featureToggles.panelLibrary) {
-    elements.push(<PanelLibraryOptionsGroup panel={panel} dashboard={dashboard} key="Panel Library" />);
+    elements.push(
+      <PanelLibraryOptionsGroup
+        panel={panel}
+        dashboard={dashboard}
+        onChange={() => onPanelConfigChange('isEditing', true)}
+        key="Panel Library"
+      />
+    );
   }
 
   return <>{elements}</>;

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationTab.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationTab.tsx
@@ -15,7 +15,7 @@ interface OwnProps {
 }
 
 interface ConnectedProps {
-  plugin?: PanelPlugin;
+  plugin: PanelPlugin;
 }
 
 interface DispatchProps {
@@ -30,9 +30,6 @@ export const VisualizationTabUnconnected = React.forwardRef<HTMLInputElement, Pr
     const theme = useTheme();
     const styles = getStyles(theme);
 
-    if (!plugin) {
-      return null;
-    }
     const onPluginTypeChange = (meta: PanelPluginMeta) => {
       if (meta.id === plugin.meta.id) {
         onToggleOptionGroup(false);
@@ -62,6 +59,10 @@ export const VisualizationTabUnconnected = React.forwardRef<HTMLInputElement, Pr
           Clear filter
         </span>
       ) : null;
+
+    if (!plugin) {
+      return null;
+    }
 
     return (
       <div className={styles.wrapper}>

--- a/public/app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup.tsx
+++ b/public/app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { css } from 'emotion';
 import pick from 'lodash/pick';
+import omit from 'lodash/omit';
 import { GrafanaTheme } from '@grafana/data';
 import { Button, stylesFactory, useStyles } from '@grafana/ui';
 
@@ -11,29 +12,47 @@ import { LibraryPanelsView } from '../LibraryPanelsView/LibraryPanelsView';
 import { PanelQueriesChangedEvent } from 'app/types/events';
 import { LibraryPanelDTO } from '../../types';
 import { toPanelModelLibraryPanel } from '../../utils';
+import { connect, MapDispatchToProps } from 'react-redux';
+import { changePanelPlugin } from 'app/features/dashboard/state/actions';
 
 interface Props {
   panel: PanelModel;
   dashboard: DashboardModel;
+  onChange: () => void;
+}
+interface DispatchProps {
+  changePanelPlugin: typeof changePanelPlugin;
 }
 
-export const PanelLibraryOptionsGroup: React.FC<Props> = ({ panel, dashboard }) => {
+export const PanelLibraryOptionsGroupUnconnected: React.FC<Props & DispatchProps> = ({
+  panel,
+  dashboard,
+  onChange,
+  changePanelPlugin,
+}) => {
   const styles = useStyles(getStyles);
   const [showingAddPanelModal, setShowingAddPanelModal] = useState(false);
 
   const useLibraryPanel = (panelInfo: LibraryPanelDTO) => {
+    const panelTypeChanged = panel.type !== panelInfo.model.type;
     panel.restoreModel({
-      ...panelInfo.model,
+      ...omit(panelInfo.model, 'type'),
       ...pick(panel, 'gridPos', 'id'),
       libraryPanel: toPanelModelLibraryPanel(panelInfo),
     });
 
+    if (panelTypeChanged) {
+      changePanelPlugin(panel, panelInfo.model.type);
+    }
+
     // Though the panel model has changed, since we're switching to an existing
     // library panel, we reset the "hasChanged" state.
     panel.hasChanged = false;
-
     panel.refresh();
     panel.events.publish(PanelQueriesChangedEvent);
+
+    // onChange is called here to force the panel editor to re-render
+    onChange();
   };
 
   const onAddToPanelLibrary = (e: React.MouseEvent) => {
@@ -92,3 +111,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
   };
 });
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = { changePanelPlugin };
+
+export const PanelLibraryOptionsGroup = connect(undefined, mapDispatchToProps)(PanelLibraryOptionsGroupUnconnected);

--- a/public/app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup.tsx
+++ b/public/app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup.tsx
@@ -12,7 +12,7 @@ import { LibraryPanelsView } from '../LibraryPanelsView/LibraryPanelsView';
 import { PanelQueriesChangedEvent } from 'app/types/events';
 import { LibraryPanelDTO } from '../../types';
 import { toPanelModelLibraryPanel } from '../../utils';
-import { connect, MapDispatchToProps } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { changePanelPlugin } from 'app/features/dashboard/state/actions';
 
 interface Props {
@@ -20,18 +20,11 @@ interface Props {
   dashboard: DashboardModel;
   onChange: () => void;
 }
-interface DispatchProps {
-  changePanelPlugin: typeof changePanelPlugin;
-}
 
-export const PanelLibraryOptionsGroupUnconnected: React.FC<Props & DispatchProps> = ({
-  panel,
-  dashboard,
-  onChange,
-  changePanelPlugin,
-}) => {
+export const PanelLibraryOptionsGroup: React.FC<Props> = ({ panel, dashboard, onChange }) => {
   const styles = useStyles(getStyles);
   const [showingAddPanelModal, setShowingAddPanelModal] = useState(false);
+  const dispatch = useDispatch();
 
   const useLibraryPanel = (panelInfo: LibraryPanelDTO) => {
     const panelTypeChanged = panel.type !== panelInfo.model.type;
@@ -42,7 +35,7 @@ export const PanelLibraryOptionsGroupUnconnected: React.FC<Props & DispatchProps
     });
 
     if (panelTypeChanged) {
-      changePanelPlugin(panel, panelInfo.model.type);
+      dispatch(changePanelPlugin(panel, panelInfo.model.type));
     }
 
     // Though the panel model has changed, since we're switching to an existing
@@ -111,7 +104,3 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
   };
 });
-
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = { changePanelPlugin };
-
-export const PanelLibraryOptionsGroup = connect(undefined, mapDispatchToProps)(PanelLibraryOptionsGroupUnconnected);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where choosing "Use instead of current panel" on a library panel wouldn't update the panel's plugin type.

See: https://github.com/grafana/grafana/issues/31305
