### PR TITLE
Babel: @babel/plugin-transform-react-constant-elements to babel config to optimize react performance

### DIFF
--- a/scripts/webpack/babel.config.js
+++ b/scripts/webpack/babel.config.js
@@ -39,8 +39,7 @@ module.exports = function getBabelConfig(options = {}) {
       ['@babel/plugin-proposal-class-properties', { loose: true }],
       ['@babel/plugin-proposal-private-methods', { loose: true }],
       ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
-      // Waiting with this need to refactoring timeSrv & locationUtil.init
-      // '@babel/plugin-transform-react-constant-elements',
+      '@babel/plugin-transform-react-constant-elements',
       '@babel/plugin-proposal-nullish-coalescing-operator',
       '@babel/plugin-proposal-optional-chaining',
       '@babel/plugin-syntax-dynamic-import', // needed for `() => import()` in routes.ts


### PR DESCRIPTION
Adds babel/plugin-transform-react-constant-elements to optimize react code.


We can consider @babel/plugin-transform-react-inline-elements as well in production builds (think it can make debugging hard). Not sure if it works with emotion when using jsx runtime though (it is not supported by emotion babel css prop plugin at least)
