### PR TITLE
SQL: Fix so that all captured errors are returned from sql engine

### DIFF
--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -185,6 +185,7 @@ func (e *dataPlugin) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 			rows, err := db.Query(rawSQL)
 			if err != nil {
 				queryResult.Error = e.queryResultTransformer.TransformQueryError(err)
+				ch <- queryResult
 				return
 			}
 			defer func() {
@@ -200,12 +201,14 @@ func (e *dataPlugin) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 				err := e.transformToTimeSeries(query, rows, &queryResult, queryContext)
 				if err != nil {
 					queryResult.Error = err
+					ch <- queryResult
 					return
 				}
 			case "table":
 				err := e.transformToTable(query, rows, &queryResult, queryContext)
 				if err != nil {
 					queryResult.Error = err
+					ch <- queryResult
 					return
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Noticed that errors from connecting to MSSQL wasn't returned to the UI nor logged server side. This should fix this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This doesn't apply to any released version of Grafana, only master.