### PR TITLE
Routing NG: force reloading of routes

### DIFF
--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -7,7 +7,8 @@ import { config } from '../config';
 export interface LocationService {
   partial: (query: Record<string, any>, replace?: boolean) => void;
   push: (location: H.Path | H.LocationDescriptor<any>) => void;
-  replace: (location: H.Path) => void;
+  replace: (location: H.Path | H.LocationDescriptor<any>, forceRouteReload?: boolean) => void;
+  reload: () => void;
   getLocation: () => H.Location;
   getHistory: () => H.History;
   getSearch: () => URLSearchParams;
@@ -116,8 +117,24 @@ class HistoryWrapper implements LocationService {
     this.history.push(location);
   }
 
-  replace(location: H.Path) {
-    this.history.replace(location);
+  replace(location: H.Path | H.LocationDescriptor, forceRouteReload?: boolean) {
+    const state = forceRouteReload ? { forceRouteReload: true } : undefined;
+
+    if (typeof location === 'string') {
+      this.history.replace(location, state);
+    } else {
+      this.history.replace({
+        ...location,
+        state,
+      });
+    }
+  }
+
+  reload() {
+    this.history.replace({
+      ...this.history.location,
+      state: { forceRouteReload: true },
+    });
   }
 
   getLocation() {

--- a/public/app/core/navigation/GrafanaRoute.test.tsx
+++ b/public/app/core/navigation/GrafanaRoute.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { GrafanaRoute } from './GrafanaRoute';
+import { locationService } from '@grafana/runtime';
 
 describe('GrafanaRoute', () => {
   it('Parses search', () => {
@@ -20,5 +21,36 @@ describe('GrafanaRoute', () => {
     );
 
     expect(capturedProps.queryParams.query).toBe('hello');
+  });
+
+  it('Should clear history forceRouteReload state after route change', () => {
+    const renderSpy = jest.fn();
+
+    const route = {
+      /* eslint-disable-next-line react/display-name */
+      component: () => {
+        renderSpy();
+        return <div />;
+      },
+    } as any;
+
+    const history = locationService.getHistory();
+
+    const { rerender } = render(
+      <GrafanaRoute location={history.location} history={history} match={{} as any} route={route} />
+    );
+
+    expect(renderSpy).toBeCalledTimes(1);
+    locationService.replace('/test', true);
+    expect(history.location.state).toMatchInlineSnapshot(`
+      Object {
+        "forceRouteReload": true,
+      }
+    `);
+
+    rerender(<GrafanaRoute location={history.location} history={history} match={{} as any} route={route} />);
+
+    expect(history.location.state).toMatchInlineSnapshot(`Object {}`);
+    expect(renderSpy).toBeCalledTimes(2);
   });
 });

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -4,6 +4,7 @@ import Drop from 'tether-drop';
 import { GrafanaRouteComponentProps } from './types';
 import { locationSearchToObject, navigationLogger } from '@grafana/runtime';
 import { keybindingSrv } from '../services/keybindingSrv';
+import { shouldReloadPage } from './utils';
 
 export interface Props extends Omit<GrafanaRouteComponentProps, 'queryParams'> {}
 
@@ -21,6 +22,13 @@ export class GrafanaRoute extends React.Component<Props> {
 
   componentDidUpdate(prevProps: Props) {
     this.cleanupDOM();
+
+    // Clear force reload state when route updates
+    if (shouldReloadPage(this.props.location)) {
+      navigationLogger('GrafanaRoute', false, 'Force reload', this.props, prevProps);
+      delete (this.props.history.location.state as any)?.forceRouteReload;
+    }
+
     navigationLogger('GrafanaRoute', false, 'Updated', this.props, prevProps);
   }
 

--- a/public/app/core/navigation/utils.ts
+++ b/public/app/core/navigation/utils.ts
@@ -1,0 +1,5 @@
+import * as H from 'history';
+
+export function shouldReloadPage(location: H.Location<any>) {
+  return !!location.state?.forceRouteReload;
+}

--- a/public/app/features/dashboard/components/VersionHistory/RevertDashboardModal.tsx
+++ b/public/app/features/dashboard/components/VersionHistory/RevertDashboardModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ConfirmModal } from '@grafana/ui';
 import { useDashboardRestore } from './useDashboardRestore';
 export interface RevertDashboardModalProps {
@@ -8,7 +8,13 @@ export interface RevertDashboardModalProps {
 
 export const RevertDashboardModal: React.FC<RevertDashboardModalProps> = ({ hideModal, version }) => {
   // TODO: how should state.error be handled?
-  const { onRestoreDashboard } = useDashboardRestore(version);
+  const { state, onRestoreDashboard } = useDashboardRestore(version);
+
+  useEffect(() => {
+    if (state.loading === false && state.value) {
+      hideModal();
+    }
+  }, [state, hideModal]);
 
   return (
     <ConfirmModal

--- a/public/app/features/dashboard/components/VersionHistory/useDashboardRestore.tsx
+++ b/public/app/features/dashboard/components/VersionHistory/useDashboardRestore.tsx
@@ -1,13 +1,12 @@
 import { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useAsyncFn } from 'react-use';
 import { AppEvents, locationUtil } from '@grafana/data';
 import appEvents from 'app/core/app_events';
-import { updateLocation } from 'app/core/reducers/location';
-import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { StoreState } from 'app/types';
 import { historySrv } from './HistorySrv';
 import { DashboardModel } from '../../state';
+import { locationService } from '@grafana/runtime';
 
 const restoreDashboard = async (version: number, dashboard: DashboardModel) => {
   return await historySrv.restoreDashboard(dashboard, version);
@@ -15,19 +14,11 @@ const restoreDashboard = async (version: number, dashboard: DashboardModel) => {
 
 export const useDashboardRestore = (version: number) => {
   const dashboard = useSelector((state: StoreState) => state.dashboard.getModel());
-  const dispatch = useDispatch();
   const [state, onRestoreDashboard] = useAsyncFn(async () => await restoreDashboard(version, dashboard!), []);
   useEffect(() => {
     if (state.value) {
       const newUrl = locationUtil.stripBaseFromUrl(state.value.url);
-      dispatch(
-        updateLocation({
-          path: newUrl,
-          replace: true,
-          query: {},
-        })
-      );
-      dashboardWatcher.reloadPage();
+      locationService.replace(newUrl, true);
       appEvents.emit(AppEvents.alertSuccess, ['Dashboard restored', 'Restored from version ' + version]);
     }
   }, [state]);

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -25,6 +25,7 @@ import { findTemplateVarChanges } from '../../variables/utils';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { getTimeSrv } from '../services/TimeSrv';
+import { shouldReloadPage } from 'app/core/navigation/utils';
 
 export interface DashboardPageRouteParams {
   uid?: string;
@@ -122,7 +123,7 @@ export class DashboardPage extends PureComponent<Props, State> {
       document.title = dashboard.title + ' - ' + Branding.AppTitle;
     }
 
-    if (prevProps.match.params.uid !== match.params.uid) {
+    if (prevProps.match.params.uid !== match.params.uid || shouldReloadPage(this.props.location)) {
       this.initDashboard();
       return;
     }

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -92,9 +92,12 @@ async function fetchDashboard(
           const currentPath = locationService.getLocation().pathname;
 
           if (dashboardUrl !== currentPath) {
-            locationService.replace(dashboardUrl);
+            // Spread current location to persist search params used for navigation
+            locationService.replace({
+              ...locationService.getLocation(),
+              pathname: dashboardUrl,
+            });
             console.log('not correct url correcting', dashboardUrl, currentPath);
-            return null;
           }
         }
         return dashDTO;

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -1,4 +1,4 @@
-import { getGrafanaLiveSrv, getLegacyAngularInjector } from '@grafana/runtime';
+import { getGrafanaLiveSrv, getLegacyAngularInjector, locationService } from '@grafana/runtime';
 import { getDashboardSrv } from '../../dashboard/services/DashboardSrv';
 import { appEvents } from 'app/core/core';
 import {
@@ -153,12 +153,7 @@ class DashboardWatcher {
   };
 
   reloadPage() {
-    const $route = getLegacyAngularInjector().get<any>('$route');
-    if ($route) {
-      $route.reload();
-    } else {
-      location.reload();
-    }
+    locationService.reload();
   }
 }
 


### PR DESCRIPTION
Intorduces `reload` method to HistoryWrapper as well as modifies `replace` method signature to allow routes reload.

Not super happy with the solution, but seems to be the one being the simples for our needs (seems likeonly dashboards need this). Idea is to utilize a transient state of history. When reload or replace with reload is called, history's state is set to forceRouteReload: true. This is then cleared as soon as GrafanaRoute is updated but the underlying page can still utilize the state when updating. 