### PR TITLE
Alerting: Add database table for persisting alerting configuration

### DIFF
--- a/pkg/services/ngalert/database_mig.go
+++ b/pkg/services/ngalert/database_mig.go
@@ -107,3 +107,19 @@ func alertInstanceMigration(mg *migrator.Migrator) {
 	mg.AddMigration("add index in alert_instance table on def_org_id, def_uid and current_state columns", migrator.NewAddIndexMigration(alertInstance, alertInstance.Indices[0]))
 	mg.AddMigration("add index in alert_instance table on def_org_id, current_state columns", migrator.NewAddIndexMigration(alertInstance, alertInstance.Indices[1]))
 }
+
+func alertmanagerConfigurationMigration(mg *migrator.Migrator) {
+	alertConfiguration := migrator.Table{
+		Name: "alert_configuration",
+		Columns: []*migrator.Column{
+			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "alertmanager_configuration", Type: migrator.DB_Text, Nullable: false},
+			{Name: "alertmanager_templates", Type: migrator.DB_Text, Nullable: true},
+			{Name: "configuration_version", Type: migrator.DB_NVarchar, Length: 3, Nullable: true}, // In a format of vXX e.g. v1, v2, v10, etc
+			{Name: "created_at", Type: migrator.DB_Int, Nullable: false},
+			{Name: "updated_at", Type: migrator.DB_Int, Nullable: false},
+		},
+	}
+
+	mg.AddMigration("create_alert_configuration_table", migrator.NewAddTableMigration(alertConfiguration))
+}

--- a/pkg/services/ngalert/database_mig.go
+++ b/pkg/services/ngalert/database_mig.go
@@ -114,7 +114,6 @@ func alertmanagerConfigurationMigration(mg *migrator.Migrator) {
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "alertmanager_configuration", Type: migrator.DB_Text, Nullable: false},
-			{Name: "alertmanager_templates", Type: migrator.DB_Text, Nullable: true},
 			{Name: "configuration_version", Type: migrator.DB_NVarchar, Length: 3}, // In a format of vXX e.g. v1, v2, v10, etc
 			{Name: "created_at", Type: migrator.DB_Int, Nullable: false},
 			{Name: "updated_at", Type: migrator.DB_Int, Nullable: false},

--- a/pkg/services/ngalert/database_mig.go
+++ b/pkg/services/ngalert/database_mig.go
@@ -115,7 +115,7 @@ func alertmanagerConfigurationMigration(mg *migrator.Migrator) {
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "alertmanager_configuration", Type: migrator.DB_Text, Nullable: false},
 			{Name: "alertmanager_templates", Type: migrator.DB_Text, Nullable: true},
-			{Name: "configuration_version", Type: migrator.DB_NVarchar, Length: 3, Nullable: true}, // In a format of vXX e.g. v1, v2, v10, etc
+			{Name: "configuration_version", Type: migrator.DB_NVarchar, Length: 3}, // In a format of vXX e.g. v1, v2, v10, etc
 			{Name: "created_at", Type: migrator.DB_Int, Nullable: false},
 			{Name: "updated_at", Type: migrator.DB_Int, Nullable: false},
 		},

--- a/pkg/services/ngalert/models/alertmanager.go
+++ b/pkg/services/ngalert/models/alertmanager.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// AlertConfiguration represents a single version of the Alerting Engine Configuration.
+type AlertConfiguration struct {
+	ID int64 `xorm:"pk autoincr 'id'"`
+
+	AlertmanagerConfiguration string
+	AlertmanagerTemplates     string
+	ConfigurationVersion      string
+	CreatedAt                 time.Time `xorm:"created"`
+	UpdatedAt                 time.Time `xorm:"updated"`
+}
+
+// GetLatestAlertmanagerConfigurationQuery is the query to get the latest alertmanager configuration.
+type GetLatestAlertmanagerConfigurationQuery struct {
+	ID int64
+
+	Result *AlertConfiguration
+}

--- a/pkg/services/ngalert/models/alertmanager.go
+++ b/pkg/services/ngalert/models/alertmanager.go
@@ -7,7 +7,6 @@ type AlertConfiguration struct {
 	ID int64 `xorm:"pk autoincr 'id'"`
 
 	AlertmanagerConfiguration string
-	AlertmanagerTemplates     string
 	ConfigurationVersion      string
 	CreatedAt                 time.Time `xorm:"created"`
 	UpdatedAt                 time.Time `xorm:"updated"`

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -104,4 +104,5 @@ func (ng *AlertNG) AddMigration(mg *migrator.Migrator) {
 	addAlertDefinitionVersionMigrations(mg)
 	// Create alert_instance table
 	alertInstanceMigration(mg)
+	alertmanagerConfigurationMigration(mg)
 }

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+var (
+	// ErrNoAlertmanagerConfiguration is an error for when no alertmanager configuration is found.
+	ErrNoAlertmanagerConfiguration = fmt.Errorf("could not find an alert configuration")
+)
+
+// GetLatestAlertmanagerConfiguration returns the lastest version of the alertmanager configuraiton.
+// It returns ErrNoAlertmanagerConfiguration if no configuration is found.
+func (st DBstore) GetLatestAlertmanagerConfiguration(cmd *models.GetLatestAlertmanagerConfigurationQuery) error {
+	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		c := &models.AlertConfiguration{}
+		// The ID is already an auto incremental column, using the ID as an order should guarantee the latest.
+		ok, err := sess.Desc("id").Limit(1).Get(c)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			return ErrNoAlertmanagerConfiguration
+		}
+
+		cmd.Result = c
+		return nil
+	})
+}

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -15,7 +15,7 @@ var (
 
 // GetLatestAlertmanagerConfiguration returns the lastest version of the alertmanager configuration.
 // It returns ErrNoAlertmanagerConfiguration if no configuration is found.
-func (st DBstore) GetLatestAlertmanagerConfiguration(cmd *models.GetLatestAlertmanagerConfigurationQuery) error {
+func (st DBstore) GetLatestAlertmanagerConfiguration(query *models.GetLatestAlertmanagerConfigurationQuery) error {
 	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		c := &models.AlertConfiguration{}
 		// The ID is already an auto incremental column, using the ID as an order should guarantee the latest.
@@ -28,7 +28,7 @@ func (st DBstore) GetLatestAlertmanagerConfiguration(cmd *models.GetLatestAlertm
 			return ErrNoAlertmanagerConfiguration
 		}
 
-		cmd.Result = c
+		query.Result = c
 		return nil
 	})
 }

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -13,7 +13,7 @@ var (
 	ErrNoAlertmanagerConfiguration = fmt.Errorf("could not find an alert configuration")
 )
 
-// GetLatestAlertmanagerConfiguration returns the lastest version of the alertmanager configuraiton.
+// GetLatestAlertmanagerConfiguration returns the lastest version of the alertmanager configuration.
 // It returns ErrNoAlertmanagerConfiguration if no configuration is found.
 func (st DBstore) GetLatestAlertmanagerConfiguration(cmd *models.GetLatestAlertmanagerConfigurationQuery) error {
 	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {

--- a/pkg/services/ngalert/store/database.go
+++ b/pkg/services/ngalert/store/database.go
@@ -35,6 +35,9 @@ type Store interface {
 	SaveAlertInstance(cmd *models.SaveAlertInstanceCommand) error
 	ValidateAlertDefinition(*models.AlertDefinition, bool) error
 	UpdateAlertDefinitionPaused(*models.UpdateAlertDefinitionPausedCommand) error
+
+	// Alertmanager
+	GetLatestAlertmanagerConfiguration(cmd *models.GetLatestAlertmanagerConfigurationQuery) error
 }
 
 // DBstore stores the alert definitions and instances in the database.


### PR DESCRIPTION
**What this PR does / why we need it**:

Alerting configuration is persisted by the API but picked up on the alerting instance via the database. We need a database table to store it.


**Special notes for your reviewer**:

This only includes the migration and a method to get configuration, I'll leave the persisting of the configuration to a separate pull request.