### PR TITLE
Explore: Fix issue when some query errors were not shown

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -2,7 +2,6 @@ import {
   buildQueryTransaction,
   clearHistory,
   DEFAULT_RANGE,
-  getFirstQueryErrorWithoutRefId,
   getRefIds,
   getValueWithRefId,
   hasNonEmptyQuery,
@@ -14,7 +13,7 @@ import {
   getTimeRangeFromUrl,
 } from './explore';
 import store from 'app/core/store';
-import { DataQueryError, dateTime, ExploreUrlState, LogsSortOrder } from '@grafana/data';
+import { dateTime, ExploreUrlState, LogsSortOrder } from '@grafana/data';
 import { RefreshPicker } from '@grafana/ui';
 import { serializeStateToUrlParam } from '@grafana/data/src/utils/url';
 
@@ -320,40 +319,6 @@ describe('getTimeRangeFromUrl', () => {
     expect(result.to.valueOf()).toEqual(dateTime('2020-10-22T11:00:00Z').valueOf());
     expect(result.raw.from.valueOf()).toEqual(dateTime('2020-10-22T10:00:00Z').valueOf());
     expect(result.raw.to.valueOf()).toEqual(dateTime('2020-10-22T11:00:00Z').valueOf());
-  });
-});
-
-describe('getFirstQueryErrorWithoutRefId', () => {
-  describe('when called with a null value', () => {
-    it('then it should return undefined', () => {
-      const errors: DataQueryError[] | undefined = undefined;
-      const result = getFirstQueryErrorWithoutRefId(errors);
-
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('when called with an array with only refIds', () => {
-    it('then it should return undefined', () => {
-      const errors: DataQueryError[] = [{ refId: 'A' }, { refId: 'B' }];
-      const result = getFirstQueryErrorWithoutRefId(errors);
-
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('when called with an array with and without refIds', () => {
-    it('then it should return undefined', () => {
-      const errors: DataQueryError[] = [
-        { refId: 'A' },
-        { message: 'A message' },
-        { refId: 'B' },
-        { message: 'B message' },
-      ];
-      const result = getFirstQueryErrorWithoutRefId(errors);
-
-      expect(result).toBe(errors[1]);
-    });
   });
 });
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -5,7 +5,6 @@ import { Unsubscribable } from 'rxjs';
 import {
   CoreApp,
   DataQuery,
-  DataQueryError,
   DataQueryRequest,
   DataSourceApi,
   dateMath,
@@ -422,14 +421,6 @@ export const getValueWithRefId = (value?: any): any => {
   return undefined;
 };
 
-export const getFirstQueryErrorWithoutRefId = (errors?: DataQueryError[]): DataQueryError | undefined => {
-  if (!errors) {
-    return undefined;
-  }
-
-  return errors.filter((error) => (error && error.refId ? false : true))[0];
-};
-
 export const getRefIds = (value: any): string[] => {
   if (!value) {
     return [];
@@ -478,11 +469,6 @@ export function getIntervals(range: TimeRange, lowLimit?: string, resolution?: n
 
   return rangeUtil.calculateInterval(range, resolution, lowLimit);
 }
-
-export const getFirstNonQueryRowSpecificError = (queryErrors?: DataQueryError[]): DataQueryError | undefined => {
-  const refId = getValueWithRefId(queryErrors);
-  return refId ? undefined : getFirstQueryErrorWithoutRefId(queryErrors);
-};
 
 export const copyStringToClipboard = (string: string) => {
   const el = document.createElement('textarea');

--- a/public/app/features/explore/ErrorContainer.tsx
+++ b/public/app/features/explore/ErrorContainer.tsx
@@ -11,7 +11,7 @@ export const ErrorContainer: FunctionComponent<ErrorContainerProps> = (props) =>
   const { queryError } = props;
   const showError = queryError ? true : false;
   const duration = showError ? 100 : 10;
-  const message = queryError ? queryError.message : null;
+  const message = queryError ? queryError.message ?? queryError.data?.message : null;
 
   return (
     <FadeIn in={showError} duration={duration}>

--- a/public/app/features/explore/ErrorContainer.tsx
+++ b/public/app/features/explore/ErrorContainer.tsx
@@ -11,7 +11,7 @@ export const ErrorContainer: FunctionComponent<ErrorContainerProps> = (props) =>
   const { queryError } = props;
   const showError = queryError ? true : false;
   const duration = showError ? 100 : 10;
-  const message = queryError ? queryError.message ?? queryError.data?.message : null;
+  const message = queryError?.message || queryError?.data?.message || 'Unknown error';
 
   return (
     <FadeIn in={showError} duration={duration}>

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { DataSourceApi, LoadingState, toUtc, DataQueryError, DataQueryRequest, CoreApp } from '@grafana/data';
-import { getFirstNonQueryRowSpecificError } from 'app/core/utils/explore';
 import { ExploreId } from 'app/types/explore';
 import { shallow } from 'enzyme';
 import { Explore, ExploreProps } from './Explore';
@@ -85,17 +84,6 @@ const dummyProps: ExploreProps = {
   splitOpen: (() => {}) as any,
 };
 
-const setupErrors = (hasRefId?: boolean) => {
-  return [
-    {
-      message: 'Error message',
-      status: '400',
-      statusText: 'Bad Request',
-      refId: hasRefId ? 'A' : '',
-    },
-  ];
-};
-
 describe('Explore', () => {
   it('should render component', () => {
     const wrapper = shallow(<Explore {...dummyProps} />);
@@ -106,22 +94,5 @@ describe('Explore', () => {
     const wrapper = shallow(<Explore {...dummyProps} />);
     expect(wrapper.find(SecondaryActions)).toHaveLength(1);
     expect(wrapper.find(SecondaryActions).props().addQueryRowButtonHidden).toBe(false);
-  });
-
-  it('should filter out a query-row-specific error when looking for non-query-row-specific errors', async () => {
-    const queryErrors = setupErrors(true);
-    const queryError = getFirstNonQueryRowSpecificError(queryErrors);
-    expect(queryError).toBeUndefined();
-  });
-
-  it('should not filter out a generic error when looking for non-query-row-specific errors', async () => {
-    const queryErrors = setupErrors();
-    const queryError = getFirstNonQueryRowSpecificError(queryErrors);
-    expect(queryError).toEqual({
-      message: 'Error message',
-      status: '400',
-      statusText: 'Bad Request',
-      refId: '',
-    });
   });
 });

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -34,13 +34,12 @@ import { StoreState } from 'app/types';
 import { ExploreToolbar } from './ExploreToolbar';
 import { NoDataSourceCallToAction } from './NoDataSourceCallToAction';
 import { getTimeZone } from '../profile/state/selectors';
-import { ErrorContainer } from './ErrorContainer';
-//TODO:unification
 import { TraceView } from './TraceView/TraceView';
 import { SecondaryActions } from './SecondaryActions';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, FilterItem } from '@grafana/ui/src/components/Table/types';
 import { ExploreGraphNGPanel } from './ExploreGraphNGPanel';
 import { NodeGraphContainer } from './NodeGraphContainer';
+import { ResponseErrorContainer } from './ResponseErrorContainer';
 
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
@@ -314,13 +313,6 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     const { openDrawer } = this.state;
     const styles = getStyles(theme);
     const showPanels = queryResponse && queryResponse.state !== LoadingState.NotStarted;
-
-    // Only show error if it does not have refId. Otherwise let query row to handle it.
-    const queryError =
-      queryResponse.state === LoadingState.Error && queryResponse?.error && !queryResponse.error.refId
-        ? queryResponse.error
-        : undefined;
-
     const showRichHistory = openDrawer === ExploreDrawer.RichHistory;
     const showQueryInspector = openDrawer === ExploreDrawer.QueryInspector;
 
@@ -344,7 +336,7 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                 onClickQueryInspectorButton={this.toggleShowQueryInspector}
               />
             </div>
-            <ErrorContainer queryError={queryError} />
+            <ResponseErrorContainer exploreId={exploreId} />
             <AutoSizer onResize={this.onResize} disableHeight>
               {({ width }) => {
                 if (width === 0) {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -31,7 +31,6 @@ import { updateTimeRange } from './state/time';
 import { scanStopAction, addQueryRow, modifyQueries, setQueries, scanStart } from './state/query';
 import { ExploreId, ExploreItemState } from 'app/types/explore';
 import { StoreState } from 'app/types';
-import { getFirstNonQueryRowSpecificError } from 'app/core/utils/explore';
 import { ExploreToolbar } from './ExploreToolbar';
 import { NoDataSourceCallToAction } from './NoDataSourceCallToAction';
 import { getTimeZone } from '../profile/state/selectors';
@@ -316,10 +315,11 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
     const styles = getStyles(theme);
     const showPanels = queryResponse && queryResponse.state !== LoadingState.NotStarted;
 
-    // gets an error without a refID, so non-query-row-related error, like a connection error
-    const queryErrors =
-      queryResponse.state === LoadingState.Error && queryResponse.error ? [queryResponse.error] : undefined;
-    const queryError = getFirstNonQueryRowSpecificError(queryErrors);
+    // Only show error if it does not have refId. Otherwise let query row to handle it.
+    const queryError =
+      queryResponse.state === LoadingState.Error && queryResponse?.error && !queryResponse.error.refId
+        ? queryResponse.error
+        : undefined;
 
     const showRichHistory = openDrawer === ExploreDrawer.RichHistory;
     const showQueryInspector = openDrawer === ExploreDrawer.QueryInspector;

--- a/public/app/features/explore/QueryRow.tsx
+++ b/public/app/features/explore/QueryRow.tsx
@@ -177,6 +177,8 @@ export class QueryRow extends PureComponent<QueryRowProps, QueryRowState> {
 
     const canToggleEditorModes = has(datasourceInstance, 'components.QueryCtrl.prototype.toggleEditorMode');
     const isNotStarted = queryResponse.state === LoadingState.NotStarted;
+
+    // We show error without refId in ResponseErrorContainer so this condition needs to match se we don't loose errors.
     const queryErrors = queryResponse.error && queryResponse.error.refId === query.refId ? [queryResponse.error] : [];
 
     return (

--- a/public/app/features/explore/ResponseErrorContainer.test.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { configureStore } from '../../store/configureStore';
+import { ResponseErrorContainer } from './ResponseErrorContainer';
+import { Provider } from 'react-redux';
+import { render, screen } from '@testing-library/react';
+import { ExploreId } from '../../types';
+import { DataQueryError, LoadingState } from '@grafana/data';
+
+describe('ResponseErrorContainer', () => {
+  it('shows error message if it does not contain refId', async () => {
+    setup({
+      message: 'test error',
+    });
+    screen.getByText('test error');
+  });
+
+  it('shows error.data.message if error.message does not exist', async () => {
+    setup({
+      data: {
+        message: 'test error',
+      },
+    });
+    screen.getByText('test error');
+  });
+
+  it('does not show error if there is refID', async () => {
+    setup({
+      refId: 'someId',
+      message: 'test error',
+    });
+    expect(screen.queryByText('test error')).toBeNull();
+  });
+
+  it('does not show error if there is refID', async () => {
+    setup({
+      refId: 'someId',
+      message: 'test error',
+    });
+    expect(screen.queryByText('test error')).toBeNull();
+  });
+});
+
+function setup(error: DataQueryError) {
+  const store = configureStore();
+  store.getState().explore[ExploreId.left].queryResponse = {
+    timeRange: {} as any,
+    series: [],
+    state: LoadingState.Error,
+    error,
+  };
+  render(
+    <Provider store={store}>
+      <ResponseErrorContainer exploreId={ExploreId.left} />
+    </Provider>
+  );
+}

--- a/public/app/features/explore/ResponseErrorContainer.test.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.test.tsx
@@ -11,7 +11,7 @@ describe('ResponseErrorContainer', () => {
     setup({
       message: 'test error',
     });
-    expect(screen.queryByText('test error')).not.toBeNull();
+    expect(screen.getByText('test error')).toBeInTheDocument();
   });
 
   it('shows error.data.message if error.message does not exist', async () => {
@@ -20,7 +20,7 @@ describe('ResponseErrorContainer', () => {
         message: 'test error',
       },
     });
-    expect(screen.queryByText('test error')).not.toBeNull();
+    expect(screen.getByText('test error')).toBeInTheDocument();
   });
 
   it('does not show error if there is refID', async () => {
@@ -28,7 +28,7 @@ describe('ResponseErrorContainer', () => {
       refId: 'someId',
       message: 'test error',
     });
-    expect(screen.queryByText('test error')).toBeNull();
+    expect(screen.queryByText('test error')).not.toBeInTheDocument();
   });
 
   it('does not show error if there is refID', async () => {
@@ -36,7 +36,7 @@ describe('ResponseErrorContainer', () => {
       refId: 'someId',
       message: 'test error',
     });
-    expect(screen.queryByText('test error')).toBeNull();
+    expect(screen.queryByText('test error')).not.toBeInTheDocument();
   });
 });
 

--- a/public/app/features/explore/ResponseErrorContainer.test.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.test.tsx
@@ -11,7 +11,7 @@ describe('ResponseErrorContainer', () => {
     setup({
       message: 'test error',
     });
-    screen.getByText('test error');
+    expect(screen.queryByText('test error')).not.toBeNull();
   });
 
   it('shows error.data.message if error.message does not exist', async () => {
@@ -20,7 +20,7 @@ describe('ResponseErrorContainer', () => {
         message: 'test error',
       },
     });
-    screen.getByText('test error');
+    expect(screen.queryByText('test error')).not.toBeNull();
   });
 
   it('does not show error if there is refID', async () => {

--- a/public/app/features/explore/ResponseErrorContainer.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.tsx
@@ -10,7 +10,8 @@ interface Props {
 export function ResponseErrorContainer(props: Props) {
   const queryResponse = useSelector((state: StoreState) => state.explore[props.exploreId]?.queryResponse);
 
-  // Only show error if it does not have refId. Otherwise let query row to handle it.
+  // Only show error if it does not have refId. Otherwise let query row to handle it so this condition has to be matched
+  // with QueryRow.tsx so we don't loose errors.
   const queryError =
     queryResponse?.state === LoadingState.Error && queryResponse?.error && !queryResponse.error.refId
       ? queryResponse.error

--- a/public/app/features/explore/ResponseErrorContainer.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { ExploreId, StoreState } from '../../types';
+import { LoadingState } from '@grafana/data';
+import { ErrorContainer } from './ErrorContainer';
+
+interface Props {
+  exploreId: ExploreId;
+}
+export function ResponseErrorContainer(props: Props) {
+  const queryResponse = useSelector((state: StoreState) => state.explore[props.exploreId]?.queryResponse);
+
+  // Only show error if it does not have refId. Otherwise let query row to handle it.
+  const queryError =
+    queryResponse?.state === LoadingState.Error && queryResponse?.error && !queryResponse.error.refId
+      ? queryResponse.error
+      : undefined;
+
+  return <ErrorContainer queryError={queryError} />;
+}

--- a/public/app/features/explore/__snapshots__/Explore.test.tsx.snap
+++ b/public/app/features/explore/__snapshots__/Explore.test.tsx.snap
@@ -26,7 +26,9 @@ exports[`Explore should render component 1`] = `
         richHistoryButtonActive={false}
       />
     </div>
-    <ErrorContainer />
+    <ResponseErrorContainer
+      exploreId="left"
+    />
     <AutoSizer
       disableHeight={true}
       disableWidth={false}


### PR DESCRIPTION
In explore we distinguish 2 types of errors. Those which are associated with particular query, which are shown next to that query and and those who are more generic and should be shown under all query rows.

To split those errors we check for refID which ties the error to the query but how that was checked was different in query rows and in explore component which resulted in some errors not to be shown at all.

Right now the backend_srv creates the errors like this: https://github.com/grafana/grafana/blob/610999cfa24896d97f1991deae43c6d9f0e1f172/public/app/core/services/backend_srv.ts#L208. So each error also has a config attribute which contains all the options for the query (usually also refId in the query object). So as we in once place checked just error.refId and on the other recursively looked anywhere in the object this was a source of error.