### PR TITLE
Plugins: Expose the `getTimeZone` function to be able to get the current selected timeZone.

### DIFF
--- a/packages/grafana-data/src/datetime/common.ts
+++ b/packages/grafana-data/src/datetime/common.ts
@@ -1,19 +1,26 @@
 import { TimeZone, DefaultTimeZone } from '../types/time';
 
 /**
- * The type describing date and time options. Used for all the helper functions
- * available to parse or format date and time values.
+ * Used for helper functions handling time zones.
  *
  * @public
  */
-export interface DateTimeOptions {
+export interface TimeZoneOptions {
   /**
    * Specify this if you want to override the timeZone used when parsing or formatting
    * a date and time value. If no timeZone is set, the default timeZone for the current
    * user is used.
    */
   timeZone?: TimeZone;
+}
 
+/**
+ * The type describing date and time options. Used for all the helper functions
+ * available to parse or format date and time values.
+ *
+ * @public
+ */
+export interface DateTimeOptions extends TimeZoneOptions {
   /**
    * Specify a {@link https://momentjs.com/docs/#/displaying/format | momentjs} format to
    * use a custom formatting pattern or parsing pattern. If no format is set,
@@ -43,11 +50,12 @@ export const setTimeZoneResolver = (resolver: TimeZoneResolver) => {
 };
 
 /**
- * Used within this package to get timeZone from an options value. If timezone
- * is not set in the options, then a default timeZone is be resolved instead.
+ * Used to get the current selected time zone. If a valid time zone is passed in the
+ * options it will be returned. If no valid time zone is passed either the time zone
+ * configured for the user account will be returned or the default for Grafana.
  *
- * @internal
+ * @public
  */
-export const getTimeZone = <T extends DateTimeOptions>(options?: T): TimeZone => {
+export const getTimeZone = <T extends TimeZoneOptions>(options?: T): TimeZone => {
   return options?.timeZone ?? defaultTimeZoneResolver() ?? DefaultTimeZone;
 };

--- a/packages/grafana-data/src/datetime/index.ts
+++ b/packages/grafana-data/src/datetime/index.ts
@@ -7,4 +7,4 @@ export * from './formats';
 export * from './formatter';
 export * from './parser';
 export { dateMath, rangeUtil };
-export { DateTimeOptions, setTimeZoneResolver, TimeZoneResolver } from './common';
+export { DateTimeOptions, setTimeZoneResolver, TimeZoneResolver, getTimeZone } from './common';


### PR DESCRIPTION
**What this PR does / why we need it**:
When developing plugins there are APIs that requires you to pass the current selected time zone. An example on such a scenario is the TimeRangePicker (https://github.com/grafana/grafana/blob/master/packages/grafana-ui/src/components/TimePicker/TimeRangePicker.tsx#L32) where you would like the user to be able to select a specific time zone but if not we should be able to use the default one.