### PR TITLE
CloudWatch: Fix broken AWS/MediaTailor dimension name

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -202,7 +202,7 @@ var dimensionsMap = map[string][]string{
 	"AWS/MediaConvert":            {"Job", "Operation", "Queue"},
 	"AWS/MediaPackage":            {"Channel", "No Dimension", "OriginEndpoint", "StatusCodeRange"},
 	"AWS/MediaStore":              {"ContainerName", "ObjectGroupName", "RequestType"},
-	"AWS/MediaTailor":             {"Configuration Name"},
+	"AWS/MediaTailor":             {"ConfigurationName"},
 	"AWS/NATGateway":              {"NatGatewayId"},
 	"AWS/Neptune":                 {"DBClusterIdentifier", "DatabaseClass", "EngineName", "Role"},
 	"AWS/NetworkELB":              {"AvailabilityZone", "LoadBalancer", "TargetGroup"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix typo in AWS/MediaTailor dimension name

**Which issue(s) this PR fixes**:
Fixes #33270
