### PR TITLE
DashboardQueryRunner: Add dashboardQuerySupport to PanelModel & PanelPlugin

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -8,6 +8,7 @@ import {
   PanelProps,
   PanelTypeChangedHandler,
   FieldConfigProperty,
+  DashboardQuerySupport,
 } from '../types';
 import { FieldConfigEditorBuilder, PanelOptionsEditorBuilder } from '../utils/OptionsUIBuilders';
 import { ComponentClass, ComponentType } from 'react';
@@ -106,6 +107,7 @@ export class PanelPlugin<
   onPanelMigration?: PanelMigrationHandler<TOptions>;
   onPanelTypeChanged?: PanelTypeChangedHandler<TOptions>;
   noPadding?: boolean;
+  dashboardQuerySupport: DashboardQuerySupport = { annotations: false, alertStates: false };
 
   /**
    * Legacy angular ctrl.  If this exists it will be used instead of the panel
@@ -256,6 +258,33 @@ export class PanelPlugin<
   setPanelOptions(builder: (builder: PanelOptionsEditorBuilder<TOptions>) => void) {
     // builder is applied lazily when options UI is created
     this.registerOptionEditors = builder;
+    return this;
+  }
+
+  /**
+   * Tells Grafana if the plugin should subscribe to DashboardQueryRunner results.
+   *
+   * @example
+   * ```typescript
+   *
+   * import { ShapePanel } from './ShapePanel';
+   *
+   * interface ShapePanelOptions {}
+   *
+   * export const plugin = new PanelPlugin<ShapePanelOptions>(ShapePanel)
+   *     .useFieldConfig({})
+   *     ...
+   *     ...
+   *     .setDashboardQuerySupport({
+   *       annotations: true,
+   *       alertStates: true,
+   *     });
+   * ```
+   *
+   * @public
+   **/
+  setDashboardQuerySupport(supportOptions: Partial<DashboardQuerySupport>) {
+    this.dashboardQuerySupport = { ...this.dashboardQuerySupport, ...supportOptions };
     return this;
   }
 

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -266,7 +266,7 @@ export class PanelPlugin<
   }
 
   /**
-   * Tells Grafana if the plugin should subscribe to annotation results.
+   * Tells Grafana if the plugin should subscribe to annotation and alertState results.
    *
    * @example
    * ```typescript
@@ -279,38 +279,17 @@ export class PanelPlugin<
    *     .useFieldConfig({})
    *     ...
    *     ...
-   *     .setAnnotationSupport(true);
+   *     .setAnnotationSupport({
+   *       annotations: true,
+   *       alertStates: true,
+   *     });
    * ```
    *
    * @public
    **/
-  setAnnotationSupport(supported: boolean) {
-    this.supportsAnnotations = supported;
-    return this;
-  }
-
-  /**
-   * @deprecated setAlertStatesSupport is deprecated and will be removed when the next generation alerting is in place
-   * Tells Grafana if the plugin should subscribe to alert state results.
-   *
-   * @example
-   * ```typescript
-   *
-   * import { ShapePanel } from './ShapePanel';
-   *
-   * interface ShapePanelOptions {}
-   *
-   * export const plugin = new PanelPlugin<ShapePanelOptions>(ShapePanel)
-   *     .useFieldConfig({})
-   *     ...
-   *     ...
-   *     .setAlertStatesSupport(true);
-   * ```
-   *
-   * @public
-   **/
-  setAlertStateSupport(supported: boolean) {
-    this.supportsAlertStates = supported;
+  setAnnotationSupport({ annotations, alertStates }: { annotations?: boolean; alertStates?: boolean }) {
+    this.supportsAlertStates = alertStates ?? this.supportsAlertStates;
+    this.supportsAnnotations = annotations ?? this.supportsAnnotations;
     return this;
   }
 

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -8,7 +8,6 @@ import {
   PanelProps,
   PanelTypeChangedHandler,
   FieldConfigProperty,
-  DashboardQuerySupport,
 } from '../types';
 import { FieldConfigEditorBuilder, PanelOptionsEditorBuilder } from '../utils/OptionsUIBuilders';
 import { ComponentClass, ComponentType } from 'react';
@@ -107,7 +106,12 @@ export class PanelPlugin<
   onPanelMigration?: PanelMigrationHandler<TOptions>;
   onPanelTypeChanged?: PanelTypeChangedHandler<TOptions>;
   noPadding?: boolean;
-  dashboardQuerySupport: DashboardQuerySupport = { annotations: false, alertStates: false };
+  supportsAnnotations = false;
+
+  /**
+   * @deprecated supportsAlertStates is deprecated and will be removed when the next generation alerting is in place
+   */
+  supportsAlertStates = false;
 
   /**
    * Legacy angular ctrl.  If this exists it will be used instead of the panel
@@ -262,7 +266,7 @@ export class PanelPlugin<
   }
 
   /**
-   * Tells Grafana if the plugin should subscribe to DashboardQueryRunner results.
+   * Tells Grafana if the plugin should subscribe to annotation results.
    *
    * @example
    * ```typescript
@@ -275,16 +279,38 @@ export class PanelPlugin<
    *     .useFieldConfig({})
    *     ...
    *     ...
-   *     .setDashboardQuerySupport({
-   *       annotations: true,
-   *       alertStates: true,
-   *     });
+   *     .setAnnotationSupport(true);
    * ```
    *
    * @public
    **/
-  setDashboardQuerySupport(supportOptions: Partial<DashboardQuerySupport>) {
-    this.dashboardQuerySupport = { ...this.dashboardQuerySupport, ...supportOptions };
+  setAnnotationSupport(supported: boolean) {
+    this.supportsAnnotations = supported;
+    return this;
+  }
+
+  /**
+   * @deprecated setAlertStatesSupport is deprecated and will be removed when the next generation alerting is in place
+   * Tells Grafana if the plugin should subscribe to alert state results.
+   *
+   * @example
+   * ```typescript
+   *
+   * import { ShapePanel } from './ShapePanel';
+   *
+   * interface ShapePanelOptions {}
+   *
+   * export const plugin = new PanelPlugin<ShapePanelOptions>(ShapePanel)
+   *     .useFieldConfig({})
+   *     ...
+   *     ...
+   *     .setAlertStatesSupport(true);
+   * ```
+   *
+   * @public
+   **/
+  setAlertStateSupport(supported: boolean) {
+    this.supportsAlertStates = supported;
     return this;
   }
 

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -8,6 +8,7 @@ import {
   PanelProps,
   PanelTypeChangedHandler,
   FieldConfigProperty,
+  PanelPluginDataSupport,
 } from '../types';
 import { FieldConfigEditorBuilder, PanelOptionsEditorBuilder } from '../utils/OptionsUIBuilders';
 import { ComponentClass, ComponentType } from 'react';
@@ -106,12 +107,10 @@ export class PanelPlugin<
   onPanelMigration?: PanelMigrationHandler<TOptions>;
   onPanelTypeChanged?: PanelTypeChangedHandler<TOptions>;
   noPadding?: boolean;
-  supportsAnnotations = false;
-
-  /**
-   * @deprecated supportsAlertStates is deprecated and will be removed when the next generation alerting is in place
-   */
-  supportsAlertStates = false;
+  dataSupport: PanelPluginDataSupport = {
+    annotations: false,
+    alertStates: false,
+  };
 
   /**
    * Legacy angular ctrl.  If this exists it will be used instead of the panel
@@ -279,7 +278,7 @@ export class PanelPlugin<
    *     .useFieldConfig({})
    *     ...
    *     ...
-   *     .setAnnotationSupport({
+   *     .setDataSupport({
    *       annotations: true,
    *       alertStates: true,
    *     });
@@ -287,9 +286,8 @@ export class PanelPlugin<
    *
    * @public
    **/
-  setAnnotationSupport({ annotations, alertStates }: { annotations?: boolean; alertStates?: boolean }) {
-    this.supportsAlertStates = alertStates ?? this.supportsAlertStates;
-    this.supportsAnnotations = annotations ?? this.supportsAnnotations;
+  setDataSupport(support: Partial<PanelPluginDataSupport>) {
+    this.dataSupport = { ...this.dataSupport, ...support };
     return this;
   }
 

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -182,3 +182,8 @@ export enum VizOrientation {
   Vertical = 'vertical',
   Horizontal = 'horizontal',
 }
+
+export interface PanelPluginDataSupport {
+  annotations: boolean;
+  alertStates: boolean;
+}

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -182,8 +182,3 @@ export enum VizOrientation {
   Vertical = 'vertical',
   Horizontal = 'horizontal',
 }
-
-export interface DashboardQuerySupport {
-  annotations: boolean;
-  alertStates: boolean;
-}

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -182,3 +182,8 @@ export enum VizOrientation {
   Vertical = 'vertical',
   Horizontal = 'horizontal',
 }
+
+export interface DashboardQuerySupport {
+  annotations: boolean;
+  alertStates: boolean;
+}

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -5,7 +5,6 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { getNextRefIdChar } from 'app/core/utils/query';
 // Types
 import {
-  DashboardQuerySupport,
   DataConfigSource,
   DataFrameDTO,
   DataLink,
@@ -151,7 +150,6 @@ export class PanelModel implements DataConfigSource {
     [key: string]: any;
   };
   declare fieldConfig: FieldConfigSource;
-  dashboardQuerySupport: DashboardQuerySupport;
 
   maxDataPoints?: number | null;
   interval?: string | null;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -5,6 +5,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { getNextRefIdChar } from 'app/core/utils/query';
 // Types
 import {
+  DashboardQuerySupport,
   DataConfigSource,
   DataFrameDTO,
   DataLink,
@@ -150,6 +151,7 @@ export class PanelModel implements DataConfigSource {
     [key: string]: any;
   };
   declare fieldConfig: FieldConfigSource;
+  dashboardQuerySupport: DashboardQuerySupport;
 
   maxDataPoints?: number | null;
   interval?: string | null;


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a property, `dashboardQuerySupport` to `PanelModel` and `PanelPlugin` to signal whether the plugin should subscribe to `DashboardQueryRunner` results.

Relates to #32834