### PR TITLE
Stat/Table: Fixes contrast color, was flipped in theme refactoring

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/__snapshots__/BigValue.test.tsx.snap
+++ b/packages/grafana-ui/src/components/BigValue/__snapshots__/BigValue.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`BigValue Render with basic options should render 1`] = `
     <FormattedDisplayValue
       style={
         Object {
-          "color": "rgb(32, 34, 38)",
+          "color": "rgb(247, 248, 250)",
           "fontSize": 230,
           "fontWeight": 500,
           "lineHeight": 1.2,

--- a/packages/grafana-ui/src/utils/colors.ts
+++ b/packages/grafana-ui/src/utils/colors.ts
@@ -114,7 +114,7 @@ function hslToHex(color: any) {
 
 export function getTextColorForBackground(color: string) {
   const b = tinycolor(color).getBrightness();
-  return b > 180 ? 'rgb(247, 248, 250)' : 'rgb(32, 34, 38)';
+  return b > 180 ? 'rgb(32, 34, 38)' : 'rgb(247, 248, 250)';
 }
 
 export let sortedColors = sortColorsByHue(colors);


### PR DESCRIPTION
When I removed the lightTheme & darkTheme these where flipped
