### PR TITLE
Enterprise: Add Redis caching documentation

### DIFF
--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -360,4 +360,4 @@ The full Redis URL of your Redis server. Example: `redis://localhost:6739/0`.
 
 ### prefix
 
-A string that prefixes all redis keys. This value must be set if using a shared database in Redis. If `prefix` is empty, then one will not be used.
+A string that prefixes all Redis keys. This value must be set if using a shared database in Redis. If `prefix` is empty, then one will not be used.

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -351,3 +351,13 @@ The default TTL (time to live) if no other TTL is available.
 ### gc_interval
 
 When storing cache data in-memory, this setting defines how often a background process cleans up stale data from the in-memory cache. More frequent "garbage collection" can keep memory usage from climbing but will increase CPU usage.
+
+## [caching.redis]
+
+### url
+
+The full redis URL of your redis server. Example: `redis://localhost:6739/0`.
+
+### prefix
+
+A string that prefixes all redis keys. This value must be set if using a shared database in Redis. If `prefix` is empty, then one will not be used.

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -356,7 +356,7 @@ When storing cache data in-memory, this setting defines how often a background p
 
 ### url
 
-The full redis URL of your redis server. Example: `redis://localhost:6739/0`.
+The full Redis URL of your Redis server. Example: `redis://localhost:6739/0`.
 
 ### prefix
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -11,7 +11,7 @@ weight = 110
 
 When query caching is enabled, Grafana temporarily stores the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself.
 
-Query caching currently works for all backend data sources. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL). The cache is in-memory only.
+Query caching currently works for all backend data sources. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL). The cache can either be in-memory or in Redis.
 
 ## Query caching benefits
 


### PR DESCRIPTION
Caching using Redis was recently merged into grafana-enterprise. This documents the available configuration options for Redis.