### PR TITLE
CloudWatch: Use latest version of aws sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
   },
   "dependencies": {
     "@emotion/core": "10.0.27",
-    "@grafana/aws-sdk": "0.0.22",
+    "@grafana/aws-sdk": "0.0.23",
     "@grafana/slate-react": "0.22.9-grafana",
     "@popperjs/core": "2.5.4",
     "@reduxjs/toolkit": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
   },
   "dependencies": {
     "@emotion/core": "10.0.27",
-    "@grafana/aws-sdk": "0.0.23",
+    "@grafana/aws-sdk": "0.0.24",
     "@grafana/slate-react": "0.22.9-grafana",
     "@popperjs/core": "2.5.4",
     "@reduxjs/toolkit": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,10 +3430,10 @@
     source-map "~0.6.1"
     typescript "~3.9.7"
 
-"@grafana/aws-sdk@0.0.22":
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.22.tgz#58389616beda01ef137804ab6d9ef07d4a4a35b0"
-  integrity sha512-gTyHmD5VeXjjnnq3zVyI2x3ktJB7dBp92GoJW+lH2t9bWNkcnXyzHSaXZZdrnNpjctaqpv85uxcocK4U7BGCvw==
+"@grafana/aws-sdk@0.0.23":
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.23.tgz#b99bfe92b9dfa294993c06b8a593f2d32d88e945"
+  integrity sha512-3qfyEsJ8Na/Eos/DZbqPx/n+8gHb5oMF+SXkZkaHlOYQ0W+4bLSNB6nK5/Eu2qhH4uhvrPw6k4cGZzAD9BWAkQ==
   dependencies:
     "@grafana/data" "7.4.0"
     "@grafana/runtime" "7.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,10 +3430,10 @@
     source-map "~0.6.1"
     typescript "~3.9.7"
 
-"@grafana/aws-sdk@0.0.23":
-  version "0.0.23"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.23.tgz#b99bfe92b9dfa294993c06b8a593f2d32d88e945"
-  integrity sha512-3qfyEsJ8Na/Eos/DZbqPx/n+8gHb5oMF+SXkZkaHlOYQ0W+4bLSNB6nK5/Eu2qhH4uhvrPw6k4cGZzAD9BWAkQ==
+"@grafana/aws-sdk@0.0.24":
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.24.tgz#30511706d5efaf52e81cadd8f933d1c21e8d1c6b"
+  integrity sha512-tKYZ5KgJn0/S+/z7KFUtcgihYC1vCpUPvDMONp8j1j02JWwUE3ivu9LDiPeWBLcicy0psUypC0mL3QG/e8prIw==
   dependencies:
     "@grafana/data" "7.4.0"
     "@grafana/runtime" "7.4.0"


### PR DESCRIPTION
Upgrade aws sdk to get [this](https://github.com/grafana/grafana-aws-sdk/pull/9) fix