### PR TITLE
Instrumentation: Add success rate metrics for email notifications

### DIFF
--- a/pkg/services/notifications/mailer.go
+++ b/pkg/services/notifications/mailer.go
@@ -61,10 +61,11 @@ func (ns *NotificationService) Send(msg *Message) (int, error) {
 	return ns.dialAndSend(messages...)
 }
 
-func (ns *NotificationService) dialAndSend(messages ...*Message) (num int, err error) {
+func (ns *NotificationService) dialAndSend(messages ...*Message) (int, error) {
+	sentEmailsCount := 0
 	dialer, err := ns.createDialer()
 	if err != nil {
-		return
+		return sentEmailsCount, err
 	}
 
 	for _, msg := range messages {
@@ -89,10 +90,10 @@ func (ns *NotificationService) dialAndSend(messages ...*Message) (num int, err e
 			continue
 		}
 
-		num++
+		sentEmailsCount++
 	}
 
-	return
+	return sentEmailsCount, err
 }
 
 // setFiles attaches files in various forms

--- a/pkg/services/notifications/mailer.go
+++ b/pkg/services/notifications/mailer.go
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	emailsSentTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	emailsSentTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name:      "emails_sent_total",
 		Help:      "Number of emails sent by Grafana",
 		Namespace: "grafana",
@@ -41,8 +41,6 @@ func init() {
 		Help:      "Number of emails Grafana failed to send",
 		Namespace: "grafana",
 	})
-
-	prometheus.MustRegister(emailsSentTotal, emailsSentFailed)
 }
 
 func (ns *NotificationService) Send(msg *Message) (int, error) {


### PR DESCRIPTION
Useful to monitor outgoing emails from Grafana. 

closes https://github.com/grafana/grafana/issues/33237

Signed-off-by: bergquist <carl.bergquist@gmail.com>
