### PR TITLE
Docs: Document plugin authentication in metadata schema

### DIFF
--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -238,7 +238,7 @@ Parameters for the token authentication request.
 |-----------------|--------|----------|-------------------------------------------------------------------------------------------|
 | `client_id`     | string | No       | OAuth client ID                                                                           |
 | `client_secret` | string | No       | OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob. |
-| `grant_type`    | string | No       | OAuth grant type Possible values are: `client_credentials`.                               |
+| `grant_type`    | string | No       | OAuth grant type                                                                          |
 | `resource`      | string | No       | OAuth resource                                                                            |
 
 

--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -197,23 +197,24 @@ For data source plugins. Token authentication section used with an JWT OAuth API
 
 #### Properties
 
-| Property | Type              | Required | Description                                                               |
-|----------|-------------------|----------|---------------------------------------------------------------------------|
-| `params` | [object](#params) | No       | For data source plugins. Parameters for the token authentication request. |
-| `url`    | string            | No       | For data source plugins. URL to fetch the JWT token.                      |
+| Property | Type              | Required | Description                                          |
+|----------|-------------------|----------|------------------------------------------------------|
+| `params` | [object](#params) | No       | Parameters for the JWT token authentication request. |
+| `scopes` | string            | No       |                                                      |
+| `url`    | string            | No       | URL to fetch the JWT token.                          |
 
 #### params
 
-For data source plugins. Parameters for the token authentication request.
+Parameters for the JWT token authentication request.
 
 ##### Properties
 
-| Property        | Type   | Required | Description                                                                                                        |
-|-----------------|--------|----------|--------------------------------------------------------------------------------------------------------------------|
-| `client_id`     | string | No       | For data source plugins. OAuth client id.                                                                          |
-| `client_secret` | string | No       | For data source plugins. OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob. |
-| `grant_type`    | string | No       | For data source plugins. OAuth grant type.                                                                         |
-| `resource`      | string | No       | For data source plugins. OAuth resource.                                                                           |
+| Property       | Type     | Required | Description |
+|----------------|----------|----------|-------------|
+| `client_email` | string   | No       |             |
+| `private_key`  | string   | No       |             |
+| `scopes`       | string[] | No       |             |
+| `token_uri`    | string   | No       |             |
 
 ### tokenAuth
 
@@ -221,22 +222,23 @@ For data source plugins. Token authentication section used with an OAuth API.
 
 #### Properties
 
-| Property | Type              | Required | Description                                                               |
-|----------|-------------------|----------|---------------------------------------------------------------------------|
-| `params` | [object](#params) | No       | For data source plugins. Parameters for the token authentication request. |
-| `url`    | string            | No       | For data source plugins. URL to fetch the authentication token.           |
+| Property | Type              | Required | Description                                      |
+|----------|-------------------|----------|--------------------------------------------------|
+| `params` | [object](#params) | No       | Parameters for the token authentication request. |
+| `scopes` | string            | No       |                                                  |
+| `url`    | string            | No       | URL to fetch the authentication token.           |
 
 #### params
 
-For data source plugins. Parameters for the token authentication request.
+Parameters for the token authentication request.
 
 ##### Properties
 
-| Property        | Type   | Required | Description                                                                                                        |
-|-----------------|--------|----------|--------------------------------------------------------------------------------------------------------------------|
-| `client_id`     | string | No       | For data source plugins. OAuth client id.                                                                          |
-| `client_secret` | string | No       | For data source plugins. OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob. |
-| `grant_type`    | string | No       | For data source plugins. OAuth grant type.                                                                         |
-| `resource`      | string | No       | For data source plugins. OAuth resource.                                                                           |
+| Property        | Type   | Required | Description                                                                               |
+|-----------------|--------|----------|-------------------------------------------------------------------------------------------|
+| `client_id`     | string | No       | OAuth client ID                                                                           |
+| `client_secret` | string | No       | OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob. |
+| `grant_type`    | string | No       | OAuth grant type Possible values are: `client_credentials`.                               |
+| `resource`      | string | No       | OAuth resource                                                                            |
 
 

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -361,28 +361,33 @@
             "properties": {
               "url": {
                 "type": "string",
-                "description": "For data source plugins. URL to fetch the authentication token."
+                "description": "URL to fetch the authentication token."
+              },
+              "scopes": {
+                "type": "string",
+                "description": ""
               },
               "params": {
                 "type": "object",
-                "description": "For data source plugins. Parameters for the token authentication request.",
+                "description": "Parameters for the token authentication request.",
                 "additionalProperties": false,
                 "properties": {
                   "grant_type": {
                     "type": "string",
-                    "description": "For data source plugins. OAuth grant type."
+                    "description": "OAuth grant type",
+                    "enum": ["client_credentials"]
                   },
                   "client_id": {
                     "type": "string",
-                    "description": "For data source plugins. OAuth client id."
+                    "description": "OAuth client ID"
                   },
                   "client_secret": {
                     "type": "string",
-                    "description": "For data source plugins. OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob."
+                    "description": "OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob."
                   },
                   "resource": {
                     "type": "string",
-                    "description": "For data source plugins. OAuth resource."
+                    "description": "OAuth resource"
                   }
                 }
               }
@@ -395,29 +400,36 @@
             "properties": {
               "url": {
                 "type": "string",
-                "description": "For data source plugins. URL to fetch the JWT token.",
+                "description": "URL to fetch the JWT token.",
                 "format": "uri"
+              },
+              "scopes": {
+                "type": "string",
+                "description": ""
               },
               "params": {
                 "type": "object",
-                "description": "For data source plugins. Parameters for the token authentication request.",
+                "description": "Parameters for the JWT token authentication request.",
                 "additionalProperties": false,
                 "properties": {
-                  "grant_type": {
-                    "type": "string",
-                    "description": "For data source plugins. OAuth grant type."
+                  "scopes": {
+                    "type": "array",
+                    "description": "",
+                    "items": {
+                      "type": "string"
+                    }
                   },
-                  "client_id": {
+                  "token_uri": {
                     "type": "string",
-                    "description": "For data source plugins. OAuth client id."
+                    "description": ""
                   },
-                  "client_secret": {
+                  "client_email": {
                     "type": "string",
-                    "description": "For data source plugins. OAuth client secret. Usually populated by decrypting the secret from the SecureJson blob."
+                    "description": ""
                   },
-                  "resource": {
+                  "private_key": {
                     "type": "string",
-                    "description": "For data source plugins. OAuth resource."
+                    "description": ""
                   }
                 }
               }

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -374,8 +374,7 @@
                 "properties": {
                   "grant_type": {
                     "type": "string",
-                    "description": "OAuth grant type",
-                    "enum": ["client_credentials"]
+                    "description": "OAuth grant type"
                   },
                   "client_id": {
                     "type": "string",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the plugin metadata schema with regards to plugin authentication.

**Special notes for the reviewer:**

I couldn't find any records of any other grant type than client_credentials, so I left it at that. Let me know if that's too restrictive.