### PR TITLE
DataSourceSettings: add support for expandable details

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -45,6 +45,7 @@ export enum HealthStatus {
  * plugin.
  *
  * If the 'message' key exists, this will be displayed in the error message in DataSourceSettingsPage
+ * If the 'verboseMessage' key exists, this will be displayed in the expandable details in the error message in DataSourceSettingsPage
  *
  * @public
  */

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
@@ -139,4 +139,19 @@ describe('Render', () => {
 
     expect(screen.getByText(mockProps.testingStatus.message)).toBeInTheDocument();
   });
+
+  it('should render verbose error message with detailed verbose error message', () => {
+    const mockProps = {
+      ...getProps(),
+      testingStatus: {
+        message: 'message',
+        status: 'error',
+        details: { message: 'detailed message', verboseMessage: 'verbose message' },
+      },
+    };
+
+    render(<DataSourceSettingsPage {...mockProps} />);
+
+    expect(screen.getByText(mockProps.testingStatus.details.verboseMessage)).toBeInTheDocument();
+  });
 });

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -241,6 +241,9 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
               aria-label={selectors.pages.DataSource.alert}
             >
               {testingStatus.details?.message ?? null}
+              {testingStatus.details?.verboseMessage ? (
+                <details style={{ whiteSpace: 'pre-wrap' }}>{testingStatus.details?.verboseMessage}</details>
+              ) : null}
             </Alert>
           )}
         </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

In our enterprise plugins, in the `ConfigEditor`, we would like to be able to display more detailed error messages that are expandable. This would be helpful for stack traces or more technical errors (that can be collapsed by users).

**Before**

The alert component only looks at the message from the details payload:

```
{testingStatus.details?.message ?? null}
```

![Screenshot 2021-04-20 at 18 57 32](https://user-images.githubusercontent.com/36230812/115443657-6c491180-a20b-11eb-8da9-7c61cf706641.png)

**After**

In the plugin's `CheckHealth`, we can additionally pass in a verbose error message in the details: 

```
response, err := datasource.API.TestDatasource(ctx)
if err != nil {
    jsonDetails := `{"message":"Could not connect to AppDynamics. This usually happens when the URL is incorrect.", "verboseMessage":"More error details here when expanded."}`

    return &backend.CheckHealthResult{
        Status:  backend.HealthStatusError,
        Message: "Authentication error (401)",
        JSONDetails: []byte(jsonDetails),
    }, nil
}
```

And this will be picked up by the page:

![Screenshot 2021-04-20 at 18 41 23](https://user-images.githubusercontent.com/36230812/115443745-897de000-a20b-11eb-9577-708d163b816e.png)

![Screenshot 2021-04-20 at 19 03 21](https://user-images.githubusercontent.com/36230812/115443722-7ff47800-a20b-11eb-95e2-812ec080c758.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/integrations-team/issues/146

**Special notes for your reviewer**:

TIA 🙏 