### PR TITLE
Init: guarantuee plugin service initialization order

### DIFF
--- a/pkg/plugins/backendplugin/manager.go
+++ b/pkg/plugins/backendplugin/manager.go
@@ -33,7 +33,11 @@ var (
 )
 
 func init() {
-	registry.RegisterService(&manager{})
+	registry.Register(&registry.Descriptor{
+		Name:         "manager",
+		Instance:     &manager{},
+		InitPriority: registry.MediumHigh,
+	})
 }
 
 // Manager manages backend plugins.

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -114,7 +114,8 @@ func IsDisabled(srv Service) bool {
 type Priority int
 
 const (
-	High   Priority = 100
-	Medium Priority = 50
-	Low    Priority = 0
+	High       Priority = 100
+	MediumHigh Priority = 75
+	Medium     Priority = 50
+	Low        Priority = 0
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Manes sure the backendplugin service gets initialized before the plugin service.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

