### PR TITLE
SSE/InfluxDB: Change InfluxQL to work with server side expressions (#…

### DIFF
--- a/pkg/tsdb/influxdb/query.go
+++ b/pkg/tsdb/influxdb/query.go
@@ -77,7 +77,29 @@ func (query *Query) renderTags() []string {
 	return res
 }
 
+func isTimeRangeNumeric(tr *tsdb.TimeRange) bool {
+	if _, err := strconv.ParseInt(tr.From, 10, 64); err != nil {
+		return false
+	}
+	if _, err := strconv.ParseInt(tr.To, 10, 64); err != nil {
+		return false
+	}
+	return true
+}
+
 func (query *Query) renderTimeFilter(queryContext *tsdb.TsdbQuery) string {
+	// If from expressions
+	if isTimeRangeNumeric(queryContext.TimeRange) {
+		from, to, err := epochMStoInfluxTime(queryContext.TimeRange)
+		if err == nil {
+			return fmt.Sprintf(" time > %s and time < %s ", from, to)
+		}
+
+		// on error fallback to original time range processing.
+		glog.Warn("failed to parse expected time range in query, falling back to non-expression time range processing", "error", err)
+	}
+
+	// else from dashboard alerting
 	from := "now() - " + queryContext.TimeRange.From
 	to := ""
 
@@ -160,4 +182,18 @@ func (query *Query) renderTz() string {
 		return ""
 	}
 	return fmt.Sprintf(" tz('%s')", tz)
+}
+
+func epochMStoInfluxTime(tr *tsdb.TimeRange) (string, string, error) {
+	from, err := strconv.ParseInt(tr.From, 10, 64)
+	if err != nil {
+		return "", "", err
+	}
+
+	to, err := strconv.ParseInt(tr.To, 10, 64)
+	if err != nil {
+		return "", "", err
+	}
+
+	return fmt.Sprintf("%dms", from), fmt.Sprintf("%dms", to), nil
 }

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -127,7 +127,7 @@ func (rp *ResponseParser) parseTimepoint(valuePair []interface{}, valuePosition 
 		return tsdb.TimePoint{}, err
 	}
 
-	return tsdb.NewTimePoint(value, timestamp), nil
+	return tsdb.NewTimePoint(value, timestamp*1000), nil
 }
 
 func (rp *ResponseParser) parseValue(value interface{}) null.Float {


### PR DESCRIPTION
…31691)

* SSE/InfluxDB: Change InfluxQL to work with server side expressions
updates the request to handle EpochMS as the time range (which is what expressions sends)
and the response to use millisecond timestamps instead of seconds.
fixes #31604
similar to https://github.com/grafana/grafana/pull/31455

(cherry picked from commit 026bf1f9cac2e29fe120d23a35881b14a6e84ec0)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

