### PR TITLE
Prometheus: Show only graph for range queries in Explore

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -278,7 +278,6 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
 
   private exploreQuery(queries: PromQueryRequest[], activeTargets: PromQuery[], end: number) {
     let runningQueriesCount = queries.length;
-    const mixedQueries = activeTargets.some((t) => t.range) && activeTargets.some((t) => t.instant);
 
     const subQueries = queries.map((query, index) => {
       const target = activeTargets[index];
@@ -293,7 +292,6 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
             query,
             target,
             responseListLength: queries.length,
-            mixedQueries,
             exemplarTraceIdDestinations: this.exemplarTraceIdDestinations,
           });
           return {

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -60,10 +60,7 @@ export function transform(
     refId: transformOptions.target.refId,
     valueWithRefId: transformOptions.target.valueWithRefId,
     meta: {
-      /**
-       * Fix for showing of Prometheus results in Explore table.
-       * We want to show result of instant query always in table and result of range query based on target.runAll;
-       */
+      // Fix for showing of Prometheus results in Explore table
       preferredVisualisationType: transformOptions.query.instant ? 'table' : 'graph',
     },
   };

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -45,7 +45,6 @@ export function transform(
     target: PromQuery;
     responseListLength: number;
     scopedVars?: ScopedVars;
-    mixedQueries?: boolean;
   }
 ) {
   // Create options object from transformOptions
@@ -65,10 +64,7 @@ export function transform(
        * Fix for showing of Prometheus results in Explore table.
        * We want to show result of instant query always in table and result of range query based on target.runAll;
        */
-      preferredVisualisationType: getPreferredVisualisationType(
-        transformOptions.query.instant,
-        transformOptions.mixedQueries
-      ),
+      preferredVisualisationType: transformOptions.query.instant ? 'table' : 'graph',
     },
   };
   const prometheusResult = response.data.data;
@@ -226,14 +222,6 @@ function sampleExemplars(events: TimeAndValue[], options: TransformOptions) {
     }
   }
   return sampledExemplars;
-}
-
-function getPreferredVisualisationType(isInstantQuery?: boolean, mixedQueries?: boolean) {
-  if (isInstantQuery) {
-    return 'table';
-  }
-
-  return mixedQueries ? 'graph' : undefined;
 }
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, for Prometheus range queries in Explore we are showing both - graph and table. When working on Query type selector, there was discussion on if we should keep the table view for range queries. We decided to keep it, but that was probably wrong decision as the table is pretty much useless and can confuse users. Therefore after conversation with @gouthamve, we agreed that it would make more sense if we removed it. 

This will also bring consistency between Loki and Prometheus, as for Loki, we are showing results of range queries only in graph and result of instant queries in table. 

And lastly, it will simplify a code a little, which is alway good. 🙂
