### PR TITLE
Add HEALTHCHECK to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,9 @@ COPY --from=go-builder /go/src/github.com/grafana/grafana/bin/linux-amd64/grafan
 COPY --from=js-builder /usr/src/app/public ./public
 COPY --from=js-builder /usr/src/app/tools ./tools
 
+HEALTHCHECK  --interval=5m --timeout=3s \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+
 EXPOSE 3000
 
 COPY ./packaging/docker/run.sh /run.sh

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -33,6 +33,10 @@ RUN go run build.go build
 FROM ubuntu:20.04
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl --fail http://localhost:3000/api/health || exit 1
+
 EXPOSE 3000
 
 ARG GF_UID="472"

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -65,6 +65,9 @@ RUN export GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
     chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
+HEALTHCHECK  --interval=5m --timeout=3s \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+
 EXPOSE 3000
 
 COPY ./run.sh /run.sh

--- a/packaging/docker/ubuntu.Dockerfile
+++ b/packaging/docker/ubuntu.Dockerfile
@@ -9,6 +9,9 @@ RUN mkdir /tmp/grafana && tar xzf /tmp/grafana.tar.gz --strip-components=1 -C /t
 
 FROM ${BASE_IMAGE}
 
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl --fail http://localhost:3000/api/health || exit 1
+
 EXPOSE 3000
 
 # Set DEBIAN_FRONTEND=noninteractive in environment at build-time


### PR DESCRIPTION
The command `wget` is included in the current `alpine:3.13` image;

The `--tries=1` is required because a non-HTTP 200 will cause wget to retry indefinitely.

`|| exit 1` because we want to convert any non-zero exit code to a `1` because that is what docker expects.

This change is needed because GKE Healthchecks on Ingress' are derived entirely from the `HEALTHCHECK` in the Docker image.