### PR TITLE
PanelEdit: update configRev on close

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -135,6 +135,7 @@ export function panelEditorCleanUp(): ThunkResult<void> {
       modifiedSaveModel.id = sourcePanel.id;
 
       sourcePanel.restoreModel(modifiedSaveModel);
+      sourcePanel.configRev++; // force check the configs
 
       // Loaded plugin is not included in the persisted properties
       // So is not handled by restoreModel


### PR DESCRIPTION
Fixes #33213

since the edit panel model is a clone of the dashboard panel model, the `configRev` changes do not necessarily trigger an update when we return to the dashboard.  This PR bumps the `sourcePanel.configRev` whenever the the editor closes.

NOTE: trying to be smart and only update if there is a real change is not worth the effort and will be error prone