### PR TITLE
ngalerting: represent nil/empty labels the same

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1422,6 +1422,7 @@ github.com/prometheus/prometheus v1.8.2-0.20210217141258-a6be548dbc17 h1:VN3p3Nb
 github.com/prometheus/prometheus v1.8.2-0.20210217141258-a6be548dbc17/go.mod h1:dv3B1syqmkrkmo665MPCU6L8PbTXIiUeg/OEQULLNxA=
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/quasilyte/go-ruleguard/dsl/fluent v0.0.0-20201222093424-5d7e62a465d3 h1:eL7x4/zMnlquMxYe7V078BD7MGskZ0daGln+SJCVzuY=
 github.com/quasilyte/go-ruleguard/dsl/fluent v0.0.0-20201222093424-5d7e62a465d3/go.mod h1:P7JlQWFT7jDcFZMtUPQbtGzzzxva3rBn6oIF+LPwFcM=
 github.com/rafaeljusto/redigomock v0.0.0-20190202135759-257e089e14a1/go.mod h1:JaY6n2sDr+z2WTsXkOmNRUfDy6FN0L6Nk7x06ndm4tY=
 github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be h1:ta7tUOvsPHVHGom5hKW5VXNc2xZIkfCKP8iaqOyYtUQ=

--- a/pkg/services/ngalert/models/instance_labels.go
+++ b/pkg/services/ngalert/models/instance_labels.go
@@ -78,9 +78,6 @@ func (t *tupleLabels) sortBtKey() {
 
 // labelsToTupleLabels converts Labels (map[string]string) to tupleLabels.
 func labelsToTupleLabels(l InstanceLabels) tupleLabels {
-	if l == nil {
-		return nil
-	}
 	t := make(tupleLabels, 0, len(l))
 	for k, v := range l {
 		t = append(t, tupleLabel{k, v})

--- a/pkg/services/ngalert/models/instance_labels.go
+++ b/pkg/services/ngalert/models/instance_labels.go
@@ -89,7 +89,7 @@ func labelsToTupleLabels(l InstanceLabels) tupleLabels {
 // tupleLabelsToLabels converts tupleLabels to Labels (map[string]string), erroring if there are duplicate keys.
 func tupleLablesToLabels(tuples tupleLabels) (InstanceLabels, error) {
 	if tuples == nil {
-		return nil, nil
+		return InstanceLabels{}, nil
 	}
 	labels := make(map[string]string)
 	for _, tuple := range tuples {

--- a/pkg/services/ngalert/tests/instance_database_test.go
+++ b/pkg/services/ngalert/tests/instance_database_test.go
@@ -54,6 +54,7 @@ func TestAlertInstanceOperations(t *testing.T) {
 			DefinitionOrgID: alertDefinition2.OrgID,
 			DefinitionUID:   alertDefinition2.UID,
 			State:           models.InstanceStateNormal,
+			Labels:          models.InstanceLabels{},
 		}
 		err := dbstore.SaveAlertInstance(saveCmd)
 		require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it so labels are saved in the database as `[]` regardless if it is nil or an empty map.

was getting duplicates of [] and null before


