### PR TITLE
API Response implements http.ResponseWriter

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -562,10 +562,10 @@ func CalculateDashboardDiff(c *models.ReqContext, apiOptions dtos.CalculateDiffO
 	}
 
 	if options.DiffType == dashdiffs.DiffDelta {
-		return response.Respond(200, result.Delta).Header("Content-Type", "application/json")
+		return response.Respond(200, result.Delta).SetHeader("Content-Type", "application/json")
 	}
 
-	return response.Respond(200, result.Delta).Header("Content-Type", "text/html")
+	return response.Respond(200, result.Delta).SetHeader("Content-Type", "text/html")
 }
 
 // RestoreDashboardVersion restores a dashboard to the given version.

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -175,7 +175,7 @@ func GetDashboardSnapshot(c *models.ReqContext) response.Response {
 
 	metrics.MApiDashboardSnapshotGet.Inc()
 
-	return response.JSON(200, dto).Header("Cache-Control", "public, max-age=3600")
+	return response.JSON(200, dto).SetHeader("Cache-Control", "public, max-age=3600")
 }
 
 func deleteExternalDashboardSnapshot(externalUrl string) error {

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -244,7 +244,7 @@ func (hs *HTTPServer) GetPluginMarkdown(c *models.ReqContext) response.Response 
 	}
 
 	resp := response.Respond(200, content)
-	resp.Header("Content-Type", "text/plain; charset=utf-8")
+	resp.SetHeader("Content-Type", "text/plain; charset=utf-8")
 	return resp
 }
 

--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -70,7 +70,7 @@ func (r *NormalResponse) WriteTo(ctx *models.ReqContext) {
 	}
 }
 
-func (r *NormalResponse) Header(key, value string) *NormalResponse {
+func (r *NormalResponse) SetHeader(key, value string) *NormalResponse {
 	r.header.Set(key, value)
 	return r
 }
@@ -137,7 +137,7 @@ func (r *RedirectResponse) Body() []byte {
 
 // JSON creates a JSON response.
 func JSON(status int, body interface{}) *NormalResponse {
-	return Respond(status, body).Header("Content-Type", "application/json")
+	return Respond(status, body).SetHeader("Content-Type", "application/json")
 }
 
 // JSONStreaming creates a streaming JSON response.

--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -1,6 +1,7 @@
 package response
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 
@@ -22,17 +23,33 @@ type Response interface {
 func CreateNormalResponse(header http.Header, body []byte, status int) *NormalResponse {
 	return &NormalResponse{
 		header: header,
-		body:   body,
+		body:   bytes.NewBuffer(body),
 		status: status,
 	}
 }
 
 type NormalResponse struct {
 	status     int
-	body       []byte
+	body       *bytes.Buffer
 	header     http.Header
 	errMessage string
 	err        error
+	http.ResponseWriter
+}
+
+// Write implements http.ResponseWriter
+func (r *NormalResponse) Write(b []byte) (int, error) {
+	return r.body.Write(b)
+}
+
+// Header implements http.ResponseWriter
+func (r *NormalResponse) Header() http.Header {
+	return r.header
+}
+
+// WriteHeader implements http.ResponseWriter
+func (r *NormalResponse) WriteHeader(statusCode int) {
+	r.status = statusCode
 }
 
 // Status gets the response's status.
@@ -42,7 +59,7 @@ func (r *NormalResponse) Status() int {
 
 // Body gets the response's body.
 func (r *NormalResponse) Body() []byte {
-	return r.body
+	return r.body.Bytes()
 }
 
 // Err gets the response's err.
@@ -65,7 +82,7 @@ func (r *NormalResponse) WriteTo(ctx *models.ReqContext) {
 		header[k] = v
 	}
 	ctx.Resp.WriteHeader(r.status)
-	if _, err := ctx.Resp.Write(r.body); err != nil {
+	if _, err := ctx.Resp.Write(r.body.Bytes()); err != nil {
 		ctx.Logger.Error("Error writing to response", "err", err)
 	}
 }
@@ -211,7 +228,7 @@ func Respond(status int, body interface{}) *NormalResponse {
 
 	return &NormalResponse{
 		status: status,
-		body:   b,
+		body:   bytes.NewBuffer(b),
 		header: make(http.Header),
 	}
 }


### PR DESCRIPTION
Followup on https://github.com/grafana/grafana/pull/31927

In order to support the new alerting initiative, we'll need to fulfill API methods with signatures like 
```go
func(ctx *models.ReqContext) response.Response
```
Currently, it's hard to use some of the existing proxy work mainly because it doesn't expose the same type signature (it omits a return value):
```go
func (p *DatasourceProxyService) ProxyDataSourceRequest(c *models.ReqContext)
```

This PR does a few things, namely:
1) Renames the `Header` method to `SetHeader` to free up the former name (reserved by `http.ResponseWriter`)
2) Implements `http.ResponseWriter` for the `*NormalResponse` type.

In turn, this should allow us to align both approaches, such as via:

```go
// withBufferedRW is a hack to work around the type signature exposed by the datasource proxy
// which uses the underlying ResponseWriter vs what we need to expose implementing the API services
// (which return a response.Response). Therefore, we replace the response writer so that we can return it.
func withBufferedRW(ctx *models.ReqContext) (*models.ReqContext, response.Response) {
	resp := response.CreateNormalResponse(make(http.Header), nil, 0)
	cpy := *ctx

	cpy.Resp = macaron.NewResponseWriter(ctx.Req.Method, resp)
	return &cpy, resp
}

// unmodofiedProxy passes a request to a datasource unaltered.
func (r *LotexRuler) unmodifiedProxy(ctx *models.ReqContext) response.Response {
	newCtx, resp := withBufferedRW(ctx)
	r.DataProxy.ProxyDatasourceRequestWithID(newCtx, ctx.ParamsInt64("DatasourceId"))
	return resp
}
```

Although this example isn't part of the PR - please let me know if you see a more elegant way to do this :)