### PR TITLE
Live: support legacy stream paths

### DIFF
--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -30,7 +30,15 @@ export class GrafanaDatasource extends DataSourceApi<GrafanaQuery> {
         continue;
       }
       if (target.queryType === GrafanaQueryType.LiveMeasurements) {
-        const { channel, filter } = target;
+        let { channel, filter } = target;
+
+        // Help migrate pre-release channel paths saved in dashboards
+        // NOTE: this should be removed before V8 is released
+        if (channel && channel.startsWith('telegraf/')) {
+          channel = 'stream/' + channel;
+          target.channel = channel; // mutate the current query object so it is saved with `stream/` prefix
+        }
+
         const addr = parseLiveChannelAddress(channel);
         if (!isValidLiveChannelAddress(addr)) {
           continue;


### PR DESCRIPTION
Before we added the recent `push` endpoint, the telegraf datasource would send data to a channel named `telegraf/${name}` this is now: `stream/telegraf/${name}`

This PR simplifies the transition and lets the old paths work for a little while and should be removed before the 8.0 release