### PR TITLE
Call server.Shutdown() as go routine

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -58,7 +58,7 @@ func StartGrafana(t *testing.T, grafDir, cfgPath string, sqlStore *sqlstore.SQLS
 		}
 	}()
 	t.Cleanup(func() {
-		server.Shutdown("test cleanup")
+		go server.Shutdown("test cleanup")
 	})
 
 	// Wait for Grafana to be ready


### PR DESCRIPTION
**What this PR does / why we need it**:
server.Shutdown() blocks trying to write to s.shutdownFinished in some cases when using a test Grafana instance for a series of integration tests. 

See https://github.com/grafana/grafana/blob/master/pkg/server/server.go#L222-L224

**Special notes for your reviewer**:
Ran into this while trying to run integration tests for unified alerting. When we had multiple tests, across more than one file, each creating a new instance of Grafana, we would wind up in a blocking state with the tests never able to exit
