### PR TITLE
Loki: Fix type errors in language_provider

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -3,7 +3,7 @@ import { LokiQueryFieldForm, LokiQueryFieldFormProps } from './LokiQueryFieldFor
 
 type LokiQueryFieldProps = Omit<
   LokiQueryFieldFormProps,
-  'labelsLoaded' | 'onLoadOptions' | 'onLabelsRefresh' | 'logLabelOptions' | 'absoluteRange'
+  'labelsLoaded' | 'onLoadOptions' | 'onLabelsRefresh' | 'absoluteRange'
 >;
 
 export const LokiQueryField: FunctionComponent<LokiQueryFieldProps> = (props) => {

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
     Object {
       "getTimeRangeParams": [Function],
       "languageProvider": LokiLanguageProvider {
-        "addLabelValuesToOptions": [Function],
         "cleanText": [Function],
         "datasource": [Circular],
         "fetchSeries": [Function],

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -87,6 +87,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
 
     this.datasource = datasource;
     this.labelKeys = [];
+    this.logLabelOptions = [];
     this.logLabelFetchTs = 0;
 
     Object.assign(this, initialValues);

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -413,10 +413,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   async fetchLogLabels(): Promise<any> {
     const url = '/loki/api/v1/label';
+    const timeRange = this.datasource.getTimeRangeParams();
     this.logLabelFetchTs = Date.now().valueOf();
-    const rangeParams = this.datasource.getTimeRangeParams();
-    const res = await this.request(url, rangeParams);
-    if (res && Array.isArray(res)) {
+
+    const res = await this.request(url, timeRange);
+    if (Array.isArray(res)) {
       this.labelKeys = res.slice().sort();
     }
 
@@ -493,8 +494,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
       // Clear value when requesting new one. Empty object being truthy also makes sure we don't request twice.
       this.labelsCache.set(cacheKey, []);
       const res = await this.request(url, params);
-      if (res && Array.isArray(res)) {
-        labelValue = res.slice().sort() as string[];
+      if (Array.isArray(res)) {
+        labelValue = res.slice().sort();
         this.labelsCache.set(cacheKey, labelValue);
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
The initial value for **logLabelOptions** wasn't set. So If we didn't fetch any log labels, we were trying to use map in `addLabelValuesToOptions` on undefined value. This fixes it. 
**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/31586
