### PR TITLE
SigV4: Add support EC2 IAM role auth and possibility to toggle auth providers 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gosimple/slug v1.9.0
 	github.com/grafana/alerting-api v0.0.0-20210323194814-03a29a4c4c27
-	github.com/grafana/grafana-aws-sdk v0.2.0
+	github.com/grafana/grafana-aws-sdk v0.3.0
 	github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4
 	github.com/grafana/grafana-plugin-sdk-go v0.89.0
 	github.com/grafana/loki v1.6.2-0.20201026154740-6978ee5d7387

--- a/go.sum
+++ b/go.sum
@@ -804,6 +804,8 @@ github.com/grafana/grafana v1.9.2-0.20210308201921-4ce0a49eac03/go.mod h1:AHRRvd
 github.com/grafana/grafana-aws-sdk v0.1.0/go.mod h1:+pPo5U+pX0zWimR7YBc7ASeSQfbRkcTyQYqMiAj7G5U=
 github.com/grafana/grafana-aws-sdk v0.2.0 h1:UTBBYwye+ad5YUIlwN7TGxLdz1wXN3Ezhl0pseDGRVA=
 github.com/grafana/grafana-aws-sdk v0.2.0/go.mod h1:+pPo5U+pX0zWimR7YBc7ASeSQfbRkcTyQYqMiAj7G5U=
+github.com/grafana/grafana-aws-sdk v0.3.0 h1:UT3rIXQFeAh0OaRJT7dUQojYaSjbI9RwOtMacaerv8I=
+github.com/grafana/grafana-aws-sdk v0.3.0/go.mod h1:+pPo5U+pX0zWimR7YBc7ASeSQfbRkcTyQYqMiAj7G5U=
 github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4 h1:SPdxCL9BChFTlyi0Khv64vdCW4TMna8+sxL7+Chx+Ag=
 github.com/grafana/grafana-plugin-model v0.0.0-20190930120109-1fc953a61fb4/go.mod h1:nc0XxBzjeGcrMltCDw269LoWF9S8ibhgxolCdA1R8To=
 github.com/grafana/grafana-plugin-sdk-go v0.79.0/go.mod h1:NvxLzGkVhnoBKwzkst6CFfpMFKwAdIUZ1q8ssuLeF60=

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "dependencies": {
     "@emotion/core": "10.0.27",
-    "@grafana/aws-sdk": "0.0.24",
+    "@grafana/aws-sdk": "0.0.241",
     "@grafana/slate-react": "0.22.9-grafana",
     "@popperjs/core": "2.5.4",
     "@reduxjs/toolkit": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "dependencies": {
     "@emotion/core": "10.0.27",
-    "@grafana/aws-sdk": "0.0.25",
+    "@grafana/aws-sdk": "0.0.3",
     "@grafana/slate-react": "0.22.9-grafana",
     "@popperjs/core": "2.5.4",
     "@reduxjs/toolkit": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
   },
   "dependencies": {
     "@emotion/core": "10.0.27",
-    "@grafana/aws-sdk": "0.0.241",
+    "@grafana/aws-sdk": "0.0.25",
     "@grafana/slate-react": "0.22.9-grafana",
     "@popperjs/core": "2.5.4",
     "@reduxjs/toolkit": "1.5.0",

--- a/packages/grafana-ui/.storybook/webpack.config.js
+++ b/packages/grafana-ui/.storybook/webpack.config.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = async ({ config, mode }) => {
+  config.node = { fs: 'empty' };
+  return config;
+};

--- a/packages/grafana-ui/.storybook/webpack.config.js
+++ b/packages/grafana-ui/.storybook/webpack.config.js
@@ -1,6 +1,0 @@
-const path = require('path');
-
-module.exports = async ({ config, mode }) => {
-  config.node = { fs: 'empty' };
-  return config;
-};

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -31,6 +31,7 @@
     "@grafana/e2e-selectors": "7.5.0-pre.0",
     "@grafana/slate-react": "0.22.9-grafana",
     "@grafana/tsconfig": "^1.0.0-rc1",
+    "@grafana/aws-sdk": "0.0.3",
     "@iconscout/react-unicons": "1.1.4",
     "@popperjs/core": "2.5.4",
     "@sentry/browser": "5.25.0",

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -28,6 +28,7 @@ const buildCjsPackage = ({ env }) => {
     external: [
       'react',
       'react-dom',
+      '@grafana/aws-sdk',
       '@grafana/data',
       '@grafana/e2e-selectors',
       'moment',

--- a/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { HttpSettingsBaseProps } from './types';
-import { DataSourceSettings, SelectableValue } from '@grafana/data';
+import { DataSourceSettings } from '@grafana/data';
 import {
   AwsAuthDataSourceSecureJsonData,
   AwsAuthDataSourceJsonData,
@@ -11,48 +11,19 @@ import {
 export const SigV4AuthSettings: React.FC<HttpSettingsBaseProps> = (props) => {
   const { dataSourceConfig, onChange } = props;
 
-  const regions = [
-    { value: 'af-south-1', label: 'af-south-1' },
-    { value: 'ap-east-1', label: 'ap-east-1' },
-    { value: 'ap-northeast-1', label: 'ap-northeast-1' },
-    { value: 'ap-northeast-2', label: 'ap-northeast-2' },
-    { value: 'ap-northeast-3', label: 'ap-northeast-3' },
-    { value: 'ap-south-1', label: 'ap-south-1' },
-    { value: 'ap-southeast-1', label: 'ap-southeast-1' },
-    { value: 'ap-southeast-2', label: 'ap-southeast-2' },
-    { value: 'ca-central-1', label: 'ca-central-1' },
-    { value: 'cn-north-1', label: 'cn-north-1' },
-    { value: 'cn-northwest-1', label: 'cn-northwest-1' },
-    { value: 'eu-central-1', label: 'eu-central-1' },
-    { value: 'eu-north-1', label: 'eu-north-1' },
-    { value: 'eu-west-1', label: 'eu-west-1' },
-    { value: 'eu-west-2', label: 'eu-west-2' },
-    { value: 'eu-west-3', label: 'eu-west-3' },
-    { value: 'me-south-1', label: 'me-south-1' },
-    { value: 'sa-east-1', label: 'sa-east-1' },
-    { value: 'us-east-1', label: 'us-east-1' },
-    { value: 'us-east-2', label: 'us-east-2' },
-    { value: 'us-gov-east-1', label: 'us-gov-east-1' },
-    { value: 'us-gov-west-1', label: 'us-gov-west-1' },
-    { value: 'us-iso-east-1', label: 'us-iso-east-1' },
-    { value: 'us-isob-east-1', label: 'us-isob-east-1' },
-    { value: 'us-west-1', label: 'us-west-1' },
-    { value: 'us-west-2', label: 'us-west-2' },
-  ] as SelectableValue[];
-
   const connectionConfigProps: ConnectionConfigProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> = {
     onOptionsChange: (awsDataSourceSettings) => {
-      const dataSourceSettings: DataSourceSettings = {
+      const dataSourceSettings: DataSourceSettings<any, any> = {
         ...dataSourceConfig,
         jsonData: {
-          ...awsDataSourceSettings.jsonData,
+          ...dataSourceConfig.jsonData,
           sigV4AuthType: awsDataSourceSettings.jsonData.authType,
           sigV4Profile: awsDataSourceSettings.jsonData.profile,
           sigV4AssumeRoleArn: awsDataSourceSettings.jsonData.assumeRoleArn,
           sigV4ExternalId: awsDataSourceSettings.jsonData.externalId,
           sigV4Region: awsDataSourceSettings.jsonData.defaultRegion,
           sigV4Endpoint: awsDataSourceSettings.jsonData.endpoint,
-        } as any, // sigV4 jsonData fields are not typed
+        },
         secureJsonFields: {
           sigV4AccessKey: awsDataSourceSettings.secureJsonFields?.accessKey,
           sigV4SecretKey: awsDataSourceSettings.secureJsonFields?.secretKey,
@@ -89,7 +60,7 @@ export const SigV4AuthSettings: React.FC<HttpSettingsBaseProps> = (props) => {
   return (
     <>
       <h6>SigV4 Auth Details</h6>
-      <ConnectionConfig {...connectionConfigProps} standardRegions={regions.map((r) => r.value)}></ConnectionConfig>
+      <ConnectionConfig {...connectionConfigProps}></ConnectionConfig>
     </>
   );
 };

--- a/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
@@ -59,8 +59,10 @@ export const SigV4AuthSettings: React.FC<HttpSettingsBaseProps> = (props) => {
 
   return (
     <>
-      <h6>SigV4 Auth Details</h6>
-      <ConnectionConfig {...connectionConfigProps}></ConnectionConfig>
+      <div className="gf-form">
+        <h6>SigV4 Auth Details</h6>
+      </div>
+      <ConnectionConfig {...connectionConfigProps} skipHeader skipEndpoint></ConnectionConfig>
     </>
   );
 };

--- a/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
@@ -11,6 +11,8 @@ import {
 export const SigV4AuthSettings: React.FC<HttpSettingsBaseProps> = (props) => {
   const { dataSourceConfig, onChange } = props;
 
+  // The @grafana/aws-sdk ConnectionConfig is designed to be rendered in a ConfigEditor,
+  // taking DataSourcePluginOptionsEditorProps as props. We therefore need to map the props accordingly.
   const connectionConfigProps: ConnectionConfigProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> = {
     onOptionsChange: (awsDataSourceSettings) => {
       const dataSourceSettings: DataSourceSettings<any, any> = {

--- a/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react';
-import { HttpSettingsProps } from './types';
-import { SelectableValue } from '@grafana/data';
+import { HttpSettingsBaseProps } from './types';
+import { DataSourcePluginOptionsEditorProps, DataSourceSettings, SelectableValue } from '@grafana/data';
+import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData, ConnectionConfig } from '@grafana/aws-sdk';
+
 import { Button, InlineFormLabel, Input } from '..';
 import Select from '../Forms/Legacy/Select/Select';
 
-export const SigV4AuthSettings: React.FC<HttpSettingsProps> = (props) => {
+export const SigV4AuthSettings: React.FC<HttpSettingsBaseProps> = (props) => {
   const { dataSourceConfig, onChange } = props;
 
   const authProviderOptions = [
@@ -90,9 +92,61 @@ export const SigV4AuthSettings: React.FC<HttpSettingsProps> = (props) => {
     onChange(state);
   };
 
+  const connectionConfigProps: DataSourcePluginOptionsEditorProps<
+    AwsAuthDataSourceJsonData,
+    AwsAuthDataSourceSecureJsonData
+  > = {
+    onOptionsChange: (
+      awsDataSourceSettings: DataSourceSettings<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData>
+    ) => {
+      const dataSourceSettings: DataSourceSettings = {
+        ...awsDataSourceSettings,
+        jsonData: {
+          ...awsDataSourceSettings.jsonData,
+          sigV4AuthType: awsDataSourceSettings.jsonData.authType,
+          sigV4Profile: awsDataSourceSettings.jsonData.profile,
+          sigV4AssumeRoleArn: awsDataSourceSettings.jsonData.assumeRoleArn,
+          sigV4ExternalId: awsDataSourceSettings.jsonData.externalId,
+          sigV4Region: awsDataSourceSettings.jsonData.defaultRegion,
+          sigV4Endpoint: awsDataSourceSettings.jsonData.endpoint,
+        } as any, // sigV4 jsonData fields are not typed
+        secureJsonFields: {
+          sigV4AccessKey: awsDataSourceSettings.secureJsonFields?.accessKey,
+          sigV4SecretKey: awsDataSourceSettings.secureJsonFields?.secretKey,
+        },
+        secureJsonData: {
+          sigV4AccessKey: awsDataSourceSettings.secureJsonData?.accessKey,
+          sigV4SecretKey: awsDataSourceSettings.secureJsonData?.secretKey,
+        },
+      };
+      onChange(dataSourceSettings);
+    },
+    options: {
+      ...dataSourceConfig,
+      jsonData: {
+        ...dataSourceConfig.jsonData,
+        authType: dataSourceConfig.jsonData.sigV4AuthType,
+        profile: dataSourceConfig.jsonData.sigV4Profile,
+        assumeRoleArn: dataSourceConfig.jsonData.sigV4AssumeRoleArn,
+        externalId: dataSourceConfig.jsonData.sigV4ExternalId,
+        defaultRegion: dataSourceConfig.jsonData.sigV4Region,
+        endpoint: dataSourceConfig.jsonData.sigV4Endpoint,
+      },
+      secureJsonFields: {
+        accessKey: dataSourceConfig.secureJsonFields?.sigV4AccessKey,
+        secretKey: dataSourceConfig.secureJsonFields?.sigV4SecretKey,
+      },
+      secureJsonData: {
+        accessKey: dataSourceConfig.secureJsonData?.sigV4AccessKey,
+        secretKey: dataSourceConfig.secureJsonData?.sigV4SecretKey,
+      },
+    },
+  };
+
   return (
     <>
       <h6>SigV4 Auth Details</h6>
+      <ConnectionConfig {...(connectionConfigProps as any)}></ConnectionConfig>
       <div className="gf-form-group">
         <div className="gf-form-inline">
           <div className="gf-form">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,53 +3430,10 @@
     source-map "~0.6.1"
     typescript "~3.9.7"
 
-"@grafana/aws-sdk@0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.25.tgz#638fab83232bea7d98ae188693bbf8ca7ebdf8c6"
-  integrity sha512-/+0jSb/i272Kx+0XH8NPT1xdiK7DIf4lFTV5yiRIMYZZ6TWAssg2XpGX0N8Gy0cfVt902B/FgRquCBvDaIKuBw==
-  dependencies:
-    "@grafana/data" "7.4.0"
-    "@grafana/runtime" "7.5.0"
-    "@grafana/ui" "7.5.0"
-
-"@grafana/data@7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-7.4.0.tgz#7e7ae998cc4d916ba7d004e27b38eab4b1199ee8"
-  integrity sha512-YlsA9uu3dO7hnbIUagjhAMXUU7puSSXxc42aOyuj/K9daPVMhOunI7lSM8PSm1uhKVifvd5DJOwlA0UQQRJqSw==
-  dependencies:
-    "@braintree/sanitize-url" "4.0.0"
-    "@types/d3-interpolate" "^1.3.1"
-    apache-arrow "0.16.0"
-    eventemitter3 "4.0.7"
-    lodash "4.17.20"
-    marked "1.2.2"
-    rxjs "6.6.3"
-    xss "1.0.6"
-
-"@grafana/data@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-7.5.0.tgz#c20479a95084a69a153b95f74a753e3f533bf943"
-  integrity sha512-sIbXcDSoRgR0WecPBOsNLDLlMGelRpmZFoJFVByjqPbVIBY8C3sxUKqffSbI6RmVr1uRiiv+h4TwNBDS89uHlA==
-  dependencies:
-    "@braintree/sanitize-url" "4.0.0"
-    "@types/d3-interpolate" "^1.3.1"
-    apache-arrow "0.16.0"
-    eventemitter3 "4.0.7"
-    lodash "4.17.21"
-    marked "2.0.1"
-    rxjs "6.6.3"
-    xss "1.0.6"
-
-"@grafana/e2e-selectors@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-7.5.0.tgz#e53c6e142af717156fa081a6354f15970fbb300f"
-  integrity sha512-ravj4DycULMU72UZGDXrZRtVm/1owOaY144/8zq0z1bh6CIDiYhFc/Dj92yKTp5S/FM2nwjzA4NwJz66LfCULA==
-  dependencies:
-    "@grafana/tsconfig" "^1.0.0-rc1"
-    commander "5.0.0"
-    execa "4.0.0"
-    typescript "4.1.2"
-    yaml "^1.8.3"
+"@grafana/aws-sdk@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.3.tgz#bc632c6c77971a5474acbe45847420503679fc75"
+  integrity sha512-V0PJLk+oU1C33knurXp8BkT5N2ctDu9b21zpK16vkJAs5aOiH/OaOhQ/IP9ipxYhB+b9PFjr8RXagV/8XJ8xwg==
 
 "@grafana/eslint-config@2.3.0":
   version "2.3.0"
@@ -3493,16 +3450,6 @@
     eslint-plugin-react-hooks "4.2.0"
     prettier "2.2.1"
     typescript "4.1.3"
-
-"@grafana/runtime@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-7.5.0.tgz#2da021ae7395e48cb54f0a359994c9926ff22f76"
-  integrity sha512-RySlvA/clXs0eHHL8TOrbuYtffZ0Gvs+xxHAswfLGuVckOP8rCPz2l2yyIQwQStdP2L2KuG+JMVco73QYKOohw==
-  dependencies:
-    "@grafana/data" "7.5.0"
-    "@grafana/ui" "7.5.0"
-    systemjs "0.20.19"
-    systemjs-plugin-css "0.1.37"
 
 "@grafana/slate-react@0.22.9-grafana":
   version "0.22.9-grafana"
@@ -3530,64 +3477,6 @@
   version "1.0.0-rc1"
   resolved "https://registry.yarnpkg.com/@grafana/tsconfig/-/tsconfig-1.0.0-rc1.tgz#d07ea16755a50cae21000113f30546b61647a200"
   integrity sha512-nucKPGyzlSKYSiJk5RA8GzMdVWhdYNdF+Hh65AXxjD9PlY69JKr5wANj8bVdQboag6dgg0BFKqgKPyY+YtV4Iw==
-
-"@grafana/ui@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-7.5.0.tgz#b070893852426a6f67752735071a222d7ecc7392"
-  integrity sha512-36luPhiCQP/StUHVYP5rrT1Wr6n4EIWOjaoC+wajSCVW9lvUS3F7S9JnoUDiPq83bRxRw/EAjw0ShV/7e9SJcQ==
-  dependencies:
-    "@emotion/core" "10.0.27"
-    "@grafana/data" "7.5.0"
-    "@grafana/e2e-selectors" "7.5.0"
-    "@grafana/slate-react" "0.22.9-grafana"
-    "@grafana/tsconfig" "^1.0.0-rc1"
-    "@iconscout/react-unicons" "1.1.4"
-    "@popperjs/core" "2.5.4"
-    "@sentry/browser" "5.25.0"
-    "@testing-library/jest-dom" "5.11.9"
-    "@torkelo/react-select" "3.0.8"
-    "@types/hoist-non-react-statics" "3.3.1"
-    "@types/react-beautiful-dnd" "12.1.2"
-    "@types/react-color" "3.0.1"
-    "@types/react-select" "3.0.8"
-    "@types/react-table" "7.0.12"
-    "@types/slate" "0.47.1"
-    "@types/slate-react" "0.22.5"
-    "@visx/event" "1.3.0"
-    "@visx/gradient" "1.0.0"
-    "@visx/scale" "1.4.0"
-    "@visx/shape" "1.4.0"
-    "@visx/tooltip" "1.3.0"
-    classnames "2.2.6"
-    d3 "5.15.0"
-    emotion "10.0.27"
-    hoist-non-react-statics "3.3.2"
-    immutable "3.8.2"
-    jquery "3.5.1"
-    lodash "4.17.21"
-    moment "2.24.0"
-    monaco-editor "0.20.0"
-    papaparse "5.3.0"
-    rc-cascader "1.0.1"
-    rc-drawer "3.1.3"
-    rc-slider "9.6.4"
-    rc-time-picker "^3.7.3"
-    react "17.0.1"
-    react-beautiful-dnd "13.0.0"
-    react-calendar "2.19.2"
-    react-color "2.18.0"
-    react-custom-scrollbars "4.2.1"
-    react-dom "17.0.1"
-    react-highlight-words "0.16.0"
-    react-hook-form "5.1.3"
-    react-monaco-editor "0.36.0"
-    react-popper "2.2.4"
-    react-storybook-addon-props-combinations "1.1.0"
-    react-table "7.0.0"
-    react-transition-group "4.4.1"
-    slate "0.47.8"
-    tinycolor2 "1.4.1"
-    uplot "1.6.7"
 
 "@icons/material@^0.2.4":
   version "0.2.4"
@@ -7277,15 +7166,6 @@
     "@typescript-eslint/types" "4.15.0"
     eslint-visitor-keys "^2.0.0"
 
-"@visx/bounds@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-1.0.0.tgz#a54eb43a7ddf1bb7f0cd6bf8bf5f94fa5ec562b8"
-  integrity sha512-QxD/OkZVkzpeP6L0YxUnIAsxlFemkDPfOumchVDRlrO4lZ3YXLmsnaEEiJpU5tSgNamZAUh+Tz3d2RbHp3qqxA==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-dom" "*"
-    prop-types "^15.5.10"
-
 "@visx/bounds@1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-1.7.0.tgz#cc32aaa5aa8711771b93ec4149ff087225dc0684"
@@ -7364,18 +7244,6 @@
     d3-shape "^1.2.0"
     lodash "^4.17.15"
     prop-types "^15.5.10"
-
-"@visx/tooltip@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@visx/tooltip/-/tooltip-1.3.0.tgz#32b3969eed51cc83e7f16d61d929258ef52b50ca"
-  integrity sha512-8ZliQmcE3R2TvNHyCnViPlT9Msnx/prn6gfsa1QMgWySQzVhFlL4Man9hkmbbIvpwU1i1OarbANF7hUqz86jZQ==
-  dependencies:
-    "@types/classnames" "^2.2.9"
-    "@types/react" "*"
-    "@visx/bounds" "1.0.0"
-    classnames "^2.2.5"
-    prop-types "^15.5.10"
-    react-use-measure "2.0.1"
 
 "@visx/tooltip@1.7.2":
   version "1.7.2"
@@ -17756,11 +17624,6 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
 lodash@4.17.21, lodash@^4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -18035,11 +17898,6 @@ markdown-to-jsx@^6.11.4:
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"
-
-marked@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.2.tgz#5d77ffb789c4cb0ae828bfe76250f7140b123f70"
-  integrity sha512-5jjKHVl/FPo0Z6ocP3zYhKiJLzkwJAw4CZoLjv57FkvbUuwOX4LIBBGGcXjAY6ATcd1q9B8UTj5T9Umauj0QYQ==
 
 marked@2.0.1:
   version "2.0.1"
@@ -22244,13 +22102,6 @@ react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-use-measure@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
-  integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==
-  dependencies:
-    debounce "^1.2.0"
 
 react-use-measure@^2.0.4:
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,7 +3455,7 @@
 
 "@grafana/data@7.5.0":
   version "7.5.0"
-  resolved "https://npm.pkg.github.com/download/@grafana/data/7.5.0/951b37761fd20c0a7f44fc605a90733de4a17548fa7cfddd0c61d69b90b96ddb#c20479a95084a69a153b95f74a753e3f533bf943"
+  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-7.5.0.tgz#c20479a95084a69a153b95f74a753e3f533bf943"
   integrity sha512-sIbXcDSoRgR0WecPBOsNLDLlMGelRpmZFoJFVByjqPbVIBY8C3sxUKqffSbI6RmVr1uRiiv+h4TwNBDS89uHlA==
   dependencies:
     "@braintree/sanitize-url" "4.0.0"
@@ -3469,7 +3469,7 @@
 
 "@grafana/e2e-selectors@7.5.0":
   version "7.5.0"
-  resolved "https://npm.pkg.github.com/download/@grafana/e2e-selectors/7.5.0/53f003db306f7e69229b8123ebae9f8d337e1eedf5d5914c05e61bb49b483ded#e53c6e142af717156fa081a6354f15970fbb300f"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-7.5.0.tgz#e53c6e142af717156fa081a6354f15970fbb300f"
   integrity sha512-ravj4DycULMU72UZGDXrZRtVm/1owOaY144/8zq0z1bh6CIDiYhFc/Dj92yKTp5S/FM2nwjzA4NwJz66LfCULA==
   dependencies:
     "@grafana/tsconfig" "^1.0.0-rc1"
@@ -3496,7 +3496,7 @@
 
 "@grafana/runtime@7.5.0":
   version "7.5.0"
-  resolved "https://npm.pkg.github.com/download/@grafana/runtime/7.5.0/fb7747492ce58712d6e9621897786d296fc7eab62efeaf455c87feb528754a65#2da021ae7395e48cb54f0a359994c9926ff22f76"
+  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-7.5.0.tgz#2da021ae7395e48cb54f0a359994c9926ff22f76"
   integrity sha512-RySlvA/clXs0eHHL8TOrbuYtffZ0Gvs+xxHAswfLGuVckOP8rCPz2l2yyIQwQStdP2L2KuG+JMVco73QYKOohw==
   dependencies:
     "@grafana/data" "7.5.0"
@@ -3533,7 +3533,7 @@
 
 "@grafana/ui@7.5.0":
   version "7.5.0"
-  resolved "https://npm.pkg.github.com/download/@grafana/ui/7.5.0/9cdb136d5e10d635c3389794f6c53e3ee33633470b4bc62dfbe106b691071a75#b070893852426a6f67752735071a222d7ecc7392"
+  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-7.5.0.tgz#b070893852426a6f67752735071a222d7ecc7392"
   integrity sha512-36luPhiCQP/StUHVYP5rrT1Wr6n4EIWOjaoC+wajSCVW9lvUS3F7S9JnoUDiPq83bRxRw/EAjw0ShV/7e9SJcQ==
   dependencies:
     "@emotion/core" "10.0.27"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,18 +3136,6 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/core@^10.0.27", "@emotion/core@^10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
-  integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    "@emotion/cache" "^10.0.27"
-    "@emotion/css" "^10.0.27"
-    "@emotion/serialize" "^0.11.15"
-    "@emotion/sheet" "0.9.4"
-    "@emotion/utils" "0.11.3"
-
 "@emotion/core@^10.0.9":
   version "10.0.21"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.21.tgz#2e8398d2b92fd90d4ed6ac4d0b66214971de3458"
@@ -3159,6 +3147,18 @@
     "@emotion/serialize" "^0.11.10"
     "@emotion/sheet" "0.9.3"
     "@emotion/utils" "0.11.2"
+
+"@emotion/core@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
+  integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.27"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
 
 "@emotion/css@^10.0.14", "@emotion/css@^10.0.9":
   version "10.0.14"
@@ -3430,14 +3430,14 @@
     source-map "~0.6.1"
     typescript "~3.9.7"
 
-"@grafana/aws-sdk@0.0.241":
-  version "0.0.241"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.241.tgz#d5789c31561e209ae4359fb767f25fdbb82d52dc"
-  integrity sha512-Wu3m2KajMIrucAYnI+J+80IPrg38RD9aFwimJ9QE1Pyz8U3W5T/wrstOk7cBRgiz1rTuAeICFp/hqhSr4Cd5CQ==
+"@grafana/aws-sdk@0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.25.tgz#638fab83232bea7d98ae188693bbf8ca7ebdf8c6"
+  integrity sha512-/+0jSb/i272Kx+0XH8NPT1xdiK7DIf4lFTV5yiRIMYZZ6TWAssg2XpGX0N8Gy0cfVt902B/FgRquCBvDaIKuBw==
   dependencies:
     "@grafana/data" "7.4.0"
-    "@grafana/runtime" "7.4.0"
-    "@grafana/ui" "7.4.0"
+    "@grafana/runtime" "7.5.0"
+    "@grafana/ui" "7.5.0"
 
 "@grafana/data@7.4.0":
   version "7.4.0"
@@ -3453,10 +3453,24 @@
     rxjs "6.6.3"
     xss "1.0.6"
 
-"@grafana/e2e-selectors@7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-7.4.0.tgz#f286dab307b26e6b0628a1d5e9907e3943c38ed3"
-  integrity sha512-RCAXLOTUlO8nWALo1Wnl0pTkZYzUGnBV6RuetwEDaRkfZEEKXn3F1OerzF5iJWFsdFJvVehCZ7sFYOPmnEl/gg==
+"@grafana/data@7.5.0":
+  version "7.5.0"
+  resolved "https://npm.pkg.github.com/download/@grafana/data/7.5.0/951b37761fd20c0a7f44fc605a90733de4a17548fa7cfddd0c61d69b90b96ddb#c20479a95084a69a153b95f74a753e3f533bf943"
+  integrity sha512-sIbXcDSoRgR0WecPBOsNLDLlMGelRpmZFoJFVByjqPbVIBY8C3sxUKqffSbI6RmVr1uRiiv+h4TwNBDS89uHlA==
+  dependencies:
+    "@braintree/sanitize-url" "4.0.0"
+    "@types/d3-interpolate" "^1.3.1"
+    apache-arrow "0.16.0"
+    eventemitter3 "4.0.7"
+    lodash "4.17.21"
+    marked "2.0.1"
+    rxjs "6.6.3"
+    xss "1.0.6"
+
+"@grafana/e2e-selectors@7.5.0":
+  version "7.5.0"
+  resolved "https://npm.pkg.github.com/download/@grafana/e2e-selectors/7.5.0/53f003db306f7e69229b8123ebae9f8d337e1eedf5d5914c05e61bb49b483ded#e53c6e142af717156fa081a6354f15970fbb300f"
+  integrity sha512-ravj4DycULMU72UZGDXrZRtVm/1owOaY144/8zq0z1bh6CIDiYhFc/Dj92yKTp5S/FM2nwjzA4NwJz66LfCULA==
   dependencies:
     "@grafana/tsconfig" "^1.0.0-rc1"
     commander "5.0.0"
@@ -3480,13 +3494,13 @@
     prettier "2.2.1"
     typescript "4.1.3"
 
-"@grafana/runtime@7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-7.4.0.tgz#c097adcdb151efd4211a4fc2bd91598c9cd7e627"
-  integrity sha512-ug2FPtzlEL4CykmrVp1Cnp6066ndzlMP8x/+rHNK7RR3HbS0ju2c+t6iq0vwU6605dwL71uOC+NOUuNIyZtYyg==
+"@grafana/runtime@7.5.0":
+  version "7.5.0"
+  resolved "https://npm.pkg.github.com/download/@grafana/runtime/7.5.0/fb7747492ce58712d6e9621897786d296fc7eab62efeaf455c87feb528754a65#2da021ae7395e48cb54f0a359994c9926ff22f76"
+  integrity sha512-RySlvA/clXs0eHHL8TOrbuYtffZ0Gvs+xxHAswfLGuVckOP8rCPz2l2yyIQwQStdP2L2KuG+JMVco73QYKOohw==
   dependencies:
-    "@grafana/data" "7.4.0"
-    "@grafana/ui" "7.4.0"
+    "@grafana/data" "7.5.0"
+    "@grafana/ui" "7.5.0"
     systemjs "0.20.19"
     systemjs-plugin-css "0.1.37"
 
@@ -3517,14 +3531,14 @@
   resolved "https://registry.yarnpkg.com/@grafana/tsconfig/-/tsconfig-1.0.0-rc1.tgz#d07ea16755a50cae21000113f30546b61647a200"
   integrity sha512-nucKPGyzlSKYSiJk5RA8GzMdVWhdYNdF+Hh65AXxjD9PlY69JKr5wANj8bVdQboag6dgg0BFKqgKPyY+YtV4Iw==
 
-"@grafana/ui@7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-7.4.0.tgz#4c5eea4c5a00a342fb87bd9a462398e32a72bb84"
-  integrity sha512-jbpqWGqzdDmU5+lCOHY/DLTlpLD0rNgXJfQLWwPq2ilOdCq0ItIaehxM+e5XqzTy3J+q5nyNQZFH2wM+wqzZRw==
+"@grafana/ui@7.5.0":
+  version "7.5.0"
+  resolved "https://npm.pkg.github.com/download/@grafana/ui/7.5.0/9cdb136d5e10d635c3389794f6c53e3ee33633470b4bc62dfbe106b691071a75#b070893852426a6f67752735071a222d7ecc7392"
+  integrity sha512-36luPhiCQP/StUHVYP5rrT1Wr6n4EIWOjaoC+wajSCVW9lvUS3F7S9JnoUDiPq83bRxRw/EAjw0ShV/7e9SJcQ==
   dependencies:
-    "@emotion/core" "^10.0.27"
-    "@grafana/data" "7.4.0"
-    "@grafana/e2e-selectors" "7.4.0"
+    "@emotion/core" "10.0.27"
+    "@grafana/data" "7.5.0"
+    "@grafana/e2e-selectors" "7.5.0"
     "@grafana/slate-react" "0.22.9-grafana"
     "@grafana/tsconfig" "^1.0.0-rc1"
     "@iconscout/react-unicons" "1.1.4"
@@ -3539,13 +3553,18 @@
     "@types/react-table" "7.0.12"
     "@types/slate" "0.47.1"
     "@types/slate-react" "0.22.5"
+    "@visx/event" "1.3.0"
+    "@visx/gradient" "1.0.0"
+    "@visx/scale" "1.4.0"
+    "@visx/shape" "1.4.0"
+    "@visx/tooltip" "1.3.0"
     classnames "2.2.6"
     d3 "5.15.0"
     emotion "10.0.27"
     hoist-non-react-statics "3.3.2"
     immutable "3.8.2"
     jquery "3.5.1"
-    lodash "4.17.20"
+    lodash "4.17.21"
     moment "2.24.0"
     monaco-editor "0.20.0"
     papaparse "5.3.0"
@@ -3568,7 +3587,7 @@
     react-transition-group "4.4.1"
     slate "0.47.8"
     tinycolor2 "1.4.1"
-    uplot "1.6.4"
+    uplot "1.6.7"
 
 "@icons/material@^0.2.4":
   version "0.2.4"
@@ -7258,6 +7277,15 @@
     "@typescript-eslint/types" "4.15.0"
     eslint-visitor-keys "^2.0.0"
 
+"@visx/bounds@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-1.0.0.tgz#a54eb43a7ddf1bb7f0cd6bf8bf5f94fa5ec562b8"
+  integrity sha512-QxD/OkZVkzpeP6L0YxUnIAsxlFemkDPfOumchVDRlrO4lZ3YXLmsnaEEiJpU5tSgNamZAUh+Tz3d2RbHp3qqxA==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-dom" "*"
+    prop-types "^15.5.10"
+
 "@visx/bounds@1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@visx/bounds/-/bounds-1.7.0.tgz#cc32aaa5aa8711771b93ec4149ff087225dc0684"
@@ -7336,6 +7364,18 @@
     d3-shape "^1.2.0"
     lodash "^4.17.15"
     prop-types "^15.5.10"
+
+"@visx/tooltip@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@visx/tooltip/-/tooltip-1.3.0.tgz#32b3969eed51cc83e7f16d61d929258ef52b50ca"
+  integrity sha512-8ZliQmcE3R2TvNHyCnViPlT9Msnx/prn6gfsa1QMgWySQzVhFlL4Man9hkmbbIvpwU1i1OarbANF7hUqz86jZQ==
+  dependencies:
+    "@types/classnames" "^2.2.9"
+    "@types/react" "*"
+    "@visx/bounds" "1.0.0"
+    classnames "^2.2.5"
+    prop-types "^15.5.10"
+    react-use-measure "2.0.1"
 
 "@visx/tooltip@1.7.2":
   version "1.7.2"
@@ -22205,6 +22245,13 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-use-measure@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
+  integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==
+  dependencies:
+    debounce "^1.2.0"
+
 react-use-measure@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.4.tgz#cb675b36eaeaf3681b94d5f5e08b2a1e081fedc9"
@@ -25877,11 +25924,6 @@ update-notifier@^2.5.0:
     latest-version "^3.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
-
-uplot@1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.4.tgz#016e9f66796d78c187957e710743f7ca405dfb4d"
-  integrity sha512-4d6JixG54HQKFDLAegzwgwf87GtEbp6pt3YlHygyLt+mJ9RHneCXYlZxr1QOhLetoSSHeeDuWP5RFMv8mdltpg==
 
 uplot@1.6.7:
   version "1.6.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3430,10 +3430,10 @@
     source-map "~0.6.1"
     typescript "~3.9.7"
 
-"@grafana/aws-sdk@0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.24.tgz#30511706d5efaf52e81cadd8f933d1c21e8d1c6b"
-  integrity sha512-tKYZ5KgJn0/S+/z7KFUtcgihYC1vCpUPvDMONp8j1j02JWwUE3ivu9LDiPeWBLcicy0psUypC0mL3QG/e8prIw==
+"@grafana/aws-sdk@0.0.241":
+  version "0.0.241"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.241.tgz#d5789c31561e209ae4359fb767f25fdbb82d52dc"
+  integrity sha512-Wu3m2KajMIrucAYnI+J+80IPrg38RD9aFwimJ9QE1Pyz8U3W5T/wrstOk7cBRgiz1rTuAeICFp/hqhSr4Cd5CQ==
   dependencies:
     "@grafana/data" "7.4.0"
     "@grafana/runtime" "7.4.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR upgrades the golang sigv4 package. The new version of the package has support for: 
* Workspace IAM role auth 
* the possibility to enable/disable [auth providers](https://grafana.com/docs/grafana/latest/administration/configuration/#allowed_auth_providers) 
* the possibility to enable/disable [assume role](https://grafana.com/docs/grafana/latest/administration/configuration/#assume_role_enabled)

It also replaces the custom SigV4 react component that was rendered in DataSourceHttpSettings with the ConnectionConfig from the @grafana/aws-sdk npm package. The ConnectionConfig component is already being used as ConfigEditor for CloudWatch, IoT Sitewise, Timestream and the X-ray plugin.

The changes in the @grafana/aws-sdk has been kept to a minimum since it's already been tested and is used by other plugins. A few minor things have been added though:
* the possibility to opt out on the component header (since SigV4 needs to have different header text and styles than for example CloudWatch)
* the possibility to opt out on the Endpoint field (since it's not needed for SigV4)
* removed dependency to grafana/runtime since config can be retrieved from grafana boot data
* unit tests

**Special notes for your reviewer**:

This does add a new dependency, grafana/aws-sdk, to grafana/ui. However, there should be no risk grafana/ui starts depending on older versions of itself since grafana/ui is specified as a dev dependency in grafana/aws-sdk. 


These changes will affect all core aws plugins, i.e elastic and prometheus. 

