### PR TITLE
Alerting: Fix persistence migration

### DIFF
--- a/pkg/services/ngalert/store/database_mig.go
+++ b/pkg/services/ngalert/store/database_mig.go
@@ -94,7 +94,6 @@ func AlertInstanceMigration(mg *migrator.Migrator) {
 			{Name: "labels_hash", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "current_state", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "current_state_since", Type: migrator.DB_BigInt, Nullable: false},
-			{Name: "current_state_end", Type: migrator.DB_BigInt, Nullable: false},
 			{Name: "last_eval_time", Type: migrator.DB_BigInt, Nullable: false},
 		},
 		PrimaryKeys: []string{"def_org_id", "def_uid", "labels_hash"},
@@ -108,6 +107,9 @@ func AlertInstanceMigration(mg *migrator.Migrator) {
 	mg.AddMigration("create alert_instance table", migrator.NewAddTableMigration(alertInstance))
 	mg.AddMigration("add index in alert_instance table on def_org_id, def_uid and current_state columns", migrator.NewAddIndexMigration(alertInstance, alertInstance.Indices[0]))
 	mg.AddMigration("add index in alert_instance table on def_org_id, current_state columns", migrator.NewAddIndexMigration(alertInstance, alertInstance.Indices[1]))
+	mg.AddMigration("add column current_state_end to alert_instance", migrator.NewAddColumnMigration(alertInstance, &migrator.Column{
+		Name: "current_state_end", Type: migrator.DB_BigInt, Nullable: false, Default: "0",
+	}))
 }
 
 func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up to https://github.com/grafana/grafana/pull/32576 , which added a column to the original table migration instead of adding a NewColumnMigration.

**Special notes for your reviewer**:
My bad for not catching it on review. The migration looks for the `migration_id`, which is the name of the migration. Since the migration will already exist for users (in the log), it will not be run be run again to update the table (and we don't want to make people have to manually drop the table and the remove the the migration log). 
