### PR TITLE
API: Datasource endpoint should return 400 bad request if id and orgId is invalid

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -73,7 +73,7 @@ func GetDataSourceById(c *models.ReqContext) response.Response {
 			return response.Error(404, "Data source not found", nil)
 		}
 		if errors.Is(err, models.ErrDataSourceIdentifierNotSet) {
-			return response.Error(400, "Invalid parameters", nil)
+			return response.Error(400, "Datasource id is missing.", nil)
 		}
 		return response.Error(500, "Failed to query datasources", err)
 	}

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -73,7 +73,7 @@ func GetDataSourceById(c *models.ReqContext) response.Response {
 			return response.Error(404, "Data source not found", nil)
 		}
 		if errors.Is(err, models.ErrDataSourceIdentifierNotSet) {
-			return response.Error(400, "Datasource id is missing.", nil)
+			return response.Error(400, "Datasource id is missing", nil)
 		}
 		return response.Error(500, "Failed to query datasources", err)
 	}

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -72,6 +72,9 @@ func GetDataSourceById(c *models.ReqContext) response.Response {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
 			return response.Error(404, "Data source not found", nil)
 		}
+		if errors.Is(err, models.ErrDataSourceIdentifierNotSet) {
+			return response.Error(400, "Invalid parameters", nil)
+		}
 		return response.Error(500, "Failed to query datasources", err)
 	}
 


### PR DESCRIPTION
We should always return 4xx for invalid requests.  

Signed-off-by: bergquist <carl.bergquist@gmail.com>
