### PR TITLE
Added License API link to HTTP API introduction page.

### DIFF
--- a/docs/sources/http_api/_index.md
+++ b/docs/sources/http_api/_index.md
@@ -38,6 +38,7 @@ dashboards, creating users and updating data sources.
 
 - [Data Source Permissions API]({{< relref "datasource_permissions.md" >}})
 - [External Group Sync API]({{< relref "external_group_sync.md" >}})
+- [License API]{{< relref "licensing.md" >}})
 - [Reporting API]({{< relref "reporting.md" >}})
 
 

--- a/docs/sources/http_api/licensing.md
+++ b/docs/sources/http_api/licensing.md
@@ -1,11 +1,13 @@
 +++
 title = "Licensing HTTP API "
-description = "Grafana Licensing HTTP API"
+description = "Enterprise Licensing HTTP API"
 keywords = ["grafana", "http", "documentation", "api", "licensing", "enterprise"]
 aliases = ["/docs/grafana/next/http_api/licensing/"]
 +++
 
-> Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../enterprise" >}}).
+# Enterprise License API
+
+Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../enterprise" >}}).
 
 ## Manually force license refresh
 


### PR DESCRIPTION
The https://grafana.com/docs/grafana/next/http_api/#grafana-enterprise-http-apis section was missing the license API link.