### PR TITLE
[WIP] Revert the location search when the dashboard selection is same as the current dashboard

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -141,6 +141,19 @@ export class DashboardPage extends PureComponent<Props, State> {
     }
 
     if (prevProps.location.search !== this.props.location.search) {
+      // If the user clicks the same dashboard from the search
+      // We just don't need to do anything but to recover the params back.
+      if (prevProps.location.search && !this.props.location.search) {
+        try {
+          const params = new URLSearchParams(prevProps.location.search);
+          params.delete('search');
+          this.props.history.push({ search: params.toString() });
+          return;
+        } catch (error) {
+          console.error(`Invalid location.search string`);
+        }
+      }
+
       const prevUrlParams = prevProps.queryParams;
       const urlParams = this.props.queryParams;
 

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -297,7 +297,8 @@ export const setOptionFromUrl = (
       throw new Error(`Couldn't find variable with name: ${variable.name}`);
     }
     // Simple case. Value in url matches existing options text or value.
-    let option = variableFromState.options.find((op) => {
+    const { options } = variableFromState;
+    let option = options.find((op) => {
       return op.text === stringUrlValue || op.value === stringUrlValue;
     });
 
@@ -329,7 +330,7 @@ export const setOptionFromUrl = (
 
       // It is possible that we did not match the value to any existing option. In that case the url value will be
       // used anyway for both text and value.
-      option = { text: defaultText, value: defaultValue, selected: false };
+      option = { text: options[0]?.text ?? defaultText, value: options[0]?.value ?? defaultValue, selected: false };
     }
 
     if (isMulti(variableFromState)) {

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -297,8 +297,7 @@ export const setOptionFromUrl = (
       throw new Error(`Couldn't find variable with name: ${variable.name}`);
     }
     // Simple case. Value in url matches existing options text or value.
-    const { options } = variableFromState;
-    let option = options.find((op) => {
+    let option = variableFromState.options.find((op) => {
       return op.text === stringUrlValue || op.value === stringUrlValue;
     });
 
@@ -330,7 +329,7 @@ export const setOptionFromUrl = (
 
       // It is possible that we did not match the value to any existing option. In that case the url value will be
       // used anyway for both text and value.
-      option = { text: options[0]?.text ?? defaultText, value: options[0]?.value ?? defaultValue, selected: false };
+      option = { text: defaultText, value: defaultValue, selected: false };
     }
 
     if (isMulti(variableFromState)) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When the url has a queryString which includes the variables, if the user clicks the dashboard to search and accidentally selects the same dashboard, let's say from `http://localhost:3000/d/Nz0YNKQGz/test-dashboard?orgId=1&var-test_value1=value1&var-test_value1=value2&var-test_value1=value3` to `http://localhost:3000/d/Nz0YNKQGz/test-dashboard`, abnormal behavior happens that the variables inputs are trying to reset the empty string to the option selection, while the new url doesn't have the previous `queryString` recovered.

**Which issue(s) this PR fixes**:

This PR fixes the following behavior:

When the user clicks the same dashboard during the dashboard search while the current dashboard url has a queryString, it will recover the previous selection.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

