### PR TITLE
Live: fix writing headers in hijacked connection with gzip enabled

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -10,23 +10,24 @@ import (
 
 const resourcesPath = "/resources"
 
+var gzipIgnoredPathPrefixes = []string{
+	"/api/datasources/proxy", // Ignore datasource proxy requests.
+	"/api/plugin-proxy/",
+	"/metrics",
+	"/live/ws", // WebSocket does not support gzip compression.
+}
+
 func Gziper() macaron.Handler {
 	gziperLogger := log.New("gziper")
 	gziper := gzip.Gziper()
 
 	return func(ctx *macaron.Context) {
 		requestPath := ctx.Req.URL.RequestURI()
-		// ignore datasource proxy requests
-		if strings.HasPrefix(requestPath, "/api/datasources/proxy") {
-			return
-		}
 
-		if strings.HasPrefix(requestPath, "/api/plugin-proxy/") {
-			return
-		}
-
-		if strings.HasPrefix(requestPath, "/metrics") {
-			return
+		for _, pathPrefix := range gzipIgnoredPathPrefixes {
+			if strings.HasPrefix(requestPath, pathPrefix) {
+				return
+			}
 		}
 
 		// ignore resources


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this change GZiP middleware attempts to touch headers on hijacked connection, so we see logs like this on every disconnect when GZIP middleware enabled:

```
2021/03/25 13:19:09 http: response.WriteHeader on hijacked connection from gopkg.in/macaron%2ev1.(*responseWriter).WriteHeader (response_writer.go:60)
2021/03/25 13:19:09 http: response.Write on hijacked connection from gopkg.in/macaron%2ev1.(*responseWriter).Write (response_writer.go:70)
```
