### PR TITLE
GraphNG: flip logic so we can explicitly say the field types to keep

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -96,7 +96,7 @@ class UnthemedGraphNG extends React.Component<GraphNGProps, GraphNGState> {
 
     return {
       ...state,
-      data: preparePlotData(frame, [FieldType.string]),
+      data: preparePlotData(frame, [FieldType.number]),
       alignedDataFrame: frame,
       seriesToDataFrameFieldIndexMap: frame.fields.map((f) => f.state!.origin!),
       dimFields,

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -35,7 +35,7 @@ export function buildPlotConfig(props: PlotProps, plugins: Record<string, PlotPl
 
 /** @internal */
 
-export function preparePlotData(frame: DataFrame, ignoreFieldTypes?: FieldType[]): AlignedData {
+export function preparePlotData(frame: DataFrame, keepFieldTypes?: FieldType[]): AlignedData {
   const result: any[] = [];
   const stackingGroups: Map<string, number[]> = new Map();
   let seriesIndex = 0;
@@ -57,7 +57,7 @@ export function preparePlotData(frame: DataFrame, ignoreFieldTypes?: FieldType[]
       seriesIndex++;
       continue;
     }
-    if (ignoreFieldTypes && ignoreFieldTypes.indexOf(f.type) > -1) {
+    if (keepFieldTypes && keepFieldTypes.indexOf(f.type) < 0) {
       continue;
     }
     collectStackingGroups(f, stackingGroups, seriesIndex);


### PR DESCRIPTION
The current code needs to explicitly exclude unsupported field types -- this is bound to break as we add new types :(

Lets flip the logic so it works with bool/boolean fields