### PR TITLE
AlertingNG: Fix TODOs in email notification channel

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -329,7 +329,7 @@ func (am *Alertmanager) buildReceiverIntegrations(receiver *apimodels.PostableAp
 		}
 		switch r.Type {
 		case "email":
-			n, err = channels.NewEmailNotifier(cfg, externalURL)
+			n, err = channels.NewEmailNotifier(cfg, externalURL, am.Settings.AppURL)
 		case "pagerduty":
 			n, err = channels.NewPagerdutyNotifier(cfg, tmpl, externalURL)
 		case "slack":

--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -71,7 +71,6 @@ func (en *EmailNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 			Subject: title,
 			Data: map[string]interface{}{
 				"Title":             title,
-				"Receiver":          data.Receiver,
 				"Status":            data.Status,
 				"Alerts":            data.Alerts,
 				"GroupLabels":       data.GroupLabels,

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -23,7 +23,7 @@ func TestEmailNotifier(t *testing.T) {
 			Settings: settingsJSON,
 		}
 
-		_, err := NewEmailNotifier(model, externalURL)
+		_, err := NewEmailNotifier(model, externalURL, "")
 		require.Error(t, err)
 	})
 
@@ -36,7 +36,7 @@ func TestEmailNotifier(t *testing.T) {
 			Name:     "ops",
 			Type:     "email",
 			Settings: settingsJSON,
-		}, externalURL)
+		}, externalURL, "")
 
 		require.NoError(t, err)
 		require.Equal(t, "ops", emailNotifier.Name)
@@ -53,7 +53,7 @@ func TestEmailNotifier(t *testing.T) {
 			Name:     "ops",
 			Type:     "email",
 			Settings: settingsJSON,
-		}, externalURL)
+		}, externalURL, "")
 
 		require.NoError(t, err)
 		require.Equal(t, "ops", emailNotifier.Name)

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -77,9 +77,8 @@ func TestEmailNotifier(t *testing.T) {
 			"single_email": false,
 			"template":     "ng_alert_notification.html",
 			"data": map[string]interface{}{
-				"Title":    "[firing:1]  (AlwaysFiring warning)",
-				"Receiver": "",
-				"Status":   "firing",
+				"Title":  "[firing:1]  (AlwaysFiring warning)",
+				"Status": "firing",
 				"Alerts": template.Alerts{
 					template.Alert{
 						Status:      "firing",

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -1,12 +1,18 @@
 package channels
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEmailNotifier(t *testing.T) {
@@ -27,37 +33,68 @@ func TestEmailNotifier(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("from settings", func(t *testing.T) {
-		json := `{"addresses": "ops@grafana.org"}`
+	t.Run("with the correct settings it should not fail and produce the expected command", func(t *testing.T) {
+		json := `{"addresses": "someops@example.com;somedev@example.com"}`
 		settingsJSON, err := simplejson.NewJson([]byte(json))
 		require.NoError(t, err)
 
 		emailNotifier, err := NewEmailNotifier(&models.AlertNotification{
-			Name:     "ops",
-			Type:     "email",
+			Name: "ops",
+			Type: "email",
+
 			Settings: settingsJSON,
 		}, externalURL, "")
 
 		require.NoError(t, err)
-		require.Equal(t, "ops", emailNotifier.Name)
-		require.Equal(t, "email", emailNotifier.Type)
-		require.Equal(t, []string{"ops@grafana.org"}, emailNotifier.Addresses)
-	})
 
-	t.Run("from settings with two emails", func(t *testing.T) {
-		json := `{"addresses": "ops@grafana.org;dev@grafana.org"}`
-		settingsJSON, err := simplejson.NewJson([]byte(json))
+		expected := map[string]interface{}{}
+		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.SendEmailCommandSync) error {
+			expected["subject"] = cmd.SendEmailCommand.Subject
+			expected["to"] = cmd.SendEmailCommand.To
+			expected["single_email"] = cmd.SendEmailCommand.SingleEmail
+			expected["template"] = cmd.SendEmailCommand.Template
+			expected["data"] = cmd.SendEmailCommand.Data
+
+			return nil
+		})
+
+		alerts := []*types.Alert{
+			{
+				Alert: model.Alert{
+					Labels:      model.LabelSet{"alertname": "AlwaysFiring", "severity": "warning"},
+					Annotations: model.LabelSet{"runbook_url": "http://fix.me"},
+				},
+			},
+		}
+
+		ok, err := emailNotifier.Notify(context.Background(), alerts...)
 		require.NoError(t, err)
+		require.True(t, ok)
 
-		emailNotifier, err := NewEmailNotifier(&models.AlertNotification{
-			Name:     "ops",
-			Type:     "email",
-			Settings: settingsJSON,
-		}, externalURL, "")
-
-		require.NoError(t, err)
-		require.Equal(t, "ops", emailNotifier.Name)
-		require.Equal(t, "email", emailNotifier.Type)
-		require.Equal(t, []string{"ops@grafana.org", "dev@grafana.org"}, emailNotifier.Addresses)
+		require.Equal(t, map[string]interface{}{
+			"subject":      "[firing:1]  (AlwaysFiring warning)",
+			"to":           []string{"someops@example.com", "somedev@example.com"},
+			"single_email": false,
+			"template":     "ng_alert_notification.html",
+			"data": map[string]interface{}{
+				"Title":    "[firing:1]  (AlwaysFiring warning)",
+				"Receiver": "",
+				"Status":   "firing",
+				"Alerts": template.Alerts{
+					template.Alert{
+						Status:      "firing",
+						Labels:      template.KV{"alertname": "AlwaysFiring", "severity": "warning"},
+						Annotations: template.KV{"runbook_url": "http://fix.me"},
+						Fingerprint: "15a37193dce72bab",
+					},
+				},
+				"GroupLabels":       template.KV{},
+				"CommonLabels":      template.KV{"alertname": "AlwaysFiring", "severity": "warning"},
+				"CommonAnnotations": template.KV{"runbook_url": "http://fix.me"},
+				"ExternalURL":       "http://localhost",
+				"RuleUrl":           "/alerting/list",
+				"AlertPageUrl":      "/alerting/list?alertState=firing&view=state",
+			},
+		}, expected)
 	})
 }


### PR DESCRIPTION
Fixes some TODOs that I had left behind.

~The firing alerts would be just a filter in the alert rule listing page (right @domasx2?), so I removed the button for alert page and keeping only the alert rule link.~