### PR TITLE
AlertingNG: Add registry for notification channels

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/alerting"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -304,4 +305,30 @@ func timeoutFunc(d time.Duration) time.Duration {
 		d = notify.MinTimeout
 	}
 	return d + waitFunc()
+}
+
+// GetAvailableNotifiers returns the metadata of all the notification channels that can be configured.
+func (am *Alertmanager) GetAvailableNotifiers() []*alerting.NotifierPlugin {
+	return []*alerting.NotifierPlugin{
+		{
+			Type:        "email",
+			Name:        "Email",
+			Description: "Sends notifications using Grafana server configured SMTP settings",
+			Heading:     "Email settings",
+			Options: []alerting.NotifierOption{
+				{
+					Label:        "Single email",
+					Description:  "Send a single email to all recipients",
+					Element:      alerting.ElementTypeCheckbox,
+					PropertyName: "singleEmail",
+				}, {
+					Label:        "Addresses",
+					Description:  "You can enter multiple email addresses using a \";\" separator",
+					Element:      alerting.ElementTypeTextArea,
+					PropertyName: "addresses",
+					Required:     true,
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to the global registry that we have for notification channels currently, I am adding a similar global registry for ngalert which the UI can use to list the channels and their options.

This will need to be served via an API for the UI to use.