### PR TITLE
DatasourceVariable: Reloads query editors when data source type is updated

### DIFF
--- a/packages/grafana-ui/src/utils/useForceUpdate.ts
+++ b/packages/grafana-ui/src/utils/useForceUpdate.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 /** @internal */
 export function useForceUpdate() {
-  const [value, setValue] = useState(0); // integer state
-  return () => setValue(value + 1); // update the state to force render
+  // @ts-ignore ignoring the return value and using the callback setter instead
+  const [_, setValue] = useState(0); // integer state
+  return () => setValue((v) => v + 1); // update the state to force render
 }

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
@@ -1,11 +1,14 @@
 import React, { PureComponent } from 'react';
-import { QueryGroup } from 'app/features/query/components/QueryGroup';
-import { PanelModel } from '../../state';
 import { getLocationSrv } from '@grafana/runtime';
-import { QueryGroupOptions } from 'app/types';
 import { DataQuery } from '@grafana/data';
 
+import { QueryGroup } from 'app/features/query/components/QueryGroup';
+import { DashboardModel, PanelModel } from '../../state';
+import { QueryGroupOptions } from 'app/types';
+
 interface Props {
+  /** Current dashboard */
+  dashboard: DashboardModel;
   /** Current panel */
   panel: PanelModel;
   /** Added here to make component re-render when queries change from outside */
@@ -13,10 +16,6 @@ interface Props {
 }
 
 export class PanelEditorQueries extends PureComponent<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   buildQueryOptions(panel: PanelModel): QueryGroupOptions {
     return {
       dataSource: {
@@ -58,7 +57,7 @@ export class PanelEditorQueries extends PureComponent<Props> {
   };
 
   render() {
-    const { panel } = this.props;
+    const { panel, dashboard } = this.props;
     const options = this.buildQueryOptions(panel);
 
     return (
@@ -68,6 +67,7 @@ export class PanelEditorQueries extends PureComponent<Props> {
         onRunQueries={this.onRunQueries}
         onOpenQueryInspector={this.onOpenQueryInspector}
         onOptionsChange={this.onOptionsChange}
+        dashboardEvents={dashboard.events}
       />
     );
   }

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -51,7 +51,9 @@ export const PanelEditorTabs: FC<PanelEditorTabsProps> = React.memo(({ panel, da
         })}
       </TabsBar>
       <TabContent className={styles.tabContent}>
-        {activeTab.id === PanelEditorTabId.Query && <PanelEditorQueries panel={panel} queries={panel.targets} />}
+        {activeTab.id === PanelEditorTabId.Query && (
+          <PanelEditorQueries dashboard={dashboard} panel={panel} queries={panel.targets} />
+        )}
         {activeTab.id === PanelEditorTabId.Alert && <AlertTab panel={panel} dashboard={dashboard} />}
         {activeTab.id === PanelEditorTabId.Transform && <TransformationsEditor panel={panel} />}
       </TabContent>

--- a/public/app/features/variables/datasource/actions.ts
+++ b/public/app/features/variables/datasource/actions.ts
@@ -10,6 +10,7 @@ import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { getVariable } from '../state/selectors';
 import { DataSourceVariableModel } from '../types';
 import { changeVariableEditorExtended } from '../editor/reducer';
+import { VariablesChangedEvent } from '../../../types/events';
 
 export interface DataSourceVariableActionDependencies {
   getDatasourceSrv: typeof getDatasourceSrv;
@@ -30,6 +31,10 @@ export const updateDataSourceVariableOptions = (
 
   dispatch(createDataSourceOptions(toVariablePayload(identifier, { sources, regex })));
   await dispatch(validateVariableSelectionState(identifier));
+  const dash = getState().dashboard.getModel();
+  if (dash) {
+    dash.events.publish(new VariablesChangedEvent(variableInState));
+  }
 };
 
 export const initDataSourceVariableEditor = (

--- a/public/app/features/variables/datasource/adapter.ts
+++ b/public/app/features/variables/datasource/adapter.ts
@@ -25,7 +25,7 @@ export const createDataSourceVariableAdapter = (): VariableAdapter<DataSourceVar
       }
       return false;
     },
-    setValue: async (variable, option, emitChanges = false) => {
+    setValue: async (variable, option, emitChanges = true) => {
       await dispatch(setOptionAsCurrent(toVariableIdentifier(variable), option, emitChanges));
     },
     setValueFromUrl: async (variable, urlValue) => {

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -1,4 +1,5 @@
 import { BusEventBase, BusEventWithPayload, eventFactory, GrafanaTheme, TimeRange } from '@grafana/data';
+import { VariableModel } from '../features/variables/types';
 
 /**
  * Event Payloads
@@ -183,4 +184,8 @@ export class HideModalEvent extends BusEventBase {
 
 export class DashboardSavedEvent extends BusEventBase {
   static type = 'dashboard-saved';
+}
+
+export class VariablesChangedEvent extends BusEventWithPayload<VariableModel> {
+  static type = 'variables-changed';
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This was a pretty hard issue to fix because it involved detecting changes to the mutable panel model on several levels of components. 
Not sure the changes and complexity in this PR are worth the fix and I would appreciate if anyone could come up with a cleaner solution.

**Which issue(s) this PR fixes**:
Fixes #32143

**Special notes for your reviewer**:

