### PR TITLE
Tempo: Search for Traces by querying Loki directly from Tempo

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -92,7 +92,7 @@ export class LokiQueryField extends React.PureComponent<LokiQueryFieldProps, Lok
     ];
   }
 
-  async componentDidUpdate() {
+  async componentDidMount() {
     await this.props.datasource.languageProvider.start();
     this.setState({ labelsLoaded: true });
   }

--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -1,35 +1,127 @@
-import { ExploreQueryFieldProps } from '@grafana/data';
+import { DataQuery, DataSourceApi, ExploreQueryFieldProps } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { LegacyForms } from '@grafana/ui';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { InlineField, InlineFieldRow, InlineLabel, LegacyForms, RadioButtonGroup } from '@grafana/ui';
+import { TraceToLogsOptions } from 'app/core/components/TraceToLogsSettings';
 import React from 'react';
-import { TempoDatasource, TempoQuery } from './datasource';
+import { LokiQueryField } from '../loki/components/LokiQueryField';
+import { TempoDatasource, TempoQuery, TempoQueryType } from './datasource';
 
 type Props = ExploreQueryFieldProps<TempoDatasource, TempoQuery>;
-export class TempoQueryField extends React.PureComponent<Props> {
-  render() {
+
+interface State {
+  linkedDatasource?: DataSourceApi;
+}
+export class TempoQueryField extends React.PureComponent<Props, State> {
+  state = {
+    linkedQueryField: undefined,
+    linkedDatasource: undefined,
+  };
+  linkedQuery: DataQuery;
+  constructor(props: Props) {
+    super(props);
+    this.linkedQuery = { refId: 'linked' };
+  }
+
+  async componentDidMount() {
+    const { datasource } = this.props;
+    // Find query field from linked datasource
+    const tracesToLogsOptions: TraceToLogsOptions = datasource.tracesToLogs || {};
+    const linkedDatasourceUid = tracesToLogsOptions.datasourceUid;
+    if (linkedDatasourceUid) {
+      console.log('Loading linked datasource for Tempo', linkedDatasourceUid);
+
+      const dsSrv = getDataSourceSrv();
+      const linkedDatasource = await dsSrv.get(linkedDatasourceUid);
+      this.setState({
+        linkedDatasource,
+      });
+    }
+  }
+
+  onChangeLinkedQuery = (value: DataQuery) => {
     const { query, onChange } = this.props;
+    this.linkedQuery = value;
+    onChange({
+      ...query,
+      linkedQuery: this.linkedQuery,
+    });
+  };
+
+  onRunLinkedQuery = () => {
+    console.log('running query', this.linkedQuery);
+    this.props.onRunQuery();
+  };
+
+  render() {
+    const { query, onChange, range } = this.props;
+    const { linkedDatasource } = this.state;
+
+    const absoluteTimeRange = { from: range!.from!.valueOf(), to: range!.to!.valueOf() }; // Range here is never optional
 
     return (
-      <LegacyForms.FormField
-        label="Trace ID"
-        labelWidth={4}
-        inputEl={
-          <div className="slate-query-field__wrapper">
-            <div className="slate-query-field" aria-label={selectors.components.QueryField.container}>
-              <input
-                style={{ width: '100%' }}
-                value={query.query || ''}
-                onChange={(e) =>
-                  onChange({
-                    ...query,
-                    query: e.currentTarget.value,
-                  })
-                }
-              />
-            </div>
-          </div>
-        }
-      />
+      <>
+        <InlineFieldRow>
+          <InlineField label="Query type">
+            <RadioButtonGroup<TempoQueryType>
+              options={[
+                { value: 'search', label: 'Search' },
+                { value: undefined, label: 'TraceID' },
+              ]}
+              value={query.queryType}
+              onChange={(v) =>
+                onChange({
+                  ...query,
+                  queryType: v,
+                })
+              }
+              size="md"
+            />
+          </InlineField>
+        </InlineFieldRow>
+        {query.queryType === 'search' && linkedDatasource && (
+          <>
+            <InlineLabel>
+              Tempo uses {((linkedDatasource as unknown) as DataSourceApi).name} to find traces.
+            </InlineLabel>
+
+            <LokiQueryField
+              datasource={linkedDatasource!}
+              onChange={this.onChangeLinkedQuery}
+              onRunQuery={this.onRunLinkedQuery}
+              query={this.linkedQuery as any}
+              history={[]}
+              absoluteRange={absoluteTimeRange}
+            />
+          </>
+        )}
+        {query.queryType === 'search' && !linkedDatasource && (
+          <div>Please set up a Traces-to-logs datasource in the datasource settings.</div>
+        )}
+        {query.queryType !== 'search' && (
+          <LegacyForms.FormField
+            label="Trace ID"
+            labelWidth={4}
+            inputEl={
+              <div className="slate-query-field__wrapper">
+                <div className="slate-query-field" aria-label={selectors.components.QueryField.container}>
+                  <input
+                    style={{ width: '100%' }}
+                    value={query.query || ''}
+                    onChange={(e) =>
+                      onChange({
+                        ...query,
+                        query: e.currentTarget.value,
+                        linkedQuery: undefined,
+                      })
+                    }
+                  />
+                </div>
+              </div>
+            }
+          />
+        )}
+      </>
     );
   }
 }

--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -8,13 +8,12 @@ import { LokiQueryField } from '../loki/components/LokiQueryField';
 import { TempoDatasource, TempoQuery, TempoQueryType } from './datasource';
 
 type Props = ExploreQueryFieldProps<TempoDatasource, TempoQuery>;
-
+const DEFAULT_QUERY_TYPE: TempoQueryType = 'traceId';
 interface State {
   linkedDatasource?: DataSourceApi;
 }
 export class TempoQueryField extends React.PureComponent<Props, State> {
   state = {
-    linkedQueryField: undefined,
     linkedDatasource: undefined,
   };
   linkedQuery: DataQuery;
@@ -29,8 +28,6 @@ export class TempoQueryField extends React.PureComponent<Props, State> {
     const tracesToLogsOptions: TraceToLogsOptions = datasource.tracesToLogs || {};
     const linkedDatasourceUid = tracesToLogsOptions.datasourceUid;
     if (linkedDatasourceUid) {
-      console.log('Loading linked datasource for Tempo', linkedDatasourceUid);
-
       const dsSrv = getDataSourceSrv();
       const linkedDatasource = await dsSrv.get(linkedDatasourceUid);
       this.setState({
@@ -49,7 +46,6 @@ export class TempoQueryField extends React.PureComponent<Props, State> {
   };
 
   onRunLinkedQuery = () => {
-    console.log('running query', this.linkedQuery);
     this.props.onRunQuery();
   };
 
@@ -66,9 +62,9 @@ export class TempoQueryField extends React.PureComponent<Props, State> {
             <RadioButtonGroup<TempoQueryType>
               options={[
                 { value: 'search', label: 'Search' },
-                { value: undefined, label: 'TraceID' },
+                { value: 'traceId', label: 'TraceID' },
               ]}
-              value={query.queryType}
+              value={query.queryType || DEFAULT_QUERY_TYPE}
               onChange={(v) =>
                 onChange({
                   ...query,
@@ -96,7 +92,7 @@ export class TempoQueryField extends React.PureComponent<Props, State> {
           </>
         )}
         {query.queryType === 'search' && !linkedDatasource && (
-          <div>Please set up a Traces-to-logs datasource in the datasource settings.</div>
+          <div className="text-warning">Please set up a Traces-to-logs datasource in the datasource settings.</div>
         )}
         {query.queryType !== 'search' && (
           <LegacyForms.FormField
@@ -112,6 +108,7 @@ export class TempoQueryField extends React.PureComponent<Props, State> {
                       onChange({
                         ...query,
                         query: e.currentTarget.value,
+                        queryType: 'traceId',
                         linkedQuery: undefined,
                       })
                     }

--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -1,0 +1,34 @@
+import { FieldType, MutableDataFrame } from '@grafana/data';
+import { createTableFrame } from './resultTransformer';
+
+describe('transformTraceList()', () => {
+  const lokiDataFrame = new MutableDataFrame({
+    fields: [
+      {
+        name: 'ts',
+        type: FieldType.time,
+        values: ['2020-02-12T15:05:14.265Z', '2020-02-12T15:05:15.265Z', '2020-02-12T15:05:16.265Z'],
+      },
+      {
+        name: 'line',
+        type: FieldType.string,
+        values: [
+          't=2020-02-12T15:04:51+0000 lvl=info msg="Starting Grafana" logger=server',
+          't=2020-02-12T15:04:52+0000 lvl=info msg="Starting Grafana" logger=server traceID=asdfa1234',
+          't=2020-02-12T15:04:53+0000 lvl=info msg="Starting Grafana" logger=server traceID=asdf88',
+        ],
+      },
+    ],
+    meta: {
+      preferredVisualisationType: 'table',
+    },
+  });
+
+  test('extracts traceIDs from log lines', () => {
+    const frame = createTableFrame(lokiDataFrame, 't1', 'tempo', 'traceID=(\\w+)');
+    expect(frame.fields[0].name).toBe('Time');
+    expect(frame.fields[0].values.get(0)).toBe('2020-02-12T15:05:15.265Z');
+    expect(frame.fields[1].name).toBe('traceID');
+    expect(frame.fields[1].values.get(0)).toBe('asdfa1234');
+  });
+});

--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -25,10 +25,13 @@ describe('transformTraceList()', () => {
   });
 
   test('extracts traceIDs from log lines', () => {
-    const frame = createTableFrame(lokiDataFrame, 't1', 'tempo', 'traceID=(\\w+)');
+    const frame = createTableFrame(lokiDataFrame, 't1', 'tempo', ['traceID=(\\w+)', 'traceID=(\\w\\w)']);
     expect(frame.fields[0].name).toBe('Time');
     expect(frame.fields[0].values.get(0)).toBe('2020-02-12T15:05:15.265Z');
     expect(frame.fields[1].name).toBe('traceID');
     expect(frame.fields[1].values.get(0)).toBe('asdfa1234');
+    // Second match in new line
+    expect(frame.fields[0].values.get(1)).toBe('2020-02-12T15:05:15.265Z');
+    expect(frame.fields[1].values.get(1)).toBe('as');
   });
 });

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -1,0 +1,143 @@
+import { DataQueryResponse, ArrayVector, DataFrame, Field, FieldType, MutableDataFrame } from '@grafana/data';
+import { createGraphFrames } from './graphTransform';
+
+export function createTableFrame(
+  logsFrame: DataFrame,
+  datasourceUid: string,
+  datasourceName: string,
+  traceRegex: string
+): DataFrame {
+  const tableFrame = new MutableDataFrame({
+    fields: [
+      {
+        name: 'Time',
+        type: FieldType.time,
+      },
+      {
+        name: 'traceID',
+        type: FieldType.string,
+        config: {
+          displayNameFromDS: 'Trace ID',
+          links: [
+            {
+              title: 'Trace: ${__value.raw}',
+              url: '',
+              internal: {
+                datasourceUid,
+                datasourceName,
+                query: {
+                  query: '${__value.raw}',
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: 'Message',
+        type: FieldType.string,
+      },
+    ],
+    meta: {
+      preferredVisualisationType: 'table',
+    },
+  });
+
+  if (!logsFrame) {
+    return tableFrame;
+  }
+
+  const timeField = logsFrame.fields.find((f) => f.type === FieldType.time);
+
+  // Going through all string fields to look for trace IDs
+  logsFrame.fields.forEach((field) => {
+    if (field.type === FieldType.string) {
+      const values = field.values.toArray();
+      for (let i = 0; i < values.length; i++) {
+        const line = values[i];
+        if (line) {
+          const match = (line as string).match(traceRegex);
+          if (match) {
+            const traceId = match[1];
+            const time = timeField ? timeField.values.get(i) : null;
+            tableFrame.fields[0].values.add(time);
+            tableFrame.fields[1].values.add(traceId);
+            tableFrame.fields[2].values.add(line);
+          }
+        }
+      }
+    }
+  });
+
+  return tableFrame;
+}
+
+export function transformTraceList(
+  response: DataQueryResponse,
+  datasourceId: string,
+  datasourceName: string,
+  traceRegex: string
+): DataQueryResponse {
+  const frame = createTableFrame(response.data[0], datasourceId, datasourceName, traceRegex);
+  response.data[0] = frame;
+  return response;
+}
+
+export function transformTrace(response: DataQueryResponse): DataQueryResponse {
+  // We need to parse some of the fields which contain stringified json.
+  // Seems like we can't just map the values as the frame we got from backend has some default processing
+  // and will stringify the json back when we try to set it. So we create a new field and swap it instead.
+  const frame: DataFrame = response.data[0];
+
+  if (!frame) {
+    return emptyDataQueryResponse;
+  }
+
+  parseJsonFields(frame);
+
+  return {
+    ...response,
+    data: [...response.data, ...createGraphFrames(frame)],
+  };
+}
+
+/**
+ * Change fields which are json string into JS objects. Modifies the frame in place.
+ */
+function parseJsonFields(frame: DataFrame) {
+  for (const fieldName of ['serviceTags', 'logs', 'tags']) {
+    const field = frame.fields.find((f) => f.name === fieldName);
+    if (field) {
+      const fieldIndex = frame.fields.indexOf(field);
+      const values = new ArrayVector();
+      const newField: Field = {
+        ...field,
+        values,
+        type: FieldType.other,
+      };
+
+      for (let i = 0; i < field.values.length; i++) {
+        const value = field.values.get(i);
+        values.set(i, value === '' ? undefined : JSON.parse(value));
+      }
+      frame.fields[fieldIndex] = newField;
+    }
+  }
+}
+
+const emptyDataQueryResponse = {
+  data: [
+    new MutableDataFrame({
+      fields: [
+        {
+          name: 'trace',
+          type: FieldType.trace,
+          values: [],
+        },
+      ],
+      meta: {
+        preferredVisualisationType: 'trace',
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
The Tempo query interface has only a field to enter a trace ID, but users generally don't have it handy. 
This POC allows the Tempo datasource to query a Loki datasource. The connection between Loki and Tempo is twofold: Tempo uses its trace-to-logs config to determine which Loki to query. Loki is using its derived fields config that is linked to this Tempo datasource as a Trace ID extractor. 

![Kapture 2021-05-05 at 22 18 28](https://user-images.githubusercontent.com/859729/117258157-f1a80500-ae4c-11eb-9dc9-0e7a3be3a9b3.gif)

To test this:

- run the TNS demo
- point a grafana with this branch to it
- set up Loki and Tempo datasources
- Configure Loki as the Tempo trace-to-logs datasource
- Add a derived field with a trace id extractor `traceID=(\\w+)` to the Loki datasource
- Run a Search query in the tempo datasource on a streams that will have traces, e.g. `{app="tns/app"}`

Follow-up work

- [ ] Update Tempo cheatsheet
- [ ] Update docs
- [ ] Provide in-app validation and error messages about two-way linkage