### PR TITLE
Panel: Fixes description markdown with inline code being rendered on newlines and full width 

### DIFF
--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -181,8 +181,11 @@ $panel-header-no-title-zindex: 1;
 
   code {
     white-space: normal;
-    display: block;
     word-wrap: break-word;
+  }
+
+  pre > code {
+    display: block;
   }
 
   .panel-info-corner-links {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/32078

Not rewriting to emotion as we are to change how the panel description will work in v8 most probably