### PR TITLE
Add documentation page for how to install Grafana and GE on K8s

### DIFF
--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -7,7 +7,7 @@ weight: 2
 
 This page explains how to install and run Grafana on Kubernetes (K8S). It uses Kubernetes manifests for the setup. If you prefer Helm, refer to the [Grafana Helm community charts](https://github.com/grafana/helm-charts). 
 
-For those interested in Grafana Enterprise (not Grafana OS), please jump to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes)
+If you are interested in Grafana Enterprise (not Grafana OS), jump to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes) section.
 
 #### Create Grafana Kubernetes manifest
 1. Create the file `grafana.yaml`, then paste the following contents in it. 

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -226,7 +226,7 @@ spec:
 kubectl apply -f grafana.yaml
 ```
 
-2. Check that it worked
+1. Check that it worked by running the following:
 ```bash
 kubectl port-forward service/grafana 3000:3000
 ```

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -10,7 +10,7 @@ This page explains how to install and run Grafana on Kubernetes (K8S). It uses K
 If you are interested in Grafana Enterprise (not Grafana OS), jump to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes) section.
 
 #### Create Grafana Kubernetes manifest
-1. Create the file `grafana.yaml`, then paste the following contents in it. 
+1. Create a file called `grafana.yaml`, then paste the contents below. 
 
 ```yaml
 ---
@@ -91,6 +91,7 @@ spec:
 
 ### Send manifest to Kubernetes API server
 
+1. Run the following command: 
 ```bash
 kubectl apply -f grafana.yaml
 ```
@@ -233,3 +234,5 @@ kubectl port-forward service/grafana 3000:3000
 Now if you navigate to `localhost:3000` in your browser, you should see the Grafana login page. 
 
 1. Use `admin` for both the username and password to login.
+
+If it worked, you should see "Enterprise (Licensed)" at the bottom of the page. 

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -131,7 +131,7 @@ Create a Kubernetes Configmap from your `grafana.ini` file with the following co
 kubectl create configmap ge-config --from-file=/path/to/your/config.ini
 ```
 ### Create Grafana Enterprise Kubernetes manifest
-Create a file called `grafana.yaml` and paste the following contents in. This yaml is identical to the yaml for the OS install except for the additional references to the Configmap that contains your Grafana config file and the Secret that contains your license.
+Create a `grafana.yaml` file, then paste the content below. This YAML is identical to the one for Grafana OS install except for the additional references to the Configmap which has your Grafana configuration file and the Secret that has your license. 
 
 ```yaml
 ---

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -115,7 +115,7 @@ Create a Kubernetes secret from your license file using the following command:
 kubectl create secret generic ge-license --from-file=/path/to/your/license.jwt
 ```
 
-### Create Grafana Enterprise Config
+### Create Grafana Enterprise configuration
 Create a Grafana config file by creating a new file called `grafana.ini` and pasting in the contents below. You will have to update the `root_url` field to the url associated with the license you were given. 
 ```yaml
 [enterprise]

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -104,7 +104,7 @@ Now if you navigate to `localhost:3000` in your browser, you should see a Grafan
 1. Use `admin` for both the username and password to login.
 
 ## Deploy Grafana Enterprise on Kubernetes
-The process for deploying Grafana Enterprise is almost identical to the process above, except for some extra steps required to add in your license file.
+The process for deploying Grafana Enterprise is almost identical to the process above, except for some extra steps required to add in your license file. They are described in the following sections.
 
 ### Obtain Grafana Enterprise license
 To run Grafana Enterprise, you need a valid license. To obtain a license, [contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise). This guide will assume you already have done this and have a `license.jwt` file. Your license should also be associated with a URL, which we will use further down in this guide. 
@@ -231,4 +231,3 @@ kubectl apply -f grafana.yaml
 kubectl port-forward service/grafana 3000:3000
 ```
 Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. Use `admin` for both the username and password values to login.
-

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -107,7 +107,7 @@ Now if you navigate to `localhost:3000` in your browser, you should see a Grafan
 The process for deploying Grafana Enterprise is almost identical to the process above, except for some extra steps required to add in your license file. They are described in the following sections.
 
 ### Obtain Grafana Enterprise license
-To run Grafana Enterprise, you need a valid license. To obtain a license, [contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise). This guide will assume you already have done this and have a `license.jwt` file. Your license should also be associated with a URL, which we will use further down in this guide. 
+To run Grafana Enterprise, you need a valid license. [Contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise) to obtain the license. This topic assumes that you already have done this and have a `license.jwt` file. Your license should also be associated with a URL, which we will use later in the topic. 
 
 ### Create License Secret
 Create a Kubernetes secret from your license file using the following command:

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -1,7 +1,9 @@
----
-title: Deploy on Kubernetes
-weight: 2
----
++++
+title = "Deploy Grafana on Kubernetes"
+description = "Guide for deploying Grafana on Kubernetes"
+keywords = ["grafana", "configuration", "documentation", "kubernetes"]
+weight = 700
++++
 
 ## Deploy Grafana on Kubernetes
 
@@ -9,7 +11,7 @@ This page explains how to install and run Grafana on Kubernetes (K8S). It uses K
 
 If you are interested in Grafana Enterprise (not Grafana OS), jump to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes) section.
 
-#### Create Grafana Kubernetes manifest
+### Create Grafana Kubernetes manifest
 1. Create a file called `grafana.yaml`, then paste the contents below. 
 
 ```yaml
@@ -96,7 +98,8 @@ spec:
 
 1. Check that it worked by running the following:
 `kubectl port-forward service/grafana 3000:3000`
-Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. 
+
+1. Navigate to `localhost:3000` in your browser. You should see a Grafana login page. 
 
 1. Use `admin` for both the username and password to login.
 
@@ -222,7 +225,8 @@ spec:
 
 1. Check that it worked by running the following:
 `kubectl port-forward service/grafana 3000:3000`
-Now if you navigate to `localhost:3000` in your browser, you should see the Grafana login page. 
+
+1. Navigate to `localhost:3000` in your browser. You should see the Grafana login page. 
 
 1. Use `admin` for both the username and password to login.
-If it worked, you should see "Enterprise (Licensed)" at the bottom of the page. 
+If it worked, you should see `Enterprise (Licensed)` at the bottom of the page. 

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -92,14 +92,10 @@ spec:
 ### Send manifest to Kubernetes API server
 
 1. Run the following command: 
-```bash
-kubectl apply -f grafana.yaml
-```
+`kubectl apply -f grafana.yaml`
 
 1. Check that it worked by running the following:
-```bash
-kubectl port-forward service/grafana 3000:3000
-```
+`kubectl port-forward service/grafana 3000:3000`
 Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. 
 
 1. Use `admin` for both the username and password to login.
@@ -222,17 +218,11 @@ spec:
 ```
  
 1. Send manifest to Kubernetes API Server
-
-```bash
-kubectl apply -f grafana.yaml
-```
+`kubectl apply -f grafana.yaml`
 
 1. Check that it worked by running the following:
-```bash
-kubectl port-forward service/grafana 3000:3000
-```
+`kubectl port-forward service/grafana 3000:3000`
 Now if you navigate to `localhost:3000` in your browser, you should see the Grafana login page. 
 
 1. Use `admin` for both the username and password to login.
-
 If it worked, you should see "Enterprise (Licensed)" at the bottom of the page. 

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -5,7 +5,7 @@ weight: 2
 
 ## Deploy Grafana on Kubernetes
 
-This guide will walk you through how to install and run Grafana on Kubernetes (K8S). It will use Kubernetes manifests for the setup. For those who prefer Helm, please see the [Grafana Helm Community Charts](https://github.com/grafana/helm-charts). 
+This page explains how to install and run Grafana on Kubernetes (K8S). It uses Kubernetes manifests for the setup. If you prefer Helm, refer to the [Grafana Helm community charts](https://github.com/grafana/helm-charts). 
 
 For those interested in Grafana Enterprise (not Grafana OS), please jump to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes)
 

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -108,7 +108,7 @@ Now if you navigate to `localhost:3000` in your browser, you should see a Grafan
 ## Deploy Grafana Enterprise on Kubernetes
 The process for deploying Grafana Enterprise is almost identical to the process above, except for some extra steps required to add in your license file.
 
-### Obtain Grafana Enterprise License
+### Obtain Grafana Enterprise license
 To run Grafana Enterprise, you need a valid license. To obtain a license, [contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise). This guide will assume you already have done this and have a `license.jwt` file. Your license should also be associated with a URL, which we will use further down in this guide. 
 
 ### Create License Secret

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -96,7 +96,7 @@ Run the following command to create the necessary resources in your cluster.
 kubectl apply -f grafana.yaml
 ```
 
-### Check that it worked
+1. Check that it worked by running the following:
 Run the following: 
 ```bash
 kubectl port-forward service/grafana 3000:3000

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -92,12 +92,10 @@ spec:
 ### Send manifest to Kubernetes API server
 
 1. Run the following command: 
-
 `kubectl apply -f grafana.yaml`
 
 1. Check that it worked by running the following:
 `kubectl port-forward service/grafana 3000:3000`
-
 Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. 
 
 1. Use `admin` for both the username and password to login.
@@ -220,12 +218,10 @@ spec:
 ```
  
 1. Send manifest to Kubernetes API Server
-
 `kubectl apply -f grafana.yaml`
 
 1. Check that it worked by running the following:
 `kubectl port-forward service/grafana 3000:3000`
-
 Now if you navigate to `localhost:3000` in your browser, you should see the Grafana login page. 
 
 1. Use `admin` for both the username and password to login.

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -92,10 +92,12 @@ spec:
 ### Send manifest to Kubernetes API server
 
 1. Run the following command: 
+
 `kubectl apply -f grafana.yaml`
 
 1. Check that it worked by running the following:
 `kubectl port-forward service/grafana 3000:3000`
+
 Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. 
 
 1. Use `admin` for both the username and password to login.
@@ -218,10 +220,12 @@ spec:
 ```
  
 1. Send manifest to Kubernetes API Server
+
 `kubectl apply -f grafana.yaml`
 
 1. Check that it worked by running the following:
 `kubectl port-forward service/grafana 3000:3000`
+
 Now if you navigate to `localhost:3000` in your browser, you should see the Grafana login page. 
 
 1. Use `admin` for both the username and password to login.

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -10,7 +10,7 @@ This page explains how to install and run Grafana on Kubernetes (K8S). It uses K
 For those interested in Grafana Enterprise (not Grafana OS), please jump to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes)
 
 #### Create Grafana Kubernetes manifest
-Create a file called `grafana.yaml` and paste the following contents in. 
+1. Create the file `grafana.yaml`, then paste the following contents in it. 
 
 ```yaml
 ---

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -91,13 +91,11 @@ spec:
 
 ### Send manifest to Kubernetes API server
 
-Run the following command to create the necessary resources in your cluster. 
 ```bash
 kubectl apply -f grafana.yaml
 ```
 
 1. Check that it worked by running the following:
-Run the following: 
 ```bash
 kubectl port-forward service/grafana 3000:3000
 ```
@@ -222,20 +220,15 @@ spec:
   type: LoadBalancer
 ```
  
-### Send manifest to Kubernetes API Server
+1. Send manifest to Kubernetes API Server
 
-Run the following command to create the necessary resources in your cluster. 
 ```bash
 kubectl apply -f grafana.yaml
 ```
 
-### Check that it worked
-Run the following: 
+2. Check that it worked
 ```bash
 kubectl port-forward service/grafana 3000:3000
 ```
 Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. Use `admin` for both the username and password values to login.
 
-A successful Grafana Enterprise installation with a valid license should show an opened lock icon when you mouse over the shield icon in the left menu bar. You can also verify by scrolling down to the bottom of the page.
-![lock_ge](../../lock_ge.png "Showing left menu")
-![bottom_ge](../../bottom_ge.png "Showing bottom pane") 

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -101,7 +101,9 @@ Run the following:
 ```bash
 kubectl port-forward service/grafana 3000:3000
 ```
-Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. Use `admin` for both the username and password values to login.
+Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. 
+
+1. Use `admin` for both the username and password to login.
 
 ## Deploy Grafana Enterprise on Kubernetes
 The process for deploying Grafana Enterprise is almost identical to the process above, except for some extra steps required to add in your license file.

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -89,7 +89,7 @@ spec:
 ```
 
 
-### Send manifest to Kubernetes API Server
+### Send manifest to Kubernetes API server
 
 Run the following command to create the necessary resources in your cluster. 
 ```bash

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -230,4 +230,6 @@ kubectl apply -f grafana.yaml
 ```bash
 kubectl port-forward service/grafana 3000:3000
 ```
-Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. Use `admin` for both the username and password values to login.
+Now if you navigate to `localhost:3000` in your browser, you should see the Grafana login page. 
+
+1. Use `admin` for both the username and password to login.

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -118,7 +118,8 @@ kubectl create secret generic ge-license --from-file=/path/to/your/license.jwt
 ```
 
 ### Create Grafana Enterprise configuration
-Create a Grafana config file by creating a new file called `grafana.ini` and pasting in the contents below. You will have to update the `root_url` field to the url associated with the license you were given. 
+Create a Grafana configuration file with the name `grafana.ini`. Then paste the content below. 
+>**Note:** You will have to update the `root_url` field to the url associated with the license you were given. 
 ```yaml
 [enterprise]
 license_path = /etc/grafana/license/license.jwt

--- a/docs/sources/installation/kubernetes.md
+++ b/docs/sources/installation/kubernetes.md
@@ -1,0 +1,238 @@
+---
+title: Deploy on Kubernetes
+weight: 2
+---
+
+## Deploy Grafana on Kubernetes
+
+This guide will walk you through how to install and run Grafana on Kubernetes (K8S). It will use Kubernetes manifests for the setup. For those who prefer Helm, please see the [Grafana Helm Community Charts](https://github.com/grafana/helm-charts). 
+
+For those interested in Grafana Enterprise (not Grafana OS), please jump to [Deploy Grafana Enterprise on Kubernetes](#deploy-grafana-enterprise-on-kubernetes)
+
+#### Create Grafana Kubernetes manifest
+Create a file called `grafana.yaml` and paste the following contents in. 
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-path
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - image: grafana/grafana:latest
+          imagePullPolicy: IfNotPresent
+          name: grafana
+          ports:
+            - containerPort: 3000
+              name: http-grafana
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /robots.txt
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            limits:
+              memory: 4Gi
+            requests:
+              cpu: 100m
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: grafana
+      volumes:
+        - name: grafana
+          persistentVolumeClaim:
+            claimName: grafana
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: http-grafana
+  selector:
+    app: grafana
+  sessionAffinity: None
+  type: LoadBalancer
+```
+
+
+### Send manifest to Kubernetes API Server
+
+Run the following command to create the necessary resources in your cluster. 
+```bash
+kubectl apply -f grafana.yaml
+```
+
+### Check that it worked
+Run the following: 
+```bash
+kubectl port-forward service/grafana 3000:3000
+```
+Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. Use `admin` for both the username and password values to login.
+
+## Deploy Grafana Enterprise on Kubernetes
+The process for deploying Grafana Enterprise is almost identical to the process above, except for some extra steps required to add in your license file.
+
+### Obtain Grafana Enterprise License
+To run Grafana Enterprise, you need a valid license. To obtain a license, [contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise). This guide will assume you already have done this and have a `license.jwt` file. Your license should also be associated with a URL, which we will use further down in this guide. 
+
+### Create License Secret
+Create a Kubernetes secret from your license file using the following command:
+```bash
+kubectl create secret generic ge-license --from-file=/path/to/your/license.jwt
+```
+
+### Create Grafana Enterprise Config
+Create a Grafana config file by creating a new file called `grafana.ini` and pasting in the contents below. You will have to update the `root_url` field to the url associated with the license you were given. 
+```yaml
+[enterprise]
+license_path = /etc/grafana/license/license.jwt
+[server]
+root_url =/your/license/root/url
+
+```
+
+### Create Configmap for Grafana Enterprise Config
+Create a Kubernetes Configmap from your `grafana.ini` file with the following command:
+```bash
+kubectl create configmap ge-config --from-file=/path/to/your/config.ini
+```
+### Create Grafana Enterprise Kubernetes manifest
+Create a file called `grafana.yaml` and paste the following contents in. This yaml is identical to the yaml for the OS install except for the additional references to the Configmap that contains your Grafana config file and the Secret that contains your license.
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-path
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - image: grafana/grafana-enterprise:latest
+          imagePullPolicy: IfNotPresent
+          name: grafana
+          ports:
+            - containerPort: 3000
+              name: http-grafana
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /robots.txt
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            limits:
+              memory: 4Gi
+            requests:
+              cpu: 100m
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: grafana
+            - mountPath: /etc/grafana
+              name: ge-config
+            - mountPath: /etc/grafana/license
+              name: ge-license
+      volumes:
+        - name: grafana
+          persistentVolumeClaim:
+            claimName: grafana
+        - name: ge-config
+          configMap:
+            name: ge-config
+        - name: ge-license
+          secret:
+            secretName: ge-license
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: http-grafana
+  selector:
+    app: grafana
+  sessionAffinity: None
+  type: LoadBalancer
+```
+ 
+### Send manifest to Kubernetes API Server
+
+Run the following command to create the necessary resources in your cluster. 
+```bash
+kubectl apply -f grafana.yaml
+```
+
+### Check that it worked
+Run the following: 
+```bash
+kubectl port-forward service/grafana 3000:3000
+```
+Now if you navigate to `localhost:3000` in your browser, you should see a Grafana login page. Use `admin` for both the username and password values to login.
+
+A successful Grafana Enterprise installation with a valid license should show an opened lock icon when you mouse over the shield icon in the left menu bar. You can also verify by scrolling down to the bottom of the page.
+![lock_ge](../../lock_ge.png "Showing left menu")
+![bottom_ge](../../bottom_ge.png "Showing bottom pane") 


### PR DESCRIPTION
This walks users through how to set up both Grafana and Grafana Enterprise in Kubernetes. 

Once we merge this, we will point the GEM documentation to the Grafana Enterprise in Kubernetes setup, since GE is a requirement for working with GEM. At the moment, GEM users could get stuck on the GE setup step since there is no documentation (we just say that having GE installed is a requirement). 

Our GEM installation is primarily targeted at K8s, so we need a GE installation guide for k8s. 

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes Grafana Enterprise 1157
https://github.com/grafana/backend-enterprise/issues/1157 

**Special notes for your reviewer**:

