### PR TITLE
GraphContextMenu: Fixes add annotation action & data links that cause full page reload 

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useLayoutEffect, useCallback } from 'react';
+import React, { useRef, useState, useLayoutEffect } from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 import { useClickAway } from 'react-use';
 import { Portal } from '../Portal/Portal';
@@ -47,12 +47,6 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
     }
   });
 
-  const onClick = useCallback(() => {
-    if (onClose) {
-      onClose();
-    }
-  }, [onClose]);
-
   const header = renderHeader && renderHeader();
   return (
     <Portal>
@@ -73,7 +67,14 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
                 target={item.target}
                 icon={item.icon}
                 active={item.active}
-                onClick={onClick}
+                onClick={() => {
+                  if (item.onClick) {
+                    item.onClick();
+                  }
+                  if (onClose) {
+                    onClose();
+                  }
+                }}
               />
             ))}
           </MenuGroup>

--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -55,6 +55,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
         ref={menuRef}
         style={positionStyles}
         ariaLabel={selectors.components.Menu.MenuComponent('Context')}
+        onClick={onClose}
       >
         {itemsGroup?.map((group, index) => (
           <MenuGroup key={`${group.label}${index}`} label={group.label} ariaLabel={group.label}>
@@ -67,14 +68,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(({ x, y, onClo
                 target={item.target}
                 icon={item.icon}
                 active={item.active}
-                onClick={() => {
-                  if (item.onClick) {
-                    item.onClick();
-                  }
-                  if (onClose) {
-                    onClose();
-                  }
-                }}
+                onClick={item.onClick}
               />
             ))}
           </MenuGroup>

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -324,7 +324,7 @@ export class LinkSrv implements LinkService {
     const info: LinkModel<T> = {
       href: locationUtil.assureBaseUrl(href.replace(/\n/g, '')),
       title: replaceVariables ? replaceVariables(link.title || '') : link.title,
-      target: link.targetBlank ? '_blank' : '_self',
+      target: link.targetBlank ? '_blank' : undefined,
       origin,
       onClick,
     };


### PR DESCRIPTION
Feels like there should be a better way to close ContextMenu
