### PR TITLE
AzureMonitor: Add support for Microsoft.SignalRService/SignalR metrics

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/supported_namespaces.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/supported_namespaces.ts
@@ -64,7 +64,7 @@ export default class SupportedNamespaces {
       'Microsoft.Relay/namespaces',
       'Microsoft.Search/searchServices',
       'Microsoft.ServiceBus/namespaces',
-      'Microsoft.SignalRService/SignalR'
+      'Microsoft.SignalRService/SignalR',
       'Microsoft.Sql/servers/databases',
       'Microsoft.Sql/servers/elasticPools',
       'Microsoft.Sql/managedInstances',

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/supported_namespaces.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/supported_namespaces.ts
@@ -64,6 +64,7 @@ export default class SupportedNamespaces {
       'Microsoft.Relay/namespaces',
       'Microsoft.Search/searchServices',
       'Microsoft.ServiceBus/namespaces',
+      'Microsoft.SignalRService/SignalR'
       'Microsoft.Sql/servers/databases',
       'Microsoft.Sql/servers/elasticPools',
       'Microsoft.Sql/managedInstances',


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR adds support of Azure SignalR metrics namespace (see [docs](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftsignalrservicesignalr)):

* ConnectionCount
* InboundTraffic
* MessageCount
* OutboundTraffic
* SystemErrors
* UserErrors


**Which issue(s) this PR fixes**:

Grafana filters out these metrics without this change. See #32933.