### PR TITLE
Explore: Show all dataFrames in data tab in Inspector

### DIFF
--- a/public/app/features/inspector/InspectDataTab.test.tsx
+++ b/public/app/features/inspector/InspectDataTab.test.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps } from 'react';
 import { FieldType } from '@grafana/data';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { InspectDataTab } from './InspectDataTab';
 
 const createProps = (propsOverride?: Partial<ComponentProps<typeof InspectDataTab>>) => {
@@ -48,18 +49,16 @@ describe('InspectDataTab', () => {
     it('should show available options', () => {
       render(<InspectDataTab {...createProps()} />);
       const dataOptions = screen.getByText(/Data options/i);
-      fireEvent.click(dataOptions);
+      userEvent.click(dataOptions);
       expect(screen.getByText(/Show data frame/i)).toBeInTheDocument();
       expect(screen.getByText(/Download for Excel/i)).toBeInTheDocument();
     });
     it('should show available dataFrame options', () => {
       render(<InspectDataTab {...createProps()} />);
       const dataOptions = screen.getByText(/Data options/i);
-      fireEvent.click(dataOptions);
-      const dataFrameInput = screen.getByLabelText(/Select dataframe/i);
-      fireEvent.change(dataFrameInput, {
-        target: { value: 1 },
-      });
+      userEvent.click(dataOptions);
+      const dataFrameInput = screen.getByRole('textbox', { name: /Select dataframe/i });
+      userEvent.click(dataFrameInput);
       expect(screen.getByText(/Second data frame/i)).toBeInTheDocument();
     });
   });

--- a/public/app/features/inspector/InspectDataTab.test.tsx
+++ b/public/app/features/inspector/InspectDataTab.test.tsx
@@ -1,0 +1,66 @@
+import React, { ComponentProps } from 'react';
+import { FieldType } from '@grafana/data';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InspectDataTab } from './InspectDataTab';
+
+const createProps = (propsOverride?: Partial<ComponentProps<typeof InspectDataTab>>) => {
+  const defaultProps = {
+    isLoading: false,
+    options: {
+      withTransforms: false,
+      withFieldConfig: false,
+    },
+    data: [
+      {
+        name: 'First data frame',
+        fields: [
+          { name: 'time', type: FieldType.time, values: [100, 200, 300] },
+          { name: 'name', type: FieldType.string, values: ['uniqueA', 'b', 'c'] },
+          { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+        ],
+        length: 3,
+      },
+      {
+        name: 'Second data frame',
+        fields: [
+          { name: 'time', type: FieldType.time, values: [400, 500, 600] },
+          { name: 'name', type: FieldType.string, values: ['d', 'e', 'g'] },
+          { name: 'value', type: FieldType.number, values: [4, 5, 6] },
+        ],
+        length: 3,
+      },
+    ],
+  };
+
+  return Object.assign(defaultProps, propsOverride) as ComponentProps<typeof InspectDataTab>;
+};
+
+describe('InspectDataTab', () => {
+  describe('when panel is not passed as prop (Explore)', () => {
+    it('should render InspectDataTab', () => {
+      render(<InspectDataTab {...createProps()} />);
+      expect(screen.getByLabelText(/Panel inspector Data content/i)).toBeInTheDocument();
+    });
+    it('should render Data Option row', () => {
+      render(<InspectDataTab {...createProps()} />);
+      expect(screen.getByText(/Data options/i)).toBeInTheDocument();
+    });
+    it('should show available options', () => {
+      render(<InspectDataTab {...createProps()} />);
+      const dataOptions = screen.getByText(/Data options/i);
+      fireEvent.click(dataOptions);
+      expect(screen.getByText(/Show data frame/i)).toBeInTheDocument();
+      expect(screen.getByText(/Download for Excel/i)).toBeInTheDocument();
+    });
+    it('should show available dataFrame options', () => {
+      render(<InspectDataTab {...createProps()} />);
+      const dataOptions = screen.getByText(/Data options/i);
+      fireEvent.click(dataOptions);
+      const dataFrameInput = screen.getByLabelText(/Select dataframe/i);
+      fireEvent.change(dataFrameInput, {
+        target: { value: 1 },
+      });
+      expect(screen.getByText(/Second data frame/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -167,18 +167,17 @@ export class InspectDataTab extends PureComponent<Props, State> {
 
   renderDataOptions(dataFrames: DataFrame[]) {
     const { options, onOptionsChange, panel, data } = this.props;
-    if (!panel || !onOptionsChange) {
-      return null;
-    }
     const { transformId, transformationOptions, selectedDataFrame } = this.state;
 
     const styles = getPanelInspectorStyles();
 
-    const panelTransformations = panel.getTransformations();
+    const panelTransformations = panel?.getTransformations();
     const showPanelTransformationsOption =
-      panelTransformations && panelTransformations.length > 0 && (transformId as any) !== 'join by time';
-    const showFieldConfigsOption = !panel.plugin?.fieldConfigRegistry.isEmpty();
-    const showDataOptions = showPanelTransformationsOption || showFieldConfigsOption;
+      onOptionsChange &&
+      panelTransformations &&
+      panelTransformations.length > 0 &&
+      (transformId as any) !== 'join by time';
+    const showFieldConfigsOption = onOptionsChange && panel && !panel.plugin?.fieldConfigRegistry.isEmpty();
 
     let dataSelect = dataFrames;
     if (selectedDataFrame === DataTransformerID.seriesToColumns) {
@@ -194,10 +193,6 @@ export class InspectDataTab extends PureComponent<Props, State> {
 
     const selectableOptions = [...transformationOptions, ...choices];
 
-    if (!showDataOptions) {
-      return null;
-    }
-
     return (
       <QueryOperationRow
         id="Data options"
@@ -206,7 +201,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
         headerElement={<DetailText>{this.getActiveString()}</DetailText>}
         isOpen={false}
       >
-        <div className={styles.options}>
+        <div className={styles.options} data-testid="dataOptions">
           <VerticalGroup spacing="none">
             {data!.length > 1 && (
               <Field label="Show data frame">
@@ -227,7 +222,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
                 >
                   <Switch
                     value={!!options.withTransforms}
-                    onChange={() => onOptionsChange({ ...options, withTransforms: !options.withTransforms })}
+                    onChange={() => onOptionsChange!({ ...options, withTransforms: !options.withTransforms })}
                   />
                 </Field>
               )}
@@ -238,7 +233,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
                 >
                   <Switch
                     value={!!options.withFieldConfig}
-                    onChange={() => onOptionsChange({ ...options, withFieldConfig: !options.withFieldConfig })}
+                    onChange={() => onOptionsChange!({ ...options, withFieldConfig: !options.withFieldConfig })}
                   />
                 </Field>
               )}

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -210,6 +210,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
                   value={selectedDataFrame}
                   onChange={this.onDataFrameChange}
                   width={30}
+                  aria-label="Select dataframe"
                 />
               </Field>
             )}

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -173,11 +173,8 @@ export class InspectDataTab extends PureComponent<Props, State> {
 
     const panelTransformations = panel?.getTransformations();
     const showPanelTransformationsOption =
-      onOptionsChange &&
-      panelTransformations &&
-      panelTransformations.length > 0 &&
-      (transformId as any) !== 'join by time';
-    const showFieldConfigsOption = onOptionsChange && panel && !panel.plugin?.fieldConfigRegistry.isEmpty();
+      Boolean(panelTransformations?.length) && (transformId as any) !== 'join by time';
+    const showFieldConfigsOption = panel && !panel.plugin?.fieldConfigRegistry.isEmpty();
 
     let dataSelect = dataFrames;
     if (selectedDataFrame === DataTransformerID.seriesToColumns) {
@@ -216,25 +213,25 @@ export class InspectDataTab extends PureComponent<Props, State> {
             )}
 
             <HorizontalGroup>
-              {showPanelTransformationsOption && (
+              {showPanelTransformationsOption && onOptionsChange && (
                 <Field
                   label="Apply panel transformations"
                   description="Table data is displayed with transformations defined in the panel Transform tab."
                 >
                   <Switch
                     value={!!options.withTransforms}
-                    onChange={() => onOptionsChange!({ ...options, withTransforms: !options.withTransforms })}
+                    onChange={() => onOptionsChange({ ...options, withTransforms: !options.withTransforms })}
                   />
                 </Field>
               )}
-              {showFieldConfigsOption && (
+              {showFieldConfigsOption && onOptionsChange && (
                 <Field
                   label="Formatted data"
                   description="Table data is formatted with options defined in the Field and Override tabs."
                 >
                   <Switch
                     value={!!options.withFieldConfig}
-                    onChange={() => onOptionsChange!({ ...options, withFieldConfig: !options.withFieldConfig })}
+                    onChange={() => onOptionsChange({ ...options, withFieldConfig: !options.withFieldConfig })}
                   />
                 </Field>
               )}


### PR DESCRIPTION
**What this PR does / why we need it**:
In Explore's Inspector and when using Panel Inspect with Logs panel, we weren't able to see/download all dataFrames, just the first one. See this on current master:
![image](https://user-images.githubusercontent.com/30407135/111782426-4bfaff80-88b9-11eb-8fe6-d1f0c826c643.png)

This PR fixes it and makes sure, that when we have multiple dataFrames, we will get the Show data frame option in Explore and LogsPanel. See this branch: 
![image](https://user-images.githubusercontent.com/30407135/111782659-941a2200-88b9-11eb-99bc-95cfd7faa1a7.png)

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/issues/28752
Fixes https://github.com/grafana/grafana/issues/31504

**Special notes for your reviewer**:

