### PR TITLE
Plugins: Remove unnecessary state

### DIFF
--- a/pkg/plugins/backendplugin/coreplugin/core_plugin.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin.go
@@ -13,9 +13,8 @@ import (
 
 // corePlugin represents a plugin that's part of Grafana core.
 type corePlugin struct {
-	isDataPlugin bool
-	pluginID     string
-	logger       log.Logger
+	pluginID string
+	logger   log.Logger
 	backend.CheckHealthHandler
 	backend.CallResourceHandler
 	backend.QueryDataHandler
@@ -44,10 +43,6 @@ func (cp *corePlugin) Logger() log.Logger {
 	return cp.logger
 }
 
-func (cp *corePlugin) CanHandleDataQueries() bool {
-	return cp.isDataPlugin
-}
-
 func (cp *corePlugin) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	tsdbQuery plugins.DataQuery) (plugins.DataResponse, error) {
 	// TODO: Inline the adapter, since it shouldn't be necessary
@@ -57,7 +52,6 @@ func (cp *corePlugin) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 }
 
 func (cp *corePlugin) Start(ctx context.Context) error {
-	cp.isDataPlugin = cp.QueryDataHandler != nil
 	return nil
 }
 

--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -40,10 +40,6 @@ func newPlugin(descriptor PluginDescriptor) backendplugin.PluginFactoryFunc {
 	}
 }
 
-func (p *grpcPlugin) CanHandleDataQueries() bool {
-	return false
-}
-
 func (p *grpcPlugin) PluginID() string {
 	return p.descriptor.pluginID
 }

--- a/pkg/plugins/backendplugin/ifaces.go
+++ b/pkg/plugins/backendplugin/ifaces.go
@@ -35,7 +35,6 @@ type Plugin interface {
 	Stop(ctx context.Context) error
 	IsManaged() bool
 	Exited() bool
-	CanHandleDataQueries() bool
 	backend.CollectMetricsHandler
 	backend.CheckHealthHandler
 	backend.CallResourceHandler

--- a/pkg/plugins/backendplugin/manager/manager.go
+++ b/pkg/plugins/backendplugin/manager/manager.go
@@ -115,7 +115,7 @@ func (m *manager) getAWSEnvironmentVariables() []string {
 
 func (m *manager) GetDataPlugin(pluginID string) interface{} {
 	plugin := m.plugins[pluginID]
-	if plugin == nil || !plugin.CanHandleDataQueries() {
+	if plugin == nil {
 		return nil
 	}
 

--- a/pkg/plugins/backendplugin/manager/manager_test.go
+++ b/pkg/plugins/backendplugin/manager/manager_test.go
@@ -337,10 +337,6 @@ func (tp *testPlugin) Logger() log.Logger {
 	return tp.logger
 }
 
-func (tp *testPlugin) CanHandleDataQueries() bool {
-	return false
-}
-
 func (tp *testPlugin) Start(ctx context.Context) error {
 	tp.mutex.Lock()
 	defer tp.mutex.Unlock()


### PR DESCRIPTION
AFAICT, this state is not necessary. All relevant core plugins will have an associated queryDataHandler