### PR TITLE
Explore/Logs: Fix escaping in ANSI logs

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -152,7 +152,9 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     });
 
     const processedRow =
-      row.hasUnescapedContent && forceEscape ? { ...row, entry: escapeUnescapedString(row.entry) } : row;
+      row.hasUnescapedContent && forceEscape
+        ? { ...row, entry: escapeUnescapedString(row.entry), raw: escapeUnescapedString(row.raw) }
+        : row;
 
     return (
       <>

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { css } from 'emotion';
 import { capitalize } from 'lodash';
+import memoizeOne from 'memoize-one';
 
 import {
   rangeUtil,
@@ -91,7 +92,6 @@ interface State {
   logsSortOrder: LogsSortOrder | null;
   isFlipping: boolean;
   showDetectedFields: string[];
-  hasUnescapedContent: boolean;
   forceEscape: boolean;
 }
 
@@ -106,7 +106,6 @@ export class UnthemedLogs extends PureComponent<Props, State> {
     logsSortOrder: null,
     isFlipping: false,
     showDetectedFields: [],
-    hasUnescapedContent: this.props.logRows.some((r) => r.hasUnescapedContent),
     forceEscape: false,
   };
 
@@ -226,6 +225,10 @@ export class UnthemedLogs extends PureComponent<Props, State> {
     });
   };
 
+  checkUnescapedContent = memoizeOne((logRows: LogRowModel[]) => {
+    return !!logRows.some((r) => r.hasUnescapedContent);
+  });
+
   render() {
     const {
       logRows,
@@ -256,7 +259,6 @@ export class UnthemedLogs extends PureComponent<Props, State> {
       logsSortOrder,
       isFlipping,
       showDetectedFields,
-      hasUnescapedContent,
       forceEscape,
     } = this.state;
 
@@ -285,6 +287,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
     const scanText = scanRange ? `Scanning ${rangeUtil.describeTimeRange(scanRange)}` : 'Scanning...';
     const series = logsSeries ? logsSeries : [];
     const styles = getStyles(theme);
+    const hasUnescapedContent = this.checkUnescapedContent(logRows);
 
     return (
       <>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR includes 2 fixes for [Escaping of incorrectly escaped newlines and tabs](https://github.com/grafana/grafana/pull/31352):
1. Escaping for logs with ANSI
2. Dynamic appear and disappear of the button for escaping

https://user-images.githubusercontent.com/30407135/110122504-00782a00-7dc0-11eb-86ac-7d4089fa0acf.mov

