### PR TITLE
Dashboard: Do not include default datasource when externally exporting dashboard with row

### DIFF
--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -109,7 +109,7 @@ export class DashboardExporter {
     };
 
     const processPanel = (panel: PanelModel) => {
-      if (panel.datasource !== undefined) {
+      if (panel.datasource !== undefined && panel.datasource !== null) {
         templateizeDatasourceUsage(panel);
       }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where previously if a dashboard was exported for sharing externally that had a row, the default datasource would be included as part of the JSON regardless of whether or not that datasource was used in a panel.

**Which issue(s) this PR fixes**:
Closes #31065
