### PR TITLE
ReduceTransform: Include series with numeric string  names

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/reduce.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.test.ts
@@ -274,4 +274,96 @@ describe('Reducer Transformer', () => {
       }
     `);
   });
+
+  it('reduces multiple data frames with decimal display name (https://github.com/grafana/grafana/issues/31580)', async () => {
+    const cfg = {
+      id: DataTransformerID.reduce,
+      options: {
+        reducers: [ReducerID.max],
+      },
+    };
+
+    const seriesA = toDataFrame({
+      name: 'a',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+        { name: 'value', type: FieldType.number, values: [3, 4, 5, 6], state: { displayName: 'a' } },
+      ],
+    });
+
+    const seriesB = toDataFrame({
+      name: '2021',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+        { name: 'value', type: FieldType.number, values: [7, 8, 9, 10], state: { displayName: '2021' } },
+      ],
+    });
+
+    await expect(transformDataFrame([cfg], [seriesA, seriesB])).toEmitValuesWith((received) => {
+      const processed = received[0];
+      const expected: Field[] = [
+        {
+          name: 'Field',
+          type: FieldType.string,
+          values: new ArrayVector(['a', '2021']),
+          config: {},
+        },
+        {
+          name: 'Max',
+          type: FieldType.number,
+          values: new ArrayVector([6, 10]),
+          config: {},
+        },
+      ];
+
+      expect(processed.length).toEqual(1);
+      expect(processed[0].length).toEqual(2);
+      expect(processed[0].fields).toEqual(expected);
+    });
+  });
+
+  it('reduces multiple data frames with decimal fields name (https://github.com/grafana/grafana/issues/31580)', async () => {
+    const cfg = {
+      id: DataTransformerID.reduce,
+      options: {
+        reducers: [ReducerID.max],
+      },
+    };
+
+    const seriesA = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+        { name: 'a', type: FieldType.number, values: [3, 4, 5, 6] },
+      ],
+    });
+
+    const seriesB = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+        { name: '2021', type: FieldType.number, values: [7, 8, 9, 10] },
+      ],
+    });
+
+    await expect(transformDataFrame([cfg], [seriesA, seriesB])).toEmitValuesWith((received) => {
+      const processed = received[0];
+      const expected: Field[] = [
+        {
+          name: 'Field',
+          type: FieldType.string,
+          values: new ArrayVector(['a', '2021']),
+          config: {},
+        },
+        {
+          name: 'Max',
+          type: FieldType.number,
+          values: new ArrayVector([6, 10]),
+          config: {},
+        },
+      ];
+
+      expect(processed.length).toEqual(1);
+      expect(processed[0].length).toEqual(2);
+      expect(processed[0].fields).toEqual(expected);
+    });
+  });
 });

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -119,10 +119,6 @@ export function reduceSeriesToRows(
     }
 
     for (const f of fields) {
-      if (f === fields[0]) {
-        continue;
-      }
-
       const t = guessFieldTypeForField(f);
 
       if (t) {
@@ -153,15 +149,18 @@ export function mergeResults(data: DataFrame[]): DataFrame | undefined {
   for (let seriesIndex = 1; seriesIndex < data.length; seriesIndex++) {
     const series = data[seriesIndex];
 
-    for (const baseField of baseFrame.fields) {
-      for (const field of series.fields) {
-        if (baseField.type !== field.type || baseField.name !== field.name) {
-          continue;
-        }
+    for (let baseIndex = 0; baseIndex < baseFrame.fields.length; baseIndex++) {
+      const baseField = baseFrame.fields[baseIndex];
+      for (let fieldIndex = 0; fieldIndex < series.fields.length; fieldIndex++) {
+        const field = series.fields[fieldIndex];
+        const isFirstField = baseIndex === 0 && fieldIndex === 0;
+        const isSameField = baseField.type === field.type && baseField.name === field.name;
 
-        const baseValues: any[] = ((baseField.values as unknown) as ArrayVector).buffer;
-        const values: any[] = ((field.values as unknown) as ArrayVector).buffer;
-        ((baseField.values as unknown) as ArrayVector).buffer = baseValues.concat(values);
+        if (isFirstField || isSameField) {
+          const baseValues: any[] = baseField.values.toArray();
+          const values: any[] = field.values.toArray();
+          ((baseField.values as unknown) as ArrayVector).buffer = baseValues.concat(values);
+        }
       }
     }
   }

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -1,7 +1,7 @@
 import { map } from 'rxjs/operators';
 
 import { DataTransformerID } from './ids';
-import { DataTransformerInfo, MatcherConfig, FieldMatcher } from '../../types/transformations';
+import { DataTransformerInfo, FieldMatcher, MatcherConfig } from '../../types/transformations';
 import { fieldReducers, reduceField, ReducerID } from '../fieldReducer';
 import { alwaysFieldMatcher, notTimeFieldMatcher } from '../matchers/predicates';
 import { DataFrame, Field, FieldType } from '../../types/dataFrame';
@@ -119,6 +119,10 @@ export function reduceSeriesToRows(
     }
 
     for (const f of fields) {
+      if (f === fields[0]) {
+        continue;
+      }
+
       const t = guessFieldTypeForField(f);
 
       if (t) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that Reduce Transform includes any series names in the result, even if they're completely numeric. There is probably a more fundamental change that needs to be addressed but I opted to just solve the specific issue here.

**Which issue(s) this PR fixes**:
Fixes #31580

**Special notes for your reviewer**:

