### PR TITLE
Chore: type backendSrv.datasourceRequest

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -158,7 +158,7 @@ export interface BackendSrv {
    * to display datasource query information. Can be skipped by adding `option.silent`
    * when initializing the request.
    */
-  datasourceRequest(options: BackendSrvRequest): Promise<any>;
+  datasourceRequest<T = any>(options: BackendSrvRequest): Promise<FetchResponse<T>>;
 
   /**
    * Observable http request interface

--- a/yarn.lock
+++ b/yarn.lock
@@ -25795,6 +25795,11 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
+uplot@1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.4.tgz#016e9f66796d78c187957e710743f7ca405dfb4d"
+  integrity sha512-4d6JixG54HQKFDLAegzwgwf87GtEbp6pt3YlHygyLt+mJ9RHneCXYlZxr1QOhLetoSSHeeDuWP5RFMv8mdltpg==
+
 uplot@1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.6.tgz#81a139acd1f422bdaeedab3f273786114131ae0f"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a generic type for `backendSrc.datasourceRequest` so it doesn't return `any`.

Shouldn't have any impact on people using it already, but it means now it can be typed a smidge more accurately ✨