### PR TITLE
Automation: Label pull requests based on author org

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -171,5 +171,12 @@
     "matches": ["public/app/features/variables/**/*", "public/app/features/templating/**/*"],
     "action": "updateLabel",
     "addLabel": "area/dashboard/templating"
+  },
+  {
+    "type": "author",
+    "name": "pr/external",
+    "notMemberOf": { "org": "grafana" },
+    "action": "updateLabel",
+    "addLabel": "pr/external"
   }
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Should add the label `pr/external` to pull requests for authors not member of the Grafana org. 

Making use of https://github.com/grafana/grafana-github-actions/pull/20
