### PR TITLE
RoutingNG: When parsing and rendering url search/query params preseve old logic of handling booleans and arrays

### DIFF
--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -23,3 +23,15 @@ describe('toUrlParams', () => {
     expect(url).toBe('server=:@');
   });
 });
+
+describe('parseKeyValue', () => {
+  it('should parse url search params to object', () => {
+    const obj = urlUtil.parseKeyValue('param=value&param2=value2&kiosk');
+    expect(obj).toEqual({ param: 'value', param2: 'value2', kiosk: true });
+  });
+
+  it('should parse same url key multiple times to array', () => {
+    const obj = urlUtil.parseKeyValue('servers=A&servers=B');
+    expect(obj).toEqual({ servers: ['A', 'B'] });
+  });
+});

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -125,11 +125,62 @@ function getUrlSearchParams() {
   return params;
 }
 
+/**
+ * Parses an escaped url query string into key-value pairs.
+ * Attribution: Code dervived from https://github.com/angular/angular.js/master/src/Angular.js#L1396
+ * @returns {Object.<string,boolean|Array>}
+ */
+export function parseKeyValue(keyValue: string) {
+  var obj: any = {};
+  const parts = (keyValue || '').split('&');
+
+  for (let keyValue of parts) {
+    let splitPoint: number | undefined;
+    let key: string | undefined;
+    let val: string | undefined | boolean;
+
+    if (keyValue) {
+      key = keyValue = keyValue.replace(/\+/g, '%20');
+      splitPoint = keyValue.indexOf('=');
+
+      if (splitPoint !== -1) {
+        key = keyValue.substring(0, splitPoint);
+        val = keyValue.substring(splitPoint + 1);
+      }
+
+      key = tryDecodeURIComponent(key);
+
+      if (key !== undefined) {
+        val = val !== undefined ? tryDecodeURIComponent(val as string) : true;
+
+        if (!obj.hasOwnProperty(key)) {
+          obj[key] = val;
+        } else if (Array.isArray(obj[key])) {
+          obj[key].push(val);
+        } else {
+          obj[key] = [obj[key], val];
+        }
+      }
+    }
+  }
+
+  return obj;
+}
+
+function tryDecodeURIComponent(value: string): string | undefined {
+  try {
+    return decodeURIComponent(value);
+  } catch (e) {
+    return undefined;
+  }
+}
+
 export const urlUtil = {
   renderUrl,
   toUrlParams,
   appendQueryToUrl,
   getUrlSearchParams,
+  parseKeyValue,
 };
 
 export function serializeStateToUrlParam(urlState: ExploreUrlState, compact?: boolean): string {

--- a/packages/grafana-runtime/src/services/LocationService.test.ts
+++ b/packages/grafana-runtime/src/services/LocationService.test.ts
@@ -5,13 +5,35 @@ describe('LocationService', () => {
     it('returns query string as object', () => {
       locationService.push('/test?query1=false&query2=123&query3=text');
 
-      expect(locationService.getSearchObject()).toMatchInlineSnapshot(`
-      Object {
-        "query1": false,
-        "query2": "123",
-        "query3": "text",
-      }
-    `);
+      expect(locationService.getSearchObject()).toEqual({
+        query1: 'false',
+        query2: '123',
+        query3: 'text',
+      });
+    });
+
+    it('returns keys added multiple times as an array', () => {
+      locationService.push('/test?servers=A&servers=B&servers=C');
+
+      expect(locationService.getSearchObject()).toEqual({
+        servers: ['A', 'B', 'C'],
+      });
+    });
+  });
+
+  describe('partial', () => {
+    it('should handle removing params and updating', () => {
+      locationService.push('/test?query1=false&query2=123&query3=text');
+      locationService.partial({ query1: null, query2: 'update' });
+
+      expect(locationService.getLocation().search).toBe('?query2=update&query3=text');
+    });
+
+    it('should handle array values', () => {
+      locationService.push('/');
+      locationService.partial({ servers: ['A', 'B', 'C'] });
+
+      expect(locationService.getLocation().search).toBe('?servers=A&servers=B&servers=C');
     });
   });
 });

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -1,4 +1,4 @@
-import { locationUtil } from '@grafana/data';
+import { locationUtil, UrlQueryMap, urlUtil } from '@grafana/data';
 import * as H from 'history';
 import { LocationUpdate } from './LocationSrv';
 import { createLogger } from '@grafana/ui';
@@ -12,7 +12,7 @@ export interface LocationService {
   getLocation: () => H.Location;
   getHistory: () => H.History;
   getSearch: () => URLSearchParams;
-  getSearchObject: () => Record<string, string | boolean>;
+  getSearchObject: () => UrlQueryMap;
 
   /**
    * This is from the old LocationSrv interface
@@ -83,33 +83,23 @@ class HistoryWrapper implements LocationService {
 
   partial(query: Record<string, any>, replace?: boolean) {
     const currentLocation = this.history.location;
-    const params = this.getSearch();
+    const newQuery = this.getSearchObject();
 
     for (const key of Object.keys(query)) {
-      if (params.has(key)) {
-        // removing params with null | undefined
-        if (query[key] === null || query[key] === undefined) {
-          params.delete(key);
-        } else {
-          params.set(key, query[key]);
-        }
+      // removing params with null | undefined
+      if (query[key] === null || query[key] === undefined) {
+        delete newQuery[key];
       } else {
-        // ignoring params with null | undefined values
-        if (query[key] !== null && query[key] !== undefined) {
-          params.append(key, query[key]);
-        }
+        newQuery[key] = query[key];
       }
     }
 
-    const locationUpdate: H.Location = {
-      ...currentLocation,
-      search: params.toString(),
-    };
+    const updatedUrl = urlUtil.renderUrl(currentLocation.pathname, newQuery);
 
     if (replace) {
-      this.history.replace(locationUpdate);
+      this.history.replace(updatedUrl);
     } else {
-      this.history.push(locationUpdate);
+      this.history.push(updatedUrl);
     }
   }
 
@@ -157,24 +147,16 @@ class HistoryWrapper implements LocationService {
   }
 }
 
-function parseValue(value: string) {
-  if (value === 'true') {
-    return true;
-  }
-  if (value === 'false') {
-    return false;
-  }
-  return value;
-}
-
 /**
  * @alpha
  * Parses a location search string to an object
  * */
-export function locationSearchToObject(search: string) {
-  const params: Array<[string, string | boolean]> = [];
-  new URLSearchParams(search).forEach((v, k) => params.push([k, parseValue(v)]));
-  return Object.fromEntries(new Map(params));
+export function locationSearchToObject(search: string): UrlQueryMap {
+  if (search.length > 0) {
+    return urlUtil.parseKeyValue(search.substring(1));
+  }
+
+  return {};
 }
 
 export const locationService: LocationService = new HistoryWrapper();

--- a/public/app/features/dashboard/containers/SoloPanelPage.test.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.test.tsx
@@ -73,7 +73,6 @@ function soloPanelPageScenario(description: string, scenarioFn: (ctx: ScenarioCo
             },
             route: { routeName: DashboardRoutes.Normal } as any,
           }),
-          $injector: {},
           initDashboard: jest.fn(),
           dashboard: null,
         };


### PR DESCRIPTION
Restores old logic of parsing search to object and vice versa. meaning &kiosk  , translates to object {kiosk: true} , and `var-servers=A&var-servers=B` gets parsed as an array and rendered as multiple query key & values