### PR TITLE
Plugins: Allow a non-dashboard page to be the default home page

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -304,7 +304,7 @@ password_hint = password
 # Default UI theme ("dark" or "light")
 default_theme = dark
 
-# Path to a custom home page. It should match a route in frontend routes and should contain a leading backslash
+# Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
 home_page =
 
 # External user management

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -304,6 +304,9 @@ password_hint = password
 # Default UI theme ("dark" or "light")
 default_theme = dark
 
+# Path to a custom home page. It should match a route in frontend routes and should contain a leading backslash
+home_page =
+
 # External user management
 external_manage_link_url =
 external_manage_link_name =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -304,6 +304,9 @@
 # Default UI theme ("dark" or "light")
 ;default_theme = dark
 
+# Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
+; home_page =
+
 # External user management, these options affect the organization users view
 ;external_manage_link_url =
 ;external_manage_link_name =

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -626,6 +626,10 @@ Text used as placeholder text on login page for password input.
 
 Set the default UI theme: `dark` or `light`. Default is `dark`.
 
+### home_page
+
+Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
+
 ### External user management
 
 If you manage users externally you can replace the user invite button for organizations with a link to an external site together with a description.

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -373,11 +373,11 @@ func (hs *HTTPServer) dashboardSaveErrorToApiResponse(err error) response.Respon
 func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) response.Response {
 	prefsQuery := models.GetPreferencesWithDefaultsQuery{User: c.SignedInUser}
 	homePage := setting.GetCfg().HomePage
+
 	if err := hs.Bus.Dispatch(&prefsQuery); err != nil {
 		return response.Error(500, "Failed to get preferences", err)
 	}
 
-	// import config, check for config.homePath and if it exists, send back the redirect.
 	if prefsQuery.Result.HomeDashboardId == 0 && homePage != "" {
 		homePageRedirect := dtos.DashboardRedirect{RedirectUri: homePage}
 		return response.JSON(200, &homePageRedirect)

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/services/guardian"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -372,13 +372,13 @@ func (hs *HTTPServer) dashboardSaveErrorToApiResponse(err error) response.Respon
 // GetHomeDashboard returns the home dashboard.
 func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) response.Response {
 	prefsQuery := models.GetPreferencesWithDefaultsQuery{User: c.SignedInUser}
-	homePage := setting.GetCfg().HomePage
+	homePage := hs.Cfg.HomePage
 
 	if err := hs.Bus.Dispatch(&prefsQuery); err != nil {
 		return response.Error(500, "Failed to get preferences", err)
 	}
 
-	if prefsQuery.Result.HomeDashboardId == 0 && homePage != "" {
+	if prefsQuery.Result.HomeDashboardId == 0 && len(homePage) > 0 {
 		homePageRedirect := dtos.DashboardRedirect{RedirectUri: homePage}
 		return response.JSON(200, &homePageRedirect)
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -366,6 +366,7 @@ type Cfg struct {
 	Quota QuotaSettings
 
 	DefaultTheme string
+	HomePage     string
 
 	AutoAssignOrg     bool
 	AutoAssignOrgId   int
@@ -1252,6 +1253,7 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	LoginHint = valueAsString(users, "login_hint", "")
 	PasswordHint = valueAsString(users, "password_hint", "")
 	cfg.DefaultTheme = valueAsString(users, "default_theme", "")
+	cfg.HomePage = valueAsString(users, "home_page", "")
 	ExternalUserMngLinkUrl = valueAsString(users, "external_manage_link_url", "")
 	ExternalUserMngLinkName = valueAsString(users, "external_manage_link_name", "")
 	ExternalUserMngInfo = valueAsString(users, "external_manage_info", "")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR introduces the concept of a homepage config setting that allows any route matched in the frontend routes (app plugin custom pages for example) to be the default homepage if the user or the org does not have a custom default dashboard set. It is a new approach based on the conversations had in #32171

**Special notes for your reviewer**:
I don't know how to golang so any input here would be most appreciated. 🙂 
