### PR TITLE
AlertingNG: Add Teams notification channel

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -368,6 +368,8 @@ func (am *Alertmanager) buildReceiverIntegrations(receiver *apimodels.PostableAp
 			n, err = channels.NewSlackNotifier(cfg, tmpl, externalURL)
 		case "telegram":
 			n, err = channels.NewTelegramNotifier(cfg, tmpl, externalURL)
+		case "teams":
+			n, err = channels.NewTeamsNotifier(cfg, tmpl, externalURL)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -24,7 +24,6 @@ type EmailNotifier struct {
 	old_notifiers.NotifierBase
 	Addresses   []string
 	SingleEmail bool
-	AutoResolve bool
 	log         log.Logger
 	externalUrl *url.URL
 	appURL      string
@@ -39,7 +38,6 @@ func NewEmailNotifier(model *models.AlertNotification, externalUrl *url.URL, app
 
 	addressesString := model.Settings.Get("addresses").MustString()
 	singleEmail := model.Settings.Get("singleEmail").MustBool(false)
-	autoResolve := model.Settings.Get("autoResolve").MustBool(true)
 
 	if addressesString == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find addresses in settings"}
@@ -52,7 +50,6 @@ func NewEmailNotifier(model *models.AlertNotification, externalUrl *url.URL, app
 		NotifierBase: old_notifiers.NewNotifierBase(model),
 		Addresses:    addresses,
 		SingleEmail:  singleEmail,
-		AutoResolve:  autoResolve,
 		appURL:       appURL,
 		log:          log.New("alerting.notifier.email"),
 		externalUrl:  externalUrl,
@@ -94,5 +91,5 @@ func (en *EmailNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 }
 
 func (en *EmailNotifier) SendResolved() bool {
-	return en.AutoResolve
+	return !en.GetDisableResolveMessage()
 }

--- a/pkg/services/ngalert/notifier/channels/teams.go
+++ b/pkg/services/ngalert/notifier/channels/teams.go
@@ -1,0 +1,106 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	gokit_log "github.com/go-kit/kit/log"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	old_notifiers "github.com/grafana/grafana/pkg/services/alerting/notifiers"
+	"github.com/pkg/errors"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+)
+
+// TeamsNotifier is responsible for sending
+// alert notifications to Microsoft teams.
+type TeamsNotifier struct {
+	old_notifiers.NotifierBase
+	URL         string
+	Message     string
+	tmpl        *template.Template
+	log         log.Logger
+	externalUrl *url.URL
+}
+
+// NewTeamsNotifier is the constructor for Teams notifier.
+func NewTeamsNotifier(model *models.AlertNotification, t *template.Template, externalUrl *url.URL) (*TeamsNotifier, error) {
+	if model.Settings == nil {
+		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
+	}
+
+	u := model.Settings.Get("url").MustString()
+	if u == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find url property in settings"}
+	}
+
+	return &TeamsNotifier{
+		NotifierBase: old_notifiers.NewNotifierBase(model),
+		URL:          u,
+		Message:      model.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		log:          log.New("alerting.notifier.teams"),
+		externalUrl:  externalUrl,
+		tmpl:         t,
+	}, nil
+}
+
+// Notify send an alert notification to Microsoft teams.
+func (tn *TeamsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+	data := notify.GetTemplateData(ctx, &template.Template{ExternalURL: tn.externalUrl}, as, gokit_log.NewNopLogger())
+	var tmplErr error
+	tmpl := notify.TmplText(tn.tmpl, data, &tmplErr)
+
+	title := getTitleFromTemplateData(data)
+	body := map[string]interface{}{
+		"@type":    "MessageCard",
+		"@context": "http://schema.org/extensions",
+		// summary MUST not be empty or the webhook request fails
+		// summary SHOULD contain some meaningful information, since it is used for mobile notifications
+		"summary":    title,
+		"title":      title,
+		"themeColor": getAlertStatusColor(types.Alerts(as...).Status()),
+		"sections": []map[string]interface{}{
+			{
+				"title": "Details",
+				"text":  tmpl(tn.Message),
+			},
+		},
+		"potentialAction": []map[string]interface{}{
+			{
+				"@context": "http://schema.org",
+				"@type":    "OpenUri",
+				"name":     "View Rule",
+				"targets": []map[string]interface{}{
+					{
+						"os": "default", "uri": "", // TODO: add the rule URL here.
+					},
+				},
+			},
+		},
+	}
+
+	if tmplErr != nil {
+		return false, errors.Wrap(tmplErr, "failed to template Teams message")
+	}
+
+	b, err := json.Marshal(&body)
+	if err != nil {
+		return false, errors.Wrap(err, "marshal json")
+	}
+	cmd := &models.SendWebhookSync{Url: tn.URL, Body: string(b)}
+
+	if err := bus.DispatchCtx(ctx, cmd); err != nil {
+		return false, errors.Wrap(err, "send notification to Teams")
+	}
+
+	return true, nil
+}
+
+func (tn *TeamsNotifier) SendResolved() bool {
+	return !tn.GetDisableResolveMessage()
+}

--- a/pkg/services/ngalert/notifier/channels/teams_test.go
+++ b/pkg/services/ngalert/notifier/channels/teams_test.go
@@ -1,0 +1,169 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+func TestTeamsNotifier(t *testing.T) {
+	tmpl, err := template.FromGlobs("templates/default.tmpl")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name         string
+		settings     string
+		alerts       []*types.Alert
+		expMsg       map[string]interface{}
+		expInitError error
+		expMsgError  error
+	}{
+		{
+			name:     "Default config with one alert",
+			settings: `{"url": "http://localhost"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"@type":      "MessageCard",
+				"@context":   "http://schema.org/extensions",
+				"summary":    "[firing:1]  (val1)",
+				"title":      "[firing:1]  (val1)",
+				"themeColor": "#D63232",
+				"sections": []map[string]interface{}{
+					{
+						"title": "Details",
+						"text":  "\n**Firing**\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: \n\n\n\n\n",
+					},
+				},
+				"potentialAction": []map[string]interface{}{
+					{
+						"@context": "http://schema.org",
+						"@type":    "OpenUri",
+						"name":     "View Rule",
+						"targets":  []map[string]interface{}{{"os": "default", "uri": ""}},
+					},
+				},
+			},
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name: "Custom config with multiple alerts",
+			settings: `{
+				"url": "http://localhost",
+				"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved"
+			}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"@type":      "MessageCard",
+				"@context":   "http://schema.org/extensions",
+				"summary":    "[firing:2]  ",
+				"title":      "[firing:2]  ",
+				"themeColor": "#D63232",
+				"sections": []map[string]interface{}{
+					{
+						"title": "Details",
+						"text":  "2 alerts are firing, 0 are resolved",
+					},
+				},
+				"potentialAction": []map[string]interface{}{
+					{
+						"@context": "http://schema.org",
+						"@type":    "OpenUri",
+						"name":     "View Rule",
+						"targets":  []map[string]interface{}{{"os": "default", "uri": ""}},
+					},
+				},
+			},
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name:         "Error in initing",
+			settings:     `{}`,
+			expInitError: alerting.ValidationError{Reason: "Could not find url property in settings"},
+		}, {
+			name: "Error in building message",
+			settings: `{
+				"url": "http://localhost",
+				"message": "{{ .Status }"
+			}`,
+			expMsgError: errors.New("failed to template Teams message: template: :1: unexpected \"}\" in operand"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
+			require.NoError(t, err)
+
+			m := &models.AlertNotification{
+				Name:     "teams_testing",
+				Type:     "teams",
+				Settings: settingsJSON,
+			}
+
+			externalURL, err := url.Parse("http://localhost")
+			require.NoError(t, err)
+			pn, err := NewTeamsNotifier(m, tmpl, externalURL)
+			if c.expInitError != nil {
+				require.Error(t, err)
+				require.Equal(t, c.expInitError.Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			body := ""
+			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+				body = webhook.Body
+				return nil
+			})
+
+			ctx := notify.WithGroupKey(context.Background(), "alertname")
+			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+			ok, err := pn.Notify(ctx, c.alerts...)
+			if c.expMsgError != nil {
+				require.False(t, ok)
+				require.Error(t, err)
+				require.Equal(t, c.expMsgError.Error(), err.Error())
+				return
+			}
+			require.True(t, ok)
+			require.NoError(t, err)
+
+			expBody, err := json.Marshal(c.expMsg)
+			require.NoError(t, err)
+
+			require.JSONEq(t, string(expBody), body)
+		})
+	}
+}

--- a/pkg/services/ngalert/notifier/channels/templates/default.tmpl
+++ b/pkg/services/ngalert/notifier/channels/templates/default.tmpl
@@ -23,7 +23,7 @@
 {{ end }}
 {{ end }}
 
-{{ define "slack.default.title" }}{{ template "__subject" . }}{{ end }}
+{{ define "slack.default.title" }}{{ template "default.title" . }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.callbackid" }}{{ end }}
@@ -35,7 +35,7 @@
 {{ define "slack.default.footer" }}{{ end }}
 
 
-{{ define "pagerduty.default.description" }}{{ template "__subject" . }}{{ end }}
+{{ define "pagerduty.default.description" }}{{ template "default.title" . }}{{ end }}
 {{ define "pagerduty.default.client" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "pagerduty.default.clientURL" }}{{ template "__alertmanagerURL" . }}{{ end }}
 {{ define "pagerduty.default.instances" }}{{ template "__text_alert_list" . }}{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Teams notification channel. Very similar to current one with changed title and message.

I also fixed some stuff in email and pagerduty in this PR.