### PR TITLE
Elasticsearch: Disable Alias field for non-timeseries queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -79,7 +79,7 @@ describe('QueryEditor', () => {
 
       render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={noop} onRunQuery={noop} />);
 
-      expect(screen.getByLabelText('Alias')).not.toBeDisabled();
+      expect(screen.getByLabelText('Alias')).toBeEnabled();
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -4,6 +4,8 @@ import { QueryEditor } from '.';
 import { ElasticDatasource } from '../../datasource';
 import { ElasticsearchQuery } from '../../types';
 
+const noop = () => void 0;
+
 describe('QueryEditor', () => {
   describe('Alias Field', () => {
     it('Should correctly render and trigger changes on blur', () => {
@@ -23,9 +25,7 @@ describe('QueryEditor', () => {
 
       const onChange = jest.fn<void, [ElasticsearchQuery]>();
 
-      render(
-        <QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={onChange} onRunQuery={() => {}} />
-      );
+      render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={onChange} onRunQuery={noop} />);
 
       let aliasField = screen.getByLabelText('Alias') as HTMLInputElement;
 
@@ -44,6 +44,42 @@ describe('QueryEditor', () => {
       // query state should match what expected
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls[0][0].alias).toBe(newAlias);
+    });
+
+    it('Should be disabled if last bucket aggregation is not Date Histogram', () => {
+      const query: ElasticsearchQuery = {
+        refId: 'A',
+        query: '',
+        metrics: [
+          {
+            id: '1',
+            type: 'avg',
+          },
+        ],
+        bucketAggs: [{ id: '2', type: 'terms' }],
+      };
+
+      render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={noop} onRunQuery={noop} />);
+
+      expect(screen.getByLabelText('Alias')).toBeDisabled();
+    });
+
+    it('Should be enabled if last bucket aggregation is Date Histogram', () => {
+      const query: ElasticsearchQuery = {
+        refId: 'A',
+        query: '',
+        metrics: [
+          {
+            id: '1',
+            type: 'avg',
+          },
+        ],
+        bucketAggs: [{ id: '2', type: 'date_histogram' }],
+      };
+
+      render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={noop} onRunQuery={noop} />);
+
+      expect(screen.getByLabelText('Alias')).not.toBeDisabled();
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -31,6 +31,9 @@ const QueryEditorForm: FunctionComponent<Props> = ({ value }) => {
   const dispatch = useDispatch();
   const nextId = useNextId();
 
+  // To be considered a time series query, the last bucked aggregation must be a Date Histogram
+  const isTimeSeriesQuery = value.bucketAggs?.slice(-1)[0]?.type === 'date_histogram';
+
   return (
     <>
       <InlineFieldRow>
@@ -45,7 +48,12 @@ const QueryEditorForm: FunctionComponent<Props> = ({ value }) => {
             portalOrigin="elasticsearch"
           />
         </InlineField>
-        <InlineField label="Alias" labelWidth={15}>
+        <InlineField
+          label="Alias"
+          labelWidth={15}
+          disabled={!isTimeSeriesQuery}
+          tooltip="Aliasing only works for timeseries queries (when the last group is 'Date Histogram'). For all other query types this field is ignored."
+        >
           <Input
             id={`ES-query-${value.refId}_alias`}
             placeholder="Alias Pattern"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The Alias field only makes sense when processing timeseries queries. This PR adds a tooltip to the field explaining this and disables the field when the last bucket aggregation in the query is not a Date Histogram.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #27521 
