### PR TITLE
Chore: Fix sqlite3 transaction retry condition operator precedence

### DIFF
--- a/pkg/services/sqlstore/transactions.go
+++ b/pkg/services/sqlstore/transactions.go
@@ -44,7 +44,7 @@ func inTransactionWithRetryCtx(ctx context.Context, engine *xorm.Engine, callbac
 
 	// special handling of database locked errors for sqlite, then we can retry 5 times
 	var sqlError sqlite3.Error
-	if errors.As(err, &sqlError) && retry < 5 && sqlError.Code == sqlite3.ErrLocked || sqlError.Code == sqlite3.ErrBusy {
+	if errors.As(err, &sqlError) && retry < 5 && (sqlError.Code == sqlite3.ErrLocked || sqlError.Code == sqlite3.ErrBusy) {
 		if rollErr := sess.Rollback(); rollErr != nil {
 			return errutil.Wrapf(err, "Rolling back transaction due to error failed: %s", rollErr)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Just noticed that transaction has a chance to stuck in an endless retry cycle with SQLite3 (maybe never happen on practice though).

See https://golang.org/ref/spec#Operator_precedence and https://play.golang.org/p/waKWtg_zt1C