### PR TITLE
AlertingNG: Replace eval.Condition with models.Condition

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -62,7 +62,7 @@ func (api *API) RegisterAPIEndpoints() {
 
 // conditionEvalEndpoint handles POST /api/alert-definitions/eval.
 func (api *API) conditionEvalEndpoint(c *models.ReqContext, cmd ngmodels.EvalAlertConditionCommand) response.Response {
-	evalCond := eval.Condition{
+	evalCond := ngmodels.Condition{
 		RefID:                 cmd.Condition,
 		OrgID:                 c.SignedInUser.OrgId,
 		QueriesAndExpressions: cmd.Data,
@@ -165,7 +165,7 @@ func (api *API) updateAlertDefinitionEndpoint(c *models.ReqContext, cmd ngmodels
 	cmd.UID = c.Params(":alertDefinitionUID")
 	cmd.OrgID = c.SignedInUser.OrgId
 
-	evalCond := eval.Condition{
+	evalCond := ngmodels.Condition{
 		RefID:                 cmd.Condition,
 		OrgID:                 c.SignedInUser.OrgId,
 		QueriesAndExpressions: cmd.Data,
@@ -185,7 +185,7 @@ func (api *API) updateAlertDefinitionEndpoint(c *models.ReqContext, cmd ngmodels
 func (api *API) createAlertDefinitionEndpoint(c *models.ReqContext, cmd ngmodels.SaveAlertDefinitionCommand) response.Response {
 	cmd.OrgID = c.SignedInUser.OrgId
 
-	evalCond := eval.Condition{
+	evalCond := ngmodels.Condition{
 		RefID:                 cmd.Condition,
 		OrgID:                 c.SignedInUser.OrgId,
 		QueriesAndExpressions: cmd.Data,
@@ -253,7 +253,7 @@ func (api *API) alertDefinitionUnpauseEndpoint(c *models.ReqContext, cmd ngmodel
 }
 
 // LoadAlertCondition returns a Condition object for the given alertDefinitionID.
-func (api *API) LoadAlertCondition(alertDefinitionUID string, orgID int64) (*eval.Condition, error) {
+func (api *API) LoadAlertCondition(alertDefinitionUID string, orgID int64) (*ngmodels.Condition, error) {
 	q := ngmodels.GetAlertDefinitionByUIDQuery{UID: alertDefinitionUID, OrgID: orgID}
 	if err := api.Store.GetAlertDefinitionByUID(&q); err != nil {
 		return nil, err
@@ -265,14 +265,14 @@ func (api *API) LoadAlertCondition(alertDefinitionUID string, orgID int64) (*eva
 		return nil, err
 	}
 
-	return &eval.Condition{
+	return &ngmodels.Condition{
 		RefID:                 alertDefinition.Condition,
 		OrgID:                 alertDefinition.OrgID,
 		QueriesAndExpressions: alertDefinition.Data,
 	}, nil
 }
 
-func (api *API) validateCondition(c eval.Condition, user *models.SignedInUser, skipCache bool) error {
+func (api *API) validateCondition(c ngmodels.Condition, user *models.SignedInUser, skipCache bool) error {
 	var refID string
 
 	if len(c.QueriesAndExpressions) == 0 {

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -63,7 +63,7 @@ func (sch *schedule) definitionRoutine(grafanaCtx context.Context, key models.Al
 					sch.log.Debug("new alert definition version fetched", "title", alertDefinition.Title, "key", key, "version", alertDefinition.Version)
 				}
 
-				condition := eval.Condition{
+				condition := models.Condition{
 					RefID:                 alertDefinition.Condition,
 					OrgID:                 alertDefinition.OrgID,
 					QueriesAndExpressions: alertDefinition.Data,


### PR DESCRIPTION
Clean up of two identical structs that were introduced by mistake, reducing it to one object.