### PR TITLE
add memcached integration test steps in starlark

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1356,6 +1356,17 @@ steps:
   - test-backend
   - test-frontend
 
+- name: memcached-integration-tests
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/dockerize -wait tcp://memcached:11211 -timeout 120s
+  - ./bin/grabpl integration-tests
+  environment:
+    MEMCACHED_HOSTS: memcached:11211
+  depends_on:
+  - test-backend
+  - test-frontend
+
 - name: upload-cdn-assets
   image: grafana/grafana-ci-deploy:1.3.1
   commands:
@@ -1379,6 +1390,7 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
   - redis-integration-tests
+  - memcached-integration-tests
 
 - name: package-enterprise2
   image: grafana/build-container:1.4.1
@@ -1443,6 +1455,7 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
   - redis-integration-tests
+  - memcached-integration-tests
 
 services:
 - name: postgres
@@ -1462,6 +1475,9 @@ services:
 
 - name: redis
   image: redis:6.2.1-alpine
+
+- name: memcached
+  image: memcached:1.6.9-alpine
 
 trigger:
   ref:
@@ -2274,6 +2290,17 @@ steps:
   - test-backend
   - test-frontend
 
+- name: memcached-integration-tests
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/dockerize -wait tcp://memcached:11211 -timeout 120s
+  - ./bin/grabpl integration-tests
+  environment:
+    MEMCACHED_HOSTS: memcached:11211
+  depends_on:
+  - test-backend
+  - test-frontend
+
 - name: upload-cdn-assets
   image: grafana/grafana-ci-deploy:1.3.1
   commands:
@@ -2297,6 +2324,7 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
   - redis-integration-tests
+  - memcached-integration-tests
 
 - name: package-enterprise2
   image: grafana/build-container:1.4.1
@@ -2361,6 +2389,7 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
   - redis-integration-tests
+  - memcached-integration-tests
 
 services:
 - name: postgres
@@ -2380,6 +2409,9 @@ services:
 
 - name: redis
   image: redis:6.2.1-alpine
+
+- name: memcached
+  image: memcached:1.6.9-alpine
 
 trigger:
   event:
@@ -3166,6 +3198,17 @@ steps:
   - test-backend
   - test-frontend
 
+- name: memcached-integration-tests
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/dockerize -wait tcp://memcached:11211 -timeout 120s
+  - ./bin/grabpl integration-tests
+  environment:
+    MEMCACHED_HOSTS: memcached:11211
+  depends_on:
+  - test-backend
+  - test-frontend
+
 - name: upload-cdn-assets
   image: grafana/grafana-ci-deploy:1.3.1
   commands:
@@ -3189,6 +3232,7 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
   - redis-integration-tests
+  - memcached-integration-tests
 
 - name: package-enterprise2
   image: grafana/build-container:1.4.1
@@ -3253,6 +3297,7 @@ steps:
   - mysql-integration-tests
   - postgres-integration-tests
   - redis-integration-tests
+  - memcached-integration-tests
 
 services:
 - name: postgres
@@ -3272,6 +3317,9 @@ services:
 
 - name: redis
   image: redis:6.2.1-alpine
+
+- name: memcached
+  image: memcached:1.6.9-alpine
 
 trigger:
   ref:

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -832,6 +832,7 @@ def memcached_integration_tests_step():
             './bin/grabpl integration-tests',
         ],
     }
+
 def release_canary_npm_packages_step(edition):
     if edition in ('enterprise', 'enterprise2'):
         return None

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -816,6 +816,22 @@ def redis_integration_tests_step():
         ],
     }
 
+def memcached_integration_tests_step():
+    return {
+        'name': 'memcached-integration-tests',
+        'image': build_image,
+        'depends_on': [
+            'test-backend',
+            'test-frontend',
+        ],
+        'environment': {
+            'MEMCACHED_HOSTS': 'memcached:11211',
+        },
+        'commands': [
+            './bin/dockerize -wait tcp://memcached:11211 -timeout 120s',
+            './bin/grabpl integration-tests',
+        ],
+    }
 def release_canary_npm_packages_step(edition):
     if edition in ('enterprise', 'enterprise2'):
         return None
@@ -882,6 +898,7 @@ def upload_packages_step(edition, ver_mode, is_downstream=False):
 
     if edition in ('enterprise', 'enterprise2'):
       dependencies.append('redis-integration-tests')
+      dependencies.append('memcached-integration-tests')
 
     return {
         'name': 'upload-packages' + enterprise2_sfx(edition),
@@ -1093,10 +1110,14 @@ def integration_test_services(edition):
     ]
 
     if edition in ('enterprise', 'enterprise2'):
-        services.append({
+        services.extend([{
             'name': 'redis',
             'image': 'redis:6.2.1-alpine',
             'environment': {},
-        })
+        }, {
+            'name': 'memcached',
+            'image': 'memcached:1.6.9-alpine',
+            'environment': {},
+        }])
 
     return services

--- a/scripts/master.star
+++ b/scripts/master.star
@@ -82,7 +82,7 @@ def get_steps(edition, is_downstream=False):
     ])
 
     if include_enterprise2:
-      steps.extends([redis_integration_tests_step(), memcached_integration_tests_step()])
+      steps.extend([redis_integration_tests_step(), memcached_integration_tests_step()])
 
     steps.extend([
         release_canary_npm_packages_step(edition),

--- a/scripts/master.star
+++ b/scripts/master.star
@@ -21,6 +21,7 @@ load(
     'postgres_integration_tests_step',
     'mysql_integration_tests_step',
     'redis_integration_tests_step',
+    'memcached_integration_tests_step',
     'get_windows_steps',
     'benchmark_ldap_step',
     'ldap_service',
@@ -81,7 +82,7 @@ def get_steps(edition, is_downstream=False):
     ])
 
     if include_enterprise2:
-      steps.append(redis_integration_tests_step())
+      steps.extends([redis_integration_tests_step(), memcached_integration_tests_step()])
 
     steps.extend([
         release_canary_npm_packages_step(edition),

--- a/scripts/pr.star
+++ b/scripts/pr.star
@@ -22,6 +22,7 @@ load(
     'postgres_integration_tests_step',
     'mysql_integration_tests_step',
     'redis_integration_tests_step',
+    'memcached_integration_tests_step',
     'benchmark_ldap_step',
     'ldap_service',
     'integration_test_services',
@@ -74,6 +75,7 @@ def pr_pipelines(edition):
     if include_enterprise2:
         steps.extend([
             redis_integration_tests_step(),
+            memcached_integration_tests_step(),
             package_step(edition=edition2, ver_mode=ver_mode, variants=['linux-x64']),
             e2e_tests_server_step(edition=edition2, port=3002),
             e2e_tests_step(edition=edition2, port=3002),

--- a/scripts/release.star
+++ b/scripts/release.star
@@ -23,6 +23,7 @@ load(
     'postgres_integration_tests_step',
     'mysql_integration_tests_step',
     'redis_integration_tests_step',
+    'memcached_integration_tests_step',
     'get_windows_steps',
     'benchmark_ldap_step',
     'ldap_service',
@@ -103,7 +104,7 @@ def get_steps(edition, ver_mode):
     ])
 
     if include_enterprise2:
-      steps.append(redis_integration_tests_step())
+      steps.extend([redis_integration_tests_step(), memcached_integration_tests_step()])
 
     if should_upload:
         steps.append(upload_cdn(edition=edition))


### PR DESCRIPTION
Adds Memcached integraion test step to the drone pipeline for use in Grafana Enterprise. This shouldn't add any additional services or steps in the Grafana drone pipeline.