### PR TITLE
Alerting: set query in rules response

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -79,7 +79,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		newGroup := &apimodels.RuleGroup{
 			Name: groupId,
 			// This doesn't make sense in our architecture
-			// so we use this field for passing to the frontend the namaspace
+			// so we use this field for passing to the frontend the namespace
 			File:           namespace,
 			LastEvaluation: time.Time{},
 			EvaluationTime: 0, // TODO: see if we are able to pass this along with evaluation results
@@ -99,8 +99,8 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 			alertingRule := apimodels.AlertingRule{
 				State:       "inactive",
 				Name:        rule.Title,
-				Query:       "", // TODO: get this from parsing AlertRule.Data
-				Duration:    rule.For.Seconds(),
+				Query:       rule.DataToString(), // TODO: don't escape <>& etc
+				Duration:    time.Duration(rule.For).Seconds(),
 				Annotations: rule.Annotations,
 			}
 

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -100,7 +100,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 				State:       "inactive",
 				Name:        rule.Title,
 				Query:       rule.DataToString(), // TODO: don't escape <>& etc
-				Duration:    time.Duration(rule.For).Seconds(),
+				Duration:    rule.For.Seconds(),
 				Annotations: rule.Annotations,
 			}
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -61,6 +61,18 @@ type AlertRule struct {
 	Labels      map[string]string
 }
 
+func (alertRule *AlertRule) DataToString() string {
+	response := "["
+	for i, part := range alertRule.Data {
+		response += string(part.Model)
+		if i < len(alertRule.Data)-1 {
+			response += ","
+		}
+	}
+	response += "]"
+	return response
+}
+
 // AlertRuleKey is the alert definition identifier
 type AlertRuleKey struct {
 	OrgID int64


### PR DESCRIPTION
**What this PR does / why we need it**:
Set `Query` when returning a response from `/prometheus/grafana/api/v1/rules`

**Special notes for your reviewer**:
some characters are being escaped by the json marshaller but this will work for the moment. 
