### PR TITLE
ngalert: json dataframe on temp endpoints

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1422,6 +1422,7 @@ github.com/prometheus/prometheus v1.8.2-0.20210217141258-a6be548dbc17 h1:VN3p3Nb
 github.com/prometheus/prometheus v1.8.2-0.20210217141258-a6be548dbc17/go.mod h1:dv3B1syqmkrkmo665MPCU6L8PbTXIiUeg/OEQULLNxA=
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/quasilyte/go-ruleguard/dsl/fluent v0.0.0-20201222093424-5d7e62a465d3 h1:eL7x4/zMnlquMxYe7V078BD7MGskZ0daGln+SJCVzuY=
 github.com/quasilyte/go-ruleguard/dsl/fluent v0.0.0-20201222093424-5d7e62a465d3/go.mod h1:P7JlQWFT7jDcFZMtUPQbtGzzzxva3rBn6oIF+LPwFcM=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be h1:ta7tUOvsPHVHGom5hKW5VXNc2xZIkfCKP8iaqOyYtUQ=

--- a/pkg/services/ngalert/api/api_trans_dev.go
+++ b/pkg/services/ngalert/api/api_trans_dev.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/expr/translate"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -40,14 +39,9 @@ func (api *API) conditionEvalOldEndpoint(c *models.ReqContext) response.Response
 	}
 
 	frame := evalResults.AsDataFrame()
-	df := plugins.NewDecodedDataFrames([]*data.Frame{&frame})
-	instances, err := df.Encoded()
-	if err != nil {
-		return response.Error(400, "Failed to encode result dataframes", err)
-	}
 
-	return response.JSON(200, util.DynMap{
-		"instances": instances,
+	return response.JSONStreaming(200, util.DynMap{
+		"instances": []*data.Frame{&frame},
 	})
 }
 
@@ -98,14 +92,9 @@ func (api *API) conditionEvalOldEndpointByID(c *models.ReqContext) response.Resp
 	}
 
 	frame := evalResults.AsDataFrame()
-	df := plugins.NewDecodedDataFrames([]*data.Frame{&frame})
-	instances, err := df.Encoded()
-	if err != nil {
-		return response.Error(400, "Failed to encode result dataframes", err)
-	}
 
-	return response.JSON(200, util.DynMap{
-		"instances": instances,
+	return response.JSONStreaming(200, util.DynMap{
+		"instances": []*data.Frame{&frame},
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Switches some of my temp translation endpoints to the json response instead of base64 binary.

**Special notes for your reviewer**:
These will go away in not to long, just need the rubber stamp.
