### PR TITLE
chore(deps): bump visx/tooltip to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,8 +297,7 @@
     "whatwg-fetch": "3.1.0"
   },
   "resolutions": {
-    "caniuse-db": "1.0.30000772",
-    "react-use-measure": "2.0.4"
+    "caniuse-db": "1.0.30000772"
   },
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
   },
   "resolutions": {
     "caniuse-db": "1.0.30000772",
-    "react-use-measure": "https://github.com/mckn/react-use-measure#remove-cjs-export"
+    "react-use-measure": "2.0.4"
   },
   "workspaces": {
     "packages": [

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -47,7 +47,7 @@
     "@visx/gradient": "1.0.0",
     "@visx/scale": "1.4.0",
     "@visx/shape": "1.4.0",
-    "@visx/tooltip": "1.3.0",
+    "@visx/tooltip": "1.7.2",
     "react-router-dom": "^5.2.0",
     "classnames": "2.2.6",
     "d3": "5.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7258,10 +7258,10 @@
     "@typescript-eslint/types" "4.15.0"
     eslint-visitor-keys "^2.0.0"
 
-"@visx/bounds@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-1.0.0.tgz#a54eb43a7ddf1bb7f0cd6bf8bf5f94fa5ec562b8"
-  integrity sha512-QxD/OkZVkzpeP6L0YxUnIAsxlFemkDPfOumchVDRlrO4lZ3YXLmsnaEEiJpU5tSgNamZAUh+Tz3d2RbHp3qqxA==
+"@visx/bounds@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-1.7.0.tgz#cc32aaa5aa8711771b93ec4149ff087225dc0684"
+  integrity sha512-ajF6PTgDoZTfwv5J0ZTx1miXY8lk3sGhMVqE3UsMubdTZBlOgeZMT4OmtTPtbCJTBTgw0FD0gd7X3gZ+3X9HgQ==
   dependencies:
     "@types/react" "*"
     "@types/react-dom" "*"
@@ -7337,17 +7337,17 @@
     lodash "^4.17.15"
     prop-types "^15.5.10"
 
-"@visx/tooltip@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@visx/tooltip/-/tooltip-1.3.0.tgz#32b3969eed51cc83e7f16d61d929258ef52b50ca"
-  integrity sha512-8ZliQmcE3R2TvNHyCnViPlT9Msnx/prn6gfsa1QMgWySQzVhFlL4Man9hkmbbIvpwU1i1OarbANF7hUqz86jZQ==
+"@visx/tooltip@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@visx/tooltip/-/tooltip-1.7.2.tgz#facbf37d1e92ea8e8f19eaa229a69f278063659e"
+  integrity sha512-QCNLaOGpgZ6RnZjCIbEJtfbu8ZkSwDOXRy5SOUvcC5J9RiEwCi0DXF1JzT7ZPv3hkLU1KiSPaUFf5q/5LNHwLg==
   dependencies:
     "@types/classnames" "^2.2.9"
     "@types/react" "*"
-    "@visx/bounds" "1.0.0"
+    "@visx/bounds" "1.7.0"
     classnames "^2.2.5"
     prop-types "^15.5.10"
-    react-use-measure "2.0.1"
+    react-use-measure "^2.0.4"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -22207,7 +22207,7 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-use-measure@2.0.1, react-use-measure@2.0.4:
+react-use-measure@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.4.tgz#cb675b36eaeaf3681b94d5f5e08b2a1e081fedc9"
   integrity sha512-7K2HIGaPMl3Q9ZQiEVjen3tRXl4UDda8LiTPy/QxP8dP2rl5gPBhf7mMH6MVjjRNv3loU7sNzey/ycPNnHVTxQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -22207,9 +22207,10 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-use-measure@2.0.1, "react-use-measure@https://github.com/mckn/react-use-measure#remove-cjs-export":
-  version "2.0.3"
-  resolved "https://github.com/mckn/react-use-measure#73530149cb2810cc629f73fa680f8681a0f398ca"
+react-use-measure@2.0.1, react-use-measure@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.4.tgz#cb675b36eaeaf3681b94d5f5e08b2a1e081fedc9"
+  integrity sha512-7K2HIGaPMl3Q9ZQiEVjen3tRXl4UDda8LiTPy/QxP8dP2rl5gPBhf7mMH6MVjjRNv3loU7sNzey/ycPNnHVTxQ==
   dependencies:
     debounce "^1.2.0"
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
@mckn and I found an issue with react-use-measure dependency overwriting the grafana-ui build exports (#31603). The author of react-use-measure has since merged a fix(pmndrs/react-use-measure/pull/38) and published a new version. Airbnb have now brought this into their visx/tooltip dependencies. This PR bumps visx/tooltip to 1.7.2 and removes the need for the interim fork that was created.

