### PR TITLE
DashNav: Pass typed event through the DashNav button onClick handler

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
@@ -8,7 +8,7 @@ import { GrafanaTheme } from '@grafana/data';
 interface Props {
   icon?: IconName;
   tooltip: string;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement) => void;
   href?: string;
   children?: React.ReactNode;
   iconType?: IconType;

--- a/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
@@ -8,7 +8,7 @@ import { GrafanaTheme } from '@grafana/data';
 interface Props {
   icon?: IconName;
   tooltip: string;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement) => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   href?: string;
   children?: React.ReactNode;
   iconType?: IconType;

--- a/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNavButton.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, MouseEvent } from 'react';
 import { css } from 'emotion';
 // Components
 import { IconName, IconType, IconSize, IconButton, useTheme, stylesFactory } from '@grafana/ui';
@@ -8,7 +8,7 @@ import { GrafanaTheme } from '@grafana/data';
 interface Props {
   icon?: IconName;
   tooltip: string;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   href?: string;
   children?: React.ReactNode;
   iconType?: IconType;


### PR DESCRIPTION
**What this PR does / why we need it**:

`Event.stopPropagation()` method needs to be called in some cases.  The proposed change addresses typescript error 

> Type '(event: ...) => void' is not assignable to type '() => void'

**Special notes for your reviewer**:

There are already some places where "event" is declared, for example

https://github.com/grafana/grafana/blob/6668161a88700399194a6e9d3b9f9a83383d023f/public/app/features/dashboard/panel_editor/QueryEditorRowTitle.tsx#L7-L14

I specified it as HTMLButtonElement because DashNav uses onClick on buttons only: [here](https://github.com/grafana/grafana/blob/010f20c1c86147920dd05a42bc7c78c879f387df/public/app/features/dashboard/components/DashNav/DashNavButton.tsx#L62-L66) and [here](https://github.com/grafana/grafana/blob/6668161a88700399194a6e9d3b9f9a83383d023f/packages/grafana-ui/src/components/IconButton/IconButton.tsx#L34-L36).