### PR TITLE
Revert 33141

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendSeriesIcon.tsx
@@ -8,29 +8,25 @@ interface Props {
   onColorChange: (color: string) => void;
 }
 
-export const VizLegendSeriesIcon = React.memo<Props>(
-  ({ disabled, color, onColorChange }) => {
-    return disabled ? (
-      <SeriesIcon color={color} />
-    ) : (
-      <SeriesColorPicker color={color} onChange={onColorChange} enableNamedColors>
-        {({ ref, showColorPicker, hideColorPicker }) => (
-          <SeriesIcon
-            color={color}
-            className="pointer"
-            ref={ref}
-            onClick={showColorPicker}
-            onMouseLeave={hideColorPicker}
-          />
-        )}
-      </SeriesColorPicker>
-    );
-  },
-  // areEqual -- return true if they are the same.
-  // onColorChange updates frequently, so ignore that
-  (prevProps, nextProps) => {
-    return prevProps.color === nextProps.color && prevProps.disabled === nextProps.disabled;
-  }
-);
+/**
+ * @internal
+ */
+export const VizLegendSeriesIcon: React.FunctionComponent<Props> = ({ disabled, color, onColorChange }) => {
+  return disabled ? (
+    <SeriesIcon color={color} />
+  ) : (
+    <SeriesColorPicker color={color} onChange={onColorChange} enableNamedColors>
+      {({ ref, showColorPicker, hideColorPicker }) => (
+        <SeriesIcon
+          color={color}
+          className="pointer"
+          ref={ref}
+          onClick={showColorPicker}
+          onMouseLeave={hideColorPicker}
+        />
+      )}
+    </SeriesColorPicker>
+  );
+};
 
 VizLegendSeriesIcon.displayName = 'VizLegendSeriesIcon';


### PR DESCRIPTION
@ryantxu I'm reverting #33141 as it breaks the behavior of the series color change via legend.

Primarily, the color change handler needs to invalidate whenever the field config changes, otherwise it keeps a reference to series color change handler with an outdated color picker.

With your change:
![Kapture 2021-04-23 at 12 59 34](https://user-images.githubusercontent.com/2376619/115861983-d3490f00-a433-11eb-8977-d61a854d83f7.gif)

Without:
![Kapture 2021-04-23 at 12 52 57](https://user-images.githubusercontent.com/2376619/115861963-ccba9780-a433-11eb-9f9e-f941e81cd65c.gif)

Let's try approaching it in another way (no idea yet how, but will explore)
