### PR TITLE
GraphNG: Use new theme props

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -52,7 +52,7 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
 
     const font = `12px ${theme.v2.typography.fontFamily}`;
 
-    const gridColor = theme.v2.isDark ? 'rgba(240, 250, 255, 0.08)' : 'rgba(0, 10, 23, 0.08)';
+    const gridColor = theme.v2.isDark ? 'rgba(240, 250, 255, 0.09)' : 'rgba(0, 10, 23, 0.09)';
 
     let config: Axis = {
       scale: scaleKey,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -50,16 +50,14 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       theme,
     } = this.props;
 
-    let { typography } = theme;
+    const font = `12px ${theme.v2.typography.fontFamily}`;
 
-    let font = `${typography.size.sm} ${typography.fontFamily.sansSerif}`;
-
-    const gridColor = theme.isDark ? theme.palette.gray25 : theme.palette.gray90;
+    const gridColor = theme.v2.isDark ? 'rgba(240, 250, 255, 0.08)' : 'rgba(0, 10, 23, 0.08)';
 
     let config: Axis = {
       scale: scaleKey,
       show,
-      stroke: theme.colors.text,
+      stroke: theme.v2.palette.text.primary,
       side: getUPlotSideFromAxis(placement),
       font,
       labelFont: font,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -299,15 +299,15 @@ describe('UPlotConfigBuilder', () => {
       Object {
         "axes": Array [
           Object {
-            "font": "12px 'Inter', 'Helvetica Neue', Arial, sans-serif",
+            "font": "12px \\"Inter\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
             "gap": 5,
             "grid": Object {
               "show": false,
-              "stroke": "#2c3235",
+              "stroke": "rgba(240, 250, 255, 0.09)",
               "width": 1,
             },
             "label": "test label",
-            "labelFont": "12px 'Inter', 'Helvetica Neue', Arial, sans-serif",
+            "labelFont": "12px \\"Inter\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
             "labelSize": 18,
             "scale": "scale-x",
             "show": true,
@@ -318,7 +318,7 @@ describe('UPlotConfigBuilder', () => {
             "stroke": "rgba(255, 255, 255, 0.77)",
             "ticks": Object {
               "show": true,
-              "stroke": "#2c3235",
+              "stroke": "rgba(240, 250, 255, 0.09)",
               "width": 1,
             },
             "timeZone": "browser",

--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -51,6 +51,10 @@ export function getElementStyles(theme: GrafanaThemeV2) {
       margin: 0 0 ${theme.spacing(2)};
     }
 
+    button {
+      letter-spacing: ${theme.typography.body.letterSpacing};
+    }
+
     // Ex: 14px base font * 85% = about 12px
     small {
       font-size: ${theme.typography.bodySmall.fontSize};


### PR DESCRIPTION
Updates grid & text colors to use new theme model and updates the grid line colors to use alpha based custom colors
