### PR TITLE
Variables: Refreshes all panels even if panel is full screen

### DIFF
--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -494,6 +494,7 @@ export const variableUpdated = (
     return Promise.all(promises).then(() => {
       if (emitChangeEvents) {
         const dashboard = getState().dashboard.getModel();
+        dashboard?.setPanelsNeedRefresh();
         dashboard?.processRepeats();
         locationService.partial(getQueryWithVariables(getState));
         dashboard?.startRefresh();
@@ -527,6 +528,7 @@ export const onTimeRangeUpdated = (
   try {
     await Promise.all(promises);
     const dashboard = getState().dashboard.getModel();
+    dashboard?.setPanelsNeedRefresh();
     dashboard?.startRefresh();
   } catch (error) {
     console.error(error);
@@ -564,6 +566,7 @@ export const templateVarsChangedInUrl = (vars: UrlQueryMap): ThunkResult<void> =
   if (update.length) {
     await Promise.all(update);
     const dashboard = getState().dashboard.getModel();
+    dashboard?.setPanelsNeedRefresh();
     dashboard?.templateVariableValueUpdated();
     dashboard?.startRefresh();
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new property to DashboardModel that forces all panels to refresh. This is useful for when a user is editing/viewing a panel and variables change then other panels are now refreshed too.

**Which issue(s) this PR fixes**:
Fixes #17537

**Special notes for your reviewer**:

