### PR TITLE
Variables: Fix unsupported data format error for null values

### DIFF
--- a/public/app/features/variables/query/operators.test.ts
+++ b/public/app/features/variables/query/operators.test.ts
@@ -290,6 +290,8 @@ describe('areMetricFindValues', () => {
     ${[{ text: { foo: 1 } }]}    | ${false}
     ${[{ text: Symbol('foo') }]} | ${false}
     ${[{ text: true }]}          | ${false}
+    ${[{ text: null }]}          | ${true}
+    ${[{ value: null }]}         | ${true}
     ${[]}                        | ${true}
     ${[{ text: '' }]}            | ${true}
     ${[{ Text: '' }]}            | ${true}

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -193,7 +193,11 @@ export function areMetricFindValues(data: any[]): data is MetricFindValue[] {
       continue;
     }
 
-    if (typeof firstValue[firstValueKey] !== 'string' && typeof firstValue[firstValueKey] !== 'number') {
+    if (
+      firstValue[firstValueKey] !== null &&
+      typeof firstValue[firstValueKey] !== 'string' &&
+      typeof firstValue[firstValueKey] !== 'number'
+    ) {
       continue;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds null as a valid MetricFindValue value.

**Which issue(s) this PR fixes**:
Fixes #32343

**Special notes for your reviewer**:

