### PR TITLE
DataQueryRequest: Remove deprecated props showingGraph and showingTabel and exploreMode

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -487,7 +487,6 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   app: CoreApp | string;
 
   cacheTimeout?: string;
-  exploreMode?: ExploreMode;
   rangeRaw?: RawTimeRange;
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;
@@ -499,11 +498,6 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
 
   // Explore state used by various datasources
   liveStreaming?: boolean;
-  /**
-   * @deprecated showingGraph and showingTable are always set to true
-   */
-  showingGraph?: boolean;
-  showingTable?: boolean;
 }
 
 export interface DataQueryTimings {

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -156,13 +156,7 @@ export function buildQueryTransaction(
       __interval_ms: { text: intervalMs, value: intervalMs },
     },
     maxDataPoints: queryOptions.maxDataPoints,
-    exploreMode: undefined,
     liveStreaming: queryOptions.liveStreaming,
-    /**
-     * @deprecated (external API) showingGraph and showingTable are always set to true and set to true
-     */
-    showingGraph: true,
-    showingTable: true,
   };
 
   return {


### PR DESCRIPTION
Found that these props are no longer used. V8 feels like a good opertunity to remove them
