### PR TITLE
Alerting: Add support for configuring avatar URL for the Discord notifier

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -437,6 +437,14 @@ The following sections detail the supported settings and secure settings for eac
 | sound      |                |
 | okSound    |                |
 
+#### Alert notification `discord`
+
+| Name           | Secure setting |
+| -------------- | -------------- |
+| url            | yes            |
+| avatar_url     |                |
+| message        |                |
+
 #### Alert notification `slack`
 
 | Name           | Secure setting |

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -229,7 +229,7 @@ Setting | Description
 ---------- | -----------
 Webhook URL | Discord webhook URL.
 Message Content | Mention a group using @ or a user using <@ID> when notifying in a channel.
-Avatar URL | Optionally provide a URL to an image to use as the avatar for the bot's message.
+Avatar URL | Optionally, provide a URL to an image to use as the avatar for the bot's message.
 
 Alternatively, you may use the [Slack](#slack) notifier by appending `/slack` to a Discord webhook URL.
 

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -52,7 +52,7 @@ Alert rule evaluation interval | Send reminders every | Reminder sent every (aft
 Name | Type | Supports images | Support alert rule tags
 -----|------|---------------- | -----------------------
 [DingDing](#dingdingdingtalk) | `dingding` | yes, external only | no
-Discord | `discord` | yes | no
+[Discord](#discord) | `discord` | yes | no
 [Email](#email) | `email` | yes | no
 [Google Hangouts Chat](#google-hangouts-chat) | `googlechat` | yes, external only | no
 Hipchat | `hipchat` | yes, external only | no
@@ -219,6 +219,19 @@ In DingTalk PC Client:
 5. In "Add Robot" panel, input a nickname for the robot and select a "message group" which the robot will join in. click "next".
 
 6. There will be a Webhook URL in the panel, looks like this: https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxxx. Copy this URL to the Grafana DingTalk setting page and then click "finish".
+
+### Discord
+
+To set up Discord, you need to create a Discord channel webhook. You can follow
+[Intro to Webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) for a guide to do that.
+
+Setting | Description
+---------- | -----------
+Webhook URL | Discord webhook URL.
+Message Content | Mention a group using @ or a user using <@ID> when notifying in a channel.
+Avatar URL | Optionally provide a URL to an image to use as the avatar for the bot's message.
+
+Alternatively, you may use the [Slack](#slack) notifier by appending `/slack` to a Discord webhook URL.
 
 ### Kafka
 

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -222,8 +222,8 @@ In DingTalk PC Client:
 
 ### Discord
 
-To set up Discord, you need to create a Discord channel webhook. You can follow
-[Intro to Webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) for a guide to do that.
+To set up Discord, you must create a Discord channel webhook. For instructions on how to create the channel, refer to 
+[Intro to Webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) f.
 
 Setting | Description
 ---------- | -----------

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -231,7 +231,7 @@ Webhook URL | Discord webhook URL.
 Message Content | Mention a group using @ or a user using <@ID> when notifying in a channel.
 Avatar URL | Optionally, provide a URL to an image to use as the avatar for the bot's message.
 
-Alternatively, you may use the [Slack](#slack) notifier by appending `/slack` to a Discord webhook URL.
+Alternately, use the [Slack](#slack) notifier by appending `/slack` to a Discord webhook URL.
 
 ### Kafka
 

--- a/pkg/services/alerting/notifiers/discord.go
+++ b/pkg/services/alerting/notifiers/discord.go
@@ -26,6 +26,13 @@ func init() {
 		Heading:     "Discord settings",
 		Options: []alerting.NotifierOption{
 			{
+				Label:        "Avatar URL",
+				Element:      alerting.ElementTypeInput,
+				InputType:    alerting.InputTypeText,
+				Description:  "Provide a URL to an image to use as the avatar for the bot's message",
+				PropertyName: "avatar_url",
+			},
+			{
 				Label:        "Message Content",
 				Description:  "Mention a group using @ or a user using <@ID> when notifying in a channel",
 				Element:      alerting.ElementTypeInput,
@@ -45,6 +52,7 @@ func init() {
 }
 
 func newDiscordNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+	avatar := model.Settings.Get("avatar_url").MustString()
 	content := model.Settings.Get("content").MustString()
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
@@ -54,6 +62,7 @@ func newDiscordNotifier(model *models.AlertNotification) (alerting.Notifier, err
 	return &DiscordNotifier{
 		NotifierBase: NewNotifierBase(model),
 		Content:      content,
+		AvatarURL:    avatar,
 		WebhookURL:   url,
 		log:          log.New("alerting.notifier.discord"),
 	}, nil
@@ -64,6 +73,7 @@ func newDiscordNotifier(model *models.AlertNotification) (alerting.Notifier, err
 type DiscordNotifier struct {
 	NotifierBase
 	Content    string
+	AvatarURL  string
 	WebhookURL string
 	log        log.Logger
 }
@@ -83,6 +93,10 @@ func (dn *DiscordNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	if dn.Content != "" {
 		bodyJSON.Set("content", dn.Content)
+	}
+
+	if dn.AvatarURL != "" {
+		bodyJSON.Set("avatar_url", dn.AvatarURL)
 	}
 
 	fields := make([]map[string]interface{}, 0)

--- a/pkg/services/alerting/notifiers/discord_test.go
+++ b/pkg/services/alerting/notifiers/discord_test.go
@@ -28,6 +28,7 @@ func TestDiscordNotifier(t *testing.T) {
 			Convey("settings should trigger incident", func() {
 				json := `
 				{
+					"avatar_url": "https://grafana.com/img/fav32.png",
 					"content": "@everyone Please check this notification",
 					"url": "https://web.hook/"
 				}`
@@ -45,6 +46,7 @@ func TestDiscordNotifier(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(discordNotifier.Name, ShouldEqual, "discord_testing")
 				So(discordNotifier.Type, ShouldEqual, "discord")
+				So(discordNotifier.AvatarURL, ShouldEqual, "https://grafana.com/img/fav32.png")
 				So(discordNotifier.Content, ShouldEqual, "@everyone Please check this notification")
 				So(discordNotifier.WebhookURL, ShouldEqual, "https://web.hook/")
 			})

--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -688,6 +688,12 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					PropertyName: "url",
 					Required:     true,
 				},
+				{
+					Label:        "Avatar URL",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					PropertyName: "avatar_url",
+				},
 			},
 		},
 		{

--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -26,6 +26,7 @@ type DiscordNotifier struct {
 	log        log.Logger
 	tmpl       *template.Template
 	Content    string
+	AvatarURL  string
 	WebhookURL string
 }
 
@@ -33,6 +34,8 @@ func NewDiscordNotifier(model *NotificationChannelConfig, t *template.Template) 
 	if model.Settings == nil {
 		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
 	}
+
+	avatarURL := model.Settings.Get("avatar_url").MustString()
 
 	discordURL := model.Settings.Get("url").MustString()
 	if discordURL == "" {
@@ -51,6 +54,7 @@ func NewDiscordNotifier(model *NotificationChannelConfig, t *template.Template) 
 			SecureSettings:        model.SecureSettings,
 		}),
 		Content:    content,
+		AvatarURL:  avatarURL,
 		WebhookURL: discordURL,
 		log:        log.New("alerting.notifier.discord"),
 		tmpl:       t,
@@ -68,6 +72,10 @@ func (d DiscordNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	tmpl := notify.TmplText(d.tmpl, data, &tmplErr)
 	if d.Content != "" {
 		bodyJSON.Set("content", tmpl(d.Content))
+	}
+
+	if d.AvatarURL != "" {
+		bodyJSON.Set("avatar_url", tmpl(d.AvatarURL))
 	}
 
 	footer := map[string]interface{}{

--- a/pkg/services/ngalert/notifier/channels/discord_test.go
+++ b/pkg/services/ngalert/notifier/channels/discord_test.go
@@ -64,6 +64,7 @@ func TestDiscordNotifier(t *testing.T) {
 		{
 			name: "Custom config with multiple alerts",
 			settings: `{
+				"avatar_url": "https://grafana.com/assets/img/fav32.png",
 				"url": "http://localhost",
 				"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved"
 			}`,
@@ -81,7 +82,8 @@ func TestDiscordNotifier(t *testing.T) {
 				},
 			},
 			expMsg: map[string]interface{}{
-				"content": "2 alerts are firing, 0 are resolved",
+				"avatar_url": "https://grafana.com/assets/img/fav32.png",
+				"content":    "2 alerts are firing, 0 are resolved",
 				"embeds": []interface{}{map[string]interface{}{
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -1385,6 +1385,22 @@ var expAvailableChannelJsonOutput = `
 		"required": true,
 		"validationRule": "",
 		"secure": false
+	  },
+	  {
+		"label": "Avatar URL",
+		"description": "",
+		"element": "input",
+		"inputType": "text",
+		"placeholder": "",
+		"propertyName": "avatar_url",
+		"selectOptions": null,
+		"showWhen": {
+		  "field": "",
+		  "is": ""
+		},
+		"required": false,
+		"validationRule": "",
+		"secure": false
 	  }
 	]
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Similar to the Slack alert options, this exposes an avatar URL field for Discord alerts.


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

![](https://i.cwlf.uk/B0oLL)

![](https://i.cwlf.uk/ll22G)
