### PR TITLE
PluginManager: Make remaining plugin state non-global

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -275,7 +275,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		apiRoute.Group("/plugins", func(pluginRoute routing.RouteRegister) {
 			pluginRoute.Get("/:pluginId/dashboards/", routing.Wrap(hs.GetPluginDashboards))
-			pluginRoute.Post("/:pluginId/settings", bind(models.UpdatePluginSettingCmd{}), routing.Wrap(UpdatePluginSetting))
+			pluginRoute.Post("/:pluginId/settings", bind(models.UpdatePluginSettingCmd{}), routing.Wrap(hs.UpdatePluginSetting))
 			pluginRoute.Get("/:pluginId/metrics", routing.Wrap(hs.CollectPluginMetrics))
 		}, reqOrgAdmin)
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -447,6 +447,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Delete("/api/snapshots/:key", reqEditorRole, routing.Wrap(DeleteDashboardSnapshot))
 
 	// Frontend logs
-	sourceMapStore := frontendlogging.NewSourceMapStore(hs.Cfg, frontendlogging.ReadSourceMapFromFS)
-	r.Post("/log", middleware.RateLimit(hs.Cfg.Sentry.EndpointRPS, hs.Cfg.Sentry.EndpointBurst, time.Now), bind(frontendlogging.FrontendSentryEvent{}), routing.Wrap(NewFrontendLogMessageHandler(sourceMapStore)))
+	sourceMapStore := frontendlogging.NewSourceMapStore(hs.Cfg, hs.PluginManager, frontendlogging.ReadSourceMapFromFS)
+	r.Post("/log", middleware.RateLimit(hs.Cfg.Sentry.EndpointRPS, hs.Cfg.Sentry.EndpointBurst, time.Now),
+		bind(frontendlogging.FrontendSentryEvent{}), routing.Wrap(NewFrontendLogMessageHandler(sourceMapStore)))
 }

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/util"
 	macaron "gopkg.in/macaron.v1"
 )
@@ -32,7 +31,7 @@ func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 
-	for _, plugin := range manager.Apps {
+	for _, plugin := range hs.PluginManager.Apps() {
 		for _, route := range plugin.Routes {
 			url := util.JoinURLFragments("/api/plugin-proxy/"+plugin.Id, route.Path)
 			handlers := make([]macaron.Handler, 0)

--- a/pkg/api/fakes.go
+++ b/pkg/api/fakes.go
@@ -4,6 +4,8 @@ import "github.com/grafana/grafana/pkg/plugins"
 
 type fakePluginManager struct {
 	plugins.Manager
+
+	staticRoutes []*plugins.PluginStaticRoute
 }
 
 func (pm *fakePluginManager) GetPlugin(id string) *plugins.PluginBase {
@@ -16,4 +18,8 @@ func (pm *fakePluginManager) GetDataSource(id string) *plugins.DataSourcePlugin 
 
 func (pm *fakePluginManager) Renderer() *plugins.RendererPlugin {
 	return nil
+}
+
+func (pm *fakePluginManager) StaticRoutes() []*plugins.PluginStaticRoute {
+	return pm.staticRoutes
 }

--- a/pkg/api/frontendlogging/source_maps.go
+++ b/pkg/api/frontendlogging/source_maps.go
@@ -12,7 +12,7 @@ import (
 	sourcemap "github.com/go-sourcemap/sourcemap"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/grafana/grafana/pkg/plugins/manager"
+	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -47,12 +47,14 @@ type SourceMapStore struct {
 	cache         map[string]*sourceMap
 	cfg           *setting.Cfg
 	readSourceMap ReadSourceMapFn
+	pluginManager plugins.Manager
 }
 
-func NewSourceMapStore(cfg *setting.Cfg, readSourceMap ReadSourceMapFn) *SourceMapStore {
+func NewSourceMapStore(cfg *setting.Cfg, pluginManager plugins.Manager, readSourceMap ReadSourceMapFn) *SourceMapStore {
 	return &SourceMapStore{
 		cache:         make(map[string]*sourceMap),
 		cfg:           cfg,
+		pluginManager: pluginManager,
 		readSourceMap: readSourceMap,
 	}
 }
@@ -69,7 +71,8 @@ func (store *SourceMapStore) guessSourceMapLocation(sourceURL string) (*sourceMa
 	}
 
 	// determine if source comes from grafana core, locally or CDN, look in public build dir on fs
-	if strings.HasPrefix(u.Path, "/public/build/") || (store.cfg.CDNRootURL != nil && strings.HasPrefix(sourceURL, store.cfg.CDNRootURL.String()) && strings.Contains(u.Path, "/public/build/")) {
+	if strings.HasPrefix(u.Path, "/public/build/") || (store.cfg.CDNRootURL != nil &&
+		strings.HasPrefix(sourceURL, store.cfg.CDNRootURL.String()) && strings.Contains(u.Path, "/public/build/")) {
 		pathParts := strings.SplitN(u.Path, "/public/build/", 2)
 		if len(pathParts) == 2 {
 			return &sourceMapLocation{
@@ -80,7 +83,7 @@ func (store *SourceMapStore) guessSourceMapLocation(sourceURL string) (*sourceMa
 		}
 		// if source comes from a plugin, look in plugin dir
 	} else if strings.HasPrefix(u.Path, "/public/plugins/") {
-		for _, route := range manager.StaticRoutes {
+		for _, route := range store.pluginManager.StaticRoutes() {
 			pluginPrefix := filepath.Join("/public/plugins/", route.PluginId)
 			if strings.HasPrefix(u.Path, pluginPrefix) {
 				return &sourceMapLocation{

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -32,7 +32,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	_ "github.com/grafana/grafana/pkg/plugins/backendplugin/manager"
-	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/plugins/plugindashboards"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -321,7 +320,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 
 	m.Use(middleware.Recovery(hs.Cfg))
 
-	for _, route := range manager.StaticRoutes {
+	for _, route := range hs.PluginManager.StaticRoutes() {
 		pluginRoute := path.Join("/public/plugins/", route.PluginId)
 		hs.log.Debug("Plugins: Adding route", "route", pluginRoute, "dir", route.Directory)
 		hs.mapStatic(m, route.Directory, "", pluginRoute)

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -57,7 +57,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.orgs.count"] = statsQuery.Result.Orgs
 	metrics["stats.playlist.count"] = statsQuery.Result.Playlists
 	metrics["stats.plugins.apps.count"] = len(manager.Apps)
-	metrics["stats.plugins.panels.count"] = len(manager.Panels)
+	metrics["stats.plugins.panels.count"] = uss.PluginManager.PanelCount()
 	metrics["stats.plugins.datasources.count"] = uss.PluginManager.DataSourceCount()
 	metrics["stats.alerts.count"] = statsQuery.Result.Alerts
 	metrics["stats.active_users.count"] = statsQuery.Result.ActiveUsers

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/plugins/manager"
 )
 
 var usageStatsURL = "https://stats.grafana.org/grafana-usage-report"
@@ -56,7 +55,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.users.count"] = statsQuery.Result.Users
 	metrics["stats.orgs.count"] = statsQuery.Result.Orgs
 	metrics["stats.playlist.count"] = statsQuery.Result.Playlists
-	metrics["stats.plugins.apps.count"] = len(manager.Apps)
+	metrics["stats.plugins.apps.count"] = uss.PluginManager.AppCount()
 	metrics["stats.plugins.panels.count"] = uss.PluginManager.PanelCount()
 	metrics["stats.plugins.datasources.count"] = uss.PluginManager.DataSourceCount()
 	metrics["stats.alerts.count"] = statsQuery.Result.Alerts

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -294,7 +294,7 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, getSystemStatsQuery.Result.Users, metrics.Get("stats.users.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Orgs, metrics.Get("stats.orgs.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Playlists, metrics.Get("stats.playlist.count").MustInt64())
-			assert.Len(t, manager.Apps, metrics.Get("stats.plugins.apps.count").MustInt())
+			assert.Equal(t, uss.PluginManager.AppCount(), metrics.Get("stats.plugins.apps.count").MustInt())
 			assert.Equal(t, uss.PluginManager.PanelCount(), metrics.Get("stats.plugins.panels.count").MustInt())
 			assert.Equal(t, uss.PluginManager.DataSourceCount(), metrics.Get("stats.plugins.datasources.count").MustInt())
 			assert.Equal(t, getSystemStatsQuery.Result.Alerts, metrics.Get("stats.alerts.count").MustInt64())

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -294,8 +294,8 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, getSystemStatsQuery.Result.Users, metrics.Get("stats.users.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Orgs, metrics.Get("stats.orgs.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Playlists, metrics.Get("stats.playlist.count").MustInt64())
-			assert.Equal(t, len(manager.Apps), metrics.Get("stats.plugins.apps.count").MustInt())
-			assert.Equal(t, len(manager.Panels), metrics.Get("stats.plugins.panels.count").MustInt())
+			assert.Len(t, manager.Apps, metrics.Get("stats.plugins.apps.count").MustInt())
+			assert.Equal(t, uss.PluginManager.PanelCount(), metrics.Get("stats.plugins.panels.count").MustInt())
 			assert.Equal(t, uss.PluginManager.DataSourceCount(), metrics.Get("stats.plugins.datasources.count").MustInt())
 			assert.Equal(t, getSystemStatsQuery.Result.Alerts, metrics.Get("stats.alerts.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.ActiveUsers, metrics.Get("stats.active_users.count").MustInt64())
@@ -546,6 +546,7 @@ type fakePluginManager struct {
 	manager.PluginManager
 
 	dataSources map[string]*plugins.DataSourcePlugin
+	panels      map[string]*plugins.PanelPlugin
 }
 
 func (pm fakePluginManager) DataSourceCount() int {
@@ -554,6 +555,10 @@ func (pm fakePluginManager) DataSourceCount() int {
 
 func (pm fakePluginManager) GetDataSource(id string) *plugins.DataSourcePlugin {
 	return pm.dataSources[id]
+}
+
+func (pm fakePluginManager) PanelCount() int {
+	return len(pm.panels)
 }
 
 func setupSomeDataSourcePlugins(t *testing.T, uss *UsageStatsService) {

--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -38,6 +38,8 @@ type Manager interface {
 	GrafanaHasUpdate() bool
 	// Plugins gets all plugins.
 	Plugins() []*PluginBase
+	// StaticRoutes gets all static routes.
+	StaticRoutes() []*PluginStaticRoute
 	// GetPluginSettings gets settings for a certain plugin.
 	GetPluginSettings(orgID int64) (map[string]*models.PluginSettingInfoDTO, error)
 	// GetPluginDashboards gets dashboards for a certain org/plugin.

--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -41,6 +41,8 @@ type Manager interface {
 		requestHandler DataRequestHandler) (PluginDashboardInfoDTO, error)
 	// ScanningErrors returns plugin scanning errors encountered.
 	ScanningErrors() []PluginError
+	// LoadPluginDashboard loads a plugin dashboard.
+	LoadPluginDashboard(pluginID, path string) (*models.Dashboard, error)
 }
 
 type ImportDashboardInput struct {

--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -21,6 +21,8 @@ type Manager interface {
 	DataSourceCount() int
 	// DataSources gets all data sources.
 	DataSources() []*DataSourcePlugin
+	// PanelCount gets the number of panels.
+	PanelCount() int
 	// GetEnabledPlugins gets enabled plugins.
 	GetEnabledPlugins(orgID int64) (*EnabledPlugins, error)
 	// GrafanaLatestVersion gets the latest Grafana version.

--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -17,12 +17,19 @@ type Manager interface {
 	GetDataPlugin(id string) DataPlugin
 	// GetPlugin gets a plugin with a certain ID.
 	GetPlugin(id string) *PluginBase
+	// GetApp gets an app plugin with a certain ID.
+	GetApp(id string) *AppPlugin
 	// DataSourceCount gets the number of data sources.
 	DataSourceCount() int
 	// DataSources gets all data sources.
 	DataSources() []*DataSourcePlugin
+	// Apps gets all app plugins.
+	Apps() []*AppPlugin
 	// PanelCount gets the number of panels.
 	PanelCount() int
+	// AppCount gets the number of apps.
+	AppCount() int
+	// GetEnabledPlugins gets enabled plugins.
 	// GetEnabledPlugins gets enabled plugins.
 	GetEnabledPlugins(orgID int64) (*EnabledPlugins, error)
 	// GrafanaLatestVersion gets the latest Grafana version.
@@ -45,6 +52,8 @@ type Manager interface {
 	ScanningErrors() []PluginError
 	// LoadPluginDashboard loads a plugin dashboard.
 	LoadPluginDashboard(pluginID, path string) (*models.Dashboard, error)
+	// IsAppInstalled returns whether an app is installed.
+	IsAppInstalled(id string) bool
 }
 
 type ImportDashboardInput struct {

--- a/pkg/plugins/manager/dashboard_import_test.go
+++ b/pkg/plugins/manager/dashboard_import_test.go
@@ -78,16 +78,14 @@ func pluginScenario(t *testing.T, desc string, fn func(*testing.T, *PluginManage
 	t.Helper()
 
 	t.Run("Given a plugin", func(t *testing.T) {
-		pm := &PluginManager{
-			Cfg: &setting.Cfg{
-				FeatureToggles: map[string]bool{},
-				PluginSettings: setting.PluginSettings{
-					"test-app": map[string]string{
-						"path": "testdata/test-app",
-					},
+		pm := newManager(&setting.Cfg{
+			FeatureToggles: map[string]bool{},
+			PluginSettings: setting.PluginSettings{
+				"test-app": map[string]string{
+					"path": "testdata/test-app",
 				},
 			},
-		}
+		})
 		err := pm.Init()
 		require.NoError(t, err)
 

--- a/pkg/plugins/manager/dashboards.go
+++ b/pkg/plugins/manager/dashboards.go
@@ -10,16 +10,16 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 )
 
-func (pm *PluginManager) GetPluginDashboards(orgId int64, pluginId string) ([]*plugins.PluginDashboardInfoDTO, error) {
-	plugin, exists := pm.plugins[pluginId]
+func (pm *PluginManager) GetPluginDashboards(orgID int64, pluginID string) ([]*plugins.PluginDashboardInfoDTO, error) {
+	plugin, exists := pm.plugins[pluginID]
 	if !exists {
-		return nil, plugins.PluginNotFoundError{PluginID: pluginId}
+		return nil, plugins.PluginNotFoundError{PluginID: pluginID}
 	}
 
 	result := make([]*plugins.PluginDashboardInfoDTO, 0)
 
 	// load current dashboards
-	query := models.GetDashboardsByPluginIdQuery{OrgId: orgId, PluginId: pluginId}
+	query := models.GetDashboardsByPluginIdQuery{OrgId: orgID, PluginId: pluginID}
 	if err := bus.Dispatch(&query); err != nil {
 		return nil, err
 	}
@@ -70,10 +70,10 @@ func (pm *PluginManager) GetPluginDashboards(orgId int64, pluginId string) ([]*p
 	return result, nil
 }
 
-func (pm *PluginManager) LoadPluginDashboard(pluginId, path string) (*models.Dashboard, error) {
-	plugin, exists := pm.plugins[pluginId]
+func (pm *PluginManager) LoadPluginDashboard(pluginID, path string) (*models.Dashboard, error) {
+	plugin, exists := pm.plugins[pluginID]
 	if !exists {
-		return nil, plugins.PluginNotFoundError{PluginID: pluginId}
+		return nil, plugins.PluginNotFoundError{PluginID: pluginID}
 	}
 
 	dashboardFilePath := filepath.Join(plugin.PluginDir, path)

--- a/pkg/plugins/manager/dashboards_test.go
+++ b/pkg/plugins/manager/dashboards_test.go
@@ -7,61 +7,53 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestPluginDashboards(t *testing.T) {
-	Convey("When asking for plugin dashboard info", t, func() {
-		pm := &PluginManager{
-			Cfg: &setting.Cfg{
-				FeatureToggles: map[string]bool{},
-				PluginSettings: setting.PluginSettings{
-					"test-app": map[string]string{
-						"path": "testdata/test-app",
-					},
-				},
+func TestGetPluginDashboards(t *testing.T) {
+	pm := newManager(&setting.Cfg{
+		FeatureToggles: map[string]bool{},
+		PluginSettings: setting.PluginSettings{
+			"test-app": map[string]string{
+				"path": "testdata/test-app",
 			},
-		}
-		err := pm.Init()
-		So(err, ShouldBeNil)
-
-		bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
-			if query.Slug == "nginx-connections" {
-				dash := models.NewDashboard("Nginx Connections")
-				dash.Data.Set("revision", "1.1")
-				query.Result = dash
-				return nil
-			}
-
-			return models.ErrDashboardNotFound
-		})
-
-		bus.AddHandler("test", func(query *models.GetDashboardsByPluginIdQuery) error {
-			var data = simplejson.New()
-			data.Set("title", "Nginx Connections")
-			data.Set("revision", 22)
-
-			query.Result = []*models.Dashboard{
-				{Slug: "nginx-connections", Data: data},
-			}
-			return nil
-		})
-
-		dashboards, err := pm.GetPluginDashboards(1, "test-app")
-		So(err, ShouldBeNil)
-
-		Convey("should return 2 dashboards", func() {
-			So(len(dashboards), ShouldEqual, 2)
-		})
-
-		Convey("should include installed version info", func() {
-			So(dashboards[0].Title, ShouldEqual, "Nginx Connections")
-			So(dashboards[0].Revision, ShouldEqual, 25)
-			So(dashboards[0].ImportedRevision, ShouldEqual, 22)
-			So(dashboards[0].ImportedUri, ShouldEqual, "db/nginx-connections")
-
-			So(dashboards[1].Revision, ShouldEqual, 2)
-			So(dashboards[1].ImportedRevision, ShouldEqual, 0)
-		})
+		},
 	})
+	err := pm.Init()
+	require.NoError(t, err)
+
+	bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+		if query.Slug == "nginx-connections" {
+			dash := models.NewDashboard("Nginx Connections")
+			dash.Data.Set("revision", "1.1")
+			query.Result = dash
+			return nil
+		}
+
+		return models.ErrDashboardNotFound
+	})
+
+	bus.AddHandler("test", func(query *models.GetDashboardsByPluginIdQuery) error {
+		var data = simplejson.New()
+		data.Set("title", "Nginx Connections")
+		data.Set("revision", 22)
+
+		query.Result = []*models.Dashboard{
+			{Slug: "nginx-connections", Data: data},
+		}
+		return nil
+	})
+
+	dashboards, err := pm.GetPluginDashboards(1, "test-app")
+	require.NoError(t, err)
+
+	assert.Len(t, dashboards, 2)
+	assert.Equal(t, "Nginx Connections", dashboards[0].Title)
+	assert.Equal(t, int64(25), dashboards[0].Revision)
+	assert.Equal(t, int64(22), dashboards[0].ImportedRevision)
+	assert.Equal(t, "db/nginx-connections", dashboards[0].ImportedUri)
+
+	assert.Equal(t, int64(2), dashboards[1].Revision)
+	assert.Equal(t, int64(0), dashboards[1].ImportedRevision)
 }

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -679,10 +679,5 @@ func (pm *PluginManager) GetDataPlugin(id string) plugins.DataPlugin {
 }
 
 func (pm *PluginManager) StaticRoutes() []*plugins.PluginStaticRoute {
-	var rslt []*plugins.PluginStaticRoute
-	for _, p := range pm.staticRoutes {
-		rslt = append(rslt, p)
-	}
-
-	return rslt
+	return pm.staticRoutes
 }

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -28,8 +28,6 @@ import (
 )
 
 var (
-	PluginTypes map[string]interface{}
-
 	plog log.Logger
 )
 
@@ -77,25 +75,17 @@ func init() {
 
 func newManager(cfg *setting.Cfg) *PluginManager {
 	return &PluginManager{
-		Cfg:          cfg,
-		dataSources:  map[string]*plugins.DataSourcePlugin{},
-		plugins:      map[string]*plugins.PluginBase{},
-		panels:       map[string]*plugins.PanelPlugin{},
-		apps:         map[string]*plugins.AppPlugin{},
-		staticRoutes: []*plugins.PluginStaticRoute{},
+		Cfg:         cfg,
+		dataSources: map[string]*plugins.DataSourcePlugin{},
+		plugins:     map[string]*plugins.PluginBase{},
+		panels:      map[string]*plugins.PanelPlugin{},
+		apps:        map[string]*plugins.AppPlugin{},
 	}
 }
 
 func (pm *PluginManager) Init() error {
 	pm.log = log.New("plugins")
 	plog = log.New("plugins")
-
-	PluginTypes = map[string]interface{}{
-		"panel":      plugins.PanelPlugin{},
-		"datasource": plugins.DataSourcePlugin{},
-		"app":        plugins.AppPlugin{},
-		"renderer":   plugins.RendererPlugin{},
-	}
 	pm.pluginScanningErrors = map[string]plugins.PluginError{}
 
 	pm.log.Info("Starting plugin search")
@@ -299,6 +289,13 @@ func (pm *PluginManager) scan(pluginDir string, requireSigned bool) error {
 
 	pm.log.Debug("Initial plugin loading done")
 
+	pluginTypes := map[string]interface{}{
+		"panel":      plugins.PanelPlugin{},
+		"datasource": plugins.DataSourcePlugin{},
+		"app":        plugins.AppPlugin{},
+		"renderer":   plugins.RendererPlugin{},
+	}
+
 	// 2nd pass: Validate and register plugins
 	for dpath, plugin := range scanner.plugins {
 		// Try to find any root plugin
@@ -327,7 +324,7 @@ func (pm *PluginManager) scan(pluginDir string, requireSigned bool) error {
 
 		pm.log.Debug("Attempting to add plugin", "id", plugin.Id)
 
-		pluginGoType, exists := PluginTypes[plugin.Type]
+		pluginGoType, exists := pluginTypes[plugin.Type]
 		if !exists {
 			return fmt.Errorf("unknown plugin type %q", plugin.Type)
 		}

--- a/pkg/plugins/manager/manager_test.go
+++ b/pkg/plugins/manager/manager_test.go
@@ -31,7 +31,7 @@ func TestPluginManager_Init(t *testing.T) {
 
 		assert.Empty(t, pm.scanningErrors)
 		assert.Greater(t, len(pm.dataSources), 1)
-		assert.Greater(t, len(Panels), 1)
+		assert.Greater(t, len(pm.panels), 1)
 		assert.Equal(t, "app/plugins/datasource/graphite/module", pm.dataSources["graphite"].Module)
 		assert.NotEmpty(t, Apps)
 		assert.Equal(t, "public/plugins/test-app/img/logo_large.png", Apps["test-app"].Info.Logos.Large)
@@ -253,15 +253,12 @@ func createManager(t *testing.T, cbs ...func(*PluginManager)) *PluginManager {
 	staticRootPath, err := filepath.Abs("../../../public/")
 	require.NoError(t, err)
 
-	pm := &PluginManager{
-		Cfg: &setting.Cfg{
-			Raw:            ini.Empty(),
-			Env:            setting.Prod,
-			StaticRootPath: staticRootPath,
-		},
-		BackendPluginManager: &fakeBackendPluginManager{},
-		dataSources:          map[string]*plugins.DataSourcePlugin{},
-	}
+	pm := newManager(&setting.Cfg{
+		Raw:            ini.Empty(),
+		Env:            setting.Prod,
+		StaticRootPath: staticRootPath,
+	})
+	pm.BackendPluginManager = &fakeBackendPluginManager{}
 	for _, cb := range cbs {
 		cb(pm)
 	}

--- a/pkg/plugins/manager/manager_test.go
+++ b/pkg/plugins/manager/manager_test.go
@@ -33,9 +33,9 @@ func TestPluginManager_Init(t *testing.T) {
 		assert.Greater(t, len(pm.dataSources), 1)
 		assert.Greater(t, len(pm.panels), 1)
 		assert.Equal(t, "app/plugins/datasource/graphite/module", pm.dataSources["graphite"].Module)
-		assert.NotEmpty(t, Apps)
-		assert.Equal(t, "public/plugins/test-app/img/logo_large.png", Apps["test-app"].Info.Logos.Large)
-		assert.Equal(t, "public/plugins/test-app/img/screenshot2.png", Apps["test-app"].Info.Screenshots[1].Path)
+		assert.NotEmpty(t, pm.apps)
+		assert.Equal(t, "public/plugins/test-app/img/logo_large.png", pm.apps["test-app"].Info.Logos.Large)
+		assert.Equal(t, "public/plugins/test-app/img/screenshot2.png", pm.apps["test-app"].Info.Screenshots[1].Path)
 	})
 
 	t.Run("With external back-end plugin lacking signature", func(t *testing.T) {

--- a/pkg/plugins/manager/queries.go
+++ b/pkg/plugins/manager/queries.go
@@ -77,7 +77,7 @@ func (pm *PluginManager) GetEnabledPlugins(orgID int64) (*plugins.EnabledPlugins
 		}
 	}
 
-	for _, panel := range Panels {
+	for _, panel := range pm.panels {
 		if _, exists := pluginSettingMap[panel.Id]; exists {
 			enabledPlugins.Panels = append(enabledPlugins.Panels, panel)
 		}

--- a/pkg/plugins/manager/queries.go
+++ b/pkg/plugins/manager/queries.go
@@ -30,7 +30,7 @@ func (pm *PluginManager) GetPluginSettings(orgID int64) (map[string]*models.Plug
 		}
 
 		// apps are disabled by default unless autoEnabled: true
-		if app, exists := Apps[pluginDef.Id]; exists {
+		if app, exists := pm.apps[pluginDef.Id]; exists {
 			opt.Enabled = app.AutoEnabled
 			opt.Pinned = app.AutoEnabled
 		}
@@ -63,7 +63,7 @@ func (pm *PluginManager) GetEnabledPlugins(orgID int64) (*plugins.EnabledPlugins
 		return enabledPlugins, err
 	}
 
-	for pluginID, app := range Apps {
+	for pluginID, app := range pm.apps {
 		if b, ok := pluginSettingMap[pluginID]; ok {
 			app.Pinned = b.Pinned
 			enabledPlugins.Apps = append(enabledPlugins.Apps, app)
@@ -87,7 +87,7 @@ func (pm *PluginManager) GetEnabledPlugins(orgID int64) (*plugins.EnabledPlugins
 }
 
 // IsAppInstalled checks if an app plugin with provided plugin ID is installed.
-func IsAppInstalled(pluginID string) bool {
-	_, exists := Apps[pluginID]
+func (pm *PluginManager) IsAppInstalled(pluginID string) bool {
+	_, exists := pm.apps[pluginID]
 	return exists
 }

--- a/pkg/plugins/plugindashboards/service.go
+++ b/pkg/plugins/plugindashboards/service.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/tsdb"
@@ -21,9 +20,9 @@ func init() {
 }
 
 type Service struct {
-	DataService   *tsdb.Service          `inject:""`
-	PluginManager *manager.PluginManager `inject:""`
-	SQLStore      *sqlstore.SQLStore     `inject:""`
+	DataService   *tsdb.Service      `inject:""`
+	PluginManager plugins.Manager    `inject:""`
+	SQLStore      *sqlstore.SQLStore `inject:""`
 
 	logger log.Logger
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/middleware"
 	_ "github.com/grafana/grafana/pkg/plugins"
+	_ "github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/registry"
 	_ "github.com/grafana/grafana/pkg/services/alerting"
 	_ "github.com/grafana/grafana/pkg/services/auth"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/middleware"
-	_ "github.com/grafana/grafana/pkg/plugins"
 	_ "github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/registry"
 	_ "github.com/grafana/grafana/pkg/services/alerting"

--- a/pkg/services/provisioning/plugins/config_reader.go
+++ b/pkg/services/provisioning/plugins/config_reader.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/plugins/manager"
+	"github.com/grafana/grafana/pkg/plugins"
 	"gopkg.in/yaml.v2"
 )
 
@@ -17,11 +17,12 @@ type configReader interface {
 }
 
 type configReaderImpl struct {
-	log log.Logger
+	log           log.Logger
+	pluginManager plugins.Manager
 }
 
-func newConfigReader(logger log.Logger) configReader {
-	return &configReaderImpl{log: logger}
+func newConfigReader(logger log.Logger, pluginManager plugins.Manager) configReader {
+	return &configReaderImpl{log: logger, pluginManager: pluginManager}
 }
 
 func (cr *configReaderImpl) readConfig(path string) ([]*pluginsAsConfig, error) {
@@ -112,8 +113,8 @@ func (cr *configReaderImpl) validatePluginsConfig(apps []*pluginsAsConfig) error
 		}
 
 		for _, app := range apps[i].Apps {
-			if !manager.IsAppInstalled(app.PluginID) {
-				return fmt.Errorf("app plugin not installed: %s", app.PluginID)
+			if !cr.pluginManager.IsAppInstalled(app.PluginID) {
+				return fmt.Errorf("app plugin not installed: %q", app.PluginID)
 			}
 		}
 	}

--- a/pkg/services/provisioning/plugins/config_reader_test.go
+++ b/pkg/services/provisioning/plugins/config_reader_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,36 +19,38 @@ const (
 
 func TestConfigReader(t *testing.T) {
 	t.Run("Broken yaml should return error", func(t *testing.T) {
-		reader := newConfigReader(log.New("test logger"))
+		reader := newConfigReader(log.New("test logger"), nil)
 		_, err := reader.readConfig(brokenYaml)
 		require.Error(t, err)
 	})
 
 	t.Run("Skip invalid directory", func(t *testing.T) {
-		cfgProvider := newConfigReader(log.New("test logger"))
+		cfgProvider := newConfigReader(log.New("test logger"), nil)
 		cfg, err := cfgProvider.readConfig(emptyFolder)
 		require.NoError(t, err)
 		require.Len(t, cfg, 0)
 	})
 
 	t.Run("Unknown app plugin should return error", func(t *testing.T) {
-		cfgProvider := newConfigReader(log.New("test logger"))
+		cfgProvider := newConfigReader(log.New("test logger"), fakePluginManager{})
 		_, err := cfgProvider.readConfig(unknownApp)
 		require.Error(t, err)
-		require.Equal(t, "app plugin not installed: nonexisting", err.Error())
+		require.Equal(t, "app plugin not installed: \"nonexisting\"", err.Error())
 	})
 
 	t.Run("Read incorrect properties", func(t *testing.T) {
-		cfgProvider := newConfigReader(log.New("test logger"))
+		cfgProvider := newConfigReader(log.New("test logger"), nil)
 		_, err := cfgProvider.readConfig(incorrectSettings)
 		require.Error(t, err)
 		require.Equal(t, "app item 1 in configuration doesn't contain required field type", err.Error())
 	})
 
 	t.Run("Can read correct properties", func(t *testing.T) {
-		manager.Apps = map[string]*plugins.AppPlugin{
-			"test-plugin":   {},
-			"test-plugin-2": {},
+		pm := fakePluginManager{
+			apps: map[string]*plugins.AppPlugin{
+				"test-plugin":   {},
+				"test-plugin-2": {},
+			},
 		}
 
 		err := os.Setenv("ENABLE_PLUGIN_VAR", "test-plugin")
@@ -58,7 +59,7 @@ func TestConfigReader(t *testing.T) {
 			_ = os.Unsetenv("ENABLE_PLUGIN_VAR")
 		})
 
-		cfgProvider := newConfigReader(log.New("test logger"))
+		cfgProvider := newConfigReader(log.New("test logger"), pm)
 		cfg, err := cfgProvider.readConfig(correctProperties)
 		require.NoError(t, err)
 		require.Len(t, cfg, 1)
@@ -84,4 +85,15 @@ func TestConfigReader(t *testing.T) {
 			require.Equal(t, tc.ExpectedEnabled, app.Enabled)
 		}
 	})
+}
+
+type fakePluginManager struct {
+	plugins.Manager
+
+	apps map[string]*plugins.AppPlugin
+}
+
+func (pm fakePluginManager) IsAppInstalled(id string) bool {
+	_, exists := pm.apps[id]
+	return exists
 }

--- a/pkg/services/provisioning/plugins/plugin_provisioner.go
+++ b/pkg/services/provisioning/plugins/plugin_provisioner.go
@@ -6,12 +6,17 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/plugins"
 )
 
 // Provision scans a directory for provisioning config files
 // and provisions the app in those files.
-func Provision(configDirectory string) error {
-	ap := newAppProvisioner(log.New("provisioning.plugins"))
+func Provision(configDirectory string, pluginManager plugins.Manager) error {
+	logger := log.New("provisioning.plugins")
+	ap := PluginProvisioner{
+		log:         logger,
+		cfgProvider: newConfigReader(logger, pluginManager),
+	}
 	return ap.applyChanges(configDirectory)
 }
 
@@ -20,13 +25,6 @@ func Provision(configDirectory string) error {
 type PluginProvisioner struct {
 	log         log.Logger
 	cfgProvider configReader
-}
-
-func newAppProvisioner(log log.Logger) PluginProvisioner {
-	return PluginProvisioner{
-		log:         log,
-		cfgProvider: newConfigReader(log),
-	}
 }
 
 func (ap *PluginProvisioner) apply(cfg *pluginsAsConfig) error {

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -43,7 +43,7 @@ func newProvisioningServiceImpl(
 	newDashboardProvisioner dashboards.DashboardProvisionerFactory,
 	provisionNotifiers func(string) error,
 	provisionDatasources func(string) error,
-	provisionPlugins func(string) error,
+	provisionPlugins func(string, plugifaces.Manager) error,
 ) *provisioningServiceImpl {
 	return &provisioningServiceImpl{
 		log:                     log.New("provisioning"),
@@ -58,13 +58,14 @@ type provisioningServiceImpl struct {
 	Cfg                     *setting.Cfg                  `inject:""`
 	RequestHandler          plugifaces.DataRequestHandler `inject:""`
 	SQLStore                *sqlstore.SQLStore            `inject:""`
+	PluginManager           plugifaces.Manager            `inject:""`
 	log                     log.Logger
 	pollingCtxCancel        context.CancelFunc
 	newDashboardProvisioner dashboards.DashboardProvisionerFactory
 	dashboardProvisioner    dashboards.DashboardProvisioner
 	provisionNotifiers      func(string) error
 	provisionDatasources    func(string) error
-	provisionPlugins        func(string) error
+	provisionPlugins        func(string, plugifaces.Manager) error
 	mutex                   sync.Mutex
 }
 
@@ -124,7 +125,7 @@ func (ps *provisioningServiceImpl) ProvisionDatasources() error {
 
 func (ps *provisioningServiceImpl) ProvisionPlugins() error {
 	appPath := filepath.Join(ps.Cfg.ProvisioningPath, "plugins")
-	err := ps.provisionPlugins(appPath)
+	err := ps.provisionPlugins(appPath, ps.PluginManager)
 	return errutil.Wrap("app provisioning error", err)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Move remaining plugin state from package namespace to `pkg/plugins/manager.PluginManager`.

**Which issue(s) this PR fixes**:
Fixes #29022.

**Special notes for your reviewer**:
I've tested and can't find the PR breaks anything with enterprise.