### PR TITLE
[v7.5.x] Prometheus: Fix instant query to run two times when exemplars enabled

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExemplarField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExemplarField.tsx
@@ -1,49 +1,47 @@
 import { GrafanaTheme } from '@grafana/data';
-import { FetchError } from '@grafana/runtime';
 import { IconButton, InlineLabel, Tooltip, useStyles } from '@grafana/ui';
 import { css, cx } from 'emotion';
 import React, { useEffect, useState } from 'react';
 import { PrometheusDatasource } from '../datasource';
-import { PromQuery } from '../types';
 
 interface Props {
-  query: PromQuery;
-  onChange: (value: PromQuery) => void;
+  isEnabled: boolean;
+  onChange: (isEnabled: boolean) => void;
   datasource: PrometheusDatasource;
 }
 
-export function PromExemplarField(props: Props) {
-  const [error, setError] = useState<FetchError>();
+export function PromExemplarField({ datasource, onChange, isEnabled }: Props) {
+  const [error, setError] = useState<string>();
   const styles = useStyles(getStyles);
 
   useEffect(() => {
-    const subscription = props.datasource.exemplarErrors.subscribe((err) => {
+    const subscription = datasource.exemplarErrors.subscribe((err) => {
       setError(err);
     });
     return () => {
       subscription.unsubscribe();
     };
-  }, [props]);
+  }, [datasource]);
 
   const iconButtonStyles = cx(
     {
-      [styles.activeIcon]: !!props.query.exemplar,
+      [styles.activeIcon]: isEnabled,
     },
     styles.eyeIcon
   );
 
   return (
     <InlineLabel width="auto">
-      <Tooltip content={!!error ? 'Exemplars are not supported in this version of prometheus.' : ''}>
+      <Tooltip content={error ?? ''}>
         <div className={styles.iconWrapper}>
           Exemplars
           <IconButton
             name="eye"
-            tooltip={!!props.query.exemplar ? 'Disable query with exemplars' : 'Enable query with exemplars'}
+            tooltip={isEnabled ? 'Disable query with exemplars' : 'Enable query with exemplars'}
             disabled={!!error}
             className={iconButtonStyles}
             onClick={() => {
-              props.onChange({ ...props.query, exemplar: !props.query.exemplar });
+              onChange(!isEnabled);
             }}
           />
         </div>

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -77,7 +77,11 @@ export const PromExploreExtraField: React.FC<PromExploreExtraFieldProps> = memo(
           />
         </div>
 
-        <PromExemplarField query={query} onChange={onChange} datasource={datasource} />
+        <PromExemplarField
+          isEnabled={Boolean(query.exemplar)}
+          onChange={(isEnabled) => onChange({ ...query, exemplar: isEnabled })}
+          datasource={datasource}
+        />
       </div>
     );
   }

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -32,6 +32,7 @@ interface State {
   interval?: string;
   intervalFactorOption: SelectableValue<number>;
   instant: boolean;
+  exemplar: boolean;
 }
 
 export class PromQueryEditor extends PureComponent<Props, State> {
@@ -55,6 +56,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
         INTERVAL_FACTOR_OPTIONS.find((option) => option.value === query.intervalFactor) || INTERVAL_FACTOR_OPTIONS[0],
       // Switch options
       instant: Boolean(query.instant),
+      exemplar: Boolean(query.exemplar),
     };
   }
 
@@ -90,6 +92,11 @@ export class PromQueryEditor extends PureComponent<Props, State> {
     this.setState({ legendFormat });
   };
 
+  onExemplarChange = (isEnabled: boolean) => {
+    this.query.exemplar = isEnabled;
+    this.setState({ exemplar: isEnabled }, this.onRunQuery);
+  };
+
   onRunQuery = () => {
     const { query } = this;
     // Change of query.hide happens outside of this component and is just passed as prop. We have to update it when running queries.
@@ -99,8 +106,8 @@ export class PromQueryEditor extends PureComponent<Props, State> {
   };
 
   render() {
-    const { datasource, query, range, data, onChange } = this.props;
-    const { formatOption, instant, interval, intervalFactorOption, legendFormat } = this.state;
+    const { datasource, query, range, data } = this.props;
+    const { formatOption, instant, interval, intervalFactorOption, legendFormat, exemplar } = this.state;
 
     return (
       <div>
@@ -186,7 +193,7 @@ export class PromQueryEditor extends PureComponent<Props, State> {
             </InlineFormLabel>
           </div>
 
-          <PromExemplarField query={this.query} onChange={onChange} datasource={this.props.datasource} />
+          <PromExemplarField isEnabled={exemplar} onChange={this.onExemplarChange} datasource={datasource} />
         </div>
       </div>
     );

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
@@ -189,16 +189,8 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
           "getPrometheusTime": [MockFunction],
         }
       }
-      onChange={[MockFunction]}
-      query={
-        Object {
-          "exemplar": true,
-          "expr": "",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A",
-        }
-      }
+      isEnabled={true}
+      onChange={[Function]}
     />
   </div>
 </div>

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1747,6 +1747,32 @@ describe('prepareTargets', () => {
       });
       expect(activeTargets[0]).toEqual(target);
     });
+    it('should give back 2 targets when exemplar enabled', () => {
+      const target: PromQuery = {
+        refId: 'A',
+        expr: 'up',
+        exemplar: true,
+      };
+
+      const { queries, activeTargets } = getPrepareTargetsContext(target);
+      expect(queries).toHaveLength(2);
+      expect(activeTargets).toHaveLength(2);
+      expect(activeTargets[0].exemplar).toBe(true);
+      expect(activeTargets[1].exemplar).toBe(false);
+    });
+    it('should give back 1 target when exemplar and instant are enabled', () => {
+      const target: PromQuery = {
+        refId: 'A',
+        expr: 'up',
+        exemplar: true,
+        instant: true,
+      };
+
+      const { queries, activeTargets } = getPrepareTargetsContext(target);
+      expect(queries).toHaveLength(1);
+      expect(activeTargets).toHaveLength(1);
+      expect(activeTargets[0].instant).toBe(true);
+    });
   });
 
   describe('when run from Explore', () => {


### PR DESCRIPTION
* Prometheus: Fix instant query to run two times when exemplars enabled

* Update exemplar messages

(cherry picked from commit 70d49b017d2776138cd481f3705406ecd33d14b2)

