### PR TITLE
ContextMenu: fixes add annotation button to work on old graph

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -73,7 +73,23 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
                 target={item.target}
                 icon={item.icon}
                 active={item.active}
-                onClick={onClick}
+                onClick={(e: React.MouseEvent<HTMLElement>) => {
+                  // We can have both url and onClick and we want to allow user to open the link in new tab/window
+                  const isSpecialKeyPressed = e.ctrlKey || e.metaKey || e.shiftKey;
+                  if (isSpecialKeyPressed && item.url) {
+                    return;
+                  }
+
+                  if (item.onClick) {
+                    e.preventDefault();
+                    item.onClick(e);
+                  }
+
+                  // Typically closes the context menu
+                  if (onClick) {
+                    onClick();
+                  }
+                }}
               />
             ))}
           </MenuGroup>

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -24,9 +24,20 @@ export interface MenuItemProps {
   /** Active */
   active?: boolean;
 }
+/** This interface was created because we are utilizing two different events in the onClick props*/
+interface ItemProps {
+  label: string;
+  ariaLabel: string;
+  target?: LinkTarget;
+  icon?: IconName;
+  url?: string;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  className?: string;
+  active?: boolean;
+}
 
 /** @internal */
-export const MenuItem: React.FC<MenuItemProps> = React.memo(
+export const MenuItem: React.FC<ItemProps> = React.memo(
   ({ url, icon, label, ariaLabel, target, onClick, className, active }) => {
     const styles = useStyles(getStyles);
     const itemStyle = cx(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes add annotation button to work on the old graph. Also added support for keyboard events and onClose handler.
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #31911 

