### PR TITLE
Elasticsearch: Fix script fields in query editor

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/MetricPicker.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/MetricPicker.tsx
@@ -23,12 +23,16 @@ interface Props {
   value?: string;
 }
 
-export const MetricPicker: FunctionComponent<Props> = ({ options, onChange, className, value }) => (
-  <Segment
-    className={cx(className, noWrap)}
-    options={toOptions(options)}
-    onChange={onChange}
-    placeholder="Select Metric"
-    value={!!value ? toOption(options.find((option) => option.id === value)!) : null}
-  />
-);
+export const MetricPicker: FunctionComponent<Props> = ({ options, onChange, className, value }) => {
+  const selectedOption = options.find((option) => option.id === value);
+
+  return (
+    <Segment
+      className={cx(className, noWrap)}
+      options={toOptions(options)}
+      onChange={onChange}
+      placeholder="Select Metric"
+      value={!!selectedOption ? toOption(selectedOption) : null}
+    />
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/SettingField.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/SettingField.tsx
@@ -4,8 +4,9 @@ import { useDispatch } from '../../../../hooks/useStatelessReducer';
 import { changeMetricSetting } from '../state/actions';
 import { ChangeMetricSettingAction } from '../state/types';
 import { SettingKeyOf } from '../../../types';
-import { MetricAggregationWithSettings } from '../aggregations';
+import { MetricAggregationWithInlineScript, MetricAggregationWithSettings } from '../aggregations';
 import { uniqueId } from 'lodash';
+import { getScriptValue } from 'app/plugins/datasource/elasticsearch/utils';
 
 interface Props<T extends MetricAggregationWithSettings, K extends SettingKeyOf<T>> {
   label: string;
@@ -26,13 +27,19 @@ export function SettingField<T extends MetricAggregationWithSettings, K extends 
   const [id] = useState(uniqueId(`es-field-id-`));
   const settings = metric.settings;
 
+  let defaultValue = settings?.[settingName as keyof typeof settings] || '';
+
+  if (settingName === 'script') {
+    defaultValue = getScriptValue(metric as MetricAggregationWithInlineScript);
+  }
+
   return (
     <InlineField label={label} labelWidth={16} tooltip={tooltip}>
       <Input
         id={id}
         placeholder={placeholder}
         onBlur={(e) => dispatch(changeMetricSetting(metric, settingName, e.target.value as any))}
-        defaultValue={settings?.[settingName as keyof typeof settings]}
+        defaultValue={defaultValue}
       />
     </InlineField>
   );

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -43,9 +43,10 @@ export interface MetricAggregationWithMissingSupport extends BaseMetricAggregati
   };
 }
 
+type InlineScript = string | { inline?: string };
 export interface MetricAggregationWithInlineScript extends BaseMetricAggregation {
   settings?: {
-    script?: string;
+    script?: InlineScript;
   };
 }
 
@@ -59,7 +60,7 @@ export interface Average
     MetricAggregationWithInlineScript {
   type: 'avg';
   settings?: {
-    script?: string;
+    script?: InlineScript;
     missing?: string;
   };
 }
@@ -67,7 +68,7 @@ export interface Average
 export interface Sum extends MetricAggregationWithField, MetricAggregationWithInlineScript {
   type: 'sum';
   settings?: {
-    script?: string;
+    script?: InlineScript;
     missing?: string;
   };
 }
@@ -75,7 +76,7 @@ export interface Sum extends MetricAggregationWithField, MetricAggregationWithIn
 export interface Max extends MetricAggregationWithField, MetricAggregationWithInlineScript {
   type: 'max';
   settings?: {
-    script?: string;
+    script?: InlineScript;
     missing?: string;
   };
 }
@@ -83,7 +84,7 @@ export interface Max extends MetricAggregationWithField, MetricAggregationWithIn
 export interface Min extends MetricAggregationWithField, MetricAggregationWithInlineScript {
   type: 'min';
   settings?: {
-    script?: string;
+    script?: InlineScript;
     missing?: string;
   };
 }
@@ -105,7 +106,7 @@ export interface ExtendedStat {
 export interface ExtendedStats extends MetricAggregationWithField, MetricAggregationWithInlineScript {
   type: 'extended_stats';
   settings?: {
-    script?: string;
+    script?: InlineScript;
     missing?: string;
     sigma?: string;
   };
@@ -118,7 +119,7 @@ export interface Percentiles extends MetricAggregationWithField, MetricAggregati
   type: 'percentiles';
   settings?: {
     percents?: string[];
-    script?: string;
+    script?: InlineScript;
     missing?: string;
   };
 }
@@ -238,7 +239,7 @@ export interface MovingFunction extends BasePipelineMetricAggregation {
   type: 'moving_fn';
   settings?: {
     window?: string;
-    script?: string;
+    script?: InlineScript;
     shift?: string;
   };
 }
@@ -267,7 +268,7 @@ export interface CumulativeSum extends BasePipelineMetricAggregation {
 export interface BucketScript extends PipelineMetricAggregationWithMultipleBucketPaths {
   type: 'bucket_script';
   settings?: {
-    script?: string;
+    script?: InlineScript;
   };
 }
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -36,6 +36,7 @@ import { bucketAggregationConfig } from './components/QueryEditor/BucketAggregat
 import { isBucketAggregationWithField } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 import { generate, Observable, of, throwError } from 'rxjs';
 import { catchError, first, map, mergeMap, skipWhile, throwIfEmpty } from 'rxjs/operators';
+import { getScriptValue } from './utils';
 
 // Those are metadata fields as defined in https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-fields.html#_identity_metadata_fields.
 // custom fields can start with underscores, therefore is not safe to exclude anything that starts with one.
@@ -425,7 +426,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
         text += metric.field;
       }
       if (isPipelineAggregationWithMultipleBucketPaths(metric)) {
-        text += metric.settings?.script?.replace(new RegExp('params.', 'g'), '');
+        text += getScriptValue(metric).replace(new RegExp('params.', 'g'), '');
       }
       text += '), ';
 

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -15,7 +15,7 @@ import {
   ExtendedStatMetaType,
   isMetricAggregationWithField,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
-import { describeMetric } from './utils';
+import { describeMetric, getScriptValue } from './utils';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
 
 const HIGHLIGHT_TAGS_EXP = `${queryDef.highlightTags.pre}([^@]+)${queryDef.highlightTags.post}`;
@@ -207,7 +207,7 @@ export class ElasticResponse {
 
               if (metric.type === 'bucket_script') {
                 //Use the formula in the column name
-                metricName = metric.settings?.script || '';
+                metricName = getScriptValue(metric);
               }
             }
 

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -306,7 +306,7 @@ export class ElasticResponse {
       if (series.metric && queryDef.isPipelineAggWithMultipleBucketPaths(series.metric)) {
         const agg: any = _.find(target.metrics, { id: series.metricId });
         if (agg && agg.settings.script) {
-          metricName = agg.settings.script;
+          metricName = getScriptValue(agg);
 
           for (const pv of agg.pipelineVariables) {
             const appliedAgg: any = _.find(target.metrics, { id: pv.pipelineAgg });

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -9,10 +9,12 @@ import {
   isMetricAggregationWithSettings,
   isPipelineAggregation,
   isPipelineAggregationWithMultipleBucketPaths,
+  MetricAggregation,
+  MetricAggregationWithInlineScript,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { defaultBucketAgg, defaultMetricAgg, findMetricById, highlightTags } from './query_def';
 import { ElasticsearchQuery } from './types';
-import { convertOrderByToMetricId } from './utils';
+import { convertOrderByToMetricId, getScriptValue } from './utils';
 
 export class ElasticQueryBuilder {
   timeField: string;
@@ -204,8 +206,9 @@ export class ElasticQueryBuilder {
     target.metrics = target.metrics || [defaultMetricAgg()];
     target.bucketAggs = target.bucketAggs || [defaultBucketAgg()];
     target.timeField = this.timeField;
+    let metric: MetricAggregation;
 
-    let i, j, pv, nestedAggs, metric;
+    let i, j, pv, nestedAggs;
     const query = {
       size: 0,
       query: {
@@ -340,7 +343,9 @@ export class ElasticQueryBuilder {
       if (isMetricAggregationWithSettings(metric)) {
         Object.entries(metric.settings || {})
           .filter(([_, v]) => v !== null)
-          .forEach(([k, v]) => (metricAgg[k] = v));
+          .forEach(([k, v]) => {
+            metricAgg[k] = k === 'script' ? getScriptValue(metric as MetricAggregationWithInlineScript) : v;
+          });
       }
 
       aggField[metric.type] = metricAgg;

--- a/public/app/plugins/datasource/elasticsearch/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.ts
@@ -1,6 +1,7 @@
 import {
   isMetricAggregationWithField,
   MetricAggregation,
+  MetricAggregationWithInlineScript,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
 
@@ -62,3 +63,31 @@ export const convertOrderByToMetricId = (orderBy: string): string | undefined =>
   const metricIdMatches = orderBy.match(/^(\d+)/);
   return metricIdMatches ? metricIdMatches[1] : void 0;
 };
+
+/** Gets the actual script value for metrics that support inline scripts.
+ *
+ *  This is needed because the `script` is a bit polymorphic.
+ *  when creating a query with Grafana < 7.4 it was stored as:
+ * ```json
+ * {
+ *    "settings": {
+ *      "script": {
+ *        "inline": "value"
+ *      }
+ *    }
+ * }
+ * ```
+ *
+ * while from 7.4 it's stored as
+ * ```json
+ * {
+ *    "settings": {
+ *      "script": "value"
+ *    }
+ * }
+ * ```
+ *
+ * This allows us to access both formats and support both queries created before 7.4 and after.
+ */
+export const getScriptValue = (metric: MetricAggregationWithInlineScript) =>
+  (typeof metric.settings?.script === 'object' ? metric.settings?.script?.inline : metric.settings?.script) || '';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder at the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
before `7.4`, `script` settings were stored like
```
settings: {
  script: {
    inline: "value"
  }
}
```

during the react refactoring this was accidentally changed to
```
settings: {
  script: "value"
}
```
which for Grafana use cases is totally equivalent (both syntaxes were/are supported by Elasticsearch)

this caused an issue with the new query editor, where the content of the settings field for the script would appear as `[object Object]`.

This PR doesn't really fix the way we store this setting (eg, rolling back to the previous version) but rather consolidate the new syntax as it fully functional and also fixes deprecation warnings as reported in  #23766

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #31531

The bug (not this PR) fixed by this PR incidentally fixed #23766


**Special notes for your reviewer**:

to properly test this works, you can use the following query model which has metric aggregations with both syntaxes.
Without modifying the query, all fields should get retrieved in every ES version (2,5,6,7) and all the script settings should be displayed correctly:

![Screenshot 2021-03-04 at 14 19 47](https://user-images.githubusercontent.com/1170767/109977528-cf7ef300-7cf4-11eb-80b2-2df35c5db6fa.png)


```json
  "targets": [
    {
      "alias": "",
      "bucketAggs": [
        {
          "field": "@timestamp",
          "id": "2",
          "settings": {
            "interval": "auto",
            "min_doc_count": 0,
            "trimEdges": 0
          },
          "type": "date_histogram"
        }
      ],
      "metrics": [
        {
          "field": "select field",
          "id": "1",
          "type": "count"
        },
        {
          "id": "3",
          "settings": {
            "script": {
              "inline": "100"
            }
          },
          "type": "avg"
        },
        {
          "id": "4",
          "settings": {
            "script": {
              "inline": "100"
            }
          },
          "type": "sum"
        },
        {
          "id": "5",
          "settings": {
            "script": {
              "inline": "100"
            }
          },
          "type": "max"
        },
        {
          "id": "6",
          "settings": {
            "script": {
              "inline": "100"
            }
          },
          "type": "min"
        },
        {
          "id": "7",
          "meta": {
            "std_deviation_bounds_lower": true,
            "std_deviation_bounds_upper": true
          },
          "settings": {
            "script": {
              "inline": "100"
            }
          },
          "type": "extended_stats"
        },
        {
          "id": "8",
          "settings": {
            "percents": ["25", "50", "75", "95", "99"],
            "script": {
              "inline": "100"
            }
          },
          "type": "percentiles"
        },
        {
          "id": "9",
          "pipelineVariables": [
            {
              "name": "var1",
              "pipelineAgg": ""
            }
          ],
          "settings": {
            "script": {
              "inline": "100"
            }
          },
          "type": "bucket_script"
        },
        {
          "id": "10",
          "settings": {
            "script": "100"
          },
          "type": "avg"
        },
        {
          "id": "11",
          "settings": {
            "script": "100"
          },
          "type": "sum"
        },
        {
          "id": "12",
          "settings": {
            "script": "100"
          },
          "type": "max"
        },
        {
          "id": "13",
          "settings": {
            "script": "100"
          },
          "type": "min"
        },
        {
          "id": "14",
          "meta": {
            "std_deviation_bounds_lower": true,
            "std_deviation_bounds_upper": true
          },
          "settings": {
            "script": "100"
          },
          "type": "extended_stats"
        },
        {
          "id": "15",
          "settings": {
            "percents": ["25", "50", "75", "95", "99"],
            "script": "100"
          },
          "type": "percentiles"
        },
        {
          "id": "16",
          "pipelineVariables": [
            {
              "name": "var1",
              "pipelineAgg": ""
            }
          ],
          "settings": {
            "script": "100"
          },
          "type": "bucket_script"
        }
      ],
      "query": "",
      "refId": "A",
      "timeField": "@timestamp"
    }
  ]
```

