### PR TITLE
Loki: Remove $__rate_interval from LogQL autocomplete

### DIFF
--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -15,7 +15,6 @@ import syntax, { FUNCTIONS, PIPE_PARSERS, PIPE_OPERATORS } from './syntax';
 import { LokiQuery } from './types';
 import { dateTime, AbsoluteTimeRange, LanguageProvider, HistoryItem } from '@grafana/data';
 import { PromQuery } from '../prometheus/types';
-import { RATE_RANGES } from '../prometheus/promql';
 
 import LokiDatasource from './datasource';
 import { CompletionItem, TypeaheadInput, TypeaheadOutput, CompletionItemGroup } from '@grafana/ui';
@@ -26,6 +25,19 @@ const EMPTY_SELECTOR = '{}';
 const HISTORY_ITEM_COUNT = 10;
 const HISTORY_COUNT_CUTOFF = 1000 * 60 * 60 * 24; // 24h
 const NS_IN_MS = 1000000;
+
+// When changing RATE_RANGES, check if Prometheus/PromQL ranges should be changed too
+// @see public/app/plugins/datasource/prometheus/promql.ts
+const RATE_RANGES: CompletionItem[] = [
+  { label: '$__interval', sortText: '$__interval' },
+  { label: '1m', sortText: '00:01:00' },
+  { label: '5m', sortText: '00:05:00' },
+  { label: '10m', sortText: '00:10:00' },
+  { label: '30m', sortText: '00:30:00' },
+  { label: '1h', sortText: '01:00:00' },
+  { label: '1d', sortText: '24:00:00' },
+];
+
 export const LABEL_REFRESH_INTERVAL = 1000 * 30; // 30sec
 
 const wrapLabel = (label: string) => ({ label, filterText: `\"${label}\"` });

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -2,8 +2,6 @@ import { PromMetricsMetadata } from './types';
 import { addLabelToQuery } from './add_label_to_query';
 import { SUGGESTIONS_LIMIT } from './language_provider';
 
-export const RATE_RANGES = ['1m', '5m', '10m', '30m', '1h'];
-
 export const processHistogramLabels = (labels: string[]) => {
   const resultSet: Set<string> = new Set();
   const regexp = new RegExp('_bucket($|:)');

--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -1,6 +1,8 @@
 import { Grammar } from 'prismjs';
 import { CompletionItem } from '@grafana/ui';
 
+// When changing RATE_RANGES, check if Loki/LogQL ranges should be changed too
+// @see public/app/plugins/datasource/loki/language_provider.ts
 export const RATE_RANGES: CompletionItem[] = [
   { label: '$__interval', sortText: '$__interval' },
   { label: '$__rate_interval', sortText: '$__rate_interval' },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

LogQL ranges in autocomplete are piggybacking on PromQL ranges. When `$__rate_interval` was added to Prometheus it was automatically added to Loki as well but this variable is not supported by Loki. I've separated ranges for both datasources. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #31593 

**Special notes for the reviewer**:

Alternatively, should we keep time-based ranges (`1m`,`5m`...) in a common list and split only variable-based ranges (`$__rate_interval`, `$__interval`) ? 

