### PR TITLE
Chore: Remove elasticsearch 1.x from devenv

### DIFF
--- a/devenv/docker/blocks/elastic1/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic1/docker-compose.yaml
@@ -1,8 +1,0 @@
-  elasticsearch1:
-    image: elasticsearch:1.7.6
-    command: elasticsearch -Des.network.host=0.0.0.0
-    ports:
-      - "11200:9200"
-      - "11300:9300"
-    volumes:
-      - ./blocks/elastic/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml

--- a/devenv/docker/blocks/elastic1/elasticsearch.yml
+++ b/devenv/docker/blocks/elastic1/elasticsearch.yml
@@ -1,2 +1,0 @@
-script.inline: on
-script.indexed: on


### PR DESCRIPTION
Our Elasticsearch plugin doesn't support ES 1.x, it probably makes no sense to have those configs in devenv.