### PR TITLE
Tempo: set authentication header properly

### DIFF
--- a/pkg/tsdb/tempo/tempo.go
+++ b/pkg/tsdb/tempo/tempo.go
@@ -60,6 +60,10 @@ func (e *tempoExecutor) Query(ctx context.Context, dsInfo *models.DataSource, ts
 		return nil, err
 	}
 
+	if dsInfo.BasicAuth {
+		req.SetBasicAuth(dsInfo.BasicAuthUser, dsInfo.DecryptedBasicAuthPassword())
+	}
+
 	req.Header.Set("Accept", "application/protobuf")
 
 	resp, err := e.httpClient.Do(req)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes the bug that tempo backend data source didn't add the auth header.
