### PR TITLE
MatcherUI: show field name even when not found in results

### DIFF
--- a/packages/grafana-ui/src/components/MatchersUI/FieldNameMatcherEditor.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldNameMatcherEditor.tsx
@@ -6,7 +6,7 @@ import { Select } from '../Select/Select';
 export const FieldNameMatcherEditor = memo<MatcherUIProps<string>>((props) => {
   const { data, options, onChange: onChangeFromProps } = props;
   const names = useFieldDisplayNames(data);
-  const selectOptions = useSelectOptions(names);
+  const selectOptions = useSelectOptions(names, options);
 
   const onChange = useCallback(
     (selection: SelectableValue<string>) => {
@@ -46,11 +46,18 @@ const useFieldDisplayNames = (data: DataFrame[]): Set<string> => {
   }, [data]);
 };
 
-const useSelectOptions = (displayNames: Set<string>): Array<SelectableValue<string>> => {
+const useSelectOptions = (displayNames: Set<string>, currentName: string): Array<SelectableValue<string>> => {
   return useMemo(() => {
-    return Array.from(displayNames).map((n) => ({
+    const vals = Array.from(displayNames).map((n) => ({
       value: n,
       label: n,
     }));
-  }, [displayNames]);
+    if (currentName && !displayNames.has(currentName)) {
+      vals.push({
+        value: currentName,
+        label: `${currentName} (not found)`,
+      });
+    }
+    return vals;
+  }, [displayNames, currentName]);
 };


### PR DESCRIPTION
Currently the override editor will show an empty value for the field name when the value is not found.  This can be confusing:
![image](https://user-images.githubusercontent.com/705951/115192500-c1681480-a09f-11eb-8464-782a30254f75.png)


This PR updates the UI to show the value and a message when it is not found in results:
![image](https://user-images.githubusercontent.com/705951/115192262-6e8e5d00-a09f-11eb-97eb-97eeec30de2d.png)
