### PR TITLE
EchoSrv: remove deprecated tti-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,7 +292,6 @@
     "tether": "1.4.7",
     "tether-drop": "https://github.com/torkelo/drop",
     "tinycolor2": "1.4.1",
-    "tti-polyfill": "0.2.2",
     "uuid": "8.3.0",
     "visjs-network": "4.25.0",
     "whatwg-fetch": "3.1.0"

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -4,8 +4,6 @@ import 'regenerator-runtime/runtime';
 
 import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'; // fetch polyfill needed for PhantomJs rendering
-// @ts-ignore
-import ttiPolyfill from 'tti-polyfill';
 
 import 'file-saver';
 import 'jquery';
@@ -115,17 +113,24 @@ function initExtensions() {
 function initEchoSrv() {
   setEchoSrv(new Echo({ debug: process.env.NODE_ENV === 'development' }));
 
-  ttiPolyfill.getFirstConsistentlyInteractive().then((tti: any) => {
+  window.addEventListener('load', (e) => {
     // Collecting paint metrics first
-    const paintMetrics = performance && performance.getEntriesByType ? performance.getEntriesByType('paint') : [];
+    if (performance && performance.getEntriesByType) {
+      performance.mark('load');
 
-    for (const metric of paintMetrics) {
-      reportPerformance(metric.name, Math.round(metric.startTime + metric.duration));
+      const paintMetrics = performance.getEntriesByType('paint');
+
+      for (const metric of paintMetrics) {
+        reportPerformance(metric.name, Math.round(metric.startTime + metric.duration));
+      }
+
+      const loadMetric = performance.getEntriesByName('load')[0];
+      reportPerformance(loadMetric.name, Math.round(loadMetric.startTime + loadMetric.duration));
     }
-    reportPerformance('tti', tti);
   });
 
   registerEchoBackend(new PerformanceBackend({}));
+
   if (config.sentry.enabled) {
     registerEchoBackend(
       new SentryEchoBackend({

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -1,18 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <script nonce="[[.Nonce]]">
-      // https://github.com/GoogleChromeLabs/tti-polyfill
-      !(function () {
-        if ('PerformanceLongTaskTiming' in window) {
-          var g = (window.__tti = { e: [] });
-          g.o = new PerformanceObserver(function (l) {
-            g.e = g.e.concat(l.getEntries());
-          });
-          g.o.observe({ entryTypes: ['longtask'] });
-        }
-      })();
-    </script>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -25486,11 +25486,6 @@ tsutils@^3.17.1:
   dependencies:
     tslib "^1.8.1"
 
-tti-polyfill@0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/tti-polyfill/-/tti-polyfill-0.2.2.tgz#f7bbf71b13afa9edf60c8bb0d0c05f134e1513b9"
-  integrity sha512-URIoJxvsHThbQEJij29hIBUDHx9UNoBBCQVjy7L8PnzkqY8N6lsAI6h8JrT1Wt2lA0avus/DkuiJxd9qpfCpqw==
-
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"


### PR DESCRIPTION
deprecation notice: https://github.com/GoogleChromeLabs/tti-polyfill

i stumbled upon a curiosity where in performance profiles `tti-polyfill` appeared to be the initiator of expensive `fetch()` requests during dev dashboard refreshes. after removing it, the same requests are now properly attributed to RxJS observable orchestration machinery.

additionally `tti-polyfill` did not really appear to work consistently and would almost never hit the tti promise resolution, and when it did it was waaaay after the actual TTI.

this PR replaces it with a simple `window.load` listener that reports the same metrics plus the "load" event. i think the absolute numbers are not very important since our current app transfer size is ~11MB decompressed, and it's better to just track relative metrics until we trim this down significantly.