### PR TITLE
Docker: Allow database url via env vars

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -86,4 +86,5 @@ exec grafana-server                                         \
   cfg:default.paths.data="$GF_PATHS_DATA"                   \
   cfg:default.paths.logs="$GF_PATHS_LOGS"                   \
   cfg:default.paths.plugins="$GF_PATHS_PLUGINS"             \
-  cfg:default.paths.provisioning="$GF_PATHS_PROVISIONING"
+  cfg:default.paths.provisioning="$GF_PATHS_PROVISIONING"   \
+  cfg:default.database.url="$GF_DATABASE_URL"


### PR DESCRIPTION
**What this PR does / why we need it**:
Running Grafana from the context of Docker would only allow configuration of the database by way of the config INI. This made usage of infrastructure tools like Terraform cumbersome. Allowing this setting to be managed through environment variables works around that problem.