### PR TITLE
Docs: fixing code example that breaks the formatting of the auto generated docs.

### DIFF
--- a/packages/grafana-data/src/dataframe/frameComparisons.ts
+++ b/packages/grafana-data/src/dataframe/frameComparisons.ts
@@ -4,6 +4,7 @@ import { DataFrame } from '../types/dataFrame';
  * Returns true if both frames have the same list of fields and configs.
  * Field may have diferent names, labels and values but share the same structure
  *
+ * @example
  * To compare multiple frames use:
  * ```
  * compareArrayValues(a, b, framesHaveSameStructure);


### PR DESCRIPTION
**What this PR does / why we need it**:
The code example is breaking the markdown structure in our web when missing the `@example` attribute.

**Which issue(s) this PR fixes**:
Fixes #31739

**Special notes for your reviewer**:

