### PR TITLE
Plugins ci images: Fix build script - nodejs conflict

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -10,7 +10,9 @@ mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 rm /bin/cp
 mv /usr/local/bin/cp /bin/cp
 
-apk add --no-cache curl 'nodejs-current=14.5.0-r0' npm yarn build-base openssh git-lfs perl-utils coreutils python3
+apk add --update nodejs
+apk add --update npm
+apk add --no-cache curl yarn build-base openssh git-lfs perl-utils coreutils python3
 
 #
 # Only relevant for testing, but cypress does not work with musl/alpine.

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -10,9 +10,7 @@ mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 rm /bin/cp
 mv /usr/local/bin/cp /bin/cp
 
-apk add --update nodejs
-apk add --update npm
-apk add --no-cache curl yarn build-base openssh git-lfs perl-utils coreutils python3
+apk add --no-cache nodejs npm curl yarn build-base openssh git-lfs perl-utils coreutils python3
 
 #
 # Only relevant for testing, but cypress does not work with musl/alpine.


### PR DESCRIPTION
**What this PR does / why we need it**:
The grafana-plugin-ci-alpine build script was failing.  Looks like apk was trying to pull an older version of nodejs.

**Special notes for your reviewer**:
@ryantxu 
needed to deploy grafana-plugin-ci-alpine:1.2.0 to dockerhub

