### PR TITLE
Stacked Graph Rendering: render time series in consistent order

### DIFF
--- a/packages/grafana-runtime/src/utils/queryResponse.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.ts
@@ -39,7 +39,7 @@ export function toDataQueryResponse(res: any, queries?: DataQuery[]): DataQueryR
     const usedResultIDs = new Set<string>(resultIDs);
     const data: DataResponse[] = [];
 
-    for (const refId of refIDs) {
+    for (const refId of refIDs.sort()) {
       const dr = results[refId] as DataResponse;
       if (!dr) {
         continue;


### PR DESCRIPTION
**What this PR does / why we need it**:
It sorts the timeseries.

We have multiple data sources in multiple data centers for redundancy. Sometimes this causes the order in which the time series are returned in the JSON to be different. This can be a problem if you are using stacking and refreshing. The order in which they are returned changes how they are stacked, which can be jarring.
