### PR TITLE
Table: Fixes so border is visible for cells with links

### DIFF
--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -27,7 +27,7 @@ export const getTableStyles = stylesFactory((theme: GrafanaTheme) => {
       ${color ? `color: ${color};` : ''};
       ${background ? `background: ${background};` : ''};
 
-      &:last-child {
+      &:last-child:not(:only-child) {
         border-right: none;
         padding-right: ${lastChildExtraPadding}px;
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR #32370 added an extra element around the cell which made the `last-child` css selector kick in. This PR tries to fix that, if there's an easier way please let me know :)

**Which issue(s) this PR fixes**:
Fixes #32845

**Special notes for your reviewer**:

