### PR TITLE
Grafana/ui: display all selected levels for Cascader

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
@@ -59,6 +59,7 @@ export const Simple = Template.bind({});
 Simple.args = {
   separator: '',
 };
+
 export const WithInitialValue = Template.bind({});
 WithInitialValue.args = {
   initialValue: '3',
@@ -69,4 +70,10 @@ WithCustomValue.args = {
   initialValue: 'Custom Initial Value',
   allowCustomValue: true,
   formatCreateLabel: (val) => 'Custom Label' + val,
+};
+
+export const WithDisplayAllSelectedLevels = Template.bind({});
+WithDisplayAllSelectedLevels.args = {
+  displayAllSelectedLevels: true,
+  separator: ',',
 };

--- a/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Cascader } from './Cascader';
 import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 const options = [
   {
@@ -58,5 +60,69 @@ describe('Cascader', () => {
 
   it('Should convert options to searchable strings', () => {
     expect(cascader.state('searchableOptions')).toEqual(flatOptions);
+  });
+
+  it('displays all levels selected with default separator when displayAllSelectedLevels is true', () => {
+    const placeholder = 'cascader-placeholder';
+    render(
+      <Cascader displayAllSelectedLevels={true} placeholder={placeholder} options={options} onSelect={() => {}} />
+    );
+
+    expect(screen.queryByDisplayValue('First/Second')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByPlaceholderText(placeholder));
+    userEvent.click(screen.getByText('First'));
+    userEvent.click(screen.getByText('Second'));
+
+    expect(screen.getByDisplayValue('First/Second')).toBeInTheDocument();
+  });
+
+  it('displays all levels selected with separator passed in when displayAllSelectedLevels is true', () => {
+    const placeholder = 'cascader-placeholder';
+    const separator = ',';
+
+    render(
+      <Cascader
+        displayAllSelectedLevels={true}
+        separator={separator}
+        placeholder={placeholder}
+        options={options}
+        onSelect={() => {}}
+      />
+    );
+
+    expect(screen.queryByDisplayValue('First/Second')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByPlaceholderText(placeholder));
+    userEvent.click(screen.getByText('First'));
+    userEvent.click(screen.getByText('Second'));
+
+    expect(screen.getByDisplayValue(`First${separator}Second`)).toBeInTheDocument();
+  });
+
+  it('displays last level selected when displayAllSelectedLevels is false', () => {
+    const placeholder = 'cascader-placeholder';
+
+    render(
+      <Cascader displayAllSelectedLevels={false} placeholder={placeholder} options={options} onSelect={() => {}} />
+    );
+
+    userEvent.click(screen.getByPlaceholderText(placeholder));
+    userEvent.click(screen.getByText('First'));
+    userEvent.click(screen.getByText('Second'));
+
+    expect(screen.getByDisplayValue('Second')).toBeInTheDocument();
+  });
+
+  it('displays last level selected when displayAllSelectedLevels is not passed in', () => {
+    const placeholder = 'cascader-placeholder';
+
+    render(<Cascader placeholder={placeholder} options={options} onSelect={() => {}} />);
+
+    userEvent.click(screen.getByPlaceholderText(placeholder));
+    userEvent.click(screen.getByText('First'));
+    userEvent.click(screen.getByText('Second'));
+
+    expect(screen.getByDisplayValue('Second')).toBeInTheDocument();
   });
 });

--- a/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Cascader } from './Cascader';
-import { shallow } from 'enzyme';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -29,41 +28,19 @@ const options = [
   },
 ];
 
-const flatOptions = [
-  {
-    singleLabel: 'Second',
-    label: 'First / Second',
-    value: ['1', '2'],
-  },
-  {
-    singleLabel: 'Third',
-    label: 'First / Third',
-    value: ['1', '3'],
-  },
-  {
-    singleLabel: 'Fourth',
-    label: 'First / Fourth',
-    value: ['1', '4'],
-  },
-  {
-    singleLabel: 'FirstFirst',
-    label: 'FirstFirst',
-    value: ['5'],
-  },
-];
-
 describe('Cascader', () => {
-  let cascader: any;
-  beforeEach(() => {
-    cascader = shallow(<Cascader options={options} onSelect={() => {}} />);
-  });
+  const placeholder = 'cascader-placeholder';
 
-  it('Should convert options to searchable strings', () => {
-    expect(cascader.state('searchableOptions')).toEqual(flatOptions);
+  it('filters results when searching', () => {
+    render(<Cascader placeholder={placeholder} options={options} onSelect={() => {}} />);
+
+    userEvent.type(screen.getByPlaceholderText(placeholder), 'Third');
+
+    expect(screen.queryByText('Second')).not.toBeInTheDocument();
+    expect(screen.getByText('First / Third')).toBeInTheDocument();
   });
 
   it('displays all levels selected with default separator when displayAllSelectedLevels is true', () => {
-    const placeholder = 'cascader-placeholder';
     render(
       <Cascader displayAllSelectedLevels={true} placeholder={placeholder} options={options} onSelect={() => {}} />
     );
@@ -78,7 +55,6 @@ describe('Cascader', () => {
   });
 
   it('displays all levels selected with separator passed in when displayAllSelectedLevels is true', () => {
-    const placeholder = 'cascader-placeholder';
     const separator = ',';
 
     render(
@@ -101,8 +77,6 @@ describe('Cascader', () => {
   });
 
   it('displays last level selected when displayAllSelectedLevels is false', () => {
-    const placeholder = 'cascader-placeholder';
-
     render(
       <Cascader displayAllSelectedLevels={false} placeholder={placeholder} options={options} onSelect={() => {}} />
     );
@@ -115,8 +89,6 @@ describe('Cascader', () => {
   });
 
   it('displays last level selected when displayAllSelectedLevels is not passed in', () => {
-    const placeholder = 'cascader-placeholder';
-
     render(<Cascader placeholder={placeholder} options={options} onSelect={() => {}} />);
 
     userEvent.click(screen.getByPlaceholderText(placeholder));

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -22,6 +22,7 @@ export interface CascaderProps {
   allowCustomValue?: boolean;
   /** A function for formatting the message for custom value creation. Only applies when allowCustomValue is set to true*/
   formatCreateLabel?: (val: string) => string;
+  displayAllSelectedLevels?: boolean;
 }
 
 interface CascaderState {
@@ -57,6 +58,8 @@ const disableDivFocus = css(`
 }
 `);
 
+const DEFAULT_SEPARATOR = '/';
+
 export class Cascader extends React.PureComponent<CascaderProps, CascaderState> {
   constructor(props: CascaderProps) {
     super(props);
@@ -81,7 +84,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
       if (!option.items) {
         selectOptions.push({
           singleLabel: cpy[cpy.length - 1].label,
-          label: cpy.map((o) => o.label).join(this.props.separator || ' / '),
+          label: cpy.map((o) => o.label).join(this.props.separator || ` ${DEFAULT_SEPARATOR} `),
           value: cpy.map((o) => o.value),
         });
       } else {
@@ -116,7 +119,9 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
     this.setState({
       rcValue: value,
       focusCascade: true,
-      activeLabel: selectedOptions[selectedOptions.length - 1].label,
+      activeLabel: this.props.displayAllSelectedLevels
+        ? selectedOptions.map((option) => option.label).join(this.props.separator || DEFAULT_SEPARATOR)
+        : selectedOptions[selectedOptions.length - 1].label,
     });
 
     this.props.onSelect(selectedOptions[selectedOptions.length - 1].value);


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, it looks like the existing `Cascader` component only supports displaying the last selected value.

However, in some cases, we would like to see the label as a concatenation of all selected levels.
Particularly, with our NewRelic plugin, there could be many sublevels which are labelled the same
e.g. `1 > 2 > 3` and `1 > 4 > 3` where we want to show the full path of the selected value to make it clear which sublevel is actually being selected.

**Work done:**

- Added new prop to be passed in to support this
- Use this prop to determine whether to display the last selected level or concatenate all levels
- Allow the separator to be used for the concatenation (default is `/` following the existing logic for displaying the results when searching - this flattens the options and separates by '/')
- Add story
- Add RTL tests

**Before**

NewRelic plugin only displays the last level (* in this case is used multiple times so is not clear what was selected):
![cascader last level](https://user-images.githubusercontent.com/36230812/110118507-62319780-7db2-11eb-95d3-4120ea50f1e0.gif)

Story (basic example):
![cascader storybook before](https://user-images.githubusercontent.com/36230812/110118932-fc91db00-7db2-11eb-9def-5cc233169338.gif)

**After**

NewRelic plugin is now able to concatenate the levels:
![cascader levels](https://user-images.githubusercontent.com/36230812/110118530-6958a580-7db2-11eb-9cf4-0b33380fbe2a.gif)

Story (sets the flag as true and passes in a custom separator):

![cascader storybook](https://user-images.githubusercontent.com/36230812/110118704-ab81e700-7db2-11eb-806b-69b9d4874388.gif)

**Which issue(s) this PR fixes**:

Needed as part of https://github.com/grafana/plugins-private/issues/1350

**Special notes for your reviewer**:

TIA 🙏 