### PR TITLE
ConfirmModal: Migrates to React with new theme

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.story.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.story.tsx
@@ -4,7 +4,9 @@ import { action } from '@storybook/addon-actions';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { ConfirmModal } from '@grafana/ui';
 import mdx from './ConfirmModal.mdx';
-import { Props } from './ConfirmModal';
+import { ConfirmModalProps } from './ConfirmModal';
+
+const defaultExcludes = ['onConfirm', 'onDismiss', 'onAlternative'];
 
 export default {
   title: 'Overlays/ConfirmModal',
@@ -18,11 +20,13 @@ export default {
       disable: true,
     },
     controls: {
-      exclude: ['isOpen', 'body'],
+      exclude: defaultExcludes,
     },
   },
   argTypes: {
-    icon: { control: { type: 'select', options: ['exclamation-triangle', 'power', 'cog', 'lock'] } },
+    icon: { control: { type: 'select', options: ['exclamation-triangle', 'power', 'cog', 'lock', 'trash-alt'] } },
+    body: { control: { type: 'text' } },
+    description: { control: { type: 'text' } },
   },
 } as Meta;
 
@@ -33,20 +37,27 @@ const defaultActions = {
   onDismiss: () => {
     action('Dismiss')('close');
   },
+  onAlternative: () => {
+    action('Alternative')('alternative');
+  },
 };
 
-interface StoryProps extends Props {
-  visible: boolean;
-  bodyText: string;
-}
-
-export const Basic: Story<StoryProps> = ({ title, bodyText, confirmText, dismissText, icon, visible }) => {
+export const Basic: Story<ConfirmModalProps> = ({
+  title,
+  body,
+  description,
+  confirmText,
+  dismissText,
+  icon,
+  isOpen,
+}) => {
   const { onConfirm, onDismiss } = defaultActions;
   return (
     <ConfirmModal
-      isOpen={visible}
+      isOpen={isOpen}
       title={title}
-      body={bodyText}
+      body={body}
+      description={description}
       confirmText={confirmText}
       dismissText={dismissText}
       icon={icon}
@@ -56,11 +67,106 @@ export const Basic: Story<StoryProps> = ({ title, bodyText, confirmText, dismiss
   );
 };
 
+Basic.parameters = {
+  controls: {
+    exclude: [...defaultExcludes, 'alternativeText', 'confirmationText'],
+  },
+};
+
 Basic.args = {
   title: 'Delete user',
-  bodyText: 'Are you sure you want to delete this user?',
+  body: 'Are you sure you want to delete this user?',
+  description: 'Removing the user will not remove any dashboards the user has created',
   confirmText: 'Delete',
   dismissText: 'Cancel',
   icon: 'exclamation-triangle',
-  visible: true,
+  isOpen: true,
+};
+
+export const AlternativeAction: Story<ConfirmModalProps> = ({
+  title,
+  body,
+  description,
+  confirmText,
+  dismissText,
+  icon,
+  alternativeText,
+  isOpen,
+}) => {
+  const { onConfirm, onDismiss, onAlternative } = defaultActions;
+  return (
+    <ConfirmModal
+      isOpen={isOpen}
+      title={title}
+      body={body}
+      description={description}
+      confirmText={confirmText}
+      dismissText={dismissText}
+      alternativeText={alternativeText}
+      icon={icon}
+      onConfirm={onConfirm}
+      onDismiss={onDismiss}
+      onAlternative={onAlternative}
+    />
+  );
+};
+
+AlternativeAction.parameters = {
+  controls: {
+    exclude: [...defaultExcludes, 'confirmationText'],
+  },
+};
+
+AlternativeAction.args = {
+  title: 'Delete row',
+  body: 'Are you sure you want to remove this row and all its panels?',
+  alternativeText: 'Delete row only',
+  confirmText: 'Yes',
+  dismissText: 'Cancel',
+  icon: 'trash-alt',
+  isOpen: true,
+};
+
+export const WithConfirmation: Story<ConfirmModalProps> = ({
+  title,
+  body,
+  description,
+  confirmationText,
+  confirmText,
+  dismissText,
+  icon,
+  isOpen,
+}) => {
+  const { onConfirm, onDismiss } = defaultActions;
+  return (
+    <ConfirmModal
+      isOpen={isOpen}
+      title={title}
+      body={body}
+      confirmationText={confirmationText}
+      description={description}
+      confirmText={confirmText}
+      dismissText={dismissText}
+      icon={icon}
+      onConfirm={onConfirm}
+      onDismiss={onDismiss}
+    />
+  );
+};
+
+WithConfirmation.parameters = {
+  controls: {
+    exclude: [...defaultExcludes, 'alternativeText'],
+  },
+};
+
+WithConfirmation.args = {
+  title: 'Delete',
+  body: 'Do you want to delete this notification channel?',
+  description: 'Deleting this notification channel will not delete from alerts any references to it',
+  confirmationText: 'Delete',
+  confirmText: 'Delete',
+  dismissText: 'Cancel',
+  icon: 'trash-alt',
+  isOpen: true,
 };

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,9 +1,9 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/css';
 import { Modal } from '../Modal/Modal';
 import { IconName } from '../../types/icon';
 import { Button } from '../Button';
-import { ThemeContext } from '../../themes';
+import { useStyles } from '../../themes';
 import { GrafanaTheme } from '@grafana/data';
 import { HorizontalGroup, Input } from '..';
 import { selectors } from '@grafana/e2e-selectors';
@@ -50,8 +50,7 @@ export const ConfirmModal = ({
   onAlternative,
 }: ConfirmModalProps): JSX.Element => {
   const [disabled, setDisabled] = useState<boolean>(Boolean(confirmationText));
-  const theme = useContext(ThemeContext);
-  const styles = getStyles(theme);
+  const styles = useStyles(getStyles);
   const onConfirmationTextChange = (event: React.FormEvent<HTMLInputElement>) => {
     setDisabled(confirmationText?.localeCompare(event.currentTarget.value, undefined, { sensitivity: 'accent' }) !== 0);
   };
@@ -100,17 +99,17 @@ const getStyles = (theme: GrafanaTheme) => ({
   modalContent: css`
     text-align: center;
   `,
-  modalText: css`
-    font-size: ${theme.typography.heading.h4};
-    color: ${theme.colors.link};
-    margin-bottom: calc(${theme.spacing.d} * 2);
-    padding-top: ${theme.spacing.d};
-  `,
-  modalDescription: css`
-    font-size: ${theme.typography.heading.h6};
-    padding-top: ${theme.spacing.d};
-  `,
-  modalConfirmationInput: css`
-    padding-top: ${theme.spacing.d};
-  `,
+  modalText: css({
+    fontSize: theme.v2.typography.h4.fontSize,
+    color: theme.v2.palette.text.primary,
+    marginBottom: `calc(${theme.v2.spacing(2)}*2)`,
+    paddingTop: theme.v2.spacing(2),
+  }),
+  modalDescription: css({
+    fontSize: theme.v2.typography.h6.fontSize,
+    paddingTop: theme.v2.spacing(2),
+  }),
+  modalConfirmationInput: css({
+    paddingTop: theme.v2.spacing(2),
+  }),
 });

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -49,10 +49,10 @@ export const ConfirmModal = ({
   onDismiss,
   onAlternative,
 }: ConfirmModalProps): JSX.Element => {
-  const [disabled, setDisabled] = useState<boolean>(Boolean(confirmationText));
+  const [disabled, setDisabled] = useState(Boolean(confirmationText));
   const styles = useStyles(getStyles);
   const onConfirmationTextChange = (event: React.FormEvent<HTMLInputElement>) => {
-    setDisabled(confirmationText?.localeCompare(event.currentTarget.value, undefined, { sensitivity: 'accent' }) !== 0);
+    setDisabled(confirmationText?.localeCompare(event.currentTarget.value) !== 0);
   };
 
   return (

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,50 +1,87 @@
-import React, { FC, useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { css } from '@emotion/css';
 import { Modal } from '../Modal/Modal';
 import { IconName } from '../../types/icon';
 import { Button } from '../Button';
-import { stylesFactory, ThemeContext } from '../../themes';
+import { ThemeContext } from '../../themes';
 import { GrafanaTheme } from '@grafana/data';
-import { HorizontalGroup } from '..';
+import { HorizontalGroup, Input } from '..';
+import { selectors } from '@grafana/e2e-selectors';
 
-export interface Props {
+export interface ConfirmModalProps {
   /** Toggle modal's open/closed state */
   isOpen: boolean;
   /** Title for the modal header */
   title: string;
   /** Modal content */
   body: React.ReactNode;
+  /** Modal description */
+  description?: React.ReactNode;
   /** Text for confirm button */
   confirmText: string;
   /** Text for dismiss button */
   dismissText?: string;
   /** Icon for the modal header */
   icon?: IconName;
+  /** Text user needs to fill in before confirming */
+  confirmationText?: string;
+  /** Text for alternative button */
+  alternativeText?: string;
   /** Confirm action callback */
   onConfirm(): void;
   /** Dismiss action callback */
   onDismiss(): void;
+  /** Alternative action callback */
+  onAlternative?(): void;
 }
 
-export const ConfirmModal: FC<Props> = ({
+export const ConfirmModal = ({
   isOpen,
   title,
   body,
+  description,
   confirmText,
+  confirmationText,
   dismissText = 'Cancel',
+  alternativeText,
   icon = 'exclamation-triangle',
   onConfirm,
   onDismiss,
-}) => {
+  onAlternative,
+}: ConfirmModalProps): JSX.Element => {
+  const [disabled, setDisabled] = useState<boolean>(Boolean(confirmationText));
   const theme = useContext(ThemeContext);
   const styles = getStyles(theme);
+  const onConfirmationTextChange = (event: React.FormEvent<HTMLInputElement>) => {
+    setDisabled(confirmationText?.localeCompare(event.currentTarget.value, undefined, { sensitivity: 'accent' }) !== 0);
+  };
 
   return (
     <Modal className={styles.modal} title={title} icon={icon} isOpen={isOpen} onDismiss={onDismiss}>
       <div className={styles.modalContent}>
-        <div className={styles.modalText}>{body}</div>
+        <div className={styles.modalText}>
+          {body}
+          {description ? <div className={styles.modalDescription}>{description}</div> : null}
+          {confirmationText ? (
+            <div className={styles.modalConfirmationInput}>
+              <HorizontalGroup justify="center">
+                <Input placeholder={`Type ${confirmationText} to confirm`} onChange={onConfirmationTextChange} />
+              </HorizontalGroup>
+            </div>
+          ) : null}
+        </div>
         <HorizontalGroup justify="center">
-          <Button variant="destructive" onClick={onConfirm}>
+          {onAlternative ? (
+            <Button variant="primary" onClick={onAlternative}>
+              {alternativeText}
+            </Button>
+          ) : null}
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={disabled}
+            aria-label={selectors.pages.ConfirmModal.delete}
+          >
             {confirmText}
           </Button>
           <Button variant="secondary" onClick={onDismiss}>
@@ -56,7 +93,7 @@ export const ConfirmModal: FC<Props> = ({
   );
 };
 
-const getStyles = stylesFactory((theme: GrafanaTheme) => ({
+const getStyles = (theme: GrafanaTheme) => ({
   modal: css`
     width: 500px;
   `,
@@ -69,4 +106,11 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => ({
     margin-bottom: calc(${theme.spacing.d} * 2);
     padding-top: ${theme.spacing.d};
   `,
-}));
+  modalDescription: css`
+    font-size: ${theme.typography.heading.h6};
+    padding-top: ${theme.spacing.d};
+  `,
+  modalConfirmationInput: css`
+    padding-top: ${theme.spacing.d};
+  `,
+});

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -33,7 +33,7 @@ export { Tag, OnTagClick } from './Tags/Tag';
 export { TagList } from './Tags/TagList';
 export { FilterPill } from './FilterPill/FilterPill';
 
-export { ConfirmModal } from './ConfirmModal/ConfirmModal';
+export { ConfirmModal, ConfirmModalProps } from './ConfirmModal/ConfirmModal';
 export { QueryField } from './QueryField/QueryField';
 
 // Code editor

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -1,4 +1,5 @@
 import { BusEventBase, BusEventWithPayload, eventFactory, GrafanaTheme, TimeRange } from '@grafana/data';
+import { IconName } from '@grafana/ui';
 
 /**
  * Event Payloads
@@ -35,7 +36,7 @@ export interface ShowConfirmModalPayload {
   altActionText?: string;
   yesText?: string;
   noText?: string;
-  icon?: string;
+  icon?: IconName;
 
   onConfirm?: () => void;
   onAltAction?: () => void;


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates implementation of ShowConfirmModalEvent to use react modal and upgrades to new Theme.

**Which issue(s) this PR fixes**:
Relates #32784

**Special notes for your reviewer**:

