### PR TITLE
Panel/DashList: Fetch folders with View permission

### DIFF
--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -18,6 +18,7 @@ export interface Props {
   dashboardId?: any;
   initialTitle?: string;
   initialFolderId?: number;
+  permissionLevel?: 'View' | 'Edit';
 }
 
 interface State {
@@ -40,11 +41,12 @@ export class FolderPicker extends PureComponent<Props, State> {
     });
   }
 
-  static defaultProps = {
+  static defaultProps: Partial<Props> = {
     rootName: 'General',
     enableReset: false,
     initialTitle: '',
     enableCreateNew: false,
+    permissionLevel: 'Edit',
   };
 
   componentDidMount = async () => {
@@ -52,11 +54,11 @@ export class FolderPicker extends PureComponent<Props, State> {
   };
 
   getOptions = async (query: string) => {
-    const { rootName, enableReset, initialTitle } = this.props;
+    const { rootName, enableReset, initialTitle, permissionLevel } = this.props;
     const params = {
       query,
       type: 'dash-folder',
-      permission: 'Edit',
+      permission: permissionLevel,
     };
 
     // TODO: move search to BackendSrv interface

--- a/public/app/plugins/panel/dashlist/module.tsx
+++ b/public/app/plugins/panel/dashlist/module.tsx
@@ -49,6 +49,7 @@ export const plugin = new PanelPlugin<DashListOptions>(DashList)
               initialFolderId={props.value}
               initialTitle="All"
               enableReset={true}
+              permissionLevel="View"
               onChange={({ id }) => props.onChange(id)}
             />
           );


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the folder picker component would only fetch folders for which the user has 'Edit' permissions, but for the
`DashList` panel, 'View' permissions are all that should be required.
This PR adds a `permissionLevel` prop to the `FolderPicker` component, so the appropriate folders can be selected.

**Which issue(s) this PR fixes**:
Closes #31357
