### PR TITLE
Query editor: avoid avoiding word wrap on query editor components

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -120,7 +120,6 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
     wrapper: css`
       margin-bottom: ${theme.spacing.md};
-      white-space: nowrap;
     `,
     header: css`
       padding: ${theme.spacing.xs} ${theme.spacing.sm};
@@ -130,6 +129,7 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      white-space: nowrap;
     `,
     dragIcon: css`
       cursor: drag;


### PR DESCRIPTION
**What this PR does / why we need it**:

Related to #30373, this fixes an issue where `white-space: nowrap` was cascading down unexpectedly into query editors themselves.

Before: 

![chrome_Pv0O1hHnHi](https://user-images.githubusercontent.com/46142/110966532-3fbcf280-834d-11eb-8fbf-7975a2dbed1f.png)

After:

![chrome_5VjytseKy3](https://user-images.githubusercontent.com/46142/110966558-451a3d00-834d-11eb-9fe7-9a2e5dfa6c6a.png)

Note that the header row is still not wrapping, as expected.

😌
