### PR TITLE
Explore: correctly cleanup state on unmount

### DIFF
--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -184,6 +184,14 @@ export const exploreReducer = (state = initialExploreState, action: AnyAction): 
 
   if (cleanupPaneAction.match(action)) {
     const { exploreId } = action.payload as CleanupPanePayload;
+
+    // We want to do this only when we remove single pane not when we are unmounting whole explore.
+    // It needs to be checked like this because in component we don't get new path (which would tell us if we are
+    // navigating out of explore) before the unmount.
+    if (!state[exploreId]?.initialized) {
+      return state;
+    }
+
     if (exploreId === ExploreId.left) {
       return {
         ...state,


### PR DESCRIPTION
This isn't a fix for https://github.com/grafana/grafana/issues/32221 as that does not happen on master after the routing update but we still cleaned up the explore state incorrectly. This did not seem to create any real bugs, but could in the future as the explore state is not in the shape you would expect.

The fix for 7.5 branch is here https://github.com/grafana/grafana/pull/32558 but at this point they are not related.