### PR TITLE
GraphNG: make sure data set and config are in sync when initializing and re-initializing uPlot

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/Plot.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.test.tsx
@@ -7,6 +7,7 @@ import uPlot from 'uplot';
 import createMockRaf from 'mock-raf';
 import { UPlotConfigBuilder } from './config/UPlotConfigBuilder';
 import { preparePlotData } from './utils';
+import { SeriesProps } from './config/UPlotSeriesBuilder';
 
 const mockRaf = createMockRaf();
 const setDataMock = jest.fn();
@@ -53,7 +54,7 @@ const mockData = () => {
   };
 
   const config = new UPlotConfigBuilder();
-  config.addSeries({});
+  config.addSeries({} as SeriesProps);
   return { data, timeRange, config };
 };
 
@@ -162,7 +163,7 @@ describe('UPlotChart', () => {
       expect(uPlot).toBeCalledTimes(1);
 
       const nextConfig = new UPlotConfigBuilder();
-      nextConfig.addSeries({});
+      nextConfig.addSeries({} as SeriesProps);
 
       rerender(
         <UPlotChart data={preparePlotData(data)} config={nextConfig} timeRange={timeRange} width={100} height={100} />
@@ -190,7 +191,7 @@ describe('UPlotChart', () => {
         mockRaf.step({ count: 1 });
       });
       const nextConfig = new UPlotConfigBuilder();
-      nextConfig.addSeries({});
+      nextConfig.addSeries({} as SeriesProps);
 
       rerender(
         <UPlotChart
@@ -211,7 +212,7 @@ describe('UPlotChart', () => {
       const { data, timeRange, config } = mockData();
 
       // 1 series in data, 2 series in config
-      config.addSeries({});
+      config.addSeries({} as SeriesProps);
 
       render(
         <UPlotChart
@@ -252,8 +253,8 @@ describe('UPlotChart', () => {
       });
 
       const nextConfig = new UPlotConfigBuilder();
-      nextConfig.addSeries({});
-      nextConfig.addSeries({});
+      nextConfig.addSeries({} as SeriesProps);
+      nextConfig.addSeries({} as SeriesProps);
 
       // 1 series in data, 2 series in config
       rerender(

--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -31,6 +31,14 @@ export const UPlotChart: React.FC<PlotProps> = (props) => {
       return;
     }
 
+    // 0. Exit if the data set length is different than number of series expected to render
+    // This may happen when GraphNG has not synced config yet with the aligned frame. Alignment happens before the render
+    // in the getDerivedStateFromProps, while the config creation happens in componentDidUpdate, causing one more render
+    // of the UPlotChart if the config needs to be updated.
+    if (currentConfig.current.series.length !== props.data.length) {
+      return;
+    }
+
     // 1. When config is ready and there is no uPlot instance, create new uPlot and return
     if (isConfigReady && !plotInstance.current) {
       plotInstance.current = initializePlot(props.data, currentConfig.current, canvasRef.current);


### PR DESCRIPTION
Due to the way data alignment(`getDerivedStateFromProps`) and config creation(`componentDidUpdate`) happens in the `GraphNG`, there might be updates to `UPlotChart` component that has data and config not in sync. In such cases, we should avoid any uPlot updates and wait until the config and data has settled.

I couldn't reproduce https://github.com/grafana/grafana/issues/31203 but I think this will fix https://github.com/grafana/grafana/issues/31203

Also, this fixes the following errors:
![image](https://user-images.githubusercontent.com/2376619/111631604-e1cc5700-87f3-11eb-974d-64c552176479.png)
