### PR TITLE
CloudWatch: Add support for EC2 IAM Role provider & implement AWS config restrictions

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -508,7 +508,7 @@ active_sync_enabled = true
 #################################### AWS ###########################
 [aws]
 # Enter a comma-separated list of allowed AWS authentication providers. 
-# Options are: default (AWS SDK Default), keys (Access && secret key), credentials (Credentials field), ec2_IAM_role (EC2 IAM Role)
+# Options are: default (AWS SDK Default), keys (Access && secret key), credentials (Credentials field), ec2_iam_role (EC2 IAM Role)
 allowed_auth_providers = default,keys,credentials
 
 # Allow AWS users to assume a role using temporary security credentials. 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -498,7 +498,7 @@
 #################################### AWS ###########################
 [aws]
 # Enter a comma-separated list of allowed AWS authentication providers. 
-# Options are: default (AWS SDK Default), keys (Access && secret key), credentials (Credentials field), ec2_IAM_role (EC2 IAM Role)
+# Options are: default (AWS SDK Default), keys (Access && secret key), credentials (Credentials field), ec2_iam_role (EC2 IAM Role)
 ; allowed_auth_providers = default,keys,credentials
 
 # Allow AWS users to assume a role using temporary security credentials. 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -780,7 +780,7 @@ You can configure core and external AWS plugins.
 
 Specify what authentication providers the AWS plugins allow. For a list of allowed providers, refer to the data-source configuration page for a given plugin. If you configure a plugin by provisioning, only providers that are specified in `allowed_auth_providers` are allowed.
 
-Options: `default` (AWS SDK default), `keys` (Access and secret key), `credentials` (Credentials file), `ec2_IAM_role` (EC2 IAM role)
+Options: `default` (AWS SDK default), `keys` (Access and secret key), `credentials` (Credentials file), `ec2_iam_role` (EC2 IAM role)
 
 ### assume_role_enabled
 

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
   },
   "dependencies": {
     "@emotion/core": "10.0.27",
-    "@grafana/aws-sdk": "0.0.153",
+    "@grafana/aws-sdk": "0.0.154",
     "@grafana/slate-react": "0.22.9-grafana",
     "@popperjs/core": "2.5.4",
     "@reduxjs/toolkit": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
   },
   "dependencies": {
     "@emotion/core": "10.0.27",
+    "@grafana/aws-sdk": "0.0.153",
     "@grafana/slate-react": "0.22.9-grafana",
     "@popperjs/core": "2.5.4",
     "@reduxjs/toolkit": "1.5.0",

--- a/pkg/tsdb/cloudwatch/log_actions_test.go
+++ b/pkg/tsdb/cloudwatch/log_actions_test.go
@@ -47,7 +47,7 @@ func TestQuery_DescribeLogGroups(t *testing.T) {
 			},
 		}
 
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -100,7 +100,7 @@ func TestQuery_DescribeLogGroups(t *testing.T) {
 			},
 		}
 
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -169,8 +169,7 @@ func TestQuery_GetLogGroupFields(t *testing.T) {
 	}
 
 	const refID = "A"
-
-	executor := newExecutor(nil)
+	executor := newExecutor(nil, newDefaultAWSSettings())
 	resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 		Queries: []plugins.DataSubQuery{
 			{
@@ -249,7 +248,7 @@ func TestQuery_StartQuery(t *testing.T) {
 			To:   "1584700643000",
 		}
 
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		_, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			TimeRange: &timeRange,
 			Queries: []plugins.DataSubQuery{
@@ -295,7 +294,7 @@ func TestQuery_StartQuery(t *testing.T) {
 			To:   "1584873443000",
 		}
 
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			TimeRange: &timeRange,
 			Queries: []plugins.DataSubQuery{
@@ -371,7 +370,7 @@ func TestQuery_StopQuery(t *testing.T) {
 		To:   "1584700643000",
 	}
 
-	executor := newExecutor(nil)
+	executor := newExecutor(nil, newDefaultAWSSettings())
 	resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 		TimeRange: &timeRange,
 		Queries: []plugins.DataSubQuery{
@@ -458,7 +457,7 @@ func TestQuery_GetQueryResults(t *testing.T) {
 		},
 	}
 
-	executor := newExecutor(nil)
+	executor := newExecutor(nil, newDefaultAWSSettings())
 	resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 		Queries: []plugins.DataSubQuery{
 			{

--- a/pkg/tsdb/cloudwatch/log_actions_test.go
+++ b/pkg/tsdb/cloudwatch/log_actions_test.go
@@ -47,7 +47,7 @@ func TestQuery_DescribeLogGroups(t *testing.T) {
 			},
 		}
 
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -100,7 +100,7 @@ func TestQuery_DescribeLogGroups(t *testing.T) {
 			},
 		}
 
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -169,7 +169,7 @@ func TestQuery_GetLogGroupFields(t *testing.T) {
 	}
 
 	const refID = "A"
-	executor := newExecutor(nil, newDefaultAWSSettings())
+	executor := newExecutor(nil, newTestConfig())
 	resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 		Queries: []plugins.DataSubQuery{
 			{
@@ -248,7 +248,7 @@ func TestQuery_StartQuery(t *testing.T) {
 			To:   "1584700643000",
 		}
 
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		_, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			TimeRange: &timeRange,
 			Queries: []plugins.DataSubQuery{
@@ -294,7 +294,7 @@ func TestQuery_StartQuery(t *testing.T) {
 			To:   "1584873443000",
 		}
 
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			TimeRange: &timeRange,
 			Queries: []plugins.DataSubQuery{
@@ -370,7 +370,7 @@ func TestQuery_StopQuery(t *testing.T) {
 		To:   "1584700643000",
 	}
 
-	executor := newExecutor(nil, newDefaultAWSSettings())
+	executor := newExecutor(nil, newTestConfig())
 	resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 		TimeRange: &timeRange,
 		Queries: []plugins.DataSubQuery{
@@ -457,7 +457,7 @@ func TestQuery_GetQueryResults(t *testing.T) {
 		},
 	}
 
-	executor := newExecutor(nil, newDefaultAWSSettings())
+	executor := newExecutor(nil, newTestConfig())
 	resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 		Queries: []plugins.DataSubQuery{
 			{

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -44,7 +44,7 @@ func TestQuery_Metrics(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -101,7 +101,7 @@ func TestQuery_Metrics(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -163,7 +163,7 @@ func TestQuery_Regions(t *testing.T) {
 		cli = fakeEC2Client{
 			regions: []string{regionName},
 		}
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -245,7 +245,7 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -348,7 +348,7 @@ func TestQuery_EBSVolumeIDs(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -448,7 +448,7 @@ func TestQuery_ResourceARNs(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil)
+		executor := newExecutor(nil, newDefaultAWSSettings())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -44,7 +44,7 @@ func TestQuery_Metrics(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -101,7 +101,7 @@ func TestQuery_Metrics(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -163,7 +163,7 @@ func TestQuery_Regions(t *testing.T) {
 		cli = fakeEC2Client{
 			regions: []string{regionName},
 		}
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -245,7 +245,7 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -348,7 +348,7 @@ func TestQuery_EBSVolumeIDs(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{
@@ -448,7 +448,7 @@ func TestQuery_ResourceARNs(t *testing.T) {
 				},
 			},
 		}
-		executor := newExecutor(nil, newDefaultAWSSettings())
+		executor := newExecutor(nil, newTestConfig())
 		resp, err := executor.DataQuery(context.Background(), fakeDataSource(), plugins.DataQuery{
 			Queries: []plugins.DataSubQuery{
 				{

--- a/pkg/tsdb/cloudwatch/query_transformer_test.go
+++ b/pkg/tsdb/cloudwatch/query_transformer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestQueryTransformer(t *testing.T) {
-	executor := newExecutor(nil)
+	executor := newExecutor(nil, &awsSettings{})
 	t.Run("One cloudwatchQuery is generated when its request query has one stat", func(t *testing.T) {
 		requestQueries := []*requestQuery{
 			{

--- a/pkg/tsdb/cloudwatch/query_transformer_test.go
+++ b/pkg/tsdb/cloudwatch/query_transformer_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestQueryTransformer(t *testing.T) {
-	executor := newExecutor(nil, &awsSettings{})
+	executor := newExecutor(nil, &setting.Cfg{})
 	t.Run("One cloudwatchQuery is generated when its request query has one stat", func(t *testing.T) {
 		requestQueries := []*requestQuery{
 			{

--- a/pkg/tsdb/cloudwatch/session.go
+++ b/pkg/tsdb/cloudwatch/session.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -34,3 +36,9 @@ var newSTSCredentials = stscreds.NewCredentials
 // Stubbable by tests.
 //nolint:gocritic
 var newEC2Metadata = ec2metadata.New
+
+// EC2 role credentials factory.
+// Stubbable by tests.
+var newEC2RoleCredentials = func(sess *session.Session) *credentials.Credentials {
+	return credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(sess), ExpiryWindow: stscreds.DefaultDuration})
+}

--- a/pkg/tsdb/cloudwatch/session_test.go
+++ b/pkg/tsdb/cloudwatch/session_test.go
@@ -127,10 +127,6 @@ func TestNewSession_AssumeRole(t *testing.T) {
 }
 
 func TestNewSession_EC2IAMRole(t *testing.T) {
-	t.Cleanup(func() {
-		sessCache = map[string]envelope{}
-	})
-
 	newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
 		cfg := aws.Config{}
 		cfg.MergeIn(cfgs...)
@@ -166,10 +162,6 @@ func TestNewSession_EC2IAMRole(t *testing.T) {
 }
 
 func TestNewSession_AllowedAuthProviders(t *testing.T) {
-	t.Cleanup(func() {
-		sessCache = map[string]envelope{}
-	})
-
 	t.Run("Not allowed auth type is used", func(t *testing.T) {
 		e := newExecutor(nil, &awsSettings{AllowedAuthProviders: []string{"keys"}})
 		e.DataSource = fakeDataSource()

--- a/pkg/tsdb/cloudwatch/session_test.go
+++ b/pkg/tsdb/cloudwatch/session_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -57,7 +58,7 @@ func TestNewSession_AssumeRole(t *testing.T) {
 
 		const roleARN = "test"
 
-		e := newExecutor(nil)
+		e := newExecutor(nil, newDefaultAWSSettings())
 		e.DataSource = fakeDataSource(fakeDataSourceCfg{
 			assumeRoleARN: roleARN,
 		})
@@ -84,7 +85,7 @@ func TestNewSession_AssumeRole(t *testing.T) {
 		const roleARN = "test"
 		const externalID = "external"
 
-		e := newExecutor(nil)
+		e := newExecutor(nil, newDefaultAWSSettings())
 		e.DataSource = fakeDataSource(fakeDataSourceCfg{
 			assumeRoleARN: roleARN,
 			externalID:    externalID,
@@ -103,5 +104,91 @@ func TestNewSession_AssumeRole(t *testing.T) {
 			return true
 		}), cmpopts.IgnoreFields(stscreds.AssumeRoleProvider{}, "Expiry"))
 		assert.Empty(t, diff)
+	})
+
+	t.Run("Assume role not enabled", func(t *testing.T) {
+		t.Cleanup(func() {
+			sessCache = map[string]envelope{}
+		})
+
+		const roleARN = "test"
+
+		e := newExecutor(nil, &awsSettings{AllowedAuthProviders: []string{"default"}, AssumeRoleEnabled: false})
+		e.DataSource = fakeDataSource(fakeDataSourceCfg{
+			assumeRoleARN: roleARN,
+		})
+
+		sess, err := e.newSession(defaultRegion)
+		require.NoError(t, err)
+		require.NotNil(t, sess)
+
+		assert.Nil(t, sess.Config.Credentials)
+	})
+}
+
+func TestNewSession_EC2IAMRole(t *testing.T) {
+	t.Cleanup(func() {
+		sessCache = map[string]envelope{}
+	})
+
+	newSession = func(cfgs ...*aws.Config) (*session.Session, error) {
+		cfg := aws.Config{}
+		cfg.MergeIn(cfgs...)
+		return &session.Session{
+			Config: &cfg,
+		}, nil
+	}
+	newEC2Metadata = func(p client.ConfigProvider, cfgs ...*aws.Config) *ec2metadata.EC2Metadata {
+		return nil
+	}
+	newEC2RoleCredentials = func(sess *session.Session) *credentials.Credentials {
+		return credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{Client: newEC2Metadata(nil), ExpiryWindow: stscreds.DefaultDuration})
+	}
+
+	t.Run("Credentials are created", func(t *testing.T) {
+		e := newExecutor(nil, &awsSettings{AllowedAuthProviders: []string{"ec2_iam_role", "keys"}})
+		e.DataSource = fakeDataSource()
+		e.DataSource.JsonData.Set("authType", "ec2_iam_role")
+
+		sess, err := e.newSession(defaultRegion)
+		require.NoError(t, err)
+		require.NotNil(t, sess)
+
+		expCreds := credentials.NewCredentials(&ec2rolecreds.EC2RoleProvider{
+			Client: newEC2Metadata(nil), ExpiryWindow: stscreds.DefaultDuration,
+		})
+
+		diff := cmp.Diff(expCreds, sess.Config.Credentials, cmp.Exporter(func(_ reflect.Type) bool {
+			return true
+		}), cmpopts.IgnoreFields(stscreds.AssumeRoleProvider{}, "Expiry"))
+		assert.Empty(t, diff)
+	})
+}
+
+func TestNewSession_AllowedAuthProviders(t *testing.T) {
+	t.Cleanup(func() {
+		sessCache = map[string]envelope{}
+	})
+
+	t.Run("Not allowed auth type is used", func(t *testing.T) {
+		e := newExecutor(nil, &awsSettings{AllowedAuthProviders: []string{"keys"}})
+		e.DataSource = fakeDataSource()
+		e.DataSource.JsonData.Set("authType", "default")
+
+		sess, err := e.newSession(defaultRegion)
+		require.Error(t, err)
+		require.Nil(t, sess)
+
+		assert.Equal(t, "attempting to use an auth type that is not allowed: default", err.Error())
+	})
+
+	t.Run("Allowed auth type is used", func(t *testing.T) {
+		e := newExecutor(nil, &awsSettings{AllowedAuthProviders: []string{"keys"}})
+		e.DataSource = fakeDataSource()
+		e.DataSource.JsonData.Set("authType", "keys")
+
+		sess, err := e.newSession(defaultRegion)
+		require.NoError(t, err)
+		require.NotNil(t, sess)
 	})
 }

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -145,3 +145,7 @@ func (c fakeRGTAClient) GetResourcesPages(in *resourcegroupstaggingapi.GetResour
 	}, true)
 	return nil
 }
+
+func newDefaultAWSSettings() *awsSettings {
+	return &awsSettings{AllowedAuthProviders: []string{"default"}, AssumeRoleEnabled: true}
+}

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/securejsondata"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type fakeDataSourceCfg struct {
@@ -146,6 +147,6 @@ func (c fakeRGTAClient) GetResourcesPages(in *resourcegroupstaggingapi.GetResour
 	return nil
 }
 
-func newDefaultAWSSettings() *awsSettings {
-	return &awsSettings{AllowedAuthProviders: []string{"default"}, AssumeRoleEnabled: true}
+func newTestConfig() *setting.Cfg {
+	return &setting.Cfg{AWSAllowedAuthProviders: []string{"default"}, AWSAssumeRoleEnabled: true}
 }

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTimeSeriesQuery(t *testing.T) {
-	executor := newExecutor(nil, newDefaultAWSSettings())
+	executor := newExecutor(nil, newTestConfig())
 
 	t.Run("End time before start time should result in error", func(t *testing.T) {
 		timeRange := plugins.NewDataTimeRange("now-1h", "now-2h")

--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTimeSeriesQuery(t *testing.T) {
-	executor := newExecutor(nil)
+	executor := newExecutor(nil, newDefaultAWSSettings())
 
 	t.Run("End time before start time should result in error", func(t *testing.T) {
 		timeRange := plugins.NewDataTimeRange("now-1h", "now-2h")

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -65,8 +65,3 @@ type metricStatMeta struct {
 	Stat   string `json:"stat"`
 	Period int    `json:"period"`
 }
-
-type awsSettings struct {
-	AllowedAuthProviders []string
-	AssumeRoleEnabled    bool
-}

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -65,3 +65,8 @@ type metricStatMeta struct {
 	Stat   string `json:"stat"`
 	Period int    `json:"period"`
 }
+
+type awsSettings struct {
+	AllowedAuthProviders []string
+	AssumeRoleEnabled    bool
+}

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ConfigEditor, { Props } from './ConfigEditor';
+import { ConfigEditor, Props } from './ConfigEditor';
+import { AwsAuthType } from '@grafana/aws-sdk';
 
 jest.mock('app/features/plugins/datasource_srv', () => ({
   getDatasourceSrv: () => ({
@@ -46,7 +47,7 @@ const setup = (propOverrides?: object) => {
         externalId: '',
         database: '',
         customMetricsNamespaces: '',
-        authType: 'keys',
+        authType: AwsAuthType.Keys,
         defaultRegion: 'us-east-2',
         timeField: '@timestamp',
       },

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor.tsx
@@ -1,339 +1,63 @@
-import React, { PureComponent } from 'react';
-import { InlineFormLabel, LegacyForms, Button } from '@grafana/ui';
-const { Select, Input } = LegacyForms;
-import {
-  AppEvents,
-  SelectableValue,
-  DataSourcePluginOptionsEditorProps,
-  onUpdateDatasourceJsonDataOptionSelect,
-  onUpdateDatasourceResetOption,
-  onUpdateDatasourceJsonDataOption,
-  onUpdateDatasourceSecureJsonDataOption,
-} from '@grafana/data';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
-import { CloudWatchDatasource } from '../datasource';
-import { CloudWatchJsonData, CloudWatchSecureJsonData } from '../types';
-import { CancelablePromise, makePromiseCancelable } from 'app/core/utils/CancelablePromise';
-import { appEvents } from 'app/core/core';
+import React, { FC, useEffect, useState } from 'react';
+import { Input, InlineField } from '@grafana/ui';
+import { DataSourcePluginOptionsEditorProps, onUpdateDatasourceJsonDataOption } from '@grafana/data';
+import { ConnectionConfig } from '@grafana/aws-sdk';
 
-const authProviderOptions = [
-  { label: 'AWS SDK Default', value: 'default' },
-  { label: 'Access & secret key', value: 'keys' },
-  { label: 'Credentials file', value: 'credentials' },
-] as SelectableValue[];
+import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
+import { store } from 'app/store/store';
+import { notifyApp } from 'app/core/actions';
+import { createWarningNotification } from 'app/core/copy/appNotification';
+
+import { CloudWatchJsonData, CloudWatchSecureJsonData } from '../types';
+import { CloudWatchDatasource } from '../datasource';
 
 export type Props = DataSourcePluginOptionsEditorProps<CloudWatchJsonData, CloudWatchSecureJsonData>;
 
-export interface State {
-  regions: SelectableValue[];
-}
+export const ConfigEditor: FC<Props> = (props: Props) => {
+  const [datasource, setDatasource] = useState<CloudWatchDatasource>();
 
-export class ConfigEditor extends PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props);
+  const addWarning = (message: string) => {
+    store.dispatch(notifyApp(createWarningNotification('CloudWatch Authentication', message)));
+  };
 
-    this.state = {
-      regions: [],
-    };
-  }
+  useEffect(() => {
+    getDatasourceSrv()
+      .loadDatasource(props.options.name)
+      .then((datasource: CloudWatchDatasource) => setDatasource(datasource));
 
-  loadRegionsPromise: CancelablePromise<any> | null = null;
-
-  componentDidMount() {
-    this.loadRegionsPromise = makePromiseCancelable(this.loadRegions());
-    this.loadRegionsPromise.promise.catch(({ isCanceled }) => {
-      if (isCanceled) {
-        console.warn('Cloud Watch ConfigEditor has unmounted, initialization was canceled');
-      }
-    });
-
-    if (this.props.options.jsonData.authType === 'arn') {
-      appEvents.emit(AppEvents.alertWarning, [
-        'Since grafana 7.3 authentication type "arn" is deprecated, falling back to default SDK provider',
-      ]);
+    if (props.options.jsonData.authType === 'arn') {
+      addWarning('Since grafana 7.3 authentication type "arn" is deprecated, falling back to default SDK provider');
     } else if (
-      this.props.options.jsonData.authType === 'credentials' &&
-      !this.props.options.jsonData.profile &&
-      !this.props.options.jsonData.database
+      props.options.jsonData.authType === 'credentials' &&
+      !props.options.jsonData.profile &&
+      !props.options.jsonData.database
     ) {
-      appEvents.emit(AppEvents.alertWarning, [
+      addWarning(
         'As of grafana 7.3 authentication type "credentials" should be used only for shared file credentials. \
-         If you don\'t have a credentials file, switch to the default SDK provider for extracting credentials \
-         from environment variables or IAM roles',
-      ]);
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.loadRegionsPromise) {
-      this.loadRegionsPromise.cancel();
-    }
-  }
-
-  async loadRegions() {
-    await getDatasourceSrv()
-      .loadDatasource(this.props.options.name)
-      .then((ds: CloudWatchDatasource) => ds.getRegions())
-      .then(
-        (regions: any) => {
-          this.setState({
-            regions: regions.map((region: any) => {
-              return {
-                value: region.value,
-                label: region.text,
-              };
-            }),
-          });
-        },
-        (err: any) => {
-          const regions = [
-            'af-south-1',
-            'ap-east-1',
-            'ap-northeast-1',
-            'ap-northeast-2',
-            'ap-northeast-3',
-            'ap-south-1',
-            'ap-southeast-1',
-            'ap-southeast-2',
-            'ca-central-1',
-            'cn-north-1',
-            'cn-northwest-1',
-            'eu-central-1',
-            'eu-north-1',
-            'eu-south-1',
-            'eu-west-1',
-            'eu-west-2',
-            'eu-west-3',
-            'me-south-1',
-            'sa-east-1',
-            'us-east-1',
-            'us-east-2',
-            'us-gov-east-1',
-            'us-gov-west-1',
-            'us-iso-east-1',
-            'us-isob-east-1',
-            'us-west-1',
-            'us-west-2',
-          ];
-
-          this.setState({
-            regions: regions.map((region: string) => ({
-              value: region,
-              label: region,
-            })),
-          });
-
-          // expected to fail when creating new datasource
-          // console.error('failed to get latest regions', err);
-        }
+             If you don\'t have a credentials file, switch to the default SDK provider for extracting credentials \
+             from environment variables or IAM roles'
       );
-  }
-
-  render() {
-    const { regions } = this.state;
-    const { options } = this.props;
-    const secureJsonData = (options.secureJsonData || {}) as CloudWatchSecureJsonData;
-    let profile = options.jsonData.profile;
-    if (profile === undefined) {
-      profile = options.database;
     }
+  }, []);
 
-    return (
-      <>
-        <h3 className="page-heading">CloudWatch Details</h3>
-        <div className="gf-form-group">
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel
-                className="width-14"
-                tooltip="Specify which AWS credentials chain to use. AWS SDK Default is the recommended option for EKS, ECS, or if you've attached an IAM role to your EC2 instance."
-              >
-                Authentication Provider
-              </InlineFormLabel>
-              <Select
-                className="width-30"
-                value={authProviderOptions.find((authProvider) => authProvider.value === options.jsonData.authType)}
-                options={authProviderOptions}
-                defaultValue={options.jsonData.authType}
-                onChange={(option) => {
-                  onUpdateDatasourceJsonDataOptionSelect(this.props, 'authType')(option);
-                }}
-              />
-            </div>
-          </div>
-          {options.jsonData.authType === 'credentials' && (
-            <div className="gf-form-inline">
-              <div className="gf-form">
-                <InlineFormLabel
-                  className="width-14"
-                  tooltip="Credentials profile name, as specified in ~/.aws/credentials, leave blank for default."
-                >
-                  Credentials Profile Name
-                </InlineFormLabel>
-                <div className="width-30">
-                  <Input
-                    className="width-30"
-                    placeholder="default"
-                    value={profile}
-                    onChange={onUpdateDatasourceJsonDataOption(this.props, 'profile')}
-                  />
-                </div>
-              </div>
-            </div>
-          )}
-          {options.jsonData.authType === 'keys' && (
-            <div>
-              {options.secureJsonFields?.accessKey ? (
-                <div className="gf-form-inline">
-                  <div className="gf-form">
-                    <InlineFormLabel className="width-14">Access Key ID</InlineFormLabel>
-                    <Input className="width-25" placeholder="Configured" disabled={true} />
-                  </div>
-                  <div className="gf-form">
-                    <div className="max-width-30 gf-form-inline">
-                      <Button
-                        variant="secondary"
-                        type="button"
-                        onClick={onUpdateDatasourceResetOption(this.props, 'accessKey')}
-                      >
-                        Reset
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="gf-form-inline">
-                  <div className="gf-form">
-                    <InlineFormLabel className="width-14">Access Key ID</InlineFormLabel>
-                    <div className="width-30">
-                      <Input
-                        className="width-30"
-                        value={secureJsonData.accessKey || ''}
-                        onChange={onUpdateDatasourceSecureJsonDataOption(this.props, 'accessKey')}
-                      />
-                    </div>
-                  </div>
-                </div>
-              )}
-              {options.secureJsonFields?.secretKey ? (
-                <div className="gf-form-inline">
-                  <div className="gf-form">
-                    <InlineFormLabel className="width-14">Secret Access Key</InlineFormLabel>
-                    <Input className="width-25" placeholder="Configured" disabled={true} />
-                  </div>
-                  <div className="gf-form">
-                    <div className="max-width-30 gf-form-inline">
-                      <Button
-                        variant="secondary"
-                        type="button"
-                        onClick={onUpdateDatasourceResetOption(this.props, 'secretKey')}
-                      >
-                        Reset
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="gf-form-inline">
-                  <div className="gf-form">
-                    <InlineFormLabel className="width-14">Secret Access Key</InlineFormLabel>
-                    <div className="width-30">
-                      <Input
-                        className="width-30"
-                        value={secureJsonData.secretKey || ''}
-                        onChange={onUpdateDatasourceSecureJsonDataOption(this.props, 'secretKey')}
-                      />
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel
-                className="width-14"
-                tooltip="Optionally, specify the ARN of a role to assume. Specifying a role here will ensure that the selected authentication provider is used to assume the specified role rather than using the credentials directly. Leave blank if you don't need to assume a role at all"
-              >
-                Assume Role ARN
-              </InlineFormLabel>
-              <div className="width-30">
-                <Input
-                  className="width-30"
-                  placeholder="arn:aws:iam:*"
-                  value={options.jsonData.assumeRoleArn || ''}
-                  onChange={onUpdateDatasourceJsonDataOption(this.props, 'assumeRoleArn')}
-                />
-              </div>
-            </div>
-            <div className="gf-form-inline">
-              <div className="gf-form">
-                <InlineFormLabel
-                  className="width-14"
-                  tooltip="If you are assuming a role in another account, that has been created with an external ID, specify the external ID here."
-                >
-                  External ID
-                </InlineFormLabel>
-                <div className="width-30">
-                  <Input
-                    className="width-30"
-                    placeholder="External ID"
-                    value={options.jsonData.externalId || ''}
-                    onChange={onUpdateDatasourceJsonDataOption(this.props, 'externalId')}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel
-                className="width-14"
-                tooltip="Specify the region, such as for US West (Oregon) use ` us-west-2 ` as the region."
-              >
-                Default Region
-              </InlineFormLabel>
-              <Select
-                className="width-30"
-                value={regions.find((region) => region.value === options.jsonData.defaultRegion)}
-                options={regions}
-                defaultValue={options.jsonData.defaultRegion}
-                onChange={onUpdateDatasourceJsonDataOptionSelect(this.props, 'defaultRegion')}
-              />
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel className="width-14" tooltip="Namespaces of Custom Metrics.">
-                Custom Metrics
-              </InlineFormLabel>
-              <Input
-                className="width-30"
-                placeholder="Namespace1,Namespace2"
-                value={options.jsonData.customMetricsNamespaces || ''}
-                onChange={onUpdateDatasourceJsonDataOption(this.props, 'customMetricsNamespaces')}
-              />
-            </div>
-          </div>
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineFormLabel className="width-14" tooltip="Optionally, specify a custom endpoint for the service.">
-                Endpoint
-              </InlineFormLabel>
-              <div className="width-30">
-                <Input
-                  className="width-30"
-                  placeholder={'https://{service}.{region}.amazonaws.com'}
-                  value={options.jsonData.endpoint || ''}
-                  onChange={onUpdateDatasourceJsonDataOption(this.props, 'endpoint')}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </>
-    );
-  }
-}
-
-export default ConfigEditor;
+  return (
+    <>
+      <ConnectionConfig
+        {...props}
+        loadRegions={
+          datasource &&
+          (() => datasource!.getRegions().then((r) => r.filter((r) => r.value !== 'default').map((v) => v.value)))
+        }
+      >
+        <InlineField label="Namespaces of Custom Metrics" labelWidth={28} tooltip="Namespaces of Custom Metrics.">
+          <Input
+            width={60}
+            placeholder="Namespace1,Namespace2"
+            value={props.options.jsonData.customMetricsNamespaces || ''}
+            onChange={onUpdateDatasourceJsonDataOption(props, 'customMetricsNamespaces')}
+          />
+        </InlineField>
+      </ConnectionConfig>
+    </>
+  );
+};

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
@@ -5,12 +5,14 @@ import React, { memo } from 'react';
 import { AbsoluteTimeRange, QueryEditorProps } from '@grafana/data';
 import { InlineFormLabel } from '@grafana/ui';
 import { CloudWatchDatasource } from '../datasource';
-import { CloudWatchLogsQuery, CloudWatchQuery } from '../types';
+import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery } from '../types';
 import { CloudWatchLogsQueryField } from './LogsQueryField';
 import CloudWatchLink from './CloudWatchLink';
 import { css } from 'emotion';
 
-type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery> & { allowCustomValue?: boolean };
+type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData> & {
+  allowCustomValue?: boolean;
+};
 
 const labelClass = css`
   margin-left: 3px;

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -22,7 +22,7 @@ import syntax from '../syntax';
 
 // Types
 import { AbsoluteTimeRange, AppEvents, ExploreQueryFieldProps, SelectableValue } from '@grafana/data';
-import { CloudWatchLogsQuery, CloudWatchQuery } from '../types';
+import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery } from '../types';
 import { CloudWatchDatasource } from '../datasource';
 import { LanguageMap, languages as prismLanguages } from 'prismjs';
 import { CloudWatchLanguageProvider } from '../language_provider';
@@ -32,7 +32,8 @@ import { appEvents } from 'app/core/core';
 import { InputActionMeta } from '@grafana/ui/src/components/Select/types';
 import { getStatsGroups } from '../utils/query/getStatsGroups';
 
-export interface CloudWatchLogsQueryFieldProps extends ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery> {
+export interface CloudWatchLogsQueryFieldProps
+  extends ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData> {
   absoluteRange: AbsoluteTimeRange;
   onLabelsRefresh?: () => void;
   ExtraFieldElement?: ReactNode;

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.test.tsx
@@ -7,11 +7,12 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { MetricsQueryEditor, normalizeQuery, Props } from './MetricsQueryEditor';
 import { CloudWatchDatasource } from '../datasource';
 import { CustomVariableModel, initialVariableModelState } from '../../../../features/variables/types';
+import { CloudWatchJsonData } from '../types';
 
 const setup = () => {
   const instanceSettings = {
     jsonData: { defaultRegion: 'us-east-1' },
-  } as DataSourceInstanceSettings;
+  } as DataSourceInstanceSettings<CloudWatchJsonData>;
 
   const templateSrv = new TemplateSrv();
   const variable: CustomVariableModel = {

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
@@ -4,11 +4,11 @@ import isEmpty from 'lodash/isEmpty';
 import { ExploreQueryFieldProps } from '@grafana/data';
 import { LegacyForms, ValidationEvents, EventsWithValidation, Icon } from '@grafana/ui';
 const { Input, Switch } = LegacyForms;
-import { CloudWatchQuery, CloudWatchMetricsQuery } from '../types';
+import { CloudWatchQuery, CloudWatchMetricsQuery, CloudWatchJsonData } from '../types';
 import { CloudWatchDatasource } from '../datasource';
 import { QueryField, Alias, MetricsQueryFieldsEditor } from './';
 
-export type Props = ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery>;
+export type Props = ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>;
 
 interface State {
   showMeta: boolean;

--- a/public/app/plugins/datasource/cloudwatch/components/PanelQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/PanelQueryEditor.tsx
@@ -2,13 +2,13 @@ import React, { PureComponent } from 'react';
 import pick from 'lodash/pick';
 import { ExploreQueryFieldProps, ExploreMode } from '@grafana/data';
 import { Segment } from '@grafana/ui';
-import { CloudWatchQuery } from '../types';
+import { CloudWatchJsonData, CloudWatchQuery } from '../types';
 import { CloudWatchDatasource } from '../datasource';
 import { QueryInlineField } from './';
 import { MetricsQueryEditor } from './MetricsQueryEditor';
 import LogsQueryEditor from './LogsQueryEditor';
 
-export type Props = ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery>;
+export type Props = ExploreQueryFieldProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>;
 
 const apiModes = {
   Metrics: { label: 'CloudWatch Metrics', value: 'Metrics' },

--- a/public/app/plugins/datasource/cloudwatch/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/cloudwatch/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -2,1265 +2,315 @@
 
 exports[`Render should disable access key id field 1`] = `
 <Fragment>
-  <h3
-    className="page-heading"
+  <ConnectionConfig
+    onOptionsChange={[MockFunction]}
+    options={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 1,
+        "isDefault": true,
+        "jsonData": Object {
+          "assumeRoleArn": "",
+          "authType": "keys",
+          "customMetricsNamespaces": "",
+          "database": "",
+          "defaultRegion": "us-east-2",
+          "externalId": "",
+          "timeField": "@timestamp",
+        },
+        "name": "CloudWatch",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonData": Object {
+          "accessKey": "",
+          "secretKey": "",
+        },
+        "secureJsonFields": Object {
+          "accessKey": false,
+          "secretKey": false,
+        },
+        "type": "cloudwatch",
+        "typeLogoUrl": "",
+        "typeName": "Cloudwatch",
+        "url": "",
+        "user": "",
+        "withCredentials": false,
+      }
+    }
+    secureJsonFields={
+      Object {
+        "secretKey": true,
+      }
+    }
   >
-    CloudWatch Details
-  </h3>
-  <div
-    className="gf-form-group"
-  >
-    <div
-      className="gf-form-inline"
+    <InlineField
+      label="Namespaces of Custom Metrics"
+      labelWidth={28}
+      tooltip="Namespaces of Custom Metrics."
     >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify which AWS credentials chain to use. AWS SDK Default is the recommended option for EKS, ECS, or if you've attached an IAM role to your EC2 instance."
-        >
-          Authentication Provider
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="keys"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={
-            Array [
-              Object {
-                "label": "AWS SDK Default",
-                "value": "default",
-              },
-              Object {
-                "label": "Access & secret key",
-                "value": "keys",
-              },
-              Object {
-                "label": "Credentials file",
-                "value": "credentials",
-              },
-            ]
-          }
-          tabSelectsValue={true}
-          value={
-            Object {
-              "label": "Access & secret key",
-              "value": "keys",
-            }
-          }
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Access Key ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Secret Access Key
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify the ARN of a role to assume. Specifying a role here will ensure that the selected authentication provider is used to assume the specified role rather than using the credentials directly. Leave blank if you don't need to assume a role at all"
-        >
-          Assume Role ARN
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="arn:aws:iam:*"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-            tooltip="If you are assuming a role in another account, that has been created with an external ID, specify the external ID here."
-          >
-            External ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              placeholder="External ID"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify the region, such as for US West (Oregon) use \` us-west-2 \` as the region."
-        >
-          Default Region
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="us-east-2"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={Array []}
-          tabSelectsValue={true}
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Namespaces of Custom Metrics."
-        >
-          Custom Metrics
-        </FormLabel>
-        <Input
-          className="width-30"
-          onChange={[Function]}
-          placeholder="Namespace1,Namespace2"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify a custom endpoint for the service."
-        >
-          Endpoint
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="https://{service}.{region}.amazonaws.com"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+      <Input
+        onChange={[Function]}
+        placeholder="Namespace1,Namespace2"
+        value=""
+        width={60}
+      />
+    </InlineField>
+  </ConnectionConfig>
 </Fragment>
 `;
 
 exports[`Render should render component 1`] = `
 <Fragment>
-  <h3
-    className="page-heading"
+  <ConnectionConfig
+    onOptionsChange={[MockFunction]}
+    options={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 1,
+        "isDefault": true,
+        "jsonData": Object {
+          "assumeRoleArn": "",
+          "authType": "keys",
+          "customMetricsNamespaces": "",
+          "database": "",
+          "defaultRegion": "us-east-2",
+          "externalId": "",
+          "timeField": "@timestamp",
+        },
+        "name": "CloudWatch",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonData": Object {
+          "accessKey": "",
+          "secretKey": "",
+        },
+        "secureJsonFields": Object {
+          "accessKey": false,
+          "secretKey": false,
+        },
+        "type": "cloudwatch",
+        "typeLogoUrl": "",
+        "typeName": "Cloudwatch",
+        "url": "",
+        "user": "",
+        "withCredentials": false,
+      }
+    }
   >
-    CloudWatch Details
-  </h3>
-  <div
-    className="gf-form-group"
-  >
-    <div
-      className="gf-form-inline"
+    <InlineField
+      label="Namespaces of Custom Metrics"
+      labelWidth={28}
+      tooltip="Namespaces of Custom Metrics."
     >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify which AWS credentials chain to use. AWS SDK Default is the recommended option for EKS, ECS, or if you've attached an IAM role to your EC2 instance."
-        >
-          Authentication Provider
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="keys"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={
-            Array [
-              Object {
-                "label": "AWS SDK Default",
-                "value": "default",
-              },
-              Object {
-                "label": "Access & secret key",
-                "value": "keys",
-              },
-              Object {
-                "label": "Credentials file",
-                "value": "credentials",
-              },
-            ]
-          }
-          tabSelectsValue={true}
-          value={
-            Object {
-              "label": "Access & secret key",
-              "value": "keys",
-            }
-          }
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Access Key ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Secret Access Key
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify the ARN of a role to assume. Specifying a role here will ensure that the selected authentication provider is used to assume the specified role rather than using the credentials directly. Leave blank if you don't need to assume a role at all"
-        >
-          Assume Role ARN
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="arn:aws:iam:*"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-            tooltip="If you are assuming a role in another account, that has been created with an external ID, specify the external ID here."
-          >
-            External ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              placeholder="External ID"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify the region, such as for US West (Oregon) use \` us-west-2 \` as the region."
-        >
-          Default Region
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="us-east-2"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={Array []}
-          tabSelectsValue={true}
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Namespaces of Custom Metrics."
-        >
-          Custom Metrics
-        </FormLabel>
-        <Input
-          className="width-30"
-          onChange={[Function]}
-          placeholder="Namespace1,Namespace2"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify a custom endpoint for the service."
-        >
-          Endpoint
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="https://{service}.{region}.amazonaws.com"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+      <Input
+        onChange={[Function]}
+        placeholder="Namespace1,Namespace2"
+        value=""
+        width={60}
+      />
+    </InlineField>
+  </ConnectionConfig>
 </Fragment>
 `;
 
 exports[`Render should show access key and secret access key fields 1`] = `
 <Fragment>
-  <h3
-    className="page-heading"
+  <ConnectionConfig
+    jsonData={
+      Object {
+        "authType": "keys",
+      }
+    }
+    onOptionsChange={[MockFunction]}
+    options={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 1,
+        "isDefault": true,
+        "jsonData": Object {
+          "assumeRoleArn": "",
+          "authType": "keys",
+          "customMetricsNamespaces": "",
+          "database": "",
+          "defaultRegion": "us-east-2",
+          "externalId": "",
+          "timeField": "@timestamp",
+        },
+        "name": "CloudWatch",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonData": Object {
+          "accessKey": "",
+          "secretKey": "",
+        },
+        "secureJsonFields": Object {
+          "accessKey": false,
+          "secretKey": false,
+        },
+        "type": "cloudwatch",
+        "typeLogoUrl": "",
+        "typeName": "Cloudwatch",
+        "url": "",
+        "user": "",
+        "withCredentials": false,
+      }
+    }
   >
-    CloudWatch Details
-  </h3>
-  <div
-    className="gf-form-group"
-  >
-    <div
-      className="gf-form-inline"
+    <InlineField
+      label="Namespaces of Custom Metrics"
+      labelWidth={28}
+      tooltip="Namespaces of Custom Metrics."
     >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify which AWS credentials chain to use. AWS SDK Default is the recommended option for EKS, ECS, or if you've attached an IAM role to your EC2 instance."
-        >
-          Authentication Provider
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="keys"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={
-            Array [
-              Object {
-                "label": "AWS SDK Default",
-                "value": "default",
-              },
-              Object {
-                "label": "Access & secret key",
-                "value": "keys",
-              },
-              Object {
-                "label": "Credentials file",
-                "value": "credentials",
-              },
-            ]
-          }
-          tabSelectsValue={true}
-          value={
-            Object {
-              "label": "Access & secret key",
-              "value": "keys",
-            }
-          }
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Access Key ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Secret Access Key
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify the ARN of a role to assume. Specifying a role here will ensure that the selected authentication provider is used to assume the specified role rather than using the credentials directly. Leave blank if you don't need to assume a role at all"
-        >
-          Assume Role ARN
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="arn:aws:iam:*"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-            tooltip="If you are assuming a role in another account, that has been created with an external ID, specify the external ID here."
-          >
-            External ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              placeholder="External ID"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify the region, such as for US West (Oregon) use \` us-west-2 \` as the region."
-        >
-          Default Region
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="us-east-2"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={Array []}
-          tabSelectsValue={true}
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Namespaces of Custom Metrics."
-        >
-          Custom Metrics
-        </FormLabel>
-        <Input
-          className="width-30"
-          onChange={[Function]}
-          placeholder="Namespace1,Namespace2"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify a custom endpoint for the service."
-        >
-          Endpoint
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="https://{service}.{region}.amazonaws.com"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+      <Input
+        onChange={[Function]}
+        placeholder="Namespace1,Namespace2"
+        value=""
+        width={60}
+      />
+    </InlineField>
+  </ConnectionConfig>
 </Fragment>
 `;
 
 exports[`Render should show arn role field 1`] = `
 <Fragment>
-  <h3
-    className="page-heading"
+  <ConnectionConfig
+    jsonData={
+      Object {
+        "authType": "arn",
+      }
+    }
+    onOptionsChange={[MockFunction]}
+    options={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 1,
+        "isDefault": true,
+        "jsonData": Object {
+          "assumeRoleArn": "",
+          "authType": "keys",
+          "customMetricsNamespaces": "",
+          "database": "",
+          "defaultRegion": "us-east-2",
+          "externalId": "",
+          "timeField": "@timestamp",
+        },
+        "name": "CloudWatch",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonData": Object {
+          "accessKey": "",
+          "secretKey": "",
+        },
+        "secureJsonFields": Object {
+          "accessKey": false,
+          "secretKey": false,
+        },
+        "type": "cloudwatch",
+        "typeLogoUrl": "",
+        "typeName": "Cloudwatch",
+        "url": "",
+        "user": "",
+        "withCredentials": false,
+      }
+    }
   >
-    CloudWatch Details
-  </h3>
-  <div
-    className="gf-form-group"
-  >
-    <div
-      className="gf-form-inline"
+    <InlineField
+      label="Namespaces of Custom Metrics"
+      labelWidth={28}
+      tooltip="Namespaces of Custom Metrics."
     >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify which AWS credentials chain to use. AWS SDK Default is the recommended option for EKS, ECS, or if you've attached an IAM role to your EC2 instance."
-        >
-          Authentication Provider
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="keys"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={
-            Array [
-              Object {
-                "label": "AWS SDK Default",
-                "value": "default",
-              },
-              Object {
-                "label": "Access & secret key",
-                "value": "keys",
-              },
-              Object {
-                "label": "Credentials file",
-                "value": "credentials",
-              },
-            ]
-          }
-          tabSelectsValue={true}
-          value={
-            Object {
-              "label": "Access & secret key",
-              "value": "keys",
-            }
-          }
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Access Key ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Secret Access Key
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify the ARN of a role to assume. Specifying a role here will ensure that the selected authentication provider is used to assume the specified role rather than using the credentials directly. Leave blank if you don't need to assume a role at all"
-        >
-          Assume Role ARN
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="arn:aws:iam:*"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-            tooltip="If you are assuming a role in another account, that has been created with an external ID, specify the external ID here."
-          >
-            External ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              placeholder="External ID"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify the region, such as for US West (Oregon) use \` us-west-2 \` as the region."
-        >
-          Default Region
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="us-east-2"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={Array []}
-          tabSelectsValue={true}
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Namespaces of Custom Metrics."
-        >
-          Custom Metrics
-        </FormLabel>
-        <Input
-          className="width-30"
-          onChange={[Function]}
-          placeholder="Namespace1,Namespace2"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify a custom endpoint for the service."
-        >
-          Endpoint
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="https://{service}.{region}.amazonaws.com"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+      <Input
+        onChange={[Function]}
+        placeholder="Namespace1,Namespace2"
+        value=""
+        width={60}
+      />
+    </InlineField>
+  </ConnectionConfig>
 </Fragment>
 `;
 
 exports[`Render should show credentials profile name field 1`] = `
 <Fragment>
-  <h3
-    className="page-heading"
+  <ConnectionConfig
+    jsonData={
+      Object {
+        "authType": "credentials",
+      }
+    }
+    onOptionsChange={[MockFunction]}
+    options={
+      Object {
+        "access": "proxy",
+        "basicAuth": false,
+        "basicAuthPassword": "",
+        "basicAuthUser": "",
+        "database": "",
+        "id": 1,
+        "isDefault": true,
+        "jsonData": Object {
+          "assumeRoleArn": "",
+          "authType": "keys",
+          "customMetricsNamespaces": "",
+          "database": "",
+          "defaultRegion": "us-east-2",
+          "externalId": "",
+          "timeField": "@timestamp",
+        },
+        "name": "CloudWatch",
+        "orgId": 1,
+        "password": "",
+        "readOnly": false,
+        "secureJsonData": Object {
+          "accessKey": "",
+          "secretKey": "",
+        },
+        "secureJsonFields": Object {
+          "accessKey": false,
+          "secretKey": false,
+        },
+        "type": "cloudwatch",
+        "typeLogoUrl": "",
+        "typeName": "Cloudwatch",
+        "url": "",
+        "user": "",
+        "withCredentials": false,
+      }
+    }
   >
-    CloudWatch Details
-  </h3>
-  <div
-    className="gf-form-group"
-  >
-    <div
-      className="gf-form-inline"
+    <InlineField
+      label="Namespaces of Custom Metrics"
+      labelWidth={28}
+      tooltip="Namespaces of Custom Metrics."
     >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify which AWS credentials chain to use. AWS SDK Default is the recommended option for EKS, ECS, or if you've attached an IAM role to your EC2 instance."
-        >
-          Authentication Provider
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="keys"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={
-            Array [
-              Object {
-                "label": "AWS SDK Default",
-                "value": "default",
-              },
-              Object {
-                "label": "Access & secret key",
-                "value": "keys",
-              },
-              Object {
-                "label": "Credentials file",
-                "value": "credentials",
-              },
-            ]
-          }
-          tabSelectsValue={true}
-          value={
-            Object {
-              "label": "Access & secret key",
-              "value": "keys",
-            }
-          }
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Access Key ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-          >
-            Secret Access Key
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify the ARN of a role to assume. Specifying a role here will ensure that the selected authentication provider is used to assume the specified role rather than using the credentials directly. Leave blank if you don't need to assume a role at all"
-        >
-          Assume Role ARN
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="arn:aws:iam:*"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="gf-form-inline"
-      >
-        <div
-          className="gf-form"
-        >
-          <FormLabel
-            className="width-14"
-            tooltip="If you are assuming a role in another account, that has been created with an external ID, specify the external ID here."
-          >
-            External ID
-          </FormLabel>
-          <div
-            className="width-30"
-          >
-            <Input
-              className="width-30"
-              onChange={[Function]}
-              placeholder="External ID"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Specify the region, such as for US West (Oregon) use \` us-west-2 \` as the region."
-        >
-          Default Region
-        </FormLabel>
-        <Select
-          allowCustomValue={false}
-          autoFocus={false}
-          backspaceRemovesValue={true}
-          className="width-30"
-          components={
-            Object {
-              "Group": [Function],
-              "IndicatorsContainer": [Function],
-              "MenuList": [Function],
-              "Option": [Function],
-              "SingleValue": [Function],
-            }
-          }
-          defaultValue="us-east-2"
-          isClearable={false}
-          isDisabled={false}
-          isLoading={false}
-          isMulti={false}
-          isSearchable={true}
-          maxMenuHeight={300}
-          onChange={[Function]}
-          openMenuOnFocus={false}
-          options={Array []}
-          tabSelectsValue={true}
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Namespaces of Custom Metrics."
-        >
-          Custom Metrics
-        </FormLabel>
-        <Input
-          className="width-30"
-          onChange={[Function]}
-          placeholder="Namespace1,Namespace2"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      className="gf-form-inline"
-    >
-      <div
-        className="gf-form"
-      >
-        <FormLabel
-          className="width-14"
-          tooltip="Optionally, specify a custom endpoint for the service."
-        >
-          Endpoint
-        </FormLabel>
-        <div
-          className="width-30"
-        >
-          <Input
-            className="width-30"
-            onChange={[Function]}
-            placeholder="https://{service}.{region}.amazonaws.com"
-            value=""
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+      <Input
+        onChange={[Function]}
+        placeholder="Namespace1,Namespace2"
+        value=""
+        width={60}
+      />
+    </InlineField>
+  </ConnectionConfig>
 </Fragment>
 `;

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -11,7 +11,13 @@ import {
 import * as redux from 'app/store/store';
 import { CloudWatchDatasource, MAX_ATTEMPTS } from '../datasource';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { CloudWatchLogsQuery, CloudWatchLogsQueryStatus, CloudWatchMetricsQuery, LogAction } from '../types';
+import {
+  CloudWatchJsonData,
+  CloudWatchLogsQuery,
+  CloudWatchLogsQueryStatus,
+  CloudWatchMetricsQuery,
+  LogAction,
+} from '../types';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { convertToStoreState } from '../../../../../test/helpers/convertToStoreState';
@@ -46,7 +52,7 @@ function getTestContext({ response = {}, throws = false, templateSrv = new Templ
   const instanceSettings = {
     jsonData: { defaultRegion: 'us-east-1' },
     name: 'TestDatasource',
-  } as DataSourceInstanceSettings;
+  } as DataSourceInstanceSettings<CloudWatchJsonData>;
 
   const timeSrv = {
     time: { from: '2016-12-31 15:00:00Z', to: '2016-12-31 16:00:00Z' },

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -1,4 +1,5 @@
-import { DataQuery, SelectableValue, DataSourceJsonData } from '@grafana/data';
+import { DataQuery, SelectableValue } from '@grafana/data';
+import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData } from '@grafana/aws-sdk';
 
 export interface CloudWatchMetricsQuery extends DataQuery {
   queryMode?: 'Metrics';
@@ -56,16 +57,14 @@ export interface AnnotationQuery extends CloudWatchMetricsQuery {
 
 export type SelectableStrings = Array<SelectableValue<string>>;
 
-export interface CloudWatchJsonData extends DataSourceJsonData {
+export interface CloudWatchJsonData extends AwsAuthDataSourceJsonData {
   timeField?: string;
-  assumeRoleArn?: string;
-  externalId?: string;
   database?: string;
   customMetricsNamespaces?: string;
   endpoint?: string;
 }
 
-export interface CloudWatchSecureJsonData {
+export interface CloudWatchSecureJsonData extends AwsAuthDataSourceSecureJsonData {
   accessKey: string;
   secretKey: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3431,6 +3431,40 @@
     source-map "~0.6.1"
     typescript "~3.9.7"
 
+"@grafana/aws-sdk@0.0.153":
+  version "0.0.153"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.153.tgz#852c9a51ad18305ae70dc2baeb20e636ec92adca"
+  integrity sha512-v9TekiVwjrMn6DPKjmvF2g/R8Q95jeBHxvQXFZKiuHQGRvTczrStwbqr4EDeWwRB+xmMwxpXlIleig1ejIyxwA==
+  dependencies:
+    "@grafana/data" "7.5.0-beta.1"
+    "@grafana/runtime" "7.5.0-beta.1"
+    "@grafana/ui" "7.5.0-beta.1"
+
+"@grafana/data@7.5.0-beta.1":
+  version "7.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-7.5.0-beta.1.tgz#4c6dcd07daee713a06e46d230b9c09877fd5f732"
+  integrity sha512-hYU3XWVp2rsLfSZVwYFM9wL0e+i1ktlNPzELGL66EcSV+ak41orlcjpwEpke4O7Vtht6t5qSoTycYlmj6+aZEw==
+  dependencies:
+    "@braintree/sanitize-url" "4.0.0"
+    "@types/d3-interpolate" "^1.3.1"
+    apache-arrow "0.16.0"
+    eventemitter3 "4.0.7"
+    lodash "4.17.21"
+    marked "2.0.1"
+    rxjs "6.6.3"
+    xss "1.0.6"
+
+"@grafana/e2e-selectors@7.5.0-beta.1":
+  version "7.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-7.5.0-beta.1.tgz#063734af7a112033d2e78219969619194fca3526"
+  integrity sha512-zn23xTrkNtCRSI4wg23CatAq2t4R2JWtqwEKvRfP3qWuJTwql2vu1pLJufJUcTkJtn3ImmwSMGvxZ/wI9SPbqQ==
+  dependencies:
+    "@grafana/tsconfig" "^1.0.0-rc1"
+    commander "5.0.0"
+    execa "4.0.0"
+    typescript "4.1.2"
+    yaml "^1.8.3"
+
 "@grafana/eslint-config@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@grafana/eslint-config/-/eslint-config-2.2.1.tgz#a7c6dd57ae0011fb2535a688e1e17969e621d21a"
@@ -3446,6 +3480,16 @@
     eslint-plugin-react-hooks "4.2.0"
     prettier "2.2.1"
     typescript "4.1.3"
+
+"@grafana/runtime@7.5.0-beta.1":
+  version "7.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-7.5.0-beta.1.tgz#f0e29a2493d440b7dd6d09def9727c2ce41cb743"
+  integrity sha512-Cn62/9N1g3TX9vaoGgpD0/bWG2U1nsAoHboLbQnKkztH8tmLoChHqUaZ/5Lsu3s9K5mxI3YA+4PrAxr4NlUPjw==
+  dependencies:
+    "@grafana/data" "7.5.0-beta.1"
+    "@grafana/ui" "7.5.0-beta.1"
+    systemjs "0.20.19"
+    systemjs-plugin-css "0.1.37"
 
 "@grafana/slate-react@0.22.9-grafana":
   version "0.22.9-grafana"
@@ -3473,6 +3517,64 @@
   version "1.0.0-rc1"
   resolved "https://registry.yarnpkg.com/@grafana/tsconfig/-/tsconfig-1.0.0-rc1.tgz#d07ea16755a50cae21000113f30546b61647a200"
   integrity sha512-nucKPGyzlSKYSiJk5RA8GzMdVWhdYNdF+Hh65AXxjD9PlY69JKr5wANj8bVdQboag6dgg0BFKqgKPyY+YtV4Iw==
+
+"@grafana/ui@7.5.0-beta.1":
+  version "7.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-7.5.0-beta.1.tgz#0de30ebe9e51df956fa20f1d0a396d286b3f8c5f"
+  integrity sha512-/+VeGVRjRtd9bOwhzdwWqk8IVrENlGoMWCuRaNQU0+q2tdPQurXYbE3rmxKVtKysPTYNzbhS5Ox5QzYkPkoriA==
+  dependencies:
+    "@emotion/core" "10.0.27"
+    "@grafana/data" "7.5.0-beta.1"
+    "@grafana/e2e-selectors" "7.5.0-beta.1"
+    "@grafana/slate-react" "0.22.9-grafana"
+    "@grafana/tsconfig" "^1.0.0-rc1"
+    "@iconscout/react-unicons" "1.1.4"
+    "@popperjs/core" "2.5.4"
+    "@sentry/browser" "5.25.0"
+    "@testing-library/jest-dom" "5.11.9"
+    "@torkelo/react-select" "3.0.8"
+    "@types/hoist-non-react-statics" "3.3.1"
+    "@types/react-beautiful-dnd" "12.1.2"
+    "@types/react-color" "3.0.1"
+    "@types/react-select" "3.0.8"
+    "@types/react-table" "7.0.12"
+    "@types/slate" "0.47.1"
+    "@types/slate-react" "0.22.5"
+    "@visx/event" "1.3.0"
+    "@visx/gradient" "1.0.0"
+    "@visx/scale" "1.4.0"
+    "@visx/shape" "1.4.0"
+    "@visx/tooltip" "1.3.0"
+    classnames "2.2.6"
+    d3 "5.15.0"
+    emotion "10.0.27"
+    hoist-non-react-statics "3.3.2"
+    immutable "3.8.2"
+    jquery "3.5.1"
+    lodash "4.17.21"
+    moment "2.24.0"
+    monaco-editor "0.20.0"
+    papaparse "5.3.0"
+    rc-cascader "1.0.1"
+    rc-drawer "3.1.3"
+    rc-slider "9.6.4"
+    rc-time-picker "^3.7.3"
+    react "17.0.1"
+    react-beautiful-dnd "13.0.0"
+    react-calendar "2.19.2"
+    react-color "2.18.0"
+    react-custom-scrollbars "4.2.1"
+    react-dom "17.0.1"
+    react-highlight-words "0.16.0"
+    react-hook-form "5.1.3"
+    react-monaco-editor "0.36.0"
+    react-popper "2.2.4"
+    react-storybook-addon-props-combinations "1.1.0"
+    react-table "7.0.0"
+    react-transition-group "4.4.1"
+    slate "0.47.8"
+    tinycolor2 "1.4.1"
+    uplot "1.6.4"
 
 "@icons/material@^0.2.4":
   version "0.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3431,10 +3431,10 @@
     source-map "~0.6.1"
     typescript "~3.9.7"
 
-"@grafana/aws-sdk@0.0.153":
-  version "0.0.153"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.153.tgz#852c9a51ad18305ae70dc2baeb20e636ec92adca"
-  integrity sha512-v9TekiVwjrMn6DPKjmvF2g/R8Q95jeBHxvQXFZKiuHQGRvTczrStwbqr4EDeWwRB+xmMwxpXlIleig1ejIyxwA==
+"@grafana/aws-sdk@0.0.154":
+  version "0.0.154"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.154.tgz#eb31f4583f7ef4f559e826747f2898230bbeda0a"
+  integrity sha512-4GJVKEnxZm7fY4Sr2NwQ/QpDa59A5S1ZqrMrVn2F+h5K0idbuASuM4p3Y7nsFB8FQKatvfwc2e7JoOkzAw8QvQ==
   dependencies:
     "@grafana/data" "7.5.0-beta.1"
     "@grafana/runtime" "7.5.0-beta.1"


### PR DESCRIPTION
What this PR does:
* restrict auth provider usage to those ones that are specified in grafana.ini
* restrict usage of assume role if it's disabled in grafana.ini
* add support for new auth option - EC2 IAM role
* consume new NPM package grafana/aws-sdk. This packages exposes a ConfigEditor that will be used by all AWS plugins. 

Regarding EC2 IAM Role: I deployed this branch to an EC2 instance and it's working fine. Since this type of auth will be used by AMG and it will be hosted externally, it's not possible for me to test this in a production like environment. I've talked to a developer at AWS who told me that AMG will be run in pods in a kubernetes cluster, but the pods are configured to intercept calls to EC2 metadata and load a role attached to the pod. I've deployed my branch to an EC2 instance, and it works fine given the role that is running the instance has the policies needed to access CloudWatch. 

This PR could be split up into two - one for adding support for EC2 IAM role, and one for restricting providers and assume role. 

Why draft mode? Because there's still a few minor things to consider for the grafana/aws-sdk npm package. 

Fixes #31764
Fixes #31082

