### PR TITLE
Change piechart plugin state to beta

### DIFF
--- a/public/app/plugins/panel/piechart/plugin.json
+++ b/public/app/plugins/panel/piechart/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Pie chart v2",
   "id": "piechart",
-  "state": "alpha",
+  "state": "beta",
 
   "info": {
     "author": {


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the piechart plugin state to beta.