### PR TITLE
SSE/NG: Add expression metadata for EvalMatch

### DIFF
--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -99,8 +99,10 @@ func (ccc *ConditionsCmd) Execute(ctx context.Context, vars mathexp.Vars) (mathe
 			if evalRes {
 				match := EvalMatch{
 					Value:  reducedNum.GetFloat64Value(),
-					Labels: reducedNum.GetLabels().Copy(),
 					Metric: series.GetName(),
+				}
+				if reducedNum.GetLabels() != nil {
+					match.Labels = reducedNum.GetLabels().Copy()
 				}
 				matches = append(matches, match)
 			}

--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -65,7 +65,7 @@ func (ccc *ConditionsCmd) NeedsVars() []string {
 type EvalMatch struct {
 	Value  *float64    `json:"value"`
 	Metric string      `json:"metric"`
-	Labels data.Labels `json:"tags"`
+	Labels data.Labels `json:"labels"`
 }
 
 // Execute runs the command and returns the results or an error if the command

--- a/pkg/expr/mathexp/type_series.go
+++ b/pkg/expr/mathexp/type_series.go
@@ -97,6 +97,14 @@ func (s Series) SetLabels(ls data.Labels) { s.Frame.Fields[s.ValueIdx].Labels = 
 
 func (s Series) GetName() string { return s.Frame.Name }
 
+func (s Series) GetMeta() interface{} {
+	return s.Frame.Meta.Custom
+}
+
+func (s Series) SetMeta(v interface{}) {
+	s.Frame.SetMeta(&data.FrameMeta{Custom: v})
+}
+
 // AsDataFrame returns the underlying *data.Frame.
 func (s Series) AsDataFrame() *data.Frame { return s.Frame }
 

--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -30,6 +30,8 @@ type Value interface {
 	Value() interface{}
 	GetLabels() data.Labels
 	SetLabels(data.Labels)
+	GetMeta() interface{}
+	SetMeta(interface{})
 	AsDataFrame() *data.Frame
 }
 
@@ -47,6 +49,14 @@ func (s Scalar) Value() interface{} { return s }
 func (s Scalar) GetLabels() data.Labels { return nil }
 
 func (s Scalar) SetLabels(ls data.Labels) {}
+
+func (s Scalar) GetMeta() interface{} {
+	return s.Frame.Meta.Custom
+}
+
+func (s Scalar) SetMeta(v interface{}) {
+	s.Frame.SetMeta(&data.FrameMeta{Custom: v})
+}
 
 // AsDataFrame returns the underlying *data.Frame.
 func (s Scalar) AsDataFrame() *data.Frame { return s.Frame }
@@ -104,4 +114,12 @@ func NewNumber(name string, labels data.Labels) Number {
 			data.NewField(name, labels, make([]*float64, 1)),
 		),
 	}
+}
+
+func (n Number) GetMeta() interface{} {
+	return n.Frame.Meta.Custom
+}
+
+func (n Number) SetMeta(v interface{}) {
+	n.Frame.SetMeta(&data.FrameMeta{Custom: v})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Start of replicating EvalMatches from a classic condition in server side expressions.

**Special notes for your reviewer**:

For now I am sticking it in Frame Meta's Custom. With SSE, attaching multiple metadata to a frame should work for this and other future MD cases. I imagine at least with in the Grafana code base it will become something more typed that is assigned  to the Frame.Meta.Custom's interface and asserted.

Another option if we become more confident in a structure to type would be to make it an actual typed (or somewhat typed) property in the frame's meta and not custom.

The two places this information will go to is:
 - UI (I think it will be a bit before it is ready to display this)
 - Notifications (But I expect it will pulled out of the frame and put somewhere as an exposed API, so moving it, or putting this info in a container type in the future should be just internal)

Related to conversation at https://github.com/grafana/grafana/pull/31693#issuecomment-792837272
