### PR TITLE
Chore: Downgrade to node:14.16.0-alpine3.13 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.11.0-alpine3.13 as js-builder
+FROM node:14.16.0-alpine3.13 as js-builder
 
 WORKDIR /usr/src/app/
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There are some flakey builds lately on Drone. After some investigation by @jackw, it seems like the issue _might have been_
caused [due to this PR](https://github.com/grafana/grafana/pull/31802).

We'll try to downgrade to the latest LTS version to see if it solves the issue.

**Special notes for your reviewer**:
Try running `make build-docker-full` on your local machine.
