### PR TITLE
Config: Add ability to override config variables with env variables

### DIFF
--- a/pkg/plugins/backendplugin/manager/plugin_settings.go
+++ b/pkg/plugins/backendplugin/manager/plugin_settings.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/setting"
@@ -10,14 +11,24 @@ import (
 type pluginSettings map[string]string
 
 func (ps pluginSettings) ToEnv(prefix string, hostEnv []string) []string {
-	env := []string{}
+	var env []string
 	for k, v := range ps {
+		key := fmt.Sprintf("%s_%s", prefix, strings.ToUpper(k))
+		v = checkForOverrides(key, v)
+
 		env = append(env, fmt.Sprintf("%s_%s=%s", prefix, strings.ToUpper(k), v))
 	}
 
 	env = append(env, hostEnv...)
 
 	return env
+}
+
+func checkForOverrides(key string, v string) string {
+	if value := os.Getenv(key); value != "" {
+		v = value
+	}
+	return v
 }
 
 func getPluginSettings(plugID string, cfg *setting.Cfg) pluginSettings {

--- a/pkg/plugins/backendplugin/manager/plugin_settings.go
+++ b/pkg/plugins/backendplugin/manager/plugin_settings.go
@@ -14,7 +14,9 @@ func (ps pluginSettings) ToEnv(prefix string, hostEnv []string) []string {
 	var env []string
 	for k, v := range ps {
 		key := fmt.Sprintf("%s_%s", prefix, strings.ToUpper(k))
-		v = checkForOverrides(key, v)
+		if value := os.Getenv(key); value != "" {
+			v = value
+		}
 
 		env = append(env, fmt.Sprintf("%s_%s=%s", prefix, strings.ToUpper(k), v))
 	}
@@ -22,13 +24,6 @@ func (ps pluginSettings) ToEnv(prefix string, hostEnv []string) []string {
 	env = append(env, hostEnv...)
 
 	return env
-}
-
-func checkForOverrides(key string, v string) string {
-	if value := os.Getenv(key); value != "" {
-		v = value
-	}
-	return v
 }
 
 func getPluginSettings(plugID string, cfg *setting.Cfg) pluginSettings {

--- a/pkg/plugins/backendplugin/manager/plugin_settings.go
+++ b/pkg/plugins/backendplugin/manager/plugin_settings.go
@@ -18,7 +18,7 @@ func (ps pluginSettings) ToEnv(prefix string, hostEnv []string) []string {
 			v = value
 		}
 
-		env = append(env, fmt.Sprintf("%s_%s=%s", prefix, strings.ToUpper(k), v))
+		env = append(env, fmt.Sprintf("%s=%s", key, v))
 	}
 
 	env = append(env, hostEnv...)

--- a/pkg/plugins/backendplugin/manager/plugin_settings_test.go
+++ b/pkg/plugins/backendplugin/manager/plugin_settings_test.go
@@ -42,33 +42,34 @@ func TestPluginSettings(t *testing.T) {
 			require.Len(t, env, 3)
 			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=value1", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
 		})
-		t.Run("Should override config variable with environmental variable ", func(t *testing.T) {
+
+		t.Run("Should override config variable with environment variable ", func(t *testing.T) {
 			_ = os.Setenv("GF_PLUGIN_KEY1", "sth")
+			t.Cleanup(func() {
+				_ = os.Unsetenv("GF_PLUGIN_KEY1")
+			})
+
 			ps := getPluginSettings("plugin", cfg)
 			env := ps.ToEnv("GF_PLUGIN", []string{"GF_VERSION=6.7.0"})
 			sort.Strings(env)
 			require.Len(t, env, 3)
 			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=sth", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
 
-			defer func() {
-				err := os.Unsetenv("GF_PLUGIN_KEY1")
-				require.NoError(t, err)
-			}()
 		})
 		t.Run("Config variable doesn't match env variable ", func(t *testing.T) {
 			_ = os.Setenv("GF_PLUGIN_KEY3", "value3")
+			t.Cleanup(func() {
+				_ = os.Unsetenv("GF_PLUGIN_KEY3")
+			})
+
 			ps := getPluginSettings("plugin", cfg)
 			env := ps.ToEnv("GF_PLUGIN", []string{"GF_VERSION=6.7.0"})
 			sort.Strings(env)
 			require.Len(t, env, 3)
 			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=value1", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
 
-			defer func() {
-				err := os.Unsetenv("GF_PLUGIN_KEY3")
-				require.NoError(t, err)
-			}()
 		})
-		t.Run("Should override missing config variable with environmental variable ", func(t *testing.T) {
+		t.Run("Should override missing config variable with environment variable ", func(t *testing.T) {
 			cfg := &setting.Cfg{
 				PluginSettings: setting.PluginSettings{
 					"plugin": map[string]string{
@@ -82,15 +83,14 @@ func TestPluginSettings(t *testing.T) {
 			require.Len(t, ps, 2)
 
 			_ = os.Setenv("GF_PLUGIN_KEY2", "sth")
+			t.Cleanup(func() {
+				_ = os.Unsetenv("GF_PLUGIN_KEY1")
+			})
+
 			env := ps.ToEnv("GF_PLUGIN", []string{"GF_VERSION=6.7.0"})
 			sort.Strings(env)
 			require.Len(t, env, 3)
 			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=value1", "GF_PLUGIN_KEY2=sth", "GF_VERSION=6.7.0"}, env)
-
-			defer func() {
-				err := os.Unsetenv("GF_PLUGIN_KEY1")
-				require.NoError(t, err)
-			}()
 		})
 	})
 }

--- a/pkg/plugins/backendplugin/manager/plugin_settings_test.go
+++ b/pkg/plugins/backendplugin/manager/plugin_settings_test.go
@@ -54,8 +54,8 @@ func TestPluginSettings(t *testing.T) {
 			sort.Strings(env)
 			require.Len(t, env, 3)
 			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=sth", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
-
 		})
+
 		t.Run("Config variable doesn't match env variable ", func(t *testing.T) {
 			_ = os.Setenv("GF_PLUGIN_KEY3", "value3")
 			t.Cleanup(func() {
@@ -67,8 +67,8 @@ func TestPluginSettings(t *testing.T) {
 			sort.Strings(env)
 			require.Len(t, env, 3)
 			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=value1", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
-
 		})
+
 		t.Run("Should override missing config variable with environment variable ", func(t *testing.T) {
 			cfg := &setting.Cfg{
 				PluginSettings: setting.PluginSettings{

--- a/pkg/plugins/backendplugin/manager/plugin_settings_test.go
+++ b/pkg/plugins/backendplugin/manager/plugin_settings_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"os"
 	"sort"
 	"testing"
 
@@ -40,6 +41,56 @@ func TestPluginSettings(t *testing.T) {
 			sort.Strings(env)
 			require.Len(t, env, 3)
 			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=value1", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
+		})
+		t.Run("Should override config variable with environmental variable ", func(t *testing.T) {
+			_ = os.Setenv("GF_PLUGIN_KEY1", "sth")
+			ps := getPluginSettings("plugin", cfg)
+			env := ps.ToEnv("GF_PLUGIN", []string{"GF_VERSION=6.7.0"})
+			sort.Strings(env)
+			require.Len(t, env, 3)
+			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=sth", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
+
+			defer func() {
+				err := os.Unsetenv("GF_PLUGIN_KEY1")
+				require.NoError(t, err)
+			}()
+		})
+		t.Run("Config variable doesn't match env variable ", func(t *testing.T) {
+			_ = os.Setenv("GF_PLUGIN_KEY3", "value3")
+			ps := getPluginSettings("plugin", cfg)
+			env := ps.ToEnv("GF_PLUGIN", []string{"GF_VERSION=6.7.0"})
+			sort.Strings(env)
+			require.Len(t, env, 3)
+			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=value1", "GF_PLUGIN_KEY2=value2", "GF_VERSION=6.7.0"}, env)
+
+			defer func() {
+				err := os.Unsetenv("GF_PLUGIN_KEY3")
+				require.NoError(t, err)
+			}()
+		})
+		t.Run("Should override missing config variable with environmental variable ", func(t *testing.T) {
+			cfg := &setting.Cfg{
+				PluginSettings: setting.PluginSettings{
+					"plugin": map[string]string{
+						"key1": "value1",
+						"key2": "",
+					},
+				},
+			}
+
+			ps := getPluginSettings("plugin", cfg)
+			require.Len(t, ps, 2)
+
+			_ = os.Setenv("GF_PLUGIN_KEY2", "sth")
+			env := ps.ToEnv("GF_PLUGIN", []string{"GF_VERSION=6.7.0"})
+			sort.Strings(env)
+			require.Len(t, env, 3)
+			require.EqualValues(t, []string{"GF_PLUGIN_KEY1=value1", "GF_PLUGIN_KEY2=sth", "GF_VERSION=6.7.0"}, env)
+
+			defer func() {
+				err := os.Unsetenv("GF_PLUGIN_KEY1")
+				require.NoError(t, err)
+			}()
 		})
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The purpose of this PR is to be able to override config variables in `default.ini` with environmental variables that follow the pattern:

```
GF_<SectionName>_<KeyName>
```

**Which issue(s) this PR fixes**:

Fixes #25258

**Special notes for your reviewer**:

I tried to use @marefr suggestion using https://github.com/grafana/grafana/blob/01ecbae2ee4898e316429d688035254838eccb49/pkg/setting/setting.go#L1181

but I think that's for assigning variables on the fly?