### PR TITLE
Elasticsearch: revert to isoWeek when resolving weekly indices

### DIFF
--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -97,6 +97,7 @@ export const toUtc = (input?: DateTimeInput, formatInput?: FormatInput): DateTim
 };
 
 export const toDuration = (input?: DurationInput, unit?: DurationUnit): DateTimeDuration => {
+  // moment built-in types are a bit flaky, for example `isoWeek` is not in the type definition but it's present in the js source.
   return moment.duration(input as DurationInputArg1, unit as DurationInputArg2) as DateTimeDuration;
 };
 

--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -1,6 +1,6 @@
 import { TimeZone } from '../types/time';
 /* eslint-disable id-blacklist, no-restricted-imports, @typescript-eslint/ban-types */
-import moment, { Moment, MomentInput, DurationInputArg1 } from 'moment';
+import moment, { Moment, MomentInput, DurationInputArg1, DurationInputArg2 } from 'moment';
 export interface DateTimeBuiltinFormat {
   __momentBuiltinFormatBrand: any;
 }
@@ -17,6 +17,7 @@ export type DurationUnit =
   | 'M'
   | 'week'
   | 'weeks'
+  | 'isoWeek'
   | 'w'
   | 'day'
   | 'days'
@@ -96,7 +97,7 @@ export const toUtc = (input?: DateTimeInput, formatInput?: FormatInput): DateTim
 };
 
 export const toDuration = (input?: DurationInput, unit?: DurationUnit): DateTimeDuration => {
-  return moment.duration(input as DurationInputArg1, unit) as DateTimeDuration;
+  return moment.duration(input as DurationInputArg1, unit as DurationInputArg2) as DateTimeDuration;
 };
 
 export const dateTime = (input?: DateTimeInput, formatInput?: FormatInput): DateTime => {

--- a/public/app/plugins/datasource/elasticsearch/index_pattern.ts
+++ b/public/app/plugins/datasource/elasticsearch/index_pattern.ts
@@ -12,7 +12,7 @@ type IntervalMap = Record<
 const intervalMap: IntervalMap = {
   Hourly: { startOf: 'hour', amount: 'hours' },
   Daily: { startOf: 'day', amount: 'days' },
-  Weekly: { startOf: 'week', amount: 'weeks' },
+  Weekly: { startOf: 'isoWeek', amount: 'weeks' },
   Monthly: { startOf: 'month', amount: 'months' },
   Yearly: { startOf: 'year', amount: 'years' },
 };

--- a/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/index_pattern.test.ts
@@ -55,6 +55,20 @@ describe('IndexPattern', () => {
         expect(pattern.getIndexList(from, to)).toEqual(expected);
       });
     });
+
+    describe('weekly', () => {
+      it('should return correct index list', () => {
+        const pattern = new IndexPattern('[asd-]YYYY.WW', 'Weekly');
+        // Sunday, February 21, 2021 1:00:00 AM
+        const from = dateTime(new Date(1613869200000));
+        // Friday, March 5, 2021 1:00:00 AM
+        const to = dateTime(new Date(1614906000000));
+
+        const expected = ['asd-2021.07', 'asd-2021.08', 'asd-2021.09'];
+
+        expect(pattern.getIndexList(from, to)).toEqual(expected);
+      });
+    });
   });
 
   describe('when getting index list from single date', () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

As described in the issue, in https://github.com/grafana/grafana/pull/29841 we mistakenly switched from `isoWeek` to `week` when resolving weekly indices in elasticsearch. This reverts the change back.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #31634




