### PR TITLE
InfluxDB: Fix Cannot read property 'length' of undefined in when parsing response

### DIFF
--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 export default class ResponseParser {
   parse(query: string, results: { results: any }) {
-    if (!results || results.results.length === 0) {
+    if (!results?.results || results.results.length === 0) {
       return [];
     }
 

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 export default class ResponseParser {
   parse(query: string, results: { results: any }) {
-    if (!results?.results || results.results.length === 0) {
+    if (!results?.results?.length === 0) {
       return [];
     }
 

--- a/public/app/plugins/datasource/influxdb/response_parser.ts
+++ b/public/app/plugins/datasource/influxdb/response_parser.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 export default class ResponseParser {
   parse(query: string, results: { results: any }) {
-    if (!results?.results?.length === 0) {
+    if (!results || results.results.length === 0) {
       return [];
     }
 


### PR DESCRIPTION
The `results.results` has type any which means it can also be `null` or `undefined`. If so, we want to return empty array as parsed results. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/31584


