### PR TITLE
Access control: Fix predefined roles

### DIFF
--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -122,6 +122,14 @@ var PredefinedRoles = map[string]RoleDTO{
 				Scope:  ScopeOrgAllUsersAll,
 			},
 			{
+				// Inherited from grafana:roles:users:admin:read
+				Action: ActionLDAPUsersRead,
+			},
+			{
+				// Inherited from grafana:roles:users:admin:read
+				Action: ActionLDAPStatusRead,
+			},
+			{
 				Action: ActionLDAPUsersSync,
 			},
 		},


### PR DESCRIPTION
This PR fixes LDAP permissions for pre-defined Grafana admin role.