### PR TITLE
Chore: Improve request distributed tracing middleware

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -319,6 +319,8 @@ func (hs *HTTPServer) applyRoutes() {
 func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	m := hs.macaron
 
+	m.Use(middleware.RequestTracing())
+
 	m.Use(middleware.Logger(hs.Cfg))
 
 	if hs.Cfg.EnableGzip {

--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -10,13 +11,26 @@ import (
 	"gopkg.in/macaron.v1"
 )
 
-func RequestTracing(handler string) macaron.Handler {
+const routeOperationNameKey = "route.operation.name"
+
+func ProvideRouteOperationName(handler string) macaron.Handler {
 	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
+		c.Data[routeOperationNameKey] = handler
+	}
+}
+
+func RequestTracing() macaron.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
+		if !strings.HasPrefix(c.Req.URL.Path, "/api/") {
+			c.Next()
+			return
+		}
+
 		rw := res.(macaron.ResponseWriter)
 
 		tracer := opentracing.GlobalTracer()
 		wireContext, _ := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
-		span := tracer.StartSpan(fmt.Sprintf("HTTP %s", handler), ext.RPCServerOption(wireContext))
+		span := tracer.StartSpan(fmt.Sprintf("HTTP %s %s", req.Method, req.URL.Path), ext.RPCServerOption(wireContext))
 		defer span.Finish()
 
 		ctx := opentracing.ContextWithSpan(req.Context(), span)
@@ -31,6 +45,10 @@ func RequestTracing(handler string) macaron.Handler {
 		ext.HTTPMethod.Set(span, req.Method)
 		if status >= 400 {
 			ext.Error.Set(span, true)
+		}
+
+		if routeOperation, exists := c.Data[routeOperationNameKey]; exists {
+			span.SetOperationName(fmt.Sprintf("HTTP %s", routeOperation.(string)))
 		}
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -273,7 +273,7 @@ func (s *Server) buildServiceGraph(services []*registry.Descriptor) error {
 	objs := []interface{}{
 		bus.GetBus(),
 		s.cfg,
-		routing.NewRouteRegister(middleware.RequestTracing, middleware.RequestMetrics(s.cfg)),
+		routing.NewRouteRegister(middleware.ProvideRouteOperationName, middleware.RequestMetrics(s.cfg)),
 		localcache.New(5*time.Minute, 10*time.Minute),
 		s,
 	}

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	cw "github.com/weaveworks/common/middleware"
 	"gopkg.in/macaron.v1"
 )
 
@@ -68,6 +69,11 @@ func (h *ContextHandler) Middleware(c *macaron.Context) {
 		AllowAnonymous: false,
 		SkipCache:      false,
 		Logger:         log.New("context"),
+	}
+
+	traceID, exist := cw.ExtractTraceID(c.Req.Request.Context())
+	if exist {
+		ctx.Logger = ctx.Logger.New("traceID", traceID)
 	}
 
 	const headerName = "X-Grafana-Org-Id"

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -71,8 +71,8 @@ func (h *ContextHandler) Middleware(c *macaron.Context) {
 		Logger:         log.New("context"),
 	}
 
-	traceID, exist := cw.ExtractTraceID(c.Req.Request.Context())
-	if exist {
+	traceID, exists := cw.ExtractTraceID(c.Req.Request.Context())
+	if exists {
 		ctx.Logger = ctx.Logger.New("traceID", traceID)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Before these changes the request tracing was added for each route registered using the `routing.RouteRegister`, see [code](https://github.com/grafana/grafana/blob/4f7728738e80d68934ef166f9f37d50acd71cf3e/pkg/server/server.go#L276). This had the consequence that middleware executed earlier/later in the request pipeline was not part of the request tracing middleware life-cycle which measures the duration of requests among other things. 

In the [logger middleware](https://github.com/grafana/grafana/blob/4f7728738e80d68934ef166f9f37d50acd71cf3e/pkg/middleware/logger.go#L64-L67) we do extract the current distributed trace identifier, if available, and set that on request info/error log messages.

With these changes we can extract the current distributed trace identifier, if available, and set that on the contextual HTTP request logger (`models.ReqContext.Logger`) which would improve the possibility to correlate all HTTP request log messages with traces. 

In addition, the request tracing middleware is now executed first and last in the request pipeline and should therefore result in more accurate timing measurements (request duration).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Might want to exclude other routes under /api/ that haven't been registered with `routing.RouteRegister`? Here's one such potential one https://github.com/grafana/grafana/blob/4f7728738e80d68934ef166f9f37d50acd71cf3e/pkg/api/app_routes.go#L50
