### PR TITLE
Loki: Show query editor in annotations

### DIFF
--- a/public/app/plugins/datasource/loki/LokiAnnotationsQueryCtrl.tsx
+++ b/public/app/plugins/datasource/loki/LokiAnnotationsQueryCtrl.tsx
@@ -4,10 +4,11 @@ import { LokiQuery } from './types';
  */
 export class LokiAnnotationsQueryCtrl {
   static templateUrl = 'partials/annotations.editor.html';
-  annotation: any;
+  declare annotation: any;
 
   /** @ngInject */
-  constructor() {
+  constructor($scope: any) {
+    this.annotation = $scope.ctrl.annotation;
     this.annotation.target = this.annotation.target || {};
     this.onQueryChange = this.onQueryChange.bind(this);
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
I have applied the same as https://github.com/grafana/grafana/pull/32903 for Loki editor in annotations. Now it displays the editor. Some functionality still doesn't work, but it is generic problem across more editors - created issue for this https://github.com/grafana/grafana/issues/33277. 


