### PR TITLE
Alerting: added time based restrictions to alert rules

### DIFF
--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -278,15 +278,15 @@ func newQueryCondition(model *simplejson.Json, index int) (*QueryCondition, erro
 	}
 	condition.Evaluator = evaluator
 
-	timeEvaluatorJson := model.Get("timeEvaluator")
-	timeEvaluator, err := NewAlertTimeEvaluator(timeEvaluatorJson)
+	timeEvaluatorJSON := model.Get("timeEvaluator")
+	timeEvaluator, err := NewAlertTimeEvaluator(timeEvaluatorJSON)
 	if err != nil {
 		return nil, fmt.Errorf("time evaluator error in condition %v: %v", index, err)
 	}
 	condition.TimeEvaluator = timeEvaluator
 
-	timeEvaluatorParentJson := model.Get("timeEvaluatorParent")
-	timeEvaluatorParent, err := NewAlertTimeEvaluator(timeEvaluatorParentJson)
+	timeEvaluatorParentJSON := model.Get("timeEvaluatorParent")
+	timeEvaluatorParent, err := NewAlertTimeEvaluator(timeEvaluatorParentJSON)
 	if err != nil {
 		return nil, fmt.Errorf("parent time evaluator error: %v", err)
 	}

--- a/pkg/services/alerting/conditions/time_evaluator.go
+++ b/pkg/services/alerting/conditions/time_evaluator.go
@@ -113,17 +113,15 @@ func dissectTimeParts(param string) (int, int, error) {
 		i, err := strconv.Atoi(timeParts[0])
 		if err != nil {
 			return 0, 0, alerting.ValidationError{Reason: "Time Evaluator has invalid parameter, must be integers"}
-		} else {
-			hour = i
 		}
+		hour = i
 	}
 	if len(timeParts) == 2 {
 		i, err := strconv.Atoi(timeParts[1])
 		if err != nil {
 			return 0, 0, alerting.ValidationError{Reason: "Time Evaluator has invalid parameter, must be integers"}
-		} else {
-			minute = i
 		}
+		minute = i
 	}
 
 	return hour, minute, nil
@@ -195,20 +193,20 @@ func NewAlertTimeEvaluator(model *simplejson.Json) (AlertTimeEvaluator, error) {
 	// default is to return AnyTime
 	if model == nil {
 		return &anyDayTimeEvaluator{}, nil
-	} else {
-		typ := model.Get("type").MustString()
-		if typ == "" {
-			return &anyDayTimeEvaluator{}, nil
-		}
-
-		if typ == "range" {
-			return newRangedTimeEvaluator(model)
-		}
-
-		if typ == "any" {
-			return newAnyTimeEvaluator(model)
-		}
-
-		return nil, fmt.Errorf("evaluator invalid evaluator type: %s", typ)
 	}
+
+	typ := model.Get("type").MustString()
+	if typ == "" {
+		return &anyDayTimeEvaluator{}, nil
+	}
+
+	if typ == "range" {
+		return newRangedTimeEvaluator(model)
+	}
+
+	if typ == "any" {
+		return newAnyTimeEvaluator(model)
+	}
+
+	return nil, fmt.Errorf("evaluator invalid evaluator type: %s", typ)
 }

--- a/pkg/services/alerting/conditions/time_evaluator.go
+++ b/pkg/services/alerting/conditions/time_evaluator.go
@@ -1,0 +1,214 @@
+package conditions
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+// AlertTimeEvaluator evaluates the reduced value of a timeseries.
+// Returning true if a timeseries is violating the condition
+// ex: AnyDayTimeEvaluator, AnyTimeEvaluator, RangedTimeEvaluator
+type AlertTimeEvaluator interface {
+	Eval(time time.Time) bool
+}
+
+// will always return true
+type anyDayTimeEvaluator struct{}
+
+func (e *anyDayTimeEvaluator) Eval(_ time.Time) bool {
+	return true
+}
+
+// will return true only on given days
+type anyTimeEvaluator struct {
+	Day string
+}
+
+func (e *anyTimeEvaluator) Eval(t time.Time) bool {
+	return evalDay(e.Day, t)
+}
+
+// will return true only on given days at given time
+type rangedTimeEvaluator struct {
+	Day      string
+	FromHour int
+	FromMin  int
+	ToHour   int
+	ToMin    int
+}
+
+func (e *rangedTimeEvaluator) Eval(t time.Time) bool {
+	return evalTime(e, t) && evalDay(e.Day, t)
+}
+
+func evalTime(e *rangedTimeEvaluator, time time.Time) bool {
+	isWithinRange := true
+	if time.Hour() < e.FromHour {
+		isWithinRange = false
+	} else if time.Hour() == e.FromHour {
+		if time.Minute() < e.FromMin {
+			isWithinRange = false
+		}
+	} else if time.Hour() > e.ToHour {
+		isWithinRange = false
+	} else if time.Hour() == e.ToHour {
+		if time.Minute() > e.ToMin {
+			isWithinRange = false
+		}
+	}
+	return isWithinRange
+}
+
+// day values defined in alertDef.ts
+// defaults to true
+func evalDay(day string, t time.Time) bool {
+	switch day {
+	case "wkdy":
+		switch t.Weekday() {
+		case time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday:
+			return true
+		default:
+			return false
+		}
+	case "wknd":
+		switch t.Weekday() {
+		case time.Saturday, time.Sunday:
+			return true
+		default:
+			return false
+		}
+	case "mon":
+		return t.Weekday() == time.Monday
+	case "tue":
+		return t.Weekday() == time.Tuesday
+	case "wed":
+		return t.Weekday() == time.Wednesday
+	case "thu":
+		return t.Weekday() == time.Thursday
+	case "fri":
+		return t.Weekday() == time.Friday
+	case "sat":
+		return t.Weekday() == time.Saturday
+	case "sun":
+		return t.Weekday() == time.Sunday
+	default:
+		return true
+	}
+}
+
+func dissectTimeParts(param string) (int, int, error) {
+	timeParts := strings.Split(param, ":")
+	if len(timeParts) > 2 {
+		return 0, 0, alerting.ValidationError{Reason: "Time Evaluator has invalid parameter, must be HH or HH:MM"}
+	}
+
+	hour := 0
+	minute := 0
+	if len(timeParts) >= 1 {
+		i, err := strconv.Atoi(timeParts[0])
+		if err != nil {
+			return 0, 0, alerting.ValidationError{Reason: "Time Evaluator has invalid parameter, must be integers"}
+		} else {
+			hour = i
+		}
+	}
+	if len(timeParts) == 2 {
+		i, err := strconv.Atoi(timeParts[1])
+		if err != nil {
+			return 0, 0, alerting.ValidationError{Reason: "Time Evaluator has invalid parameter, must be integers"}
+		} else {
+			minute = i
+		}
+	}
+
+	return hour, minute, nil
+}
+
+func isTimeBefore(fromHour int, fromMin int, toHour int, toMin int) bool {
+	if fromHour == toHour {
+		if fromMin > toMin {
+			return false
+		}
+	} else if fromHour > toHour {
+		return false
+	}
+	return true
+}
+
+func newRangedTimeEvaluator(model *simplejson.Json) (*rangedTimeEvaluator, error) {
+	params := model.Get("params").MustArray()
+	if len(params) < 2 {
+		return nil, alerting.ValidationError{Reason: "Evaluator missing threshold parameter"}
+	}
+
+	if params[0] == nil || params[1] == nil {
+		return nil, alerting.ValidationError{Reason: "Evaluator missing threshold parameter"}
+	}
+
+	firstParam := params[0].(string)
+	secondParam := params[1].(string)
+
+	fromHour, fromMin, fromErr := dissectTimeParts(firstParam)
+	toHour, toMin, toErr := dissectTimeParts(secondParam)
+
+	if fromErr != nil {
+		return nil, fromErr
+	}
+	if toErr != nil {
+		return nil, toErr
+	}
+
+	// verify from is before to
+	if !isTimeBefore(fromHour, fromMin, toHour, toMin) {
+		return nil, alerting.ValidationError{Reason: "'From' time must be before 'To' time"}
+	}
+
+	rangedEval := &rangedTimeEvaluator{}
+	rangedEval.FromHour = fromHour
+	rangedEval.FromMin = fromMin
+	rangedEval.ToHour = toHour
+	rangedEval.ToMin = toMin
+
+	day := model.Get("day").MustString("all")
+	rangedEval.Day = day
+
+	return rangedEval, nil
+}
+
+func newAnyTimeEvaluator(model *simplejson.Json) (AlertTimeEvaluator, error) {
+	day := model.Get("day").MustString("all")
+
+	timeEval := &anyTimeEvaluator{}
+	timeEval.Day = day
+
+	return timeEval, nil
+}
+
+// NewAlertTimeEvaluator is a factory function for returning
+// an `AlertTimeEvaluator` depending on the json model.
+func NewAlertTimeEvaluator(model *simplejson.Json) (AlertTimeEvaluator, error) {
+	// default is to return AnyTime
+	if model == nil {
+		return &anyDayTimeEvaluator{}, nil
+	} else {
+		typ := model.Get("type").MustString()
+		if typ == "" {
+			return &anyDayTimeEvaluator{}, nil
+		}
+
+		if typ == "range" {
+			return newRangedTimeEvaluator(model)
+		}
+
+		if typ == "any" {
+			return newAnyTimeEvaluator(model)
+		}
+
+		return nil, fmt.Errorf("evaluator invalid evaluator type: %s", typ)
+	}
+}

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -129,6 +129,9 @@ func (e *DashAlertExtractor) getAlertFromPanels(jsonWithPanels *simplejson.Json,
 		for _, condition := range jsonAlert.Get("conditions").MustArray() {
 			jsonCondition := simplejson.NewFromAny(condition)
 
+			// set parent on each individual condition as conditions are checked independently
+			jsonCondition.Set("timeEvaluatorParent", jsonAlert.Get("timeEvaluator"))
+
 			jsonQuery := jsonCondition.Get("query")
 			queryRefID := jsonQuery.Get("params").MustArray()[0].(string)
 			panelQuery := findPanelQueryByRefID(panel, queryRefID)

--- a/public/app/features/alerting/AlertTabCtrl.ts
+++ b/public/app/features/alerting/AlertTabCtrl.ts
@@ -24,6 +24,9 @@ export class AlertTabCtrl {
   conditionModels: any;
   evalFunctions: any;
   evalOperators: any;
+  timeEvalFunctions: any;
+  timeEvalDays: any;
+  timeEvaluator: any;
   noDataModes: any;
   executionErrorModes: any;
   addNotificationSegment: any;
@@ -50,6 +53,8 @@ export class AlertTabCtrl {
     this.subTabIndex = 0;
     this.evalFunctions = alertDef.evalFunctions;
     this.evalOperators = alertDef.evalOperators;
+    this.timeEvalFunctions = alertDef.timeEvalFunctions;
+    this.timeEvalDays = alertDef.timeEvalDays;
     this.conditionTypes = alertDef.conditionTypes;
     this.noDataModes = alertDef.noDataModes;
     this.executionErrorModes = alertDef.executionErrorModes;
@@ -207,6 +212,8 @@ export class AlertTabCtrl {
 
     const defaultName = this.panel.title + ' alert';
     alert.name = alert.name || defaultName;
+
+    alert.timeEvaluator = alert.timeEvaluator || getDefaultCondition().timeEvaluator;
 
     this.conditionModels = _.reduce(
       alert.conditions,
@@ -366,6 +373,8 @@ export class AlertTabCtrl {
     cm.queryPart = new QueryPart(source.query, alertDef.alertQueryDef);
     cm.reducerPart = alertDef.createReducerPart(source.reducer);
     cm.evaluator = source.evaluator;
+    // setting default to keep backwards-compatibility with test data, but should fix test data
+    cm.timeEvaluator = source.timeEvaluator || getDefaultCondition().timeEvaluator; // { type: 'any', params: [] as any[], day: 'all' };
     cm.operator = source.operator;
 
     return cm;
@@ -478,6 +487,22 @@ export class AlertTabCtrl {
       }
       case 'no_value': {
         evaluator.params = [];
+      }
+    }
+
+    this.evaluatorParamsChanged();
+  }
+
+  timeEvaluatorTypeChanged(evaluator: any) {
+    // ensure params array is correct length
+    switch (evaluator.type) {
+      case 'range': {
+        evaluator.params = [null, null];
+        break;
+      }
+      case 'any': {
+        evaluator.params = [];
+        break;
       }
     }
 

--- a/public/app/features/alerting/getAlertingValidationMessage.ts
+++ b/public/app/features/alerting/getAlertingValidationMessage.ts
@@ -6,6 +6,7 @@ export const getDefaultCondition = () => ({
   query: { params: ['A', '5m', 'now'] },
   reducer: { type: 'avg', params: [] as any[] },
   evaluator: { type: 'gt', params: [null] as any[] },
+  timeEvaluator: { type: 'any', params: [] as any[], day: 'all' },
   operator: { type: 'and' },
 });
 

--- a/public/app/features/alerting/partials/alert_tab.html
+++ b/public/app/features/alerting/partials/alert_tab.html
@@ -38,6 +38,45 @@
           firing for more than For duration, then the alert changes to Alerting and sends alert notifications.
         </info-popover>
       </div>
+      <div style="width:25px;"></div>
+      <div class="gf-form">
+        <label class="gf-form-label width-2">ON</label>
+        <info-popover mode="right-absolute">
+          Will check condition only during specified days and time.
+        </info-popover>
+      </div>
+      <div class="gf-form">
+        <div class="gf-form-select-wrapper">
+          <select
+            class="gf-form-input"
+            ng-model="ctrl.alert.timeEvaluator.day"
+            ng-options="f.value as f.text for f in ctrl.timeEvalDays"
+          >
+          </select>
+        </div>
+        <div class="gf-form-select-wrapper">
+          <select
+            class="gf-form-input"
+            ng-model="ctrl.alert.timeEvaluator.type"
+            ng-options="f.value as f.text for f in ctrl.timeEvalFunctions"
+            ng-change="ctrl.timeEvaluatorTypeChanged(ctrl.alert.timeEvaluator)"
+          >
+          </select>
+        </div>
+        <input
+          class="gf-form-input max-width-4"
+          type="text"
+          ng-hide="ctrl.alert.timeEvaluator.params.length === 0"
+          ng-model="ctrl.alert.timeEvaluator.params[0]"
+        />
+        <label class="gf-form-label query-keyword" ng-show="ctrl.alert.timeEvaluator.params.length === 2">TO</label>
+        <input
+          class="gf-form-input max-width-4"
+          type="text"
+          ng-if="ctrl.alert.timeEvaluator.params.length === 2"
+          ng-model="ctrl.alert.timeEvaluator.params[1]"
+        />
+      </div>
     </div>
     <div class="gf-form" ng-if="ctrl.frequencyWarning">
       <label class="gf-form-label text-warning">
@@ -100,6 +139,42 @@
           ng-if="conditionModel.evaluator.params.length === 2"
           ng-model="conditionModel.evaluator.params[1]"
           ng-change="ctrl.evaluatorParamsChanged()"
+        />
+      </div>
+      <div style="width:25px;"></div>
+      <div class="gf-form">
+        <label class="gf-form-label width-2">ON</label>
+        <info-popover mode="right-absolute">
+          Will check condition only during specified days and time.
+        </info-popover>
+      </div>
+      <div class="gf-form">
+        <metric-segment-model
+          property="conditionModel.timeEvaluator.day"
+          options="ctrl.timeEvalDays"
+          custom="false"
+          css-class="query-keyword"
+          on-change="ctrl.evaluatorParamsChanged()"
+        ></metric-segment-model>
+        <metric-segment-model
+          property="conditionModel.timeEvaluator.type"
+          options="ctrl.timeEvalFunctions"
+          custom="false"
+          css-class="query-keyword"
+          on-change="ctrl.timeEvaluatorTypeChanged(conditionModel.timeEvaluator)"
+        ></metric-segment-model>
+        <input
+          class="gf-form-input max-width-4"
+          type="text"
+          ng-hide="conditionModel.timeEvaluator.params.length === 0"
+          ng-model="conditionModel.timeEvaluator.params[0]"
+        />
+        <label class="gf-form-label query-keyword" ng-show="conditionModel.timeEvaluator.params.length === 2">TO</label>
+        <input
+          class="gf-form-input max-width-4"
+          type="text"
+          ng-if="conditionModel.timeEvaluator.params.length === 2"
+          ng-model="conditionModel.timeEvaluator.params[1]"
         />
       </div>
       <div class="gf-form">

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -46,6 +46,24 @@ const evalOperators = [
   { text: 'AND', value: 'and' },
 ];
 
+const timeEvalFunctions = [
+  { text: 'ALL DAY', value: 'any' },
+  { text: 'FROM', value: 'range' },
+];
+
+const timeEvalDays = [
+  { text: 'ALL DAYS', value: 'all' },
+  { text: 'WEEKDAYS', value: 'wkdy' },
+  { text: 'WEEKENDS', value: 'wknd' },
+  { text: 'MONDAY', value: 'mon' },
+  { text: 'TUESDAY', value: 'tue' },
+  { text: 'WEDNESDAY', value: 'wed' },
+  { text: 'THURSDAY', value: 'thu' },
+  { text: 'FRIDAY', value: 'fri' },
+  { text: 'SATURDAY', value: 'sat' },
+  { text: 'SUNDAY', value: 'sun' },
+];
+
 const reducerTypes = [
   { text: 'avg()', value: 'avg' },
   { text: 'min()', value: 'min' },
@@ -170,6 +188,8 @@ export default {
   conditionTypes: conditionTypes,
   evalFunctions: evalFunctions,
   evalOperators: evalOperators,
+  timeEvalFunctions: timeEvalFunctions,
+  timeEvalDays: timeEvalDays,
   noDataModes: noDataModes,
   executionErrorModes: executionErrorModes,
   reducerTypes: reducerTypes,


### PR DESCRIPTION
anyone else sick of these +1 emails that go on for years and years and years....??

well i had some extra time this week and felt like giving this a `go` ;)

here's what the alert tab looks like with my changes
![grafana_alert_layout](https://user-images.githubusercontent.com/2244826/115044116-31f61200-9ea3-11eb-8f7a-f80405556342.png)


features:
- db-agnostic as long as regular alerting is supported
- panel level time restrictions
- condition level time restrictions
- restrictions by day and/or time
- backward compatible with existing dashboards (hopefully)

tried to minimize touch points as i'm pretty sure this entire alerting framework will change sooner than later.  actually had a merge conflict even though i pulled a few days ago.

it feels like the alerts started as a super simple straightforward query check (1 condition).  then as different needs came up, it slowly got augmented which all the other bells and whistles we see today, like thresholds, frequency, emails, dashboards, etc.  however, under the covers, there is still a strong dependency to check specific 'conditions'.  based on my interaction with it so far, it doesn't really seem like this is a sustainable design moving forward. 

also see this ticket comment: https://github.com/grafana/grafana/issues/7832#issuecomment-760227291 

i really had to shoe-horn the idea of time to the backend evaluators, especially the idea of a 'parent' time for the whole panel.  is it the cleanest code i've written? i'm sure there's a much cleaner way to incorporate with the existing AlertEvaluator's, but like i said, there's a lot of churn in these files and i'm trying to balance my time with minimizing touch points.

some gotchas:
 - dashboard must be saved in order for alerting to take place, backend db is what drives the overall framework
 - timezone is based on server where grafana backend is running
 -- there is a context level 'starttime' parameter that gets set when the alerting check is kicked off (driven by top-level 'evaluate every' input)
 -- that time parameter is what drives the alert range time and there is no guarantee when it actually runs, so be careful about super specific time requirements, probably not good enough for 12:00:01
 - no hard checks on min [0, 59] or hour [0-23]
 - on the dashboard, the 'Test Rule' doesn't evaluate the parent time restriction, only the condition level; so triple-check that's correct
 - did not test this super thoroughly for backwards compatability (did make some effort); the only additional json changes are labeled 'timeEvaluator' so make a new dashboard and look at it's json to get an idea if you run into trouble
 - no validation stop on parent level parameters so make sure those are accurate when saving, however will log any errors

this fork is off of latest master 4/15/21, but i'm thinking this could be backported to whatever version first had an alerting framework.  the files in the framework have changed slightly so i don't think the patch will necessarily apply cleanly, however it should be obvious where the changes go.

i have a pretty good handle on the alerting framework now, so if you guys want anything else lemme know.
unless it's javascript... i battled that render maze long enough today.

ps grafana hmu, my fees are reasonable
