### PR TITLE
Annotations: Fixes issues loading angular annotation query editors and updating annotation query model 

### DIFF
--- a/public/app/features/dashboard/components/AnnotationSettings/AngularEditorLoader.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AngularEditorLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { AnnotationQuery, DataSourceApi } from '@grafana/data';
 import { AngularComponent, getAngularLoader } from '@grafana/runtime';
 
@@ -8,43 +8,52 @@ export interface Props {
   onChange: (annotation: AnnotationQuery) => void;
 }
 
-export const AngularEditorLoader: React.FC<Props> = React.memo(({ annotation, datasource, onChange }) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const [angularComponent, setAngularComponent] = useState<AngularComponent | null>(null);
+export class AngularEditorLoader extends React.PureComponent<Props> {
+  ref: HTMLDivElement | null = null;
+  angularComponent: AngularComponent;
 
-  useEffect(() => {
-    return () => {
-      if (angularComponent) {
-        angularComponent.destroy();
-      }
-    };
-  }, [angularComponent]);
-
-  useEffect(() => {
-    if (ref.current) {
-      const loader = getAngularLoader();
-      const template = `<plugin-component ng-if="!ctrl.currentDatasource.annotations" type="annotations-query-ctrl"> </plugin-component>`;
-      const scopeProps = {
-        ctrl: {
-          currentDatasource: datasource,
-          currentAnnotation: annotation,
-        },
-      };
-
-      const component = loader.load(ref.current, scopeProps, template);
-      component.digest();
-      component.getScope().$watch(() => {
-        onChange({
-          ...annotation,
-        });
-      });
-
-      setAngularComponent(component);
+  componentWillUnmount() {
+    if (this.angularComponent) {
+      this.angularComponent.destroy();
     }
-    // specifying annotation or onChange causes angular error `Cannot read property '$$nextSibling' of null`
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref, datasource]);
+  }
 
-  return <div ref={ref} />;
-});
-AngularEditorLoader.displayName = 'AngularEditorLoader';
+  componentDidMount() {
+    if (this.ref) {
+      this.loadAngular();
+    }
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.datasource !== this.props.datasource) {
+      this.loadAngular();
+    }
+  }
+
+  loadAngular() {
+    if (this.angularComponent) {
+      this.angularComponent.destroy();
+    }
+
+    const loader = getAngularLoader();
+    const template = `<plugin-component ng-if="!ctrl.currentDatasource.annotations" type="annotations-query-ctrl"> </plugin-component>`;
+    const scopeProps = {
+      ctrl: {
+        currentDatasource: this.props.datasource,
+        currentAnnotation: this.props.annotation,
+      },
+    };
+
+    this.angularComponent = loader.load(this.ref, scopeProps, template);
+    this.angularComponent.digest();
+    this.angularComponent.getScope().$watch(() => {
+      this.props.onChange({
+        ...this.props.annotation,
+      });
+    });
+  }
+
+  render() {
+    return <div ref={(element) => (this.ref = element)} />;
+  }
+}

--- a/public/app/features/dashboard/components/AnnotationSettings/AngularEditorLoader.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AngularEditorLoader.tsx
@@ -41,7 +41,9 @@ export const AngularEditorLoader: React.FC<Props> = React.memo(({ annotation, da
 
       setAngularComponent(component);
     }
-  }, [ref]);
+    // specifying annotation or onChange causes angular error `Cannot read property '$$nextSibling' of null`
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref, datasource]);
 
   return <div ref={ref} />;
 });

--- a/public/app/features/dashboard/components/AnnotationSettings/AngularEditorLoader.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AngularEditorLoader.tsx
@@ -28,6 +28,10 @@ export class AngularEditorLoader extends React.PureComponent<Props> {
     if (prevProps.datasource !== this.props.datasource) {
       this.loadAngular();
     }
+
+    if (this.angularComponent && prevProps.annotation !== this.props.annotation) {
+      this.angularComponent.getScope().ctrl.currentAnnotation = this.props.annotation;
+    }
   }
 
   loadAngular() {
@@ -48,7 +52,7 @@ export class AngularEditorLoader extends React.PureComponent<Props> {
     this.angularComponent.digest();
     this.angularComponent.getScope().$watch(() => {
       this.props.onChange({
-        ...this.props.annotation,
+        ...scopeProps.ctrl.currentAnnotation,
       });
     });
   }

--- a/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
+++ b/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts
@@ -3,10 +3,12 @@ import { AnnotationQuery } from './types';
 
 export class CloudWatchAnnotationsQueryCtrl {
   static templateUrl = 'partials/annotations.editor.html';
-  annotation: any;
+  declare annotation: any;
 
   /** @ngInject */
-  constructor() {
+  constructor($scope: any) {
+    this.annotation = $scope.ctrl.annotation;
+
     _.defaultsDeep(this.annotation, {
       namespace: '',
       metricName: '',

--- a/public/app/plugins/datasource/grafana/annotation_ctrl.ts
+++ b/public/app/plugins/datasource/grafana/annotation_ctrl.ts
@@ -7,11 +7,13 @@ export const annotationTypes: Array<SelectableValue<GrafanaAnnotationType>> = [
 ];
 
 export class GrafanaAnnotationsQueryCtrl {
-  annotation: any;
+  declare annotation: any;
 
   types = annotationTypes;
 
-  constructor() {
+  /** @ngInject */
+  constructor($scope: any) {
+    this.annotation = $scope.ctrl.annotation;
     this.annotation.type = this.annotation.type || GrafanaAnnotationType.Tags;
     this.annotation.limit = this.annotation.limit || 100;
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Merging #31950 brought an eslint warning into master. This PR silences it. 

Unfortunately it seems that adding `annotation` or `onChange` to the dependency list causes angular to error with `Cannot read property '$$nextSibling' of null` and the AngularEditor to fail to load anything. I believe it's something to do with the `digest` that's being called within the useEffect but don't know enough about Angular to be able to figure it out. 


