### PR TITLE
TSDB: add deprication comments to many tsdb structs

### DIFF
--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// nolint:staticcheck // plugins.DataPlugin deprecated
 func TestService(t *testing.T) {
 	dsDF := data.NewFrame("test",
 		data.NewField("time", nil, []*time.Time{utp(1)}),
@@ -102,6 +103,7 @@ type mockEndpoint struct {
 	Frames data.Frames
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (me *mockEndpoint) DataQuery(ctx context.Context, ds *models.DataSource, query plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	return plugins.DataResponse{

--- a/pkg/plugins/backendplugin/coreplugin/core_plugin.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin.go
@@ -43,6 +43,7 @@ func (cp *corePlugin) Logger() log.Logger {
 	return cp.logger
 }
 
+//nolint: staticcheck // plugins.DataResponse deprecated
 func (cp *corePlugin) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	tsdbQuery plugins.DataQuery) (plugins.DataResponse, error) {
 	// TODO: Inline the adapter, since it shouldn't be necessary

--- a/pkg/plugins/backendplugin/coreplugin/query_endpoint_adapter.go
+++ b/pkg/plugins/backendplugin/coreplugin/query_endpoint_adapter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/adapters"
 )
 
+// nolint:staticcheck // plugins.DataPlugin deprecated
 func newQueryEndpointAdapter(pluginID string, logger log.Logger, handler backend.QueryDataHandler) plugins.DataPlugin {
 	return &queryEndpointAdapter{
 		pluginID: pluginID,
@@ -45,6 +46,7 @@ func modelToInstanceSettings(ds *models.DataSource) (*backend.DataSourceInstance
 	}, nil
 }
 
+// nolint:staticcheck // plugins.DataQuery deprecated
 func (a *queryEndpointAdapter) DataQuery(ctx context.Context, ds *models.DataSource, query plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	instanceSettings, err := modelToInstanceSettings(ds)

--- a/pkg/plugins/backendplugin/manager/manager.go
+++ b/pkg/plugins/backendplugin/manager/manager.go
@@ -113,6 +113,7 @@ func (m *manager) getAWSEnvironmentVariables() []string {
 	return variables
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (m *manager) GetDataPlugin(pluginID string) interface{} {
 	plugin := m.plugins[pluginID]
 	if plugin == nil {

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -664,6 +664,7 @@ func collectPluginFilesWithin(rootDir string) ([]string, error) {
 }
 
 // GetDataPlugin gets a DataPlugin with a certain name. If none is found, nil is returned.
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (pm *PluginManager) GetDataPlugin(id string) plugins.DataPlugin {
 	if p, exists := pm.dataSources[id]; exists && p.CanHandleDataQueries() {
 		return p

--- a/pkg/plugins/tsdb.go
+++ b/pkg/plugins/tsdb.go
@@ -16,7 +16,7 @@ import (
 	"github.com/timberio/go-datemath"
 )
 
-// Deprecated: DataSubQuery represents a data sub-query.  New work should use the plugin SDK.
+// DataSubQuery represents a data sub-query.  New work should use the plugin SDK.
 type DataSubQuery struct {
 	RefID         string             `json:"refId"`
 	Model         *simplejson.Json   `json:"model,omitempty"`
@@ -26,7 +26,7 @@ type DataSubQuery struct {
 	QueryType     string             `json:"queryType"`
 }
 
-// Deprecated: DataQuery contains all information about a data query request.  New work should use the plugin SDK.
+// DataQuery contains all information about a data query request.  New work should use the plugin SDK.
 type DataQuery struct {
 	TimeRange *DataTimeRange
 	Queries   []DataSubQuery
@@ -41,7 +41,6 @@ type DataTimeRange struct {
 	Now  time.Time
 }
 
-// Deprecated: DataTable should use DataFrames from the SDK
 type DataTable struct {
 	Columns []DataTableColumn `json:"columns"`
 	Rows    []DataRowValues   `json:"rows"`
@@ -181,7 +180,7 @@ func (r *DataQueryResult) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Deprecated: DataTimeSeries -- this structure is deprecated, all new work should use DataFrames from the SDK
+// DataTimeSeries -- this structure is deprecated, all new work should use DataFrames from the SDK
 type DataTimeSeries struct {
 	Name   string               `json:"name"`
 	Points DataTimeSeriesPoints `json:"points"`
@@ -237,7 +236,6 @@ type DataPlugin interface {
 	DataQuery(ctx context.Context, ds *models.DataSource, query DataQuery) (DataResponse, error)
 }
 
-// Deprecated: use the plugin SDK
 func NewDataTimeRange(from, to string) DataTimeRange {
 	return DataTimeRange{
 		From: from,

--- a/pkg/plugins/tsdb.go
+++ b/pkg/plugins/tsdb.go
@@ -16,7 +16,7 @@ import (
 	"github.com/timberio/go-datemath"
 )
 
-// DataSubQuery represents a data sub-query.
+// Deprecated: DataSubQuery represents a data sub-query.  New work should use the plugin SDK.
 type DataSubQuery struct {
 	RefID         string             `json:"refId"`
 	Model         *simplejson.Json   `json:"model,omitempty"`
@@ -26,7 +26,7 @@ type DataSubQuery struct {
 	QueryType     string             `json:"queryType"`
 }
 
-// DataQuery contains all information about a data query request.
+// Deprecated: DataQuery contains all information about a data query request.  New work should use the plugin SDK.
 type DataQuery struct {
 	TimeRange *DataTimeRange
 	Queries   []DataSubQuery
@@ -41,6 +41,7 @@ type DataTimeRange struct {
 	Now  time.Time
 }
 
+// Deprecated: DataTable should use DataFrames from the SDK
 type DataTable struct {
 	Columns []DataTableColumn `json:"columns"`
 	Rows    []DataRowValues   `json:"rows"`
@@ -55,6 +56,7 @@ type DataTimeSeriesPoints []DataTimePoint
 type DataTimeSeriesSlice []DataTimeSeries
 type DataRowValues []interface{}
 
+// Deprecated: DataQueryResult should use backend.QueryDataResponse
 type DataQueryResult struct {
 	Error       error               `json:"-"`
 	ErrorString string              `json:"error,omitempty"`
@@ -179,12 +181,14 @@ func (r *DataQueryResult) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// Deprecated: DataTimeSeries -- this structure is deprecated, all new work should use DataFrames from the SDK
 type DataTimeSeries struct {
 	Name   string               `json:"name"`
 	Points DataTimeSeriesPoints `json:"points"`
 	Tags   map[string]string    `json:"tags,omitempty"`
 }
 
+// Deprecated: DataResponse -- this structure is deprecated, all new work should use backend.QueryDataResponse
 type DataResponse struct {
 	Results map[string]DataQueryResult `json:"results"`
 	Message string                     `json:"message,omitempty"`
@@ -228,10 +232,12 @@ func (r DataResponse) ToBackendDataResponse() (*backend.QueryDataResponse, error
 	return qdr, nil
 }
 
+// Deprecated: use the plugin SDK
 type DataPlugin interface {
 	DataQuery(ctx context.Context, ds *models.DataSource, query DataQuery) (DataResponse, error)
 }
 
+// Deprecated: use the plugin SDK
 func NewDataTimeRange(from, to string) DataTimeRange {
 	return DataTimeRange{
 		From: from,

--- a/pkg/services/alerting/conditions/query_test.go
+++ b/pkg/services/alerting/conditions/query_test.go
@@ -189,6 +189,7 @@ type queryConditionTestContext struct {
 
 type queryConditionScenarioFunc func(c *queryConditionTestContext)
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (ctx *queryConditionTestContext) exec() (*alerting.ConditionResult, error) {
 	jsonModel, err := simplejson.NewJson([]byte(`{
             "type": "query",
@@ -228,9 +229,11 @@ func (ctx *queryConditionTestContext) exec() (*alerting.ConditionResult, error) 
 }
 
 type fakeReqHandler struct {
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	response plugins.DataResponse
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (rh fakeReqHandler) HandleRequest(context.Context, *models.DataSource, plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	return rh.response, nil

--- a/pkg/services/alerting/conditions/reducer.go
+++ b/pkg/services/alerting/conditions/reducer.go
@@ -18,6 +18,7 @@ type queryReducer struct {
 }
 
 //nolint: gocyclo
+//nolint: staticcheck // plugins.DataTimeSeries deprecated
 func (s *queryReducer) Reduce(series plugins.DataTimeSeries) null.Float {
 	if len(series.Points) == 0 {
 		return null.FloatFromPtr(nil)
@@ -126,6 +127,7 @@ func newSimpleReducer(t string) *queryReducer {
 	return &queryReducer{Type: t}
 }
 
+//nolint: staticcheck // plugins.* deprecated
 func calculateDiff(series plugins.DataTimeSeries, allNull bool, value float64, fn func(float64, float64) float64) (bool, float64) {
 	var (
 		points = series.Points

--- a/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
+++ b/pkg/tsdb/azuremonitor/applicationinsights-datasource.go
@@ -49,6 +49,7 @@ type ApplicationInsightsQuery struct {
 	aggregation string
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (e *ApplicationInsightsDatasource) executeTimeSeriesQuery(ctx context.Context,
 	originalQueries []plugins.DataSubQuery,
 	timeRange plugins.DataTimeRange) (plugins.DataResponse, error) {
@@ -142,6 +143,7 @@ func (e *ApplicationInsightsDatasource) buildQueries(queries []plugins.DataSubQu
 	return applicationInsightsQueries, nil
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (e *ApplicationInsightsDatasource) executeQuery(ctx context.Context, query *ApplicationInsightsQuery) (
 	plugins.DataQueryResult, error) {
 	queryResult := plugins.DataQueryResult{Meta: simplejson.New(), RefID: query.RefID}

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -45,6 +45,7 @@ type AzureLogAnalyticsQuery struct {
 // 1. build the AzureMonitor url and querystring for each query
 // 2. executes each query by calling the Azure Monitor API
 // 3. parses the responses for each query into the timeseries format
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *AzureLogAnalyticsDatasource) executeTimeSeriesQuery(ctx context.Context, originalQueries []plugins.DataSubQuery,
 	timeRange plugins.DataTimeRange) (plugins.DataResponse, error) {
 	result := plugins.DataResponse{
@@ -111,6 +112,7 @@ func (e *AzureLogAnalyticsDatasource) buildQueries(queries []plugins.DataSubQuer
 	return azureLogAnalyticsQueries, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *AzureLogAnalyticsQuery,
 	queries []plugins.DataSubQuery, timeRange plugins.DataTimeRange) plugins.DataQueryResult {
 	queryResult := plugins.DataQueryResult{RefID: query.RefID}

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -41,6 +41,7 @@ const azureMonitorAPIVersion = "2018-01-01"
 // 1. build the AzureMonitor url and querystring for each query
 // 2. executes each query by calling the Azure Monitor API
 // 3. parses the responses for each query into the timeseries format
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *AzureMonitorDatasource) executeTimeSeriesQuery(ctx context.Context, originalQueries []plugins.DataSubQuery,
 	timeRange plugins.DataTimeRange) (plugins.DataResponse, error) {
 	result := plugins.DataResponse{
@@ -172,6 +173,7 @@ func (e *AzureMonitorDatasource) buildQueries(queries []plugins.DataSubQuery, ti
 	return azureMonitorQueries, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, query *AzureMonitorQuery, queries []plugins.DataSubQuery,
 	timeRange plugins.DataTimeRange) (plugins.DataQueryResult, AzureMonitorResponse, error) {
 	queryResult := plugins.DataQueryResult{RefID: query.RefID}

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -433,6 +433,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			azData := loadTestFile(t, "azuremonitor/"+tt.responseFile)
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 			require.NotNil(t, res)
 			dframes, err := datasource.parseResponse(azData, tt.mockQuery)

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -41,6 +41,7 @@ type AzureMonitorExecutor struct {
 }
 
 // NewAzureMonitorExecutor initializes a http client
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (s *Service) NewExecutor(dsInfo *models.DataSource) (plugins.DataPlugin, error) {
 	httpClient, err := dsInfo.GetHttpClient()
 	if err != nil {
@@ -58,6 +59,7 @@ func (s *Service) NewExecutor(dsInfo *models.DataSource) (plugins.DataPlugin, er
 // expected by chosen Azure Monitor service (Azure Monitor, App Insights etc.)
 // executes the queries against the API and parses the response into
 // the right format
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *AzureMonitorExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	tsdbQuery plugins.DataQuery) (plugins.DataResponse, error) {
 	var err error

--- a/pkg/tsdb/azuremonitor/insights-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/insights-analytics-datasource.go
@@ -39,6 +39,7 @@ type InsightsAnalyticsQuery struct {
 	Target string
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *InsightsAnalyticsDatasource) executeTimeSeriesQuery(ctx context.Context,
 	originalQueries []plugins.DataSubQuery, timeRange plugins.DataTimeRange) (plugins.DataResponse, error) {
 	result := plugins.DataResponse{
@@ -96,6 +97,7 @@ func (e *InsightsAnalyticsDatasource) buildQueries(queries []plugins.DataSubQuer
 	return iaQueries, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *InsightsAnalyticsDatasource) executeQuery(ctx context.Context, query *InsightsAnalyticsQuery) plugins.DataQueryResult {
 	queryResult := plugins.DataQueryResult{RefID: query.RefID}
 

--- a/pkg/tsdb/cloudmonitoring/annotation_query.go
+++ b/pkg/tsdb/cloudmonitoring/annotation_query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 )
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *Executor) executeAnnotationQuery(ctx context.Context, tsdbQuery plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	result := plugins.DataResponse{
@@ -36,6 +37,7 @@ func (e *Executor) executeAnnotationQuery(ctx context.Context, tsdbQuery plugins
 	return result, err
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func transformAnnotationToTable(data []map[string]string, result *plugins.DataQueryResult) {
 	table := plugins.DataTable{
 		Columns: make([]plugins.DataTableColumn, 4),

--- a/pkg/tsdb/cloudmonitoring/annotation_query_test.go
+++ b/pkg/tsdb/cloudmonitoring/annotation_query_test.go
@@ -14,6 +14,7 @@ func TestExecutor_parseToAnnotations(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, d.TimeSeries, 3)
 
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "annotationQuery"}
 	query := &cloudMonitoringTimeSeriesFilter{}
 
@@ -30,6 +31,7 @@ func TestExecutor_parseToAnnotations(t *testing.T) {
 }
 
 func TestCloudMonitoringExecutor_parseToAnnotations_emptyTimeSeries(t *testing.T) {
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "annotationQuery"}
 	query := &cloudMonitoringTimeSeriesFilter{}
 
@@ -46,6 +48,7 @@ func TestCloudMonitoringExecutor_parseToAnnotations_emptyTimeSeries(t *testing.T
 }
 
 func TestCloudMonitoringExecutor_parseToAnnotations_noPointsInSeries(t *testing.T) {
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "annotationQuery"}
 	query := &cloudMonitoringTimeSeriesFilter{}
 

--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -88,6 +88,7 @@ type Executor struct {
 }
 
 // NewExecutor returns an Executor.
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (s *Service) NewExecutor(dsInfo *models.DataSource) (plugins.DataPlugin, error) {
 	httpClient, err := dsInfo.GetHttpClient()
 	if err != nil {
@@ -108,6 +109,7 @@ func init() {
 // Query takes in the frontend queries, parses them into the CloudMonitoring query format
 // executes the queries against the CloudMonitoring API and parses the response into
 // the time series or table format
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *Executor) DataQuery(ctx context.Context, dsInfo *models.DataSource, tsdbQuery plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	var result plugins.DataResponse
@@ -128,11 +130,14 @@ func (e *Executor) DataQuery(ctx context.Context, dsInfo *models.DataSource, tsd
 	return result, err
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *Executor) getGCEDefaultProject(ctx context.Context, tsdbQuery plugins.DataQuery) (plugins.DataResponse, error) {
 	result := plugins.DataResponse{
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		Results: make(map[string]plugins.DataQueryResult),
 	}
 	refID := tsdbQuery.Queries[0].RefID
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	queryResult := plugins.DataQueryResult{Meta: simplejson.New(), RefID: refID}
 
 	gceDefaultProject, err := e.getDefaultProject(ctx)
@@ -147,9 +152,11 @@ func (e *Executor) getGCEDefaultProject(ctx context.Context, tsdbQuery plugins.D
 	return result, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *Executor) executeTimeSeriesQuery(ctx context.Context, tsdbQuery plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	result := plugins.DataResponse{
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		Results: make(map[string]plugins.DataQueryResult),
 	}
 

--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring_test.go
@@ -595,6 +595,7 @@ func TestCloudMonitoring(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(data.TimeSeries))
 
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 			query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
 			err = query.parseResponse(res, data, "")
@@ -619,7 +620,7 @@ func TestCloudMonitoring(t *testing.T) {
 			data, err := loadTestFile("./test-data/2-series-response-no-agg.json")
 			require.NoError(t, err)
 			assert.Equal(t, 3, len(data.TimeSeries))
-
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 			query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
 			err = query.parseResponse(res, data, "")
@@ -657,7 +658,7 @@ func TestCloudMonitoring(t *testing.T) {
 			data, err := loadTestFile("./test-data/2-series-response-no-agg.json")
 			require.NoError(t, err)
 			assert.Equal(t, 3, len(data.TimeSeries))
-
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 			query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}, GroupBys: []string{
 				"metric.label.instance_name", "resource.label.zone",
@@ -677,7 +678,7 @@ func TestCloudMonitoring(t *testing.T) {
 			data, err := loadTestFile("./test-data/2-series-response-no-agg.json")
 			require.NoError(t, err)
 			assert.Equal(t, 3, len(data.TimeSeries))
-
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 
 			t.Run("and the alias pattern is for metric type, a metric label and a resource label", func(t *testing.T) {
@@ -711,7 +712,7 @@ func TestCloudMonitoring(t *testing.T) {
 			data, err := loadTestFile("./test-data/3-series-response-distribution-exponential.json")
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(data.TimeSeries))
-
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 			query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}, AliasBy: "{{bucket}}"}
 			err = query.parseResponse(res, data, "")
@@ -753,7 +754,7 @@ func TestCloudMonitoring(t *testing.T) {
 			data, err := loadTestFile("./test-data/4-series-response-distribution-explicit.json")
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(data.TimeSeries))
-
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 			query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}, AliasBy: "{{bucket}}"}
 			err = query.parseResponse(res, data, "")
@@ -788,7 +789,7 @@ func TestCloudMonitoring(t *testing.T) {
 			data, err := loadTestFile("./test-data/5-series-response-meta-data.json")
 			require.NoError(t, err)
 			assert.Equal(t, 3, len(data.TimeSeries))
-
+			//nolint: staticcheck // plugins.DataPlugin deprecated
 			res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 			query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}, AliasBy: "{{bucket}}"}
 			err = query.parseResponse(res, data, "")
@@ -824,6 +825,7 @@ func TestCloudMonitoring(t *testing.T) {
 			assert.Equal(t, 3, len(data.TimeSeries))
 
 			t.Run("and systemlabel contains key with array of string", func(t *testing.T) {
+				//nolint: staticcheck // plugins.DataPlugin deprecated
 				res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 				query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}, AliasBy: "{{metadata.system_labels.test}}"}
 				err = query.parseResponse(res, data, "")
@@ -838,6 +840,7 @@ func TestCloudMonitoring(t *testing.T) {
 			})
 
 			t.Run("and systemlabel contains key with array of string2", func(t *testing.T) {
+				//nolint: staticcheck // plugins.DataPlugin deprecated
 				res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 				query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}, AliasBy: "{{metadata.system_labels.test2}}"}
 				err = query.parseResponse(res, data, "")
@@ -855,6 +858,7 @@ func TestCloudMonitoring(t *testing.T) {
 			assert.Equal(t, 1, len(data.TimeSeries))
 
 			t.Run("and alias by is expanded", func(t *testing.T) {
+				//nolint: staticcheck // plugins.DataPlugin deprecated
 				res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 				query := &cloudMonitoringTimeSeriesFilter{
 					Params:      url.Values{},
@@ -878,6 +882,7 @@ func TestCloudMonitoring(t *testing.T) {
 			assert.Equal(t, 1, len(data.TimeSeries))
 
 			t.Run("and alias by is expanded", func(t *testing.T) {
+				//nolint: staticcheck // plugins.DataPlugin deprecated
 				res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 				query := &cloudMonitoringTimeSeriesFilter{
 					Params:      url.Values{},
@@ -899,7 +904,7 @@ func TestCloudMonitoring(t *testing.T) {
 				data, err := loadTestFile("./test-data/1-series-response-agg-one-metric.json")
 				require.NoError(t, err)
 				assert.Equal(t, 1, len(data.TimeSeries))
-
+				//nolint: staticcheck // plugins.DataPlugin deprecated
 				res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 				query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
 				err = query.parseResponse(res, data, "")
@@ -913,7 +918,7 @@ func TestCloudMonitoring(t *testing.T) {
 				data, err := loadTestFile("./test-data/2-series-response-no-agg.json")
 				require.NoError(t, err)
 				assert.Equal(t, 3, len(data.TimeSeries))
-
+				//nolint: staticcheck // plugins.DataPlugin deprecated
 				res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 				query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
 				err = query.parseResponse(res, data, "")
@@ -932,6 +937,7 @@ func TestCloudMonitoring(t *testing.T) {
 
 			t.Run("and alias by is expanded", func(t *testing.T) {
 				fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
+				//nolint: staticcheck // plugins.DataPlugin deprecated
 				res := &plugins.DataQueryResult{Meta: simplejson.New(), RefID: "A"}
 				query := &cloudMonitoringTimeSeriesQuery{
 					ProjectName: "test-proj",

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) run(ctx context.Context, tsdbQuery plugins.DataQuery,
 	e *Executor) (plugins.DataQueryResult, cloudMonitoringResponse, string, error) {
 	queryResult := plugins.DataQueryResult{Meta: simplejson.New(), RefID: timeSeriesFilter.RefID}
@@ -79,6 +80,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) run(ctx context.Context
 	return queryResult, data, req.URL.RawQuery, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes *plugins.DataQueryResult,
 	response cloudMonitoringResponse, executedQueryString string) error {
 	labels := make(map[string]map[string]bool)
@@ -241,6 +243,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 	return nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) handleNonDistributionSeries(series timeSeries,
 	defaultMetricName string, seriesLabels map[string]string, queryRes *plugins.DataQueryResult,
 	frame *data.Frame) {
@@ -272,6 +275,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) handleNonDistributionSe
 	setDisplayNameAsFieldName(dataField)
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseToAnnotations(queryRes *plugins.DataQueryResult,
 	response cloudMonitoringResponse, title string, text string, tags string) error {
 	frames := data.Frames{}

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, tsdbQuery plugins.DataQuery,
 	e *Executor) (plugins.DataQueryResult, cloudMonitoringResponse, string, error) {
 	queryResult := plugins.DataQueryResult{Meta: simplejson.New(), RefID: timeSeriesQuery.RefID}
@@ -94,6 +95,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) run(ctx context.Context, t
 	return queryResult, data, timeSeriesQuery.Query, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *plugins.DataQueryResult,
 	response cloudMonitoringResponse, executedQueryString string) error {
 	labels := make(map[string]map[string]bool)
@@ -264,6 +266,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *pl
 	return nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseToAnnotations(queryRes *plugins.DataQueryResult,
 	data cloudMonitoringResponse, title string, text string, tags string) error {
 	annotations := make([]map[string]string, 0)

--- a/pkg/tsdb/cloudmonitoring/types.go
+++ b/pkg/tsdb/cloudmonitoring/types.go
@@ -10,9 +10,12 @@ import (
 
 type (
 	cloudMonitoringQueryExecutor interface {
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		run(ctx context.Context, tsdbQuery plugins.DataQuery, e *Executor) (
 			plugins.DataQueryResult, cloudMonitoringResponse, string, error)
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		parseResponse(queryRes *plugins.DataQueryResult, data cloudMonitoringResponse, executedQueryString string) error
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		parseToAnnotations(queryRes *plugins.DataQueryResult, data cloudMonitoringResponse, title string, text string, tags string) error
 		buildDeepLink() string
 		getRefID() string

--- a/pkg/tsdb/cloudwatch/live.go
+++ b/pkg/tsdb/cloudwatch/live.go
@@ -108,6 +108,7 @@ func (r *logQueryRunner) publishResults(channelName string) error {
 
 // executeLiveLogQuery executes a CloudWatch Logs query with live updates over WebSocket.
 // A WebSocket channel is created, which goroutines send responses over.
+//nolint: staticcheck // plugins.DataResponse deprecated
 func (e *cloudWatchExecutor) executeLiveLogQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	responseChannelName := uuid.New().String()
 	responseChannel := make(chan plugins.DataResponse)
@@ -133,6 +134,7 @@ func (e *cloudWatchExecutor) executeLiveLogQuery(ctx context.Context, req *backe
 	return response, nil
 }
 
+//nolint: staticcheck // plugins.DataResponse deprecated
 func (e *cloudWatchExecutor) sendLiveQueriesToChannel(req *backend.QueryDataRequest, responseChannel chan plugins.DataResponse) {
 	defer close(responseChannel)
 
@@ -210,6 +212,7 @@ func (e *cloudWatchExecutor) fetchConcurrentQueriesQuota(region string, pluginCt
 	return defaultConcurrentQueries
 }
 
+//nolint: staticcheck // plugins.DataResponse deprecated
 func (e *cloudWatchExecutor) startLiveQuery(ctx context.Context, responseChannel chan plugins.DataResponse, query backend.DataQuery, timeRange backend.TimeRange, pluginCtx backend.PluginContext) error {
 	model, err := simplejson.NewJson(query.JSON)
 	if err != nil {

--- a/pkg/tsdb/cloudwatch/logs.go
+++ b/pkg/tsdb/cloudwatch/logs.go
@@ -14,7 +14,8 @@ func init() {
 
 // LogsService provides methods for querying CloudWatch Logs.
 type LogsService struct {
-	channelMu        sync.Mutex
+	channelMu sync.Mutex
+	// nolint:staticcheck // plugins.DataQueryResult deprecated
 	responseChannels map[string]chan plugins.DataResponse
 	queues           map[string](chan bool)
 	queueLock        sync.Mutex
@@ -22,11 +23,13 @@ type LogsService struct {
 
 // Init is called by the DI framework to initialize the instance.
 func (s *LogsService) Init() error {
+	// nolint:staticcheck // plugins.DataQueryResult deprecated
 	s.responseChannels = make(map[string]chan plugins.DataResponse)
 	s.queues = make(map[string](chan bool))
 	return nil
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (s *LogsService) AddResponseChannel(name string, channel chan plugins.DataResponse) error {
 	s.channelMu.Lock()
 	defer s.channelMu.Unlock()
@@ -39,6 +42,7 @@ func (s *LogsService) AddResponseChannel(name string, channel chan plugins.DataR
 	return nil
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (s *LogsService) GetResponseChannel(name string) (chan plugins.DataResponse, error) {
 	s.channelMu.Lock()
 	defer s.channelMu.Unlock()

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -16,6 +16,7 @@ type Executor struct {
 }
 
 // NewExecutor creates a new Executor.
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(*models.DataSource) (plugins.DataPlugin, error) {
 	return &Executor{
 		intervalCalculator: interval.NewCalculator(),
@@ -23,6 +24,7 @@ func NewExecutor(*models.DataSource) (plugins.DataPlugin, error) {
 }
 
 // Query handles an elasticsearch datasource request
+//nolint: staticcheck // plugins.DataResponse deprecated
 func (e *Executor) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	tsdbQuery plugins.DataQuery) (plugins.DataResponse, error) {
 	if len(tsdbQuery.Queries) == 0 {

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -40,6 +40,7 @@ var newResponseParser = func(responses []*es.SearchResponse, targets []*Query, d
 	}
 }
 
+// nolint:staticcheck // plugins.DataResponse deprecated
 func (rp *responseParser) getTimeSeries() (plugins.DataResponse, error) {
 	result := plugins.DataResponse{
 		Results: make(map[string]plugins.DataQueryResult),
@@ -87,6 +88,7 @@ func (rp *responseParser) getTimeSeries() (plugins.DataResponse, error) {
 	return result, nil
 }
 
+// nolint:staticcheck // plugins.* deprecated
 func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Query,
 	series *plugins.DataTimeSeriesSlice, table *plugins.DataTable, props map[string]string, depth int) error {
 	var err error
@@ -165,6 +167,7 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 	return nil
 }
 
+// nolint:staticcheck // plugins.* deprecated
 func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, series *plugins.DataTimeSeriesSlice,
 	props map[string]string) error {
 	for _, metric := range target.Metrics {
@@ -294,6 +297,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 	return nil
 }
 
+// nolint:staticcheck // plugins.* deprecated
 func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef *BucketAgg, target *Query,
 	table *plugins.DataTable, props map[string]string) error {
 	propKeys := make([]string, 0)
@@ -437,6 +441,7 @@ func (rp *responseParser) nameSeries(seriesList plugins.DataTimeSeriesSlice, tar
 
 var aliasPatternRegex = regexp.MustCompile(`\{\{([\s\S]+?)\}\}`)
 
+// nolint:staticcheck // plugins.* deprecated
 func (rp *responseParser) getSeriesName(series plugins.DataTimeSeries, target *Query, metricTypeCount int) string {
 	metricType := series.Tags["metric"]
 	metricName := rp.getMetricName(metricType)
@@ -569,6 +574,7 @@ func findAgg(target *Query, aggID string) (*BucketAgg, error) {
 	return nil, errors.New("can't found aggDef, aggID:" + aggID)
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func getErrorFromElasticResponse(response *es.SearchResponse) plugins.DataQueryResult {
 	var result plugins.DataQueryResult
 	json := simplejson.NewFromAny(response.Error)

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -26,6 +26,7 @@ var newTimeSeriesQuery = func(client es.Client, dataQuery plugins.DataQuery,
 	}
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (e *timeSeriesQuery) execute() (plugins.DataResponse, error) {
 	tsQueryParser := newTimeSeriesQueryParser()
 	queries, err := tsQueryParser.parse(e.tsdbQuery)
@@ -60,6 +61,7 @@ func (e *timeSeriesQuery) execute() (plugins.DataResponse, error) {
 	return rp.getTimeSeries()
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to string,
 	result plugins.DataResponse) error {
 	minInterval, err := e.client.GetMinInterval(q.Interval)

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -912,6 +912,7 @@ func newDataQuery(body string) (plugins.DataQuery, error) {
 	}, nil
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func executeTsdbQuery(c es.Client, body string, from, to time.Time, minInterval time.Duration) (
 	plugins.DataResponse, error) {
 	json, err := simplejson.NewJson([]byte(body))

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -26,12 +26,14 @@ type GraphiteExecutor struct {
 	HttpClient *http.Client
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(*models.DataSource) (plugins.DataPlugin, error) {
 	return &GraphiteExecutor{}, nil
 }
 
 var glog = log.New("tsdb.graphite")
 
+//nolint: staticcheck // plugins.DataQuery deprecated
 func (e *GraphiteExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource, tsdbQuery plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	// This logic is used when called from Dashboard Alerting.

--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -21,6 +21,7 @@ func init() {
 }
 
 // Query builds flux queries, executes them, and returns the results.
+//nolint: staticcheck // plugins.DataQuery deprecated
 func Query(ctx context.Context, dsInfo *models.DataSource, tsdbQuery plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	glog.Debug("Received a query", "query", tsdbQuery)
@@ -98,6 +99,7 @@ func runnerFromDataSource(dsInfo *models.DataSource) (*runner, error) {
 // backendDataResponseToDataResponse takes the SDK's style response and changes it into a
 // plugins.DataQueryResult. This is a wrapper so less of existing code needs to be changed. This should
 // be able to be removed in the near future https://github.com/grafana/grafana/pull/25472.
+//nolint: staticcheck // plugins.DataQueryResult deprecated
 func backendDataResponseToDataResponse(dr *backend.DataResponse, refID string) plugins.DataQueryResult {
 	qr := plugins.DataQueryResult{
 		RefID: refID,

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -22,6 +22,7 @@ type Executor struct {
 	ResponseParser *ResponseParser
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(*models.DataSource) (plugins.DataPlugin, error) {
 	return &Executor{
 		QueryParser:    &InfluxdbQueryParser{},
@@ -39,6 +40,7 @@ func init() {
 	glog = log.New("tsdb.influxdb")
 }
 
+//nolint: staticcheck // plugins.DataResponse deprecated
 func (e *Executor) DataQuery(ctx context.Context, dsInfo *models.DataSource, tsdbQuery plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	glog.Debug("Received a query request", "numQueries", len(tsdbQuery.Queries))

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -23,6 +23,7 @@ func init() {
 	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$\s*([\@\/\w-]+?)*`)
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (rp *ResponseParser) Parse(buf io.ReadCloser, query *Query) plugins.DataQueryResult {
 	var queryRes plugins.DataQueryResult
 

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -17,12 +17,14 @@ func prepare(text string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(text))
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func decodedFrames(t *testing.T, result plugins.DataQueryResult) data.Frames {
 	decoded, err := result.Dataframes.Decoded()
 	require.NoError(t, err)
 	return decoded
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func assertSeriesName(t *testing.T, result plugins.DataQueryResult, index int, name string) {
 	decoded := decodedFrames(t, result)
 

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -24,6 +24,7 @@ type LokiExecutor struct {
 	intervalCalculator interval.Calculator
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(dsInfo *models.DataSource) (plugins.DataPlugin, error) {
 	return newExecutor(), nil
 }
@@ -40,6 +41,7 @@ var (
 )
 
 // DataQuery executes a Loki query.
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *LokiExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	queryContext plugins.DataQuery) (plugins.DataResponse, error) {
 	result := plugins.DataResponse{
@@ -153,6 +155,7 @@ func (e *LokiExecutor) parseQuery(dsInfo *models.DataSource, queryContext plugin
 	return qs, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func parseResponse(value *loghttp.QueryResponse, query *lokiQuery) (plugins.DataQueryResult, error) {
 	var queryRes plugins.DataQueryResult
 	frames := data.Frames{}

--- a/pkg/tsdb/loki/loki_test.go
+++ b/pkg/tsdb/loki/loki_test.go
@@ -98,6 +98,7 @@ func TestLoki(t *testing.T) {
 
 func TestParseResponse(t *testing.T) {
 	t.Run("value is not of type matrix", func(t *testing.T) {
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		queryRes := plugins.DataQueryResult{}
 
 		value := loghttp.QueryResponse{

--- a/pkg/tsdb/mssql/mssql.go
+++ b/pkg/tsdb/mssql/mssql.go
@@ -21,6 +21,7 @@ import (
 
 var logger = log.New("tsdb.mssql")
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(datasource *models.DataSource) (plugins.DataPlugin, error) {
 	cnnstr, err := generateConnectionString(datasource)
 	if err != nil {

--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -24,6 +24,7 @@ func characterEscape(s string, escapeChar string) string {
 	return strings.ReplaceAll(s, escapeChar, url.QueryEscape(escapeChar))
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(datasource *models.DataSource) (plugins.DataPlugin, error) {
 	logger := log.New("tsdb.mysql")
 

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -24,6 +24,7 @@ import (
 type OpenTsdbExecutor struct {
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func NewExecutor(*models.DataSource) (plugins.DataPlugin, error) {
 	return &OpenTsdbExecutor{}, nil
 }
@@ -32,6 +33,7 @@ var (
 	plog = log.New("tsdb.opentsdb")
 )
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (e *OpenTsdbExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	queryContext plugins.DataQuery) (plugins.DataResponse, error) {
 	var tsdbQuery OpenTsdbQuery
@@ -101,6 +103,7 @@ func (e *OpenTsdbExecutor) createRequest(dsInfo *models.DataSource, data OpenTsd
 	return req, nil
 }
 
+// nolint:staticcheck // plugins.DataQueryResult deprecated
 func (e *OpenTsdbExecutor) parseResponse(query OpenTsdbQuery, res *http.Response) (map[string]plugins.DataQueryResult, error) {
 	queryResults := make(map[string]plugins.DataQueryResult)
 	queryRes := plugins.DataQueryResult{}

--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -37,6 +37,7 @@ func (s *PostgresService) Init() error {
 	return nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (s *PostgresService) NewExecutor(datasource *models.DataSource) (plugins.DataPlugin, error) {
 	s.logger.Debug("Creating Postgres query endpoint")
 

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -40,6 +40,7 @@ func (bat basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	return bat.Transport.RoundTrip(req)
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(dsInfo *models.DataSource) (plugins.DataPlugin, error) {
 	transport, err := dsInfo.GetHttpTransport()
 	if err != nil {
@@ -83,6 +84,7 @@ func (e *PrometheusExecutor) getClient(dsInfo *models.DataSource) (apiv1.API, er
 	return apiv1.NewAPI(client), nil
 }
 
+//nolint: staticcheck // plugins.DataResponse deprecated
 func (e *PrometheusExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	tsdbQuery plugins.DataQuery) (plugins.DataResponse, error) {
 	result := plugins.DataResponse{
@@ -191,6 +193,7 @@ func (e *PrometheusExecutor) parseQuery(dsInfo *models.DataSource, query plugins
 	return qs, nil
 }
 
+//nolint: staticcheck // plugins.DataQueryResult deprecated
 func parseResponse(value model.Value, query *PrometheusQuery) (plugins.DataQueryResult, error) {
 	var queryRes plugins.DataQueryResult
 	frames := data.Frames{}

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -145,6 +145,7 @@ func TestPrometheus(t *testing.T) {
 
 func TestParseResponse(t *testing.T) {
 	t.Run("value is not of type matrix", func(t *testing.T) {
+		//nolint: staticcheck // plugins.DataQueryResult deprecated
 		queryRes := plugins.DataQueryResult{}
 		value := p.Vector{}
 		res, err := parseResponse(value, nil)

--- a/pkg/tsdb/request_test.go
+++ b/pkg/tsdb/request_test.go
@@ -61,13 +61,16 @@ func TestHandleRequest(t *testing.T) {
 	})
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 type resultsFn func(context plugins.DataQuery) plugins.DataQueryResult
 
 type fakeExecutor struct {
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	results   map[string]plugins.DataQueryResult
 	resultsFn map[string]resultsFn
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *fakeExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource, context plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	result := plugins.DataResponse{Results: make(map[string]plugins.DataQueryResult)}
@@ -84,6 +87,7 @@ func (e *fakeExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 }
 
 func (e *fakeExecutor) Return(refID string, series plugins.DataTimeSeriesSlice) {
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	e.results[refID] = plugins.DataQueryResult{
 		RefID: refID, Series: series,
 	}
@@ -107,9 +111,11 @@ func createService() (Service, *fakeExecutor) {
 		BackendPluginManager: fakeBackendPM{},
 	}
 	e := &fakeExecutor{
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		results:   make(map[string]plugins.DataQueryResult),
 		resultsFn: make(map[string]resultsFn),
 	}
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	s.registry["test"] = func(*models.DataSource) (plugins.DataPlugin, error) {
 		return e, nil
 	}

--- a/pkg/tsdb/service.go
+++ b/pkg/tsdb/service.go
@@ -26,6 +26,7 @@ import (
 // NewService returns a new Service.
 func NewService() Service {
 	return Service{
+		//nolint: staticcheck // plugins.DataPlugin deprecated
 		registry: map[string]func(*models.DataSource) (plugins.DataPlugin, error){},
 	}
 }
@@ -47,6 +48,7 @@ type Service struct {
 	AzureMonitorService    *azuremonitor.Service         `inject:""`
 	PluginManager          plugins.Manager               `inject:""`
 
+	//nolint: staticcheck // plugins.DataPlugin deprecated
 	registry map[string]func(*models.DataSource) (plugins.DataPlugin, error)
 }
 
@@ -67,6 +69,7 @@ func (s *Service) Init() error {
 	return nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (s *Service) HandleRequest(ctx context.Context, ds *models.DataSource, query plugins.DataQuery) (
 	plugins.DataResponse, error) {
 	plugin := s.PluginManager.GetDataPlugin(ds.Type)
@@ -90,6 +93,7 @@ func (s *Service) HandleRequest(ctx context.Context, ds *models.DataSource, quer
 
 // RegisterQueryHandler registers a query handler factory.
 // This is only exposed for tests!
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (s *Service) RegisterQueryHandler(name string, factory func(*models.DataSource) (plugins.DataPlugin, error)) {
 	s.registry[name] = factory
 }

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -86,6 +86,7 @@ type DataPluginConfiguration struct {
 }
 
 // NewDataPlugin returns a new plugins.DataPlugin
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewDataPlugin(config DataPluginConfiguration, queryResultTransformer SqlQueryResultTransformer,
 	macroEngine SQLMacroEngine, log log.Logger) (plugins.DataPlugin, error) {
 	plugin := dataPlugin{
@@ -135,6 +136,7 @@ func NewDataPlugin(config DataPluginConfiguration, queryResultTransformer SqlQue
 const rowLimit = 1000000
 
 // Query is the main function for the SqlQueryEndpoint
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *dataPlugin) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	queryContext plugins.DataQuery) (plugins.DataResponse, error) {
 	var timeRange plugins.DataTimeRange
@@ -251,6 +253,7 @@ var Interpolate = func(query plugins.DataSubQuery, timeRange plugins.DataTimeRan
 	return sql, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *dataPlugin) transformToTable(query plugins.DataSubQuery, rows *core.Rows,
 	result *plugins.DataQueryResult, queryContext plugins.DataQuery) error {
 	columnNames, err := rows.Columns()
@@ -341,6 +344,7 @@ func newProcessCfg(query plugins.DataSubQuery, queryContext plugins.DataQuery, r
 	return cfg, nil
 }
 
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func (e *dataPlugin) transformToTimeSeries(query plugins.DataSubQuery, rows *core.Rows,
 	result *plugins.DataQueryResult, queryContext plugins.DataQuery) error {
 	cfg, err := newProcessCfg(query, queryContext, rows)

--- a/pkg/tsdb/tempo/tempo.go
+++ b/pkg/tsdb/tempo/tempo.go
@@ -18,7 +18,8 @@ type tempoExecutor struct {
 	httpClient *http.Client
 }
 
-// NewExecutor returns a tempoExecutor.
+// NewExecutor returns a tempoExecutor.DataQueryResult
+//nolint: staticcheck // plugins.DataPlugin deprecated
 func NewExecutor(dsInfo *models.DataSource) (plugins.DataPlugin, error) {
 	httpClient, err := dsInfo.GetHttpClient()
 	if err != nil {
@@ -34,6 +35,7 @@ var (
 	tlog = log.New("tsdb.tempo")
 )
 
+//nolint: staticcheck // plugins.DataQuery deprecated
 func (e *tempoExecutor) DataQuery(ctx context.Context, dsInfo *models.DataSource,
 	queryContext plugins.DataQuery) (plugins.DataResponse, error) {
 	refID := queryContext.Queries[0].RefID


### PR DESCRIPTION
All new work should use the plugin SDK and not depend on the tsdb structs -- these are now converted to `backend.QueryDataResponse` before getting sent to the browser

This required putting LOTS of `//nolint: staticcheck` all over -- but that is better than having people start new datasources using "old" interfaces (ie tempo!)