### PR TITLE
Removed references to dev env. Added reference to Uche's blog about u…

### DIFF
--- a/docs/sources/getting-started/getting-started-sql.md
+++ b/docs/sources/getting-started/getting-started-sql.md
@@ -19,33 +19,12 @@ Use the instructions in [Getting started with Grafana]({{< relref "getting-start
 
 ## Step 2. Download MS SQL Server
 
-MS SQL Server can be installed on many different operating systems. Refer to the [MS SQL Server downloads page](https://www.microsoft.com/en-us/sql-server/sql-server-downloads), for a complete list of all available options.
-
-Alternately, if you are working on Mac or Linux, then you can install MS SQL Server using the resources available in [grafana/grafana](https://github.com/grafana/grafana) GitHub repository (recommended). Here you will find a collection of supported data sources, including MS SQL Server, along with test data and pre-configured dashboards for use.
-
-> **Note:** Installing MS SQL Server on Windows from the [grafana/grafana](https://github.com/grafana/grafana/tree/master/devenv) GitHub repository is not supported at this time.
-
+MS SQL Server can be installed on Windows or Linux operating systems and also on Docker containers. Refer to the [MS SQL Server downloads page](https://www.microsoft.com/en-us/sql-server/sql-server-downloads), for a complete list of all available options.
 ## Step 3. Install MS SQL Server
 
 You can install MS SQL Server on the host running Grafana or on a remote server. To install the software from the [downloads page](https://www.microsoft.com/en-us/sql-server/sql-server-downloads), follow their setup prompts.
 
-Otherwise, follow the instructions below to install and configure MS SQL Server from the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository.
-
-1. Clone the [grafana/grafana](https://github.com/grafana/grafana/tree/master) repository to your local system.
-1. Install Docker or verify that it is installed on your machine.
-1. Within your local `grafana` repository, change directory to [devenv](https://github.com/grafana/grafana/tree/master/devenv).
-1. Run the bash command to setup data sources and dashboards.
-   ```
-    ./setup.sh
-   ```
-1. Restart the Grafana server.
-1. Change directory back to [master](https://github.com/grafana/grafana/tree/master/devenv).
-1. Run the make command to create the MS SQL Server database.
-   ```
-    make devenv sources=mssql
-   ```
-This creates an image of the SQL Server database and runs it as a Docker container.
-
+If you are on a Windows host but want to use Grafana and MS SQL data source on a Linux environment, refer to the [WSL to set up your Grafana development environment](https://grafana.com/blog/2021/03/03/.how-to-set-up-a-grafana-development-environment-on-a-windows-pc-using-wsl). This will allow you to leverage the resources available in [grafana/grafana](https://github.com/grafana/grafana) GitHub repository. Here you will find a collection of supported data sources, including MS SQL Server, along with test data and pre-configured dashboards for use.
 ## Step 4. Adding the MS SQL data source
 
 To add MS SQL Server data source:


### PR DESCRIPTION
After reviewing the Getting Started with Grafana and MS SQL topic with Daniel, we decided to remove references to `devenv` as it is applicable to Linux/Unix environment only. Most MS SQL customers are likely to be on Windows.

Added reference to Uche's blog "[How to set up a Grafana development environment on a Windows PC using WSL](https://grafana.com/blog/2021/03/03/how-to-set-up-a-grafana-development-environment-on-a-windows-pc-using-wsl/)" instead. 