### PR TITLE
GraphNG: uPlot 1.6.8

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -78,7 +78,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.7"
+    "uplot": "1.6.8"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25002,10 +25002,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.7.tgz#d3faaec899791ee3fdf5d2835b19a33d9117566a"
-  integrity sha512-6aYZmGywrHTqTgT1GfYHnU77xDUdutR1EJbVX4P9I45CGrtXN77S69/cgW2BXPL1lR4g6V6bh7ujJsFyvHw1hg==
+uplot@1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.8.tgz#0a7920018de24fa9aa0ba78ab59c99b4a23f8322"
+  integrity sha512-Hqg7iv/3fJlD9nockD7heaUj28RhrIwzugXglnoX//W27wgRAJIJMV2VFMZ5oRVM0RIchByAle1ylf/GdnXgjA==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
among the goodies, an important fix that properly syncs the cursor position during scrolling. previously only scrolling of `window` was being handled, but dashboard scrolling is of DOM elements, and those events don't bubble. switched to a capturing-phase listener to get access to all scroll events on the page.

Changelog: https://github.com/leeoniya/uPlot/releases/tag/1.6.8

![image](https://user-images.githubusercontent.com/43234/114247720-6d508800-995b-11eb-9fcc-b5a962004565.png)