### PR TITLE
Experiment: Systemjs compat layer

### DIFF
--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -9,5 +9,11 @@ export * from './utils';
 export * from './themes';
 export * from './slate-plugins';
 
+export const useNewTheme = () => 'NEW THEME';
+
+export const DEPRECATED_COMPAT_EXPORTS = {
+  useNewTheme: () => 'DEPRECATED OLD THEME',
+};
+
 // Exposes standard editors for registries of optionsUi config and panel options UI
 export { getStandardFieldConfigs, getStandardOptionEditors } from './utils/standardEditors';

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -30,7 +30,7 @@ import { reportPerformance } from './core/services/echo/EchoSrv';
 import { PerformanceBackend } from './core/services/echo/backends/PerformanceBackend';
 import 'app/routes/GrafanaCtrl';
 import 'app/features/all';
-import { getScrollbarWidth, getStandardFieldConfigs, getStandardOptionEditors } from '@grafana/ui';
+import { useNewTheme, getScrollbarWidth, getStandardFieldConfigs, getStandardOptionEditors } from '@grafana/ui';
 import { getDefaultVariableAdapters, variableAdapters } from './features/variables/adapters';
 import { initDevFeatures } from './dev';
 import { getStandardTransformers } from 'app/core/utils/standardTransformers';
@@ -59,6 +59,8 @@ if (process.env.NODE_ENV === 'development') {
   initDevFeatures();
 }
 
+// eslint-disable-next-line
+console.info(useNewTheme());
 export class GrafanaApp {
   angularApp: AngularApp;
 


### PR DESCRIPTION
# This is -  **with every probability** -  a very very bad idea

it basically adds a compat layer for old plugins:

the result is when doing `import {useNewTheme} from '@grafana/ui` it will correctly use the one defined in `DEPRECATED_COMPAT_EXPORTS` instead of the actual new one when the conditions in plugin-loader are met.

this means older plugins will still be able to use things before v8 (given we put them in `DEPRECATED_COMPAT_EXPORTS`) without the need for them to be updated.
