### PR TITLE
Graphite: Show query syntax errors

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -453,6 +453,8 @@ export interface DataQuery {
    * For non mixed scenarios this is undefined.
    */
   datasource?: string | null;
+
+  syntaxError: string;
 }
 
 export enum DataQueryErrorType {

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -454,7 +454,7 @@ export interface DataQuery {
    */
   datasource?: string | null;
 
-  syntaxError: string;
+  syntaxError?: string;
 }
 
 export enum DataQueryErrorType {

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -49,7 +49,6 @@ export default class GraphiteQuery {
     if (astNode.type === 'error') {
       this.error = astNode.message + ' at position: ' + astNode.pos;
       this.target.textEditor = true;
-      return;
     }
 
     try {

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -34,10 +34,7 @@ export default class GraphiteQuery {
     this.tags = [];
     this.seriesByTagUsed = false;
     this.error = null;
-
-    if (this.target.textEditor) {
-      return;
-    }
+    this.target.syntaxError = null;
 
     const parser = new Parser(this.target.target);
     const astNode = parser.getAst();
@@ -48,7 +45,12 @@ export default class GraphiteQuery {
 
     if (astNode.type === 'error') {
       this.error = astNode.message + ' at position: ' + astNode.pos;
+      this.target.syntaxError = astNode.message + ' at position: ' + astNode.pos;
       this.target.textEditor = true;
+    }
+
+    if (this.target.textEditor) {
+      return;
     }
 
     try {

--- a/public/app/plugins/datasource/graphite/query_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/query_ctrl.ts
@@ -245,6 +245,7 @@ export class GraphiteQueryCtrl extends QueryCtrl {
 
   targetTextChanged() {
     this.updateModelTarget();
+    this.parseTarget();
     this.refresh();
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Graphite query parser can detect syntax errors in the query. At the moment these errors are not being displayed. The query is submitted anyway but unfortunately Graphite-web tends to handle them silently with no errors and no data returned which may be misleading :( We could display the syntax error message to help users find what's wrong with the query:

![parsing-errors](https://user-images.githubusercontent.com/745532/113422212-99ed2880-93cc-11eb-9f49-5d6f6da15562.gif)

It's just and idea so please let me know what you thinkg. It seems to be useful mostly for Graphite, other datasources return syntax errors once the query is submitted.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes -

**Special notes for your reviewer**: -

