### PR TITLE
Explore: Adjust time to the selected timezone

### DIFF
--- a/public/app/features/explore/ExploreTimeControls.tsx
+++ b/public/app/features/explore/ExploreTimeControls.tsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 
 // Types
 import { ExploreId } from 'app/types';
-import { TimeRange, TimeZone, RawTimeRange, dateTimeForTimeZone } from '@grafana/data';
+import { TimeRange, TimeZone, RawTimeRange, dateTimeForTimeZone, dateMath } from '@grafana/data';
 
 // State
 
@@ -42,7 +42,13 @@ export class ExploreTimeControls extends Component<Props> {
   onMoveBack = () => this.onMoveTimePicker(-1);
 
   onChangeTimePicker = (timeRange: TimeRange) => {
-    this.props.onChangeTime(timeRange.raw);
+    const adjustedFrom = dateMath.isMathString(timeRange.raw.from) ? timeRange.raw.from : timeRange.from;
+    const adjustedTo = dateMath.isMathString(timeRange.raw.to) ? timeRange.raw.to : timeRange.to;
+
+    this.props.onChangeTime({
+      from: adjustedFrom,
+      to: adjustedTo,
+    });
   };
 
   onZoom = () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Problem**

The timezone is not applied to the selected time in Explore when a relative time is used in from/to fields. It works fine if both `from` and `to` are set to absolute times (see explanation below).

Steps to reproduce:

1. Select a timezone that is different than your local time zone.
2. Set `from` to an absolute time, e.g. "2020-01-01 00:00:00"
3. Set `from` to a relative time, e.g. "now"
4. Click "Apply time range"

Result: Instead of "2020-01-01 00:00:00", `from` time will shifted (depending on the selected timezone).

If you like travelling in time, there's another bug caused by the same root cause, but will become visible only if you're not in UTC timezone:

1. Open Explore but **don't** change the timezone
2. Set `from` to an absolute time, e.g. "2020-01-01 00:00:00"
3. Set `from` to a relative time, e.g. "now"
4. Click "Apply time range"
5. Refresh the page. 

Result: your range will shift by the offset you're from UTC time zone. Here's an example in action (check how date in the date picker moves by 2 hours just after clicking apply button + refreshing the page):

![timezones](https://user-images.githubusercontent.com/745532/115865867-2f626200-a439-11eb-96d5-a15c8085cff1.gif)

**Root cause**

Date picker returns data in `TimeRange` type defined as:

```typescript
export interface TimeRange {
  from: DateTime;
  to: DateTime;
  raw: RawTimeRange;
}
export interface RawTimeRange {
  from: DateTime | string;
  to: DateTime | string;
}
```

Notice that `RawTimeRange` can return data in `DateTime` or `string`. It returns `DateTime` only if both (from and to) are specified as *absolute times* (e.g. "2020-01-01 00:00:00"). If either `from` or `to` is *relative* (e.g. "now-1h") it returns **both** as string.  

The component that is using the time picker should decide what to do with the data but in Explore (and Dashboards) we want to use `DateTime` object for *absolute* times and raw text for *relative* (for example to put them in the URL). This also means that Explore and Dashboards needs to parse *relative* times at some point to get its value.

Explore, however, always reads `RawTimeRange` and does not check which property is *absolute* and which is *relative*. Dashboard does it [here](https://github.com/grafana/grafana/blob/master/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx#L58). 

Since Explore is not doing this, it always attempts to parse both properties (`from` and `to`) to get the correct value. The parser for *relative* times does not handle time zones however (it's not needed for relative times), and it always returns time for current time zone when an *absolute* date as a string is passed there. That's why we should not parse *absolute* times but just just whatever is returned from the date picker.

Not sure how much of it makes sense. I recommend putting breaking points in these files to play with it:
* [ExploreTimeControls.onChangeTimePicker](https://github.com/grafana/grafana/blob/master/public/app/features/explore/ExploreTimeControls.tsx#L44)
* [explore/state/time:updateTime](https://github.com/grafana/grafana/blob/master/public/app/features/explore/state/time.ts#L70)
* [DashNavTimeControls.onChangeTimePicker](https://github.com/grafana/grafana/blob/master/public/app/features/dashboard/components/DashNav/DashNavTimeControls.tsx#L58)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #33167

**Special notes for your reviewer**: -

