### PR TITLE
Graphite: Improve error handling for Graphite 0.9 and 1.0

### DIFF
--- a/public/app/plugins/datasource/graphite/utils.test.ts
+++ b/public/app/plugins/datasource/graphite/utils.test.ts
@@ -1,0 +1,90 @@
+import { reduceError } from './utils';
+
+const SAMPLE_500_PAGE = `<body style="background-color: #666666; color: black;">
+<center>
+<h2 style='font-family: "Arial"'>
+<p>Graphite encountered an unexpected error while handling your request.</p>
+<p>Please contact your site administrator if the problem persists.</p>
+</h2>
+<br/>
+<div style="width: 50%; text-align: center; font-family: monospace; background-color: black; font-weight: bold; color: #ff4422;">
+
+</div>
+
+<div style="width: 70%; text-align: left; background-color: black; color: #44ff22; border: thin solid gray;">
+<pre>
+Traceback (most recent call last):
+  File &quot;/usr/lib/python2.7/dist-packages/django/core/handlers/base.py&quot;, line 112, in get_response
+    response = wrapped_callback(request, *callback_args, **callback_kwargs)
+  File &quot;/var/lib/graphite/webapp/graphite/render/views.py&quot;, line 125, in renderView
+    seriesList = evaluateTarget(requestContext, target)
+  File &quot;/var/lib/graphite/webapp/graphite/render/evaluator.py&quot;, line 10, in evaluateTarget
+    result = evaluateTokens(requestContext, tokens)
+  File &quot;/var/lib/graphite/webapp/graphite/render/evaluator.py&quot;, line 21, in evaluateTokens
+    return evaluateTokens(requestContext, tokens.expression)
+  File &quot;/var/lib/graphite/webapp/graphite/render/evaluator.py&quot;, line 27, in evaluateTokens
+    func = SeriesFunctions[tokens.call.func]
+KeyError: u&#39;aliasByNodde&#39;
+
+</pre>
+</div>
+
+</center>
+`;
+
+describe('Graphite utils', () => {
+  it('should reduce HTML based errors', () => {
+    const error = {
+      status: 500,
+      data: {
+        message: SAMPLE_500_PAGE,
+      },
+    };
+
+    expect(reduceError(error)).toMatchObject({
+      data: {
+        message: 'Graphite encountered an unexpected error while handling your request. KeyError: aliasByNodde',
+      },
+    });
+  });
+
+  it('should return original error for non-HTML 500 error pages', () => {
+    const error = {
+      status: 500,
+      data: {
+        message: 'ERROR MESSAGE',
+      },
+    };
+
+    expect(reduceError(error)).toMatchObject({
+      data: {
+        message: 'ERROR MESSAGE',
+      },
+    });
+  });
+
+  it('should return original error for non 500 errors', () => {
+    const error = {
+      status: 400,
+      data: {
+        message: 'ERROR MESSAGE',
+      },
+    };
+
+    expect(reduceError(error)).toMatchObject({
+      data: {
+        message: 'ERROR MESSAGE',
+      },
+    });
+  });
+
+  it('should return original error for errors other than FetchError (not data property)', () => {
+    const error = {
+      message: 'ERROR MESSAGE',
+    };
+
+    expect(reduceError(error)).toMatchObject({
+      message: 'ERROR MESSAGE',
+    });
+  });
+});

--- a/public/app/plugins/datasource/graphite/utils.ts
+++ b/public/app/plugins/datasource/graphite/utils.ts
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+
+/**
+ * Graphite-web before v1.6 returns HTTP 500 with full stack traces in an HTML page
+ * when a query fails. It results in massive error alerts with HTML tags in the UI.
+ * This function removes all HTML tags and keeps only the last line from the stack
+ * trace which should be the most meaningful.
+ */
+export function reduceError(error: any): any {
+  if (error && error.status === 500 && error.data?.message?.startsWith('<body')) {
+    // Remove all HTML tags and take the last line from the stack trace
+    const newMessage = _.last<string>(
+      error.data.message
+        .replace(/(<([^>]+)>)/gi, '')
+        .trim()
+        .split(/\n/)
+    )!.replace(/u?&#[^;]+;/g, '');
+    error.data.message = `Graphite encountered an unexpected error while handling your request. ${newMessage}`;
+  }
+  return error;
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Just an idea to improve error handling in Graphite. Before Graphite 1.6 any query failures would return HTTP 500 with HTML including the stack trace. It creates a big alert message that is not very readable:

<img width="1721" alt="Screenshot 2021-04-02 at 14 50 10" src="https://user-images.githubusercontent.com/745532/113419457-c3578580-93c7-11eb-9194-0c2794929214.png">

The idea is to extract the last line from the stack trace to get more meaningful error. It's possible to override the default 500 error page in graphite-web - in such case the error should be displayed with whatever  was returned by the API (as long as it doesn't start with `<body>` tag):

<img width="1716" alt="Screenshot 2021-04-02 at 15 06 42" src="https://user-images.githubusercontent.com/745532/113419511-e41fdb00-93c7-11eb-85f3-c8edb03ce9cf.png">


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes: -

**Special notes for your reviewer**: -

