### PR TITLE
Utils: Global debugger utils

### DIFF
--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -1,7 +1,7 @@
 import { deprecationWarning, UrlQueryMap, urlUtil } from '@grafana/data';
 import * as H from 'history';
 import { LocationUpdate } from './LocationSrv';
-import { attachDebbuger, createLogger } from '@grafana/ui';
+import { attachDebugger, createLogger } from '@grafana/ui';
 import { config } from '../config';
 
 /**
@@ -156,4 +156,4 @@ const navigationLog = createLogger('Router');
 export const navigationLogger = navigationLog.logger;
 
 // For debugging purposes the location service is attached to global _debug variable
-attachDebbuger('location', locationService, navigationLog);
+attachDebugger('location', locationService, navigationLog);

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -1,7 +1,7 @@
 import { deprecationWarning, UrlQueryMap, urlUtil } from '@grafana/data';
 import * as H from 'history';
 import { LocationUpdate } from './LocationSrv';
-import { createLogger } from '@grafana/ui';
+import { attachDebbuger, createLogger } from '@grafana/ui';
 import { config } from '../config';
 
 /**
@@ -34,24 +34,6 @@ export class HistoryWrapper implements LocationService {
       history || process.env.NODE_ENV === 'test'
         ? H.createMemoryHistory({ initialEntries: ['/'] })
         : H.createBrowserHistory({ basename: config.appSubUrl ?? '/' });
-
-    // For debugging purposes the location service is attached to global _debug variable
-    if (process.env.NODE_ENV !== 'production') {
-      // @ts-ignore
-      let debugGlobal = window['_debug'];
-      if (debugGlobal) {
-        debugGlobal = {
-          ...debugGlobal,
-          location: this,
-        };
-      } else {
-        debugGlobal = {
-          location: this,
-        };
-      }
-      // @ts-ignore
-      window['_debug'] = debugGlobal;
-    }
 
     this.partial = this.partial.bind(this);
     this.push = this.push.bind(this);
@@ -168,5 +150,10 @@ export const setLocationService = (location: LocationService) => {
   locationService = location;
 };
 
+const navigationLog = createLogger('Router');
+
 /** @internal */
-export const navigationLogger = createLogger('Router');
+export const navigationLogger = navigationLog.logger;
+
+// For debugging purposes the location service is attached to global _debug variable
+attachDebbuger('location', locationService, navigationLog);

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -2,7 +2,7 @@ import { DataFrame, dateTime, FieldType } from '@grafana/data';
 import { AlignedData, Options } from 'uplot';
 import { PlotPlugin, PlotProps } from './types';
 import { createLogger } from '../../utils/logger';
-import { attachDebbuger } from '../../utils/debug';
+import { attachDebugger } from '../../utils';
 
 const ALLOWED_FORMAT_STRINGS_REGEX = /\b(YYYY|YY|MMMM|MMM|MM|M|DD|D|WWWW|WWW|HH|H|h|AA|aa|a|mm|m|ss|s|fff)\b/g;
 

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -66,4 +66,4 @@ export function preparePlotData(frame: DataFrame, ignoreFieldTypes?: FieldType[]
 export const pluginLogger = createLogger('uPlot Plugin');
 export const pluginLog = pluginLogger.logger;
 
-attachDebbuger('graphng', undefined, pluginLogger);
+attachDebugger('graphng', undefined, pluginLogger);

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -2,8 +2,8 @@ import { DataFrame, dateTime, FieldType } from '@grafana/data';
 import { AlignedData, Options } from 'uplot';
 import { PlotPlugin, PlotProps } from './types';
 import { createLogger } from '../../utils/logger';
+import { attachDebbuger } from '../../utils/debug';
 
-const LOGGING_ENABLED = false;
 const ALLOWED_FORMAT_STRINGS_REGEX = /\b(YYYY|YY|MMMM|MMM|MM|M|DD|D|WWWW|WWW|HH|H|h|AA|aa|a|mm|m|ss|s|fff)\b/g;
 
 export function timeFormatToTemplate(f: string) {
@@ -63,4 +63,7 @@ export function preparePlotData(frame: DataFrame, ignoreFieldTypes?: FieldType[]
 // Dev helpers
 
 /** @internal */
-export const pluginLog = createLogger('uPlot Plugin', LOGGING_ENABLED);
+export const pluginLogger = createLogger('uPlot Plugin');
+export const pluginLog = pluginLogger.logger;
+
+attachDebbuger('graphng', undefined, pluginLogger);

--- a/packages/grafana-ui/src/utils/debug.ts
+++ b/packages/grafana-ui/src/utils/debug.ts
@@ -4,7 +4,7 @@ import { Logger } from './logger';
  * Allows debug helpers attachement to the window object
  * @internal
  */
-export function attachDebbuger(key: string, thebugger?: any, logger?: Logger) {
+export function attachDebugger(key: string, thebugger?: any, logger?: Logger) {
   if (process.env.NODE_ENV === 'production') {
     return;
   }

--- a/packages/grafana-ui/src/utils/debug.ts
+++ b/packages/grafana-ui/src/utils/debug.ts
@@ -1,0 +1,30 @@
+import { Logger } from './logger';
+
+/**
+ * Allows debug helpers attachement to the window object
+ * @internal
+ */
+export function attachDebbuger(key: string, thebugger?: any, logger?: Logger) {
+  if (process.env.NODE_ENV !== 'production') {
+    let completeDebugger = thebugger ? { ...thebugger } : {};
+
+    if (logger !== undefined) {
+      completeDebugger = { ...completeDebugger, enable: () => logger.enable(), disable: () => logger.disable() };
+    }
+
+    // @ts-ignore
+    let debugGlobal = window['_debug'];
+    if (debugGlobal) {
+      debugGlobal = {
+        ...debugGlobal,
+        [key]: completeDebugger,
+      };
+    } else {
+      debugGlobal = {
+        [key]: completeDebugger,
+      };
+    }
+    // @ts-ignore
+    window['_debug'] = debugGlobal;
+  }
+}

--- a/packages/grafana-ui/src/utils/debug.ts
+++ b/packages/grafana-ui/src/utils/debug.ts
@@ -5,7 +5,9 @@ import { Logger } from './logger';
  * @internal
  */
 export function attachDebbuger(key: string, thebugger?: any, logger?: Logger) {
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
     let completeDebugger = thebugger ? { ...thebugger } : {};
 
     if (logger !== undefined) {

--- a/packages/grafana-ui/src/utils/debug.ts
+++ b/packages/grafana-ui/src/utils/debug.ts
@@ -15,17 +15,8 @@ export function attachDebbuger(key: string, thebugger?: any, logger?: Logger) {
     }
 
     // @ts-ignore
-    let debugGlobal = window['_debug'];
-    if (debugGlobal) {
-      debugGlobal = {
-        ...debugGlobal,
-        [key]: completeDebugger,
-      };
-    } else {
-      debugGlobal = {
-        [key]: completeDebugger,
-      };
-    }
+    let debugGlobal = window['_debug'] ?? {};
+    debugGlobal[key] = completeDebugger;
     // @ts-ignore
     window['_debug'] = debugGlobal;
   }

--- a/packages/grafana-ui/src/utils/debug.ts
+++ b/packages/grafana-ui/src/utils/debug.ts
@@ -8,7 +8,7 @@ export function attachDebugger(key: string, thebugger?: any, logger?: Logger) {
   if (process.env.NODE_ENV === 'production') {
     return;
   }
-  let completeDebugger = thebugger ? { ...thebugger } : {};
+  let completeDebugger = thebugger || {};
 
   if (logger !== undefined) {
     completeDebugger = { ...completeDebugger, enable: () => logger.enable(), disable: () => logger.disable() };

--- a/packages/grafana-ui/src/utils/debug.ts
+++ b/packages/grafana-ui/src/utils/debug.ts
@@ -8,16 +8,15 @@ export function attachDebugger(key: string, thebugger?: any, logger?: Logger) {
   if (process.env.NODE_ENV === 'production') {
     return;
   }
-    let completeDebugger = thebugger ? { ...thebugger } : {};
+  let completeDebugger = thebugger ? { ...thebugger } : {};
 
-    if (logger !== undefined) {
-      completeDebugger = { ...completeDebugger, enable: () => logger.enable(), disable: () => logger.disable() };
-    }
-
-    // @ts-ignore
-    let debugGlobal = window['_debug'] ?? {};
-    debugGlobal[key] = completeDebugger;
-    // @ts-ignore
-    window['_debug'] = debugGlobal;
+  if (logger !== undefined) {
+    completeDebugger = { ...completeDebugger, enable: () => logger.enable(), disable: () => logger.disable() };
   }
+
+  // @ts-ignore
+  let debugGlobal = window['_debug'] ?? {};
+  debugGlobal[key] = completeDebugger;
+  // @ts-ignore
+  window['_debug'] = debugGlobal;
 }

--- a/packages/grafana-ui/src/utils/index.ts
+++ b/packages/grafana-ui/src/utils/index.ts
@@ -12,4 +12,4 @@ import * as DOMUtil from './dom'; // includes Element.closest polyfill
 export { DOMUtil };
 export { renderOrCallToRender } from './renderOrCallToRender';
 export { createLogger } from './logger';
-export { attachDebbuger } from './debug';
+export { attachDebugger } from './debug';

--- a/packages/grafana-ui/src/utils/index.ts
+++ b/packages/grafana-ui/src/utils/index.ts
@@ -12,3 +12,4 @@ import * as DOMUtil from './dom'; // includes Element.closest polyfill
 export { DOMUtil };
 export { renderOrCallToRender } from './renderOrCallToRender';
 export { createLogger } from './logger';
+export { attachDebbuger } from './debug';

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -1,15 +1,33 @@
 import throttle from 'lodash/throttle';
 
-/** @internal */
+/**
+ * @internal
+ * */
 const throttledLog = throttle((...t: any[]) => {
   console.log(...t);
 }, 500);
 
+/**
+ * @internal
+ */
+export interface Logger {
+  logger: (...t: any[]) => void;
+  enable: () => void;
+  disable: () => void;
+}
+
 /** @internal */
-export const createLogger = (name: string, enable = true) => (id: string, throttle = false, ...t: any[]) => {
-  if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !enable) {
-    return;
-  }
-  const fn = throttle ? throttledLog : console.log;
-  fn(`[${name}: ${id}]: `, ...t);
+export const createLogger = (name: string): Logger => {
+  let LOGGIN_ENABLED = false;
+  return {
+    logger: (id: string, throttle = false, ...t: any[]) => {
+      if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !LOGGIN_ENABLED) {
+        return;
+      }
+      const fn = throttle ? throttledLog : console.log;
+      fn(`[${name}: ${id}]: `, ...t);
+    },
+    enable: () => (LOGGIN_ENABLED = true),
+    disable: () => (LOGGIN_ENABLED = false),
+  };
 };


### PR DESCRIPTION
Cherry picked from https://github.com/grafana/grafana/pull/32906


Allows global debugger atachement to window object for runtime services/utils inspection and logging. The attached debuggers are available under `_debug` key.

Two things attached currenly are LocationService and GraphNG logger. 

API:
```
export function attachDebbuger(key: string, thebugger?: any, logger?: Logger) {
```

If `logger` is provided the attached debugger allows enabling/disabling debugger's logger for runtime logs of a given service/util. With this, there is no longer a need for changing the flag in the code to enable/disable i.e. LocationService and GraphNG loggers. All loggers are **disabled** by default. 

If you wanna enable logger, in your console type `_debug.graphng.enable()`. To disable: `_debug.graphng.disable()`