### PR TITLE
Docs: Document upgrading of protobuf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@ go.sum @grafana/backend-platform
 # Backend code docs
 /contribute/style-guides/backend.md @grafana/backend-platform
 /contribute/architecture/backend @grafana/backend-platform
+/contribute/engineering/backend @grafana/backend-platform
 
 /e2e @grafana/grafana-frontend-platform
 /packages @grafana/grafana-frontend-platform

--- a/contribute/engineering/backend/upgrading-dependencies.md
+++ b/contribute/engineering/backend/upgrading-dependencies.md
@@ -1,0 +1,12 @@
+# Upgrading dependencies
+
+Notes on upgrading various backend dependencies.
+
+# Protobuf
+
+When upgrading the [protobuf](http://github.com/golang/protobuf) library in Grafana and the plugin SDK, it might be 
+wise to test that things still work:
+
+* Test a plugin built with upgraded SDK on upgraded Grafana
+* Test a plugin built with non-upgraded SDK on upgraded Grafana
+* Test a plugin built with upgraded SDK on non-upgraded Grafana

--- a/contribute/engineering/backend/upgrading-dependencies.md
+++ b/contribute/engineering/backend/upgrading-dependencies.md
@@ -4,8 +4,18 @@ Notes on upgrading various backend dependencies.
 
 # Protobuf
 
-When upgrading the [protobuf](http://github.com/golang/protobuf) library in Grafana and the plugin SDK, it might be 
-wise to test that things still work:
+When upgrading the [protobuf](http://github.com/golang/protobuf) library in Grafana and the plugin SDK,
+you typically also want to upgrade your protobuf compiler toolchain and re-compile protobuf files:
+
+```
+cd $GRAFANA
+make protobuf
+cd $GRAFANA_PLUGIN_SDK_GO
+mage protobuf
+```
+
+After upgrading the protobuf dependency in Grafana and the plugin SDK, it might be wise to test that things still work,
+before making corresponding PRs:
 
 * Test a plugin built with upgraded SDK on upgraded Grafana
 * Test a plugin built with non-upgraded SDK on upgraded Grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade procedure for upgrading of backend protobuf dependency. 