### PR TITLE
TablePanel: Make sorting case-insensitive

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -14,7 +14,7 @@ import {
   useTable,
 } from 'react-table';
 import { FixedSizeList } from 'react-window';
-import { getColumns } from './utils';
+import { getColumns, sortCaseInsensitive } from './utils';
 import { useTheme } from '../../themes';
 import {
   TableColumnResizeActionCallback,
@@ -151,6 +151,9 @@ export const Table: FC<Props> = memo((props: Props) => {
       disableResizing: !resizable,
       stateReducer: stateReducer,
       initialState: getInitialState(initialSortBy, memoizedColumns),
+      sortTypes: {
+        'alphanumeric-insensitive': sortCaseInsensitive,
+      },
     }),
     [initialSortBy, memoizedColumns, memoizedData, resizable, stateReducer]
   );

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -206,15 +206,5 @@ export function getFilteredOptions(options: SelectableValue[], filterValues?: Se
 }
 
 export function sortCaseInsensitive(a: Row<any>, b: Row<any>, id: string) {
-  const aLowerCase = a.values[id].toLowerCase();
-  const bLowerCase = b.values[id].toLowerCase();
-
-  if (aLowerCase < bLowerCase) {
-    return -1;
-  }
-  if (aLowerCase > bLowerCase) {
-    return 1;
-  }
-
-  return 0;
+  return a.values[id].localeCompare(b.values[id], undefined, { sensitivity: 'base' });
 }

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -206,5 +206,5 @@ export function getFilteredOptions(options: SelectableValue[], filterValues?: Se
 }
 
 export function sortCaseInsensitive(a: Row<any>, b: Row<any>, id: string) {
-  return a.values[id].localeCompare(b.values[id], undefined, { sensitivity: 'base' });
+  return String(a.values[id]).localeCompare(String(b.values[id]), undefined, { sensitivity: 'base' });
 }

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -63,7 +63,7 @@ export function getColumns(data: DataFrame, availableWidth: number, columnMinWid
         case FieldType.time:
           return 'basic';
         default:
-          return 'alphanumeric';
+          return 'alphanumeric-insensitive';
       }
     };
 
@@ -203,4 +203,18 @@ export function getFilteredOptions(options: SelectableValue[], filterValues?: Se
   }
 
   return options.filter((option) => filterValues.some((filtered) => filtered.value === option.value));
+}
+
+export function sortCaseInsensitive(a: Row<any>, b: Row<any>, id: string) {
+  const aLowerCase = a.values[id].toLowerCase();
+  const bLowerCase = b.values[id].toLowerCase();
+
+  if (aLowerCase < bLowerCase) {
+    return -1;
+  }
+  if (aLowerCase > bLowerCase) {
+    return 1;
+  }
+
+  return 0;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a sort type 'alphanumeric-insensitive' to the `Table` component and makes it the default for non-numeric fields.

**Which issue(s) this PR fixes**:
Closes #30476

**Special notes for your reviewer**:

