### PR TITLE
Alerting: Add ability to include aliases with dashes (/) and at (@) signs in InfluxDB

### DIFF
--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -18,7 +18,7 @@ var (
 )
 
 func init() {
-	legendFormat = regexp.MustCompile(`\[\[([\w-]+)(\.[\w-]+)*\]\]*|\$\s*([\w-]+?)*`)
+	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$\s*([\@\/\w-]+?)*`)
 }
 
 func (rp *ResponseParser) Parse(response *Response, query *Query) plugins.DataQueryResult {

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -70,6 +70,8 @@ func TestInfluxdbResponseParser(t *testing.T) {
 								"datacenter":     "America",
 								"dc.region.name": "Northeast",
 								"cluster-name":   "Cluster",
+								"/cluster/name/": "Cluster/",
+								"@cluster@name@": "Cluster@",
 							},
 							Values: [][]interface{}{
 								{json.Number("111"), json.Number("222"), json.Number("333")},
@@ -141,6 +143,16 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		result = parser.Parse(response, query)
 
 		require.Equal(t, result.Series[0].Name, "alias Cluster")
+
+		query = &Query{Alias: "alias [[tag_/cluster/name/]]"}
+		result = parser.Parse(response, query)
+
+		require.Equal(t, result.Series[0].Name, "alias Cluster/")
+
+		query = &Query{Alias: "alias [[tag_@cluster@name@]]"}
+		result = parser.Parse(response, query)
+
+		require.Equal(t, result.Series[0].Name, "alias Cluster@")
 	})
 
 	t.Run("Influxdb response parser with errors", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Related to #32224, tiny fix, to make InfluxDB metrics include dashes (/) and at (@) signs in their names when aliasing.

**Which issue(s) this PR fixes**:

Fixes #32493

