### PR TITLE
Grafana/ui: fix searchable options for Cascader with options update

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
@@ -2,9 +2,35 @@ import { Story } from '@storybook/react';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { NOOP_CONTROL } from '../../utils/storybook/noopControl';
 import { Cascader } from '@grafana/ui';
-import { CascaderProps } from './Cascader';
+import { CascaderOption, CascaderProps } from './Cascader';
 import mdx from './Cascader.mdx';
 import React from 'react';
+
+const onSelect = (val: string) => console.log(val);
+const options = [
+  {
+    label: 'First',
+    value: '1',
+    items: [
+      {
+        label: 'Second',
+        value: '2',
+      },
+      {
+        label: 'Third',
+        value: '3',
+      },
+      {
+        label: 'Fourth',
+        value: '4',
+      },
+    ],
+  },
+  {
+    label: 'FirstFirst',
+    value: '5',
+  },
+];
 
 export default {
   title: 'Forms/Cascader',
@@ -19,31 +45,8 @@ export default {
     },
   },
   args: {
-    onSelect: (val: string) => console.log(val),
-    options: [
-      {
-        label: 'First',
-        value: '1',
-        items: [
-          {
-            label: 'Second',
-            value: '2',
-          },
-          {
-            label: 'Third',
-            value: '3',
-          },
-          {
-            label: 'Fourth',
-            value: '4',
-          },
-        ],
-      },
-      {
-        label: 'FirstFirst',
-        value: '5',
-      },
-    ],
+    onSelect,
+    options,
   },
   argTypes: {
     width: { control: { type: 'range', min: 0, max: 70 } },
@@ -76,4 +79,17 @@ export const WithDisplayAllSelectedLevels = Template.bind({});
 WithDisplayAllSelectedLevels.args = {
   displayAllSelectedLevels: true,
   separator: ',',
+};
+
+export const WithOptionsStateUpdate = () => {
+  const [updatedOptions, setOptions] = React.useState<CascaderOption[]>([
+    {
+      label: 'Initial state option',
+      value: 'initial',
+    },
+  ]);
+
+  setTimeout(() => setOptions(options), 2000);
+
+  return <Cascader options={updatedOptions} onSelect={onSelect} />;
 };

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -7,6 +7,7 @@ import { Input } from '../Input/Input';
 import { SelectableValue } from '@grafana/data';
 import { css } from 'emotion';
 import { onChangeCascader } from './optionMappings';
+import memoizeOne from 'memoize-one';
 
 export interface CascaderProps {
   /** The separator between levels in the search */
@@ -27,7 +28,6 @@ export interface CascaderProps {
 
 interface CascaderState {
   isSearching: boolean;
-  searchableOptions: Array<SelectableValue<string[]>>;
   focusCascade: boolean;
   //Array for cascade navigation
   rcValue: SelectableValue<string[]>;
@@ -63,12 +63,11 @@ const DEFAULT_SEPARATOR = '/';
 export class Cascader extends React.PureComponent<CascaderProps, CascaderState> {
   constructor(props: CascaderProps) {
     super(props);
-    const searchableOptions = this.flattenOptions(props.options);
+    const searchableOptions = this.getSearchableOptions(props.options);
     const { rcValue, activeLabel } = this.setInitialValue(searchableOptions, props.initialValue);
     this.state = {
       isSearching: false,
       focusCascade: false,
-      searchableOptions,
       rcValue,
       activeLabel,
     };
@@ -93,6 +92,8 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
     }
     return selectOptions;
   };
+
+  getSearchableOptions = memoizeOne((options: CascaderOption[]) => this.flattenOptions(options));
 
   setInitialValue(searchableOptions: Array<SelectableValue<string[]>>, initValue?: string) {
     if (!initValue) {
@@ -182,20 +183,11 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
     });
   };
 
-  // update the searchableOptions when the options has been updated
-  componentDidUpdate(prevProps: CascaderProps) {
-    if (prevProps.options === this.props.options) {
-      return;
-    }
-
-    this.setState({
-      searchableOptions: this.flattenOptions(this.props.options),
-    });
-  }
-
   render() {
-    const { allowCustomValue, placeholder, width, changeOnSelect } = this.props;
-    const { focusCascade, isSearching, searchableOptions, rcValue, activeLabel } = this.state;
+    const { allowCustomValue, placeholder, width, changeOnSelect, options } = this.props;
+    const { focusCascade, isSearching, rcValue, activeLabel } = this.state;
+
+    const searchableOptions = this.getSearchableOptions(options);
 
     return (
       <div>

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -182,6 +182,17 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
     });
   };
 
+  // update the searchableOptions when the options has been updated
+  componentDidUpdate(prevProps: CascaderProps) {
+    if (prevProps.options === this.props.options) {
+      return;
+    }
+
+    this.setState({
+      searchableOptions: this.flattenOptions(this.props.options),
+    });
+  }
+
   render() {
     const { allowCustomValue, placeholder, width, changeOnSelect } = this.props;
     const { focusCascade, isSearching, searchableOptions, rcValue, activeLabel } = this.state;


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if we update the options for the `Cascader` component after its initial render, the component will display the updated options, but the search functionality will still be looking at the previous options list.

**Work done:**

- Update `searchableOptions` to use latest `options` whenever `options` has changed
- Added RTL tests
- Added story

**Before**

Given an initial options of:
```
[
    {
      label: 'Initial state option',
      value: 'initial',
    },
 ]
```

The component renders the updated options:

![Screenshot 2021-03-11 at 14 06 03](https://user-images.githubusercontent.com/36230812/110799363-fe581480-8272-11eb-9de2-939762229f0b.png)

Searching doesn't search against the new options

![Screenshot 2021-03-11 at 14 06 11](https://user-images.githubusercontent.com/36230812/110799437-0e6ff400-8273-11eb-8dfe-513b8ab713f2.png)

but rather the old options

![Screenshot 2021-03-11 at 14 06 17](https://user-images.githubusercontent.com/36230812/110799426-0adc6d00-8273-11eb-9962-c001816aac82.png)

![cascader search before](https://user-images.githubusercontent.com/36230812/110800213-e2a13e00-8273-11eb-8a85-ec7aed73abdc.gif)

**After**

The component renders the updated options and searching searches against these updated options:

![cascader search fix](https://user-images.githubusercontent.com/36230812/110800192-dddc8a00-8273-11eb-8be6-4371fb7ef008.gif)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

This is required for our NewRelic plugin work: https://github.com/grafana/plugins-private/issues/1350

**Special notes for your reviewer**:

TIA 🙏 