### PR TITLE
Permissions: Fix inherited folder permissions can prevent new permissions being added to a dashboard

### DIFF
--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -24,7 +24,7 @@ func (hs *HTTPServer) GetDashboardPermissionList(c *models.ReqContext) response.
 		return dashboardGuardianResponse(err)
 	}
 
-	acl, err := g.GetAcl()
+	acl, err := g.GetAclWithoutDuplicates()
 	if err != nil {
 		return response.Error(500, "Failed to get dashboard permissions", err)
 	}

--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -24,7 +24,7 @@ func (hs *HTTPServer) GetDashboardPermissionList(c *models.ReqContext) response.
 		return dashboardGuardianResponse(err)
 	}
 
-	acl, err := g.GetAclWithoutDuplicates()
+	acl, err := g.GetACLWithoutDuplicates()
 	if err != nil {
 		return response.Error(500, "Failed to get dashboard permissions", err)
 	}

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -22,7 +22,14 @@ type DashboardGuardian interface {
 	CanAdmin() (bool, error)
 	HasPermission(permission models.PermissionType) (bool, error)
 	CheckPermissionBeforeUpdate(permission models.PermissionType, updatePermissions []*models.DashboardAcl) (bool, error)
+
+	// GetAcl returns ACL.
 	GetAcl() ([]*models.DashboardAclInfoDTO, error)
+
+	// GetAclWithoutDuplicates returns ACL and strips any permission
+	// that already has an inherited permission with higher or equal
+	// permission.
+	GetAclWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error)
 	GetHiddenACL(*setting.Cfg) ([]*models.DashboardAcl, error)
 }
 
@@ -202,6 +209,42 @@ func (g *dashboardGuardianImpl) GetAcl() ([]*models.DashboardAclInfoDTO, error) 
 	return g.acl, nil
 }
 
+func (g *dashboardGuardianImpl) GetAclWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error) {
+	acl, err := g.GetAcl()
+	if err != nil {
+		return nil, err
+	}
+
+	nonInherited := []*models.DashboardAclInfoDTO{}
+	inherited := []*models.DashboardAclInfoDTO{}
+	for _, aclItem := range acl {
+		if aclItem.Inherited {
+			inherited = append(inherited, aclItem)
+		} else {
+			nonInherited = append(nonInherited, aclItem)
+		}
+	}
+
+	result := []*models.DashboardAclInfoDTO{}
+	for _, nonInheritedAclItem := range nonInherited {
+		duplicate := false
+		for _, inheritedAclItem := range inherited {
+			if nonInheritedAclItem.IsDuplicateOf(inheritedAclItem) && nonInheritedAclItem.Permission <= inheritedAclItem.Permission {
+				duplicate = true
+				break
+			}
+		}
+
+		if !duplicate {
+			result = append(result, nonInheritedAclItem)
+		}
+	}
+
+	result = append(inherited, result...)
+
+	return result, nil
+}
+
 func (g *dashboardGuardianImpl) getTeams() ([]*models.TeamDTO, error) {
 	if g.teams != nil {
 		return g.teams, nil
@@ -288,6 +331,10 @@ func (g *FakeDashboardGuardian) CheckPermissionBeforeUpdate(permission models.Pe
 
 func (g *FakeDashboardGuardian) GetAcl() ([]*models.DashboardAclInfoDTO, error) {
 	return g.GetAclValue, nil
+}
+
+func (g *FakeDashboardGuardian) GetAclWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error) {
+	return g.GetAcl()
 }
 
 func (g *FakeDashboardGuardian) GetHiddenACL(cfg *setting.Cfg) ([]*models.DashboardAcl, error) {

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -26,10 +26,10 @@ type DashboardGuardian interface {
 	// GetAcl returns ACL.
 	GetAcl() ([]*models.DashboardAclInfoDTO, error)
 
-	// GetAclWithoutDuplicates returns ACL and strips any permission
+	// GetACLWithoutDuplicates returns ACL and strips any permission
 	// that already has an inherited permission with higher or equal
 	// permission.
-	GetAclWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error)
+	GetACLWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error)
 	GetHiddenACL(*setting.Cfg) ([]*models.DashboardAcl, error)
 }
 
@@ -209,7 +209,7 @@ func (g *dashboardGuardianImpl) GetAcl() ([]*models.DashboardAclInfoDTO, error) 
 	return g.acl, nil
 }
 
-func (g *dashboardGuardianImpl) GetAclWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error) {
+func (g *dashboardGuardianImpl) GetACLWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error) {
 	acl, err := g.GetAcl()
 	if err != nil {
 		return nil, err
@@ -333,7 +333,7 @@ func (g *FakeDashboardGuardian) GetAcl() ([]*models.DashboardAclInfoDTO, error) 
 	return g.GetAclValue, nil
 }
 
-func (g *FakeDashboardGuardian) GetAclWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error) {
+func (g *FakeDashboardGuardian) GetACLWithoutDuplicates() ([]*models.DashboardAclInfoDTO, error) {
 	return g.GetAcl()
 }
 

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -728,8 +728,8 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 }
 
 func TestGuardianGetAclWithoutDuplicates(t *testing.T) {
-	Convey("Get hidden ACL tests", t, func() {
-		bus.ClearBusHandlers()
+	t.Run("Get hidden ACL tests", func(t *testing.T) {
+		t.Cleanup(bus.ClearBusHandlers)
 
 		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = []*models.DashboardAclInfoDTO{
@@ -745,7 +745,7 @@ func TestGuardianGetAclWithoutDuplicates(t *testing.T) {
 			return nil
 		})
 
-		Convey("Should get acl without duplicates", func() {
+		t.Run("Should get acl without duplicates", func(t *testing.T) {
 			user := &models.SignedInUser{
 				OrgId:  orgID,
 				UserId: 1,
@@ -753,18 +753,18 @@ func TestGuardianGetAclWithoutDuplicates(t *testing.T) {
 			}
 			g := New(dashboardID, orgID, user)
 
-			acl, err := g.GetAclWithoutDuplicates()
-			So(err, ShouldBeNil)
-			So(acl, ShouldNotBeNil)
-			So(acl, ShouldHaveLength, 6)
-			So(acl, ShouldResemble, []*models.DashboardAclInfoDTO{
+			acl, err := g.GetACLWithoutDuplicates()
+			require.NoError(t, err)
+			require.NotNil(t, acl)
+			require.Len(t, acl, 6)
+			require.ElementsMatch(t, []*models.DashboardAclInfoDTO{
 				{Inherited: true, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_EDIT},
 				{Inherited: true, UserId: 4, UserLogin: "user4", Permission: models.PERMISSION_ADMIN},
 				{Inherited: true, UserId: 6, UserLogin: "user6", Permission: models.PERMISSION_VIEW},
 				{Inherited: false, UserId: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
 				{Inherited: false, UserId: 5, UserLogin: "user5", Permission: models.PERMISSION_EDIT},
 				{Inherited: false, UserId: 6, UserLogin: "user6", Permission: models.PERMISSION_EDIT},
-			})
+			}, acl)
 		})
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In the case permissions has been added on dashboard(s). Later permissions for the parent folder of the dashboard is edited in such a way that dashboard in that folder has a permission that is a duplicate of an inherited one. This PR changes so that duplicate permissions are now filtered out from `/api/dashboards/id/<dashboard id>/permissions`.

Duplicate permission are not filtered out if the permission on dashboard is higher than on the inherited folder.

**Which issue(s) this PR fixes**:
Fixes #33296 

**Special notes for your reviewer**:

