### PR TITLE
FieldDisplay: Smarter naming of stat values when visualising row values (all values) in stat panels

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -205,15 +205,16 @@ describe('FieldDisplay', () => {
   });
 
   describe('auto option', () => {
-    it('No string fields', () => {
+    it('No string fields, single value', () => {
       const options = createDisplayOptions({
+        reduceOptions: {
+          values: true,
+          calcs: [],
+        },
         data: [
           toDataFrame({
             name: 'Series Name',
-            fields: [
-              { name: 'A', values: [10] },
-              { name: 'B', values: [20] },
-            ],
+            fields: [{ name: 'A', values: [10] }],
           }),
         ],
       });
@@ -221,12 +222,14 @@ describe('FieldDisplay', () => {
       const result = getFieldDisplayValues(options);
       expect(result[0].display.title).toEqual('A');
       expect(result[0].display.text).toEqual('10');
-      expect(result[1].display.title).toEqual('B');
-      expect(result[1].display.text).toEqual('20');
     });
 
-    it('String field', () => {
+    it('Single other string field', () => {
       const options = createDisplayOptions({
+        reduceOptions: {
+          values: true,
+          calcs: [],
+        },
         data: [
           toDataFrame({
             fields: [
@@ -241,6 +244,56 @@ describe('FieldDisplay', () => {
       expect(result[0].display.title).toEqual('A');
       expect(result[0].display.text).toEqual('10');
       expect(result[1].display.title).toEqual('B');
+      expect(result[1].display.text).toEqual('20');
+    });
+
+    it('Single string field multiple value fields', () => {
+      const options = createDisplayOptions({
+        reduceOptions: {
+          values: true,
+          calcs: [],
+        },
+        data: [
+          toDataFrame({
+            fields: [
+              { name: 'Name', values: ['A', 'B'] },
+              { name: 'SensorA', values: [10, 20] },
+              { name: 'SensorB', values: [10, 20] },
+            ],
+          }),
+        ],
+      });
+
+      const result = getFieldDisplayValues(options);
+      expect(result[0].display.title).toEqual('A SensorA');
+      expect(result[0].display.text).toEqual('10');
+      expect(result[1].display.title).toEqual('B SensorA');
+      expect(result[1].display.text).toEqual('20');
+      expect(result[2].display.title).toEqual('A SensorB');
+      expect(result[3].display.title).toEqual('B SensorB');
+    });
+
+    it('Multiple other string fields', () => {
+      const options = createDisplayOptions({
+        reduceOptions: {
+          values: true,
+          calcs: [],
+        },
+        data: [
+          toDataFrame({
+            fields: [
+              { name: 'Country', values: ['Sweden', 'Norway'] },
+              { name: 'City', values: ['Stockholm', 'Oslo'] },
+              { name: 'Value', values: [10, 20] },
+            ],
+          }),
+        ],
+      });
+
+      const result = getFieldDisplayValues(options);
+      expect(result[0].display.title).toEqual('Sweden Stockholm');
+      expect(result[0].display.text).toEqual('10');
+      expect(result[1].display.title).toEqual('Norway Oslo');
       expect(result[1].display.text).toEqual('20');
     });
   });

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -203,6 +203,47 @@ describe('FieldDisplay', () => {
       expect(result[3].display.text).toEqual(mappedValue);
     });
   });
+
+  describe('auto option', () => {
+    it('No string fields', () => {
+      const options = createDisplayOptions({
+        data: [
+          toDataFrame({
+            name: 'Series Name',
+            fields: [
+              { name: 'A', values: [10] },
+              { name: 'B', values: [20] },
+            ],
+          }),
+        ],
+      });
+
+      const result = getFieldDisplayValues(options);
+      expect(result[0].display.title).toEqual('A');
+      expect(result[0].display.text).toEqual('10');
+      expect(result[1].display.title).toEqual('B');
+      expect(result[1].display.text).toEqual('20');
+    });
+
+    it('String field', () => {
+      const options = createDisplayOptions({
+        data: [
+          toDataFrame({
+            fields: [
+              { name: 'Name', values: ['A', 'B'] },
+              { name: 'Value', values: [10, 20] },
+            ],
+          }),
+        ],
+      });
+
+      const result = getFieldDisplayValues(options);
+      expect(result[0].display.title).toEqual('A');
+      expect(result[0].display.text).toEqual('10');
+      expect(result[1].display.title).toEqual('B');
+      expect(result[1].display.text).toEqual('20');
+    });
+  });
 });
 
 function createEmptyDisplayOptions(extend = {}): GetFieldDisplayValuesOptions {

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -108,7 +108,6 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
   const data = options.data ?? [];
   const limit = reduceOptions.limit ? reduceOptions.limit : DEFAULT_FIELD_DISPLAY_VALUES_LIMIT;
   const scopedVars: ScopedVars = {};
-  const defaultDisplayName = getTitleTemplate(calcs);
 
   let hitLimit = false;
 

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -45,17 +45,6 @@ export const VAR_FIELD_LABELS = '__field.labels';
 export const VAR_CALC = '__calc';
 export const VAR_CELL_PREFIX = '__cell_'; // consistent with existing table templates
 
-function getTitleTemplate(stats: string[]): string {
-  const parts: string[] = [];
-  if (stats.length > 1) {
-    parts.push('${' + VAR_CALC + '}');
-  }
-
-  parts.push('${' + VAR_FIELD_NAME + '}');
-
-  return parts.join(' ');
-}
-
 export interface FieldSparkline {
   y: Field; // Y values
   x?: Field; // if this does not exist, use the index


### PR DESCRIPTION
I have struggled with this problem for over a year,  tried multiple times, but think we need to solve this. 

Fixes #26826

The problem is naming stat / gauge / bar gauge / pie chart elements when the data looks like this (Which it does for Elasticsearch for queries without date histogram) 

| Hostname  | Count |
| ------------- | ------------- |
| ServerA  | 10  |
| ServerB  | 20 |
| ServerC  | 30 |

Currently, all the stat panels, show a single value here (the last 30), as by default it will calculate a value using the last reducer. You have to manually set it to All values. Then you get a gauge or bar for each row BUT all have the same name Count. To make grafana use the value of another row as the name/title of a bar/guage you have to enter a cryptic expression `$__cell_0` in the field display. 

This PR:

* When all values is enabled and no displayName set automatically check if there are other string fields and use those for name 
* only add the name of the current field if there is more than one numeric field 

See unit tests for more examples. 

Big open question. Could this be a big-breaking change? 

I also considering a new "Auto" mode in addition to Calculate & All values that can be smart and try to choose between calculating or all values depending on the structure of the data (but hard to get right) 

Elasticsearch example that now just works:

<img width="746" alt="Screen Shot 2021-03-05 at 08 36 13" src="https://user-images.githubusercontent.com/10999/110082640-ea517600-7d8d-11eb-890d-21827f17b987.png">
