### PR TITLE
Docs: In Flux documentation replace incorrect v.timeRangeEnd for v.timeRangeStop

### DIFF
--- a/docs/sources/datasources/influxdb.md
+++ b/docs/sources/datasources/influxdb.md
@@ -145,7 +145,7 @@ The macros support copying and pasting from [Chronograph](https://www.influxdata
 Macro example        | Description
 ------------         | -------------
 `v.timeRangeStart`   | Will be replaced by the start of the currently active time selection. For example, *2020-06-11T13:31:00Z*
-`v.timeRangeEnd`     | Will be replaced by the end of the currently active time selection. For example, *2020-06-11T14:31:00Z*
+`v.timeRangeStop`     | Will be replaced by the end of the currently active time selection. For example, *2020-06-11T14:31:00Z*
 `v.windowPeriod`     | Will be replaced with an interval string compatible with Flux that corresponds to Grafana's calculated interval based on the time range of the active time selection. For example, *5s*
 `v.defaultBucket`    | Will be replaced with the data source configuration's "Default Bucket" setting
 `v.organization`     | Will be replaced with the data source configuration's "Organization" setting

--- a/docs/sources/datasources/influxdb.md
+++ b/docs/sources/datasources/influxdb.md
@@ -145,7 +145,7 @@ The macros support copying and pasting from [Chronograph](https://www.influxdata
 Macro example        | Description
 ------------         | -------------
 `v.timeRangeStart`   | Will be replaced by the start of the currently active time selection. For example, *2020-06-11T13:31:00Z*
-`v.timeRangeStop`     | Will be replaced by the end of the currently active time selection. For example, *2020-06-11T14:31:00Z*
+`v.timeRangeStop`    | Will be replaced by the end of the currently active time selection. For example, *2020-06-11T14:31:00Z*
 `v.windowPeriod`     | Will be replaced with an interval string compatible with Flux that corresponds to Grafana's calculated interval based on the time range of the active time selection. For example, *5s*
 `v.defaultBucket`    | Will be replaced with the data source configuration's "Default Bucket" setting
 `v.organization`     | Will be replaced with the data source configuration's "Organization" setting


### PR DESCRIPTION
@oddlittlebird I see that this issue was assigned to you. I hope it is okay that I created this fix. If you were working on it/doing more changes, I can close the PR. 🙂
**What this PR does / why we need it**:
Flux variable `v.timeRangeEnd` doesn't exist. It should be `v.timeRangeStop`. The list of predefined Flux variables can be find here https://docs.influxdata.com/influxdb/v2.0/visualize-data/variables/#vtimerangestop. 

In the Grafana we are using correct variable `(Sample query -> Simple query)`, so the incorrect variable was only in documentation.
![image](https://user-images.githubusercontent.com/30407135/113002344-f7d20400-9171-11eb-89c0-29be85f9b753.png)


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/27866

