### PR TITLE
Bugfix: making sure we have proper padding when scrolling is added to bar gauge

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -106,7 +106,7 @@ export class PanelPlugin<
   onPanelMigration?: PanelMigrationHandler<TOptions>;
   onPanelTypeChanged?: PanelTypeChangedHandler<TOptions>;
   noPadding?: boolean;
-  scrollableY?: boolean;
+  scrollable?: boolean;
 
   /**
    * Legacy angular ctrl.  If this exists it will be used instead of the panel
@@ -200,8 +200,8 @@ export class PanelPlugin<
     return this;
   }
 
-  setScrollable(scrollableY = false) {
-    this.scrollableY = scrollableY;
+  setScrollable(scrollable = false) {
+    this.scrollable = scrollable;
     return this;
   }
 

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -106,6 +106,7 @@ export class PanelPlugin<
   onPanelMigration?: PanelMigrationHandler<TOptions>;
   onPanelTypeChanged?: PanelTypeChangedHandler<TOptions>;
   noPadding?: boolean;
+  scrollableY?: boolean;
 
   /**
    * Legacy angular ctrl.  If this exists it will be used instead of the panel
@@ -196,6 +197,11 @@ export class PanelPlugin<
 
   setNoPadding() {
     this.noPadding = true;
+    return this;
+  }
+
+  setScrollable(scrollableY = false) {
+    this.scrollableY = scrollableY;
     return this;
   }
 

--- a/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
+++ b/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
@@ -152,7 +152,6 @@ export class VizRepeater<V, D = {}> extends PureComponent<Props<V, D>, State<V>>
 
     const repeaterStyle: React.CSSProperties = {
       display: 'flex',
-      overflow: minVizHeight ? 'hidden auto' : 'hidden',
     };
 
     let vizHeight = height;

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -1,10 +1,10 @@
 // Libraries
-import React, { Component } from 'react';
+import React, { Component, CSSProperties } from 'react';
 import classNames from 'classnames';
 import { Subscription } from 'rxjs';
 // Components
 import { PanelHeader } from './PanelHeader/PanelHeader';
-import { ErrorBoundary } from '@grafana/ui';
+import { CustomScrollbar, ErrorBoundary } from '@grafana/ui';
 // Utils & Services
 import { getTimeSrv, TimeSrv } from '../services/TimeSrv';
 import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
@@ -274,38 +274,47 @@ export class PanelChrome extends Component<Props, State> {
     const headerHeight = this.hasOverlayHeader() ? 0 : theme.panelHeaderHeight;
     const chromePadding = plugin.noPadding ? 0 : theme.panelPadding;
     const panelWidth = width - chromePadding * 2 - PANEL_BORDER;
-    const scrollableYMargin = plugin.scrollableY ? theme.panelPadding : 0;
-    const innerPanelHeight = height - headerHeight - chromePadding * 2 - PANEL_BORDER - scrollableYMargin;
-    const panelContentClassNames = classNames({
-      'panel-content': true,
-      'panel-content--no-padding': plugin.noPadding,
-      'panel-content--scrollable-y': plugin.scrollableY,
-    });
+    //const scrollableYMargin = plugin.scrollable ? chromePadding : 0;
+    const innerPanelHeight = height - headerHeight - chromePadding * 2 - PANEL_BORDER;
+
+    const contentStyles: CSSProperties = {
+      padding: chromePadding,
+      width: '100%',
+      flexGrow: 1,
+      height: `calc(100% - ${headerHeight}px)`,
+      overflow: 'hidden',
+    };
+
+    if (plugin.scrollable) {
+      contentStyles.paddingRight = '0';
+    }
+
     const panelOptions = panel.getOptions();
+    const panelComponent = (
+      <PanelComponent
+        id={panel.id}
+        data={data}
+        title={panel.title}
+        timeRange={timeRange}
+        timeZone={this.props.dashboard.getTimezone()}
+        options={panelOptions}
+        fieldConfig={panel.fieldConfig}
+        transparent={panel.transparent}
+        width={panelWidth}
+        height={innerPanelHeight}
+        renderCounter={renderCounter}
+        replaceVariables={panel.replaceVariables}
+        onOptionsChange={this.onOptionsChange}
+        onFieldConfigChange={this.onFieldConfigChange}
+        onChangeTimeRange={this.onChangeTimeRange}
+        eventBus={dashboard.events}
+      />
+    );
 
     return (
-      <>
-        <div className={panelContentClassNames}>
-          <PanelComponent
-            id={panel.id}
-            data={data}
-            title={panel.title}
-            timeRange={timeRange}
-            timeZone={this.props.dashboard.getTimezone()}
-            options={panelOptions}
-            fieldConfig={panel.fieldConfig}
-            transparent={panel.transparent}
-            width={panelWidth}
-            height={innerPanelHeight}
-            renderCounter={renderCounter}
-            replaceVariables={panel.replaceVariables}
-            onOptionsChange={this.onOptionsChange}
-            onFieldConfigChange={this.onFieldConfigChange}
-            onChangeTimeRange={this.onChangeTimeRange}
-            eventBus={dashboard.events}
-          />
-        </div>
-      </>
+      <div className="panel-content" style={contentStyles}>
+        {plugin.scrollable ? <CustomScrollbar autoHeightMin="100%">{panelComponent}</CustomScrollbar> : panelComponent}
+      </div>
     );
   }
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -274,10 +274,12 @@ export class PanelChrome extends Component<Props, State> {
     const headerHeight = this.hasOverlayHeader() ? 0 : theme.panelHeaderHeight;
     const chromePadding = plugin.noPadding ? 0 : theme.panelPadding;
     const panelWidth = width - chromePadding * 2 - PANEL_BORDER;
-    const innerPanelHeight = height - headerHeight - chromePadding * 2 - PANEL_BORDER;
+    const scrollableYMargin = plugin.scrollableY ? theme.panelPadding : 0;
+    const innerPanelHeight = height - headerHeight - chromePadding * 2 - PANEL_BORDER - scrollableYMargin;
     const panelContentClassNames = classNames({
       'panel-content': true,
       'panel-content--no-padding': plugin.noPadding,
+      'panel-content--scrollable-y': plugin.scrollableY,
     });
     const panelOptions = panel.getOptions();
 

--- a/public/app/plugins/panel/bargauge/module.tsx
+++ b/public/app/plugins/panel/bargauge/module.tsx
@@ -7,6 +7,7 @@ import { barGaugePanelMigrationHandler } from './BarGaugeMigrations';
 
 export const plugin = new PanelPlugin<BarGaugeOptions>(BarGaugePanel)
   .useFieldConfig()
+  .setScrollable(true)
   .setPanelOptions((builder) => {
     addStandardDataReduceOptions(builder);
     addOrientationOption(builder);

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -102,7 +102,6 @@ div.flot-text {
   width: 100%;
   flex-grow: 1;
   height: calc(100% - #{$panel-header-height});
-  overflow: hidden;
 
   &--no-padding {
     padding: 0;

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -107,15 +107,6 @@ div.flot-text {
   &--no-padding {
     padding: 0;
   }
-
-  &--scrollable-y {
-    overflow: hidden auto;
-    margin-bottom: $panel-padding;
-  }
-
-  &--no-padding.panel-content--scrollable-y {
-    margin-bottom: 0;
-  }
 }
 
 .dashboard-header {

--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -102,11 +102,22 @@ div.flot-text {
   width: 100%;
   flex-grow: 1;
   height: calc(100% - #{$panel-header-height});
+  overflow: hidden;
 
   &--no-padding {
     padding: 0;
   }
+
+  &--scrollable-y {
+    overflow: hidden auto;
+    margin-bottom: $panel-padding;
+  }
+
+  &--no-padding.panel-content--scrollable-y {
+    margin-bottom: 0;
+  }
 }
+
 .dashboard-header {
   font-size: $font-size-h2;
   text-align: center;


### PR DESCRIPTION
What this PR does / why we need it:
Prior to this PR the scrollbar will hide the values in the bar gauge (and probably other visualizations). I added a setScrollable to apply the scrolling in the PanelChrome instead of in the vizRepeater which results in getting the padding in the right place for all browsers.

Which issue(s) this PR fixes:
Fixes #32083

**Special notes for your reviewer**:
This PR has a dependency on the following PR before it can be merged: #32833