### PR TITLE
Caching: add cache config tab to data source settings

### DIFF
--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -61,6 +61,14 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
       text: 'Insights',
       url: `datasources/edit/${dataSource.id}/insights`,
     });
+
+    navModel.children!.push({
+      active: false,
+      icon: 'database',
+      id: `datasource-cache-${dataSource.id}`,
+      text: 'Cache',
+      url: `datasources/edit/${dataSource.id}/cache`,
+    });
   }
 
   return navModel;


### PR DESCRIPTION
Adds the cache config tab to the data source settings in Grafana Enterprise