### PR TITLE
Docs: Adjust sizes of images in Loki documentation

### DIFF
--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -43,7 +43,7 @@ Each derived field consists of:
 - **Internal link -** Select if the link is internal or external. In case of internal link, a data source selector allows you to select the target data source. Only tracing data sources are supported.
 
 You can use a debug section to see what your fields extract and how the URL is interpolated. Click **Show example log message** to show the text area where you can enter a log message.
-{{< docs-imagebox img="/img/docs/v75/loki_derived_fields_settings.png" class="docs-image--no-shadow" caption="Screenshot of the derived fields debugging" >}}
+{{< docs-imagebox img="/img/docs/v75/loki_derived_fields_settings.png" class="docs-image--no-shadow" max-width="800px" caption="Screenshot of the derived fields debugging" >}}
 
 The new field with the link shown in log details:
 {{< docs-imagebox img="/img/docs/explore/detected-fields-link-7-4.png" max-width="800px" caption="Detected fields link in Explore" >}}

--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -66,7 +66,7 @@ With Loki log browser you can easily navigate trough your list of labels and val
 2. Pick the values for selected labels. Log browser supports facetting and therefore it shows you only possible label combinations. 
 3. Choose the type of query - logs query or rate metrics query. Additionally, you can also validate selector.
 
-{{< docs-imagebox img="/img/docs/v75/loki_log_browser.png" class="docs-image--no-shadow" caption="Screenshot of the derived fields debugging" >}}
+{{< docs-imagebox img="/img/docs/v75/loki_log_browser.png" class="docs-image--no-shadow" max-width="800px" caption="Screenshot of the derived fields debugging" >}}
 
 ## Querying with Loki
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of the images in Loki documentation are too big https://grafana.com/docs/grafana/latest/datasources/loki/#log-browser. This PR adjusts it. 

Before: 
![image](https://user-images.githubusercontent.com/30407135/112363142-755ec580-8cd5-11eb-8864-c0ce1a4918b7.png)
![image](https://user-images.githubusercontent.com/30407135/112363180-7ee82d80-8cd5-11eb-8520-82156c305f2c.png)

After: 
![image](https://user-images.githubusercontent.com/30407135/112363301-a0e1b000-8cd5-11eb-9eaa-e9085ee0966b.png)
![image](https://user-images.githubusercontent.com/30407135/112363339-ae973580-8cd5-11eb-9691-fbf40ccbde38.png)

