### PR TITLE
Instrumentation: log skipped, performed and duration for migrations

### DIFF
--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -79,11 +79,15 @@ func (mg *Migrator) Start() error {
 		return err
 	}
 
+	migrationsPerformed := 0
+	migrationsSkipped := 0
+	start := time.Now()
 	for _, m := range mg.migrations {
 		m := m
 		_, exists := logMap[m.Id()]
 		if exists {
 			mg.Logger.Debug("Skipping migration: Already executed", "id", m.Id())
+			migrationsSkipped++
 			continue
 		}
 
@@ -107,12 +111,17 @@ func (mg *Migrator) Start() error {
 			}
 			record.Success = true
 			_, err = sess.Insert(&record)
+			if err == nil {
+				migrationsPerformed++
+			}
 			return err
 		})
 		if err != nil {
 			return errutil.Wrap("migration failed", err)
 		}
 	}
+
+	mg.Logger.Info("migrations completed", "performed", migrationsPerformed, "skipped", migrationsSkipped, "duration", time.Since(start))
 
 	// Make sure migrations are synced
 	return mg.x.Sync2()


### PR DESCRIPTION
DB migrations take quite some time when starting an instance for the first time. We would like to know how long it takes and how long it takes when instances are upgraded. 