### PR TITLE
Alerting: Fix issue where Slack notifications won't link to user IDs

### DIFF
--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -281,7 +281,6 @@ func (sn *SlackNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"attachments": []map[string]interface{}{
 			attachment,
 		},
-		"parse": "full", // to linkify urls, users and channels in alert message.
 	}
 	if len(blocks) > 0 {
 		body["blocks"] = blocks


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR resolves the issue described in #32860 where user IDs and channel IDs used in the alert message box aren't properly linked to usernames and thus do not notify the corresponding users.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #32860

**Special notes for your reviewer**:

I'm guessing this bug was caused by a few confusing phrases in the Slack API documentation. I've included details of this problem in the linked issue. 

Hopefully, changes here should not interfere with #32511 as chat.postMessage shares the same "parse" argument with the same behavior. 

