### PR TITLE
Docs: add query caching to Enterprise docs

### DIFF
--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -340,7 +340,7 @@ The caching backend to use when storing cached queries. Options: memory
 
 ### enabled
 
-Setting 'enabled' to true enables caching datasource queries for all datasources.
+Setting 'enabled' to true enables caching datasource queries for all data sources.
 
 ### ttl
 

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -330,7 +330,7 @@ A list of cookies that are stripped from the outgoing data source and alerting r
 ## [caching]
 
 > **Note:** Available in Grafana Enterprise v7.5 and later versions.
-> **Note:** Redis and memcached sections are in the defaults.ini setting, but redis and memcached backends are unavailable in Grafana Enterprise v7.5
+> **Note:** Redis and memcached sections are in the defaults.ini setting, but Redis and Memcached backends are unavailable in Grafana Enterprise v7.5
 
 When query caching is enabled, Grafana temporarily stores the results of data source queries and serves cached responses to similar requests.
 

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -326,3 +326,22 @@ A list of headers that are stripped from the outgoing data source and alerting r
 ### cookie_drop_list
 
 A list of cookies that are stripped from the outgoing data source and alerting requests.
+
+## [caching]
+
+> **Note:** Available in Grafana Enterprise v7.5 and later versions.
+> **Note:** Redis and memcached sections are in the defaults.ini setting, but redis and memcached backends are unavailable in Grafana Enterprise v7.5
+
+When query caching is enabled, Grafana temporarily stores the results of data source queries and serves cached responses to similar requests.
+
+### backend
+
+The caching backend to use when storing cached queries. Options: memory
+
+### enabled
+
+Setting 'enabled' to true enables caching datasource queries for all datasources.
+
+### ttl
+
+The default TTL (time to live) if no other TTL is available.

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -21,4 +21,4 @@ Query caching currently works for all backend data sources. You can enable the c
 
 ## Enable query caching
 
-To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#query-caching" >}})
+To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#query-caching" >}}).

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -7,7 +7,7 @@ weight = 110
 
 # Query caching
 
-> Query caching is available behind a feature flag in Grafana Enterprise v7.5+.
+> **Note:** Query caching is available behind a feature flag in Grafana Enterprise 7.5+.
 
 When query caching is enabled, Grafana will temporarily store the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself. This results in faster dashboard load times, especially for popular dashboards, as well as reduced API costs and reduced likelihood that APIs will rate-limit or throttle requests.
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -19,7 +19,6 @@ Query caching currently works for all backend data sources. You can enable the c
 - Reduced API costs.
 - Reduced likelihood that APIs will rate-limit or throttle requests.
 
-Query caching currently works for all backend data sources. You can enable the cache globally or per data source, and you can configure the cache duration per data source. The cache is in-memory only.
 
 ## Enable query caching
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -19,7 +19,6 @@ Query caching currently works for all backend data sources. You can enable the c
 - Reduced API costs.
 - Reduced likelihood that APIs will rate-limit or throttle requests.
 
-
 ## Enable query caching
 
 To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#query-caching" >}})

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -1,0 +1,18 @@
++++
+title = "Query caching"
+description = "Grafana Enterprise data source query caching"
+keywords = ["grafana", "plugins", "query", "caching"]
+weight = 110
++++
+
+# Query caching
+
+> Query caching is available behind a feature flag in Grafana Enterprise v7.5+.
+
+When query caching is enabled, Grafana will temporarily store the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself. This results in faster dashboard load times, especially for popular dashboards, as well as reduced API costs and reduced likelihood that APIs will rate-limit or throttle requests.
+
+Query caching currently works for all backend data sources. You can enable the cache globally or per data source, and you can configure the cache duration per data source. The cache is in-memory only.
+
+## Enable query caching
+
+To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#query-caching" >}})

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -9,7 +9,15 @@ weight = 110
 
 > **Note:** Query caching is available behind a feature flag in Grafana Enterprise 7.5+.
 
-When query caching is enabled, Grafana will temporarily store the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself. This results in faster dashboard load times, especially for popular dashboards, as well as reduced API costs and reduced likelihood that APIs will rate-limit or throttle requests.
+When query caching is enabled, Grafana temporarily stores the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself.
+
+Query caching currently works for all backend data sources. You can enable the cache globally or per data source, and you can configure the cache duration per data source. The cache is in-memory only.
+
+## Query caching benefits
+
+- Faster dashboard load times, especially for popular dashboards.
+- Reduced API costs.
+- Reduced likelihood that APIs will rate-limit or throttle requests.
 
 Query caching currently works for all backend data sources. You can enable the cache globally or per data source, and you can configure the cache duration per data source. The cache is in-memory only.
 


### PR DESCRIPTION
Add a new docs page and configuration options for Query caching to Enterprise docs.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds documentation for the new Enterprise query caching feature released in Grafana 7.5 https://github.com/grafana/grafana-enterprise/pull/1112

**Which issue(s) this PR fixes**:
https://github.com/grafana/integrations-team/issues/86

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

