### PR TITLE
Toolkit: catch errors in version output

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -60,10 +60,10 @@ export const prepare = () =>
 
 export const versions = async () => {
   const nodeVersion = await execa('node', ['--version']);
-  console.log(`Using Node.js ${nodeVersion}`);
+  console.log(`Using Node.js ${nodeVersion.stdout}`);
 
   const toolkitVersion = await execa('grafana-toolkit', ['--version']);
-  console.log(`Using @grafana/toolkit ${toolkitVersion}`);
+  console.log(`Using @grafana/toolkit ${toolkitVersion.stdout}`);
 };
 
 // @ts-ignore

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -59,11 +59,15 @@ export const prepare = () =>
   );
 
 export const versions = async () => {
-  const nodeVersion = await execa('node', ['--version']);
-  console.log(`Using Node.js ${nodeVersion.stdout}`);
+  try {
+    const nodeVersion = await execa('node', ['--version']);
+    console.log(`Using Node.js ${nodeVersion.stdout}`);
 
-  const toolkitVersion = await execa('grafana-toolkit', ['--version']);
-  console.log(`Using @grafana/toolkit ${toolkitVersion.stdout}`);
+    const toolkitVersion = await execa('grafana-toolkit', ['--version']);
+    console.log(`Using @grafana/toolkit ${toolkitVersion.stdout}`);
+  } catch (err) {
+    console.log(`Error reading versions`, err);
+  }
 };
 
 // @ts-ignore


### PR DESCRIPTION
Toolkit currently reports errors like this:
![image](https://user-images.githubusercontent.com/705951/113982972-403a9300-97fe-11eb-953d-360d63dc4d3e.png)

and I am struggling to debug why plugin CI stopped working :face_with_head_bandage: 
![image](https://user-images.githubusercontent.com/705951/113983055-5a747100-97fe-11eb-95be-095adb22d172.png)

