### PR TITLE
Variables: Improves inspection performance and unknown filtering

### DIFF
--- a/public/app/features/variables/editor/VariableEditorContainer.tsx
+++ b/public/app/features/variables/editor/VariableEditorContainer.tsx
@@ -17,6 +17,11 @@ const mapStateToProps = (state: StoreState) => ({
   variables: getEditorVariables(state),
   idInEditor: state.templating.editor.id,
   dashboard: state.dashboard.getModel(),
+  unknownsNetwork: state.templating.inspect.unknownsNetwork,
+  unknownExists: state.templating.inspect.unknownExits,
+  usagesNetwork: state.templating.inspect.usagesNetwork,
+  unknown: state.templating.inspect.unknown,
+  usages: state.templating.inspect.usages,
 });
 
 const mapDispatchToProps = {
@@ -67,6 +72,7 @@ class VariableEditorContainerUnconnected extends PureComponent<Props> {
 
   render() {
     const variableToEdit = this.props.variables.find((s) => s.id === this.props.idInEditor) ?? null;
+
     return (
       <div>
         <div className="page-action-bar">
@@ -114,8 +120,10 @@ class VariableEditorContainerUnconnected extends PureComponent<Props> {
               onChangeVariableOrder={this.onChangeVariableOrder}
               onDuplicateVariable={this.onDuplicateVariable}
               onRemoveVariable={this.onRemoveVariable}
+              usages={this.props.usages}
+              usagesNetwork={this.props.usagesNetwork}
             />
-            <VariablesUnknownTable dashboard={this.props.dashboard} variables={this.props.variables} />
+            {this.props.unknownExists ? <VariablesUnknownTable usages={this.props.unknownsNetwork} /> : null}
           </>
         )}
         {variableToEdit && <VariableEditorEditor identifier={toVariableIdentifier(variableToEdit)} />}

--- a/public/app/features/variables/editor/VariableEditorList.tsx
+++ b/public/app/features/variables/editor/VariableEditorList.tsx
@@ -8,13 +8,15 @@ import EmptyListCTA from '../../../core/components/EmptyListCTA/EmptyListCTA';
 import { QueryVariableModel, VariableModel } from '../types';
 import { toVariableIdentifier, VariableIdentifier } from '../state/types';
 import { DashboardModel } from '../../dashboard/state';
-import { getVariableUsages } from '../inspect/utils';
+import { getVariableUsages, UsagesToNetwork, VariableUsageTree } from '../inspect/utils';
 import { isAdHoc } from '../guard';
 import { VariableUsagesButton } from '../inspect/VariableUsagesButton';
 
 export interface Props {
   variables: VariableModel[];
   dashboard: DashboardModel | null;
+  usages: VariableUsageTree[];
+  usagesNetwork: UsagesToNetwork[];
   onAddClick: (event: MouseEvent) => void;
   onEditClick: (identifier: VariableIdentifier) => void;
   onChangeVariableOrder: (identifier: VariableIdentifier, fromIndex: number, toIndex: number) => void;
@@ -97,7 +99,7 @@ export class VariableEditorList extends PureComponent<Props> {
                       : typeof variable.query === 'string'
                       ? variable.query
                       : '';
-                    const usages = getVariableUsages(variable.id, this.props.variables, this.props.dashboard);
+                    const usages = getVariableUsages(variable.id, this.props.usages);
                     const passed = usages > 0 || isAdHoc(variable);
                     return (
                       <tr key={`${variable.name}-${index}`}>
@@ -129,9 +131,9 @@ export class VariableEditorList extends PureComponent<Props> {
 
                         <td style={{ width: '1%' }}>
                           <VariableUsagesButton
-                            variable={variable}
-                            variables={this.props.variables}
-                            dashboard={this.props.dashboard}
+                            id={variable.id}
+                            isAdhoc={isAdHoc(variable)}
+                            usages={this.props.usagesNetwork}
                           />
                         </td>
 

--- a/public/app/features/variables/inspect/VariableUsagesButton.tsx
+++ b/public/app/features/variables/inspect/VariableUsagesButton.tsx
@@ -1,33 +1,18 @@
 import React, { FC, useMemo } from 'react';
-import { Provider } from 'react-redux';
 import { IconButton } from '@grafana/ui';
 
-import { createUsagesNetwork, transformUsagesToNetwork } from './utils';
-import { store } from '../../../store/store';
-import { isAdHoc } from '../guard';
+import { UsagesToNetwork } from './utils';
 import { NetworkGraphModal } from './NetworkGraphModal';
-import { VariableModel } from '../types';
-import { DashboardModel } from '../../dashboard/state';
 
-interface OwnProps {
-  variables: VariableModel[];
-  variable: VariableModel;
-  dashboard: DashboardModel | null;
+interface Props {
+  id: string;
+  usages: UsagesToNetwork[];
+  isAdhoc: boolean;
 }
 
-interface ConnectedProps {}
-
-interface DispatchProps {}
-
-type Props = OwnProps & ConnectedProps & DispatchProps;
-
-export const UnProvidedVariableUsagesGraphButton: FC<Props> = ({ variables, variable, dashboard }) => {
-  const { id } = variable;
-  const { usages } = useMemo(() => createUsagesNetwork(variables, dashboard), [variables, dashboard]);
-  const network = useMemo(() => transformUsagesToNetwork(usages).find((n) => n.variable.id === id), [usages, id]);
-  const adhoc = useMemo(() => isAdHoc(variable), [variable]);
-
-  if (usages.length === 0 || adhoc || !network) {
+export const VariableUsagesButton: FC<Props> = ({ id, usages, isAdhoc }) => {
+  const network = useMemo(() => usages.find((n) => n.variable.id === id), [usages, id]);
+  if (usages.length === 0 || isAdhoc || !network) {
     return null;
   }
 
@@ -46,9 +31,3 @@ export const UnProvidedVariableUsagesGraphButton: FC<Props> = ({ variables, vari
     </NetworkGraphModal>
   );
 };
-
-export const VariableUsagesButton: FC<Props> = (props) => (
-  <Provider store={store}>
-    <UnProvidedVariableUsagesGraphButton {...props} />
-  </Provider>
-);

--- a/public/app/features/variables/inspect/VariablesUnknownButton.tsx
+++ b/public/app/features/variables/inspect/VariablesUnknownButton.tsx
@@ -1,31 +1,17 @@
 import React, { FC, useMemo } from 'react';
-import { Provider } from 'react-redux';
 import { IconButton } from '@grafana/ui';
-import { createUsagesNetwork, transformUsagesToNetwork } from './utils';
-import { store } from '../../../store/store';
-import { VariableModel } from '../types';
-import { DashboardModel } from '../../dashboard/state';
+import { UsagesToNetwork } from './utils';
 import { NetworkGraphModal } from './NetworkGraphModal';
 
-interface OwnProps {
-  variable: VariableModel;
-  variables: VariableModel[];
-  dashboard: DashboardModel | null;
+interface Props {
+  id: string;
+  usages: UsagesToNetwork[];
 }
 
-interface ConnectedProps {}
+export const VariablesUnknownButton: FC<Props> = ({ id, usages }) => {
+  const network = useMemo(() => usages.find((n) => n.variable.id === id), [id, usages]);
 
-interface DispatchProps {}
-
-type Props = OwnProps & ConnectedProps & DispatchProps;
-
-export const UnProvidedVariablesUnknownGraphButton: FC<Props> = ({ variable, variables, dashboard }) => {
-  const { id } = variable;
-  const { unknown } = useMemo(() => createUsagesNetwork(variables, dashboard), [variables, dashboard]);
-  const network = useMemo(() => transformUsagesToNetwork(unknown).find((n) => n.variable.id === id), [id, unknown]);
-  const unknownExist = useMemo(() => Object.keys(unknown).length > 0, [unknown]);
-
-  if (!unknownExist || !network) {
+  if (!network) {
     return null;
   }
 
@@ -44,9 +30,3 @@ export const UnProvidedVariablesUnknownGraphButton: FC<Props> = ({ variable, var
     </NetworkGraphModal>
   );
 };
-
-export const VariablesUnknownButton: FC<Props> = (props) => (
-  <Provider store={store}>
-    <UnProvidedVariablesUnknownGraphButton {...props} />
-  </Provider>
-);

--- a/public/app/features/variables/inspect/VariablesUnknownTable.tsx
+++ b/public/app/features/variables/inspect/VariablesUnknownTable.tsx
@@ -1,35 +1,16 @@
-import React, { FC, useMemo } from 'react';
-import { Provider } from 'react-redux';
+import React, { FC } from 'react';
 import { css } from 'emotion';
 import { Icon, Tooltip, useStyles } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
-import { createUsagesNetwork, transformUsagesToNetwork } from './utils';
-import { store } from '../../../store/store';
+import { UsagesToNetwork } from './utils';
 import { VariablesUnknownButton } from './VariablesUnknownButton';
-import { VariableModel } from '../types';
-import { DashboardModel } from '../../dashboard/state';
 
-interface OwnProps {
-  variables: VariableModel[];
-  dashboard: DashboardModel | null;
+interface Props {
+  usages: UsagesToNetwork[];
 }
 
-interface ConnectedProps {}
-
-interface DispatchProps {}
-
-type Props = OwnProps & ConnectedProps & DispatchProps;
-
-export const UnProvidedVariablesUnknownTable: FC<Props> = ({ variables, dashboard }) => {
+export const VariablesUnknownTable: FC<Props> = ({ usages }) => {
   const style = useStyles(getStyles);
-  const { unknown } = useMemo(() => createUsagesNetwork(variables, dashboard), [variables, dashboard]);
-  const networks = useMemo(() => transformUsagesToNetwork(unknown), [unknown]);
-  const unknownExist = useMemo(() => Object.keys(unknown).length > 0, [unknown]);
-
-  if (!unknownExist) {
-    return null;
-  }
-
   return (
     <div className={style.container}>
       <h5>
@@ -48,8 +29,8 @@ export const UnProvidedVariablesUnknownTable: FC<Props> = ({ variables, dashboar
             </tr>
           </thead>
           <tbody>
-            {networks.map((network) => {
-              const { variable } = network;
+            {usages.map((usage) => {
+              const { variable } = usage;
               const { id, name } = variable;
               return (
                 <tr key={id}>
@@ -60,7 +41,7 @@ export const UnProvidedVariablesUnknownTable: FC<Props> = ({ variables, dashboar
                   <td className={style.defaultColumn} />
                   <td className={style.defaultColumn} />
                   <td className={style.lastColumn}>
-                    <VariablesUnknownButton variable={variable} variables={variables} dashboard={dashboard} />
+                    <VariablesUnknownButton id={variable.id} usages={usages} />
                   </td>
                 </tr>
               );
@@ -97,9 +78,3 @@ const getStyles = (theme: GrafanaTheme) => ({
     text-align: right;
   `,
 });
-
-export const VariablesUnknownTable: FC<Props> = (props) => (
-  <Provider store={store}>
-    <UnProvidedVariablesUnknownTable {...props} />
-  </Provider>
-);

--- a/public/app/features/variables/inspect/reducer.test.ts
+++ b/public/app/features/variables/inspect/reducer.test.ts
@@ -1,0 +1,29 @@
+import { reducerTester } from '../../../../test/core/redux/reducerTester';
+import { initialVariableInspectState, initInspect, variableInspectReducer } from './reducer';
+import { textboxBuilder } from '../shared/testing/builders';
+
+describe('variableInspectReducer', () => {
+  describe('when initInspect is dispatched', () => {
+    it('then state should be correct', () => {
+      const variable = textboxBuilder().withId('text').withName('text').build();
+      reducerTester()
+        .givenReducer(variableInspectReducer, { ...initialVariableInspectState })
+        .whenActionIsDispatched(
+          initInspect({
+            unknownExits: true,
+            unknownsNetwork: [{ edges: [], nodes: [], showGraph: true, variable }],
+            usagesNetwork: [{ edges: [], nodes: [], showGraph: true, variable }],
+            usages: [{ variable, tree: {} }],
+            unknown: [{ variable, tree: {} }],
+          })
+        )
+        .thenStateShouldEqual({
+          unknownExits: true,
+          unknownsNetwork: [{ edges: [], nodes: [], showGraph: true, variable }],
+          usagesNetwork: [{ edges: [], nodes: [], showGraph: true, variable }],
+          usages: [{ variable, tree: {} }],
+          unknown: [{ variable, tree: {} }],
+        });
+    });
+  });
+});

--- a/public/app/features/variables/inspect/reducer.ts
+++ b/public/app/features/variables/inspect/reducer.ts
@@ -1,0 +1,46 @@
+import { UsagesToNetwork, VariableUsageTree } from './utils';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface VariableInspectState {
+  unknown: VariableUsageTree[];
+  usages: VariableUsageTree[];
+  unknownsNetwork: UsagesToNetwork[];
+  usagesNetwork: UsagesToNetwork[];
+  unknownExits: boolean;
+}
+
+export const initialVariableInspectState: VariableInspectState = {
+  unknown: [],
+  usages: [],
+  unknownsNetwork: [],
+  usagesNetwork: [],
+  unknownExits: false,
+};
+
+const variableInspectReducerSlice = createSlice({
+  name: 'templating/inspect',
+  initialState: initialVariableInspectState,
+  reducers: {
+    initInspect: (
+      state,
+      action: PayloadAction<{
+        unknown: VariableUsageTree[];
+        usages: VariableUsageTree[];
+        unknownsNetwork: UsagesToNetwork[];
+        usagesNetwork: UsagesToNetwork[];
+        unknownExits: boolean;
+      }>
+    ) => {
+      const { unknown, usages, unknownExits, unknownsNetwork, usagesNetwork } = action.payload;
+      state.usages = usages;
+      state.unknown = unknown;
+      state.unknownsNetwork = unknownsNetwork;
+      state.unknownExits = unknownExits;
+      state.usagesNetwork = usagesNetwork;
+    },
+  },
+});
+
+export const variableInspectReducer = variableInspectReducerSlice.reducer;
+
+export const { initInspect } = variableInspectReducerSlice.actions;

--- a/public/app/features/variables/inspect/utils.test.ts
+++ b/public/app/features/variables/inspect/utils.test.ts
@@ -44,4 +44,104 @@ describe('getPropsWithVariable', () => {
       },
     });
   });
+
+  it('when called with a valid an id that is not part of valid names it should return the correct graph', () => {
+    const value = {
+      targets: [
+        {
+          id: 'A',
+          description: '$tag_host-[[tag_host]]',
+          query:
+            'SELECT mean(total) AS "total" FROM "disk" WHERE "host" =~ /$host$/ AND $timeFilter GROUP BY time($interval), "host", "path"',
+          alias: '$tag_host [[tag_host]] $col $host',
+        },
+      ],
+    };
+
+    const result = getPropsWithVariable(
+      'host',
+      {
+        key: 'model',
+        value,
+      },
+      {}
+    );
+
+    expect(result).toEqual({
+      targets: {
+        A: {
+          alias: '$tag_host [[tag_host]] $col $host',
+          query:
+            'SELECT mean(total) AS "total" FROM "disk" WHERE "host" =~ /$host$/ AND $timeFilter GROUP BY time($interval), "host", "path"',
+        },
+      },
+    });
+  });
+
+  it('when called with an id that is part of valid alias names it should return the correct graph', () => {
+    const value = {
+      targets: [
+        {
+          id: 'A',
+          description: '[[tag_host1]]',
+          description2: '$tag_host1',
+          query:
+            'SELECT mean(total) AS "total" FROM "disk" WHERE "host" =~ /$host$/ AND $timeFilter GROUP BY time($interval), "host", "path"',
+          alias: '[[tag_host1]] $tag_host1 $col $host',
+        },
+      ],
+    };
+
+    const tagHostResult = getPropsWithVariable(
+      'tag_host1',
+      {
+        key: 'model',
+        value,
+      },
+      {}
+    );
+
+    expect(tagHostResult).toEqual({
+      targets: {
+        A: {
+          description: '[[tag_host1]]',
+          description2: '$tag_host1',
+        },
+      },
+    });
+  });
+
+  it('when called with an id that is part of valid query names it should return the correct graph', () => {
+    const value = {
+      targets: [
+        {
+          id: 'A',
+          description: '[[timeFilter]]',
+          description2: '$timeFilter',
+          query:
+            'SELECT mean(total) AS "total" FROM "disk" WHERE "host" =~ /$host$/ AND $timeFilter GROUP BY time($interval), "host", "path"',
+          alias: '[[timeFilter]] $timeFilter $col $host',
+        },
+      ],
+    };
+
+    const tagHostResult = getPropsWithVariable(
+      'timeFilter',
+      {
+        key: 'model',
+        value,
+      },
+      {}
+    );
+
+    expect(tagHostResult).toEqual({
+      targets: {
+        A: {
+          description: '[[timeFilter]]',
+          description2: '$timeFilter',
+          alias: '[[timeFilter]] $timeFilter $col $host',
+        },
+      },
+    });
+  });
 });

--- a/public/app/features/variables/inspect/utils.ts
+++ b/public/app/features/variables/inspect/utils.ts
@@ -146,10 +146,15 @@ export const getPropsWithVariable = (variableId: string, parent: { key: string; 
   return result;
 };
 
+export interface VariableUsageTree {
+  variable: VariableModel;
+  tree: any;
+}
+
 export interface VariableUsages {
   unUsed: VariableModel[];
-  unknown: Array<{ variable: VariableModel; tree: any }>;
-  usages: Array<{ variable: VariableModel; tree: any }>;
+  unknown: VariableUsageTree[];
+  usages: VariableUsageTree[];
 }
 
 export const createUsagesNetwork = (variables: VariableModel[], dashboard: DashboardModel | null): VariableUsages => {
@@ -158,8 +163,8 @@ export const createUsagesNetwork = (variables: VariableModel[], dashboard: Dashb
   }
 
   const unUsed: VariableModel[] = [];
-  let usages: Array<{ variable: VariableModel; tree: any }> = [];
-  let unknown: Array<{ variable: VariableModel; tree: any }> = [];
+  let usages: VariableUsageTree[] = [];
+  let unknown: VariableUsageTree[] = [];
   const model = dashboard.getSaveModelClone();
 
   const unknownVariables = getUnknownVariableStrings(variables, model);
@@ -220,7 +225,7 @@ export const traverseTree = (usage: UsagesToNetwork, parent: { id: string; value
   return usage;
 };
 
-export const transformUsagesToNetwork = (usages: Array<{ variable: VariableModel; tree: any }>): UsagesToNetwork[] => {
+export const transformUsagesToNetwork = (usages: VariableUsageTree[]): UsagesToNetwork[] => {
   const results: UsagesToNetwork[] = [];
 
   for (const usage of usages) {
@@ -249,12 +254,7 @@ const countLeaves = (object: any): number => {
   return (total as unknown) as number;
 };
 
-export const getVariableUsages = (
-  variableId: string,
-  variables: VariableModel[],
-  dashboard: DashboardModel | null
-): number => {
-  const { usages } = createUsagesNetwork(variables, dashboard);
+export const getVariableUsages = (variableId: string, usages: VariableUsageTree[]): number => {
   const usage = usages.find((usage) => usage.variable.id === variableId);
   if (!usage) {
     return 0;

--- a/public/app/features/variables/state/reducers.ts
+++ b/public/app/features/variables/state/reducers.ts
@@ -4,12 +4,14 @@ import { variableEditorReducer, VariableEditorState } from '../editor/reducer';
 import { variablesReducer } from './variablesReducer';
 import { VariableModel } from '../types';
 import { transactionReducer, TransactionState } from './transactionReducer';
+import { variableInspectReducer, VariableInspectState } from '../inspect/reducer';
 
 export interface TemplatingState {
   variables: Record<string, VariableModel>;
   optionsPicker: OptionsPickerState;
   editor: VariableEditorState;
   transaction: TransactionState;
+  inspect: VariableInspectState;
 }
 
 export const templatingReducers = combineReducers({
@@ -17,6 +19,7 @@ export const templatingReducers = combineReducers({
   variables: variablesReducer,
   optionsPicker: optionsPickerReducer,
   transaction: transactionReducer,
+  inspect: variableInspectReducer,
 });
 
 export default {


### PR DESCRIPTION
**What this PR does / why we need it**:
Variables inspection was the outcome of a Hack Day so it was not performance polished at all. I found we were making a lot of calls to `createUsagesNetwork` https://github.com/grafana/grafana/blob/d60727311e80486fd74a11af8f612a6be1da011e/public/app/features/variables/inspect/utils.ts#L155 and that could explain the performance issues in  #31563.

The solution was to pass necessary data down to components from `VariableEditorContainer` instead and call `createUsagesNetwork` once and store the values in Redux.

This solution also fixes so we filter out any "valid" macros from unknowns as explained in #31212.

**Which issue(s) this PR fixes**:
Fixes #31563
Fixes #31212

**Special notes for your reviewer**:

