### PR TITLE
Chore: Fix `make build-docker-full` by adding git before yarn call 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app/
 COPY package.json yarn.lock ./
 COPY packages packages
 
+RUN apk add --no-cache git
 RUN yarn install --pure-lockfile --no-progress
 
 COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js ./


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds git package dependencies in Dockerfile. When running `yarn install --pure-lockfile --no-progress` without having install git package beforehand, the following error is produced:

```
 => ERROR [js-builder  5/11] RUN yarn install --pure-lockfile --no-progress                                                                                                                                                      206.1s
------
 > [js-builder  5/11] RUN yarn install --pure-lockfile --no-progress:
#26 1.461 yarn install v1.22.5
#26 2.251 [1/5] Validating package.json...
#26 2.341 [2/5] Resolving packages...
#26 6.956 [3/5] Fetching packages...
#26 7.296 error Couldn't find the binary git
#26 7.297 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

```

**Which issue(s) this PR fixes**:

Fixes #31697

**Special notes for your reviewer**:

* Try and run `make build-docker-full` from master.
* Then checkout branch, and try again to check if it works correctly.
