### PR TITLE
Filter by value: respect field config coming from the datasource

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
@@ -56,15 +56,13 @@ describe('FilterByValue transformer', () => {
           name: 'time',
           type: FieldType.time,
           values: new ArrayVector([6000, 7000]),
-          state: { displayName: 'time' },
-          config: {},
+          state: {},
         },
         {
           name: 'numbers',
           type: FieldType.number,
           values: new ArrayVector([6, 7]),
-          state: { displayName: 'numbers' },
-          config: {},
+          state: {},
         },
       ]);
     });
@@ -99,15 +97,13 @@ describe('FilterByValue transformer', () => {
           name: 'time',
           type: FieldType.time,
           values: new ArrayVector([1000, 2000, 3000, 4000, 5000]),
-          state: { displayName: 'time' },
-          config: {},
+          state: {},
         },
         {
           name: 'numbers',
           type: FieldType.number,
           values: new ArrayVector([1, 2, 3, 4, 5]),
-          state: { displayName: 'numbers' },
-          config: {},
+          state: {},
         },
       ]);
     });
@@ -151,15 +147,13 @@ describe('FilterByValue transformer', () => {
           name: 'time',
           type: FieldType.time,
           values: new ArrayVector([1000, 2000, 3000, 4000, 7000]),
-          state: { displayName: 'time' },
-          config: {},
+          state: {},
         },
         {
           name: 'numbers',
           type: FieldType.number,
           values: new ArrayVector([1, 2, 3, 4, 7]),
-          state: { displayName: 'numbers' },
-          config: {},
+          state: {},
         },
       ]);
     });
@@ -203,15 +197,13 @@ describe('FilterByValue transformer', () => {
           name: 'time',
           type: FieldType.time,
           values: new ArrayVector([4000, 5000]),
-          state: { displayName: 'time' },
-          config: {},
+          state: {},
         },
         {
           name: 'numbers',
           type: FieldType.number,
           values: new ArrayVector([4, 5]),
-          state: { displayName: 'numbers' },
-          config: {},
+          state: {},
         },
       ]);
     });

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -110,11 +110,11 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
               }
             }
 
-            // TODO: what parts needs to be excluded from field.
+            // We keep field config, but clean the state as it's being recalculated when the field overrides are applied
             fields.push({
               ...field,
               values: new ArrayVector(buffer),
-              config: {},
+              state: {},
             });
           }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/31874

Field config should be preserved, as the transformation does not affect it. But state of the field is affected, hence I'm cleaning it and it's being recalculated in a later stap of the Panel Query Runner getData pipeline, when the overrides are applied.