### PR TITLE
Influx/Azure: Fix issue in query editors due to babel upgrade

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/query_ctrl.ts
@@ -34,7 +34,7 @@ export class AzureMonitorQueryCtrl extends QueryCtrl {
 
   // target: AzureMonitorQuery;
 
-  target: {
+  declare target: {
     // should be: AzureMonitorQuery
     refId: string;
     queryType: AzureQueryType;

--- a/public/app/plugins/datasource/influxdb/query_ctrl.ts
+++ b/public/app/plugins/datasource/influxdb/query_ctrl.ts
@@ -11,7 +11,7 @@ import InfluxDatasource from './datasource';
 export class InfluxQueryCtrl extends QueryCtrl {
   static templateUrl = 'partials/query.editor.html';
 
-  datasource: InfluxDatasource;
+  declare datasource: InfluxDatasource;
   queryModel: InfluxQueryModel;
   queryBuilder: any;
   groupBySegment: any;


### PR DESCRIPTION
If you define a class property that you do not set anywhere, so only set it for typing and say it's set dynamically or by an untyped base class then
babel will set it to undefined in the constructor (after the super constructor potentially sets it).

