### PR TITLE
Prometheus: remove carriage-return characters from queries

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -161,7 +161,7 @@ describe('PrometheusDatasource', () => {
       expect(result).toMatchObject({ expr: DEFAULT_QUERY_EXPRESSION });
     });
 
-    it('replace any carriage-return ("\\r") character', () => {
+    it('replaces any carriage-return ("\\r") character', () => {
       const result = ds.createQuery({ expr: 'metric{job="foo\\r"} - metric' } as any, { interval: '15s' } as any, 0, 0);
       expect(result).toMatchObject({ expr: DEFAULT_QUERY_EXPRESSION });
     });

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -161,6 +161,11 @@ describe('PrometheusDatasource', () => {
       expect(result).toMatchObject({ expr: DEFAULT_QUERY_EXPRESSION });
     });
 
+    it('replace any carriage-return ("\\r") character', () => {
+      const result = ds.createQuery({ expr: 'metric{job="foo\\r"} - metric' } as any, { interval: '15s' } as any, 0, 0);
+      expect(result).toMatchObject({ expr: DEFAULT_QUERY_EXPRESSION });
+    });
+
     it('should add filters to expression', () => {
       templateSrvStub.getAdhocFilters.mockReturnValue([
         {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -447,6 +447,10 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     // Only replace vars in expression after having (possibly) updated interval vars
     query.expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
 
+    // Replace carriage-return characters which can be invisible if copied from
+    // somewhere (e.g. Excel) that implements its own parsing.
+    query.expr = query.expr.replace('\\r', '');
+
     // Align query interval with step to allow query caching and to ensure
     // that about-same-time query results look the same.
     const adjusted = alignRange(start, end, query.step, this.timeSrv.timeRange().to.utcOffset() * 60);

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -447,8 +447,8 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     // Only replace vars in expression after having (possibly) updated interval vars
     query.expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
 
-    // Replace carriage-return characters which can be invisible if copied from
-    // somewhere (e.g. Excel) that implements its own parsing.
+    // Replace carriage-return characters which can be invisible if the query is copied
+    // from somewhere (e.g. Excel) that implements its own parsing/formatting.
     query.expr = query.expr.replace('\\r', '');
 
     // Align query interval with step to allow query caching and to ensure


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

**What this PR does / why we need it**: This PR replaces `\r` (carriage-return) characters in Prometheus queries. As seen in the screenshot in the linked issue, nothing appears wrong with the text (the carriage-return character is not visible) and no error is shown - just "0 series returned".

![image](https://user-images.githubusercontent.com/43791257/112690580-50588700-8e7c-11eb-8e44-e0f9bbbc6441.png)

In this case, as noted by @ivanahuckova, the user copied the text from Excel, which has its own formatting/parsing. To be user-friendly, we should replace these characters.


**Which issue(s) this PR fixes**:

Fixes  #32159

**Special notes for your reviewer**: @ivanahuckova I am not sure if this is your area to review but I wanted to check in with you here because I didn't find the issue to be at ` public/app/core/utils/explore.ts` as mentioned [here](https://github.com/grafana/grafana/issues/32159#issuecomment-808160321). I console logged at that point but nothing was present - did I miss something?

The first place in the chain that I did find it was `locationSearchToObject` in `LocationService`, which is called at `GrafanaRoute.render()`

```javascript
return <RouteComponent {...props} queryParams={locationSearchToObject(props.location.search)} />;
```

But I figure this is just passing the query back to the frontend, whereas, as the `datasource/prometheus` tag you applied to the issue suggests, the issue should be cleaned on the backend (such that the query resolves as the user expects).

Please let me know if I've misunderstood anything there! Thanks 🙏 

Below I've explicitly added a carriage-return character because I actually don't have Excel, but I verified that the URL encoding was the same as if it were invisible, like in the linked issue,

![image](https://user-images.githubusercontent.com/43791257/112690461-17201700-8e7c-11eb-9128-29e173ffb784.png)

