### PR TITLE
Fix access control service init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-	gotest.tools v2.2.0+incompatible
 	xorm.io/core v0.7.3
 	xorm.io/xorm v0.8.2
 )

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gotest.tools v2.2.0+incompatible
 	xorm.io/core v0.7.3
 	xorm.io/xorm v0.8.2
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	_ "github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/registry"
+	_ "github.com/grafana/grafana/pkg/services/accesscontrol/manager"
 	_ "github.com/grafana/grafana/pkg/services/alerting"
 	_ "github.com/grafana/grafana/pkg/services/auth"
 	_ "github.com/grafana/grafana/pkg/services/cleanup"

--- a/pkg/services/accesscontrol/manager/manager.go
+++ b/pkg/services/accesscontrol/manager/manager.go
@@ -40,6 +40,10 @@ func (m *Manager) Init() error {
 }
 
 func (m *Manager) IsDisabled() bool {
+	if m.Cfg == nil {
+		return true
+	}
+
 	_, exists := m.Cfg.FeatureToggles["accesscontrol"]
 	return !exists
 }


### PR DESCRIPTION
This PR fixes access control service init by adding package import into the `server` package. Also, added `nil` check for Cfg, since it might be not initialized in some tests.