### PR TITLE
PanelEditor: Fixes issue with data source picker not updating when selecting mixed data source

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
@@ -55,6 +55,8 @@ export class PanelEditorQueries extends PureComponent<Props> {
       // trigger queries when changing data source
       setTimeout(this.onRunQueries, 10);
     }
+
+    this.forceUpdate();
   };
 
   render() {


### PR DESCRIPTION
Fixes issue introduced by https://github.com/grafana/grafana/pull/32204 where I removed State from PanelEditorQueries relying on
the parent PanelEditorTabs to trigger re-render. But this does not always happen due to the mutable state in PanelModel and not
everything being passed via props.

This is messy situtaion (the whole events passing to trigger updates in part of PanelEditor). Needs a big rethink / refactoring. This
is just a hacky temporary fix.

Fixes #32320
