### PR TITLE
MSSQL: By default let driver choose port

### DIFF
--- a/docs/sources/datasources/mssql.md
+++ b/docs/sources/datasources/mssql.md
@@ -16,7 +16,7 @@ Grafana ships with a built-in Microsoft SQL Server (MS SQL) data source plugin t
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `Name`           | The data source name. This is how you refer to the data source in panels and queries.                                                 |
 | `Default`        | Default data source means that it will be pre-selected for new panels.                                                                |
-| `Host`           | The IP address/hostname and optional port of your MS SQL instance. If port is omitted, default 1433 will be used.                     |
+| `Host`           | The IP address/hostname and optional port of your MS SQL instance. If the port is omitted, the driver default will be used (0).       |
 | `Database`       | Name of your MS SQL database.                                                                                                         |
 | `Authentication` | Authentication mode. Either using SQL Server Authentication or Windows Authentication (single sign on for Windows users).             |
 | `User`           | Database user's login/username                                                                                                        |

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -93,7 +93,7 @@ func generateConnectionString(dataSource *models.DataSource) (string, error) {
 	}
 
 	logger.Debug("Generating connection string", args...)
-	encrypt := datasource.JsonData.Get("encrypt").MustString("false")
+	encrypt := dataSource.JsonData.Get("encrypt").MustString("false")
 	connStr := fmt.Sprintf("server=%s;database=%s;user id=%s;password=%s;",
 		addr.Host,
 		dataSource.Database,

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -66,11 +66,11 @@ func ParseURL(u string) (*url.URL, error) {
 	}, nil
 }
 
-func generateConnectionString(datasource *models.DataSource) (string, error) {
+func generateConnectionString(dataSource *models.DataSource) (string, error) {
 	const dfltPort = "0"
 	var addr util.NetworkAddress
-	if datasource.Url != "" {
-		u, err := ParseURL(datasource.Url)
+	if dataSource.Url != "" {
+		u, err := ParseURL(dataSource.Url)
 		if err != nil {
 			return "", err
 		}
@@ -86,7 +86,7 @@ func generateConnectionString(datasource *models.DataSource) (string, error) {
 	}
 
 	args := []interface{}{
-		"url", datasource.Url, "host", addr.Host,
+		"url", dataSource.Url, "host", addr.Host,
 	}
 	if addr.Port != "0" {
 		args = append(args, "port", addr.Port)
@@ -96,9 +96,9 @@ func generateConnectionString(datasource *models.DataSource) (string, error) {
 	encrypt := datasource.JsonData.Get("encrypt").MustString("false")
 	connStr := fmt.Sprintf("server=%s;database=%s;user id=%s;password=%s;",
 		addr.Host,
-		datasource.Database,
-		datasource.User,
-		datasource.DecryptedPassword(),
+		dataSource.Database,
+		dataSource.User,
+		dataSource.DecryptedPassword(),
 	)
 	// Port number 0 means to determine the port automatically, so we can let the driver choose
 	if addr.Port != "0" {

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -85,7 +85,14 @@ func generateConnectionString(datasource *models.DataSource) (string, error) {
 		}
 	}
 
-	logger.Debug("Generating connection string", "url", datasource.Url, "host", addr.Host, "port", addr.Port)
+	args := []interface{}{
+		"url", datasource.Url, "host", addr.Host,
+	}
+	if addr.Port != "0" {
+		args = append(args, "port", addr.Port)
+	}
+
+	logger.Debug("Generating connection string", args...)
 	encrypt := datasource.JsonData.Get("encrypt").MustString("false")
 	connStr := fmt.Sprintf("server=%s;database=%s;user id=%s;password=%s;",
 		addr.Host,

--- a/public/app/plugins/datasource/mssql/partials/config.html
+++ b/public/app/plugins/datasource/mssql/partials/config.html
@@ -4,7 +4,7 @@
 <div class="gf-form-group">
 	<div class="gf-form max-width-30">
 		<span class="gf-form-label width-7">Host</span>
-		<input type="text" class="gf-form-input" style="width: 352px" ng-model='ctrl.current.url' placeholder="localhost:1433" bs-typeahead="{{['localhost', 'localhost:1433']}}" required></input>
+		<input type="text" class="gf-form-input" style="width: 352px" ng-model='ctrl.current.url' placeholder="localhost" bs-typeahead="{{['localhost', 'localhost" required></input>
 	</div>
 
 	<div class="gf-form max-width-30">


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of hardcoding default MSSQL port, let the driver choose it. The driver will pick port 0 (automatic discovery) by default, so if the data source's port is 0 (or not configured), we might as well interpret it as "pick the default", and defer to the driver to make the choice (i.e. not providing the port parameter). This should fix the bug when someone specifies a named SQL Server instance, in which case the hardwired default (1433) most likely wrong (since named instances typically have other ports, often at random).

**Which issue(s) this PR fixes**:

Fixes #27224.

**Special notes for your reviewer**:

