### PR TITLE
Prometheus: align exemplars check to latest api change

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -510,6 +510,20 @@ describe('Prometheus Result Transformer', () => {
       expect(result[0].length).toBe(1);
     });
 
+    it('should return with an empty array when data is empty', () => {
+      const result = transform(
+        {
+          data: {
+            status: 'success',
+            data: [],
+          },
+        } as any,
+        options
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
     it('should remove exemplars that are too close to each other', () => {
       const response = {
         status: 'success',

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -63,7 +63,7 @@ export interface PromDataErrorResponse<T = PromData> {
   data: T;
 }
 
-export type PromData = PromMatrixData | PromVectorData | PromScalarData | PromExemplarData[] | null;
+export type PromData = PromMatrixData | PromVectorData | PromScalarData | PromExemplarData[];
 
 export interface Labels {
   [index: string]: any;
@@ -120,7 +120,7 @@ export function isExemplarData(result: PromData): result is PromExemplarData[] {
   if (result == null || !Array.isArray(result)) {
     return false;
   }
-  return 'exemplars' in result[0];
+  return result.length ? 'exemplars' in result[0] : false;
 }
 
 export type MatrixOrVectorResult = PromMatrixData['result'][0] | PromVectorData['result'][0];


### PR DESCRIPTION
**What this PR does / why we need it**:

The empty result for exemplars changed in Prometheus 2.26 rc and it breaks our code. 

Previously:
```
{
    "status": "success",
    "data": null
}
```
v2.26-rc:
```
{
    "status": "success",
    "data": []
}
```

