### PR TITLE
TimeSeries: Fixes issue with time x-axis and hour ticks that stretches across more than one day

### DIFF
--- a/packages/grafana-ui/src/components/Graph/utils.ts
+++ b/packages/grafana-ui/src/components/Graph/utils.ts
@@ -123,13 +123,13 @@ export const graphTimeFormat = (ticks: number | null, min: number | null, max: n
     if (secPerTick <= 45) {
       return systemDateFormats.interval.second;
     }
-    if (secPerTick <= 7200 && range <= oneDay) {
+    if (range <= oneDay) {
       return systemDateFormats.interval.minute;
     }
     if (secPerTick <= 80000) {
       return systemDateFormats.interval.hour;
     }
-    if (secPerTick <= 2419200 && range <= oneYear) {
+    if (range <= oneYear) {
       return systemDateFormats.interval.day;
     }
     if (secPerTick <= 31536000) {

--- a/packages/grafana-ui/src/components/Graph/utils.ts
+++ b/packages/grafana-ui/src/components/Graph/utils.ts
@@ -123,13 +123,13 @@ export const graphTimeFormat = (ticks: number | null, min: number | null, max: n
     if (secPerTick <= 45) {
       return systemDateFormats.interval.second;
     }
-    if (secPerTick <= 7200 || range <= oneDay) {
+    if (secPerTick <= 7200 && range <= oneDay) {
       return systemDateFormats.interval.minute;
     }
     if (secPerTick <= 80000) {
       return systemDateFormats.interval.hour;
     }
-    if (secPerTick <= 2419200 || range <= oneYear) {
+    if (secPerTick <= 2419200 && range <= oneYear) {
       return systemDateFormats.interval.day;
     }
     if (secPerTick <= 31536000) {

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -163,11 +163,11 @@ function formatTime(self: uPlot, splits: number[], axisIdx: number, foundSpace: 
     format = systemDateFormats.interval.second.replace('ss', 'ss.SS');
   } else if (foundIncr <= timeUnitSize.minute) {
     format = systemDateFormats.interval.second;
-  } else if (foundIncr <= timeUnitSize.hour || range <= timeUnitSize.day) {
+  } else if (foundIncr <= timeUnitSize.hour && range <= timeUnitSize.day) {
     format = systemDateFormats.interval.minute;
   } else if (foundIncr <= timeUnitSize.day) {
     format = systemDateFormats.interval.hour;
-  } else if (foundIncr <= timeUnitSize.month || range < timeUnitSize.year) {
+  } else if (foundIncr <= timeUnitSize.month && range < timeUnitSize.year) {
     format = systemDateFormats.interval.day;
   } else if (incrementRoundedToDay === yearRoundedToDay) {
     format = systemDateFormats.interval.year;

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -163,11 +163,11 @@ function formatTime(self: uPlot, splits: number[], axisIdx: number, foundSpace: 
     format = systemDateFormats.interval.second.replace('ss', 'ss.SS');
   } else if (foundIncr <= timeUnitSize.minute) {
     format = systemDateFormats.interval.second;
-  } else if (foundIncr <= timeUnitSize.hour && range <= timeUnitSize.day) {
+  } else if (range <= timeUnitSize.day) {
     format = systemDateFormats.interval.minute;
   } else if (foundIncr <= timeUnitSize.day) {
     format = systemDateFormats.interval.hour;
-  } else if (foundIncr <= timeUnitSize.month && range < timeUnitSize.year) {
+  } else if (range < timeUnitSize.year) {
     format = systemDateFormats.interval.day;
   } else if (incrementRoundedToDay === yearRoundedToDay) {
     format = systemDateFormats.interval.year;


### PR DESCRIPTION
Fixes #32325


@leeoniya Seeing something strange on really wide 2 day range time series graphs, the last x-axis ticks are not the same size as the others. 

![Screenshot from 2021-03-28 08-46-38](https://user-images.githubusercontent.com/10999/112744648-4e88e380-8fa2-11eb-9069-c3b600eac940.png)

