### PR TITLE
PieChart: Cleans up piechart options

### DIFF
--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,13 +1,13 @@
-import { FieldColorModeId, FieldConfigProperty, PanelPlugin } from '@grafana/data';
+import { FieldColorModeId, FieldConfigProperty, PanelPlugin, ReducerID, standardEditorsRegistry } from '@grafana/data';
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions } from './types';
-import { addStandardDataReduceOptions } from '../stat/types';
 import { LegendDisplayMode, PieChartType, PieChartLabels, PieChartLegendValues } from '@grafana/ui';
 import { PieChartPanelChangedHandler } from './migrations';
 
 export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
   .setPanelChangeHandler(PieChartPanelChangedHandler)
   .useFieldConfig({
+    disableStandardOptions: [FieldConfigProperty.Thresholds],
     standardOptions: {
       [FieldConfigProperty.Color]: {
         settings: {
@@ -22,9 +22,17 @@ export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
     },
   })
   .setPanelOptions((builder) => {
-    addStandardDataReduceOptions(builder);
-
     builder
+      .addCustomEditor({
+        id: 'reduceOptions.calcs',
+        path: 'reduceOptions.calcs',
+        name: 'Calculation',
+        description: 'Choose a reducer function / calculation',
+        editor: standardEditorsRegistry.get('stats-picker').editor as any,
+        defaultValue: [ReducerID.lastNotNull],
+        // Hides it when all values mode is on
+        showIf: (currentConfig) => currentConfig.reduceOptions.values === false,
+      })
       .addRadio({
         name: 'Piechart type',
         description: 'How the piechart should be rendered',


### PR DESCRIPTION
Cuts thresholds
Cuts display all values

**What this PR does / why we need it**:
This PR should mainly be seen as a discussion about whether to cut or keep the thresholds and display all values options.

Thresholds: I'm not sure grouping a lot of slices to the same color with thresholds is a very useful feature in the PieChart. The slices are mainly differentiated by the colors and having multiple slices use the same color feels like bad ux.

Display all values: I'm not sure that displaying all values makes as much sense as it does in the other single stat panels. I'm not sure there is a use case for this.

