### PR TITLE
Docs: Add Loki to list of data sources that support alerting

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -37,7 +37,7 @@ The actual notifications are configured and shared between multiple alerts.
 ## Alert execution
 
 Alert rules are evaluated in the Grafana backend in a scheduler and query execution engine that is part
-of core Grafana. Only some data sources are supported right now. They include `Graphite`, `Prometheus`, `InfluxDB`, `Elasticsearch`,
+of core Grafana. Only some data sources are supported right now. They include `Graphite`, `Prometheus`, `Loki`, `InfluxDB`, `Elasticsearch`,
 `Google Cloud Monitoring`, `Cloudwatch`, `Azure Monitor`, `MySQL`, `PostgreSQL`, `MSSQL`, `OpenTSDB`, `Oracle`, and `Azure Data Explorer`.
 
 ## Metrics from the alert engine


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds documentation for https://github.com/grafana/grafana/pull/31424