### PR TITLE
Loki, Prometheus: Change the placement for query type explanation

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -18,8 +18,8 @@ export interface LokiOptionFieldsProps {
 type LokiQueryType = 'instant' | 'range';
 
 const queryTypeOptions = [
-  { value: 'range', label: 'Range' },
-  { value: 'instant', label: 'Instant' },
+  { value: 'range', label: 'Range', description: 'Range query queries over a range of time.' },
+  { value: 'instant', label: 'Instant', description: 'Instant query queries against a single point in time.' },
 ];
 
 export function LokiOptionFields(props: LokiOptionFieldsProps) {
@@ -79,12 +79,7 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
         )}
         aria-label="Query type field"
       >
-        <InlineFormLabel
-          tooltip="Choose the type of query you would like to run. An instant query queries against a single point in time. A range query queries over a range of time."
-          width="auto"
-        >
-          Query type
-        </InlineFormLabel>
+        <InlineFormLabel width="auto">Query type</InlineFormLabel>
 
         <RadioButtonGroup
           options={queryTypeOptions}

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -18,11 +18,11 @@ export interface LokiOptionFieldsProps {
 type LokiQueryType = 'instant' | 'range';
 
 const queryTypeOptions = [
-  { value: 'range', label: 'Range', description: 'Range query queries over a range of time.' },
+  { value: 'range', label: 'Range', description: 'Run query over a range of time.' },
   {
     value: 'instant',
     label: 'Instant',
-    description: 'Instant query queries against a single point in time. For this query, the "To" time is used.',
+    description: 'Run query against a single point in time. For this query, the "To" time is used.',
   },
 ];
 

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -19,7 +19,11 @@ type LokiQueryType = 'instant' | 'range';
 
 const queryTypeOptions = [
   { value: 'range', label: 'Range', description: 'Range query queries over a range of time.' },
-  { value: 'instant', label: 'Instant', description: 'Instant query queries against a single point in time.' },
+  {
+    value: 'instant',
+    label: 'Instant',
+    description: 'Instant query queries against a single point in time. For this query, the "To" time is used.',
+  },
 ];
 
 export function LokiOptionFields(props: LokiOptionFieldsProps) {

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -20,9 +20,9 @@ export interface PromExploreExtraFieldProps {
 export const PromExploreExtraField: React.FC<PromExploreExtraFieldProps> = memo(
   ({ queryType, stepValue, query, onChange, onStepChange, onQueryTypeChange, onKeyDownFunc }) => {
     const rangeOptions = [
-      { value: 'range', label: 'Range' },
-      { value: 'instant', label: 'Instant' },
-      { value: 'both', label: 'Both' },
+      { value: 'range', label: 'Range', description: 'Range query queries over a range of time.' },
+      { value: 'instant', label: 'Instant', description: 'Instant query queries against a single point in time.' },
+      { value: 'both', label: 'Both', description: "With both, you'll run two queries - one instant and one range." },
     ];
 
     return (
@@ -38,12 +38,7 @@ export const PromExploreExtraField: React.FC<PromExploreExtraFieldProps> = memo(
           )}
           aria-label="Query type field"
         >
-          <InlineFormLabel
-            width="auto"
-            tooltip="Choose the type of query you would like to run. An instant query queries against a single point in time. A range query queries over a range of time. With both, you'll run two queries - one instant and one range. "
-          >
-            Query type
-          </InlineFormLabel>
+          <InlineFormLabel width="auto">Query type</InlineFormLabel>
 
           <RadioButtonGroup options={rangeOptions} value={queryType} onChange={onQueryTypeChange} />
         </div>

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -20,13 +20,13 @@ export interface PromExploreExtraFieldProps {
 export const PromExploreExtraField: React.FC<PromExploreExtraFieldProps> = memo(
   ({ queryType, stepValue, query, onChange, onStepChange, onQueryTypeChange, onKeyDownFunc }) => {
     const rangeOptions = [
-      { value: 'range', label: 'Range', description: 'Range query queries over a range of time.' },
+      { value: 'range', label: 'Range', description: 'Run query over a range of time.' },
       {
         value: 'instant',
         label: 'Instant',
-        description: 'Instant query queries against a single point in time. For this query, the "To" time is used.',
+        description: 'Run query against a single point in time. For this query, the "To" time is used.',
       },
-      { value: 'both', label: 'Both', description: "With both, you'll run two queries - one instant and one range." },
+      { value: 'both', label: 'Both', description: 'Run an Instant query and a Range query.' },
     ];
 
     return (

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -21,7 +21,11 @@ export const PromExploreExtraField: React.FC<PromExploreExtraFieldProps> = memo(
   ({ queryType, stepValue, query, onChange, onStepChange, onQueryTypeChange, onKeyDownFunc }) => {
     const rangeOptions = [
       { value: 'range', label: 'Range', description: 'Range query queries over a range of time.' },
-      { value: 'instant', label: 'Instant', description: 'Instant query queries against a single point in time.' },
+      {
+        value: 'instant',
+        label: 'Instant',
+        description: 'Instant query queries against a single point in time. For this query, the "To" time is used.',
+      },
       { value: 'both', label: 'Both', description: "With both, you'll run two queries - one instant and one range." },
     ];
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I have [started with fixing the tooltip popover and improving the experience
](https://github.com/grafana/grafana/commit/9232c393ec48ad534942d9703f3be8ef0e4fc5b4) and have almost ready PR for this option, but during working on this, I started to wonder, if we need tooltip on label and if tooltip on radio buttons isn't better option. We use tooltip on radio buttons across a lot of place (deduplication, choosing of log direction in logs panel). 
![image](https://user-images.githubusercontent.com/30407135/110348056-88b13600-8031-11eb-8750-1ee8715424b7.png)

Let me know what do you think!

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/31755

