### PR TITLE
Variables: Confirm selection before opening new picker

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.test.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, screen } from '@testing-library/react';
+
+import { VariablePickerProps } from '../types';
+import { QueryVariableModel } from '../../types';
+import { queryBuilder } from '../../shared/testing/builders';
+import { optionPickerFactory } from './OptionsPicker';
+import { initialState, OptionsPickerState, showOptions } from './reducer';
+import { selectors } from '@grafana/e2e-selectors';
+import userEvent from '@testing-library/user-event';
+import { LoadingState } from '@grafana/data';
+
+interface Args {
+  pickerState?: Partial<OptionsPickerState>;
+  variable?: Partial<QueryVariableModel>;
+}
+
+const defaultVariable = queryBuilder()
+  .withId('query0')
+  .withName('query0')
+  .withMulti()
+  .withCurrent(['A', 'C'])
+  .withOptions('A', 'B', 'C')
+  .build();
+
+function setupTestContext({ pickerState = {}, variable = {} }: Args = {}) {
+  const v = {
+    ...defaultVariable,
+    ...variable,
+  };
+  const onVariableChange = jest.fn();
+  const props: VariablePickerProps<QueryVariableModel> = {
+    variable: v,
+    onVariableChange,
+  };
+  const Picker = optionPickerFactory();
+  const optionsPicker: OptionsPickerState = { ...initialState, ...pickerState };
+  const dispatch = jest.fn();
+  const subscribe = jest.fn();
+  const getState = jest.fn().mockReturnValue({
+    templating: {
+      variables: {
+        [v.id]: { ...v },
+      },
+      optionsPicker,
+    },
+  });
+  const store: any = { getState, dispatch, subscribe };
+  const { rerender } = render(
+    <Provider store={store}>
+      <Picker {...props} />
+    </Provider>
+  );
+  return { onVariableChange, variable, rerender, dispatch };
+}
+
+function getSubMenu(text: string) {
+  return screen.getByLabelText(selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(text));
+}
+
+function getOption(text: string) {
+  return screen.getByLabelText(selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownOptionTexts('A'));
+}
+
+describe('OptionPicker', () => {
+  describe('when mounted and picker id is not set', () => {
+    it('should render link with correct text', () => {
+      setupTestContext();
+      expect(getSubMenu('A + C')).toBeInTheDocument();
+    });
+
+    it('link text should be clickable', () => {
+      const { dispatch } = setupTestContext();
+
+      dispatch.mockClear();
+      userEvent.click(getSubMenu('A + C'));
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith(showOptions(defaultVariable));
+    });
+  });
+
+  describe('when mounted and picker id differs from variable id', () => {
+    it('should render link with correct text', () => {
+      setupTestContext({
+        variable: defaultVariable,
+        pickerState: { id: 'Other' },
+      });
+      expect(getSubMenu('A + C')).toBeInTheDocument();
+    });
+
+    it('link text should not be clickable', () => {
+      const { dispatch } = setupTestContext({
+        variable: defaultVariable,
+        pickerState: { id: 'Other' },
+      });
+
+      dispatch.mockClear();
+      userEvent.click(getSubMenu('A + C'));
+      expect(dispatch).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('when mounted and variable is loading', () => {
+    it('should render link with correct text and loading indicator should be visible', () => {
+      setupTestContext({
+        variable: { ...defaultVariable, state: LoadingState.Loading },
+      });
+      expect(getSubMenu('A + C')).toBeInTheDocument();
+      expect(screen.getByLabelText(selectors.components.LoadingIndicator.icon)).toBeInTheDocument();
+    });
+
+    it('link text should not be clickable', () => {
+      const { dispatch } = setupTestContext({
+        variable: { ...defaultVariable, state: LoadingState.Loading },
+      });
+
+      dispatch.mockClear();
+      userEvent.click(getSubMenu('A + C'));
+      expect(dispatch).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('when mounted and picker id equals the variable id', () => {
+    it('should render input, drop down list with correct options', () => {
+      setupTestContext({
+        variable: defaultVariable,
+        pickerState: { id: defaultVariable.id, options: defaultVariable.options, multi: defaultVariable.multi },
+      });
+
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toHaveValue('');
+      expect(
+        screen.getByLabelText(selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownDropDown)
+      ).toBeInTheDocument();
+      expect(getOption('A')).toBeInTheDocument();
+      expect(getOption('B')).toBeInTheDocument();
+      expect(getOption('C')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -72,16 +72,19 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
     }
 
     renderLink(variable: VariableWithOptions) {
+      const { picker } = this.props;
       const linkText = formatVariableLabel(variable);
       const tags = getSelectedTags(variable);
       const loading = variable.state === LoadingState.Loading;
+      const disabled = Boolean(picker.id && picker.id !== variable.id);
 
       return (
         <VariableLink
           text={linkText}
           tags={tags}
-          onClick={this.onShowOptions}
           loading={loading}
+          disabled={disabled}
+          onClick={this.onShowOptions}
           onCancel={this.onCancel}
         />
       );

--- a/public/app/features/variables/pickers/shared/VariableLink.tsx
+++ b/public/app/features/variables/pickers/shared/VariableLink.tsx
@@ -1,5 +1,5 @@
 import React, { FC, MouseEvent, useCallback } from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import { getTagColorsFromName, Icon, Tooltip, useStyles } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 import { GrafanaTheme } from '@grafana/data';
@@ -7,33 +7,37 @@ import { GrafanaTheme } from '@grafana/data';
 import { VariableTag } from '../../types';
 
 interface Props {
-  onClick: () => void;
   text: string;
   tags: VariableTag[];
   loading: boolean;
+  disabled: boolean;
+  onClick: () => void;
   onCancel: () => void;
 }
 
-export const VariableLink: FC<Props> = ({ loading, onClick: propsOnClick, tags, text, onCancel }) => {
+export const VariableLink: FC<Props> = ({ loading, onClick: propsOnClick, tags, text, onCancel, disabled }) => {
   const styles = useStyles(getStyles);
   const onClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>) => {
       event.stopPropagation();
       event.preventDefault();
-      propsOnClick();
+      if (!disabled && !loading) {
+        propsOnClick();
+        return;
+      }
     },
-    [propsOnClick]
+    [propsOnClick, disabled, loading]
   );
 
-  if (loading) {
+  if (loading || disabled) {
     return (
       <div
-        className={styles.container}
+        className={cx(styles.container, styles.loading)}
         aria-label={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownValueLinkTexts(`${text}`)}
         title={text}
       >
         <VariableLinkText tags={tags} text={text} />
-        <LoadingIndicator onCancel={onCancel} />
+        {loading && <LoadingIndicator onCancel={onCancel} />}
       </div>
     );
   }
@@ -110,6 +114,9 @@ const getStyles = (theme: GrafanaTheme) => ({
     .label-tag {
       margin: 0 5px;
     }
+  `,
+  loading: css`
+    cursor: not-allowed;
   `,
   textAndTags: css`
     overflow: hidden;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that we confirm the selection within a Picker before opening a new Picker by preventing the user from clicking on another Picker while one is opened. A different approach might be to commit values before opening a new picker but that would add more complexity.

**Which issue(s) this PR fixes**:
Fixes #30735

**Special notes for your reviewer**:

