### PR TITLE
Tempo: Add test for backend data source

### DIFF
--- a/pkg/tsdb/tempo/tempo_test.go
+++ b/pkg/tsdb/tempo/tempo_test.go
@@ -1,0 +1,23 @@
+package tempo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTempo(t *testing.T) {
+	plug, err := NewExecutor(&models.DataSource{})
+	executor := plug.(*tempoExecutor)
+	require.NoError(t, err)
+
+	t.Run("createRequest should set Auth header when basic auth is true ", func(t *testing.T) {
+		req, err := executor.createRequest(context.Background(), &models.DataSource{BasicAuth: true, BasicAuthUser: "john", BasicAuthPassword: "pass"}, "traceID")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(req.Header))
+		assert.NotEqual(t, req.Header.Get("Authorization"), "")
+	})
+}


### PR DESCRIPTION
Added test for tempo data source to make sure we set the auth header and changed the error response from Error to ErrorString this way it shows up in the UI.
