### PR TITLE
[Alerting] use more mature routes & allow POST

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -253,8 +253,8 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if proxy.ctx.Req.Request.Method == "PUT" {
 			return errors.New("puts not allowed on proxied Prometheus datasource")
 		}
-		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range" || proxy.proxyPath == "api/v1/series" || proxy.proxyPath == "api/v1/labels") {
-			return errors.New("posts not allowed on proxied Prometheus datasource except on /query, /query_range, /series and /labels")
+		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range" || proxy.proxyPath == "api/v1/series" || proxy.proxyPath == "api/v1/labels" || strings.HasPrefix(proxy.proxyPath, "api/v1/rules")) {
+			return errors.New("posts not allowed on proxied Prometheus datasource except on /query, /query_range, /series, /labels, or paths prefixed with /rules")
 		}
 	}
 

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -254,7 +254,7 @@ func (proxy *DataSourceProxy) validateRequest() error {
 			return errors.New("puts not allowed on proxied Prometheus datasource")
 		}
 		if proxy.ctx.Req.Request.Method == "POST" && !(proxy.proxyPath == "api/v1/query" || proxy.proxyPath == "api/v1/query_range" || proxy.proxyPath == "api/v1/series" || proxy.proxyPath == "api/v1/labels" || strings.HasPrefix(proxy.proxyPath, "api/v1/rules")) {
-			return errors.New("posts not allowed on proxied Prometheus datasource except on /query, /query_range, /series, /labels, or paths prefixed with /rules")
+			return errors.New("posts not allowed on proxied Prometheus datasource except on /query, /query_range, /series, /labels, or paths prefixed with /api/v1/rules")
 		}
 	}
 

--- a/pkg/services/ngalert/api/lotex.go
+++ b/pkg/services/ngalert/api/lotex.go
@@ -17,8 +17,8 @@ import (
 )
 
 var dsTypeToRulerPrefix = map[string]string{
-	"prometheus": "/rules",
-	"loki":       "/api/prom/rules",
+	"prometheus": "/api/v1/rules",
+	"loki":       "/loki/api/v1/rules",
 }
 
 type LotexRuler struct {


### PR DESCRIPTION
This PR does two things:
1) uses the non legacy ruler prefixes for Prometheus compatible backends: (`/api/v1/rules`) and Loki (`/loki/api/v1/rules`).
2) allow-lists this path for the Prometheus datasource proxy.

I'm leaving this as a draft because I could use some pointers on how to add the role validation for this route to the Prometheus plugin.