### PR TITLE
AzureMonitor: Fix migration error from older versions of App Insights queries

### DIFF
--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
@@ -102,7 +102,10 @@ func (e *ApplicationInsightsDatasource) buildQueries(queries []plugins.DataSubQu
 		azureURL := fmt.Sprintf("metrics/%s", insightsJSONModel.MetricName)
 		timeGrain := insightsJSONModel.TimeGrain
 		timeGrains := insightsJSONModel.AllowedTimeGrainsMs
-		if timeGrain == "auto" {
+
+		// Previous versions of the query model don't specify a time grain, so we
+		// need to fallback to a default value
+		if timeGrain == "auto" || timeGrain == "" {
 			timeGrain, err = setAutoTimeGrain(query.IntervalMS, timeGrains)
 			if err != nil {
 				return nil, err

--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource_test.go
@@ -81,6 +81,25 @@ func TestApplicationInsightsDatasource(t *testing.T) {
 				So(queries[0].Params["interval"][0], ShouldEqual, "PT15M")
 			})
 
+			Convey("and has an empty time grain", func() {
+				tsdbQuery.Queries[0].Model = simplejson.NewFromAny(map[string]interface{}{
+					"appInsights": map[string]interface{}{
+						"rawQuery":    false,
+						"timeGrain":   "",
+						"aggregation": "Average",
+						"metricName":  "Percentage CPU",
+						"alias":       "testalias",
+						"queryType":   "Application Insights",
+					},
+				})
+				tsdbQuery.Queries[0].IntervalMS = 400000
+
+				queries, err := datasource.buildQueries(tsdbQuery.Queries, *tsdbQuery.TimeRange)
+				So(err, ShouldBeNil)
+
+				So(queries[0].Params["interval"][0], ShouldEqual, "PT15M")
+			})
+
 			Convey("and has a time grain set to auto and the metric has a limited list of allowed time grains", func() {
 				tsdbQuery.Queries[0].Model = simplejson.NewFromAny(map[string]interface{}{
 					"appInsights": map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:

Provides fallback value for timeGrain for older schemas

**Which issue(s) this PR fixes**:

Fixes #32326
