### PR TITLE
Build: Use read commited isolation level in mysql integration tests

### DIFF
--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -30,7 +30,7 @@ func MySQLTestDB() TestDB {
 	}
 	return TestDB{
 		DriverName: "mysql",
-		ConnStr:    fmt.Sprintf("grafana:password@tcp(%s:%s)/grafana_tests?collation=utf8mb4_unicode_ci", host, port),
+		ConnStr:    fmt.Sprintf("grafana:password@tcp(%s:%s)/grafana_tests?collation=utf8mb4_unicode_ci&tx_isolation='READ-COMMITTED'", host, port),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing out isolation level read committed for mysql integration tests.

**Which issue(s) this PR fixes**:
Ref #31371 

**Special notes for your reviewer**:

