### PR TITLE
Docs: add Grafana basics section

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -52,7 +52,7 @@ aliases = ["/docs/grafana/v1.1", "/docs/grafana/latest/guides/reference/admin", 
         <h4>Configure Grafana</h4>
         <p>Review the configuration and setup options.</p>
     </a>
-    <a href="{{< relref "getting-started/timeseries.md" >}}" class="nav-cards__item nav-cards__item--guide">
+    <a href="{{< relref "basics/timeseries.md" >}}" class="nav-cards__item nav-cards__item--guide">
         <h4>Intro to time series</h4>
         <p>Learn about time series data.</p>
     </a>

--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -267,4 +267,4 @@ This URL is based on the [domain]({{< relref "../administration/configuration/#d
 
 > **Note:** Alert notification templating is only available in Grafana v7.4 and above.
 
-The alert notification template feature allows you to take the [label]({{< relref "../getting-started/timeseries-dimensions.md#labels" >}}) value from an alert query and [inject that into alert notifications]({{< relref "./add-notification-template.md" >}}).
+The alert notification template feature allows you to take the [label]({{< relref "../basics/timeseries-dimensions.md#labels" >}}) value from an alert query and [inject that into alert notifications]({{< relref "./add-notification-template.md" >}}).

--- a/docs/sources/basics/_index.md
+++ b/docs/sources/basics/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Getting started"
+title = "Grafana basics"
 weight = 15
 +++
 

--- a/docs/sources/basics/_index.md
+++ b/docs/sources/basics/_index.md
@@ -1,0 +1,28 @@
++++
+title = "Getting started"
+weight = 15
++++
+
+# Grafana basics
+
+This section provides basic information about observability topics in general and Grafana in particular. These topics will help people who are just starting out with observability and monitoring.
+
+SINGLE SOURCE
+
+{{< docs/shared "basics/what-is-grafana.md" >}}
+
+
+
+## Grafana Cloud
+
+Grafana Cloud is a highly available, fast, fully managed OpenSaaS logging and metrics platform. Everything you love about Grafana, but Grafana Labs hosts it for you and handles all the headaches.
+
+[Learn more about Grafana Cloud](https://grafana.com/cloud/) or try the [Grafana Cloud Linux host Quickstart](/docs/grafana-cloud/quickstart/).
+
+## Grafana Enterprise
+
+[Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}) is a commercial edition of Grafana that includes additional features not found in the open source version.
+
+Building on everything you already know and love about Grafana, Grafana Enterprise adds enterprise data sources, advanced authentication options, more permission controls, 24x7x365 support, and training from the core Grafana team.
+
+[Learn more about Grafana Enterprise](https://grafana.com/enterprise). To purchase Enterprise or obtain a trial license, contact the Grafana Labs [Sales Team](https://grafana.com/contact?about=support&topic=Grafana%20Enterprise).

--- a/docs/sources/basics/_index.md
+++ b/docs/sources/basics/_index.md
@@ -7,22 +7,8 @@ weight = 15
 
 This section provides basic information about observability topics in general and Grafana in particular. These topics will help people who are just starting out with observability and monitoring.
 
-SINGLE SOURCE
-
 {{< docs/shared "basics/what-is-grafana.md" >}}
 
+{{< docs/shared "basics/grafana-cloud.md" >}}
 
-
-## Grafana Cloud
-
-Grafana Cloud is a highly available, fast, fully managed OpenSaaS logging and metrics platform. Everything you love about Grafana, but Grafana Labs hosts it for you and handles all the headaches.
-
-[Learn more about Grafana Cloud](https://grafana.com/cloud/) or try the [Grafana Cloud Linux host Quickstart](/docs/grafana-cloud/quickstart/).
-
-## Grafana Enterprise
-
-[Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}) is a commercial edition of Grafana that includes additional features not found in the open source version.
-
-Building on everything you already know and love about Grafana, Grafana Enterprise adds enterprise data sources, advanced authentication options, more permission controls, 24x7x365 support, and training from the core Grafana team.
-
-[Learn more about Grafana Enterprise](https://grafana.com/enterprise). To purchase Enterprise or obtain a trial license, contact the Grafana Labs [Sales Team](https://grafana.com/contact?about=support&topic=Grafana%20Enterprise).
+{{< docs/shared "basics/grafana-enterprise.md" >}}

--- a/docs/sources/basics/glossary.md
+++ b/docs/sources/basics/glossary.md
@@ -2,7 +2,7 @@
 title = "Glossary"
 description = "Grafana glossary"
 keywords = ["grafana", "intro", "glossary", "dictionary"]
-aliases = ["/docs/grafana/latest/guides/glossary"]
+aliases = ["/docs/grafana/latest/guides/glossary", "/docs/grafana/latest/getting-started/glossary"]
 weight = 800
 +++
 

--- a/docs/sources/basics/intro-histograms.md
+++ b/docs/sources/basics/intro-histograms.md
@@ -2,6 +2,7 @@
 title = "Histograms and heatmaps"
 description = "An introduction to histograms and heatmaps"
 keywords = ["grafana", "heatmap", "panel", "documentation", "histogram"]
+aliases = ["/docs/grafana/latest/getting-started/intro-histograms"]
 weight = 700
 +++
 

--- a/docs/sources/basics/timeseries-dimensions.md
+++ b/docs/sources/basics/timeseries-dimensions.md
@@ -2,7 +2,7 @@
 title = "Time series dimensions"
 description = "time series dimensions"
 keywords = ["grafana", "intro", "guide", "concepts", "timeseries", "labels"]
-aliases = ["/docs/grafana/latest/guides/timeseries-dimensions"]
+aliases = ["/docs/grafana/latest/guides/timeseries-dimensions", "/docs/grafana/latest/getting-started/timeseries-dimensions"]
 weight = 600
 +++
 

--- a/docs/sources/basics/timeseries.md
+++ b/docs/sources/basics/timeseries.md
@@ -2,7 +2,7 @@
 title = "Time series"
 description = "Introduction to time series"
 keywords = ["grafana", "intro", "guide", "concepts", "timeseries"]
-aliases = ["/docs/grafana/latest/guides/timeseries"]
+aliases = ["/docs/grafana/latest/guides/timeseries", "/docs/grafana/latest/getting-started/timeseries"]
 weight = 500
 +++
 

--- a/docs/sources/best-practices/_index.md
+++ b/docs/sources/best-practices/_index.md
@@ -12,5 +12,3 @@ This section provides information about best practices for intermediate Grafana 
 - [Best practices for managing dashboards]({{< relref "best-practices-for-managing-dashboards" >}})
 - [Common observability strategies]({{< relref "common-observability-strategies" >}})
 - [Dashboard management maturity model]({{< relref "dashboard-management-maturity-levels" >}})
-
-  

--- a/docs/sources/developers/plugins/data-frames.md
+++ b/docs/sources/developers/plugins/data-frames.md
@@ -72,7 +72,7 @@ A data transformation is any function that accepts a data frame as input, and re
 
 A data frame with at least one time field is considered a _time series_.
 
-For more information on time series, refer to our [Introduction to time series]({{< relref "../../getting-started/timeseries.md" >}}).
+For more information on time series, refer to our [Introduction to time series]({{< relref "../../basics/timeseries.md" >}}).
 
 ### Wide format
 

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -72,16 +72,6 @@ Refer to [Provisioning]({{< relref "../administration/provisioning.md" >}}) for 
 
 When organizations have one Grafana and multiple teams, they often want the ability to both keep things separate and share dashboards. You can create a team of users and then set [permissions]({{< relref "../permissions/_index.md" >}}) on folders, dashboards, and down to the [data source level]({{< relref "../enterprise/datasource_permissions.md" >}}) if you're using [Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}).
 
-## Grafana Cloud
+{{< docs/shared "basics/grafana-cloud.md" >}}
 
-Grafana Cloud is a highly available, fast, fully managed OpenSaaS logging and metrics platform. Everything you love about Grafana, but Grafana Labs hosts it for you and handles all the headaches.
-
-[Learn more about Grafana Cloud](https://grafana.com/cloud/) or try the [Grafana Cloud Linux host Quickstart](/docs/grafana-cloud/quickstart/).
-
-## Grafana Enterprise
-
-[Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}) is a commercial edition of Grafana that includes additional features not found in the open source version.
-
-Building on everything you already know and love about Grafana, Grafana Enterprise adds enterprise data sources, advanced authentication options, more permission controls, 24x7x365 support, and training from the core Grafana team.
-
-[Learn more about Grafana Enterprise](https://grafana.com/enterprise). To purchase Enterprise or obtain a trial license, contact the Grafana Labs [Sales Team](https://grafana.com/contact?about=support&topic=Grafana%20Enterprise).
+{{< docs/shared "basics/grafana-enterprise.md" >}}

--- a/docs/sources/getting-started/_index.md
+++ b/docs/sources/getting-started/_index.md
@@ -8,9 +8,7 @@ aliases = ["/docs/grafana/latest/guides/what-is-grafana"]
 
 This section provides a high-level look at Grafana, the Grafana process, and Grafana features. It's a good place to learn how to use the Grafana software.
 
-## What is Grafana?
-
-Grafana is open source visualization and analytics software. It allows you to query, visualize, alert on, and explore your metrics no matter where they are stored. In plain English, it provides you with tools to turn your time-series database (TSDB) data into beautiful graphs and visualizations.
+{{< docs/shared "basics/what-is-grafana.md" >}}
 
 After creating a dashboard like you do in [Getting started]({{< relref "getting-started.md" >}}), there are many possible things you might do next. It all depends on your needs and your use case.
 

--- a/docs/sources/panels/_index.md
+++ b/docs/sources/panels/_index.md
@@ -23,4 +23,4 @@ You can drag and drop panels by clicking and holding the panel title, then dragg
 - Click series name in the legend to hide series.
 - Ctrl/Shift/Meta + click legend name to hide other series.
 - Hover your cursor over a panel and press `e` to open the panel editor.
-- Hover your cursor over a panel and press `v` to open the panel in fullscreen view.
+- Hover your cursor over a panel and press `v` to open the panel in full screen view.

--- a/docs/sources/panels/expressions.md
+++ b/docs/sources/panels/expressions.md
@@ -21,7 +21,7 @@ Expressions are meant to augment data sources by enabling queries from different
 
 > **Note:** When possible, you should do data processing inside the data source. Copying data from storage to the Grafana server for processing is inefficient, so expressions are targeted at lightweight data processing.
 
-Expressions work with data source queries that return time series or number data. They also operate on [multiple-dimensional data]({{< relref "../getting-started/timeseries-dimensions.md" >}}). For example, a query that returns multiple series, where each series is identified by labels or tags.
+Expressions work with data source queries that return time series or number data. They also operate on [multiple-dimensional data]({{< relref "../basics/timeseries-dimensions.md" >}}). For example, a query that returns multiple series, where each series is identified by labels or tags.
 
 An individual expression takes one or more queries or other expressions as input and adds data to the result. Each individual expression or query is represented by a variable that is a named identifier known as its RefID (e.g., the default letter `A` or `B`).
 
@@ -34,7 +34,7 @@ Expressions work with two types of data.
 - A collections of time series.
 - A collection of numbers, where each collection could be a single series or single number.
 
-Each collection is returned from a single data source query or expression and represented by the RefID. Each collection is a set, where each item in the set is uniquely identified by it dimensions which are stored as [labels]({{< relref "../getting-started/timeseries-dimensions.md#labels" >}}) or key-value pairs.
+Each collection is returned from a single data source query or expression and represented by the RefID. Each collection is a set, where each item in the set is uniquely identified by it dimensions which are stored as [labels]({{< relref "../basics/timeseries-dimensions.md#labels" >}}) or key-value pairs.
 
 ## Data source queries
 

--- a/docs/sources/panels/visualizations/graph-panel.md
+++ b/docs/sources/panels/visualizations/graph-panel.md
@@ -120,7 +120,7 @@ Options are identical for both Y-axes.
     - **Value -**  The aggregation type to use for the values. The default is total (summing the values together).
   - **Histogram -** Converts the graph into a histogram. A histogram is a kind of bar chart that groups numbers into ranges, often called buckets or bins. Taller bars show that more data falls in that range.
 
-    For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../getting-started/intro-histograms.md" >}}).
+    For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../basics/intro-histograms.md" >}}).
     - **Buckets -** The number of buckets to group the values by. If left empty, then Grafana tries to calculate a suitable number of buckets.
     - **X-Min -** Filters out values from the histogram that are under this minimum limit.
     - **X-Max -** Filters out values that are greater than this maximum limit.

--- a/docs/sources/panels/visualizations/heatmap.md
+++ b/docs/sources/panels/visualizations/heatmap.md
@@ -8,7 +8,7 @@ weight = 600
 
 # Heatmap panel
 
-The Heatmap panel visualization allows you to view histograms over time. For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../getting-started/intro-histograms.md" >}}).
+The Heatmap panel visualization allows you to view histograms over time. For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../basics/intro-histograms.md" >}}).
 
 ![](/img/docs/v43/heatmap_panel_cover.jpg)
 

--- a/docs/sources/shared/basics/grafana-cloud.md
+++ b/docs/sources/shared/basics/grafana-cloud.md
@@ -1,0 +1,9 @@
+---
+title: Grafana Cloud
+---
+
+## Grafana Cloud
+
+Grafana Cloud is a highly available, fast, fully managed OpenSaaS logging and metrics platform. Everything you love about Grafana, but Grafana Labs hosts it for you and handles all the headaches.
+
+[Learn more about Grafana Cloud](https://grafana.com/cloud/) or try the [Grafana Cloud Linux host quickstart](/docs/grafana-cloud/quickstart/).

--- a/docs/sources/shared/basics/grafana-enterprise.md
+++ b/docs/sources/shared/basics/grafana-enterprise.md
@@ -4,7 +4,7 @@ title: Grafana Enterprise
 
 ## Grafana Enterprise
 
-[Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}) is a commercial edition of Grafana that includes additional features not found in the open source version.
+[Grafana Enterprise]({{< relref "../../enterprise/_index.md" >}}) is a commercial edition of Grafana that includes additional features not found in the open source version.
 
 Building on everything you already know and love about Grafana, Grafana Enterprise adds enterprise data sources, advanced authentication options, more permission controls, 24x7x365 support, and training from the core Grafana team.
 

--- a/docs/sources/shared/basics/grafana-enterprise.md
+++ b/docs/sources/shared/basics/grafana-enterprise.md
@@ -1,0 +1,11 @@
+---
+title: Grafana Enterprise
+---
+
+## Grafana Enterprise
+
+[Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}) is a commercial edition of Grafana that includes additional features not found in the open source version.
+
+Building on everything you already know and love about Grafana, Grafana Enterprise adds enterprise data sources, advanced authentication options, more permission controls, 24x7x365 support, and training from the core Grafana team.
+
+[Learn more about Grafana Enterprise](https://grafana.com/enterprise). To purchase Enterprise or obtain a trial license, contact the Grafana Labs [Sales Team](https://grafana.com/contact?about=support&topic=Grafana%20Enterprise).

--- a/docs/sources/shared/basics/what-is-grafana.md
+++ b/docs/sources/shared/basics/what-is-grafana.md
@@ -1,0 +1,7 @@
+---
+title: What is Grafana?
+---
+
+## What is Grafana?
+
+Grafana is open source visualization and analytics software. It allows you to query, visualize, alert on, and explore your metrics no matter where they are stored. In plain English, it provides you with tools to turn your time-series database (TSDB) data into beautiful graphs and visualizations.

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -95,7 +95,7 @@ The following topics were updated as a result of this feature:
 
 _Server-side expressions_ is an experimental feature that allows you to manipulate data returned from backend data source queries. Expressions allow you to manipulate data with math and other operations when the data source is a backend data source or a **--Mixed--** data source.
 
-The main use case is for [multi-dimensional]({{< relref "../getting-started/timeseries-dimensions.md" >}}) data sources used with the upcoming next generation alerting, but expressions can be used with backend data sources and visualization as well.
+The main use case is for [multi-dimensional]({{< relref "../basics/timeseries-dimensions.md" >}}) data sources used with the upcoming next generation alerting, but expressions can be used with backend data sources and visualization as well.
 
 > **Note:** Queries built with this feature might break with minor version upgrades until Grafana 8 is released. This feature does not work with the current Grafana alerting.
 


### PR DESCRIPTION
We have enough content for "Getting started with Grafana and XX" that we can break other basic content out into another section, so I did that.

- Created a folder and moved content out of Getting started and into it.
- Single sourced some of the intro content.

Reviewers, feel free to expand the intro.