### PR TITLE
AdHocVariable: Add default data source to picker

### DIFF
--- a/public/app/features/variables/adhoc/actions.test.ts
+++ b/public/app/features/variables/adhoc/actions.test.ts
@@ -351,6 +351,7 @@ describe('adhoc actions', () => {
   describe('when initAdHocVariableEditor is dispatched', () => {
     it('then correct actions are dispatched', async () => {
       const datasources = [
+        { ...createDatasource('default', true), value: null },
         createDatasource('elasticsearch-v1'),
         createDatasource('loki', false),
         createDatasource('influx'),
@@ -367,6 +368,7 @@ describe('adhoc actions', () => {
 
       const expectedDatasources = [
         { text: '', value: '' },
+        { text: 'default (default)', value: null },
         { text: 'elasticsearch-v1', value: 'elasticsearch-v1' },
         { text: 'influx', value: 'influx' },
         { text: 'elasticsearch-v7', value: 'elasticsearch-v7' },

--- a/public/app/features/variables/adhoc/actions.ts
+++ b/public/app/features/variables/adhoc/actions.ts
@@ -80,7 +80,7 @@ export const setFiltersFromUrl = (id: string, filters: AdHocVariableFilter[]): T
   };
 };
 
-export const changeVariableDatasource = (datasource: string): ThunkResult<void> => {
+export const changeVariableDatasource = (datasource?: string): ThunkResult<void> => {
   return async (dispatch, getState) => {
     const { editor } = getState().templating;
     const variable = getVariable(editor.id, getState());
@@ -111,15 +111,13 @@ export const changeVariableDatasource = (datasource: string): ThunkResult<void> 
 export const initAdHocVariableEditor = (): ThunkResult<void> => (dispatch) => {
   const dataSources = getDatasourceSrv().getMetricSources();
   const selectable = dataSources.reduce(
-    (all: Array<{ text: string; value: string }>, ds) => {
-      if (ds.meta.mixed || ds.value === null) {
+    (all: Array<{ text: string; value: string | null }>, ds) => {
+      if (ds.meta.mixed) {
         return all;
       }
 
-      all.push({
-        text: ds.name,
-        value: ds.value,
-      });
+      const text = ds.value === null ? `${ds.name} (default)` : ds.name;
+      all.push({ text: text, value: ds.value });
 
       return all;
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the default data source to the data source picker for AdHoc variables. Using the default data source as the value for a AdHoc variable can be problematic as that could potentially change.

**Which issue(s) this PR fixes**:
Fixes #32309

**Special notes for your reviewer**:

