### PR TITLE
Build: prefer root node_modules to reduce duplication during bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "re-resizable": "^6.2.0",
     "react": "17.0.1",
     "react-beautiful-dnd": "13.0.0",
+    "react-color": "2.18.0",
     "react-diff-viewer": "^3.1.1",
     "react-dom": "17.0.1",
     "react-grid-layout": "1.2.0",

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -53,10 +53,10 @@ module.exports = {
       prismjs: path.resolve(__dirname, '../../node_modules/prismjs'),
     },
     modules: [
-      'node_modules',
-      path.resolve('public'),
       // we need full path to root node_modules for grafana-enterprise symlink to work
       path.resolve('node_modules'),
+      'node_modules',
+      path.resolve('public'),
     ],
   },
   stats: {


### PR DESCRIPTION
this eliminates the entire (duplicated) `packages` section on the right:

![image](https://user-images.githubusercontent.com/43234/113240317-17e8ec80-9272-11eb-8111-9ee37a10d704.png)