### PR TITLE
Theme: Theme toggle is only persisted for signed in users

### DIFF
--- a/public/app/core/services/toggleTheme.ts
+++ b/public/app/core/services/toggleTheme.ts
@@ -3,6 +3,7 @@ import { ThemeChangedEvent } from 'app/types/events';
 import appEvents from '../app_events';
 import { config } from '../config';
 import { PreferencesService } from './PreferencesService';
+import { contextSrv } from '../core';
 
 export async function toggleTheme(runtimeOnly: boolean) {
   const currentTheme = config.theme;
@@ -30,6 +31,10 @@ export async function toggleTheme(runtimeOnly: boolean) {
       // As the new css file is loading
       setTimeout(() => link.remove(), 500);
     }
+  }
+
+  if (!contextSrv.isSignedIn) {
+    return;
   }
 
   // Persist new theme


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure we don't persist toggled theme changes for users that aren't signed in.

**Which issue(s) this PR fixes**:
Fixes #33089

**Special notes for your reviewer**:

