### PR TITLE
Chore: Refactor Server Run and Shutdown 

### DIFF
--- a/pkg/cmd/grafana-server/main.go
+++ b/pkg/cmd/grafana-server/main.go
@@ -194,6 +194,7 @@ func listenToSystemSignals(s *server.Server) {
 			}
 		case sig := <-signalChan:
 			s.Shutdown(fmt.Sprintf("System signal: %s", sig))
+			return
 		}
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -78,7 +78,7 @@ func TestServer_Run_Error(t *testing.T) {
 	}
 
 	err := s.Run()
-	require.Equal(t, testErr, err)
+	require.ErrorIs(t, err, testErr)
 	require.NotZero(t, s.ExitCode(err))
 }
 
@@ -108,7 +108,6 @@ func TestServer_Shutdown(t *testing.T) {
 		s.Shutdown("test interrupt")
 	}()
 	err := s.Run()
-	require.Equal(t, context.Canceled, err)
+	require.NoError(t, err)
 	require.Zero(t, s.ExitCode(err))
-	require.Equal(t, "test interrupt", s.shutdownReason)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/registry"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testServiceRegistry struct {
+	services []*registry.Descriptor
+}
+
+func (r *testServiceRegistry) GetServices() []*registry.Descriptor {
+	return r.services
+}
+
+func (r *testServiceRegistry) IsDisabled(_ registry.Service) bool {
+	return false
+}
+
+type testService struct {
+	started chan struct{}
+	initErr error
+	runErr  error
+}
+
+func newTestService(initErr, runErr error) *testService {
+	return &testService{
+		started: make(chan struct{}),
+		initErr: initErr,
+		runErr:  runErr,
+	}
+}
+
+func (s *testService) Init() error {
+	return s.initErr
+}
+
+func (s *testService) Run(ctx context.Context) error {
+	if s.runErr != nil {
+		return s.runErr
+	}
+	close(s.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func testServer() *Server {
+	s := newServer(Config{})
+	// Required to skip configuration initialization that causes
+	// DI errors in this test.
+	s.isInitialized = true
+	return s
+}
+
+func TestServer_Run_Error(t *testing.T) {
+	s := testServer()
+
+	var testErr = errors.New("boom")
+
+	s.serviceRegistry = &testServiceRegistry{
+		services: []*registry.Descriptor{
+			{
+				Name:         "TestService1",
+				Instance:     newTestService(nil, nil),
+				InitPriority: registry.High,
+			},
+			{
+				Name:         "TestService2",
+				Instance:     newTestService(nil, testErr),
+				InitPriority: registry.High,
+			},
+		},
+	}
+
+	err := s.Run()
+	require.Equal(t, testErr, err)
+	require.NotZero(t, s.ExitCode(err))
+}
+
+func TestServer_Shutdown(t *testing.T) {
+	s := testServer()
+	services := []*registry.Descriptor{
+		{
+			Name:         "TestService1",
+			Instance:     newTestService(nil, nil),
+			InitPriority: registry.High,
+		},
+		{
+			Name:         "TestService2",
+			Instance:     newTestService(nil, nil),
+			InitPriority: registry.High,
+		},
+	}
+	s.serviceRegistry = &testServiceRegistry{
+		services: services,
+	}
+
+	go func() {
+		// Wait until all services launched.
+		for _, svc := range services {
+			<-svc.Instance.(*testService).started
+		}
+		s.Shutdown("test interrupt")
+	}()
+	err := s.Run()
+	require.Equal(t, context.Canceled, err)
+	require.Zero(t, s.ExitCode(err))
+	require.Equal(t, "test interrupt", s.shutdownReason)
+}

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -56,7 +56,7 @@ func StartGrafana(t *testing.T, grafDir, cfgPath string, sqlStore *sqlstore.SQLS
 		}
 	}()
 	t.Cleanup(func() {
-		server.Shutdown("")
+		server.Shutdown("test cleanup")
 	})
 
 	// Wait for Grafana to be ready


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr refactors how Server Run and Shutdown methods work with context. Also added tests for Run and Shutdown methods.

**Which issue(s) this PR fixes**:

* real error from services now propagate to `errgroup.Group.Wait()` thus Grafana has a chance to display a shutdown error message caused by error during specific service shutdown - the real error from service.Run is now properly propagates to the end (if there are several errors happened we will still get the first one though).
* we now see stop Debug logs from all running services, not only those returned context.Canceled error - for example we previously did not see a stop log entry from `HTTPServer` service (since it returnea `nil` instead of `ctx.Err()` - maybe worth to fix this later). 
* exit from signal handler after calling shutdown
* refactor shutdown to not wait on error group in different goroutines (changes also makes it possible to shutdown with timeout in the future)
* get rid of `shutdownInProgress` flag - just use context to not start services if shutdown initiated

I believe that the behaviour should mostly stay the same here (just some additional logging and error propagation on shutdown).
