### PR TITLE
GraphNG: use theme font family and size for axis labels

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -50,6 +50,10 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       theme,
     } = this.props;
 
+    let { typography } = theme;
+
+    let font = `${typography.size.sm} ${typography.fontFamily.sansSerif}`;
+
     const gridColor = theme.isDark ? theme.palette.gray25 : theme.palette.gray90;
 
     let config: Axis = {
@@ -57,8 +61,8 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       show,
       stroke: theme.colors.text,
       side: getUPlotSideFromAxis(placement),
-      font: `12px 'Roboto'`,
-      labelFont: `12px 'Roboto'`,
+      font,
+      labelFont: font,
       size: this.props.size ?? calculateAxisSize,
       gap,
       grid: {

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -1,7 +1,6 @@
 // TODO: migrate tests below to the builder
 
 import { UPlotConfigBuilder } from './UPlotConfigBuilder';
-import { GrafanaTheme } from '@grafana/data';
 import {
   GraphGradientMode,
   AxisPlacement,
@@ -292,7 +291,7 @@ describe('UPlotConfigBuilder', () => {
       formatValue: () => 'test value',
       grid: false,
       show: true,
-      theme: { isDark: true, palette: { gray25: '#ffffff' }, colors: { text: 'gray' } } as GrafanaTheme,
+      theme: darkTheme,
       values: [],
     });
 
@@ -300,15 +299,15 @@ describe('UPlotConfigBuilder', () => {
       Object {
         "axes": Array [
           Object {
-            "font": "12px 'Roboto'",
+            "font": "12px 'Inter', 'Helvetica Neue', Arial, sans-serif",
             "gap": 5,
             "grid": Object {
               "show": false,
-              "stroke": "#ffffff",
+              "stroke": "#2c3235",
               "width": 1,
             },
             "label": "test label",
-            "labelFont": "12px 'Roboto'",
+            "labelFont": "12px 'Inter', 'Helvetica Neue', Arial, sans-serif",
             "labelSize": 18,
             "scale": "scale-x",
             "show": true,
@@ -316,10 +315,10 @@ describe('UPlotConfigBuilder', () => {
             "size": [Function],
             "space": [Function],
             "splits": undefined,
-            "stroke": "gray",
+            "stroke": "rgba(255, 255, 255, 0.77)",
             "ticks": Object {
               "show": true,
-              "stroke": "#ffffff",
+              "stroke": "#2c3235",
               "width": 1,
             },
             "timeZone": "browser",

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -100,8 +100,8 @@ $dashboard-bg: #0d0f16;
 
 $text-color-strong: #fff;
 $text-color: rgba(255, 255, 255, 0.77);
-$text-color-semi-weak: rgba(255, 255, 255, 0.55);
-$text-color-weak: rgba(255, 255, 255, 0.55);
+$text-color-semi-weak: rgba(255, 255, 255, 0.50);
+$text-color-weak: rgba(255, 255, 255, 0.50);
 $text-color-faint: rgba(255, 255, 255, 0.35);
 $text-color-emphasis: #fff;
 $text-blue: #33a2e5;


### PR DESCRIPTION
removes hardcoded font family and font size from axis labels. (follow-up to #32988).

the scss file changes were auto-generated during `yarn start`, think it just missed the train.