### PR TITLE
Update scripts and Dockerfiles to use Go 1.16.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -28,7 +28,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition oss
   environment:
@@ -37,7 +37,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -45,21 +45,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -69,7 +69,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -78,7 +78,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --variants linux-x64,linux-x64-musl,osx64,win64 --no-pull-enterprise
   depends_on:
@@ -87,7 +87,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -95,7 +95,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
@@ -103,7 +103,7 @@ steps:
   - lint-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -117,14 +117,14 @@ steps:
   - check-dashboard-schemas
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64
   depends_on:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -144,7 +144,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -154,7 +154,7 @@ steps:
   - package
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
@@ -171,7 +171,7 @@ steps:
   - build-frontend-docs
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -188,7 +188,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -205,7 +205,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -256,7 +256,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -282,7 +282,7 @@ steps:
       from_secret: drone_token
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition oss
   environment:
@@ -291,7 +291,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -299,21 +299,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -323,7 +323,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -332,7 +332,7 @@ steps:
   - initialize
 
 - name: publish-frontend-metrics
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
   environment:
@@ -343,7 +343,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -352,7 +352,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -360,7 +360,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -371,7 +371,7 @@ steps:
   - lint-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -385,7 +385,7 @@ steps:
   - check-dashboard-schemas
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -403,7 +403,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -423,7 +423,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -446,14 +446,14 @@ steps:
   - end-to-end-tests
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -484,7 +484,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -501,7 +501,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -517,7 +517,7 @@ steps:
   - test-frontend
 
 - name: release-canary-npm-packages
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./scripts/circle-release-canary-packages.sh
   environment:
@@ -638,7 +638,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -723,7 +723,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -738,7 +738,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition oss
   environment:
@@ -747,7 +747,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -755,21 +755,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -779,7 +779,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -788,7 +788,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -800,7 +800,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise ${DRONE_TAG}
   depends_on:
@@ -808,7 +808,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -819,7 +819,7 @@ steps:
   - lint-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
@@ -833,7 +833,7 @@ steps:
   - check-dashboard-schemas
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -851,7 +851,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -871,7 +871,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -881,7 +881,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -912,7 +912,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -929,7 +929,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -982,7 +982,7 @@ steps:
   - end-to-end-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./scripts/build/release-packages.sh ${DRONE_TAG}
   environment:
@@ -1081,7 +1081,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -1094,7 +1094,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -1114,7 +1114,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition enterprise
   environment:
@@ -1123,7 +1123,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1131,21 +1131,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise
@@ -1155,7 +1155,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1164,7 +1164,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -1176,7 +1176,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise ${DRONE_TAG}
   depends_on:
@@ -1184,7 +1184,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -1195,7 +1195,7 @@ steps:
   - lint-backend
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition enterprise2
   environment:
@@ -1204,7 +1204,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise2
@@ -1214,7 +1214,7 @@ steps:
   - lint-backend-enterprise2
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -1226,7 +1226,7 @@ steps:
   - test-backend-enterprise2
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
@@ -1242,7 +1242,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -1260,7 +1260,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -1282,7 +1282,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -1313,7 +1313,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1330,7 +1330,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1369,7 +1369,7 @@ steps:
   - postgres-integration-tests
 
 - name: package-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -1397,7 +1397,7 @@ steps:
   - package-enterprise2
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -1537,7 +1537,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -1642,7 +1642,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -1657,7 +1657,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition oss
   environment:
@@ -1666,7 +1666,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1674,21 +1674,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -1698,7 +1698,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1707,7 +1707,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -1719,7 +1719,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise v7.3.0-test
   depends_on:
@@ -1727,7 +1727,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -1738,7 +1738,7 @@ steps:
   - lint-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version v7.3.0-test
   depends_on:
@@ -1752,7 +1752,7 @@ steps:
   - check-dashboard-schemas
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -1770,7 +1770,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -1790,7 +1790,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1800,7 +1800,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -1825,7 +1825,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1842,7 +1842,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1892,7 +1892,7 @@ steps:
   - end-to-end-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   environment:
     GITHUB_PACKAGE_TOKEN:
       from_secret: github_package_token
@@ -1989,7 +1989,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -2002,7 +2002,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -2022,7 +2022,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition enterprise
   environment:
@@ -2031,7 +2031,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2039,21 +2039,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise
@@ -2063,7 +2063,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2072,7 +2072,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -2084,7 +2084,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise v7.3.0-test
   depends_on:
@@ -2092,7 +2092,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -2103,7 +2103,7 @@ steps:
   - lint-backend
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition enterprise2
   environment:
@@ -2112,7 +2112,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise2
@@ -2122,7 +2122,7 @@ steps:
   - lint-backend-enterprise2
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -2134,7 +2134,7 @@ steps:
   - test-backend-enterprise2
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version v7.3.0-test
   depends_on:
@@ -2150,7 +2150,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -2168,7 +2168,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -2190,7 +2190,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -2215,7 +2215,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2232,7 +2232,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2271,7 +2271,7 @@ steps:
   - postgres-integration-tests
 
 - name: package-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -2299,7 +2299,7 @@ steps:
   - package-enterprise2
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -2439,7 +2439,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -2544,7 +2544,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -2558,7 +2558,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition oss
   environment:
@@ -2567,7 +2567,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2575,21 +2575,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -2599,7 +2599,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2608,7 +2608,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2617,7 +2617,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2625,7 +2625,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -2636,7 +2636,7 @@ steps:
   - lint-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -2650,7 +2650,7 @@ steps:
   - check-dashboard-schemas
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -2668,7 +2668,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -2688,7 +2688,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -2698,7 +2698,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -2723,7 +2723,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2740,7 +2740,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2862,7 +2862,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v0.5.43/grabpl
@@ -2875,7 +2875,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -2894,7 +2894,7 @@ steps:
   - clone
 
 - name: lint-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition enterprise
   environment:
@@ -2903,7 +2903,7 @@ steps:
   - initialize
 
 - name: codespell
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2911,21 +2911,21 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: check-dashboard-schemas
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - cue export --out openapi -o - ./dashboard-schemas/...
   depends_on:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise
@@ -2935,7 +2935,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2944,7 +2944,7 @@ steps:
   - initialize
 
 - name: build-backend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2953,7 +2953,7 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
@@ -2961,7 +2961,7 @@ steps:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -2972,7 +2972,7 @@ steps:
   - lint-backend
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl lint-backend --edition enterprise2
   environment:
@@ -2981,7 +2981,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise2
@@ -2991,7 +2991,7 @@ steps:
   - lint-backend-enterprise2
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER} --variants linux-x64 --no-pull-enterprise
   depends_on:
@@ -3000,7 +3000,7 @@ steps:
   - test-backend-enterprise2
 
 - name: gen-version
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -3016,7 +3016,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -3034,7 +3034,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server
@@ -3056,7 +3056,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -3066,7 +3066,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -3091,7 +3091,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -3108,7 +3108,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -3147,7 +3147,7 @@ steps:
   - postgres-integration-tests
 
 - name: package-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64 --sign
   environment:
@@ -3175,7 +3175,7 @@ steps:
   - package-enterprise2
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.4.0
+  image: grafana/build-container:1.4.1
   detach: true
   commands:
   - ./e2e/start-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.16.0-alpine3.13 as go-builder
+FROM golang:1.16.1-alpine3.13 as go-builder
 
 RUN apk add --no-cache gcc g++
 

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -18,8 +18,8 @@ apk add --no-cache curl 'nodejs-current=14.5.0-r0' npm yarn build-base openssh g
 # apk add --no-cache xvfb glib nss nspr gdk-pixbuf "gtk+3.0" pango atk cairo dbus-libs libxcomposite libxrender libxi libxtst libxrandr libxscrnsaver alsa-lib at-spi2-atk at-spi2-core cups-libs gcompat libc6-compat
 
 # Install Go
-filename="go1.16.linux-amd64.tar.gz"
-get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
+filename="go1.16.1.linux-amd64.tar.gz"
+get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769"
 untar_file "/tmp/$filename"
 
 # Install golangci-lint

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
@@ -22,8 +22,8 @@ source "/etc/profile"
 npm i -g yarn
 
 # Install Go
-filename="go1.16.linux-amd64.tar.gz"
-get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
+filename="go1.16.1.linux-amd64.tar.gz"
+get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769"
 untar_file "/tmp/$filename"
 
 # Install golangci-lint

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
@@ -2,8 +2,8 @@
 source "./deploy-common.sh"
 
 # Install Go
-filename="go1.16.linux-amd64.tar.gz"
-get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
+filename="go1.16.1.linux-amd64.tar.gz"
+get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769"
 untar_file "/tmp/$filename"
 
 # Install golangci-lint

--- a/scripts/build/ci-build-windows/Dockerfile
+++ b/scripts/build/ci-build-windows/Dockerfile
@@ -8,7 +8,7 @@ RUN powershell Invoke-Expression (New-Object System.Net.WebClient).DownloadStrin
 # Scoop first of all needs git to update itself
 # Run Scoop under PowerShell since it can otherwise fail
 RUN powershell -Command scoop install git@2.29.1.windows.1
-RUN powershell -Command scoop install go@1.16 unzip@6.00 gcc@9.3.0-2
+RUN powershell -Command scoop install go@1.16.1 unzip@6.00 gcc@9.3.0-2
 
 # Install diffutils, in case we need them
 RUN powershell (New-Object Net.WebClient).DownloadFile(\

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -100,7 +100,7 @@ RUN tar xf cue_${CUE_VERSION}_Linux_x86_64.tar.gz -C /tmp cue
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20210208
 
-ENV GOVERSION=1.16 \
+ENV GOVERSION=1.16.1 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=14.15.5-1nodesource1 \

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -103,7 +103,7 @@ FROM debian:stretch-20210208
 ENV GOVERSION=1.16.1 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=14.15.5-1nodesource1 \
+    NODEVERSION=14.16.0-1nodesource1 \
     YARNVERSION=1.22.5-1
 
 # Use ARG so as not to persist environment variable in image

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.4.0"
+_version="1.4.1"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
-ARG GOVERSION=1.16 \
-  GO_CHECKSUM=013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2 \
+ARG GOVERSION=1.16.1 \
+  GO_CHECKSUM=3edc22f8332231c3ba8be246f184b736b8d28f06ce24f08168d8ecf052549769 \
   DEBIAN_FRONTEND=noninteractive
 
 ENV PATH=/usr/local/go/bin:$PATH \

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,5 +1,5 @@
 grabpl_version = '0.5.43'
-build_image = 'grafana/build-container:1.4.0'
+build_image = 'grafana/build-container:1.4.1'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 alpine_image = 'alpine:3.13'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is responsible for upgrading Go version to `1.16.1`

Steps:

- [x] Update scripts and Dockerfiles
- [x] Publish images to Dockerhub
- [x] Update Drone related srcipts