### PR TITLE
Docs: additional caching documentation

### DIFF
--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -350,4 +350,4 @@ The default TTL (time to live) if no other TTL is available.
 
 ### gc_interval
 
-When storing cache data in-memory, this setting defines how often a background process will clean up stale data from the in-memory cache. More frequent "garbage collection" can keep memory usage from climbing but will increase CPU usage.
+When storing cache data in-memory, this setting defines how often a background process cleans up stale data from the in-memory cache. More frequent "garbage collection" can keep memory usage from climbing but will increase CPU usage.

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -350,4 +350,4 @@ The default TTL (time to live) if no other TTL is available.
 
 ### gc_interval
 
-When storing cache data in-memory, this setting defines how often a background process will clean up stale data from the in-memory cache. More frequent "garbage collection" can keep memory using from climbing but will increase CPU usage.
+When storing cache data in-memory, this setting defines how often a background process will clean up stale data from the in-memory cache. More frequent "garbage collection" can keep memory usage from climbing but will increase CPU usage.

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -345,3 +345,9 @@ Setting 'enabled' to true enables caching datasource queries for all data source
 ### ttl
 
 The default TTL (time to live) if no other TTL is available.
+
+## [caching.memory]
+
+### gc_interval
+
+When storing cache data in-memory, this setting defines how often a background process will clean up stale data from the in-memory cache. More frequent "garbage collection" can keep memory using from climbing but will increase CPU usage.

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -23,6 +23,6 @@ Query caching currently works for all backend data sources. You can enable the c
 
 To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#query-caching" >}}).
 
-## Skip caching per request
+## Sending a request without cache
 
-Requests that contain the header `X-Cache-Skip` with any value are skipped. This can be particularly useful when debugging data source queries using cURL.
+If the data source query request contains an `X-Cache-Skip` header, then Grafana skips the caching middleware, and does not search the cache for a response. This can be particularly useful when debugging data source queries using cURL.

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -22,3 +22,7 @@ Query caching currently works for all backend data sources. You can enable the c
 ## Enable query caching
 
 To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#query-caching" >}}).
+
+## Skip caching per request
+
+Requests that contain the header `X-Cache-Skip` with any value will be skipped. This can be particularly useful when debugging datasource queries using cURL.

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -25,4 +25,4 @@ To enable and configure query caching, please refer the the [Query caching secti
 
 ## Skip caching per request
 
-Requests that contain the header `X-Cache-Skip` with any value will be skipped. This can be particularly useful when debugging datasource queries using cURL.
+Requests that contain the header `X-Cache-Skip` with any value are skipped. This can be particularly useful when debugging data source queries using cURL.


### PR DESCRIPTION
**What this PR does / why we need it**:

A new option for in-memory caching was added, as well as an optional header that can be sent to skip caching for a single request if it's enabled.
