### PR TITLE
Allow `SQLStore.SkipMigrations` to be set in the test SQL store

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -447,6 +447,15 @@ func InitTestDB(t ITestDB, opts ...InitTestDBOpt) *SQLStore {
 			}
 		}
 
+		// useful if you already have a database that you want to use for tests.
+		// cannot just set it on testSQLStore as it overrides the config in Init
+		if _, present := os.LookupEnv("SKIP_MIGRATIONS"); present {
+			t.Log("Skipping database migrations")
+			if _, err := sec.NewKey("skip_migrations", "true"); err != nil {
+				t.Fatalf("Failed to create key: %s", err)
+			}
+		}
+
 		// need to get engine to clean db before we init
 		t.Logf("Creating database connection: %q", sec.Key("connection_string"))
 		engine, err := xorm.NewEngine(dbType, sec.Key("connection_string").String())


### PR DESCRIPTION
allow skip migrations in tests via environment variable

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:


This PR allows us to configure the test SQL store to skip_migrations if the `SKIP_MIGRATIONS` flag is set. This is useful if we want to run the tests against an existing database which may not have the migration_log table present.


**Special notes for your reviewer**:

This is related to the [`SkipMigrations` property](https://github.com/grafana/grafana/blob/master/pkg/services/sqlstore/sqlstore.go#L523) on the SQLStore - we want to be able to set this property in the test suite.


