### PR TITLE
Input: Prevents alpha numeric chars in number inputs

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
@@ -83,6 +83,7 @@ export class Input extends PureComponent<Props, State> {
           {...inputElementProps}
           ref={inputRef}
           className={inputClassName}
+          type={type}
           onBeforeInput={onBeforeNumberInput({ type, onBeforeInput })}
         />
         {error && !hideErrorMessage && <span>{error}</span>}

--- a/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
@@ -1,7 +1,8 @@
-import React, { PureComponent, ChangeEvent } from 'react';
+import React, { ChangeEvent, PureComponent } from 'react';
 import classNames from 'classnames';
-import { validate, EventsWithValidation, hasValidationEvent } from '../../../../utils';
+import { EventsWithValidation, hasValidationEvent, validate } from '../../../../utils';
 import { ValidationEvents, ValidationRule } from '../../../../types';
+import { onBeforeNumberInput } from '../../../Input/Input';
 
 export enum LegacyInputStatus {
   Invalid = 'invalid',
@@ -71,14 +72,19 @@ export class Input extends PureComponent<Props, State> {
   };
 
   render() {
-    const { validationEvents, className, hideErrorMessage, inputRef, ...restProps } = this.props;
+    const { validationEvents, className, hideErrorMessage, inputRef, type, onBeforeInput, ...restProps } = this.props;
     const { error } = this.state;
     const inputClassName = classNames('gf-form-input', { invalid: this.isInvalid }, className);
     const inputElementProps = this.populateEventPropsWithStatus(restProps, validationEvents);
 
     return (
       <div style={{ flexGrow: 1 }}>
-        <input {...inputElementProps} ref={inputRef} className={inputClassName} />
+        <input
+          {...inputElementProps}
+          ref={inputRef}
+          className={inputClassName}
+          onBeforeInput={onBeforeNumberInput({ type, onBeforeInput })}
+        />
         {error && !hideErrorMessage && <span>{error}</span>}
       </div>
     );

--- a/packages/grafana-ui/src/components/Forms/Legacy/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Input/__snapshots__/Input.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Input renders correctly 1`] = `
 >
   <input
     className="gf-form-input"
+    onBeforeInput={[Function]}
   />
 </div>
 `;

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -253,6 +253,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             paddingLeft: prefixRect ? prefixRect.width : undefined,
             paddingRight: suffixRect ? suffixRect.width : undefined,
           }}
+          type={type}
           onBeforeInput={onBeforeNumberInput({ type, onBeforeInput })}
         />
 

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -210,7 +210,19 @@ export const getInputStyles = stylesFactory(({ theme, invalid = false, width }: 
 });
 
 export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { className, addonAfter, addonBefore, prefix, suffix, invalid, loading, width = 0, ...restProps } = props;
+  const {
+    className,
+    addonAfter,
+    addonBefore,
+    prefix,
+    suffix,
+    invalid,
+    loading,
+    width = 0,
+    type,
+    onBeforeInput,
+    ...restProps
+  } = props;
   /**
    * Prefix & suffix are positioned absolutely within inputWrapper. We use client rects below to apply correct padding to the input
    * when prefix/suffix is larger than default (28px = 16px(icon) + 12px(left/right paddings)).
@@ -241,6 +253,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             paddingLeft: prefixRect ? prefixRect.width : undefined,
             paddingRight: suffixRect ? suffixRect.width : undefined,
           }}
+          onBeforeInput={onBeforeNumberInput({ type, onBeforeInput })}
         />
 
         {(suffix || loading) && (
@@ -257,3 +270,25 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
 });
 
 Input.displayName = 'Input';
+
+export function onBeforeNumberInput({
+  onBeforeInput,
+  type,
+}: Pick<HTMLProps<HTMLInputElement>, 'type' | 'onBeforeInput'>) {
+  return function (event: React.FormEvent<HTMLInputElement> & { data: string }) {
+    if (onBeforeInput) {
+      onBeforeInput(event);
+      return;
+    }
+
+    if (type === 'number') {
+      const isNotNumber = isNaN(Number(event.data));
+      const length = event.data?.trim().length;
+      const hasLength = Boolean(length);
+      if (isNotNumber || !hasLength) {
+        event.preventDefault();
+      }
+      return;
+    }
+  };
+}

--- a/public/app/plugins/datasource/cloudwatch/components/__snapshots__/Alias.test.tsx.snap
+++ b/public/app/plugins/datasource/cloudwatch/components/__snapshots__/Alias.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Alias should render component 1`] = `
 >
   <input
     className="gf-form-input gf-form-input width-16"
+    onBeforeInput={[Function]}
     onChange={[Function]}
     type="text"
     value="legend"


### PR DESCRIPTION
**What this PR does / why we need it**:
Alternative solution to #29558, needs lots of testing I guess. But it works on MacOS:
![image](https://user-images.githubusercontent.com/562238/114557792-4ef3d080-9c6a-11eb-9c3f-1cc86b1582c2.png)

with Browsers:
![image](https://user-images.githubusercontent.com/562238/114557531-0f2ce900-9c6a-11eb-8db7-af5c71d7574a.png)
![image](https://user-images.githubusercontent.com/562238/114557589-1f44c880-9c6a-11eb-8645-99eee4ff7b3e.png)
![image](https://user-images.githubusercontent.com/562238/114557687-34215c00-9c6a-11eb-94ff-48e11e82f989.png)

**Which issue(s) this PR fixes**:
Fixes #29207

**Special notes for your reviewer**:
This doesn't currently handle decimals in inputs. For that we would need to use onInput instead and things get more complicated.
