### PR TITLE
GraphNG: Fix PlotLegend field display name being outdated

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { DataFrame, DisplayValue, fieldReducers, reduceField } from '@grafana/data';
+import { DataFrame, DisplayValue, fieldReducers, getFieldDisplayName, reduceField } from '@grafana/data';
 import { UPlotConfigBuilder } from './config/UPlotConfigBuilder';
 import { VizLegendItem, VizLegendOptions } from '../VizLegend/types';
 import { AxisPlacement } from './config';
@@ -55,12 +55,13 @@ export const PlotLegend: React.FC<PlotLegendProps> = ({
       }
 
       const field = data[fieldIndex.frameIndex]?.fields[fieldIndex.fieldIndex];
+      const label = getFieldDisplayName(field, data[fieldIndex.frameIndex]!);
 
       return {
         disabled: !seriesConfig.show ?? false,
         fieldIndex,
         color: seriesConfig.lineColor!,
-        label: seriesConfig.fieldName,
+        label,
         yAxis: axisPlacement === AxisPlacement.Left ? 1 : 2,
         getDisplayValues: () => {
           if (!calcs?.length) {
@@ -80,6 +81,7 @@ export const PlotLegend: React.FC<PlotLegendProps> = ({
             };
           });
         },
+        getItemKey: () => `${label}-${fieldIndex.frameIndex}-${fieldIndex.fieldIndex}`,
       };
     })
     .filter((i) => i !== undefined) as VizLegendItem[];


### PR DESCRIPTION
Plot legend uses plot config to generate legend items. But the plot config is not being refreshed when number of series or just names of the series change to optimize uPLot reinitialization, hence the once stored series name in the config may not reflect the current name.

This PR, in a way similar to TooltiplPlugin, gets the field name for the legend using the getFIeldDisplayName function.

fixes https://github.com/grafana/grafana/issues/31714