### PR TITLE
Alerting: Fix alert frequency check to prevent throwing message on undefined string

### DIFF
--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -266,7 +266,11 @@ export class AlertTabCtrl {
   checkFrequency() {
     this.frequencyWarning = '';
 
-    if (!(this.alert.frequency || '').match(/^\d+([dhms])$/)) {
+    if (!this.alert.frequency) {
+      return;
+    }
+
+    if (!this.alert.frequency.match(/^\d+([dhms])$/)) {
       this.frequencyWarning =
         'Invalid frequency, has to be numeric followed by one of the following units: "d, h, m, s"';
       return;


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug that introduced on #32477, where the following happens:

![image](https://user-images.githubusercontent.com/15115078/114686893-dea58780-9d1b-11eb-8ef4-af28ddf97286.png)

The cause of this is that when the alert is first created, the frequency field is an `undefined string` and this makes the condition `(!(this.alert.frequency || '').match(/^\d+([dhms])$/))` true.

**Special notes for your reviewer**:

* Create a dashboard with a datasource
* Try to add an alert, the above message as shown in the GIF shouldn't appear