### PR TITLE
Bugfix: fix url query parser treating empty string as a number

### DIFF
--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -40,6 +40,11 @@ describe('parseKeyValue', () => {
     expect(obj).toEqual({ num1: 12, num2: 12.2 });
   });
 
+  it('should not parse empty strinhg as number', () => {
+    const obj = urlUtil.parseKeyValue('num1=&num2=12.2');
+    expect(obj).toEqual({ num1: '', num2: 12.2 });
+  });
+
   it('should parse boolean params', () => {
     const obj = urlUtil.parseKeyValue('bool1&bool2=true&bool3=false');
     expect(obj).toEqual({ bool1: true, bool2: true, bool3: false });

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -155,7 +155,7 @@ export function parseKeyValue(keyValue: string) {
         val = val !== undefined ? tryDecodeURIComponent(val as string) : true;
 
         let parsedVal: any;
-        if (typeof val === 'string') {
+        if (typeof val === 'string' && val !== '') {
           parsedVal = val === 'true' || val === 'false' ? val === 'true' : _.toNumber(val);
         } else {
           parsedVal = val;


### PR DESCRIPTION
Encountered a problem where `locationSearchToObject` would parse `?query=` as `{ query: 0 }`, unexpected!
I traced this to `parseKeyValue` in url utils. It doesn't take into account the fact that for reasons unknown js thinks empty string is a number: `isNaN('') === false; Number('') === 0`.

This PR fixes `parseKeyValue` to not parse empty strings as numbers.

Though in general I think trying to implicitly guess the type of query param based on it's value is a footgun

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

