### PR TITLE
Emotion: Remove emotion import

### DIFF
--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -1,6 +1,3 @@
-// Needed for emotion types
-import '@emotion/react';
-
 /**
  * A library containing the different design components of the Grafana ecosystem.
  *


### PR DESCRIPTION
Not sure we need this after the emotion upgrade. And I think this is causing issues in external plugins.
