### PR TITLE
Tempo: Add cheat sheet to query editor

### DIFF
--- a/public/app/plugins/datasource/tempo/CheatSheet.tsx
+++ b/public/app/plugins/datasource/tempo/CheatSheet.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function CheatSheet() {
+  return (
+    <div>
+      <h2 id="tempo-cheat-sheet">Tempo Cheat Sheet</h2>
+      <p>
+        Tempo is a trace id lookup store. Enter a trace id in the above field and hit “Run Query” to retrieve your
+        trace. Tempo is generally paired with other datasources such as Loki or Prometheus to find traces.
+      </p>
+      <p>
+        Here are some{' '}
+        <a href="https://grafana.com/docs/tempo/latest/guides/instrumentation/" target="blank">
+          instrumentation examples
+        </a>{' '}
+        to get you started with trace discovery through logs and metrics (exemplars).
+      </p>
+    </div>
+  );
+}

--- a/public/app/plugins/datasource/tempo/module.ts
+++ b/public/app/plugins/datasource/tempo/module.ts
@@ -1,8 +1,10 @@
 import { DataSourcePlugin } from '@grafana/data';
+import CheatSheet from './CheatSheet';
+import { ConfigEditor } from './ConfigEditor';
 import { TempoDatasource } from './datasource';
 import { TempoQueryField } from './QueryField';
-import { ConfigEditor } from './ConfigEditor';
 
 export const plugin = new DataSourcePlugin(TempoDatasource)
   .setConfigEditor(ConfigEditor)
+  .setQueryEditorHelp(CheatSheet)
   .setExploreQueryField(TempoQueryField);


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a cheat sheet to the Tempo data source.

![Screenshot 2021-04-22 at 14 54 06](https://user-images.githubusercontent.com/13729989/115718114-1c895800-a37b-11eb-92d1-f0444a72edfb.png)
