### PR TITLE
Explore: Don't connect null values in line graph

### DIFF
--- a/public/app/features/explore/ExploreGraphNGPanel.tsx
+++ b/public/app/features/explore/ExploreGraphNGPanel.tsx
@@ -65,7 +65,6 @@ export function ExploreGraphNGPanel({
         drawStyle: DrawStyle.Line,
         fillOpacity: 0,
         pointSize: 5,
-        spanNulls: true,
       },
     },
     overrides: [],


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts https://github.com/grafana/grafana/pull/30707 as we want to use default spanNull value.