### PR TITLE
Chore: avoid hard-coding IDs in integration tests

### DIFF
--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -62,9 +62,17 @@ func TestAlertingDataAccess(t *testing.T) {
 		})
 
 		Convey("Can set new states", func() {
+
+			// Get alert so we can use its ID in tests
+			alertQuery := models.GetAlertsQuery{DashboardIDs: []int64{testDash.Id}, PanelId: 1, OrgId: 1, User: &models.SignedInUser{OrgRole: models.ROLE_ADMIN}}
+			err2 := HandleAlertsQuery(&alertQuery)
+			So(err2, ShouldBeNil)
+
+			insertedAlert := alertQuery.Result[0]
+
 			Convey("new state ok", func() {
 				cmd := &models.SetAlertStateCommand{
-					AlertId: 1,
+					AlertId: insertedAlert.Id,
 					State:   models.AlertStateOK,
 				}
 
@@ -72,7 +80,7 @@ func TestAlertingDataAccess(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
-			alert, _ := getAlertById(1)
+			alert, _ := getAlertById(insertedAlert.Id)
 			stateDateBeforePause := alert.NewStateDate
 
 			Convey("can pause all alerts", func() {
@@ -81,7 +89,7 @@ func TestAlertingDataAccess(t *testing.T) {
 
 				Convey("cannot updated paused alert", func() {
 					cmd := &models.SetAlertStateCommand{
-						AlertId: 1,
+						AlertId: insertedAlert.Id,
 						State:   models.AlertStateOK,
 					}
 
@@ -90,13 +98,13 @@ func TestAlertingDataAccess(t *testing.T) {
 				})
 
 				Convey("alert is paused", func() {
-					alert, _ = getAlertById(1)
+					alert, _ = getAlertById(insertedAlert.Id)
 					currentState := alert.State
 					So(currentState, ShouldEqual, "paused")
 				})
 
 				Convey("pausing alerts should update their NewStateDate", func() {
-					alert, _ = getAlertById(1)
+					alert, _ = getAlertById(insertedAlert.Id)
 					stateDateAfterPause := alert.NewStateDate
 					So(stateDateBeforePause, ShouldHappenBefore, stateDateAfterPause)
 				})
@@ -104,7 +112,7 @@ func TestAlertingDataAccess(t *testing.T) {
 				Convey("unpausing alerts should update their NewStateDate again", func() {
 					err := pauseAllAlerts(false)
 					So(err, ShouldBeNil)
-					alert, _ = getAlertById(1)
+					alert, _ = getAlertById(insertedAlert.Id)
 					stateDateAfterUnpause := alert.NewStateDate
 					So(stateDateBeforePause, ShouldHappenBefore, stateDateAfterUnpause)
 				})
@@ -259,7 +267,6 @@ func TestAlertingDataAccess(t *testing.T) {
 				query := models.GetAlertsQuery{DashboardIDs: []int64{testDash.Id}, OrgId: 1, User: &models.SignedInUser{OrgRole: models.ROLE_ADMIN}}
 				err2 := HandleAlertsQuery(&query)
 
-				So(testDash.Id, ShouldEqual, 1)
 				So(err2, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 0)
 			})
@@ -280,12 +287,20 @@ func TestPausingAlerts(t *testing.T) {
 
 		stateDateBeforePause := alert.NewStateDate
 		stateDateAfterPause := stateDateBeforePause
+
+		// Get alert so we can use its ID in tests
+		alertQuery := models.GetAlertsQuery{DashboardIDs: []int64{testDash.Id}, PanelId: 1, OrgId: 1, User: &models.SignedInUser{OrgRole: models.ROLE_ADMIN}}
+		err2 := HandleAlertsQuery(&alertQuery)
+		So(err2, ShouldBeNil)
+
+		insertedAlert := alertQuery.Result[0]
+
 		Convey("when paused", func() {
-			_, err := pauseAlert(testDash.OrgId, 1, true)
+			_, err := pauseAlert(testDash.OrgId, insertedAlert.Id, true)
 			So(err, ShouldBeNil)
 
 			Convey("the NewStateDate should be updated", func() {
-				alert, err := getAlertById(1)
+				alert, err := getAlertById(insertedAlert.Id)
 				So(err, ShouldBeNil)
 
 				stateDateAfterPause = alert.NewStateDate
@@ -294,11 +309,11 @@ func TestPausingAlerts(t *testing.T) {
 		})
 
 		Convey("when unpaused", func() {
-			_, err := pauseAlert(testDash.OrgId, 1, false)
+			_, err := pauseAlert(testDash.OrgId, insertedAlert.Id, false)
 			So(err, ShouldBeNil)
 
 			Convey("the NewStateDate should be updated again", func() {
-				alert, err := getAlertById(1)
+				alert, err := getAlertById(insertedAlert.Id)
 				So(err, ShouldBeNil)
 
 				stateDateAfterUnpause := alert.NewStateDate

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -28,7 +28,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			savedFolder := insertTestDashboard(t, sqlStore, "1 test dash folder", 1, 0, true, "prod", "webapp")
 			savedDash := insertTestDashboard(t, sqlStore, "test dash 23", 1, savedFolder.Id, false, "prod", "webapp")
 			insertTestDashboard(t, sqlStore, "test dash 45", 1, savedFolder.Id, false, "prod")
-			insertTestDashboard(t, sqlStore, "test dash 67", 1, 0, false, "prod", "webapp")
+			savedDash2 := insertTestDashboard(t, sqlStore, "test dash 67", 1, 0, false, "prod")
 
 			Convey("Should return dashboard model", func() {
 				So(savedDash.Title, ShouldEqual, "test dash 23")
@@ -343,7 +343,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			Convey("Should be able to search for dashboard by dashboard ids", func() {
 				Convey("should be able to find two dashboards by id", func() {
 					query := search.FindPersistedDashboardsQuery{
-						DashboardIds: []int64{2, 3},
+						DashboardIds: []int64{savedDash.Id, savedDash2.Id},
 						SignedInUser: &models.SignedInUser{OrgId: 1, OrgRole: models.ROLE_EDITOR},
 					}
 

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -299,7 +299,7 @@ func TestAccountDataAccess(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						Convey("Should remove dependent permissions for deleted org user", func() {
-							permQuery := &models.GetDashboardAclInfoListQuery{DashboardID: 1, OrgID: ac1.OrgId}
+							permQuery := &models.GetDashboardAclInfoListQuery{DashboardID: dash1.Id, OrgID: ac1.OrgId}
 							err = GetDashboardAclInfoList(permQuery)
 							So(err, ShouldBeNil)
 
@@ -307,7 +307,7 @@ func TestAccountDataAccess(t *testing.T) {
 						})
 
 						Convey("Should not remove dashboard permissions for same user in another org", func() {
-							permQuery := &models.GetDashboardAclInfoListQuery{DashboardID: 2, OrgID: ac3.OrgId}
+							permQuery := &models.GetDashboardAclInfoListQuery{DashboardID: dash2.Id, OrgID: ac3.OrgId}
 							err = GetDashboardAclInfoList(permQuery)
 							So(err, ShouldBeNil)
 

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -363,7 +363,7 @@ func TestUserDataAccess(t *testing.T) {
 		require.True(t, found)
 
 		disableCmd := models.BatchDisableUsersCommand{
-			UserIds:    []int64{1, 2, 3, 4, 5},
+			UserIds:    []int64{users[0].Id, users[1].Id, users[2].Id, users[3].Id, users[4].Id},
 			IsDisabled: true,
 		}
 
@@ -406,7 +406,7 @@ func TestUserDataAccess(t *testing.T) {
 
 	t.Run("Testing DB - enable all users", func(t *testing.T) {
 
-		createFiveTestUsers(t, ss, func(i int) *models.CreateUserCommand {
+		users := createFiveTestUsers(t, ss, func(i int) *models.CreateUserCommand {
 			return &models.CreateUserCommand{
 				Email:      fmt.Sprint("user", i, "@test.com"),
 				Name:       fmt.Sprint("user", i),
@@ -416,7 +416,7 @@ func TestUserDataAccess(t *testing.T) {
 		})
 
 		disableCmd := models.BatchDisableUsersCommand{
-			UserIds:    []int64{1, 2, 3, 4, 5},
+			UserIds:    []int64{users[0].Id, users[1].Id, users[2].Id, users[3].Id, users[4].Id},
 			IsDisabled: false,
 		}
 
@@ -607,7 +607,7 @@ func TestUserDataAccess(t *testing.T) {
 		require.Nil(t, err)
 
 		// Cannot make themselves a non-admin
-		updatePermsError := ss.UpdateUserPermissions(1, false)
+		updatePermsError := ss.UpdateUserPermissions(user.Id, false)
 
 		require.Equal(t, updatePermsError, models.ErrLastGrafanaAdmin)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This change removes problematic tests where database record IDs are hard-coded into test assertions. Instead, we get the IDs from the database.

This is useful for when we're running these tests against a database which isn't completely destroyed between tests - the auto_increment is therefore not set back to zero.

**Special notes for your reviewer**:

This PR fixes some issues with work internal to Grafana Labs, please ping me on Slack for any further context. Cheers!

