### PR TITLE
Alerting: Remove field limitation from Slack notifications

### DIFF
--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -198,16 +198,12 @@ func (sn *SlackNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 
 	fields := make([]map[string]interface{}, 0)
-	fieldLimitCount := 4
-	for index, evt := range evalContext.EvalMatches {
+	for _, evt := range evalContext.EvalMatches {
 		fields = append(fields, map[string]interface{}{
 			"title": evt.Metric,
 			"value": evt.Value,
 			"short": true,
 		})
-		if index > fieldLimitCount {
-			break
-		}
 	}
 
 	if evalContext.Error != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, there's a hardcoded limitation for printing fields/series on slack notifications, which defaults to 4.

**Which issue(s) this PR fixes**:

Fixes #33030

**Special notes for your reviewer**:

* Try to create a panel with more than 6 different queries, and create an alert for that.
* You'll see that the notification that you receive on slack, will include only the first 6 ones (indexes [0,1,2,3,4,5])
* Checkout this branch, run again.
* You'll see that all series are being shown correctly.