### PR TITLE
SSE: (WIP) SSE specific query endpoint

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/frontendlogging"
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/middleware"
@@ -363,8 +364,11 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Get("/tsdb/testdata/gensql", reqGrafanaAdmin, routing.Wrap(GenerateSQLTestData))
 		apiRoute.Get("/tsdb/testdata/random-walk", routing.Wrap(hs.GetTestDataRandomWalk))
 
-		// DataSource w/ expressions
+		// DataSource w/ server side expressions
 		apiRoute.Post("/ds/query", bind(dtos.MetricRequest{}), routing.Wrap(hs.QueryMetricsV2))
+
+		// Always server side expressions, time range per query.
+		apiRoute.Post("/ds/sse/query", bind([]*simplejson.Json{}), routing.Wrap(hs.QuerySSE))
 
 		apiRoute.Group("/alerts", func(alertsRoute routing.RouteRegister) {
 			alertsRoute.Post("/test", bind(dtos.AlertTestCommand{}), routing.Wrap(hs.AlertTest))

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -148,7 +148,7 @@ func (hs *HTTPServer) QuerySSE(c *models.ReqContext, queries []*simplejson.Json)
 		request.Queries = append(request.Queries, backend.DataQuery{
 			RefID:         query.Get("refId").MustString("A"),
 			MaxDataPoints: query.Get("maxDataPoints").MustInt64(100),
-			Interval:      time.Duration(time.Second * time.Duration(query.Get("intervalMs").MustInt64(1000))),
+			Interval:      time.Second * time.Duration(query.Get("intervalMs").MustInt64(1000)),
 			QueryType:     query.Get("queryType").MustString(""),
 			JSON:          encodedQuery,
 			TimeRange: backend.TimeRange{


### PR DESCRIPTION
**What this PR does / why we need it**:
SSE (Server Side Expressions) specific endpoint. Queries are executed via SSE even if there isn't an expression.

Primary meant for visualization with alerting, also introduces per query times ranges.

**Special notes for your reviewer**:

- Perhaps this should be an endpoint under alerting and more specific.
- There should maybe be a containing object for this array for other properties
- from and to are unix epoch timestamps (and per query) (this is different from the saved alerting query model with is relative time).
- data source is identified solely by UID

This is pretty dirty but trying to unblock FE.

Example:
```

POST http://admin:admin@localhost:3000/api/ds/sse/query
Content-Type: application/json

[
  {
    "points": [],
    "stream": {
      "type": "signal",
      "speed": 250,
      "spread": 3.5,
      "noise": 2.2,
      "bands": 1
    },
    "pulseWave": {
      "timeStep": 300,
      "onCount": 3,
      "onValue": 2,
      "offCount": 3,
      "offValue": 1
    },
    "csvWave": {
      "timeStep": 60,
      "valuesCSV": "0,0,2,2,1,1"
    },
    "stringInput": "",
    "scenarioId": "predictable_pulse",
    "lines": 10,
    "refId": "A",
    "alias": "",
    "datasourceUid": "000000004",
    "timeRange": {
      "from": 161883908000,
      "to": 161883928000
    }
  },
  {
    "type": "reduce",
    "datasourceUid": "-100",
    "reducer": "mean",
    "expression": "A",
    "refId": "B"
  },
  {
    "type": "math",
    "datasourceUid": "-100",
    "expression": "$B > 10",
    "refId": "C"
  }
]
```

Response is like (frames json encoded, not base64): 

```
  "results": {
    "C": {
      "frames": [
        {
...
```