### PR TITLE
AlertingNG: rename Condition properties to match front end

### DIFF
--- a/pkg/expr/translate/translate.go
+++ b/pkg/expr/translate/translate.go
@@ -213,7 +213,7 @@ func (dc *dashConditionsJSON) GetNew(orgID int64) (*ngmodels.Condition, error) {
 				RelativeTimeRange: *rTR,
 				DatasourceUID:     getDsInfo.Uid,
 			}
-			ngCond.QueriesAndExpressions = append(ngCond.QueriesAndExpressions, alertQuery)
+			ngCond.Data = append(ngCond.Data, alertQuery)
 		}
 	}
 
@@ -236,7 +236,7 @@ func (dc *dashConditionsJSON) GetNew(orgID int64) (*ngmodels.Condition, error) {
 	if err != nil {
 		return nil, err
 	}
-	ngCond.RefID = ccRefID // set the alert condition to point to the classic condition
+	ngCond.Condition = ccRefID // set the alert condition to point to the classic condition
 	ngCond.OrgID = orgID
 
 	exprModel := struct {
@@ -261,17 +261,17 @@ func (dc *dashConditionsJSON) GetNew(orgID int64) (*ngmodels.Condition, error) {
 		Model: exprModelJSON,
 	}
 
-	ngCond.QueriesAndExpressions = append(ngCond.QueriesAndExpressions, ccAlertQuery)
+	ngCond.Data = append(ngCond.Data, ccAlertQuery)
 
-	for i := range ngCond.QueriesAndExpressions {
-		err := ngCond.QueriesAndExpressions[i].PreSave() // Set query model properties
+	for i := range ngCond.Data {
+		err := ngCond.Data[i].PreSave() // Set query model properties
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	sort.Slice(ngCond.QueriesAndExpressions, func(i, j int) bool {
-		return ngCond.QueriesAndExpressions[i].RefID < ngCond.QueriesAndExpressions[j].RefID
+	sort.Slice(ngCond.Data, func(i, j int) bool {
+		return ngCond.Data[i].RefID < ngCond.Data[j].RefID
 	})
 
 	return ngCond, nil

--- a/pkg/expr/translate/translate_test.go
+++ b/pkg/expr/translate/translate_test.go
@@ -31,24 +31,24 @@ func TestDashboardAlertConditions(t *testing.T) {
 			name:           "two conditions one query but different time ranges",
 			inputJSONFName: `sameQueryDifferentTimeRange.json`,
 			spotCheckFn: func(t *testing.T, cond *ngmodels.Condition) {
-				require.Equal(t, "C", cond.RefID, "unexpected refId for condition")
-				require.Equal(t, 3, len(cond.QueriesAndExpressions), "unexpected query/expression array length")
+				require.Equal(t, "C", cond.Condition, "unexpected refId for condition")
+				require.Equal(t, 3, len(cond.Data), "unexpected query/expression array length")
 
-				firstQuery := cond.QueriesAndExpressions[0]
+				firstQuery := cond.Data[0]
 				require.Equal(t, "A", firstQuery.RefID, "unexpected refId for first query")
 				require.Equal(t, ngmodels.RelativeTimeRange{
 					From: ngmodels.Duration(time.Second * 600),
 					To:   ngmodels.Duration(time.Second * 300),
 				}, firstQuery.RelativeTimeRange, "unexpected timerange for first query")
 
-				secondQuery := cond.QueriesAndExpressions[1]
+				secondQuery := cond.Data[1]
 				require.Equal(t, "B", secondQuery.RefID, "unexpected refId for second query")
 				require.Equal(t, ngmodels.RelativeTimeRange{
 					From: ngmodels.Duration(time.Second * 300),
 					To:   ngmodels.Duration(0),
 				}, secondQuery.RelativeTimeRange, "unexpected timerange for second query")
 
-				condQuery := cond.QueriesAndExpressions[2]
+				condQuery := cond.Data[2]
 				require.Equal(t, "C", condQuery.RefID, "unexpected refId for second query")
 				isExpr, err := condQuery.IsExpression()
 				require.NoError(t, err)
@@ -78,10 +78,10 @@ func TestDashboardAlertConditions(t *testing.T) {
 			name:           "mixed shared and unshared time ranges",
 			inputJSONFName: `mixedSharedUnsharedTimeRange.json`,
 			spotCheckFn: func(t *testing.T, cond *ngmodels.Condition) {
-				require.Equal(t, "G", cond.RefID, "unexpected refId for condition")
-				require.Equal(t, 7, len(cond.QueriesAndExpressions), "unexpected query/expression array length")
+				require.Equal(t, "G", cond.Condition, "unexpected refId for condition")
+				require.Equal(t, 7, len(cond.Data), "unexpected query/expression array length")
 
-				condQuery := cond.QueriesAndExpressions[6]
+				condQuery := cond.Data[6]
 				isExpr, err := condQuery.IsExpression()
 				require.NoError(t, err)
 				require.Equal(t, true, isExpr, "expected last query to be an expression")
@@ -123,7 +123,7 @@ func TestDashboardAlertConditions(t *testing.T) {
 }
 
 func alertRuleByRefId(cond *ngmodels.Condition, refID string) (ngmodels.AlertQuery, error) {
-	for _, aq := range cond.QueriesAndExpressions {
+	for _, aq := range cond.Data {
 		if aq.RefID == refID {
 			return aq, nil
 		}

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -185,9 +185,9 @@ func (api *API) conditionEvalOldEndpointByID(c *models.ReqContext) response.Resp
 // conditionEvalEndpoint handles POST /api/alert-definitions/eval.
 func (api *API) conditionEvalEndpoint(c *models.ReqContext, cmd ngmodels.EvalAlertConditionCommand) response.Response {
 	evalCond := ngmodels.Condition{
-		RefID:                 cmd.Condition,
-		OrgID:                 c.SignedInUser.OrgId,
-		QueriesAndExpressions: cmd.Data,
+		Condition: cmd.Condition,
+		OrgID:     c.SignedInUser.OrgId,
+		Data:      cmd.Data,
 	}
 	if err := api.validateCondition(evalCond, c.SignedInUser, c.SkipCache); err != nil {
 		return response.Error(400, "invalid condition", err)
@@ -288,9 +288,9 @@ func (api *API) updateAlertDefinitionEndpoint(c *models.ReqContext, cmd ngmodels
 	cmd.OrgID = c.SignedInUser.OrgId
 
 	evalCond := ngmodels.Condition{
-		RefID:                 cmd.Condition,
-		OrgID:                 c.SignedInUser.OrgId,
-		QueriesAndExpressions: cmd.Data,
+		Condition: cmd.Condition,
+		OrgID:     c.SignedInUser.OrgId,
+		Data:      cmd.Data,
 	}
 	if err := api.validateCondition(evalCond, c.SignedInUser, c.SkipCache); err != nil {
 		return response.Error(400, "invalid condition", err)
@@ -308,9 +308,9 @@ func (api *API) createAlertDefinitionEndpoint(c *models.ReqContext, cmd ngmodels
 	cmd.OrgID = c.SignedInUser.OrgId
 
 	evalCond := ngmodels.Condition{
-		RefID:                 cmd.Condition,
-		OrgID:                 c.SignedInUser.OrgId,
-		QueriesAndExpressions: cmd.Data,
+		Condition: cmd.Condition,
+		OrgID:     c.SignedInUser.OrgId,
+		Data:      cmd.Data,
 	}
 	if err := api.validateCondition(evalCond, c.SignedInUser, c.SkipCache); err != nil {
 		return response.Error(400, "invalid condition", err)
@@ -388,22 +388,22 @@ func (api *API) LoadAlertCondition(alertDefinitionUID string, orgID int64) (*ngm
 	}
 
 	return &ngmodels.Condition{
-		RefID:                 alertDefinition.Condition,
-		OrgID:                 alertDefinition.OrgID,
-		QueriesAndExpressions: alertDefinition.Data,
+		Condition: alertDefinition.Condition,
+		OrgID:     alertDefinition.OrgID,
+		Data:      alertDefinition.Data,
 	}, nil
 }
 
 func (api *API) validateCondition(c ngmodels.Condition, user *models.SignedInUser, skipCache bool) error {
 	var refID string
 
-	if len(c.QueriesAndExpressions) == 0 {
+	if len(c.Data) == 0 {
 		return nil
 	}
 
-	for _, query := range c.QueriesAndExpressions {
-		if c.RefID == query.RefID {
-			refID = c.RefID
+	for _, query := range c.Data {
+		if c.Condition == query.RefID {
+			refID = c.Condition
 		}
 
 		datasourceUID, err := query.GetDatasource()
@@ -426,7 +426,7 @@ func (api *API) validateCondition(c ngmodels.Condition, user *models.SignedInUse
 	}
 
 	if refID == "" {
-		return fmt.Errorf("condition %s not found in any query or expression", c.RefID)
+		return fmt.Errorf("condition %s not found in any query or expression", c.Condition)
 	}
 	return nil
 }

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -110,8 +110,8 @@ func GetQueryDataRequest(ctx AlertExecCtx, c *models.Condition, now time.Time) (
 		Queries: []backend.DataQuery{},
 	}
 
-	for i := range c.QueriesAndExpressions {
-		q := c.QueriesAndExpressions[i]
+	for i := range c.Data {
+		q := c.Data[i]
 		model, err := q.GetModel()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get query model: %w", err)
@@ -157,7 +157,7 @@ func execute(ctx AlertExecCtx, c *models.Condition, now time.Time, dataService *
 	}
 
 	for refID, res := range pbRes.Responses {
-		if refID != c.RefID {
+		if refID != c.Condition {
 			continue
 		}
 		result.Results = res.Frames

--- a/pkg/services/ngalert/models/models.go
+++ b/pkg/services/ngalert/models/models.go
@@ -134,14 +134,17 @@ type UpdateAlertDefinitionPausedCommand struct {
 // Condition contains backend expressions and queries and the RefID
 // of the query or expression that will be evaluated.
 type Condition struct {
-	RefID string `json:"refId"`
-	OrgID int64  `json:"-"`
+	// Condition is the RefID of the query or expression from
+	// the Data property to get the results for.
+	Condition string `json:"condition"`
+	OrgID     int64  `json:"-"`
 
-	QueriesAndExpressions []AlertQuery `json:"queriesAndExpressions"`
+	// Data is an array of data source queries and/or server side expressions.
+	Data []AlertQuery `json:"data"`
 }
 
 // IsValid checks the condition's validity.
 func (c Condition) IsValid() bool {
 	// TODO search for refIDs in QueriesAndExpressions
-	return len(c.QueriesAndExpressions) != 0
+	return len(c.Data) != 0
 }

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -64,9 +64,9 @@ func (sch *schedule) definitionRoutine(grafanaCtx context.Context, key models.Al
 				}
 
 				condition := models.Condition{
-					RefID:                 alertDefinition.Condition,
-					OrgID:                 alertDefinition.OrgID,
-					QueriesAndExpressions: alertDefinition.Data,
+					Condition: alertDefinition.Condition,
+					OrgID:     alertDefinition.OrgID,
+					Data:      alertDefinition.Data,
 				}
 				results, err := sch.evaluator.ConditionEval(&condition, ctx.now, sch.dataService)
 				end = timeNow()


### PR DESCRIPTION
**What this PR does / why we need it**:
Internal rename to keep property names consistent with what front-end sends and is saved in the DB.

**Special notes for your reviewer**:
Previous conversation https://github.com/grafana/grafana/pull/31719#discussion_r588302446
