### PR TITLE
Fix access control store init

### DIFF
--- a/pkg/services/accesscontrol/manager/manager.go
+++ b/pkg/services/accesscontrol/manager/manager.go
@@ -14,10 +14,10 @@ import (
 
 // Manager is the service implementing role based access control.
 type Manager struct {
-	Cfg           *setting.Cfg          `inject:""`
-	RouteRegister routing.RouteRegister `inject:""`
-	Log           log.Logger
-	*database.AccessControlStore
+	Cfg                          *setting.Cfg          `inject:""`
+	RouteRegister                routing.RouteRegister `inject:""`
+	Log                          log.Logger
+	*database.AccessControlStore `inject:""`
 }
 
 func init() {


### PR DESCRIPTION
This PR fixes crash on startup when `accesscontrol` feature toggle enabled. Crash caused by access to non-initialized service.