### PR TITLE
Logs: If log message missing, use empty string

### DIFF
--- a/public/app/core/logs_model.test.ts
+++ b/public/app/core/logs_model.test.ts
@@ -678,6 +678,56 @@ describe('logSeriesToLogsModel', () => {
       },
     ]);
   });
+
+  it('should return cempty string if message field is undefined', () => {
+    const logSeries: DataFrame[] = [
+      toDataFrame({
+        fields: [
+          {
+            name: 'ts',
+            type: FieldType.time,
+            values: ['1970-01-01T00:00:01Z', '1970-02-01T00:00:01Z', '1970-03-01T00:00:01Z'],
+          },
+          {
+            name: 'line',
+            type: FieldType.string,
+            values: ['WARN boooo 0', undefined, 'WARN boooo 2'],
+            labels: {
+              foo: 'bar',
+              level: 'dbug',
+            },
+          },
+          {
+            name: 'id',
+            type: FieldType.string,
+            values: ['0', '1', '2'],
+          },
+        ],
+        refId: 'A',
+        meta: {},
+      }),
+    ];
+
+    const logsModel = dataFrameToLogsModel(logSeries, 0, 'utc');
+    expect(logsModel.rows).toHaveLength(3);
+    expect(logsModel.rows).toMatchObject([
+      {
+        entry: 'WARN boooo 0',
+        labels: { foo: 'bar' },
+        logLevel: LogLevel.debug,
+      },
+      {
+        entry: '',
+        labels: { foo: 'bar' },
+        logLevel: LogLevel.debug,
+      },
+      {
+        entry: 'WARN boooo 2',
+        labels: { foo: 'bar' },
+        logLevel: LogLevel.debug,
+      },
+    ]);
+  });
 });
 
 describe('getSeriesProperties()', () => {

--- a/public/app/core/logs_model.test.ts
+++ b/public/app/core/logs_model.test.ts
@@ -679,7 +679,7 @@ describe('logSeriesToLogsModel', () => {
     ]);
   });
 
-  it('should return cempty string if message field is undefined', () => {
+  it('should return empty string if message field is undefined', () => {
     const logSeries: DataFrame[] = [
       toDataFrame({
         fields: [

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -356,7 +356,8 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
       const tsNs = timeNanosecondField ? timeNanosecondField.values.get(j) : undefined;
       const timeEpochNs = tsNs ? tsNs : time.valueOf() + '000000';
 
-      const messageValue: unknown = stringField.values.get(j);
+      // In edge cases, this can be undefined. If undefined, we want to replace it with empty string.
+      const messageValue: unknown = stringField.values.get(j) ?? '';
       // This should be string but sometimes isn't (eg elastic) because the dataFrame is not strongly typed.
       const message: string = typeof messageValue === 'string' ? messageValue : JSON.stringify(messageValue);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When we are processing log message, we rely on the fact that it is string. However, in some edge cases, we can get log message to be undefined. In this case, we want to replace it with empty string, so the processing of log isn't broken and we don't throw an error.

