### PR TITLE
Chore: Update testing field in latest.json to 7.5.0-beta1

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -1,4 +1,4 @@
 {
   "stable": "7.4.3",
-  "testing": "7.4.3"
+  "testing": "7.5.0-beta1"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated `"testing"` field in `latest.json` after `7.5.0-beta1` release
