### PR TITLE
Postgres/MySQL/MSSQL: Don't return connection failure details to the client

### DIFF
--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -148,7 +148,7 @@ func (t *mssqlQueryResultTransformer) TransformQueryResult(columnTypes []*sql.Co
 }
 
 func (t *mssqlQueryResultTransformer) TransformQueryError(err error) error {
-	// go-mssql overrides source error why we currently match on string
+	// go-mssql overrides source error, so we currently match on string
 	// ref https://github.com/denisenkom/go-mssqldb/blob/045585d74f9069afe2e115b6235eb043c8047043/tds.go#L904
 	if strings.HasPrefix(strings.ToLower(err.Error()), "unable to open tcp connection with host") {
 		t.log.Error("query error", "err", err)

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -2,7 +2,6 @@ package mssql
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -152,10 +151,8 @@ func (t *mssqlQueryResultTransformer) TransformQueryError(err error) error {
 	// ref https://github.com/denisenkom/go-mssqldb/blob/045585d74f9069afe2e115b6235eb043c8047043/tds.go#L904
 	if strings.HasPrefix(strings.ToLower(err.Error()), "unable to open tcp connection with host") {
 		t.log.Error("query error", "err", err)
-		return errConnectionFailed
+		return sqleng.ErrConnectionFailed
 	}
 
 	return err
 }
-
-var errConnectionFailed = errors.New("failed to connect - please inspect Grafana server log for details")

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -4,8 +4,10 @@ import (
 	"container/list"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"math"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -28,6 +30,8 @@ import (
 
 // MetaKeyExecutedQueryString is the key where the executed query should get stored
 const MetaKeyExecutedQueryString = "executedQueryString"
+
+var errConnectionFailed = errors.New("failed to connect to server - please inspect Grafana server log for details")
 
 // SQLMacroEngine interpolates macros into sql. It takes in the Query to have access to query context and
 // timeRange to be able to generate queries that use from and to.
@@ -184,7 +188,7 @@ func (e *dataPlugin) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 
 			rows, err := db.Query(rawSQL)
 			if err != nil {
-				queryResult.Error = e.queryResultTransformer.TransformQueryError(err)
+				queryResult.Error = e.transformQueryError(err)
 				ch <- queryResult
 				return
 			}
@@ -429,6 +433,20 @@ func (e *dataPlugin) transformToTimeSeries(query plugins.DataSubQuery, rows *cor
 
 	result.Meta.Set("rowCount", cfg.rowCount)
 	return nil
+}
+
+func (e *dataPlugin) transformQueryError(err error) error {
+	// OpError is the error type usually returned by functions in the net
+	// package. It describes the operation, network type, and address of
+	// an error. We log this error rather than returing it to the client
+	// for security purposes.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		e.log.Error("query error", "err", err)
+		return errConnectionFailed
+	}
+
+	return e.queryResultTransformer.TransformQueryError(err)
 }
 
 type processCfg struct {

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -31,7 +31,7 @@ import (
 // MetaKeyExecutedQueryString is the key where the executed query should get stored
 const MetaKeyExecutedQueryString = "executedQueryString"
 
-var errConnectionFailed = errors.New("failed to connect to server - please inspect Grafana server log for details")
+var ErrConnectionFailed = errors.New("failed to connect to server - please inspect Grafana server log for details")
 
 // SQLMacroEngine interpolates macros into sql. It takes in the Query to have access to query context and
 // timeRange to be able to generate queries that use from and to.
@@ -443,7 +443,7 @@ func (e *dataPlugin) transformQueryError(err error) error {
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
 		e.log.Error("query error", "err", err)
-		return errConnectionFailed
+		return ErrConnectionFailed
 	}
 
 	return e.queryResultTransformer.TransformQueryError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
For security reasons, log any SQL connection error details rather than returning it to the client.

**Which issue(s) this PR fixes**:
Fixes #26623 
Fixes #22000 

**Special notes for your reviewer**:
- OpError in net package: https://github.com/golang/go/blob/d4b26382342c98a95b85140b2863bc30c48edd68/src/net/net.go#L435
- go-mssql connection error: https://github.com/denisenkom/go-mssqldb/blob/045585d74f9069afe2e115b6235eb043c8047043/tds.go#L904 
