### PR TITLE
AlertingNG: Fix the alerting stage for legacy alerts

### DIFF
--- a/pkg/services/ngalert/notifier/alert_reception.go
+++ b/pkg/services/ngalert/notifier/alert_reception.go
@@ -32,6 +32,9 @@ type AlertProvider struct {
 	stage notify.Stage
 }
 
+// NewAlertProvider returns AlertProvider that also supports legacy alerts via PutPostableAlert.
+// The notify.Stage should be of the type notify.RoutingStage or something similar that takes
+// notification channel name from the context.
 func NewAlertProvider(s notify.Stage, m types.Marker, l log.Logger) (*AlertProvider, error) {
 	alerts, err := mem.NewAlerts(context.Background(), m, 30*time.Minute, l)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

For legacy notifications, we only need the routing stage to map receiver name to the corresponding stage. So in this PR I am using that and removing the wrapper that we had.