### PR TITLE
FolderPicker: Prevent dropdown menu from disappearing off screen

### DIFF
--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -161,7 +161,6 @@ export class FolderPicker extends PureComponent<Props, State> {
           loadOptions={this.debouncedSearch}
           onChange={this.onFolderChange}
           onCreateOption={this.createNewFolder}
-          menuPosition="fixed"
         />
       </div>
     );

--- a/public/app/core/components/Select/__snapshots__/FolderPicker.test.tsx.snap
+++ b/public/app/core/components/Select/__snapshots__/FolderPicker.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`FolderPicker should render 1`] = `
     defaultValue={Object {}}
     loadOptions={[Function]}
     loadingMessage="Loading folders..."
-    menuPosition="fixed"
     onChange={[Function]}
     onCreateOption={[Function]}
     value={Object {}}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes odd positioning issue with the FolderPicker component that causes it to appear offscreen.

| Before | After |
| --- | --- |
|  <img width="800" alt="Screenshot 2021-04-01 at 16 30 12" src="https://user-images.githubusercontent.com/73201/113309595-980d6180-9307-11eb-9972-3e8959de0100.png"> | <img width="800" alt="Screenshot 2021-04-01 at 16 29 01" src="https://user-images.githubusercontent.com/73201/113309720-b96e4d80-9307-11eb-9428-04c86c1c476c.png"> |

I also followed  the same implementation in [this earlier PR](https://github.com/grafana/grafana/pull/30481) to fix issues around select menus not being able to expand beyond the modal container.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #32474

**Special notes for your reviewer**:

I tested the following uses of `FolderPicker` and couldn't find any visual issues with these changes:

- public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
- public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx
- public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
- public/app/features/search/components/MoveToFolderModal.tsx
- public/app/plugins/panel/alertlist/module.tsx
- public/app/plugins/panel/dashlist/module.tsx
