### PR TITLE
GraphNG: uPlot 1.6.6

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -77,7 +77,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.4"
+    "uplot": "1.6.6"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -80,7 +80,7 @@ export const UPlotChart: React.FC<PlotProps> = (props) => {
   );
 };
 
-function initializePlot(data: AlignedData | null, config: Options, el: HTMLDivElement) {
+function initializePlot(data: AlignedData, config: Options, el: HTMLDivElement) {
   pluginLog('UPlotChart: init uPlot', false, 'initialized with', data, config);
   return new uPlot(config, data, el);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25693,10 +25693,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.4.tgz#016e9f66796d78c187957e710743f7ca405dfb4d"
-  integrity sha512-4d6JixG54HQKFDLAegzwgwf87GtEbp6pt3YlHygyLt+mJ9RHneCXYlZxr1QOhLetoSSHeeDuWP5RFMv8mdltpg==
+uplot@1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.6.tgz#81a139acd1f422bdaeedab3f273786114131ae0f"
+  integrity sha512-iy2hv7rGswvS4yWyPKOTQ3T7qEzv8h8EjSugq5iD2ybGjmg/6EHQB1FhJhWvw/Ibn1MrE75wignQudAr1p/PrQ==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
this bump covers 2 versions (1.6.4 -> 1.6.6): https://github.com/leeoniya/uPlot/releases

![image](https://user-images.githubusercontent.com/43234/110425001-4dcaf480-8069-11eb-8085-b7750db903af.png)
