### PR TITLE
Library Panels: Add template var import functionality

### DIFF
--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
@@ -8,7 +8,7 @@ const setup = (propOverrides?: object) => {
     dashboard: {} as DashboardModel,
     panel: {} as PanelModel,
     addPanel: jest.fn() as any,
-    initDashboardTemplating: {} as any,
+    updateTemplateVariables: {} as any,
   };
 
   Object.assign(props, propOverrides);

--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.test.tsx
@@ -8,6 +8,7 @@ const setup = (propOverrides?: object) => {
     dashboard: {} as DashboardModel,
     panel: {} as PanelModel,
     addPanel: jest.fn() as any,
+    initDashboardTemplating: {} as any,
   };
 
   Object.assign(props, propOverrides);

--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.tsx
@@ -6,11 +6,12 @@ import tinycolor from 'tinycolor2';
 import { locationService } from '@grafana/runtime';
 import { Icon, IconButton, ModalsController, styleMixins, useStyles } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
-import { DateTimeInput, GrafanaTheme, VariableModel } from '@grafana/data';
+import { DateTimeInput, GrafanaTheme } from '@grafana/data';
 
 import config from 'app/core/config';
 import store from 'app/core/store';
-import { initDashboardTemplating } from 'app/features/variables/state/actions';
+import { VariableModel } from 'app/features/variables/types';
+import { updateTemplateVariables } from 'app/features/variables/state/actions';
 import { addPanel } from 'app/features/dashboard/state/reducers';
 import { DashboardModel, PanelModel } from '../../state';
 import { LibraryPanelsView } from '../../../library-panels/components/LibraryPanelsView/LibraryPanelsView';
@@ -32,7 +33,7 @@ export interface OwnProps {
 
 export interface DispatchProps {
   addPanel: typeof addPanel;
-  initDashboardTemplating: typeof initDashboardTemplating;
+  updateTemplateVariables: typeof updateTemplateVariables;
 }
 
 export type Props = OwnProps & DispatchProps;
@@ -60,7 +61,7 @@ const getCopiedPanelPlugins = () => {
   return _.sortBy(copiedPanels, 'sort');
 };
 
-export const AddPanelWidgetUnconnected: React.FC<Props> = ({ panel, dashboard, initDashboardTemplating }) => {
+export const AddPanelWidgetUnconnected: React.FC<Props> = ({ panel, dashboard, updateTemplateVariables }) => {
   const [addPanelView, setAddPanelView] = useState(false);
 
   const onCancelAddPanel = (evt: React.MouseEvent<HTMLButtonElement>) => {
@@ -133,7 +134,7 @@ export const AddPanelWidgetUnconnected: React.FC<Props> = ({ panel, dashboard, i
         onSubmit: (newVars: VariableModel[]) => {
           dashboard.addPanel(newPanel);
           dashboard.removePanel(panel);
-          updateTemplateVariables(newVars);
+          updateTemplateVariables(dashboard, newVars);
           hideModal();
         },
         onDismiss: hideModal,
@@ -144,20 +145,6 @@ export const AddPanelWidgetUnconnected: React.FC<Props> = ({ panel, dashboard, i
       dashboard.addPanel(newPanel);
       dashboard.removePanel(panel);
     }
-  };
-
-  const updateTemplateVariables = (newVars: VariableModel[]) => {
-    const varMap = dashboard.templating.list.reduce((acc, cur) => {
-      acc[cur.name] = cur;
-      return acc;
-    }, {} as Record<string, VariableModel>);
-
-    for (const newVar of newVars) {
-      varMap[newVar.name] = newVar;
-    }
-
-    dashboard.templating.list = Object.values(varMap);
-    initDashboardTemplating(dashboard.templating.list);
   };
 
   const onCreateNewRow = () => {
@@ -224,7 +211,7 @@ export const AddPanelWidgetUnconnected: React.FC<Props> = ({ panel, dashboard, i
   );
 };
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = { addPanel, initDashboardTemplating };
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = { addPanel, updateTemplateVariables };
 
 export const AddPanelWidget = connect(undefined, mapDispatchToProps)(AddPanelWidgetUnconnected);
 

--- a/public/app/features/library-panels/components/VarImportModal/VarImportModal.tsx
+++ b/public/app/features/library-panels/components/VarImportModal/VarImportModal.tsx
@@ -1,4 +1,4 @@
-import { AsyncSelect, Button, Checkbox, Field, Modal, useStyles } from '@grafana/ui';
+import { AsyncSelect, Button, Checkbox, Field, HorizontalGroup, Modal, useStyles } from '@grafana/ui';
 import React, { FC, useCallback, useMemo, useState } from 'react';
 import { css } from 'emotion';
 import { QueryVariableModel, VariableModel } from 'app/features/variables/types';
@@ -95,7 +95,6 @@ export const VarImportModal: FC<VarImportModalProps> = ({ panelVars, dashboard, 
           loadOptions={searchDashboards}
           onChange={onDashboardSelect}
           value={selectedDash}
-          className={styles.dashSelect}
         />
       </Field>
 
@@ -166,12 +165,12 @@ export const VarImportModal: FC<VarImportModalProps> = ({ panelVars, dashboard, 
         </>
       )}
 
-      <div className={styles.buttons}>
+      <HorizontalGroup>
         <Button onClick={submitNewVars}>Import template variables and add panel</Button>
         <Button variant="secondary" onClick={onDismiss}>
           Cancel
         </Button>
-      </div>
+      </HorizontalGroup>
     </Modal>
   );
 };
@@ -182,36 +181,29 @@ const getStyles = (theme: GrafanaTheme) => ({
     font-style: normal;
   `,
   selectAll: css`
-    margin-left: 9px;
+    margin-left: ${theme.spacing.sm};
   `,
   checkbox: css`
     margin-top: -20px;
-  `,
-  dashSelect: css`
-    margin-bottom: ${theme.spacing.md};
-  `,
-  buttons: css`
-    display: flex;
-    gap: 10px;
   `,
   table: css`
     width: 100%;
   `,
   p: css`
-    margin-top: 14px;
-    margin-bottom: 14px;
+    margin-top: ${theme.spacing.md};
+    margin-bottom: ${theme.spacing.md};
   `,
   rowHeader: css`
     font-size: ${theme.typography.size.sm};
     font-weight: ${theme.typography.weight.bold};
     color: ${theme.colors.textSemiWeak};
-    height: 36px;
-    min-height: 36px;
-    max-height: 36px;
+    height: ${theme.spacing.xl};
+    min-height: ${theme.spacing.xl};
+    max-height: ${theme.spacing.xl};
     > th {
-      height: 36px;
-      min-height: 36px;
-      max-height: 36px;
+      height: ${theme.spacing.xl};
+      min-height: ${theme.spacing.xl};
+      max-height: ${theme.spacing.xl};
     }
   `,
   dataTable: css`
@@ -222,7 +214,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     width: 100%;
     td,
     th {
-      padding: 9px;
+      padding: ${theme.spacing.sm};
     }
     tbody > tr:nth-child(odd) {
       background: ${theme.colors.panelBorder};

--- a/public/app/features/library-panels/components/VarImportModal/VarImportModal.tsx
+++ b/public/app/features/library-panels/components/VarImportModal/VarImportModal.tsx
@@ -1,0 +1,231 @@
+import { AsyncSelect, Button, Checkbox, Field, Modal, useStyles } from '@grafana/ui';
+import React, { FC, useCallback, useMemo, useState } from 'react';
+import { css } from 'emotion';
+import { QueryVariableModel, VariableModel } from 'app/features/variables/types';
+
+import { useAsyncFn } from 'react-use';
+import { SearchSrv } from 'app/core/services/search_srv';
+import { DashboardSearchItemType } from 'app/features/search/types';
+import { GrafanaTheme, SelectableValue } from '@grafana/data';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { DashboardModel } from 'app/features/dashboard/state';
+
+export interface VarImportModalProps {
+  panelVars: VariableModel[];
+  dashboard: DashboardModel;
+  onSubmit: (newVars: VariableModel[]) => void;
+  onDismiss?: () => void;
+  isOpen?: boolean;
+}
+
+const varDef = (v?: QueryVariableModel) => {
+  if (v === undefined) {
+    return '';
+  }
+
+  return v.definition ? v.definition : typeof v.query === 'string' ? v.query : '';
+};
+
+export const VarImportModal: FC<VarImportModalProps> = ({ panelVars, dashboard, onDismiss, onSubmit, isOpen }) => {
+  const styles = useStyles(getStyles);
+  const searchSrv = useMemo(() => new SearchSrv(), []);
+  const [selectedDash, setSelectedDash] = useState<undefined | SelectableValue<string>>(undefined);
+  const [, searchDashboards] = useAsyncFn(
+    async (query = ''): Promise<Array<SelectableValue<string>>> => {
+      const res = await searchSrv.search({
+        query,
+        type: DashboardSearchItemType.DashDB,
+        skipRecent: true,
+        skipStarred: true,
+      });
+      return res?.[0].items
+        .map((v: any) => ({ value: v.uid, label: v.title }))
+        .filter((v: any) => v.value !== dashboard.uid);
+    }
+  );
+
+  const [clashingVars, safeVars] = useMemo(() => {
+    const dashVars = dashboard.templating.list as VariableModel[];
+    const dashVarMap = dashVars.reduce((acc, cur) => {
+      acc[cur.name] = cur;
+      return acc;
+    }, {} as Record<string, VariableModel>);
+
+    const clashes = [];
+    const safe = [];
+    for (const panelVar of panelVars) {
+      if (dashVarMap[panelVar.name] !== undefined) {
+        clashes.push(dashVarMap[panelVar.name]);
+      } else {
+        safe.push(panelVar);
+      }
+    }
+    return [clashes, safe];
+  }, [panelVars]);
+  const [checkedVars, setCheckedVars] = useState<boolean[]>(clashingVars.map(() => false));
+
+  const [dashVars, fetchDashVars] = useAsyncFn(async (dashUid: string) => {
+    const dash = await backendSrv.getDashboardByUid(dashUid);
+    const dashModel = dash.dashboard as DashboardModel;
+    const sourceVars = dashModel.templating.list as VariableModel[];
+    const sourceVarsMap = sourceVars.reduce((acc, cur) => {
+      acc[cur.name] = cur;
+      return acc;
+    }, {} as Record<string, VariableModel>);
+    return sourceVarsMap;
+  }, []);
+
+  const onDashboardSelect = useCallback(async (selectedDash: SelectableValue<string>) => {
+    setSelectedDash(selectedDash);
+    await fetchDashVars(selectedDash.value!);
+  }, []);
+
+  const submitNewVars = useCallback(() => {
+    const selected = clashingVars.filter((v, i) => checkedVars[i]);
+    const newVars = [...safeVars, ...selected].map((v) => dashVars.value?.[v.name]).filter((v) => v !== undefined);
+    onSubmit(newVars as VariableModel[]);
+  }, [dashVars.value, checkedVars, clashingVars, safeVars]);
+
+  const selectedCount = checkedVars.reduce((total, cur) => total + Number(cur), 0);
+  return (
+    <Modal icon="x" title="Template variables will be imported" onDismiss={onDismiss} isOpen={isOpen}>
+      <Field label="Dashboard">
+        <AsyncSelect
+          defaultOptions={true}
+          loadOptions={searchDashboards}
+          onChange={onDashboardSelect}
+          value={selectedDash}
+          className={styles.dashSelect}
+        />
+      </Field>
+
+      {clashingVars.length > 0 && (
+        <>
+          <p>
+            The library panel is trying to import some template variables. There are{' '}
+            <em className={styles.emph}>conflicts with some of the definitions</em>. Check which variables you want to
+            overwrite with the definition from the selected dashboard:
+          </p>
+          <Checkbox
+            label={selectedCount === 0 ? 'Select all' : `${selectedCount} selected`}
+            onClick={() => {
+              setCheckedVars(checkedVars.map(() => !(selectedCount === checkedVars.length)));
+            }}
+            value={selectedCount === checkedVars.length}
+            className={styles.selectAll}
+          />
+          <table className={styles.dataTable}>
+            <thead>
+              <tr className={styles.rowHeader}>
+                <th></th>
+                <th>Variable</th>
+                <th>Current definition</th>
+                <th>Definition in selected dashboard</th>
+              </tr>
+            </thead>
+            <tbody>
+              {clashingVars.map((v, i) => (
+                <tr key={i}>
+                  <td>
+                    <Checkbox
+                      className={styles.checkbox}
+                      checked={checkedVars[i]}
+                      onClick={() =>
+                        setCheckedVars([...checkedVars.slice(0, i), !checkedVars[i], ...checkedVars.slice(i + 1)])
+                      }
+                    />
+                  </td>
+                  <td>{v.name}</td>
+                  <td>{varDef(v as QueryVariableModel)}</td>
+                  <td>{varDef(dashVars.value?.[v.name] as QueryVariableModel) ?? ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+      {safeVars.length > 0 && (
+        <>
+          <p className={styles.p}>The following {safeVars.length} template variables will be imported:</p>
+          <table className={styles.dataTable}>
+            <thead>
+              <tr className={styles.rowHeader}>
+                <th>Variable</th>
+                <th>Definition in selected dashboard</th>
+              </tr>
+            </thead>
+            <tbody>
+              {safeVars.map((v, i) => (
+                <tr key={i}>
+                  <td>{v.name}</td>
+                  <td>{varDef(dashVars.value?.[v.name] as QueryVariableModel) ?? ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      <div className={styles.buttons}>
+        <Button onClick={submitNewVars}>Import template variables and add panel</Button>
+        <Button variant="secondary" onClick={onDismiss}>
+          Cancel
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme) => ({
+  emph: css`
+    font-weight: ${theme.typography.weight.bold};
+    font-style: normal;
+  `,
+  selectAll: css`
+    margin-left: 9px;
+  `,
+  checkbox: css`
+    margin-top: -20px;
+  `,
+  dashSelect: css`
+    margin-bottom: ${theme.spacing.md};
+  `,
+  buttons: css`
+    display: flex;
+    gap: 10px;
+  `,
+  table: css`
+    width: 100%;
+  `,
+  p: css`
+    margin-top: 14px;
+    margin-bottom: 14px;
+  `,
+  rowHeader: css`
+    font-size: ${theme.typography.size.sm};
+    font-weight: ${theme.typography.weight.bold};
+    color: ${theme.colors.textSemiWeak};
+    height: 36px;
+    min-height: 36px;
+    max-height: 36px;
+    > th {
+      height: 36px;
+      min-height: 36px;
+      max-height: 36px;
+    }
+  `,
+  dataTable: css`
+    font-size: ${theme.typography.size.md};
+    margin-bottom: ${theme.spacing.md};
+    background: ${theme.colors.panelBg};
+    color: ${theme.colors.textSemiWeak};
+    width: 100%;
+    td,
+    th {
+      padding: 9px;
+    }
+    tbody > tr:nth-child(odd) {
+      background: ${theme.colors.panelBorder};
+    }
+  `,
+});

--- a/public/app/features/variables/editor/actions.ts
+++ b/public/app/features/variables/editor/actions.ts
@@ -109,7 +109,8 @@ export const switchToListMode = (): ThunkResult<void> => (dispatch, getState) =>
   const state = getState();
   const variables = getEditorVariables(state);
   const dashboard = state.dashboard.getModel();
-  const { unknown, usages } = createUsagesNetwork(variables, dashboard);
+  const saveModelClone = dashboard?.getSaveModelClone();
+  const { unknown, usages } = createUsagesNetwork(variables, saveModelClone);
   const unknownsNetwork = transformUsagesToNetwork(unknown);
   const unknownExits = Object.keys(unknown).length > 0;
   const usagesNetwork = transformUsagesToNetwork(usages);

--- a/public/app/features/variables/inspect/utils.ts
+++ b/public/app/features/variables/inspect/utils.ts
@@ -2,7 +2,6 @@
 import vis from 'visjs-network';
 
 import { variableAdapters } from '../adapters';
-import { DashboardModel } from '../../dashboard/state';
 import { isAdHoc } from '../guard';
 import { safeStringifyValue } from '../../../core/utils/explore';
 import { VariableModel } from '../types';
@@ -183,15 +182,14 @@ export interface VariableUsages {
   usages: VariableUsageTree[];
 }
 
-export const createUsagesNetwork = (variables: VariableModel[], dashboard: DashboardModel | null): VariableUsages => {
-  if (!dashboard) {
+export const createUsagesNetwork = (variables: VariableModel[], model: any | null): VariableUsages => {
+  if (!model) {
     return { unUsed: [], unknown: [], usages: [] };
   }
 
   const unUsed: VariableModel[] = [];
   let usages: VariableUsageTree[] = [];
   let unknown: VariableUsageTree[] = [];
-  const model = dashboard.getSaveModelClone();
 
   const unknownVariables = getUnknownVariableStrings(variables, model);
   for (const unknownVariable of unknownVariables) {

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -111,6 +111,22 @@ export const initDashboardTemplating = (list: VariableModel[]): ThunkResult<void
   };
 };
 
+export const updateTemplateVariables = (dashboard: DashboardModel, newVars: VariableModel[]): ThunkResult<void> => (
+  dispatch
+) => {
+  const varMap = dashboard.templating.list.reduce((acc, cur) => {
+    acc[cur.name] = cur;
+    return acc;
+  }, {} as Record<string, VariableModel>);
+
+  for (const newVar of newVars) {
+    varMap[newVar.name] = newVar;
+  }
+
+  dashboard.templating.list = Object.values(varMap);
+  dispatch(initDashboardTemplating(dashboard.templating.list));
+};
+
 export const addSystemTemplateVariables = (dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
     const dashboardModel: DashboardVariableModel = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to import template variable definitions from other dashboards when adding a library panel.
Suspect some additional iteration will be done over the course of this PR's lifetime, but this is a start at least.

