### PR TITLE
Grafana-UI: allow pass through of monaco options

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -64,7 +64,7 @@ class UnthemedCodeEditor extends React.PureComponent<Props> {
   };
 
   render() {
-    const { theme, language, width, height, showMiniMap, showLineNumbers, readOnly } = this.props;
+    const { theme, language, width, height, showMiniMap, showLineNumbers, readOnly, monacoOptions } = this.props;
     const value = this.props.value ?? '';
     const longText = value.length > 100;
 
@@ -97,7 +97,10 @@ class UnthemedCodeEditor extends React.PureComponent<Props> {
           language={language}
           theme={theme.isDark ? 'vs-dark' : 'vs-light'}
           value={value}
-          options={options}
+          options={{
+            ...options,
+            ...(monacoOptions ?? {}),
+          }}
           editorWillMount={this.editorWillMount}
           editorDidMount={this.editorDidMount}
         />

--- a/packages/grafana-ui/src/components/Monaco/types.ts
+++ b/packages/grafana-ui/src/components/Monaco/types.ts
@@ -1,3 +1,5 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
 export type CodeEditorChangeHandler = (value: string) => void;
 export type CodeEditorSuggestionProvider = () => CodeEditorSuggestionItem[];
 
@@ -10,6 +12,7 @@ export interface CodeEditorProps {
   readOnly?: boolean;
   showMiniMap?: boolean;
   showLineNumbers?: boolean;
+  monacoOptions?: monaco.editor.IEditorConstructionOptions;
 
   /**
    * Callback after the editor has mounted that gives you raw access to monaco


### PR DESCRIPTION
**What this PR does / why we need it**:

I wanted to disable overscroll, so rather than creating a new option for each monaco option, this allows consumers to specify any of the [Monaco options](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html) directly. 

Not certain on the prop name `monacoOptions` vs `options`.
