### PR TITLE
Chore: Update console message for failed plugin runs

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -57,7 +57,7 @@ func runPluginCommand(command func(commandLine utils.CommandLine) error) func(co
 			return err
 		}
 
-		logger.Info("\nRestart grafana after installing plugins . <service grafana-server restart>\n\n")
+		logger.Info("\nRestart Grafana after installing plugins. Refer to Grafana documentation for instructions if necessary.\n\n\n\n")
 		return nil
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the console print from `Restart grafana after installing plugins . <service grafana-server restart>` to `Restart Grafana after installing plugins. Refer to Grafana documentation for instructions if necessary.`

**Which issue(s) this PR fixes**:

Fixes #20983

