### PR TITLE
PanelInspect: Interpolates variables in CSV file name

### DIFF
--- a/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectDataTab.tsx
@@ -3,6 +3,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import {
   applyFieldOverrides,
   applyRawFieldOverrides,
+  CSVConfig,
   DataFrame,
   DataTransformerID,
   dateTimeFormat,
@@ -10,9 +11,8 @@ import {
   SelectableValue,
   toCSV,
   transformDataFrame,
-  CSVConfig,
 } from '@grafana/data';
-import { Button, Container, Field, HorizontalGroup, Spinner, Select, Switch, Table, VerticalGroup } from '@grafana/ui';
+import { Button, Container, Field, HorizontalGroup, Select, Spinner, Switch, Table, VerticalGroup } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { getPanelInspectorStyles } from './styles';
@@ -94,7 +94,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
       type: 'text/csv;charset=utf-8',
     });
     const transformation = transformId !== DataTransformerID.noop ? '-as-' + transformId.toLocaleLowerCase() : '';
-    const fileName = `${panel.title}-data${transformation}-${dateTimeFormat(new Date())}.csv`;
+    const fileName = `${panel.getDisplayTitle()}-data${transformation}-${dateTimeFormat(new Date())}.csv`;
     saveAs(blob, fileName);
   };
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
@@ -37,6 +37,7 @@ function setupTestContext(options: Partial<Props>) {
       events: { subscribe: jest.fn() },
       getQueryRunner: () => panelQueryRunner,
       getOptions: jest.fn(),
+      getDisplayTitle: jest.fn(),
     } as unknown) as PanelModel,
     dashboard: ({
       panelInitialized: jest.fn(),

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -28,7 +28,7 @@ export interface Props {
 
 export const PanelHeader: FC<Props> = ({ panel, error, isViewing, isEditing, data, alertState, dashboard }) => {
   const onCancelQuery = () => panel.getQueryRunner().cancelQuery();
-  const title = panel.replaceVariables(panel.title, {}, 'text');
+  const title = panel.getDisplayTitle();
   const className = cx('panel-header', !(isViewing || isEditing) ? 'grid-drag-handle' : '');
 
   return (

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -59,6 +59,7 @@ const notPersistedProperties: { [str: string]: boolean } = {
   replaceVariables: true,
   editSourceId: true,
   hasChanged: true,
+  getDisplayTitle: true,
 };
 
 // For angular panels we need to clean up properties when changing type
@@ -102,6 +103,7 @@ const mustKeepProps: { [str: string]: boolean } = {
   interval: true,
   replaceVariables: true,
   libraryPanel: true,
+  getDisplayTitle: true,
 };
 
 const defaults: any = {
@@ -550,6 +552,14 @@ export class PanelModel implements DataConfigSource {
    * */
   getSavedId(): number {
     return this.editSourceId ?? this.id;
+  }
+
+  /*
+   * This is the title used when displaying the title in the UI so it will include any interpolated variables.
+   * If you need the raw title without interpolation use title property instead.
+   * */
+  getDisplayTitle(): string {
+    return this.replaceVariables(this.title, {}, 'text');
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `getDisplayTitle` function to the `PanelModel` so that we can use that function to retrieve the displayed panel title (with interpolated variables) in all places where the display value of the panel title is needed. For instance, when downloading CSV data from Panel Inspect.

**Which issue(s) this PR fixes**:
Fixes #31889

**Special notes for your reviewer**:

