### PR TITLE
Docs: Add Cloudwatch link 7.5

### DIFF
--- a/docs/sources/datasources/cloudwatch.md
+++ b/docs/sources/datasources/cloudwatch.md
@@ -6,19 +6,17 @@ aliases = ["/docs/grafana/latest/datasources/cloudwatch"]
 weight = 200
 +++
 
-# Using AWS CloudWatch in Grafana
+# AWS CloudWatch data source
 
-Grafana ships with built-in support for CloudWatch. Add it as a data source, then you are ready to
-build dashboards or use Explore with CloudWatch metrics and CloudWatch Logs.
+Grafana ships with built-in support for CloudWatch. Add it as a data source, then you are ready to build dashboards or use Explore with CloudWatch metrics and CloudWatch Logs.
 
-## Adding the data source
+This topic explains options, variables, querying, and other options specific to this data source. Refer to [Add a data source]({{< relref "add-a-data-source.md" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 
-1. In the side menu under the `Configuration` link, click on `Data Sources`.
-1. Click the `Add data source` button.
-1. Select `Cloudwatch` in the `Cloud` section.
+> **Note:** If you have issues with getting this data source to work and Grafana is giving you undescriptive errors, then check your log file (try looking in /var/log/grafana/grafana.log).
 
-> **Note:** If at any moment you have issues with getting this data source to work and Grafana is giving you undescriptive errors then don't
-> forget to check your log file (try looking in /var/log/grafana/grafana.log).
+## Cloudwatch settings
+
+To access data source settings, hover your mouse over the **Configuration** (gear) icon, then click **Data Sources**, and then click the AWS Cloudwatch data source.
 
 | Name                       | Description                                                                                                             |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/whatsnew/whats-new-in-v7-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-5.md
@@ -77,7 +77,7 @@ For more information, refer to [Deprecating Application Insights and Insights An
 - Support for region eu-south-1 has been added to the CloudWatch data source. New metrics have also been added to the namespaces AWS/Timestream, AWS/RDS (RDS Proxy metrics), AWS/NetworkFirewall, AWS/GroundStation, and AWS/DDoSProtection. Many thanks to [relvira](https://github.com/relvira), [ilyastoli](https://github.com/ilyastoli), and [rubycut](https://github.com/rubycut) for contributing!
 - You can now specify a custom endpoint in the CloudWatch data source configuration page. This field is optional, and if it is left empty, then the default endpoint for CloudWatch is used. By specifying a regional endpoint, you can reduce request latency.
 
-  [Cloudwatch data source]({{< relref "../datasources/cloudwatch.md#endpoint" >}}) was updated as a result of this change.
+  [AWS Cloudwatch data source]({{< relref "../datasources/cloudwatch.md#endpoint" >}}) was updated as a result of this change.
 
 ### Increased API limit for CloudMonitoring Services
 

--- a/docs/sources/whatsnew/whats-new-in-v7-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-5.md
@@ -77,6 +77,8 @@ For more information, refer to [Deprecating Application Insights and Insights An
 - Support for region eu-south-1 has been added to the CloudWatch data source. New metrics have also been added to the namespaces AWS/Timestream, AWS/RDS (RDS Proxy metrics), AWS/NetworkFirewall, AWS/GroundStation, and AWS/DDoSProtection. Many thanks to [relvira](https://github.com/relvira), [ilyastoli](https://github.com/ilyastoli), and [rubycut](https://github.com/rubycut) for contributing!
 - You can now specify a custom endpoint in the CloudWatch data source configuration page. This field is optional, and if it is left empty, then the default endpoint for CloudWatch is used. By specifying a regional endpoint, you can reduce request latency.
 
+  [Cloudwatch data source]({{< relref "../datasources/cloudwatch.md#endpoint" >}}) was updated as a result of this change.
+
 ### Increased API limit for CloudMonitoring Services
 
 In previous versions, when querying metrics for Service Level Objectives (SLOs) in the CloudMonitoring data source, only the first 100 services were listed in the **Service** field list. To overcome this issue, the API limit for listing services has been increased to 1000.


### PR DESCRIPTION
- Added Cloudwatch link to What's new in Grafana 7.5
- Edited the title and intro of Cloudwatch topic to remove incorrect information