### PR TITLE
[grafana/UI] Normalize color string before using them as IDs

### DIFF
--- a/packages/grafana-ui/src/components/PieChart/PieChart.tsx
+++ b/packages/grafana-ui/src/components/PieChart/PieChart.tsx
@@ -144,7 +144,7 @@ export const PieChartSvg: FC<SvgProps> = ({
   }
 
   const getValue = (d: FieldDisplay) => d.display.numeric;
-  const getGradientId = (color: string) => `${componentInstanceId}-${color}`;
+  const getGradientId = (color: string) => `${componentInstanceId}-${tinycolor(color).toHex()}`;
   const getGradientColor = (color: string) => {
     return `url(#${getGradientId(color)})`;
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
This normalizes the color strings in the Piechart V2 to hex values before using them. The rgb strings does not work as identifiers for the svg fill.

**Which issue(s) this PR fixes**:
Fixes #32671 

