### PR TITLE
API: Return 409 on datasource version conflict

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -240,7 +240,7 @@ func UpdateDataSource(c *models.ReqContext, cmd models.UpdateDataSourceCommand) 
 	err = bus.Dispatch(&cmd)
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceUpdatingOldVersion) {
-			return response.Error(500, "Failed to update datasource. Reload new version and try again", err)
+			return response.Error(409, "Datasource have already been updated by someone else. Reload new version and try again", err)
 		}
 		return response.Error(500, "Failed to update datasource", err)
 	}

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -240,7 +240,7 @@ func UpdateDataSource(c *models.ReqContext, cmd models.UpdateDataSourceCommand) 
 	err = bus.Dispatch(&cmd)
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceUpdatingOldVersion) {
-			return response.Error(409, "Datasource have already been updated by someone else. Reload new version and try again", err)
+			return response.Error(409, "Datasource has already been updated by someone else. Please reload and try again", err)
 		}
 		return response.Error(500, "Failed to update datasource", err)
 	}


### PR DESCRIPTION
Trying to update an old datasource version should not return an `5xx`. 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409