### PR TITLE
InfluxDB: Fix the ordering of results for influxql queries

### DIFF
--- a/public/app/plugins/datasource/influxdb/specs/response_parser.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/response_parser.test.ts
@@ -121,6 +121,39 @@ describe('influxdb response parser', () => {
     });
   });
 
+  describe('SELECT response where ordering matters', () => {
+    const query = 'SELECT "val" from "num"';
+    const response = {
+      results: [
+        {
+          series: [
+            {
+              name: 'num',
+              columns: ['time', 'val'],
+              values: [
+                [1620041231000, 2],
+                [1620041233000, 3],
+                [1620041235000, 4],
+                [1620041238000, 5],
+                [1620041239000, 1],
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    it('should keep the order returned by influxdb, even for numbers', () => {
+      expect(parser.parse(query, response)).toStrictEqual([
+        { text: '2' },
+        { text: '3' },
+        { text: '4' },
+        { text: '5' },
+        { text: '1' },
+      ]);
+    });
+  });
+
   describe('SHOW FIELD response', () => {
     const query = 'SHOW FIELD KEYS FROM "cpu"';
 


### PR DESCRIPTION
explanation:
- currently when we parse the influxdb-response, we go through the items in the response, and we do not want to keep duplicates. we use a javascript object (`{}`) to collect the items and eliminate the duplicates. the problem is, for a javascript-object does not always keep the order of the items as they were inserted (in short, if the key looks like a number, they will be numerically sorted, otherwise insertion order).
- this causes that when one uses an influxql-query as a variable, if the result of the query is list-of-strings-that-does-not-look-like-numbers 😁  , they will be in the right order. but if they look like numbers, they will be sorted.
- this pull-request switches from the javascript-object to a `Set<string>`. `Set`s guarantee the iteration-order to be insertion-order ( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#description )

how to test:
- you need some data that has numbers and is ordered "wrong". this might be hard to find, so a simple way to populate such data in influxdb:
  - `make devenv=influxdb` . this will run a docker-container named "influxdb"
  - `docker exec -it influxdb influx write -b mybucket -o myorg -t mytoken 'nums val=1'`
  - `docker exec -it influxdb influx write -b mybucket -o myorg -t mytoken 'nums val=5'`
  - `docker exec -it influxdb influx write -b mybucket -o myorg -t mytoken 'nums val=2'`
  - `docker exec -it influxdb influx write -b mybucket -o myorg -t mytoken 'nums val=4'`
  - `docker exec -it influxdb influx write -b mybucket -o myorg -t mytoken 'nums val=3'` 
- go to a dashboard, create a variable, data-source `gdev-influxdb-influxql`, use a query like this: `SELECT val FROM nums`
- verify that the displayed returned values are in insertion-order (in this case: 1,5,2,4,3)


fixes https://github.com/grafana/grafana/issues/33224