### PR TITLE
Grafana/ui: display all selected levels for selected value when searching

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.test.tsx
@@ -88,6 +88,17 @@ describe('Cascader', () => {
     expect(screen.getByText('First / Third')).toBeInTheDocument();
   });
 
+  it('displays selected value with all levels when displayAllSelectedLevels is true and selecting a value from the search', () => {
+    render(
+      <Cascader displayAllSelectedLevels={true} placeholder={placeholder} options={options} onSelect={jest.fn()} />
+    );
+
+    userEvent.type(screen.getByPlaceholderText(placeholder), 'Third');
+    userEvent.click(screen.getByText('First / Third'));
+
+    expect(screen.getByDisplayValue('First / Third')).toBeInTheDocument();
+  });
+
   it('displays all levels selected with default separator when displayAllSelectedLevels is true', () => {
     render(
       <Cascader displayAllSelectedLevels={true} placeholder={placeholder} options={options} onSelect={() => {}} />

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -105,7 +105,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
       if (optionPath.indexOf(initValue) === optionPath.length - 1) {
         return {
           rcValue: optionPath,
-          activeLabel: option.singleLabel || '',
+          activeLabel: this.props.displayAllSelectedLevels ? option.label : option.singleLabel || '',
         };
       }
     }
@@ -132,7 +132,7 @@ export class Cascader extends React.PureComponent<CascaderProps, CascaderState> 
   onSelect = (obj: SelectableValue<string[]>) => {
     const valueArray = obj.value || [];
     this.setState({
-      activeLabel: obj.singleLabel || '',
+      activeLabel: this.props.displayAllSelectedLevels ? obj.label : obj.singleLabel || '',
       rcValue: valueArray,
       isSearching: false,
     });


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/31729 was merged, we are now able to support displaying the full path of selected values. However, the full path is not displayed when selecting a value when searching.

**Before**

When selecting a value after searching, only the last value is displayed (even though `displayAllSelectedLevels={true}`).

![cascader search full before](https://user-images.githubusercontent.com/36230812/111325966-16110d80-8664-11eb-81c7-25907e1fcd90.gif)

**After**

When selecting a value after searching, the full path is now displayed (because `displayAllSelectedLevels={true}`).

![cascader search full after](https://user-images.githubusercontent.com/36230812/111325984-19a49480-8664-11eb-9081-9a1d8f98cc1b.gif)

**Which issue(s) this PR fixes**:

We need this for our NR plugin: https://github.com/grafana/plugins-private/issues/1350

**Special notes for your reviewer**:

TIA 🙏 