### PR TITLE
ReactRouter: Fixes some scenarios after migration

### DIFF
--- a/e2e/suite1/specs/variables/load-options-from-url.ts
+++ b/e2e/suite1/specs/variables/load-options-from-url.ts
@@ -1,6 +1,6 @@
 import { e2e } from '@grafana/e2e';
 
-const PAGE_UNDER_TEST = '-Y-tnEDWk';
+const PAGE_UNDER_TEST = '-Y-tnEDWk/templating-nested-template-variables';
 
 describe('Variables - Load options from Url', () => {
   it('default options should be correct', () => {
@@ -58,7 +58,7 @@ describe('Variables - Load options from Url', () => {
 
   it('options set in url should load correct options', () => {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?var-datacenter=B&var-server=BB&var-pod=BBB` });
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1&var-datacenter=B&var-server=BB&var-pod=BBB` });
     e2e().server();
     e2e()
       .route({
@@ -122,7 +122,7 @@ describe('Variables - Load options from Url', () => {
       return true;
     });
 
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?var-datacenter=X` });
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1&var-datacenter=X` });
     e2e().server();
     e2e()
       .route({

--- a/e2e/suite1/specs/variables/new-query-variable.ts
+++ b/e2e/suite1/specs/variables/new-query-variable.ts
@@ -1,11 +1,11 @@
 import { e2e } from '@grafana/e2e';
 
-const PAGE_UNDER_TEST = '-Y-tnEDWk';
+const PAGE_UNDER_TEST = '-Y-tnEDWk/templating-nested-template-variables';
 
 describe('Variables - Add variable', () => {
   it('query variable should be default and default fields should be correct', () => {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?editview=templating` });
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1&editview=templating` });
 
     e2e.pages.Dashboard.Settings.Variables.List.newButton().should('be.visible').click();
 
@@ -73,7 +73,7 @@ describe('Variables - Add variable', () => {
 
   it('adding a single value query variable', () => {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?editview=templating` });
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1&editview=templating` });
 
     e2e.pages.Dashboard.Settings.Variables.List.newButton().should('be.visible').click();
 
@@ -127,7 +127,7 @@ describe('Variables - Add variable', () => {
 
   it('adding a multi value query variable', () => {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?editview=templating` });
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1&editview=templating` });
 
     e2e.pages.Dashboard.Settings.Variables.List.newButton().should('be.visible').click();
 

--- a/e2e/suite1/specs/variables/set-options-from-ui.ts
+++ b/e2e/suite1/specs/variables/set-options-from-ui.ts
@@ -1,11 +1,11 @@
 import { e2e } from '@grafana/e2e';
 
-const PAGE_UNDER_TEST = '-Y-tnEDWk';
+const PAGE_UNDER_TEST = '-Y-tnEDWk/templating-nested-template-variables';
 
 describe('Variables - Set options from ui', () => {
   it('clicking a value that is not part of dependents options should change these to All', () => {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?var-datacenter=A&var-server=AA&var-pod=AAA` });
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1&var-datacenter=A&var-server=AA&var-pod=AAA` });
     e2e().server();
     e2e()
       .route({
@@ -25,6 +25,8 @@ describe('Variables - Set options from ui', () => {
     e2e().wait('@query');
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('B').scrollIntoView().should('be.visible');
+
+    e2e.components.LoadingIndicator.icon().should('have.length', 0);
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('All').should('have.length', 2);
 
@@ -63,7 +65,7 @@ describe('Variables - Set options from ui', () => {
 
   it('adding a value that is not part of dependents options should add the new values dependant options', () => {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?var-datacenter=A&var-server=AA&var-pod=AAA` });
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?orgId=1&var-datacenter=A&var-server=AA&var-pod=AAA` });
     e2e().server();
     e2e()
       .route({
@@ -83,6 +85,8 @@ describe('Variables - Set options from ui', () => {
     e2e().wait(500);
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('A + B').scrollIntoView().should('be.visible');
+
+    e2e.components.LoadingIndicator.icon().should('have.length', 0);
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('AA').should('be.visible').click();
 
@@ -117,7 +121,7 @@ describe('Variables - Set options from ui', () => {
   it('removing a value that is part of dependents options should remove the new values dependant options', () => {
     e2e.flows.login('admin', 'admin');
     e2e.flows.openDashboard({
-      uid: `${PAGE_UNDER_TEST}?var-datacenter=A&var-datacenter=B&var-server=AA&var-server=BB&var-pod=AAA&var-pod=BBB`,
+      uid: `${PAGE_UNDER_TEST}?orgId=1&var-datacenter=A&var-datacenter=B&var-server=AA&var-server=BB&var-pod=AAA&var-pod=BBB`,
     });
     e2e().server();
     e2e()
@@ -138,6 +142,8 @@ describe('Variables - Set options from ui', () => {
     e2e().wait(500);
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('B').scrollIntoView().should('be.visible');
+
+    e2e.components.LoadingIndicator.icon().should('have.length', 0);
 
     e2e.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts('BB').should('be.visible').click();
 

--- a/e2e/suite1/specs/variables/textbox-variables.ts
+++ b/e2e/suite1/specs/variables/textbox-variables.ts
@@ -5,32 +5,16 @@ const PAGE_UNDER_TEST = 'AejrN1AMz';
 describe('TextBox - load options scenarios', function () {
   it('default options should be correct', function () {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: PAGE_UNDER_TEST });
-    e2e().server();
-    e2e()
-      .route({
-        method: 'GET',
-        url: `/api/dashboards/uid/${PAGE_UNDER_TEST}`,
-      })
-      .as('dash');
-
-    e2e().wait('@dash');
+    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}/templating-textbox-e2e-scenarios?orgId=1` });
 
     validateTextboxAndMarkup('default value');
   });
 
   it('loading variable from url should be correct', function () {
     e2e.flows.login('admin', 'admin');
-    e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?var-text=not default value` });
-    e2e().server();
-    e2e()
-      .route({
-        method: 'GET',
-        url: `/api/dashboards/uid/${PAGE_UNDER_TEST}`,
-      })
-      .as('dash');
-
-    e2e().wait('@dash');
+    e2e.flows.openDashboard({
+      uid: `${PAGE_UNDER_TEST}/templating-textbox-e2e-scenarios?orgId=1&var-text=not default value`,
+    });
 
     validateTextboxAndMarkup('not default value');
   });
@@ -159,7 +143,7 @@ function copyExistingDashboard() {
       url: /\/api\/dashboards\/uid\/(?!AejrN1AMz)\w+/,
     })
     .as('load-dash');
-  e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}?editview=settings&orgId=1` });
+  e2e.flows.openDashboard({ uid: `${PAGE_UNDER_TEST}/templating-textbox-e2e-scenarios?orgId=1&editview=settings` });
 
   e2e().wait('@dash-settings');
 

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -178,4 +178,7 @@ export const Components = {
     dropDown: 'Dashboard link dropdown',
     link: 'Dashboard link',
   },
+  LoadingIndicator: {
+    icon: 'Loading indicator',
+  },
 };

--- a/public/app/features/variables/pickers/shared/VariableLink.tsx
+++ b/public/app/features/variables/pickers/shared/VariableLink.tsx
@@ -83,7 +83,13 @@ const LoadingIndicator: FC<Pick<Props, 'onCancel'>> = ({ onCancel }) => {
 
   return (
     <Tooltip content="Cancel query">
-      <Icon className="spin-clockwise" name="sync" size="xs" onClick={onClick} />
+      <Icon
+        className="spin-clockwise"
+        name="sync"
+        size="xs"
+        onClick={onClick}
+        aria-label={selectors.components.LoadingIndicator.icon}
+      />
     </Tooltip>
   );
 };


### PR DESCRIPTION
Things I found during looking at the e2e tests and trying to fix them:

1. Minor: previously as a user you could enter `http://localhost:3000/-Y-tnEDWk/?var-datacenter=A&var-server=AA&var-pod=AAA` and the Angular router would resolve this to `http://localhost:3000/-Y-tnEDWk/templating-nested-template-variables?orgId=1&var-datacenter=A&var-server=AA&var-pod=AAA`. I've tried to change the e2e scenarios that use this shortcut.
2. Major: multi-select variable urls aren't working at all. Entering `http://localhost:3000/d/-Y-tnEDWk/templating-nested-template-variables?orgId=1&var-datacenter=A&var-datacenter=C` should mean that both `A + C` are selected for the variable `datacenter`. Only the last one i.e. `C` in this case is selected.
3. Major: selecting a value in a multi-select variable is broken. Selecting `A + C` in `datacenter` here `http://localhost:3000/d/-Y-tnEDWk/templating-nested-template-variables?orgId=1` results in a comma separated list `http://localhost:3000/d/-Y-tnEDWk/templating-nested-template-variables?orgId=1&var-datacenter=A%2CC` instead of `http://localhost:3000/d/-Y-tnEDWk/templating-nested-template-variables?orgId=1&var-datacenter=A&var-datacenter=C`
 