### PR TITLE
Elasticsearch: Force re-rendering of each editor row on type change

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/index.tsx
@@ -21,7 +21,7 @@ export const BucketAggregationsEditor: FunctionComponent<Props> = ({ nextId }) =
     <>
       {bucketAggs!.map((bucketAgg, index) => (
         <QueryEditorRow
-          key={bucketAgg.id}
+          key={`${bucketAgg.type}-${bucketAgg.id}`}
           label={index === 0 ? 'Group By' : 'Then By'}
           onRemoveClick={totalBucketAggs > 1 && (() => dispatch(removeBucketAggregation(bucketAgg.id)))}
         >

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
@@ -22,7 +22,7 @@ export const MetricAggregationsEditor: FunctionComponent<Props> = ({ nextId }) =
     <>
       {metrics?.map((metric, index) => (
         <QueryEditorRow
-          key={metric.id}
+          key={`${metric.type}-${metric.id}`}
           label={`Metric (${metric.id})`}
           hidden={metric.hide}
           onHideClick={() => dispatch(toggleMetricVisibility(metric.id))}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Input fields in each metric/bucket aggregation are uncontrolled, each row relied on the aggregation id for change detection and this caused react to opt-out from updating the DOM for a setting field when switching between different types of aggregations that have the same setting field, resulting in inputs showing a default value not reflected by the underlying state.

This force rerendering the whole row whenever the aggregation type changes in order to prevent this desynchronization.

