### PR TITLE
Chore: Give backend platform ownership over backend architecture docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@ go.sum @grafana/backend-platform
 
 # Backend code docs
 /contribute/style-guides/backend.md @grafana/backend-platform
+/contribute/architecture/backend @grafana/backend-platform
 
 /e2e @grafana/grafana-frontend-platform
 /packages @grafana/grafana-frontend-platform


### PR DESCRIPTION
**What this PR does / why we need it**:
Give backend platform ownership over backend architecture docs in .github/CODEOWNERS.
