### PR TITLE
Tracing: Small improvements to trace types

### DIFF
--- a/packages/grafana-data/src/types/trace.ts
+++ b/packages/grafana-data/src/types/trace.ts
@@ -1,9 +1,15 @@
-type TraceKeyValuePair = {
+/**
+ * Type representing a tag in a trace span or fields of a log.
+ */
+export type TraceKeyValuePair = {
   key: string;
   value: any;
 };
 
-type TraceLog = {
+/**
+ * Type representing a log in a span.
+ */
+export type TraceLog = {
   // Millisecond epoch time
   timestamp: number;
   fields: TraceKeyValuePair[];
@@ -16,7 +22,7 @@ type TraceLog = {
 export interface TraceSpanRow {
   traceID: string;
   spanID: string;
-  parentSpanID?: string;
+  parentSpanID: string | undefined;
   operationName: string;
   serviceName: string;
   serviceTags: TraceKeyValuePair[];


### PR DESCRIPTION
- add doc comments
- make some of the types external so they are accessible and visible in docs
- make `parentSpanID` non optional as only the root span can have `undefined` as value
