### PR TITLE
UsageStatsService: Don't use global state

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -21,17 +21,16 @@ var metricsLogger log.Logger = log.New("metrics")
 func init() {
 	registry.RegisterService(&UsageStatsService{
 		log:             log.New("infra.usagestats"),
-		externalMetrics: make(map[string]MetricFunc),
+		externalMetrics: make(map[string]metricFunc),
 	})
 }
 
-type UsageStats interface {
-	GetUsageReport(ctx context.Context) (UsageReport, error)
-
-	RegisterMetric(name string, fn MetricFunc)
+type usageStats interface {
+	getUsageReport(ctx context.Context) (UsageReport, error)
+	registerMetric(name string, fn metricFunc)
 }
 
-type MetricFunc func() (interface{}, error)
+type metricFunc func() (interface{}, error)
 
 type UsageStatsService struct {
 	Cfg                *setting.Cfg               `inject:""`
@@ -43,7 +42,7 @@ type UsageStatsService struct {
 	log log.Logger
 
 	oauthProviders           map[string]bool
-	externalMetrics          map[string]MetricFunc
+	externalMetrics          map[string]metricFunc
 	concurrentUserStatsCache memoConcurrentUserStats
 }
 

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -25,9 +25,9 @@ func init() {
 	})
 }
 
-type usageStats interface {
-	getUsageReport(ctx context.Context) (UsageReport, error)
-	registerMetric(name string, fn metricFunc)
+type UsageStats interface {
+	GetUsageReport(ctx context.Context) (UsageReport, error)
+	RegisterMetric(name string, fn metricFunc)
 }
 
 type metricFunc func() (interface{}, error)

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -21,16 +21,16 @@ var metricsLogger log.Logger = log.New("metrics")
 func init() {
 	registry.RegisterService(&UsageStatsService{
 		log:             log.New("infra.usagestats"),
-		externalMetrics: make(map[string]metricFunc),
+		externalMetrics: make(map[string]MetricFunc),
 	})
 }
 
 type UsageStats interface {
 	GetUsageReport(ctx context.Context) (UsageReport, error)
-	RegisterMetric(name string, fn metricFunc)
+	RegisterMetric(name string, fn MetricFunc)
 }
 
-type metricFunc func() (interface{}, error)
+type MetricFunc func() (interface{}, error)
 
 type UsageStatsService struct {
 	Cfg                *setting.Cfg               `inject:""`
@@ -42,7 +42,7 @@ type UsageStatsService struct {
 	log log.Logger
 
 	oauthProviders           map[string]bool
-	externalMetrics          map[string]metricFunc
+	externalMetrics          map[string]MetricFunc
 	concurrentUserStatsCache memoConcurrentUserStats
 }
 

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/manager"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 var usageStatsURL = "https://stats.grafana.org/grafana-usage-report"
@@ -28,19 +27,23 @@ type UsageReport struct {
 	Packaging       string                 `json:"packaging"`
 }
 
-func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, error) {
-	version := strings.ReplaceAll(setting.BuildVersion, ".", "_")
+func (uss *UsageStatsService) getUsageReport(ctx context.Context) (UsageReport, error) {
+	version := strings.ReplaceAll(uss.Cfg.BuildVersion, ".", "_")
 
 	metrics := map[string]interface{}{}
 
+	edition := "oss"
+	if uss.Cfg.IsEnterprise {
+		edition = "enterprise"
+	}
 	report := UsageReport{
 		Version:         version,
 		Metrics:         metrics,
 		Os:              runtime.GOOS,
 		Arch:            runtime.GOARCH,
-		Edition:         getEdition(),
+		Edition:         edition,
 		HasValidLicense: uss.License.HasValidLicense(),
-		Packaging:       setting.Packaging,
+		Packaging:       uss.Cfg.Packaging,
 	}
 
 	statsQuery := models.GetSystemStatsQuery{}
@@ -69,9 +72,19 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.total_auth_token.count"] = statsQuery.Result.AuthTokens
 	metrics["stats.dashboard_versions.count"] = statsQuery.Result.DashboardVersions
 	metrics["stats.annotations.count"] = statsQuery.Result.Annotations
-	metrics["stats.valid_license.count"] = getValidLicenseCount(uss.License.HasValidLicense())
-	metrics["stats.edition.oss.count"] = getOssEditionCount()
-	metrics["stats.edition.enterprise.count"] = getEnterpriseEditionCount()
+	validLicCount := 0
+	if uss.License.HasValidLicense() {
+		validLicCount = 1
+	}
+	metrics["stats.valid_license.count"] = validLicCount
+	ossEditionCount := 1
+	enterpriseEditionCount := 0
+	if uss.Cfg.IsEnterprise {
+		enterpriseEditionCount = 1
+		ossEditionCount = 0
+	}
+	metrics["stats.edition.oss.count"] = ossEditionCount
+	metrics["stats.edition.enterprise.count"] = enterpriseEditionCount
 
 	uss.registerExternalMetrics(metrics)
 
@@ -102,8 +115,8 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	}
 	metrics["stats.ds.other.count"] = dsOtherCount
 
-	metrics["stats.packaging."+setting.Packaging+".count"] = 1
-	metrics["stats.distributor."+setting.ReportingDistributor+".count"] = 1
+	metrics["stats.packaging."+uss.Cfg.Packaging+".count"] = 1
+	metrics["stats.distributor."+uss.Cfg.ReportingDistributor+".count"] = 1
 
 	// Alerting stats
 	alertingUsageStats, err := uss.AlertingUsageStats.QueryUsageStats()
@@ -170,10 +183,10 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 
 	// Add stats about auth configuration
 	authTypes := map[string]bool{}
-	authTypes["anonymous"] = setting.AnonymousEnabled
-	authTypes["basic_auth"] = setting.BasicAuthEnabled
-	authTypes["ldap"] = setting.LDAPEnabled
-	authTypes["auth_proxy"] = setting.AuthProxyEnabled
+	authTypes["anonymous"] = uss.Cfg.AnonymousEnabled
+	authTypes["basic_auth"] = uss.Cfg.BasicAuthEnabled
+	authTypes["ldap"] = uss.Cfg.LDAPEnabled
+	authTypes["auth_proxy"] = uss.Cfg.AuthProxyEnabled
 
 	for provider, enabled := range uss.oauthProviders {
 		authTypes["oauth_"+provider] = enabled
@@ -216,18 +229,18 @@ func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interfa
 	}
 }
 
-func (uss *UsageStatsService) RegisterMetric(name string, fn MetricFunc) {
+func (uss *UsageStatsService) registerMetric(name string, fn metricFunc) {
 	uss.externalMetrics[name] = fn
 }
 
 func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
-	if !setting.ReportingEnabled {
+	if !uss.Cfg.ReportingEnabled {
 		return nil
 	}
 
 	metricsLogger.Debug(fmt.Sprintf("Sending anonymous usage stats to %s", usageStatsURL))
 
-	report, err := uss.GetUsageReport(ctx)
+	report, err := uss.getUsageReport(ctx)
 	if err != nil {
 		return err
 	}
@@ -237,9 +250,17 @@ func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
 		return err
 	}
 	data := bytes.NewBuffer(out)
+	sendUsageStats(data)
 
-	client := http.Client{Timeout: 5 * time.Second}
+	return nil
+}
+
+// sendUsageStats sends usage statistics.
+//
+// Stubbable by tests.
+var sendUsageStats = func(data *bytes.Buffer) {
 	go func() {
+		client := http.Client{Timeout: 5 * time.Second}
 		resp, err := client.Post(usageStatsURL, "application/json", data)
 		if err != nil {
 			metricsLogger.Error("Failed to send usage stats", "err", err)
@@ -249,8 +270,6 @@ func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
 			metricsLogger.Warn("Failed to close response body", "err", err)
 		}
 	}()
-
-	return nil
 }
 
 func (uss *UsageStatsService) updateTotalStats() {
@@ -297,34 +316,4 @@ func (uss *UsageStatsService) shouldBeReported(dsType string) bool {
 	}
 
 	return ds.Signature.IsValid() || ds.Signature.IsInternal()
-}
-
-func getEdition() string {
-	edition := "oss"
-	if setting.IsEnterprise {
-		edition = "enterprise"
-	}
-
-	return edition
-}
-
-func getEnterpriseEditionCount() int {
-	if setting.IsEnterprise {
-		return 1
-	}
-	return 0
-}
-
-func getOssEditionCount() int {
-	if setting.IsEnterprise {
-		return 0
-	}
-	return 1
-}
-
-func getValidLicenseCount(validLicense bool) int {
-	if validLicense {
-		return 1
-	}
-	return 0
 }

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -27,7 +27,7 @@ type UsageReport struct {
 	Packaging       string                 `json:"packaging"`
 }
 
-func (uss *UsageStatsService) getUsageReport(ctx context.Context) (UsageReport, error) {
+func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, error) {
 	version := strings.ReplaceAll(uss.Cfg.BuildVersion, ".", "_")
 
 	metrics := map[string]interface{}{}
@@ -229,7 +229,7 @@ func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interfa
 	}
 }
 
-func (uss *UsageStatsService) registerMetric(name string, fn metricFunc) {
+func (uss *UsageStatsService) RegisterMetric(name string, fn metricFunc) {
 	uss.externalMetrics[name] = fn
 }
 
@@ -240,7 +240,7 @@ func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
 
 	metricsLogger.Debug(fmt.Sprintf("Sending anonymous usage stats to %s", usageStatsURL))
 
-	report, err := uss.getUsageReport(ctx)
+	report, err := uss.GetUsageReport(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -229,7 +229,7 @@ func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interfa
 	}
 }
 
-func (uss *UsageStatsService) RegisterMetric(name string, fn metricFunc) {
+func (uss *UsageStatsService) RegisterMetric(name string, fn MetricFunc) {
 	uss.externalMetrics[name] = fn
 }
 

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -240,7 +240,7 @@ func TestMetrics(t *testing.T) {
 			select {
 			case resp = <-ch:
 				require.NoError(t, resp.err, "Fake server experienced an error")
-			case _ = <-ticker.C:
+			case <-ticker.C:
 				t.Fatalf("Timed out waiting for HTTP request")
 			}
 
@@ -506,20 +506,6 @@ func (aum *alertingUsageMock) QueryUsageStats() (*alerting.UsageStats, error) {
 			"unknown-datasource": 90,
 		},
 	}, nil
-}
-
-type fakePluginManager struct {
-	manager.PluginManager
-
-	dataSources map[string]*plugins.DataSourcePlugin
-}
-
-func (pm fakePluginManager) NumDataSources() int {
-	return len(pm.dataSources)
-}
-
-func (pm fakePluginManager) GetDataSource(id string) *plugins.DataSourcePlugin {
-	return pm.dataSources[id]
 }
 
 func setupSomeDataSourcePlugins(t *testing.T, uss *UsageStatsService) {

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"runtime"
-	"sync"
 	"testing"
 	"time"
 
@@ -29,7 +28,7 @@ import (
 
 // This is to ensure that the interface contract is held by the implementation
 func Test_InterfaceContractValidity(t *testing.T) {
-	newUsageStats := func() UsageStats {
+	newUsageStats := func() usageStats {
 		return &UsageStatsService{}
 	}
 	v, ok := newUsageStats().(*UsageStatsService)
@@ -40,13 +39,8 @@ func Test_InterfaceContractValidity(t *testing.T) {
 
 func TestMetrics(t *testing.T) {
 	t.Run("When sending usage stats", func(t *testing.T) {
-		setupSomeDataSourcePlugins(t)
-
-		uss := &UsageStatsService{
-			Bus:      bus.New(),
-			SQLStore: sqlstore.InitTestDB(t),
-			License:  &licensing.OSSLicensingService{},
-		}
+		uss := createService(t, setting.Cfg{})
+		setupSomeDataSourcePlugins(t, uss)
 
 		var getSystemStatsQuery *models.GetSystemStatsQuery
 		uss.Bus.AddHandler(func(query *models.GetSystemStatsQuery) error {
@@ -166,22 +160,6 @@ func TestMetrics(t *testing.T) {
 		createConcurrentTokens(t, uss.SQLStore)
 		uss.AlertingUsageStats = &alertingUsageMock{}
 
-		var wg sync.WaitGroup
-		var responseBuffer *bytes.Buffer
-		var req *http.Request
-		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			req = r
-			buf, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				t.Fatalf("Failed to read response body, err=%v", err)
-			}
-			responseBuffer = bytes.NewBuffer(buf)
-			wg.Done()
-		}))
-		usageStatsURL = ts.URL
-
-		defer ts.Close()
-
 		uss.oauthProviders = map[string]bool{
 			"github":        true,
 			"gitlab":        true,
@@ -195,125 +173,163 @@ func TestMetrics(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("Given reporting not enabled and sending usage stats", func(t *testing.T) {
-			setting.ReportingEnabled = false
+			origSendUsageStats := sendUsageStats
+			t.Cleanup(func() {
+				sendUsageStats = origSendUsageStats
+			})
+			statsSent := false
+			sendUsageStats = func(*bytes.Buffer) {
+				statsSent = true
+			}
+
+			uss.Cfg.ReportingEnabled = false
 			err := uss.sendUsageStats(context.Background())
 			require.NoError(t, err)
 
-			t.Run("Should not gather stats or call http endpoint", func(t *testing.T) {
-				assert.Nil(t, getSystemStatsQuery)
-				assert.Nil(t, getDataSourceStatsQuery)
-				assert.Nil(t, getDataSourceAccessStatsQuery)
-				assert.Nil(t, req)
-			})
+			require.False(t, statsSent)
+			assert.Nil(t, getSystemStatsQuery)
+			assert.Nil(t, getDataSourceStatsQuery)
+			assert.Nil(t, getDataSourceAccessStatsQuery)
 		})
 
-		t.Run("Given reporting enabled and sending usage stats", func(t *testing.T) {
-			setting.ReportingEnabled = true
-			setting.BuildVersion = "5.0.0"
-			setting.AnonymousEnabled = true
-			setting.BasicAuthEnabled = true
-			setting.LDAPEnabled = true
-			setting.AuthProxyEnabled = true
-			setting.Packaging = "deb"
-			setting.ReportingDistributor = "hosted-grafana"
+		t.Run("Given reporting enabled, stats should be gathered and sent to HTTP endpoint", func(t *testing.T) {
+			origCfg := uss.Cfg
+			t.Cleanup(func() {
+				uss.Cfg = origCfg
+			})
+			uss.Cfg = &setting.Cfg{
+				ReportingEnabled:     true,
+				BuildVersion:         "5.0.0",
+				AnonymousEnabled:     true,
+				BasicAuthEnabled:     true,
+				LDAPEnabled:          true,
+				AuthProxyEnabled:     true,
+				Packaging:            "deb",
+				ReportingDistributor: "hosted-grafana",
+			}
 
-			wg.Add(1)
+			ch := make(chan httpResp)
+			ticker := time.NewTicker(2 * time.Second)
+			ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				buf, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Logf("Fake HTTP handler received an error: %s", err.Error())
+					ch <- httpResp{
+						err: err,
+					}
+					return
+				}
+				require.NoError(t, err, "Failed to read response body, err=%v", err)
+				t.Logf("Fake HTTP handler received a response")
+				ch <- httpResp{
+					responseBuffer: bytes.NewBuffer(buf),
+					req:            r,
+				}
+			}))
+			t.Cleanup(ts.Close)
+			t.Cleanup(func() {
+				close(ch)
+			})
+			usageStatsURL = ts.URL
+
 			err := uss.sendUsageStats(context.Background())
 			require.NoError(t, err)
 
-			t.Run("Should gather stats and call http endpoint", func(t *testing.T) {
-				if waitTimeout(&wg, 2*time.Second) {
-					t.Fatalf("Timed out waiting for http request")
-				}
+			// Wait for fake HTTP server to receive a request
+			var resp httpResp
+			select {
+			case resp = <-ch:
+				require.NoError(t, resp.err, "Fake server experienced an error")
+			case _ = <-ticker.C:
+				t.Fatalf("Timed out waiting for HTTP request")
+			}
 
-				assert.NotNil(t, getSystemStatsQuery)
-				assert.NotNil(t, getDataSourceStatsQuery)
-				assert.NotNil(t, getDataSourceAccessStatsQuery)
-				assert.NotNil(t, getAlertNotifierUsageStatsQuery)
-				assert.NotNil(t, req)
+			t.Logf("Received response from fake HTTP server: %+v\n", resp)
 
-				assert.Equal(t, http.MethodPost, req.Method)
-				assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+			assert.NotNil(t, getSystemStatsQuery)
+			assert.NotNil(t, getDataSourceStatsQuery)
+			assert.NotNil(t, getDataSourceAccessStatsQuery)
+			assert.NotNil(t, getAlertNotifierUsageStatsQuery)
+			assert.NotNil(t, resp.req)
 
-				assert.NotNil(t, responseBuffer)
+			assert.Equal(t, http.MethodPost, resp.req.Method)
+			assert.Equal(t, "application/json", resp.req.Header.Get("Content-Type"))
 
-				j, err := simplejson.NewFromReader(responseBuffer)
-				assert.Nil(t, err)
+			require.NotNil(t, resp.responseBuffer)
 
-				assert.Equal(t, "5_0_0", j.Get("version").MustString())
-				assert.Equal(t, runtime.GOOS, j.Get("os").MustString())
-				assert.Equal(t, runtime.GOARCH, j.Get("arch").MustString())
+			j, err := simplejson.NewFromReader(resp.responseBuffer)
+			require.NoError(t, err)
 
-				metrics := j.Get("metrics")
-				assert.Equal(t, getSystemStatsQuery.Result.Dashboards, metrics.Get("stats.dashboards.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Users, metrics.Get("stats.users.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Orgs, metrics.Get("stats.orgs.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Playlists, metrics.Get("stats.playlist.count").MustInt64())
-				assert.Equal(t, len(manager.Apps), metrics.Get("stats.plugins.apps.count").MustInt())
-				assert.Equal(t, len(manager.Panels), metrics.Get("stats.plugins.panels.count").MustInt())
-				assert.Equal(t, len(manager.DataSources), metrics.Get("stats.plugins.datasources.count").MustInt())
-				assert.Equal(t, getSystemStatsQuery.Result.Alerts, metrics.Get("stats.alerts.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.ActiveUsers, metrics.Get("stats.active_users.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Datasources, metrics.Get("stats.datasources.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Stars, metrics.Get("stats.stars.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Folders, metrics.Get("stats.folders.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.DashboardPermissions, metrics.Get("stats.dashboard_permissions.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.FolderPermissions, metrics.Get("stats.folder_permissions.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.ProvisionedDashboards, metrics.Get("stats.provisioned_dashboards.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Snapshots, metrics.Get("stats.snapshots.count").MustInt64())
-				assert.Equal(t, getSystemStatsQuery.Result.Teams, metrics.Get("stats.teams.count").MustInt64())
-				assert.Equal(t, 15, metrics.Get("stats.total_auth_token.count").MustInt())
-				assert.Equal(t, 5, metrics.Get("stats.avg_auth_token_per_user.count").MustInt())
-				assert.Equal(t, 16, metrics.Get("stats.dashboard_versions.count").MustInt())
-				assert.Equal(t, 17, metrics.Get("stats.annotations.count").MustInt())
+			assert.Equal(t, "5_0_0", j.Get("version").MustString())
+			assert.Equal(t, runtime.GOOS, j.Get("os").MustString())
+			assert.Equal(t, runtime.GOARCH, j.Get("arch").MustString())
 
-				assert.Equal(t, 9, metrics.Get("stats.ds."+models.DS_ES+".count").MustInt())
-				assert.Equal(t, 10, metrics.Get("stats.ds."+models.DS_PROMETHEUS+".count").MustInt())
-				assert.Equal(t, 11+12, metrics.Get("stats.ds.other.count").MustInt())
+			metrics := j.Get("metrics")
+			assert.Equal(t, getSystemStatsQuery.Result.Dashboards, metrics.Get("stats.dashboards.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Users, metrics.Get("stats.users.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Orgs, metrics.Get("stats.orgs.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Playlists, metrics.Get("stats.playlist.count").MustInt64())
+			assert.Equal(t, len(manager.Apps), metrics.Get("stats.plugins.apps.count").MustInt())
+			assert.Equal(t, len(manager.Panels), metrics.Get("stats.plugins.panels.count").MustInt())
+			assert.Equal(t, len(manager.DataSources), metrics.Get("stats.plugins.datasources.count").MustInt())
+			assert.Equal(t, getSystemStatsQuery.Result.Alerts, metrics.Get("stats.alerts.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.ActiveUsers, metrics.Get("stats.active_users.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Datasources, metrics.Get("stats.datasources.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Stars, metrics.Get("stats.stars.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Folders, metrics.Get("stats.folders.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DashboardPermissions, metrics.Get("stats.dashboard_permissions.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.FolderPermissions, metrics.Get("stats.folder_permissions.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.ProvisionedDashboards, metrics.Get("stats.provisioned_dashboards.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Snapshots, metrics.Get("stats.snapshots.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Teams, metrics.Get("stats.teams.count").MustInt64())
+			assert.Equal(t, 15, metrics.Get("stats.total_auth_token.count").MustInt())
+			assert.Equal(t, 5, metrics.Get("stats.avg_auth_token_per_user.count").MustInt())
+			assert.Equal(t, 16, metrics.Get("stats.dashboard_versions.count").MustInt())
+			assert.Equal(t, 17, metrics.Get("stats.annotations.count").MustInt())
 
-				assert.Equal(t, 1, metrics.Get("stats.ds_access."+models.DS_ES+".direct.count").MustInt())
-				assert.Equal(t, 2, metrics.Get("stats.ds_access."+models.DS_ES+".proxy.count").MustInt())
-				assert.Equal(t, 3, metrics.Get("stats.ds_access."+models.DS_PROMETHEUS+".proxy.count").MustInt())
-				assert.Equal(t, 6+7, metrics.Get("stats.ds_access.other.direct.count").MustInt())
-				assert.Equal(t, 4+8, metrics.Get("stats.ds_access.other.proxy.count").MustInt())
+			assert.Equal(t, 9, metrics.Get("stats.ds."+models.DS_ES+".count").MustInt())
+			assert.Equal(t, 10, metrics.Get("stats.ds."+models.DS_PROMETHEUS+".count").MustInt())
+			assert.Equal(t, 11+12, metrics.Get("stats.ds.other.count").MustInt())
 
-				assert.Equal(t, 1, metrics.Get("stats.alerting.ds.prometheus.count").MustInt())
-				assert.Equal(t, 2, metrics.Get("stats.alerting.ds.graphite.count").MustInt())
-				assert.Equal(t, 5, metrics.Get("stats.alerting.ds.mysql.count").MustInt())
-				assert.Equal(t, 90, metrics.Get("stats.alerting.ds.other.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.ds_access."+models.DS_ES+".direct.count").MustInt())
+			assert.Equal(t, 2, metrics.Get("stats.ds_access."+models.DS_ES+".proxy.count").MustInt())
+			assert.Equal(t, 3, metrics.Get("stats.ds_access."+models.DS_PROMETHEUS+".proxy.count").MustInt())
+			assert.Equal(t, 6+7, metrics.Get("stats.ds_access.other.direct.count").MustInt())
+			assert.Equal(t, 4+8, metrics.Get("stats.ds_access.other.proxy.count").MustInt())
 
-				assert.Equal(t, 1, metrics.Get("stats.alert_notifiers.slack.count").MustInt())
-				assert.Equal(t, 2, metrics.Get("stats.alert_notifiers.webhook.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.alerting.ds.prometheus.count").MustInt())
+			assert.Equal(t, 2, metrics.Get("stats.alerting.ds.graphite.count").MustInt())
+			assert.Equal(t, 5, metrics.Get("stats.alerting.ds.mysql.count").MustInt())
+			assert.Equal(t, 90, metrics.Get("stats.alerting.ds.other.count").MustInt())
 
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.anonymous.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.basic_auth.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.ldap.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.auth_proxy.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_github.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_gitlab.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_google.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_azuread.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_generic_oauth.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_grafana_com.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.alert_notifiers.slack.count").MustInt())
+			assert.Equal(t, 2, metrics.Get("stats.alert_notifiers.webhook.count").MustInt())
 
-				assert.Equal(t, 1, metrics.Get("stats.packaging.deb.count").MustInt())
-				assert.Equal(t, 1, metrics.Get("stats.distributor.hosted-grafana.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.anonymous.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.basic_auth.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.ldap.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.auth_proxy.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_github.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_gitlab.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_google.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_azuread.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_generic_oauth.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.auth_enabled.oauth_grafana_com.count").MustInt())
 
-				assert.Equal(t, 1, metrics.Get("stats.auth_token_per_user_le_3").MustInt())
-				assert.Equal(t, 2, metrics.Get("stats.auth_token_per_user_le_6").MustInt())
-				assert.Equal(t, 3, metrics.Get("stats.auth_token_per_user_le_9").MustInt())
-				assert.Equal(t, 4, metrics.Get("stats.auth_token_per_user_le_12").MustInt())
-				assert.Equal(t, 5, metrics.Get("stats.auth_token_per_user_le_15").MustInt())
-				assert.Equal(t, 6, metrics.Get("stats.auth_token_per_user_le_inf").MustInt())
-			})
+			assert.Equal(t, 1, metrics.Get("stats.packaging.deb.count").MustInt())
+			assert.Equal(t, 1, metrics.Get("stats.distributor.hosted-grafana.count").MustInt())
+
+			assert.Equal(t, 1, metrics.Get("stats.auth_token_per_user_le_3").MustInt())
+			assert.Equal(t, 2, metrics.Get("stats.auth_token_per_user_le_6").MustInt())
+			assert.Equal(t, 3, metrics.Get("stats.auth_token_per_user_le_9").MustInt())
+			assert.Equal(t, 4, metrics.Get("stats.auth_token_per_user_le_12").MustInt())
+			assert.Equal(t, 5, metrics.Get("stats.auth_token_per_user_le_15").MustInt())
+			assert.Equal(t, 6, metrics.Get("stats.auth_token_per_user_le_inf").MustInt())
 		})
 	})
 
 	t.Run("When updating total stats", func(t *testing.T) {
-		uss := &UsageStatsService{
-			Bus: bus.New(),
-			Cfg: setting.NewCfg(),
-		}
+		uss := createService(t, setting.Cfg{})
 		uss.Cfg.MetricsEndpointEnabled = true
 		uss.Cfg.MetricsEndpointDisableTotalStats = false
 		getSystemStatsWasCalled := false
@@ -323,94 +339,76 @@ func TestMetrics(t *testing.T) {
 			return nil
 		})
 
-		t.Run("When metrics is disabled and total stats is enabled", func(t *testing.T) {
+		t.Run("When metrics is disabled and total stats is enabled, stats should not be updated", func(t *testing.T) {
 			uss.Cfg.MetricsEndpointEnabled = false
 			uss.Cfg.MetricsEndpointDisableTotalStats = false
-			t.Run("Should not update stats", func(t *testing.T) {
-				uss.updateTotalStats()
+			uss.updateTotalStats()
 
-				assert.False(t, getSystemStatsWasCalled)
-			})
+			assert.False(t, getSystemStatsWasCalled)
 		})
 
-		t.Run("When metrics is enabled and total stats is disabled", func(t *testing.T) {
+		t.Run("When metrics is enabled and total stats is disabled, stats should not be updated", func(t *testing.T) {
 			uss.Cfg.MetricsEndpointEnabled = true
 			uss.Cfg.MetricsEndpointDisableTotalStats = true
 
-			t.Run("Should not update stats", func(t *testing.T) {
-				uss.updateTotalStats()
+			uss.updateTotalStats()
 
-				assert.False(t, getSystemStatsWasCalled)
-			})
+			assert.False(t, getSystemStatsWasCalled)
 		})
 
-		t.Run("When metrics is disabled and total stats is disabled", func(t *testing.T) {
+		t.Run("When metrics is disabled and total stats is disabled, stats should not be updated", func(t *testing.T) {
 			uss.Cfg.MetricsEndpointEnabled = false
 			uss.Cfg.MetricsEndpointDisableTotalStats = true
 
-			t.Run("Should not update stats", func(t *testing.T) {
-				uss.updateTotalStats()
+			uss.updateTotalStats()
 
-				assert.False(t, getSystemStatsWasCalled)
-			})
+			assert.False(t, getSystemStatsWasCalled)
 		})
 
-		t.Run("When metrics is enabled and total stats is enabled", func(t *testing.T) {
+		t.Run("When metrics is enabled and total stats is enabled, stats should be updated", func(t *testing.T) {
 			uss.Cfg.MetricsEndpointEnabled = true
 			uss.Cfg.MetricsEndpointDisableTotalStats = false
 
-			t.Run("Should update stats", func(t *testing.T) {
-				uss.updateTotalStats()
+			uss.updateTotalStats()
 
-				assert.True(t, getSystemStatsWasCalled)
-			})
+			assert.True(t, getSystemStatsWasCalled)
 		})
 	})
 
 	t.Run("When registering a metric", func(t *testing.T) {
-		uss := &UsageStatsService{
-			Bus:             bus.New(),
-			Cfg:             setting.NewCfg(),
-			externalMetrics: make(map[string]MetricFunc),
-		}
+		uss := createService(t, setting.Cfg{})
 		metricName := "stats.test_metric.count"
 
 		t.Run("Adds a new metric to the external metrics", func(t *testing.T) {
-			uss.RegisterMetric(metricName, func() (interface{}, error) {
+			uss.registerMetric(metricName, func() (interface{}, error) {
 				return 1, nil
 			})
 
-			metric, _ := uss.externalMetrics[metricName]()
+			metric, err := uss.externalMetrics[metricName]()
+			require.NoError(t, err)
 			assert.Equal(t, 1, metric)
 		})
 
-		t.Run("When metric already exists", func(t *testing.T) {
-			uss.RegisterMetric(metricName, func() (interface{}, error) {
+		t.Run("When metric already exists, the metric should be overridden", func(t *testing.T) {
+			uss.registerMetric(metricName, func() (interface{}, error) {
 				return 1, nil
 			})
 
-			metric, _ := uss.externalMetrics[metricName]()
+			metric, err := uss.externalMetrics[metricName]()
+			require.NoError(t, err)
 			assert.Equal(t, 1, metric)
 
-			t.Run("Overrides the metric", func(t *testing.T) {
-				uss.RegisterMetric(metricName, func() (interface{}, error) {
-					return 2, nil
-				})
-				newMetric, _ := uss.externalMetrics[metricName]()
-				assert.Equal(t, 2, newMetric)
+			uss.registerMetric(metricName, func() (interface{}, error) {
+				return 2, nil
 			})
+			newMetric, err := uss.externalMetrics[metricName]()
+			require.NoError(t, err)
+			assert.Equal(t, 2, newMetric)
 		})
 	})
 
 	t.Run("When getting usage report", func(t *testing.T) {
-		uss := &UsageStatsService{
-			Bus:                bus.New(),
-			Cfg:                setting.NewCfg(),
-			SQLStore:           sqlstore.InitTestDB(t),
-			License:            &licensing.OSSLicensingService{},
-			AlertingUsageStats: &alertingUsageMock{},
-			externalMetrics:    make(map[string]MetricFunc),
-		}
+		uss := createService(t, setting.Cfg{})
 		metricName := "stats.test_metric.count"
 
 		uss.Bus.AddHandler(func(query *models.GetSystemStatsQuery) error {
@@ -436,7 +434,7 @@ func TestMetrics(t *testing.T) {
 		createConcurrentTokens(t, uss.SQLStore)
 
 		t.Run("Should include metrics for concurrent users", func(t *testing.T) {
-			report, err := uss.GetUsageReport(context.Background())
+			report, err := uss.getUsageReport(context.Background())
 			require.NoError(t, err)
 
 			assert.Equal(t, int32(1), report.Metrics["stats.auth_token_per_user_le_3"])
@@ -448,12 +446,12 @@ func TestMetrics(t *testing.T) {
 		})
 
 		t.Run("Should include external metrics", func(t *testing.T) {
-			uss.RegisterMetric(metricName, func() (interface{}, error) {
+			uss.registerMetric(metricName, func() (interface{}, error) {
 				return 1, nil
 			})
 
-			report, err := uss.GetUsageReport(context.Background())
-			assert.Nil(t, err, "Expected no error")
+			report, err := uss.getUsageReport(context.Background())
+			require.NoError(t, err, "Expected no error")
 
 			metric := report.Metrics[metricName]
 			assert.Equal(t, 1, metric)
@@ -461,32 +459,26 @@ func TestMetrics(t *testing.T) {
 	})
 
 	t.Run("When registering external metrics", func(t *testing.T) {
-		uss := &UsageStatsService{
-			Bus:             bus.New(),
-			Cfg:             setting.NewCfg(),
-			externalMetrics: make(map[string]MetricFunc),
-		}
+		uss := createService(t, setting.Cfg{})
 		metrics := map[string]interface{}{"stats.test_metric.count": 1, "stats.test_metric_second.count": 2}
 		extMetricName := "stats.test_external_metric.count"
 
-		t.Run("Should add to metrics", func(t *testing.T) {
-			uss.RegisterMetric(extMetricName, func() (interface{}, error) {
-				return 1, nil
-			})
-
-			uss.registerExternalMetrics(metrics)
-
-			assert.Equal(t, 1, metrics[extMetricName])
+		uss.registerMetric(extMetricName, func() (interface{}, error) {
+			return 1, nil
 		})
 
+		uss.registerExternalMetrics(metrics)
+
+		assert.Equal(t, 1, metrics[extMetricName])
+
 		t.Run("When loading a metric results to an error", func(t *testing.T) {
-			uss.RegisterMetric(extMetricName, func() (interface{}, error) {
+			uss.registerMetric(extMetricName, func() (interface{}, error) {
 				return 1, nil
 			})
 			extErrorMetricName := "stats.test_external_metric_error.count"
 
 			t.Run("Should not add it to metrics", func(t *testing.T) {
-				uss.RegisterMetric(extErrorMetricName, func() (interface{}, error) {
+				uss.registerMetric(extErrorMetricName, func() (interface{}, error) {
 					return 1, errors.New("some error")
 				})
 
@@ -495,26 +487,12 @@ func TestMetrics(t *testing.T) {
 				extErrorMetric := metrics[extErrorMetricName]
 				extMetric := metrics[extMetricName]
 
-				assert.Nil(t, extErrorMetric, "Invalid metric should not be added")
+				require.Nil(t, extErrorMetric, "Invalid metric should not be added")
 				assert.Equal(t, 1, extMetric)
 				assert.Len(t, metrics, 3, "Expected only one available metric")
 			})
 		})
 	})
-}
-
-func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		wg.Wait()
-	}()
-	select {
-	case <-c:
-		return false // completed normally
-	case <-time.After(timeout):
-		return true // timed out
-	}
 }
 
 type alertingUsageMock struct{}
@@ -530,40 +508,72 @@ func (aum *alertingUsageMock) QueryUsageStats() (*alerting.UsageStats, error) {
 	}, nil
 }
 
-func setupSomeDataSourcePlugins(t *testing.T) {
+type fakePluginManager struct {
+	manager.PluginManager
+
+	dataSources map[string]*plugins.DataSourcePlugin
+}
+
+func (pm fakePluginManager) NumDataSources() int {
+	return len(pm.dataSources)
+}
+
+func (pm fakePluginManager) GetDataSource(id string) *plugins.DataSourcePlugin {
+	return pm.dataSources[id]
+}
+
+func setupSomeDataSourcePlugins(t *testing.T, uss *UsageStatsService) {
+	t.Helper()
+
 	originalDataSources := manager.DataSources
 	t.Cleanup(func() { manager.DataSources = originalDataSources })
-
-	manager.DataSources = make(map[string]*plugins.DataSourcePlugin)
-
-	manager.DataSources[models.DS_ES] = &plugins.DataSourcePlugin{
-		FrontendPluginBase: plugins.FrontendPluginBase{
-			PluginBase: plugins.PluginBase{
-				Signature: "internal",
+	manager.DataSources = map[string]*plugins.DataSourcePlugin{
+		models.DS_ES: {
+			FrontendPluginBase: plugins.FrontendPluginBase{
+				PluginBase: plugins.PluginBase{
+					Signature: "internal",
+				},
+			},
+		},
+		models.DS_PROMETHEUS: {
+			FrontendPluginBase: plugins.FrontendPluginBase{
+				PluginBase: plugins.PluginBase{
+					Signature: "internal",
+				},
+			},
+		},
+		models.DS_GRAPHITE: {
+			FrontendPluginBase: plugins.FrontendPluginBase{
+				PluginBase: plugins.PluginBase{
+					Signature: "internal",
+				},
+			},
+		},
+		models.DS_MYSQL: {
+			FrontendPluginBase: plugins.FrontendPluginBase{
+				PluginBase: plugins.PluginBase{
+					Signature: "internal",
+				},
 			},
 		},
 	}
-	manager.DataSources[models.DS_PROMETHEUS] = &plugins.DataSourcePlugin{
-		FrontendPluginBase: plugins.FrontendPluginBase{
-			PluginBase: plugins.PluginBase{
-				Signature: "internal",
-			},
-		},
-	}
+}
 
-	manager.DataSources[models.DS_GRAPHITE] = &plugins.DataSourcePlugin{
-		FrontendPluginBase: plugins.FrontendPluginBase{
-			PluginBase: plugins.PluginBase{
-				Signature: "internal",
-			},
-		},
-	}
+type httpResp struct {
+	req            *http.Request
+	responseBuffer *bytes.Buffer
+	err            error
+}
 
-	manager.DataSources[models.DS_MYSQL] = &plugins.DataSourcePlugin{
-		FrontendPluginBase: plugins.FrontendPluginBase{
-			PluginBase: plugins.PluginBase{
-				Signature: "internal",
-			},
-		},
+func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
+	t.Helper()
+
+	return &UsageStatsService{
+		Bus:                bus.New(),
+		Cfg:                &cfg,
+		SQLStore:           sqlstore.InitTestDB(t),
+		License:            &licensing.OSSLicensingService{},
+		AlertingUsageStats: &alertingUsageMock{},
+		externalMetrics:    make(map[string]metricFunc),
 	}
 }

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -28,7 +28,7 @@ import (
 
 // This is to ensure that the interface contract is held by the implementation
 func Test_InterfaceContractValidity(t *testing.T) {
-	newUsageStats := func() usageStats {
+	newUsageStats := func() UsageStats {
 		return &UsageStatsService{}
 	}
 	v, ok := newUsageStats().(*UsageStatsService)
@@ -380,7 +380,7 @@ func TestMetrics(t *testing.T) {
 		metricName := "stats.test_metric.count"
 
 		t.Run("Adds a new metric to the external metrics", func(t *testing.T) {
-			uss.registerMetric(metricName, func() (interface{}, error) {
+			uss.RegisterMetric(metricName, func() (interface{}, error) {
 				return 1, nil
 			})
 
@@ -390,7 +390,7 @@ func TestMetrics(t *testing.T) {
 		})
 
 		t.Run("When metric already exists, the metric should be overridden", func(t *testing.T) {
-			uss.registerMetric(metricName, func() (interface{}, error) {
+			uss.RegisterMetric(metricName, func() (interface{}, error) {
 				return 1, nil
 			})
 
@@ -398,7 +398,7 @@ func TestMetrics(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, 1, metric)
 
-			uss.registerMetric(metricName, func() (interface{}, error) {
+			uss.RegisterMetric(metricName, func() (interface{}, error) {
 				return 2, nil
 			})
 			newMetric, err := uss.externalMetrics[metricName]()
@@ -434,7 +434,7 @@ func TestMetrics(t *testing.T) {
 		createConcurrentTokens(t, uss.SQLStore)
 
 		t.Run("Should include metrics for concurrent users", func(t *testing.T) {
-			report, err := uss.getUsageReport(context.Background())
+			report, err := uss.GetUsageReport(context.Background())
 			require.NoError(t, err)
 
 			assert.Equal(t, int32(1), report.Metrics["stats.auth_token_per_user_le_3"])
@@ -446,11 +446,11 @@ func TestMetrics(t *testing.T) {
 		})
 
 		t.Run("Should include external metrics", func(t *testing.T) {
-			uss.registerMetric(metricName, func() (interface{}, error) {
+			uss.RegisterMetric(metricName, func() (interface{}, error) {
 				return 1, nil
 			})
 
-			report, err := uss.getUsageReport(context.Background())
+			report, err := uss.GetUsageReport(context.Background())
 			require.NoError(t, err, "Expected no error")
 
 			metric := report.Metrics[metricName]
@@ -463,7 +463,7 @@ func TestMetrics(t *testing.T) {
 		metrics := map[string]interface{}{"stats.test_metric.count": 1, "stats.test_metric_second.count": 2}
 		extMetricName := "stats.test_external_metric.count"
 
-		uss.registerMetric(extMetricName, func() (interface{}, error) {
+		uss.RegisterMetric(extMetricName, func() (interface{}, error) {
 			return 1, nil
 		})
 
@@ -472,13 +472,13 @@ func TestMetrics(t *testing.T) {
 		assert.Equal(t, 1, metrics[extMetricName])
 
 		t.Run("When loading a metric results to an error", func(t *testing.T) {
-			uss.registerMetric(extMetricName, func() (interface{}, error) {
+			uss.RegisterMetric(extMetricName, func() (interface{}, error) {
 				return 1, nil
 			})
 			extErrorMetricName := "stats.test_external_metric_error.count"
 
 			t.Run("Should not add it to metrics", func(t *testing.T) {
-				uss.registerMetric(extErrorMetricName, func() (interface{}, error) {
+				uss.RegisterMetric(extErrorMetricName, func() (interface{}, error) {
 					return 1, errors.New("some error")
 				})
 

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -560,6 +560,6 @@ func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
 		SQLStore:           sqlstore.InitTestDB(t),
 		License:            &licensing.OSSLicensingService{},
 		AlertingUsageStats: &alertingUsageMock{},
-		externalMetrics:    make(map[string]metricFunc),
+		externalMetrics:    make(map[string]MetricFunc),
 	}
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -141,10 +141,8 @@ var (
 	appliedEnvOverrides          []string
 
 	// analytics
-	ReportingEnabled     bool
-	ReportingDistributor string
-	GoogleAnalyticsId    string
-	GoogleTagManagerId   string
+	GoogleAnalyticsId  string
+	GoogleTagManagerId string
 
 	// LDAP
 	LDAPEnabled           bool
@@ -336,7 +334,9 @@ type Cfg struct {
 	Env string
 
 	// Analytics
-	CheckForUpdates bool
+	CheckForUpdates      bool
+	ReportingDistributor string
+	ReportingEnabled     bool
 
 	// LDAP
 	LDAPEnabled     bool
@@ -830,10 +830,10 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	cfg.CheckForUpdates = analytics.Key("check_for_updates").MustBool(true)
 	GoogleAnalyticsId = analytics.Key("google_analytics_ua_id").String()
 	GoogleTagManagerId = analytics.Key("google_tag_manager_id").String()
-	ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
-	ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana-labs")
-	if len(ReportingDistributor) >= 100 {
-		ReportingDistributor = ReportingDistributor[:100]
+	cfg.ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
+	cfg.ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana-labs")
+	if len(cfg.ReportingDistributor) >= 100 {
+		cfg.ReportingDistributor = cfg.ReportingDistributor[:100]
 	}
 
 	if err := readAlertingSettings(iniFile); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove global state usage from UsageStatsService.

I made the tests more deterministic by avoiding the use of a goroutine when unnecessary, and by using a channel for goroutine communication/synchronization instead of a waitgroup. This made debugging failing tests a lot easier.

Some sub-tests are removed, since sub-tests should only be used for distinct (sub-)test cases (for example, each starts a new goroutine), and not to convey test case details.