### PR TITLE
Docs: Update license exiration

### DIFF
--- a/docs/sources/enterprise/license-expiration.md
+++ b/docs/sources/enterprise/license-expiration.md
@@ -38,7 +38,7 @@ Your current data source permissions will keep working as expected, but you'll b
 ### LDAP authentication
 
 - LDAP synchronization is not affected by an expired license.
-- Enhanced LDAP debugging is unavailable.
+- Team sync debugging is unavailable.
 
 ### SAML authentication
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Clarifies that with an expired license, only Team to LDAP group mapping is unavailable in LDAP Debug View.
- Updates LDAP Debug view screenshot: current screenshot is taken on Enterprise version, there should not be team to LDAP grouping mapping in OSS. 

