### PR TITLE
Dparrott/labels on alert rule

### DIFF
--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -14,7 +14,7 @@ func FromAlertStateToPostableAlerts(firingStates []state.AlertState) []*notifier
 		if alertState.State == eval.Alerting {
 			alerts = append(alerts, &notifier.PostableAlert{
 				PostableAlert: models.PostableAlert{
-					Annotations: models.LabelSet{}, //TODO: add annotations to evaluation results, add them to the alertState struct, and then set them before sending to the notifier
+					Annotations: alertState.Annotations,
 					StartsAt:    strfmt.DateTime(alertState.StartsAt),
 					EndsAt:      strfmt.DateTime(alertState.EndsAt),
 					Alert: models.Alert{

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -80,7 +80,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key models.AlertRul
 					return err
 				}
 
-				processedStates := stateTracker.ProcessEvalResults(key.UID, results, condition)
+				processedStates := stateTracker.ProcessEvalResults(alertRule, results)
 				sch.saveAlertStates(processedStates)
 				alerts := FromAlertStateToPostableAlerts(processedStates)
 				sch.log.Debug("sending alerts to notifier", "count", len(alerts))

--- a/pkg/services/ngalert/state/state_tracker.go
+++ b/pkg/services/ngalert/state/state_tracker.go
@@ -22,6 +22,7 @@ type AlertState struct {
 	StartsAt           time.Time
 	EndsAt             time.Time
 	LastEvaluationTime time.Time
+	Annotations        map[string]string
 }
 
 type StateEvaluation struct {
@@ -53,22 +54,28 @@ func NewStateTracker(logger log.Logger) *StateTracker {
 	return tracker
 }
 
-func (st *StateTracker) getOrCreate(uid string, orgId int64, result eval.Result) AlertState {
+func (st *StateTracker) getOrCreate(alertRule *ngModels.AlertRule, result eval.Result) AlertState {
 	st.stateCache.mu.Lock()
 	defer st.stateCache.mu.Unlock()
+	lbs := result.Instance
+	lbs["__alert_rule_uid__"] = alertRule.UID
+	lbs["__alert_rule_namespace_uid__"] = alertRule.NamespaceUID
+	lbs["__alert_rule_title__"] = alertRule.Title
 
-	idString := fmt.Sprintf("%s %s", uid, map[string]string(result.Instance))
+	idString := fmt.Sprintf("%s", map[string]string(lbs))
 	if state, ok := st.stateCache.cacheMap[idString]; ok {
 		return state
 	}
 	st.Log.Debug("adding new alert state cache entry", "cacheId", idString, "state", result.State.String(), "evaluatedAt", result.EvaluatedAt.String())
+
 	newState := AlertState{
-		UID:     uid,
-		OrgID:   orgId,
-		CacheId: idString,
-		Labels:  result.Instance,
-		State:   result.State,
-		Results: []StateEvaluation{},
+		UID:         alertRule.UID,
+		OrgID:       alertRule.OrgID,
+		CacheId:     idString,
+		Labels:      lbs,
+		State:       result.State,
+		Results:     []StateEvaluation{},
+		Annotations: alertRule.Annotations,
 	}
 	if result.State == eval.Alerting {
 		newState.StartsAt = result.EvaluatedAt
@@ -96,11 +103,11 @@ func (st *StateTracker) ResetCache() {
 	st.stateCache.cacheMap = make(map[string]AlertState)
 }
 
-func (st *StateTracker) ProcessEvalResults(uid string, results eval.Results, condition ngModels.Condition) []AlertState {
-	st.Log.Info("state tracker processing evaluation results", "uid", uid, "resultCount", len(results))
+func (st *StateTracker) ProcessEvalResults(alertRule *ngModels.AlertRule, results eval.Results) []AlertState {
+	st.Log.Info("state tracker processing evaluation results", "uid", alertRule.UID, "resultCount", len(results))
 	var changedStates []AlertState
 	for _, result := range results {
-		s, _ := st.setNextState(uid, condition.OrgID, result)
+		s, _ := st.setNextState(alertRule, result)
 		changedStates = append(changedStates, s)
 	}
 	st.Log.Debug("returning changed states to scheduler", "count", len(changedStates))
@@ -113,9 +120,9 @@ func (st *StateTracker) ProcessEvalResults(uid string, results eval.Results, con
 // 3. The base interval defined by the scheduler - in the case where #2 is not yet an option we can use the base interval at which every alert runs.
 //Set the current state based on evaluation results
 //return the state and a bool indicating whether a state transition occurred
-func (st *StateTracker) setNextState(uid string, orgId int64, result eval.Result) (AlertState, bool) {
-	currentState := st.getOrCreate(uid, orgId, result)
-	st.Log.Debug("setting alert state", "uid", uid)
+func (st *StateTracker) setNextState(alertRule *ngModels.AlertRule, result eval.Result) (AlertState, bool) {
+	currentState := st.getOrCreate(alertRule, result)
+	st.Log.Debug("setting alert state", "uid", alertRule.UID)
 	switch {
 	case currentState.State == result.State:
 		st.Log.Debug("no state transition", "cacheId", currentState.CacheId, "state", currentState.State.String())

--- a/pkg/services/ngalert/state/state_tracker.go
+++ b/pkg/services/ngalert/state/state_tracker.go
@@ -57,7 +57,10 @@ func NewStateTracker(logger log.Logger) *StateTracker {
 func (st *StateTracker) getOrCreate(alertRule *ngModels.AlertRule, result eval.Result) AlertState {
 	st.stateCache.mu.Lock()
 	defer st.stateCache.mu.Unlock()
-	lbs := result.Instance
+	lbs := data.Labels{}
+	if len(result.Instance) > 0 {
+		lbs = result.Instance
+	}
 	lbs["__alert_rule_uid__"] = alertRule.UID
 	lbs["__alert_rule_namespace_uid__"] = alertRule.NamespaceUID
 	lbs["__alert_rule_title__"] = alertRule.Title

--- a/pkg/services/ngalert/state/state_tracker.go
+++ b/pkg/services/ngalert/state/state_tracker.go
@@ -57,7 +57,7 @@ func NewStateTracker(logger log.Logger) *StateTracker {
 func (st *StateTracker) getOrCreate(alertRule *ngModels.AlertRule, result eval.Result) AlertState {
 	st.stateCache.mu.Lock()
 	defer st.stateCache.mu.Unlock()
-	lbs := alertRule.Labels
+	lbs := data.Labels{}
 	if len(result.Instance) > 0 {
 		lbs = result.Instance
 	}

--- a/pkg/services/ngalert/state/state_tracker.go
+++ b/pkg/services/ngalert/state/state_tracker.go
@@ -57,7 +57,7 @@ func NewStateTracker(logger log.Logger) *StateTracker {
 func (st *StateTracker) getOrCreate(alertRule *ngModels.AlertRule, result eval.Result) AlertState {
 	st.stateCache.mu.Lock()
 	defer st.stateCache.mu.Unlock()
-	lbs := data.Labels{}
+	lbs := alertRule.Labels
 	if len(result.Instance) > 0 {
 		lbs = result.Instance
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Labels and annotations to alerts sent to the notifier and in the state cache

**Which issue(s) this PR fixes**:
https://github.com/grafana/alerting-squad/issues/69
https://github.com/grafana/alerting-squad/issues/74

Fixes #

**Special notes for your reviewer**:
Does not currently set annotations on alerts. That will be handled in a future PR because it involves adding a migration and significant alterations to Instance
