### PR TITLE
Units: add inches (in) and pounds (lb)

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -685,10 +685,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
-	    {
+            {
               "text": "inch (in)",
               "value": "lengthin"
-	    },
+            },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -731,7 +731,7 @@
               "text": "gram (g)",
               "value": "massg"
             },
-	    {
+            {
               "text": "pound (lb)",
               "value": "masslb"
             },
@@ -1796,10 +1796,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
-	    {
+            {
               "text": "inch (in)",
               "value": "lengthin"
-	    },
+            },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -1842,7 +1842,7 @@
               "text": "gram (g)",
               "value": "massg"
             },
-	    {
+            {
               "text": "pound (lb)",
               "value": "masslb"
             },
@@ -2887,7 +2887,7 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
-	    {
+            {
               "text": "inch (in)",
               "value": "lengthin"
 	    },
@@ -2933,7 +2933,7 @@
               "text": "gram (g)",
               "value": "massg"
             },
-	    {
+            {
               "text": "pound (lb)",
               "value": "masslb"
             },

--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -2890,7 +2890,7 @@
             {
               "text": "inch (in)",
               "value": "lengthin"
-	    },
+            },
             {
               "text": "feet (ft)",
               "value": "lengthft"

--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -731,6 +731,10 @@
               "text": "gram (g)",
               "value": "massg"
             },
+	    {
+              "text": "pound (lb)",
+              "value": "masslb"
+            },
             {
               "text": "kilogram (kg)",
               "value": "masskg"
@@ -1838,6 +1842,10 @@
               "text": "gram (g)",
               "value": "massg"
             },
+	    {
+              "text": "pound (lb)",
+              "value": "masslb"
+            },
             {
               "text": "kilogram (kg)",
               "value": "masskg"
@@ -2924,6 +2932,10 @@
             {
               "text": "gram (g)",
               "value": "massg"
+            },
+	    {
+              "text": "pound (lb)",
+              "value": "masslb"
             },
             {
               "text": "kilogram (kg)",

--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -685,6 +685,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
+	    {
+              "text": "inch (in)",
+              "value": "lengthin"
+	    },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -1788,6 +1792,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
+	    {
+              "text": "inch (in)",
+              "value": "lengthin"
+	    },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -2871,6 +2879,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
+	    {
+              "text": "inch (in)",
+              "value": "lengthin"
+	    },
             {
               "text": "feet (ft)",
               "value": "lengthft"

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -685,10 +685,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
-	    {
+            {
               "text": "inch (in)",
               "value": "lengthin"
-	    },
+            },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -731,7 +731,7 @@
               "text": "gram (g)",
               "value": "massg"
             },
-	    {
+            {
               "text": "pound (lb)",
               "value": "masslb"
             },
@@ -1796,10 +1796,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
-	    {
+            {
               "text": "inch (in)",
               "value": "lengthin"
-	    },
+            },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -1842,7 +1842,7 @@
               "text": "gram (g)",
               "value": "massg"
             },
-	    {
+            {
               "text": "pound (lb)",
               "value": "masslb"
             },
@@ -2887,10 +2887,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
-	    {
+            {
               "text": "inch (in)",
               "value": "lengthin"
-	    },
+            },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -2933,7 +2933,7 @@
               "text": "gram (g)",
               "value": "massg"
             },
-	    {
+            {
               "text": "pound (lb)",
               "value": "masslb"
             },

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -731,6 +731,10 @@
               "text": "gram (g)",
               "value": "massg"
             },
+	    {
+              "text": "pound (lb)",
+              "value": "masslb"
+            },
             {
               "text": "kilogram (kg)",
               "value": "masskg"
@@ -1838,6 +1842,10 @@
               "text": "gram (g)",
               "value": "massg"
             },
+	    {
+              "text": "pound (lb)",
+              "value": "masslb"
+            },
             {
               "text": "kilogram (kg)",
               "value": "masskg"
@@ -2924,6 +2932,10 @@
             {
               "text": "gram (g)",
               "value": "massg"
+            },
+	    {
+              "text": "pound (lb)",
+              "value": "masslb"
             },
             {
               "text": "kilogram (kg)",

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -685,6 +685,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
+	    {
+              "text": "inch (in)",
+              "value": "lengthin"
+	    },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -1788,6 +1792,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
+	    {
+              "text": "inch (in)",
+              "value": "lengthin"
+	    },
             {
               "text": "feet (ft)",
               "value": "lengthft"
@@ -2871,6 +2879,10 @@
               "text": "meter (m)",
               "value": "lengthm"
             },
+	    {
+              "text": "inch (in)",
+              "value": "lengthin"
+	    },
             {
               "text": "feet (ft)",
               "value": "lengthft"

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -288,6 +288,7 @@ export const getCategories = (): ValueFormatCategory[] => [
     name: 'Length',
     formats: [
       { name: 'millimeter (mm)', id: 'lengthmm', fn: SIPrefix('m', -1) },
+      { name: 'inch (in)', id: 'lengthin', fn: toFixedUnit('in') },
       { name: 'feet (ft)', id: 'lengthft', fn: toFixedUnit('ft') },
       { name: 'meter (m)', id: 'lengthm', fn: SIPrefix('m') },
       { name: 'kilometer (km)', id: 'lengthkm', fn: SIPrefix('m', 1) },

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -280,6 +280,7 @@ export const getCategories = (): ValueFormatCategory[] => [
     formats: [
       { name: 'milligram (mg)', id: 'massmg', fn: SIPrefix('g', -1) },
       { name: 'gram (g)', id: 'massg', fn: SIPrefix('g') },
+      { name: 'pound (lb)', id: 'masslb', fn: toFixedUnit('lb') },
       { name: 'kilogram (kg)', id: 'masskg', fn: SIPrefix('g', 1) },
       { name: 'metric ton (t)', id: 'masst', fn: toFixedUnit('t') },
     ],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

These commits add inches (in) as a unit of measure for length, and pounds (lb) as a unit of measure for mass.

With regards to inches, I have a dashboard where I am monitoring a weather station and it is reporting rainfall in inches.

With regards to pounds, I have a dashboard monitoring an industrial weigh hopper which reports it's weight in pounds.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #32184 
Fixes #32185 

**Special notes for your reviewer**:

This is my first contribution, but I've pretty much copied a few other commits I've seen done which are similar. The only uncertainty I had was whether or not to use in or " as the symbol for inches. I chose 'in' to be consistent with feet using 'ft', but I did notice that inches mercury is using "Hg instead of inHg.
