### PR TITLE
Routing NG: Fix persistent modal after dashboard delete

### DIFF
--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -4,6 +4,7 @@ import sumBy from 'lodash/sumBy';
 import { Modal, ConfirmModal, HorizontalGroup, Button } from '@grafana/ui';
 import { DashboardModel, PanelModel } from '../../state';
 import { useDashboardDelete } from './useDashboardDelete';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
 
 type DeleteDashboardModalProps = {
   hideModal(): void;
@@ -12,7 +13,13 @@ type DeleteDashboardModalProps = {
 
 export const DeleteDashboardModal: React.FC<DeleteDashboardModalProps> = ({ hideModal, dashboard }) => {
   const isProvisioned = dashboard.meta.provisioned;
-  const { onRestoreDashboard } = useDashboardDelete(dashboard.uid);
+  const { onDeleteDashboard } = useDashboardDelete(dashboard.uid);
+
+  const [, onConfirm] = useAsyncFn(async () => {
+    await onDeleteDashboard();
+    hideModal();
+  }, [hideModal]);
+
   const modalBody = getModalBody(dashboard.panels, dashboard.title);
 
   if (isProvisioned) {
@@ -23,7 +30,7 @@ export const DeleteDashboardModal: React.FC<DeleteDashboardModalProps> = ({ hide
     <ConfirmModal
       isOpen={true}
       body={modalBody}
-      onConfirm={onRestoreDashboard}
+      onConfirm={onConfirm}
       onDismiss={hideModal}
       title="Delete"
       icon="trash-alt"

--- a/public/app/features/dashboard/components/DeleteDashboard/useDashboardDelete.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/useDashboardDelete.tsx
@@ -6,7 +6,7 @@ import { deleteDashboard } from 'app/features/manage-dashboards/state/actions';
 import { locationService } from '@grafana/runtime';
 
 export const useDashboardDelete = (uid: string) => {
-  const [state, onRestoreDashboard] = useAsyncFn(() => deleteDashboard(uid, false), []);
+  const [state, onDeleteDashboard] = useAsyncFn(() => deleteDashboard(uid, false), []);
 
   useEffect(() => {
     if (state.value) {
@@ -15,5 +15,5 @@ export const useDashboardDelete = (uid: string) => {
     }
   }, [state]);
 
-  return { state, onRestoreDashboard };
+  return { state, onDeleteDashboard };
 };


### PR DESCRIPTION
Ref https://github.com/grafana/grafana/issues/31873

>  I deleted a dashboard and confirm modal showed up, clicked Delete and got redirected to home dashboard, but modal didn't close