### PR TITLE
gtime: Make ParseInterval deterministic

### DIFF
--- a/pkg/components/gtime/gtime.go
+++ b/pkg/components/gtime/gtime.go
@@ -20,16 +20,15 @@ func ParseInterval(inp string) (time.Duration, error) {
 		return dur, nil
 	}
 
-	num := time.Duration(dur)
 	switch period {
 	case "d":
-		return num * time.Hour * 24, nil
+		return dur * time.Hour * 24, nil
 	case "w":
-		return num * time.Hour * 24 * 7, nil
+		return dur * time.Hour * 24 * 7, nil
 	case "M":
-		return num * time.Hour * 730, nil
+		return dur * time.Hour * 730, nil
 	case "y":
-		return num * time.Hour * 8760, nil
+		return dur * time.Hour * 8760, nil
 	}
 
 	return 0, fmt.Errorf("invalid interval %q", inp)

--- a/pkg/components/gtime/gtime.go
+++ b/pkg/components/gtime/gtime.go
@@ -20,18 +20,16 @@ func ParseInterval(inp string) (time.Duration, error) {
 		return dur, nil
 	}
 
-	num := int(dur)
-
-	now := time.Now()
+	num := time.Duration(dur)
 	switch period {
 	case "d":
-		return now.Sub(now.AddDate(0, 0, -num)), nil
+		return num * time.Hour * 24, nil
 	case "w":
-		return now.Sub(now.AddDate(0, 0, -num*7)), nil
+		return num * time.Hour * 24 * 7, nil
 	case "M":
-		return now.Sub(now.AddDate(0, -num, 0)), nil
+		return num * time.Hour * 730, nil
 	case "y":
-		return now.Sub(now.AddDate(-num, 0, 0)), nil
+		return num * time.Hour * 8760, nil
 	}
 
 	return 0, fmt.Errorf("invalid interval %q", inp)

--- a/pkg/components/gtime/gtime_test.go
+++ b/pkg/components/gtime/gtime_test.go
@@ -18,9 +18,9 @@ func TestParseInterval(t *testing.T) {
 		{inp: "1d", duration: 24 * time.Hour},
 		{inp: "1w", duration: 168 * time.Hour},
 		{inp: "2w", duration: 2 * 168 * time.Hour},
-		{inp: "1M", duration: 730 * time.Hour},
+		{inp: "1M", duration: 744 * time.Hour},
 		{inp: "1y", duration: 8760 * time.Hour},
-		{inp: "5y", duration: 5 * 8760 * time.Hour},
+		{inp: "5y", duration: 43824 * time.Hour},
 		{inp: "invalid-duration", err: regexp.MustCompile(`^time: invalid duration "?invalid-duration"?$`)},
 	}
 	for i, tc := range tcs {

--- a/pkg/components/gtime/gtime_test.go
+++ b/pkg/components/gtime/gtime_test.go
@@ -10,19 +10,17 @@ import (
 )
 
 func TestParseInterval(t *testing.T) {
-	now := time.Now()
-
 	tcs := []struct {
 		inp      string
 		duration time.Duration
 		err      *regexp.Regexp
 	}{
-		{inp: "1d", duration: now.Sub(now.AddDate(0, 0, -1))},
-		{inp: "1w", duration: now.Sub(now.AddDate(0, 0, -7))},
-		{inp: "2w", duration: now.Sub(now.AddDate(0, 0, -14))},
-		{inp: "1M", duration: now.Sub(now.AddDate(0, -1, 0))},
-		{inp: "1y", duration: now.Sub(now.AddDate(-1, 0, 0))},
-		{inp: "5y", duration: now.Sub(now.AddDate(-5, 0, 0))},
+		{inp: "1d", duration: 24 * time.Hour},
+		{inp: "1w", duration: 168 * time.Hour},
+		{inp: "2w", duration: 2 * 168 * time.Hour},
+		{inp: "1M", duration: 730 * time.Hour},
+		{inp: "1y", duration: 8760 * time.Hour},
+		{inp: "5y", duration: 5 * 8760 * time.Hour},
 		{inp: "invalid-duration", err: regexp.MustCompile(`^time: invalid duration "?invalid-duration"?$`)},
 	}
 	for i, tc := range tcs {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix gtime.ParseInterval so it's deterministic, i.e. base it on UTC so daylight saving doesn't cause surprises.

**Which issue(s) this PR fixes**:
Backend tests are currently failing due to a discrepancy in interval calculation caused by daylight saving.

**Special notes for your reviewer**:
@marefr does this make sense, or should we fix the failing tests instead?