### PR TITLE
Chore: add alias for what's new 7.5

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v7-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-5.md
@@ -3,6 +3,7 @@ title = "What's new in Grafana v7.5"
 description = "Feature and improvement highlights for Grafana v7.5"
 keywords = ["grafana", "new", "documentation", "7.5", "release notes"]
 weight = -32
+aliases = ["/docs/grafana/latest/guides/whats-new-in-v7-5/"]
 [_build]
 list = false
 +++


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds alias for what's new docs
