### PR TITLE
Fix loading timezone info on windows

### DIFF
--- a/pkg/setting/date_formats.go
+++ b/pkg/setting/date_formats.go
@@ -1,8 +1,6 @@
 package setting
 
 import (
-	"os"
-	"runtime"
 	"time"
 
 	"gopkg.in/ini.v1"
@@ -25,9 +23,6 @@ type DateFormatIntervals struct {
 }
 
 const localBrowserTimezone = "browser"
-
-// zoneInfo is the key for setting the path to look for the timezone database in go
-const zoneInfo = "ZONEINFO"
 
 func valueAsTimezone(section *ini.Section, keyName string) (string, error) {
 	timezone := section.Key(keyName).MustString(localBrowserTimezone)
@@ -54,23 +49,9 @@ func (cfg *Cfg) readDateFormats() {
 	cfg.DateFormats.Interval.Year = "YYYY"
 	cfg.DateFormats.UseBrowserLocale = dateFormats.Key("date_format_use_browser_locale").MustBool(false)
 
-	if err := setZoneInfo(); err != nil {
-		cfg.Logger.Error("Can't set ZONEINFO environment variable", "err", err)
-	}
 	timezone, err := valueAsTimezone(dateFormats, "default_timezone")
 	if err != nil {
 		cfg.Logger.Warn("Unknown timezone as default_timezone", "err", err)
 	}
 	cfg.DateFormats.DefaultTimezone = timezone
-}
-
-func setZoneInfo() error {
-	// Fix for missing IANA db on Windows
-	_, zoneInfoSet := os.LookupEnv(zoneInfo)
-	if runtime.GOOS == "windows" && !zoneInfoSet {
-		if err := os.Setenv(zoneInfo, HomePath+"/tools/zoneinfo.zip"); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/setting/date_formats.go
+++ b/pkg/setting/date_formats.go
@@ -1,6 +1,8 @@
 package setting
 
 import (
+	"os"
+	"runtime"
 	"time"
 
 	"gopkg.in/ini.v1"
@@ -23,6 +25,9 @@ type DateFormatIntervals struct {
 }
 
 const localBrowserTimezone = "browser"
+
+// zoneInfo is the key for setting the path to look for the timezone database in go
+const zoneInfo = "ZONEINFO"
 
 func valueAsTimezone(section *ini.Section, keyName string) (string, error) {
 	timezone := section.Key(keyName).MustString(localBrowserTimezone)
@@ -49,9 +54,23 @@ func (cfg *Cfg) readDateFormats() {
 	cfg.DateFormats.Interval.Year = "YYYY"
 	cfg.DateFormats.UseBrowserLocale = dateFormats.Key("date_format_use_browser_locale").MustBool(false)
 
+	if err := setZoneInfo(); err != nil {
+		cfg.Logger.Error("Can't set ZONEINFO environment variable", "err", err)
+	}
 	timezone, err := valueAsTimezone(dateFormats, "default_timezone")
 	if err != nil {
 		cfg.Logger.Warn("Unknown timezone as default_timezone", "err", err)
 	}
 	cfg.DateFormats.DefaultTimezone = timezone
+}
+
+func setZoneInfo() error {
+	// Fix for missing IANA db on Windows
+	_, zoneInfoSet := os.LookupEnv(zoneInfo)
+	if runtime.GOOS == "windows" && !zoneInfoSet {
+		if err := os.Setenv(zoneInfo, HomePath+"/tools/zoneinfo.zip"); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +48,9 @@ const (
 const (
 	authProxySyncTTL = 60
 )
+
+// zoneInfo names environment variable for setting the path to look for the timezone database in go
+const zoneInfo = "ZONEINFO"
 
 var (
 	// App settings.
@@ -756,6 +760,14 @@ func (cfg *Cfg) validateStaticRootPath() error {
 
 func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	setHomePath(args)
+
+	// Fix for missing IANA db on Windows
+	_, zoneInfoSet := os.LookupEnv(zoneInfo)
+	if runtime.GOOS == "windows" && !zoneInfoSet {
+		if err := os.Setenv(zoneInfo, HomePath+"/tools/zoneinfo.zip"); err != nil {
+			cfg.Logger.Error("Can't set ZONEINFO environment variable", "err", err)
+		}
+	}
 
 	iniFile, err := cfg.loadConfiguration(args)
 	if err != nil {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -764,7 +764,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	// Fix for missing IANA db on Windows
 	_, zoneInfoSet := os.LookupEnv(zoneInfo)
 	if runtime.GOOS == "windows" && !zoneInfoSet {
-		if err := os.Setenv(zoneInfo, HomePath+"/tools/zoneinfo.zip"); err != nil {
+		if err := os.Setenv(zoneInfo, filepath.Join(HomePath, "tools", "zoneinfo.zip")); err != nil {
 			cfg.Logger.Error("Can't set ZONEINFO environment variable", "err", err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`date_format`.`default_timezone` configuration setting doesn't work on Windows without Go installed.
When it is set to a timezone value, there’s a message in a log `"Unknown timezone as a default_timezone"`

It happens due to `time.LoadLocation` returning an error: when called it scans the dir/file named by the `ZONEINFO` environment variable. Though we bundle `zoneinfo.zip` into Grafana package, we don’t set `ZONEINFO` environment variable with a path to `tools\zoneinfo.zip` file.

This issue impacts the Enterprise reporting feature: once `time.LoadLocation` is called, the env variable is not being evaluated again (even if it’s set in the reporting service Init).

**Special notes for your reviewer** 

It may be not the best solution. If in the future we add `time.LoadLocation` call that happens before the environment variable is set, it will reintroduce the issue. Is there a better place in the code where I could put this (given that it depends on the HomePath)?