### PR TITLE
Devenv: Fix prometheus config so that it scrapes your dev instance like before

### DIFF
--- a/devenv/docker/blocks/prometheus/prometheus.yml
+++ b/devenv/docker/blocks/prometheus/prometheus.yml
@@ -32,7 +32,7 @@ scrape_configs:
 
   - job_name: 'grafana'
     static_configs:
-      - targets: ['grafana:3000']
+      - targets: ['localhost:3000']
 
   - job_name: 'prometheus-random-data'
     static_configs:

--- a/devenv/docker/blocks/prometheus2/prometheus.yml
+++ b/devenv/docker/blocks/prometheus2/prometheus.yml
@@ -32,7 +32,7 @@ scrape_configs:
 
   - job_name: 'grafana'
     static_configs:
-      - targets: ['grafana:3000']
+      - targets: ['127.0.0.1:3000']
 
   - job_name: 'prometheus-random-data'
     static_configs:


### PR DESCRIPTION

Been wondering why prometheus has not scraped my dev instance for months. It only works if you also run grafana in another docker container which we hardly ever do when developing.

related to this change:
https://github.com/grafana/grafana/pull/23850
