### PR TITLE
SingleStat: Fix issue with panel links 

### DIFF
--- a/public/app/plugins/panel/singlestat/module.ts
+++ b/public/app/plugins/panel/singlestat/module.ts
@@ -23,6 +23,7 @@ import {
   locationUtil,
   getFieldDisplayName,
   getColorForTheme,
+  InterpolateFunction,
 } from '@grafana/data';
 
 import { convertOldAngularValueMapping } from '@grafana/ui';
@@ -621,7 +622,9 @@ class SingleStatCtrl extends MetricsPanelCtrl {
       elem.toggleClass('pointer', panel.links.length > 0);
 
       if (panel.links.length > 0) {
-        linkInfo = linkSrv.getDataLinkUIModel(panel.links[0], data.scopedVars, {});
+        const replace: InterpolateFunction = (value, vars) =>
+          templateSrv.replace(value, { ...vars, ...data.scopedVars });
+        linkInfo = linkSrv.getDataLinkUIModel(panel.links[0], replace, {});
       } else {
         linkInfo = null;
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: I noticed a regression in Grafana 7.4.0, where SingleStat links stopped working. It was a bug introduced in 683ce69347e3517d79d047324d8250877fe5cea6, where the signature of getDataLinkUIModel changed but was not updated properly in the SingleStat panel. I updated it following similar changes made in that commit.

**Which issue(s) this PR fixes**: I did not see any issue created for this PR, I can create one if needed.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**: I know that SingleStat panels are deprecated and that Stat panels now provide the same panel-link functionality (thanks for that!), but we have several dashboards and migration is taking time. This PR being included would allow us to keep updating Grafana without breaking dashboards.

A funny thing that I noticed while debugging this is that the link would work properly if there was no data for the panel. I couldn't see why that happened, but I found it weird.

