### PR TITLE
Chore: Modify observability-squad code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,12 +23,18 @@ go.mod @grafana/backend-platform
 go.sum @grafana/backend-platform
 
 # Cloud Datasources backend code
-/pkg/tsdb/cloudwatch @grafana/cloud-datasources
+/pkg/tsdb/cloudwatch @grafana/cloud-datasources @grafana/observability-squad
 /pkg/tsdb/azuremonitor @grafana/cloud-datasources
 /pkg/tsdb/cloudmonitoring @grafana/cloud-datasources
 
 # Observability backend code
 /pkg/tsdb/influxdb @grafana/observability-squad
+/pkg/tsdb/elasticsearch @grafana/observability-squad
+/pkg/tsdb/graphite @grafana/observability-squad
+/pkg/tsdb/jaeger @grafana/observability-squad
+/pkg/tsdb/loki @grafana/observability-squad
+/pkg/tsdb/zipkin @grafana/observability-squad
+/pkg/tsdb/tempo @grafana/observability-squad
 
 # Database migrations
 /pkg/services/sqlstore/migrations @grafana/backend-platform @grafana/hosted-grafana-team
@@ -76,6 +82,7 @@ lerna.json @grafana/grafana-frontend-platform
 /public/app/plugins/datasource/prometheus @grafana/observability-squad
 /public/app/plugins/datasource/cloud-monitoring @grafana/cloud-datasources
 /public/app/plugins/datasource/zipkin @grafana/observability-squad
+/public/app/plugins/datasource/tempo @grafana/observability-squad
 
 # Cloud middleware
 /grafana-mixin/ @grafana/cloud-middleware

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,10 +22,13 @@
 go.mod @grafana/backend-platform
 go.sum @grafana/backend-platform
 
-#Cloud Datasources backend code
+# Cloud Datasources backend code
 /pkg/tsdb/cloudwatch @grafana/cloud-datasources
 /pkg/tsdb/azuremonitor @grafana/cloud-datasources
 /pkg/tsdb/cloudmonitoring @grafana/cloud-datasources
+
+# Observability backend code
+/pkg/tsdb/influxdb @grafana/observability-squad
 
 # Database migrations
 /pkg/services/sqlstore/migrations @grafana/backend-platform @grafana/hosted-grafana-team


### PR DESCRIPTION
**What this PR does / why we need it**:

Modifies `observability-team` as code owners on:

* `influxdb`
* `elasticsearch`
* `graphite`
* `jaeger`
* `loki`
* `zipkin`
* `tempo`