### PR TITLE
GraphNG: Ignore string fields when building data for uPlot in GraphNG

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -7,6 +7,7 @@ import {
   DataFrameFieldIndex,
   FieldMatcherID,
   fieldMatchers,
+  FieldType,
   TimeRange,
   TimeZone,
 } from '@grafana/data';
@@ -92,7 +93,7 @@ class UnthemedGraphNG extends React.Component<GraphNGProps, GraphNGState> {
 
     return {
       ...state,
-      data: preparePlotData(frame),
+      data: preparePlotData(frame, [FieldType.string]),
       alignedDataFrame: frame,
       seriesToDataFrameFieldIndexMap: frame.fields.map((f) => f.state!.origin!),
       dimFields,

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -33,21 +33,31 @@ export function buildPlotConfig(props: PlotProps, plugins: Record<string, PlotPl
 }
 
 /** @internal */
-export function preparePlotData(frame: DataFrame): AlignedData {
-  return frame.fields.map((f) => {
+export function preparePlotData(frame: DataFrame, ignoreFieldTypes?: FieldType[]): AlignedData {
+  const result: any[] = [];
+
+  for (let i = 0; i < frame.fields.length; i++) {
+    const f = frame.fields[i];
+
     if (f.type === FieldType.time) {
       if (f.values.length > 0 && typeof f.values.get(0) === 'string') {
         const timestamps = [];
         for (let i = 0; i < f.values.length; i++) {
           timestamps.push(dateTime(f.values.get(i)).valueOf());
         }
-        return timestamps;
+        result.push(timestamps);
+        continue;
       }
-      return f.values.toArray();
+      result.push(f.values.toArray());
+      continue;
     }
 
-    return f.values.toArray();
-  }) as AlignedData;
+    if (ignoreFieldTypes && ignoreFieldTypes.indexOf(f.type) > -1) {
+      continue;
+    }
+    result.push(f.values.toArray());
+  }
+  return result as AlignedData;
 }
 
 // Dev helpers


### PR DESCRIPTION
This is a quick fix for https://github.com/grafana/grafana/issues/32139

The issue is that we have not decided yet on what data should be passed to uPlot in the aligned frame. This is a quick fix and we need to followup on more solid approach going forward.