### PR TITLE
[v7.5.x] Postgres: Fix time group macro when TimescaleDB is enabled and interval is less than a second

### DIFF
--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -107,7 +107,7 @@ func (m *postgresMacroEngine) evaluateMacro(name string, args []string) (string,
 		}
 
 		if m.timescaledb {
-			return fmt.Sprintf("time_bucket('%.0fs',%s)", interval.Seconds(), args[0]), nil
+			return fmt.Sprintf("time_bucket('%.1fs',%s)", interval.Seconds(), args[0]), nil
 		}
 
 		return fmt.Sprintf(

--- a/pkg/tsdb/postgres/macros_test.go
+++ b/pkg/tsdb/postgres/macros_test.go
@@ -94,21 +94,28 @@ func TestMacroEngine(t *testing.T) {
 				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column,'5m')")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
+				So(sql, ShouldEqual, "GROUP BY time_bucket('300.0s',time_column)")
 			})
 
 			Convey("interpolate __timeGroup function with spaces between args and TimescaleDB enabled", func() {
 				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column , '5m')")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "GROUP BY time_bucket('300s',time_column)")
+				So(sql, ShouldEqual, "GROUP BY time_bucket('300.0s',time_column)")
 			})
 
 			Convey("interpolate __timeGroup function with large time range as an argument and TimescaleDB enabled", func() {
 				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column , '12d')")
 				So(err, ShouldBeNil)
 
-				So(sql, ShouldEqual, "GROUP BY time_bucket('1036800s',time_column)")
+				So(sql, ShouldEqual, "GROUP BY time_bucket('1036800.0s',time_column)")
+			})
+
+			Convey("interpolate __timeGroup function with small time range as an argument and TimescaleDB enabled", func() {
+				sql, err := engineTS.Interpolate(query, timeRange, "GROUP BY $__timeGroup(time_column , '200ms')")
+				So(err, ShouldBeNil)
+
+				So(sql, ShouldEqual, "GROUP BY time_bucket('0.2s',time_column)")
 			})
 
 			Convey("interpolate __unixEpochFilter function", func() {


### PR DESCRIPTION
Backport dd0ba96d7c75c6c5f3624d3349b0a3c8c2e5103a from #33153 