### PR TITLE
Test datasource: add option to set field config returned by the datasource

### DIFF
--- a/public/app/plugins/datasource/testdata/types.ts
+++ b/public/app/plugins/datasource/testdata/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery } from '@grafana/data';
+import { DataQuery, FieldConfig } from '@grafana/data';
 
 export interface Scenario {
   id: string;
@@ -27,6 +27,7 @@ export interface TestDataQuery extends DataQuery {
   levelColumn?: boolean;
   channel?: string; // for grafana live
   nodes?: NodesQuery;
+  dsFieldConfig?: FieldConfig;
 }
 
 export interface NodesQuery {


### PR DESCRIPTION
Hack day project, inspired by one of the issues (can't recall number) when I had to debug issues with display name set by the datasource.

This adds a new option to test data scenarios that enable you to set a field config returned by the datasource:

![image](https://user-images.githubusercontent.com/2376619/113153543-7f357b00-9237-11eb-8e82-4c6e06e772a7.png)


UI needs some love, but functionality wise it works. Note - this is my first attempt to write some Golang code, so bplease be forgicing when reviewing this :)


TODO:
- [ ] add support for thresholds, mappings and data links
- [ ] tests