### PR TITLE
Prometheus: Add legend name to dataframes config

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -216,7 +216,7 @@ func parseResponse(value model.Value, query *PrometheusQuery) (plugins.DataQuery
 		}
 		frames = append(frames, data.NewFrame(name,
 			data.NewField("time", nil, timeVector),
-			data.NewField("value", tags, values)))
+			data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: name})))
 	}
 	queryRes.Dataframes = plugins.NewDecodedDataFrames(frames)
 

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -182,6 +182,7 @@ func TestParseResponse(t *testing.T) {
 		require.Len(t, decoded[0].Fields[1].Labels, 2)
 		require.Equal(t, decoded[0].Fields[1].Labels.String(), "app=Application, tag2=tag2")
 		require.Equal(t, decoded[0].Fields[1].Name, "value")
+		require.Equal(t, decoded[0].Fields[1].Config.DisplayNameFromDS, "legend Application")
 
 		// Ensure the timestamps are UTC zoned
 		testValue := decoded[0].Fields[0].At(0)


### PR DESCRIPTION
**What this PR does / why we need it**:

The purpose of this PR is to fix the legend format, to be added into the [FieldConfig](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data#FieldConfig) field. This way, the legend will not be overridden by the field name plus tags.

**Which issue(s) this PR fixes**:

