### PR TITLE
ImportDashboard: Fixes backend handler not found error when importing dashboard

### DIFF
--- a/pkg/services/dashboards/dashboard_service.go
+++ b/pkg/services/dashboards/dashboard_service.go
@@ -334,12 +334,12 @@ func (dr *dashboardServiceImpl) ImportDashboard(dto *SaveDashboardDTO) (
 		return nil, err
 	}
 
-	err = bus.Dispatch(cmd)
+	dash, err := dr.dashboardStore.SaveDashboard(*cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	return cmd.Result, nil
+	return dash, nil
 }
 
 // UnprovisionDashboard removes info about dashboard being provisioned. Used after provisioning configs are changed


### PR DESCRIPTION
Fixes #32296
