### PR TITLE
[WIP] Github Actions: Add `go mod tidy` github action

### DIFF
--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -2,10 +2,10 @@
 # It is meant to run daily based on a cronjob.
 name: go tidy
 
+# Go tidy is meant to run daily at midnight
 on:
-  push:
-    branches:
-      - test-go-tidy-github-action
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
@@ -19,7 +19,6 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
-        with: { ref: test-go-tidy-github-action }
       -
         name: Set up Git
         run: |

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -52,7 +52,7 @@ jobs:
         uses: dsotirakis/create-pull-request@v3
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
-          branch: pr-creator
+          branch: update-go-modules
           commit-message: Update go modules
           path: grafana
           title: 'Chore(deps): Update go modules'
@@ -60,3 +60,4 @@ jobs:
           body: >
             Auto-generated PR to update go modules.
           labels: type/chore
+          delete-branch: true

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -42,14 +42,13 @@ jobs:
           git config user.email ${EMAIL}
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/grafana/grafana.git
       -
-        name: Run go mod tidy
-        run: |
-          cd grafana
-          rm -f go.sum
-          go mod tidy
-      -
         name: Checkout OSS repo
         uses: actions/checkout@v2
+      -
+        name: Run go mod tidy
+        run: |
+          rm -f go.sum
+          go mod tidy
       -
         name: Create Pull Request
         uses: dsotirakis/create-pull-request@v3

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -4,8 +4,7 @@ name: go tidy
 on:
   push:
     branches:
-    - master
-    - v[0-9]+.[0-9]+.[0-9]+
+    - test-go-tidy-github-action
 
 env:
   GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
@@ -17,22 +16,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
+        name: Checkout OSS repo
         uses: actions/checkout@v2
+        with:
+          repository: grafana/grafana
+          path: grafana
+      -
+        name: Checkout enterprise
+        uses: actions/checkout@v2
+        with:
+          repository: grafana/grafana-enterprise
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          path: grafana-enterprise
+      -
+        name: Copy enterprise bits into OSS repo
+        run: |
+          cd grafana-enterprise
+          git fetch && git checkout $(echo $GITHUB_REF | cut -d'/' -f 3)
+          git branch --show-current
+          ./dev.sh >/dev/null
       -
         name: Set up Git
         run: |
+          cd ../grafana/grafana
           git config user.name ${USERNAME}
           git config user.email ${EMAIL}
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/grafana/grafana.git
       -
         name: Run go mod tidy
         run: |
+          cd grafana
           rm -f go.sum
           go mod tidy
       -
         name: Commit and push go.sum
         run: |
+          cd grafana
           git add .
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
             git commit -m 'Update go module dependencies'

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -1,0 +1,41 @@
+# This action is responsible for running `go mod tidy` to sync go dependencies.
+# It is meant to run daily based on a cronjob.
+name: go tidy
+
+on:
+  push:
+    branches:
+      - test-go-tidy-github-action
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+  USERNAME: grafanabot
+  EMAIL: bot@grafana.com
+
+jobs:
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with: { ref: test-go-tidy-github-action }
+      -
+        name: Set up Git
+        run: |
+          git config user.name ${USERNAME}
+          git config user.email ${EMAIL}
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/grafana/grafana.git
+      -
+        name: Run go mod tidy
+        run: |
+          rm -f go.sum
+          go mod tidy
+      -
+        name: Commit and push go.sum
+        run: |
+          git add .
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'Update go module dependencies'
+            git push
+          fi

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -22,6 +22,11 @@ jobs:
           repository: grafana/grafana
           path: grafana
       -
+        name: Get current branch name
+        id: triggered_branch
+        run: |
+          echo ::set-output name=branch_name::$(echo $GITHUB_REF | cut -d'/' -f 3)
+      -
         name: Checkout enterprise
         uses: actions/checkout@v2
         with:
@@ -53,6 +58,7 @@ jobs:
         with:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           branch: update-go-modules
+          base: ${{ steps.triggered_branch.outputs.branch_name }}
           commit-message: Update go modules
           path: grafana
           title: 'Chore(deps): Update go modules'

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -1,11 +1,11 @@
 # This action is responsible for running `go mod tidy` to sync go dependencies.
-# It is meant to run daily based on a cronjob.
 name: go tidy
 
-# Go tidy is meant to run daily at midnight
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches:
+    - master
+    - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
@@ -13,7 +13,7 @@ env:
   EMAIL: bot@grafana.com
 
 jobs:
-  tidy:
+  tidy-master:
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -42,11 +42,9 @@ jobs:
           git config user.email ${EMAIL}
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/grafana/grafana.git
       -
-        name: Checkout OSS repo
-        uses: actions/checkout@v2
-      -
         name: Run go mod tidy
         run: |
+          cd grafana
           rm -f go.sum
           go mod tidy
       -
@@ -56,6 +54,7 @@ jobs:
           token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           branch: pr-creator
           commit-message: Update go modules
+          path: grafana
           title: 'Chore(deps): Update go modules'
           author: grafanabot <bot@grafana.com>
           body: >

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -12,7 +12,7 @@ env:
   EMAIL: bot@grafana.com
 
 jobs:
-  tidy-master:
+  go-tidy:
     runs-on: ubuntu-latest
     steps:
       -
@@ -33,7 +33,6 @@ jobs:
         run: |
           cd grafana-enterprise
           git fetch && git checkout $(echo $GITHUB_REF | cut -d'/' -f 3)
-          git branch --show-current
           ./dev.sh >/dev/null
       -
         name: Set up Git

--- a/.github/workflows/go-tidy.yml
+++ b/.github/workflows/go-tidy.yml
@@ -37,7 +37,7 @@ jobs:
       -
         name: Set up Git
         run: |
-          cd ../grafana/grafana
+          cd grafana
           git config user.name ${USERNAME}
           git config user.email ${EMAIL}
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/grafana/grafana.git
@@ -48,11 +48,17 @@ jobs:
           rm -f go.sum
           go mod tidy
       -
-        name: Commit and push go.sum
-        run: |
-          cd grafana
-          git add .
-          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-            git commit -m 'Update go module dependencies'
-            git push
-          fi
+        name: Checkout OSS repo
+        uses: actions/checkout@v2
+      -
+        name: Create Pull Request
+        uses: dsotirakis/create-pull-request@v3
+        with:
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          branch: pr-creator
+          commit-message: Update go modules
+          title: 'Chore(deps): Update go modules'
+          author: grafanabot <bot@grafana.com>
+          body: >
+            Auto-generated PR to update go modules.
+          labels: type/chore

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,6 @@ cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOY
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
-cloud.google.com/go v0.75.0 h1:XgtDnVJRCPEUG21gjFiRPz4zI1Mjg16R+NYQjfmU4XY=
 cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPTY=
 cloud.google.com/go v0.78.0 h1:oKpsiyKMfVpwR3zSAkQixGzlVE5ovitBuO0qSmCf0bI=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
@@ -233,7 +232,6 @@ github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b h1:L/QXpzIa3pO
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/bsm/sarama-cluster v2.1.13+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
-github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee h1:BnPxIde0gjtTnc9Er7cxvBk8DHLWhEux0SxayC8dP6I=
 github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=


### PR DESCRIPTION
**What this PR does / why we need it**:

Recently, we got onto an issue about go modules de-syncronisation between `grafana` and `grafana-enterprise`, resulting to failing pipelines on the enterprise side. This was due to an outdated `go.sum` between `v7.5.x` versions of the repos.

Until today, `dependabot` was responsible for tidying the go modules, but after Go 1.16, there are some known issues where `dependabot` cannot perform the command.

About a month ago, we removed `tidy-checks` from lint steps on our pipelines, since it was preventing us from running lints properly and proceeding to next steps.

A (temporary until dependabot is fixed?) solution, is to introduce a new github action to perform `go mod tidy` checks daily, to be sure we don't face de-sync issues between `grafana` and `grafana-enterprise` and branches per se.

**Special notes for your reviewer**:

You can check the first commit in this PR, where I triggered the job manually, and it produced the desired output.

- Github action: https://github.com/grafana/grafana/runs/2129407679
- Commit: https://github.com/grafana/grafana/pull/32052/commits/947d10a0880fe08ce94b004cadd41977c7d8879a
