### PR TITLE
Loki: Fix autocomplete when re-editing Loki label values

### DIFF
--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -167,6 +167,25 @@ describe('Language completion provider', () => {
         },
       ]);
     });
+    it('returns label values suggestions from Loki when re-editing', async () => {
+      const datasource = makeMockLokiDatasource({ label1: ['label1_val1', 'label1_val2'], label2: [] });
+      const provider = await getLanguageProvider(datasource);
+      const input = createTypeaheadInput('{label1="label1_v"}', 'label1_v', 'label1', 17, [
+        'attr-value',
+        'context-labels',
+      ]);
+      let result = await provider.provideCompletionItems(input);
+      expect(result.context).toBe('context-label-values');
+      expect(result.suggestions).toEqual([
+        {
+          items: [
+            { label: 'label1_val1', filterText: '"label1_val1"' },
+            { label: 'label1_val2', filterText: '"label1_val2"' },
+          ],
+          label: 'Label values for "label1"',
+        },
+      ]);
+    });
   });
 
   describe('label values', () => {

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -269,7 +269,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       selector = EMPTY_SELECTOR;
     }
 
-    if (!labelKey && !isValueStart && selector === EMPTY_SELECTOR) {
+    if (!labelKey && selector === EMPTY_SELECTOR) {
       // start task gets all labels
       await this.start();
       const allLabels = this.getLabelKeys();

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -269,7 +269,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       selector = EMPTY_SELECTOR;
     }
 
-    if (!isValueStart && selector === EMPTY_SELECTOR) {
+    if (!labelKey && !isValueStart && selector === EMPTY_SELECTOR) {
       // start task gets all labels
       await this.start();
       const allLabels = this.getLabelKeys();


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-editing of Loki label values was problem if user had just 1 log stream selector. In that case, this part of code `if (!labelKey && !isValueStart && selector === EMPTY_SELECTOR) {` resulted in wrong/non-functional autocomplete, because selector was at that time empty and we weren't at the labelValueStart. As soon as we had 2 log stream selectors this wasn't an issue because `if (!labelKey && !isValueStart && selector === EMPTY_SELECTOR) {` would be falsy (we would have non-empty selector) and there this would be skipped and autocomplete would work as expected.

This PR fixed the autocomplete when re-editing Loki label values by making sure, that we check if we have a labelKey. If we do, we naturally want to skip this part of code as we don't need to list all labelKeys. If we don't have it, then we want to list all labelKeys. 

Fixed:
https://user-images.githubusercontent.com/30407135/110500759-d42f1700-80f9-11eb-848b-5b5d0282d25c.mov

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/31705


