### PR TITLE
Variables: Do not reset description on variable type change

### DIFF
--- a/public/app/features/variables/state/sharedReducer.test.ts
+++ b/public/app/features/variables/state/sharedReducer.test.ts
@@ -6,6 +6,7 @@ import {
   addVariable,
   changeVariableOrder,
   changeVariableProp,
+  changeVariableType,
   duplicateVariable,
   removeVariable,
   setCurrentVariableValue,
@@ -16,7 +17,7 @@ import {
   variableStateNotStarted,
 } from './sharedReducer';
 import { ConstantVariableModel, QueryVariableModel, VariableHide, VariableOption } from '../types';
-import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE, toVariablePayload } from './types';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE, toVariablePayload, VariableIdentifier } from './types';
 import { variableAdapters } from '../adapters';
 import { createQueryVariableAdapter } from '../query/adapter';
 import { initialQueryVariableModelState } from '../query/reducer';
@@ -485,6 +486,38 @@ describe('sharedReducer', () => {
           '0': {
             ...initialState[0],
             name: 'A new name',
+          },
+        });
+    });
+  });
+
+  describe('when changeVariableType is dispatched', () => {
+    it('then state should be correct', () => {
+      const queryAdapter = createQueryVariableAdapter();
+      const { initialState: queryAdapterState } = getVariableTestContext(queryAdapter);
+      const constantAdapter = createConstantVariableAdapter();
+      const { initialState: constantAdapterState } = getVariableTestContext(constantAdapter);
+      const newType = 'constant' as VariableType;
+      const identifier: VariableIdentifier = { id: '0', type: 'query' };
+      const payload = toVariablePayload(identifier, { newType });
+      reducerTester<VariablesState>()
+        .givenReducer(sharedReducer, cloneDeep(queryAdapterState))
+        .whenActionIsDispatched(changeVariableNameSucceeded(toVariablePayload(identifier, { newName: 'test' })))
+        .whenActionIsDispatched(
+          changeVariableProp(toVariablePayload(identifier, { propName: 'description', propValue: 'new description' }))
+        )
+        .whenActionIsDispatched(
+          changeVariableProp(toVariablePayload(identifier, { propName: 'label', propValue: 'new label' }))
+        )
+        .whenActionIsDispatched(changeVariableType(payload))
+        .thenStateShouldEqual({
+          ...constantAdapterState,
+          '0': {
+            ...constantAdapterState[0],
+            name: 'test',
+            description: 'new description',
+            label: 'new label',
+            type: 'constant',
           },
         });
     });

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -101,7 +101,7 @@ const sharedReducerSlice = createSlice({
     },
     changeVariableType: (state: VariablesState, action: PayloadAction<VariablePayload<{ newType: VariableType }>>) => {
       const { id } = action.payload;
-      const { label, name, index } = state[id];
+      const { label, name, index, description } = state[id];
 
       state[id] = {
         ...cloneDeep(variableAdapters.get(action.payload.data.newType).initialState),
@@ -109,6 +109,7 @@ const sharedReducerSlice = createSlice({
         label,
         name,
         index,
+        description,
       };
     },
     setCurrentVariableValue: (

--- a/public/test/core/redux/reducerTester.ts
+++ b/public/test/core/redux/reducerTester.ts
@@ -18,6 +18,7 @@ export interface When<State> {
 export interface Then<State> {
   thenStateShouldEqual: (state: State) => When<State>;
   thenStatePredicateShouldEqual: (predicate: (resultingState: State) => boolean) => When<State>;
+  whenActionIsDispatched: (action: PayloadAction<any> | Action<any>) => Then<State>;
 }
 
 interface ObjectType extends Object {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes the issue where variable description was reset on variable type change, when creating/editing a variable.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/31917


