### PR TITLE
Loki: Prevent submitting the datasource form in Loki's datasource configuration page

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/CustomHeadersSettings.test.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/CustomHeadersSettings.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { CustomHeadersSettings, Props } from './CustomHeadersSettings';
+import { Button } from '../Button';
 
 const setup = (propOverrides?: object) => {
   const props: Props = {
@@ -46,6 +47,11 @@ describe('Render', () => {
     addButton.simulate('click', { preventDefault: () => {} });
     expect(wrapper.find('FormField').exists()).toBeTruthy();
     expect(wrapper.find('SecretFormField').exists()).toBeTruthy();
+  });
+
+  it('add header button should not submit the form', () => {
+    const wrapper = setup();
+    expect(wrapper.find(Button).getDOMNode()).toHaveAttribute('type', 'button');
   });
 
   it('should remove a header', () => {

--- a/packages/grafana-ui/src/components/DataSourceSettings/CustomHeadersSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/CustomHeadersSettings.tsx
@@ -206,6 +206,7 @@ export class CustomHeadersSettings extends PureComponent<Props, State> {
           <Button
             variant="secondary"
             icon="plus"
+            type="button"
             onClick={(e) => {
               this.onHeaderAdd();
             }}

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx
@@ -38,6 +38,12 @@ describe('DerivedFields', () => {
     expect(wrapper.find(Button).filterWhere((button: any) => button.contains('Show example log message')).length).toBe(
       1
     );
+    expect(
+      wrapper
+        .find(Button)
+        .filterWhere((button: any) => button.contains('Show example log message'))
+        .getDOMNode()
+    ).toHaveAttribute('type', 'button');
     expect(wrapper.find(DerivedField).length).toBe(2);
   });
 

--- a/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedFields.tsx
@@ -82,7 +82,7 @@ export const DerivedFields = (props: Props) => {
           </Button>
 
           {value && value.length > 0 && (
-            <Button variant="secondary" onClick={() => setShowDebug(!showDebug)}>
+            <Button variant="secondary" type="button" onClick={() => setShowDebug(!showDebug)}>
               {showDebug ? 'Hide example log message' : 'Show example log message'}
             </Button>
           )}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is to fix #31641. 

"Show example log message" button had `type="submit"`. It's not set explicitly but it's the default value in almost all browsers (except IE7, https://www.w3.org/TR/html401/interact/forms.html#h-17.5). This causes the main configuration form to be submitted every time the button is pressed. The saving however should happen only when "Save & Test" button is pressed.

The same problem is caused by more generic "Add Header" button so I've changed it too just to get consistent behaviour for Loki config page. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #31641

**Special notes for your reviewer**:

This might be a bit more widespread problem because it may happen with buttons without explicit `type` in other places and it'd be good to unify it (e.g. setting the `type` attribute explicitly, adding `preventDefault` or changing default `type` in our `Button` component). I'll try to check other buttons and create a separate issue to discuss it if needed.