### PR TITLE
Templating: use dashboard timerange when variables are set to refresh 'On Dashboard Load'

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
@@ -418,7 +418,7 @@ function createMultiVariable(extend?: Partial<QueryVariableModel>): QueryVariabl
     tagsQuery: 'tags-query',
     tagValuesQuery: '',
     useTags: true,
-    refresh: VariableRefresh.onDashboardLoad,
+    refresh: VariableRefresh.never,
     regex: '',
     multi: true,
     includeAll: true,

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -144,7 +144,7 @@ const fetchTagValues = (tagText: string): ThunkResult<Promise<string[]>> => {
 };
 
 const getTimeRange = (variable: QueryVariableModel) => {
-  if (variable.refresh === VariableRefresh.onTimeRangeChanged) {
+  if (variable.refresh === VariableRefresh.onTimeRangeChanged || variable.refresh === VariableRefresh.onDashboardLoad) {
     return getTimeSrv().timeRange();
   }
   return undefined;

--- a/public/app/features/variables/query/queryRunners.test.ts
+++ b/public/app/features/variables/query/queryRunners.test.ts
@@ -70,6 +70,41 @@ describe('QueryRunners', () => {
       });
     });
 
+    describe('and calling runRequest with a variable that refreshes on dashboard load', () => {
+      const { datasource, runner, runnerArgs, request, timeSrv, defaultTimeRange } = getLegacyTestContext({
+        query: 'A query',
+        refresh: VariableRefresh.onDashboardLoad,
+      });
+      const observable = runner.runRequest(runnerArgs, request);
+
+      it('then it should return correct observable', async () => {
+        await expect(observable).toEmitValuesWith((received) => {
+          const value = received[0];
+          expect(value).toEqual({
+            series: [{ text: 'A', value: 'A' }],
+            state: 'Done',
+            timeRange: defaultTimeRange,
+          });
+        });
+      });
+
+      it('and it should call timeSrv.timeRange()', () => {
+        expect(timeSrv.timeRange).toHaveBeenCalledTimes(1);
+      });
+
+      it('and it should call metricFindQuery with correct options', () => {
+        expect(datasource.metricFindQuery).toHaveBeenCalledTimes(1);
+        expect(datasource.metricFindQuery).toHaveBeenCalledWith('A query', {
+          range: defaultTimeRange,
+          searchFilter: 'A searchFilter',
+          variable: {
+            query: 'A query',
+            refresh: VariableRefresh.onDashboardLoad,
+          },
+        });
+      });
+    });
+
     describe('and calling runRequest with a variable that does not refresh when time range changes', () => {
       const { datasource, runner, runnerArgs, request, timeSrv } = getLegacyTestContext({
         query: 'A query',

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -137,7 +137,7 @@ export function getTemplatedRegex(variable: QueryVariableModel, templateSrv = ge
 
 export function getLegacyQueryOptions(variable: QueryVariableModel, searchFilter?: string, timeSrv = getTimeSrv()) {
   const queryOptions: any = { range: undefined, variable, searchFilter };
-  if (variable.refresh === VariableRefresh.onTimeRangeChanged) {
+  if (variable.refresh === VariableRefresh.onTimeRangeChanged || variable.refresh === VariableRefresh.onDashboardLoad) {
     queryOptions.range = timeSrv.timeRange();
   }
 


### PR DESCRIPTION




**What this PR does / why we need it**:
This change makes sure we pass the current dashboard time range when a query variable is set to refresh "on dashboard load"

for more context on why this is needed see https://github.com/grafana/grafana/issues/31474#issuecomment-790687646

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #31474, #31165

**Special notes for your reviewer**:

I couldn't find tests that specifically test when/how variables are refreshed. the test file I changed seems to be "unrelated" to this, meaning it only tests actions payload and not when / how many times "variables get refreshed".

I most likely overlooked something, if someone could point me to where this is/should be tested i'd be happy to add a few more tests.

Also, I'd consider this a "feature" rather than a fix so I'm targeting `7.5.0`, should I instead target`7.4.x` and consider this a fix?

/cc. @ivanahuckova we talked about this yesterday, what's your take on this?
