### PR TITLE
Fix docs for GID

### DIFF
--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -193,7 +193,7 @@ Version | User    | User ID | Group | Group ID
 --------|---------|---------|---------|---------
 < 5.1   | grafana | 104 | grafana | 107
 \>= 5.1  | grafana | 472 | grafana | 472
-\>= 7.3  | grafana | 472 | root | 1
+\>= 7.3  | grafana | 472 | root | 0
 
 There are two possible solutions to this problem. Either you start the new container as the root user and change ownership from `104` to `472`, or you start the upgraded container as user `104`.
 


### PR DESCRIPTION
The Dockerfile and other parts of the docs state GID of zero is used. Update to correct this.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

