### PR TITLE
Build: drop TS checking from `yarn build`

### DIFF
--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -4,7 +4,6 @@ const merge = require('webpack-merge');
 const TerserPlugin = require('terser-webpack-plugin');
 const common = require('./webpack.common.js');
 const path = require('path');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -50,20 +49,6 @@ module.exports = merge(common, {
     ],
   },
   plugins: [
-    new ForkTsCheckerWebpackPlugin({
-      eslint: {
-        enabled: true,
-        files: ['public/app/**/*.{ts,tsx}', 'packages/*/src/**/*.{ts,tsx}'],
-      },
-      typescript: {
-        mode: 'write-references',
-        memoryLimit: 4096,
-        diagnosticOptions: {
-          semantic: true,
-          syntactic: true,
-        },
-      },
-    }),
     new MiniCssExtractPlugin({
       filename: 'grafana.[name].[hash].css',
     }),


### PR DESCRIPTION
this removes `ForkTsCheckerWebpackPlugin` from running during production builds, which drops `yarn build` by 30-40s on my machine. i believe this is safe because:

1. we already run all type-checks as part of `test-frontend`:

https://github.com/grafana/grafana/blob/4be1d84f23a6630667ff179037f749a7ca526a95/package.json#L46

2. `build-frontend`, which maps to `yarn build`:

https://github.com/grafana/grafana/blob/4be1d84f23a6630667ff179037f749a7ca526a95/build.go#L127-L128

...already depends on `test-frontend`:

https://github.com/grafana/grafana/blob/4be1d84f23a6630667ff179037f749a7ca526a95/.drone.yml#L339-L345