### PR TITLE
devenv: fix incorrect url in datasource-config

### DIFF
--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -60,7 +60,7 @@ datasources:
     access: proxy
     database: telegraf
     user: grafana
-    url: http://telegraf:8086
+    url: http://influxdb:8086
     jsonData:
       timeInterval: "10s"
     secureJsonData:


### PR DESCRIPTION
in `devenv`, when running in `docker` mode, the `gdev-influxdb-telegraf` datasource has wrong database-URL. this PR fixes it.
tested with `make devenv sources=influxdb,grafana grafana_version=7.5.0-beta1`