### PR TITLE
NgAlerting: loki & cortex have different prom & ruler endpoint prefixes

### DIFF
--- a/pkg/services/ngalert/api/lotex.go
+++ b/pkg/services/ngalert/api/lotex.go
@@ -156,8 +156,8 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 	return r.withReq(ctx, req, jsonExtractor(nil))
 }
 
-func (p *LotexRuler) getPrefix(ctx *models.ReqContext) (string, error) {
-	ds, err := p.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
+func (r *LotexRuler) getPrefix(ctx *models.ReqContext) (string, error) {
+	ds, err := r.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/services/ngalert/api/lotex.go
+++ b/pkg/services/ngalert/api/lotex.go
@@ -16,7 +16,10 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 )
 
-const legacyRulerPrefix = "/api/prom/rules"
+var dsTypeToRulerPrefix = map[string]string{
+	"prometheus": "/rules",
+	"loki":       "/api/prom/rules",
+}
 
 type LotexRuler struct {
 	log log.Logger
@@ -31,13 +34,17 @@ func NewLotexRuler(proxy *AlertingProxy, log log.Logger) *LotexRuler {
 }
 
 func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	legacyRulerPrefix, err := r.getPrefix(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
 	return r.withReq(
 		ctx,
 		&http.Request{
 			Method: "DELETE",
 			URL: withPath(
 				*ctx.Req.URL,
-				fmt.Sprintf("/api/prom/rules/%s", ctx.Params("Namespace")),
+				fmt.Sprintf("%s/%s", legacyRulerPrefix, ctx.Params("Namespace")),
 			),
 		},
 		messageExtractor,
@@ -45,6 +52,10 @@ func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) res
 }
 
 func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
+	legacyRulerPrefix, err := r.getPrefix(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
 	return r.withReq(
 		ctx,
 		&http.Request{
@@ -64,6 +75,10 @@ func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response
 }
 
 func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	legacyRulerPrefix, err := r.getPrefix(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
 	return r.withReq(
 		ctx, &http.Request{
 			URL: withPath(
@@ -80,6 +95,10 @@ func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respon
 }
 
 func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
+	legacyRulerPrefix, err := r.getPrefix(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
 	return r.withReq(
 		ctx,
 		&http.Request{
@@ -98,6 +117,10 @@ func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.R
 }
 
 func (r *LotexRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Response {
+	legacyRulerPrefix, err := r.getPrefix(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
 	return r.withReq(
 		ctx,
 		&http.Request{
@@ -111,6 +134,10 @@ func (r *LotexRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Respon
 }
 
 func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimodels.RuleGroupConfig) response.Response {
+	legacyRulerPrefix, err := r.getPrefix(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
 	yml, err := yaml.Marshal(conf)
 	if err != nil {
 		return response.Error(500, "Failed marshal rule group", err)
@@ -127,6 +154,18 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 		ContentLength: ln,
 	}
 	return r.withReq(ctx, req, jsonExtractor(nil))
+}
+
+func (p *LotexRuler) getPrefix(ctx *models.ReqContext) (string, error) {
+	ds, err := p.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
+	if err != nil {
+		return "", err
+	}
+	prefix, ok := dsTypeToRulerPrefix[ds.Type]
+	if !ok {
+		return "", fmt.Errorf("unexpected datasource type. expecting loki or prometheus")
+	}
+	return prefix, nil
 }
 
 func withPath(u url.URL, newPath string) *url.URL {

--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -10,11 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 )
 
-const (
-	promRulesPath  = "/prometheus/api/v1/rules"
-	promAlertsPath = "/prometheus/api/v1/alerts"
-)
-
 type promEndpoints struct {
 	rules, alerts string
 }

--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	apimodels "github.com/grafana/alerting-api/pkg/api"
@@ -13,6 +14,21 @@ const (
 	promRulesPath  = "/prometheus/api/v1/rules"
 	promAlertsPath = "/prometheus/api/v1/alerts"
 )
+
+type promEndpoints struct {
+	rules, alerts string
+}
+
+var dsTypeToLotexRoutes = map[string]promEndpoints{
+	"prometheus": {
+		rules:  "/api/v1/rules",
+		alerts: "/api/v1/alerts",
+	},
+	"loki": {
+		rules:  "/prometheus/api/v1/rules",
+		alerts: "/prometheus/api/v1/alerts",
+	},
+}
 
 type LotexProm struct {
 	log log.Logger
@@ -27,11 +43,16 @@ func NewLotexProm(proxy *AlertingProxy, log log.Logger) *LotexProm {
 }
 
 func (p *LotexProm) RouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
+	endpoints, err := p.getEndpoints(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
+
 	return p.withReq(
 		ctx, &http.Request{
 			URL: withPath(
 				*ctx.Req.URL,
-				promAlertsPath,
+				endpoints.alerts,
 			),
 		},
 		jsonExtractor(&apimodels.AlertResponse{}),
@@ -39,13 +60,30 @@ func (p *LotexProm) RouteGetAlertStatuses(ctx *models.ReqContext) response.Respo
 }
 
 func (p *LotexProm) RouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
+	endpoints, err := p.getEndpoints(ctx)
+	if err != nil {
+		return response.Error(500, err.Error(), nil)
+	}
+
 	return p.withReq(
 		ctx, &http.Request{
 			URL: withPath(
 				*ctx.Req.URL,
-				promRulesPath,
+				endpoints.rules,
 			),
 		},
 		jsonExtractor(&apimodels.RuleResponse{}),
 	)
+}
+
+func (p *LotexProm) getEndpoints(ctx *models.ReqContext) (*promEndpoints, error) {
+	ds, err := p.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
+	if err != nil {
+		return nil, err
+	}
+	routes, ok := dsTypeToLotexRoutes[ds.Type]
+	if !ok {
+		return nil, fmt.Errorf("unexpected datasource type. expecting loki or prometheus")
+	}
+	return &routes, nil
 }


### PR DESCRIPTION
I tested and only Loki worked :D need to use different prom endpoint prefixes for loki and for cortex

Long story: 
Cortex prometheus api prefix is `/api/prom` while Loki prometheus api prefix is `/prometheus`. However in grafana prometheus datasources pointing to cortex are already pre-configured with `/api/prom` prefix, so in the backend proxy we should not add any extra prefix. For Loki we still need to add `/prometheus` prefix.

Ruler endpoints are the same for both Cortex and Loki, `/api/prom/rules*`. However because prometheus datasources already preconfigure the `/api/prom` prefix, we must add this prefix only for requests to Loki.

TL;DR: I fixed it

I tested this to work with both Loki and Cortex
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

