### PR TITLE
Timeline: Renames component to avoid casing conflicts

### DIFF
--- a/packages/grafana-ui/src/components/Timeline/TimelineChart.tsx
+++ b/packages/grafana-ui/src/components/Timeline/TimelineChart.tsx
@@ -11,7 +11,7 @@ import { LegendDisplayMode } from '../VizLegend/types';
 import { VizLayout } from '../VizLayout/VizLayout';
 import { TimelineProps } from './types';
 
-class UnthemedTimeline extends React.Component<TimelineProps, GraphNGState> {
+class UnthemedTimelineChart extends React.Component<TimelineProps, GraphNGState> {
   constructor(props: TimelineProps) {
     super(props);
     let dimFields = props.fields;
@@ -191,5 +191,5 @@ class UnthemedTimeline extends React.Component<TimelineProps, GraphNGState> {
   }
 }
 
-export const Timeline = withTheme(UnthemedTimeline);
-Timeline.displayName = 'Timeline';
+export const TimelineChart = withTheme(UnthemedTimelineChart);
+TimelineChart.displayName = 'TimelineChart';

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -188,7 +188,7 @@ export { PluginSignatureBadge, PluginSignatureBadgeProps } from './PluginSignatu
 export { InlineFormLabel } from './FormLabel/FormLabel';
 
 // Select
-import { Select, AsyncSelect } from './Forms/Legacy/Select/Select';
+import { AsyncSelect, Select } from './Forms/Legacy/Select/Select';
 import { IndicatorsContainer } from './Forms/Legacy/Select/IndicatorsContainer';
 import { NoOptionsMessage } from './Forms/Legacy/Select/NoOptionsMessage';
 
@@ -221,7 +221,7 @@ export { usePlotContext, usePlotPluginContext } from './uPlot/context';
 export { GraphNG, FIXED_UNIT } from './GraphNG/GraphNG';
 export { useGraphNGContext } from './GraphNG/hooks';
 export { BarChart } from './BarChart/BarChart';
-export { Timeline } from './Timeline/Timeline';
+export { TimelineChart } from './Timeline/TimelineChart';
 export { BarChartOptions, BarStackingMode, BarValueVisibility, BarChartFieldConfig } from './BarChart/types';
 export { TimelineOptions, TimelineFieldConfig } from './Timeline/types';
 export { GraphNGLegendEvent, GraphNGLegendEventMode } from './GraphNG/types';

--- a/public/app/plugins/panel/timeline/TimelinePanel.tsx
+++ b/public/app/plugins/panel/timeline/TimelinePanel.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { PanelProps } from '@grafana/data';
-import { Timeline, GraphNGLegendEvent, TimelineOptions } from '@grafana/ui';
+import { GraphNGLegendEvent, TimelineChart, TimelineOptions } from '@grafana/ui';
 import { changeSeriesColorConfigFactory } from '../timeseries/overrides/colorSeriesConfigFactory';
 import { hideSeriesConfigFactory } from '../timeseries/overrides/hideSeriesConfigFactory';
 
@@ -42,7 +42,7 @@ export const TimelinePanel: React.FC<TimelinePanelProps> = ({
   }
 
   return (
-    <Timeline
+    <TimelineChart
       data={data.series}
       timeRange={timeRange}
       timeZone={timeZone}


### PR DESCRIPTION
**What this PR does / why we need it**:
Gets rid of casing issues on MacOS:
![image](https://user-images.githubusercontent.com/562238/113816932-cf4f9880-9775-11eb-81a7-46860509cdd8.png)

**Which issue(s) this PR fixes**:
Related #31973

**Special notes for your reviewer**:

