### PR TITLE
Access control: Fix the index on permissions table

### DIFF
--- a/pkg/services/accesscontrol/database/database_mig.go
+++ b/pkg/services/accesscontrol/database/database_mig.go
@@ -14,7 +14,7 @@ func AddAccessControlMigrations(mg *migrator.Migrator) {
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 		},
 		Indices: []*migrator.Index{
-			{Cols: []string{"role_id", "permission", "scope"}},
+			{Cols: []string{"role_id", "permission", "scope"}, Type: migrator.UniqueIndex},
 		},
 	}
 

--- a/pkg/services/accesscontrol/database/database_mig.go
+++ b/pkg/services/accesscontrol/database/database_mig.go
@@ -14,14 +14,14 @@ func AddAccessControlMigrations(mg *migrator.Migrator) {
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 		},
 		Indices: []*migrator.Index{
-			{Cols: []string{"role_id"}},
+			{Cols: []string{"role_id", "permission", "scope"}},
 		},
 	}
 
 	mg.AddMigration("create permission table", migrator.NewAddTableMigration(permissionV1))
 
 	//-------  indexes ------------------
-	mg.AddMigration("add unique index permission.role_id", migrator.NewAddIndexMigration(permissionV1, permissionV1.Indices[0]))
+	mg.AddMigration("add unique index role_id_permission_scope", migrator.NewAddIndexMigration(permissionV1, permissionV1.Indices[0]))
 
 	roleV1 := migrator.Table{
 		Name: "role",


### PR DESCRIPTION
Permissions can be assigned to multiple roles, thus index on `role_id` only won't work. The constraint we have from business logic is the `role_id_permission_scope`. If I understand the code right, this is also going to support sufficient queries.

With current behaviour, the seeder is failing to start.

Related issue: https://github.com/grafana/grafana-enterprise/issues/1091