### PR TITLE
Azure Monitor: Fix aggregation reset bug

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/datasource.ts
@@ -25,8 +25,8 @@ export default function createMockDatasource() {
     getMetricNamespaces: jest.fn().mockResolvedValueOnce([]),
     getMetricNames: jest.fn().mockResolvedValueOnce([]),
     getMetricMetadata: jest.fn().mockResolvedValueOnce({
-      primaryAggType: 'average',
-      supportedAggTypes: [],
+      primaryAggType: 'Average',
+      supportedAggTypes: ['Average', 'Maximum', 'Minimum'],
       supportedTimeGrains: [],
       dimensions: [],
     }),

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -75,7 +75,9 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
       item.azureMonitor.metricDefinition &&
       item.azureMonitor.metricDefinition !== defaultDropdownValue &&
       item.azureMonitor.metricName &&
-      item.azureMonitor.metricName !== defaultDropdownValue
+      item.azureMonitor.metricName !== defaultDropdownValue &&
+      item.azureMonitor.aggregation &&
+      item.azureMonitor.aggregation !== defaultDropdownValue
     );
   }
 
@@ -123,7 +125,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
   }
 
   buildAzurePortalUrl(metricQuery: AzureMetricQuery, subscriptionId: string, timeRange: TimeRange) {
-    const aggregationType = aggregationTypeMap[metricQuery.aggregation] ?? aggregationTypeMap.Average;
+    const aggregationType = aggregationTypeMap[metricQuery.aggregation ?? 'Todo'] ?? aggregationTypeMap.Average;
 
     const chartDef = this.stringifyAzurePortalUrlParam({
       v2charts: [

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -125,7 +125,8 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
   }
 
   buildAzurePortalUrl(metricQuery: AzureMetricQuery, subscriptionId: string, timeRange: TimeRange) {
-    const aggregationType = aggregationTypeMap[metricQuery.aggregation ?? 'Todo'] ?? aggregationTypeMap.Average;
+    const aggregationType =
+      (metricQuery.aggregation && aggregationTypeMap[metricQuery.aggregation]) ?? aggregationTypeMap.Average;
 
     const chartDef = this.stringifyAzurePortalUrlParam({
       v2charts: [

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -68,7 +68,7 @@ describe('Azure Monitor QueryEditor', () => {
         metricNamespace: undefined,
         resourceName: undefined,
         metricName: undefined,
-        aggregation: 'None',
+        aggregation: undefined,
         timeGrain: '',
         dimensionFilters: [],
       },
@@ -104,11 +104,79 @@ describe('Azure Monitor QueryEditor', () => {
     const metrics = await screen.findByLabelText('Metric');
     await selectEvent.select(metrics, 'Metric B');
 
-    expect(onChange).toHaveBeenCalledWith({
+    expect(onChange).toHaveBeenLastCalledWith({
       ...mockQuery,
       azureMonitor: {
         ...mockQuery.azureMonitor,
         metricName: 'metric-b',
+      },
+    });
+  });
+
+  it('should auto select a default aggregation if none exists once a metric is selected', async () => {
+    const mockDatasource = createMockDatasource();
+    const onChange = jest.fn();
+    const mockQuery = createMockQuery();
+    mockQuery.azureMonitor.aggregation = undefined;
+    mockDatasource.getMetricNames = jest.fn().mockResolvedValue([
+      {
+        value: 'metric-a',
+        text: 'Metric A',
+      },
+      {
+        value: 'metric-b',
+        text: 'Metric B',
+      },
+    ]);
+    render(
+      <MetricsQueryEditor
+        subscriptionId="123"
+        query={createMockQuery()}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onChange={onChange}
+        setError={() => {}}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
+
+    const metrics = await screen.findByLabelText('Metric');
+    await selectEvent.select(metrics, 'Metric B');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...mockQuery,
+      azureMonitor: {
+        ...mockQuery.azureMonitor,
+        metricName: 'metric-b',
+        aggregation: 'Average',
+      },
+    });
+  });
+
+  it('should change the aggregation type when selected', async () => {
+    const mockDatasource = createMockDatasource();
+    const onChange = jest.fn();
+    const mockQuery = createMockQuery();
+    render(
+      <MetricsQueryEditor
+        subscriptionId="123"
+        query={createMockQuery()}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onChange={onChange}
+        setError={() => {}}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
+
+    const aggregation = await screen.findByLabelText('Aggregation');
+    await selectEvent.select(aggregation, 'Maximum');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...mockQuery,
+      azureMonitor: {
+        ...mockQuery.azureMonitor,
+        aggregation: 'Maximum',
       },
     });
   });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/NamespaceField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/NamespaceField.tsx
@@ -45,7 +45,7 @@ const NamespaceField: React.FC<AzureQueryEditorFieldProps> = ({
           resourceName: undefined,
           metricNamespace: undefined,
           metricName: undefined,
-          aggregation: 'None',
+          aggregation: undefined,
           timeGrain: '',
           dimensionFilters: [],
         },

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceGroupsField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceGroupsField.tsx
@@ -47,7 +47,7 @@ const ResourceGroupsField: React.FC<AzureQueryEditorFieldProps> = ({
           resourceName: undefined,
           metricNamespace: undefined,
           metricName: undefined,
-          aggregation: 'None',
+          aggregation: undefined,
           timeGrain: '',
           dimensionFilters: [],
         },

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceNameField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceNameField.tsx
@@ -45,7 +45,7 @@ const ResourceNameField: React.FC<AzureQueryEditorFieldProps> = ({
 
           metricNamespace: undefined,
           metricName: undefined,
-          aggregation: 'None',
+          aggregation: undefined,
           timeGrain: '',
           dimensionFilters: [],
         },

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
@@ -84,7 +84,7 @@ const SubscriptionField: React.FC<SubscriptionFieldProps> = ({
           metricNamespace: undefined,
           resourceName: undefined,
           metricName: undefined,
-          aggregation: 'None',
+          aggregation: undefined,
           timeGrain: '',
           dimensionFilters: [],
         };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
@@ -50,8 +50,8 @@ export function useMetricsMetadata(
           ...query,
           azureMonitor: {
             ...query.azureMonitor,
-            aggregation: metadata.primaryAggType,
-            timeGrain: 'auto',
+            aggregation: query.azureMonitor.aggregation || metadata.primaryAggType,
+            timeGrain: query.azureMonitor.timeGrain || 'auto',
             allowedTimeGrainsMs: convertTimeGrainsToMs(metadata.supportedTimeGrains),
           },
         });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
@@ -50,7 +50,10 @@ export function useMetricsMetadata(
           ...query,
           azureMonitor: {
             ...query.azureMonitor,
-            aggregation: query.azureMonitor.aggregation || metadata.primaryAggType,
+            aggregation:
+              query.azureMonitor.aggregation && metadata.supportedAggTypes.includes(query.azureMonitor.aggregation)
+                ? query.azureMonitor.aggregation
+                : metadata.primaryAggType,
             timeGrain: query.azureMonitor.timeGrain || 'auto',
             allowedTimeGrainsMs: convertTimeGrainsToMs(metadata.supportedTimeGrains),
           },

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types.ts
@@ -63,7 +63,7 @@ export interface AzureMetricQuery {
   timeGrainUnit?: string;
   timeGrain: string;
   allowedTimeGrainsMs: number[];
-  aggregation: string;
+  aggregation: string | undefined;
   dimensionFilters: AzureMetricDimension[];
   alias: string;
   top: string;


### PR DESCRIPTION
**What this PR does / why we need it**:

When using the Azure Monitor datasource plugin, if you select a Metrics query, the plugin tries to auto select a default aggregation and timegrain setting which overrides any selection you make. This PR ensures that when we load the component, we respect what's in the query and only override it if there has not been a selection made yet.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/32718


