### PR TITLE
Chore: Fix admin password change which contains special characters on Ubuntu

### DIFF
--- a/packaging/wrappers/grafana-cli
+++ b/packaging/wrappers/grafana-cli
@@ -36,4 +36,4 @@ OPTS="--homepath=${GRAFANA_HOME} \
                         cfg:default.paths.logs=${LOG_DIR} \
                         cfg:default.paths.plugins=${PLUGINS_DIR}'"
 
-eval $EXECUTABLE "$OPTS" "$@"
+eval $EXECUTABLE "$OPTS" '$@'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is for allowing users to add passwords with special characters, running on _Ubuntu_ using **`.deb`** package.

**Which issue(s) this PR fixes**:

Fixes #28996

**Steps to reproduce**:

* Download and install `.deb` file on Ubuntu.
* Try `$ sudo grafana-cli admin reset-admin-password '#"U:n;O.R7Gi^:1~y+1Y)'` 
You'll get: 
```
/usr/sbin/grafana-cli: eval: line 39: syntax error near unexpected token `('
/usr/sbin/grafana-cli: eval: line 39: `/usr/share/grafana/bin/grafana-cli --homepath=/usr/share/grafana       --config=/etc/grafana/grafana.ini       --pluginsDir=/var/lib/grafana/plugins       --configOverrides='cfg:default.paths.provisioning=/etc/grafana/provisioning                         cfg:default.paths.data=/var/lib/grafana                         cfg:default.paths.logs=/var/log/grafana                         cfg:default.paths.plugins=/var/lib/grafana/plugins' admin reset-admin-password (admin)'
```
* Then run `$ which grafana-cli`
* `$ sudo vi {GRAFANA_CLI_PATH}`
*  Change last line as it is this PR (remove double quotes - add single)
* Run `$ sudo grafana-cli admin reset-admin-password '#"U:n;O.R7Gi^:1~y+1Y)'` again
You'll see:
```
INFO[03-29|16:38:27] Connecting to DB                         logger=sqlstore dbtype=sqlite3
INFO[03-29|16:38:27] Starting DB migrations                   logger=migrator
INFO[03-29|16:38:27] migrations completed                     logger=migrator performed=0 skipped=279 duration=705.052µs
 
Admin password changed successfully ✔
```
