### PR TITLE
Docs: Add mention of preferredVisualisationType in logs datasource guide

### DIFF
--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -14,6 +14,7 @@ To add logs support to an existing data source, you need to:
 
 - Enable logs support
 - Construct the log data
+- (Optional) Encourage Grafana to treat the data as logs
 
 ### Enable logs support
 
@@ -49,6 +50,25 @@ frame.add({ time: 1589189406480, content: 'user logged in' });
 That's all you need to start returning log data from your data source. Go ahead and try it out in [Explore]({{< relref "../../explore/_index.md" >}}) or by adding a [Logs panel]({{< relref "../../panels/visualizations/logs-panel.md" >}}).
 
 Congratulations, you just wrote your first logs data source plugin! Next, let's look at a couple of features that can further improve the experience for the user.
+
+### (Optional) Encourage Grafana to treat the data as logs
+
+By default Grafana might not realize you're returning logs and so won't show the log view in Explore. It can be told to show that view by setting `meta.preferredVisualisationType` to `'logs'`.
+
+**Example:**
+
+```ts
+const frame = new MutableDataFrame({
+  refId: query.refId,
+  meta: {
+    preferredVisualisationType: 'logs',
+  },
+  fields: [
+    { name: 'time', type: FieldType.time },
+    { name: 'content', type: FieldType.string },
+  ],
+});
+```
 
 ## Add labels to your logs
 

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -53,7 +53,7 @@ Congratulations, you just wrote your first logs data source plugin! Next, let's 
 
 ### (Optional) Add preferred visualisation type hint to the data frame
 
-By default Grafana might not realize you're returning logs and so won't show the log view in Explore. It can be told to show that view by setting `meta.preferredVisualisationType` to `'logs'`.
+To make sure Grafana recognizes data as logs and shows logs visualization automatically in Explore you have do set `meta.preferredVisualisationType` to `'logs'` in the returned data frame. See [Selecting preferred visualisation section]({{< relref "add-support-for-explore-queries.md#selecting-preferred-visualisation" >}})
 
 **Example:**
 

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -51,7 +51,7 @@ That's all you need to start returning log data from your data source. Go ahead 
 
 Congratulations, you just wrote your first logs data source plugin! Next, let's look at a couple of features that can further improve the experience for the user.
 
-### (Optional) Encourage Grafana to treat the data as logs
+### (Optional) Add preferred visualisation type hint to the data frame
 
 By default Grafana might not realize you're returning logs and so won't show the log view in Explore. It can be told to show that view by setting `meta.preferredVisualisationType` to `'logs'`.
 

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -14,7 +14,7 @@ To add logs support to an existing data source, you need to:
 
 - Enable logs support
 - Construct the log data
-- (Optional) Encourage Grafana to treat the data as logs
+- (Optional) Add preferred visualisation type hint to the data frame
 
 ### Enable logs support
 


### PR DESCRIPTION
The instructions don't work right now. As described, it was necessary for me to set the preferredVisualisationType to 'logs' to get the log view in Explore. I spent several hours digging around the code to figure this out, so hopefully we can save others the time with this doc update.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

