### PR TITLE
UserInviteForm: remove "invalid" attribute from the Switch field

### DIFF
--- a/public/app/features/org/UserInviteForm.tsx
+++ b/public/app/features/org/UserInviteForm.tsx
@@ -71,7 +71,7 @@ export const UserInviteForm: FC<Props> = ({ updateLocation }) => {
             <Field invalid={!!errors.role} label="Role">
               <InputControl as={RadioButtonGroup} control={control} options={roles} name="role" />
             </Field>
-            <Field invalid={!!errors.sendEmail} label="Send invite email">
+            <Field label="Send invite email">
               <Switch name="sendEmail" ref={register} />
             </Field>
             <HorizontalGroup>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Switch component doesn't handle `invalid` prop and when it receives it from the `Field`, the prop ends up passed all the way to the underlying input element, causing an error to be logged in console. 


