### PR TITLE
FeatureToggles: Add index signature

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -41,6 +41,8 @@ export enum GrafanaEdition {
  * @public
  */
 export interface FeatureToggles {
+  [name: string]: boolean;
+
   live: boolean;
   ngalert: boolean;
   panelLibrary: boolean;


### PR DESCRIPTION
**What this PR does / why we need it**:

Since feature toggles tend to have arbitrary names, it seems to me that this should have an index signature.

**Which issue(s) this PR fixes**:

Not needing to use `@ts-ignore` any more when doing e.g.:
```ts
config.featureToggles['myToggle']
```
