### PR TITLE
devenv: add influxQL-compatible influxDB2 data-source

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -46,6 +46,16 @@ datasources:
       organization: myorg
       defaultBucket: mybucket
 
+  - name: gdev-influxdb2-influxql
+    type: influxdb
+    access: proxy
+    database: site
+    url: http://localhost:8087
+    jsonData:
+      httpHeaderName1: "Authorization"
+    secureJsonData:
+      httpHeaderValue1: "Token mytoken"
+
   - name: gdev-influxdb-telegraf
     type: influxdb
     access: proxy

--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -45,6 +45,16 @@ datasources:
       organization: myorg
       defaultBucket: mybucket
       
+  - name: gdev-influxdb2-influxql
+    type: influxdb
+    access: proxy
+    database: site
+    url: http://influxdb2:8086
+    jsonData:
+      httpHeaderName1: "Authorization"
+    secureJsonData:
+      httpHeaderValue1: "Token mytoken"
+
   - name: gdev-influxdb-telegraf
     type: influxdb
     access: proxy

--- a/devenv/docker/blocks/influxdb2/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb2/docker-compose.yaml
@@ -14,8 +14,8 @@
       - influxdb2
     image: quay.io/influxdb/influxdb:v2.0.3
     # The following long command does 2 things:
-    #   1. it initializes the database
-    #   2. enabled backward-compatible access (influxql queries)
+    #   1. It initializes the bucket
+    #   2. Maps bucket to database to enable backward-compatible access (influxql queries)
     # Use these same configurations parameters in your telegraf configuration, mytelegraf.conf.
     entrypoint: bash -c "influx setup --bucket mybucket -t mytoken -o myorg --username=grafana --password=grafana12345 --host=http://influxdb2:8086 -f && influx -t mytoken -o myorg --host=http://influxdb2:8086 bucket list -n mybucket --hide-headers | cut -f 1 | xargs influx -t mytoken -o myorg --host=http://influxdb2:8086 v1 dbrp create --db site --rp default --default --bucket-id"
       # Wait for the influxd service in the influxdb container has fully bootstrapped before trying to setup an influxdb instance with the influxdb_cli service.

--- a/devenv/docker/blocks/influxdb2/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb2/docker-compose.yaml
@@ -13,8 +13,11 @@
     links:
       - influxdb2
     image: quay.io/influxdb/influxdb:v2.0.3
+    # The following long command does 2 things:
+    #   1. it initializes the database
+    #   2. enabled backward-compatible access (influxql queries)
     # Use these same configurations parameters in your telegraf configuration, mytelegraf.conf.
-    entrypoint: influx setup --bucket mybucket -t mytoken -o myorg --username=grafana --password=grafana12345 --host=http://influxdb2:8086 -f
+    entrypoint: bash -c "influx setup --bucket mybucket -t mytoken -o myorg --username=grafana --password=grafana12345 --host=http://influxdb2:8086 -f && influx -t mytoken -o myorg --host=http://influxdb2:8086 bucket list -n mybucket --hide-headers | cut -f 1 | xargs influx -t mytoken -o myorg --host=http://influxdb2:8086 v1 dbrp create --db site --rp default --default --bucket-id"
       # Wait for the influxd service in the influxdb container has fully bootstrapped before trying to setup an influxdb instance with the influxdb_cli service.
     restart: on-failure:10
     depends_on:


### PR DESCRIPTION
InfluxDB2 uses the new FluxQL query-language, but it is possible to query it with the "old" InfluxQL query language too, if it is set up that way.

this pull-requests adds a new datasource named "gdev-influxdb2-influxql" that allows querying in that mode, and adjusts the influxdb2 devenv-database to support this.

tested with:
- `make devenv sources=influxdb2`
-  `make devenv sources=influxdb2,grafana grafana_version=7.5.0-beta1`