### PR TITLE
Fix whatsNewUrl version to 7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ci:test-frontend": "yarn run prettier:check && yarn run typecheck && yarn run lint && yarn run test:ci && yarn grafana-toolkit node-version-check && ./scripts/ci-check-strict.sh"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/latest/guides/whats-new-in-v7-4/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v7-5/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/latest/release-notes/"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ci:test-frontend": "yarn run prettier:check && yarn run typecheck && yarn run lint && yarn run test:ci && yarn grafana-toolkit node-version-check && ./scripts/ci-check-strict.sh"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v7-5/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/latest/guides/whats-new-in-v7-5/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/latest/release-notes/"
   },
   "husky": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes What's new url version to 7.5