### PR TITLE
Button: Introduce buttonStyle prop

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -86,6 +86,12 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
 
   whiteBase = '201, 209, 217';
 
+  border = {
+    weak: `rgba(${this.whiteBase}, 0.10)`,
+    medium: `rgba(${this.whiteBase}, 0.15)`,
+    strong: `rgba(${this.whiteBase}, 0.25)`,
+  };
+
   text = {
     primary: `rgb(${this.whiteBase})`,
     secondary: `rgba(${this.whiteBase}, 0.65)`,
@@ -103,8 +109,9 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   secondary = {
     main: `rgba(${this.whiteBase}, 0.1)`,
     shade: `rgba(${this.whiteBase}, 0.15)`,
-    text: `rgba(${this.whiteBase}, 0.13)`,
+    text: this.text.primary,
     contrastText: `rgb(${this.whiteBase})`,
+    border: this.border.strong,
   };
 
   info = this.primary;
@@ -128,12 +135,6 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
     canvas: palette.gray05,
     primary: palette.gray10,
     secondary: palette.gray15,
-  };
-
-  border = {
-    weak: `rgba(${this.whiteBase}, 0.10)`,
-    medium: `rgba(${this.whiteBase}, 0.15)`,
-    strong: `rgba(${this.whiteBase}, 0.20)`,
   };
 
   action = {
@@ -167,10 +168,26 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
     text: palette.blueLightText,
   };
 
+  text = {
+    primary: `rgba(${this.blackBase}, 1)`,
+    secondary: `rgba(${this.blackBase}, 0.75)`,
+    disabled: `rgba(${this.blackBase}, 0.50)`,
+    link: this.primary.text,
+    maxContrast: palette.black,
+  };
+
+  border = {
+    weak: `rgba(${this.blackBase}, 0.12)`,
+    medium: `rgba(${this.blackBase}, 0.30)`,
+    strong: `rgba(${this.blackBase}, 0.40)`,
+  };
+
   secondary = {
     main: `rgba(${this.blackBase}, 0.11)`,
     shade: `rgba(${this.blackBase}, 0.16)`,
     contrastText: `rgba(${this.blackBase},  1)`,
+    text: this.text.primary,
+    border: this.border.strong,
   };
 
   info = {
@@ -194,27 +211,11 @@ class LightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
     text: palette.orangeLightText,
   };
 
-  text = {
-    primary: `rgba(${this.blackBase}, 1)`,
-    secondary: `rgba(${this.blackBase}, 0.75)`,
-    disabled: `rgba(${this.blackBase}, 0.50)`,
-    link: this.primary.text,
-    maxContrast: palette.black,
-  };
-
   background = {
     canvas: palette.gray90,
     primary: palette.white,
     secondary: palette.gray100,
   };
-
-  border = {
-    weak: `rgba(${this.blackBase}, 0.12)`,
-    medium: `rgba(${this.blackBase}, 0.30)`,
-    strong: `rgba(${this.blackBase}, 0.40)`,
-  };
-
-  divider = this.border.weak;
 
   action = {
     hover: `rgba(${this.blackBase}, 0.04)`,

--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import { Button } from './Button';
 
 <Meta title="MDX|Button" component={Button} />
@@ -11,7 +11,7 @@ Used for "call to action", i.e. triggering the main action. There should never b
 
 If there is no primary action, all `Button` components should be secondary.
 
-<Canvas>
+<Preview>
   <div>
     <Button variant="primary" size="sm" style={{ margin: '5px' }}>
       Small
@@ -23,7 +23,7 @@ If there is no primary action, all `Button` components should be secondary.
       Large
     </Button>
   </div>
-</Canvas>
+</Preview>
 
 ## Secondary
 
@@ -32,7 +32,7 @@ The secondary `Button` is the default button style and can trigger various actio
 1. When next to the primary `Button`, the Secondary style can for example be used for "Cancel" or "Abort" actions.
 2. When there is no main important action on a given page, all `Button` components should use the secondary style.
 
-<Canvas>
+<Preview>
   <div>
     <Button variant="secondary" size="sm" style={{ margin: '5px' }}>
       Small
@@ -44,13 +44,13 @@ The secondary `Button` is the default button style and can trigger various actio
       Large
     </Button>
   </div>
-</Canvas>
+</Preview>
 
 ## Destructive
 
 Used for triggering a removing or deleting action. Because of its dominant coloring, it should be used sparingly. If you need multiple Destructive `Button` components in one view, we recommend using a secondary `Button` or Link variant instead and only use the Destructive variant to double confirm.
 
-<Canvas>
+<Preview>
   <div>
     <Button variant="destructive" size="sm" style={{ margin: '5px' }}>
       Small
@@ -62,13 +62,13 @@ Used for triggering a removing or deleting action. Because of its dominant color
       Large
     </Button>
   </div>
-</Canvas>
+</Preview>
 
 ## Link
 
 Used for hyperlinks.
 
-<Canvas>
+<Preview>
   <div>
     <Button href="/" variant="link" size="sm" style={{ margin: '5px' }}>
       Small
@@ -80,6 +80,6 @@ Used for hyperlinks.
       Large
     </Button>
   </div>
-</Canvas>
+</Preview>
 
-<ArgsTable story={PRIMARY_STORY} />
+<Props of={Button} />

--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
 import { Button } from './Button';
 
 <Meta title="MDX|Button" component={Button} />
@@ -11,7 +11,7 @@ Used for "call to action", i.e. triggering the main action. There should never b
 
 If there is no primary action, all `Button` components should be secondary.
 
-<Preview>
+<Canvas>
   <div>
     <Button variant="primary" size="sm" style={{ margin: '5px' }}>
       Small
@@ -23,7 +23,7 @@ If there is no primary action, all `Button` components should be secondary.
       Large
     </Button>
   </div>
-</Preview>
+</Canvas>
 
 ## Secondary
 
@@ -32,7 +32,7 @@ The secondary `Button` is the default button style and can trigger various actio
 1. When next to the primary `Button`, the Secondary style can for example be used for "Cancel" or "Abort" actions.
 2. When there is no main important action on a given page, all `Button` components should use the secondary style.
 
-<Preview>
+<Canvas>
   <div>
     <Button variant="secondary" size="sm" style={{ margin: '5px' }}>
       Small
@@ -44,13 +44,13 @@ The secondary `Button` is the default button style and can trigger various actio
       Large
     </Button>
   </div>
-</Preview>
+</Canvas>
 
 ## Destructive
 
 Used for triggering a removing or deleting action. Because of its dominant coloring, it should be used sparingly. If you need multiple Destructive `Button` components in one view, we recommend using a secondary `Button` or Link variant instead and only use the Destructive variant to double confirm.
 
-<Preview>
+<Canvas>
   <div>
     <Button variant="destructive" size="sm" style={{ margin: '5px' }}>
       Small
@@ -62,13 +62,13 @@ Used for triggering a removing or deleting action. Because of its dominant color
       Large
     </Button>
   </div>
-</Preview>
+</Canvas>
 
 ## Link
 
 Used for hyperlinks.
 
-<Preview>
+<Canvas>
   <div>
     <Button href="/" variant="link" size="sm" style={{ margin: '5px' }}>
       Small
@@ -80,6 +80,6 @@ Used for hyperlinks.
       Large
     </Button>
   </div>
-</Preview>
+</Canvas>
 
-<Props of={Button} />
+<ArgsTable story={PRIMARY_STORY} />

--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import { Button } from './Button';
+import { Button, LinkButton } from './Button';
 
 <Meta title="MDX|Button" component={Button} />
 
@@ -64,22 +64,38 @@ Used for triggering a removing or deleting action. Because of its dominant color
   </div>
 </Preview>
 
-## Link
-
-Used for hyperlinks.
+## Text
 
 <Preview>
   <div>
-    <Button href="/" variant="link" size="sm" style={{ margin: '5px' }}>
+    <Button buttonStyle="text" size="sm" style={{ margin: '5px' }}>
       Small
     </Button>
-    <Button href="/" variant="link" size="md" style={{ margin: '5px' }}>
+    <Button buttonStyle="text" size="md" style={{ margin: '5px' }}>
       Medium
     </Button>
-    <Button href="/" variant="link" size="lg" style={{ margin: '5px' }}>
+    <Button buttonStyle="text" size="lg" style={{ margin: '5px' }}>
       Large
     </Button>
   </div>
 </Preview>
 
 <Props of={Button} />
+
+## Links
+
+To add an anchor that looks like a button use the `<LinkButton>` component and pass a href prop.
+
+<Preview>
+  <div>
+    <LinkButton href="/" size="sm" style={{ margin: '5px' }}>
+      Small
+    </LinkButton>
+    <LinkButton href="/" size="md" style={{ margin: '5px' }}>
+      Medium
+    </LinkButton>
+    <LinkButton href="/" size="lg" style={{ margin: '5px' }}>
+      Large
+    </LinkButton>
+  </div>
+</Preview>

--- a/packages/grafana-ui/src/components/Button/Button.mdx
+++ b/packages/grafana-ui/src/components/Button/Button.mdx
@@ -68,13 +68,13 @@ Used for triggering a removing or deleting action. Because of its dominant color
 
 <Preview>
   <div>
-    <Button buttonStyle="text" size="sm" style={{ margin: '5px' }}>
+    <Button fill="text" size="sm" style={{ margin: '5px' }}>
       Small
     </Button>
-    <Button buttonStyle="text" size="md" style={{ margin: '5px' }}>
+    <Button fill="text" size="md" style={{ margin: '5px' }}>
       Medium
     </Button>
-    <Button buttonStyle="text" size="lg" style={{ margin: '5px' }}>
+    <Button fill="text" size="lg" style={{ margin: '5px' }}>
       Large
     </Button>
   </div>

--- a/packages/grafana-ui/src/components/Button/Button.story.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.story.tsx
@@ -31,18 +31,10 @@ export default {
 
 export const Variants: Story<ButtonProps> = ({ children, ...args }) => {
   const sizes: ComponentSize[] = ['lg', 'md', 'sm'];
-  /**
-   * Contained Buttons
-   * Text Buttons
-   * Outlined Buttons
-   * Sizes
-   *
-   */
   return (
     <VerticalGroup>
       {allButtonStyles.map((buttonStyle) => (
         <VerticalGroup key={buttonStyle}>
-          <h1>{buttonStyle}</h1>
           <HorizontalGroup spacing="lg">
             {allButtonVariants.map((variant) => (
               <VerticalGroup spacing="lg" key={`${buttonStyle}-${variant}`}>
@@ -57,7 +49,7 @@ export const Variants: Story<ButtonProps> = ({ children, ...args }) => {
               </VerticalGroup>
             ))}
           </HorizontalGroup>
-          <div style={{ borderBottom: '1px solid', margin: '20px 0', padding: '20px 0', width: '100%' }} />
+          <div style={{ padding: '20px 0', width: '100%' }} />
         </VerticalGroup>
       ))}
       <HorizontalGroup spacing="lg">

--- a/packages/grafana-ui/src/components/Button/Button.story.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Story } from '@storybook/react';
-import { allButtonVariants, Button, ButtonProps } from './Button';
+import { Story, Meta } from '@storybook/react';
+import { allButtonVariants, allButtonStyles, Button, ButtonProps } from './Button';
 import { iconOptions } from '../../utils/storybook/knobs';
 import mdx from './Button.mdx';
 import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
@@ -12,11 +12,9 @@ export default {
   title: 'Buttons/Button',
   component: Button,
   argTypes: {
-    variant: { control: { type: 'select', options: ['primary', 'secondary', 'destructive', 'link'] } },
-    size: { control: { type: 'select', options: ['sm', 'md', 'lg'] } },
+    variant: { control: 'select' },
+    size: { control: 'select' },
     icon: { control: { type: 'select', options: iconOptions } },
-    css: { control: { disable: true } },
-    className: { control: { disable: true } },
   },
   parameters: {
     docs: {
@@ -25,29 +23,43 @@ export default {
     knobs: {
       disable: true,
     },
+    controls: {
+      exclude: ['css', 'className'],
+    },
   },
-};
+} as Meta;
 
 export const Variants: Story<ButtonProps> = ({ children, ...args }) => {
   const sizes: ComponentSize[] = ['lg', 'md', 'sm'];
-
+  /**
+   * Contained Buttons
+   * Text Buttons
+   * Outlined Buttons
+   * Sizes
+   *
+   */
   return (
     <VerticalGroup>
-      <HorizontalGroup spacing="lg">
-        {allButtonVariants.map((variant) => (
-          <VerticalGroup spacing="lg" key={variant}>
-            {sizes.map((size) => (
-              <Button variant={variant} size={size} key={size}>
-                {variant} {size}
-              </Button>
+      {allButtonStyles.map((buttonStyle) => (
+        <VerticalGroup key={buttonStyle}>
+          <h1>{buttonStyle}</h1>
+          <HorizontalGroup spacing="lg">
+            {allButtonVariants.map((variant) => (
+              <VerticalGroup spacing="lg" key={`${buttonStyle}-${variant}`}>
+                {sizes.map((size) => (
+                  <Button variant={variant} buttonStyle={buttonStyle} size={size} key={size}>
+                    {variant} {size}
+                  </Button>
+                ))}
+                <Button variant={variant} buttonStyle={buttonStyle} disabled>
+                  {variant} disabled
+                </Button>
+              </VerticalGroup>
             ))}
-            <Button variant={variant} disabled>
-              {variant} disabled
-            </Button>
-          </VerticalGroup>
-        ))}
-      </HorizontalGroup>
-      <div />
+          </HorizontalGroup>
+          <div style={{ borderBottom: '1px solid', margin: '20px 0', padding: '20px 0', width: '100%' }} />
+        </VerticalGroup>
+      ))}
       <HorizontalGroup spacing="lg">
         <div>With icon and text</div>
         <Button icon="cloud" size="sm">

--- a/packages/grafana-ui/src/components/Button/Button.story.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
-import { allButtonVariants, allButtonStyles, Button, ButtonProps } from './Button';
+import { allButtonVariants, allButtonFills, Button, ButtonProps } from './Button';
 import { iconOptions } from '../../utils/storybook/knobs';
 import mdx from './Button.mdx';
 import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
@@ -33,17 +33,17 @@ export const Variants: Story<ButtonProps> = ({ children, ...args }) => {
   const sizes: ComponentSize[] = ['lg', 'md', 'sm'];
   return (
     <VerticalGroup>
-      {allButtonStyles.map((buttonStyle) => (
-        <VerticalGroup key={buttonStyle}>
+      {allButtonFills.map((buttonFill) => (
+        <VerticalGroup key={buttonFill}>
           <HorizontalGroup spacing="lg">
             {allButtonVariants.map((variant) => (
-              <VerticalGroup spacing="lg" key={`${buttonStyle}-${variant}`}>
+              <VerticalGroup spacing="lg" key={`${buttonFill}-${variant}`}>
                 {sizes.map((size) => (
-                  <Button variant={variant} buttonStyle={buttonStyle} size={size} key={size}>
+                  <Button variant={variant} fill={buttonFill} size={size} key={size}>
                     {variant} {size}
                   </Button>
                 ))}
-                <Button variant={variant} buttonStyle={buttonStyle} disabled>
+                <Button variant={variant} fill={buttonFill} disabled>
                   {variant} disabled
                 </Button>
               </VerticalGroup>

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -9,7 +9,7 @@ import { getFocusStyles, getMouseFocusStyles } from '../../themes/mixins';
 import { Icon } from '../Icon/Icon';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'link';
-export const allButtonVariants: ButtonVariant[] = ['primary', 'secondary', 'destructive', 'link'];
+export const allButtonVariants: ButtonVariant[] = ['primary', 'secondary', 'destructive'];
 export type ButtonStyle = 'solid' | 'outline' | 'text';
 export const allButtonStyles: ButtonStyle[] = ['solid', 'outline', 'text'];
 

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -107,7 +107,7 @@ export const getButtonStyles = (props: StyleProps) => {
   const { theme, variant, buttonStyle = 'solid', size, iconOnly, fullWidth } = props;
   const { height, padding, fontSize } = getPropertiesForButtonSize(size, theme);
   const variantStyles = getPropertiesForVariant(theme, variant, buttonStyle);
-  const disabledStyles = getPropertiesForDisabled(theme, buttonStyle);
+  const disabledStyles = getPropertiesForDisabled(theme, variant, buttonStyle);
 
   const focusStyle = getFocusStyles(theme);
 
@@ -211,7 +211,7 @@ function getButtonVariantStyles(theme: GrafanaThemeV2, color: ThemeRichColor, st
   };
 }
 
-function getPropertiesForDisabled(theme: GrafanaThemeV2, style: ButtonStyle) {
+function getPropertiesForDisabled(theme: GrafanaThemeV2, variant: ButtonVariant, style: ButtonStyle) {
   const disabledStyles: CSSObject = {
     cursor: 'not-allowed',
     boxShadow: 'none',
@@ -220,18 +220,19 @@ function getPropertiesForDisabled(theme: GrafanaThemeV2, style: ButtonStyle) {
     transition: 'none',
   };
 
+  if (style === 'text' || variant === 'link') {
+    return {
+      ...disabledStyles,
+      background: 'transparent',
+      border: `1px solid transparent`,
+    };
+  }
+
   if (style === 'outline') {
     return {
       ...disabledStyles,
       background: 'transparent',
       border: `1px solid ${theme.colors.action.disabledText}`,
-    };
-  }
-
-  if (style === 'text') {
-    return {
-      ...disabledStyles,
-      background: 'transparent',
     };
   }
 

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -40,6 +40,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       iconOnly: !children,
     });
 
+    deprecatedProp(
+      variant === 'link',
+      `${Button.displayName}: Prop variant="link" is deprecated. Please use buttonStyle="text".`
+    );
+
     return (
       <button className={cx(styles.button, className)} {...otherProps} ref={ref}>
         {icon && <Icon name={icon} size={size} className={styles.icon} />}
@@ -81,6 +86,11 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
     });
 
     const linkButtonStyles = cx(styles.button, { [styles.disabled]: disabled }, className);
+
+    deprecatedProp(
+      variant === 'link',
+      `${LinkButton.displayName}: Prop variant="link" is deprecated. Please use buttonStyle="text".`
+    );
 
     return (
       <a className={linkButtonStyles} {...otherProps} tabIndex={disabled ? -1 : 0} ref={ref}>
@@ -257,5 +267,11 @@ export function getPropertiesForVariant(theme: GrafanaThemeV2, variant: ButtonVa
     case 'primary':
     default:
       return getButtonVariantStyles(theme, theme.colors.primary, buttonStyle);
+  }
+}
+
+function deprecatedProp(test: boolean, message: string) {
+  if (process.env.NODE_ENV === 'development' && test) {
+    console.warn(message);
   }
 }

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -272,6 +272,6 @@ export function getPropertiesForVariant(theme: GrafanaThemeV2, variant: ButtonVa
 
 function deprecatedProp(test: boolean, message: string) {
   if (process.env.NODE_ENV === 'development' && test) {
-    console.warn(message);
+    console.warn(`@grafana/ui ${message}`);
   }
 }

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -161,14 +161,14 @@ function getButtonVariantStyles(theme: GrafanaThemeV2, color: ThemeRichColor, st
     return {
       background: 'transparent',
       color: color.text,
-      border: `1px solid ${color.main}`,
+      border: `1px solid ${color.border}`,
       transition: theme.transitions.create(['background-color', 'border-color', 'color'], {
         duration: theme.transitions.duration.short,
       }),
 
       '&:hover': {
-        background: colorManipulator.alpha(color.shade, theme.colors.action.hoverOpacity),
-        borderColor: color.shade,
+        background: colorManipulator.alpha(color.main, theme.colors.action.hoverOpacity),
+        borderColor: theme.colors.emphasize(color.border, 0.25),
         color: color.text,
       },
     };
@@ -185,12 +185,12 @@ function getButtonVariantStyles(theme: GrafanaThemeV2, color: ThemeRichColor, st
 
       '&:focus': {
         outline: 'none',
-        textDecoration: 'underline',
+        textDecoration: 'none',
       },
 
       '&:hover': {
         background: colorManipulator.alpha(color.shade, theme.colors.action.hoverOpacity),
-        textDecoration: 'underline',
+        textDecoration: 'none',
       },
     };
   }

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -40,7 +40,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       iconOnly: !children,
     });
 
-    deprecatedProp(
+    deprecatedPropWarning(
       variant === 'link',
       `${Button.displayName}: Prop variant="link" is deprecated. Please use buttonStyle="text".`
     );
@@ -87,7 +87,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 
     const linkButtonStyles = cx(styles.button, { [styles.disabled]: disabled }, className);
 
-    deprecatedProp(
+    deprecatedPropWarning(
       variant === 'link',
       `${LinkButton.displayName}: Prop variant="link" is deprecated. Please use buttonStyle="text".`
     );
@@ -270,7 +270,7 @@ export function getPropertiesForVariant(theme: GrafanaThemeV2, variant: ButtonVa
   }
 }
 
-function deprecatedProp(test: boolean, message: string) {
+function deprecatedPropWarning(test: boolean, message: string) {
   if (process.env.NODE_ENV === 'development' && test) {
     console.warn(`@grafana/ui ${message}`);
   }

--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -10,13 +10,13 @@ import { Icon } from '../Icon/Icon';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'link';
 export const allButtonVariants: ButtonVariant[] = ['primary', 'secondary', 'destructive'];
-export type ButtonStyle = 'solid' | 'outline' | 'text';
-export const allButtonStyles: ButtonStyle[] = ['solid', 'outline', 'text'];
+export type ButtonFill = 'solid' | 'outline' | 'text';
+export const allButtonFills: ButtonFill[] = ['solid', 'outline', 'text'];
 
 type CommonProps = {
   size?: ComponentSize;
   variant?: ButtonVariant;
-  buttonStyle?: ButtonStyle;
+  fill?: ButtonFill;
   icon?: IconName;
   className?: string;
   children?: React.ReactNode;
@@ -26,23 +26,20 @@ type CommonProps = {
 export type ButtonProps = CommonProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    { variant = 'primary', size = 'md', buttonStyle = 'solid', icon, fullWidth, children, className, ...otherProps },
-    ref
-  ) => {
+  ({ variant = 'primary', size = 'md', fill = 'solid', icon, fullWidth, children, className, ...otherProps }, ref) => {
     const theme = useTheme2();
     const styles = getButtonStyles({
       theme,
       size,
       variant,
-      buttonStyle,
+      fill,
       fullWidth,
       iconOnly: !children,
     });
 
     deprecatedPropWarning(
       variant === 'link',
-      `${Button.displayName}: Prop variant="link" is deprecated. Please use buttonStyle="text".`
+      `${Button.displayName}: Prop variant="link" is deprecated. Please use fill="text".`
     );
 
     return (
@@ -63,7 +60,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
     {
       variant = 'primary',
       size = 'md',
-      buttonStyle = 'solid',
+      fill = 'solid',
       icon,
       fullWidth,
       children,
@@ -81,7 +78,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       fullWidth,
       size,
       variant,
-      buttonStyle,
+      fill,
       iconOnly: !children,
     });
 
@@ -89,7 +86,7 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 
     deprecatedPropWarning(
       variant === 'link',
-      `${LinkButton.displayName}: Prop variant="link" is deprecated. Please use buttonStyle="text".`
+      `${LinkButton.displayName}: Prop variant="link" is deprecated. Please use fill="text".`
     );
 
     return (
@@ -106,7 +103,7 @@ LinkButton.displayName = 'LinkButton';
 export interface StyleProps {
   size: ComponentSize;
   variant: ButtonVariant;
-  buttonStyle?: ButtonStyle;
+  fill?: ButtonFill;
   iconOnly?: boolean;
   theme: GrafanaThemeV2;
   fullWidth?: boolean;
@@ -114,10 +111,10 @@ export interface StyleProps {
 }
 
 export const getButtonStyles = (props: StyleProps) => {
-  const { theme, variant, buttonStyle = 'solid', size, iconOnly, fullWidth } = props;
+  const { theme, variant, fill = 'solid', size, iconOnly, fullWidth } = props;
   const { height, padding, fontSize } = getPropertiesForButtonSize(size, theme);
-  const variantStyles = getPropertiesForVariant(theme, variant, buttonStyle);
-  const disabledStyles = getPropertiesForDisabled(theme, variant, buttonStyle);
+  const variantStyles = getPropertiesForVariant(theme, variant, fill);
+  const disabledStyles = getPropertiesForDisabled(theme, variant, fill);
 
   const focusStyle = getFocusStyles(theme);
 
@@ -166,8 +163,8 @@ export const getButtonStyles = (props: StyleProps) => {
   };
 };
 
-function getButtonVariantStyles(theme: GrafanaThemeV2, color: ThemeRichColor, style: ButtonStyle): CSSObject {
-  if (style === 'outline') {
+function getButtonVariantStyles(theme: GrafanaThemeV2, color: ThemeRichColor, fill: ButtonFill): CSSObject {
+  if (fill === 'outline') {
     return {
       background: 'transparent',
       color: color.text,
@@ -184,7 +181,7 @@ function getButtonVariantStyles(theme: GrafanaThemeV2, color: ThemeRichColor, st
     };
   }
 
-  if (style === 'text') {
+  if (fill === 'text') {
     return {
       background: 'transparent',
       color: color.text,
@@ -221,7 +218,7 @@ function getButtonVariantStyles(theme: GrafanaThemeV2, color: ThemeRichColor, st
   };
 }
 
-function getPropertiesForDisabled(theme: GrafanaThemeV2, variant: ButtonVariant, style: ButtonStyle) {
+function getPropertiesForDisabled(theme: GrafanaThemeV2, variant: ButtonVariant, fill: ButtonFill) {
   const disabledStyles: CSSObject = {
     cursor: 'not-allowed',
     boxShadow: 'none',
@@ -230,7 +227,7 @@ function getPropertiesForDisabled(theme: GrafanaThemeV2, variant: ButtonVariant,
     transition: 'none',
   };
 
-  if (style === 'text' || variant === 'link') {
+  if (fill === 'text' || variant === 'link') {
     return {
       ...disabledStyles,
       background: 'transparent',
@@ -238,7 +235,7 @@ function getPropertiesForDisabled(theme: GrafanaThemeV2, variant: ButtonVariant,
     };
   }
 
-  if (style === 'outline') {
+  if (fill === 'outline') {
     return {
       ...disabledStyles,
       background: 'transparent',
@@ -253,20 +250,20 @@ function getPropertiesForDisabled(theme: GrafanaThemeV2, variant: ButtonVariant,
   };
 }
 
-export function getPropertiesForVariant(theme: GrafanaThemeV2, variant: ButtonVariant, style: ButtonStyle) {
+export function getPropertiesForVariant(theme: GrafanaThemeV2, variant: ButtonVariant, fill: ButtonFill) {
   const buttonVariant = variant === 'link' ? 'primary' : variant;
-  const buttonStyle = variant === 'link' ? 'text' : style;
+  const buttonFill = variant === 'link' ? 'text' : fill;
 
   switch (buttonVariant) {
     case 'secondary':
-      return getButtonVariantStyles(theme, theme.colors.secondary, buttonStyle);
+      return getButtonVariantStyles(theme, theme.colors.secondary, buttonFill);
 
     case 'destructive':
-      return getButtonVariantStyles(theme, theme.colors.error, buttonStyle);
+      return getButtonVariantStyles(theme, theme.colors.error, buttonFill);
 
     case 'primary':
     default:
-      return getButtonVariantStyles(theme, theme.colors.primary, buttonStyle);
+      return getButtonVariantStyles(theme, theme.colors.primary, buttonFill);
   }
 }
 

--- a/packages/grafana-ui/src/components/Button/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/Button/ToolbarButton.tsx
@@ -105,8 +105,8 @@ function renderIcon(icon: IconName | React.ReactNode) {
 }
 
 const getStyles = (theme: GrafanaThemeV2) => {
-  const primaryVariant = getPropertiesForVariant(theme, 'primary');
-  const destructiveVariant = getPropertiesForVariant(theme, 'destructive');
+  const primaryVariant = getPropertiesForVariant(theme, 'primary', 'solid');
+  const destructiveVariant = getPropertiesForVariant(theme, 'destructive', 'solid');
 
   return {
     button: css`

--- a/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.tsx
+++ b/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.tsx
@@ -143,7 +143,7 @@ class UnThemedConfirmButton extends PureComponent<Props, State> {
       <span className={styles.buttonContainer}>
         {typeof children === 'string' ? (
           <span className={buttonClass}>
-            <Button size={size} variant="link" onClick={onClick}>
+            <Button size={size} buttonStyle="text" onClick={onClick}>
               {children}
             </Button>
           </span>
@@ -153,7 +153,7 @@ class UnThemedConfirmButton extends PureComponent<Props, State> {
           </span>
         )}
         <span className={confirmButtonClass}>
-          <Button size={size} variant="link" onClick={this.onClickCancel}>
+          <Button size={size} buttonStyle="text" onClick={this.onClickCancel}>
             Cancel
           </Button>
           <Button size={size} variant={confirmButtonVariant} onClick={this.onConfirm}>

--- a/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.tsx
+++ b/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.tsx
@@ -143,7 +143,7 @@ class UnThemedConfirmButton extends PureComponent<Props, State> {
       <span className={styles.buttonContainer}>
         {typeof children === 'string' ? (
           <span className={buttonClass}>
-            <Button size={size} buttonStyle="text" onClick={onClick}>
+            <Button size={size} fill="text" onClick={onClick}>
               {children}
             </Button>
           </span>
@@ -153,7 +153,7 @@ class UnThemedConfirmButton extends PureComponent<Props, State> {
           </span>
         )}
         <span className={confirmButtonClass}>
-          <Button size={size} buttonStyle="text" onClick={this.onClickCancel}>
+          <Button size={size} fill="text" onClick={this.onClickCancel}>
             Cancel
           </Button>
           <Button size={size} variant={confirmButtonVariant} onClick={this.onConfirm}>

--- a/packages/grafana-ui/src/components/Table/FilterPopup.tsx
+++ b/packages/grafana-ui/src/components/Table/FilterPopup.tsx
@@ -64,7 +64,7 @@ export const FilterPopup: FC<Props> = ({ column: { preFilteredRows, filterValue,
             </HorizontalGroup>
             {clearFilterVisible && (
               <HorizontalGroup>
-                <Button variant="link" size="sm" onClick={onClearFilter}>
+                <Button buttonStyle="text" size="sm" onClick={onClearFilter}>
                   Clear filter
                 </Button>
               </HorizontalGroup>

--- a/packages/grafana-ui/src/components/Table/FilterPopup.tsx
+++ b/packages/grafana-ui/src/components/Table/FilterPopup.tsx
@@ -64,7 +64,7 @@ export const FilterPopup: FC<Props> = ({ column: { preFilteredRows, filterValue,
             </HorizontalGroup>
             {clearFilterVisible && (
               <HorizontalGroup>
-                <Button buttonStyle="text" size="sm" onClick={onClearFilter}>
+                <Button fill="text" size="sm" onClick={onClearFilter}>
                   Clear filter
                 </Button>
               </HorizontalGroup>

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -53,7 +53,7 @@ export const TagsInput: FC<Props> = ({ placeholder = 'New tag (enter key to add)
           onKeyUp={onKeyboardAdd}
           suffix={
             newTagName.length > 0 && (
-              <Button variant="link" className={styles.addButtonStyle} onClick={onAdd} size="md">
+              <Button buttonStyle="text" className={styles.addButtonStyle} onClick={onAdd} size="md">
                 Add
               </Button>
             )

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -53,7 +53,7 @@ export const TagsInput: FC<Props> = ({ placeholder = 'New tag (enter key to add)
           onKeyUp={onKeyboardAdd}
           suffix={
             newTagName.length > 0 && (
-              <Button buttonStyle="text" className={styles.addButtonStyle} onClick={onAdd} size="md">
+              <Button fill="text" className={styles.addButtonStyle} onClick={onAdd} size="md">
                 Add
               </Button>
             )

--- a/public/app/core/components/FilterInput/FilterInput.tsx
+++ b/public/app/core/components/FilterInput/FilterInput.tsx
@@ -13,7 +13,7 @@ export interface Props {
 export const FilterInput: FC<Props> = ({ value, placeholder, width, onChange, autoFocus }) => {
   const suffix =
     value !== '' ? (
-      <Button icon="times" variant="link" size="sm" onClick={() => onChange('')}>
+      <Button icon="times" buttonStyle="text" size="sm" onClick={() => onChange('')}>
         Clear
       </Button>
     ) : null;

--- a/public/app/core/components/FilterInput/FilterInput.tsx
+++ b/public/app/core/components/FilterInput/FilterInput.tsx
@@ -13,7 +13,7 @@ export interface Props {
 export const FilterInput: FC<Props> = ({ value, placeholder, width, onChange, autoFocus }) => {
   const suffix =
     value !== '' ? (
-      <Button icon="times" buttonStyle="text" size="sm" onClick={() => onChange('')}>
+      <Button icon="times" fill="text" size="sm" onClick={() => onChange('')}>
         Clear
       </Button>
     ) : null;

--- a/public/app/core/components/ForgottenPassword/ChangePassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ChangePassword.tsx
@@ -50,7 +50,7 @@ export const ChangePassword: FC<Props> = ({ onSubmit, onSkip }) => {
                 content="If you skip you will be prompted to change password next time you log in."
                 placement="bottom"
               >
-                <Button variant="link" onClick={onSkip} type="button" aria-label={selectors.pages.Login.skip}>
+                <Button buttonStyle="text" onClick={onSkip} type="button" aria-label={selectors.pages.Login.skip}>
                   Skip
                 </Button>
               </Tooltip>

--- a/public/app/core/components/ForgottenPassword/ChangePassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ChangePassword.tsx
@@ -50,7 +50,7 @@ export const ChangePassword: FC<Props> = ({ onSubmit, onSkip }) => {
                 content="If you skip you will be prompted to change password next time you log in."
                 placement="bottom"
               >
-                <Button buttonStyle="text" onClick={onSkip} type="button" aria-label={selectors.pages.Login.skip}>
+                <Button fill="text" onClick={onSkip} type="button" aria-label={selectors.pages.Login.skip}>
                   Skip
                 </Button>
               </Tooltip>

--- a/public/app/core/components/ForgottenPassword/ForgottenPassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ForgottenPassword.tsx
@@ -55,7 +55,7 @@ export const ForgottenPassword: FC = () => {
           </Field>
           <HorizontalGroup>
             <Button>Send reset email</Button>
-            <LinkButton variant="link" href={loginHref}>
+            <LinkButton buttonStyle="text" href={loginHref}>
               Back to login
             </LinkButton>
           </HorizontalGroup>

--- a/public/app/core/components/ForgottenPassword/ForgottenPassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ForgottenPassword.tsx
@@ -55,7 +55,7 @@ export const ForgottenPassword: FC = () => {
           </Field>
           <HorizontalGroup>
             <Button>Send reset email</Button>
-            <LinkButton buttonStyle="text" href={loginHref}>
+            <LinkButton fill="text" href={loginHref}>
               Back to login
             </LinkButton>
           </HorizontalGroup>

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -50,7 +50,7 @@ export const LoginPage: FC = () => {
                       <HorizontalGroup justify="flex-end">
                         <LinkButton
                           className={forgottenPasswordStyles}
-                          variant="link"
+                          buttonStyle="text"
                           href={`${config.appSubUrl}/user/password/send-reset-email`}
                         >
                           Forgot your password?

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -50,7 +50,7 @@ export const LoginPage: FC = () => {
                       <HorizontalGroup justify="flex-end">
                         <LinkButton
                           className={forgottenPasswordStyles}
-                          buttonStyle="text"
+                          fill="text"
                           href={`${config.appSubUrl}/user/password/send-reset-email`}
                         >
                           Forgot your password?

--- a/public/app/core/components/Signup/SignupPage.tsx
+++ b/public/app/core/components/Signup/SignupPage.tsx
@@ -112,7 +112,7 @@ export const SignupPage: FC<Props> = (props) => {
 
               <HorizontalGroup>
                 <Button type="submit">Submit</Button>
-                <LinkButton variant="link" href={getConfig().appSubUrl + '/login'}>
+                <LinkButton buttonStyle="text" href={getConfig().appSubUrl + '/login'}>
                   Back to login
                 </LinkButton>
               </HorizontalGroup>

--- a/public/app/core/components/Signup/SignupPage.tsx
+++ b/public/app/core/components/Signup/SignupPage.tsx
@@ -112,7 +112,7 @@ export const SignupPage: FC<Props> = (props) => {
 
               <HorizontalGroup>
                 <Button type="submit">Submit</Button>
-                <LinkButton buttonStyle="text" href={getConfig().appSubUrl + '/login'}>
+                <LinkButton fill="text" href={getConfig().appSubUrl + '/login'}>
                   Back to login
                 </LinkButton>
               </HorizontalGroup>

--- a/public/app/core/components/Signup/VerifyEmail.tsx
+++ b/public/app/core/components/Signup/VerifyEmail.tsx
@@ -51,7 +51,7 @@ export const VerifyEmail: FC = () => {
           </Field>
           <HorizontalGroup>
             <Button>Send verification email</Button>
-            <LinkButton variant="link" href={getConfig().appSubUrl + '/login'}>
+            <LinkButton buttonStyle="text" href={getConfig().appSubUrl + '/login'}>
               Back to login
             </LinkButton>
           </HorizontalGroup>

--- a/public/app/core/components/Signup/VerifyEmail.tsx
+++ b/public/app/core/components/Signup/VerifyEmail.tsx
@@ -51,7 +51,7 @@ export const VerifyEmail: FC = () => {
           </Field>
           <HorizontalGroup>
             <Button>Send verification email</Button>
-            <LinkButton buttonStyle="text" href={getConfig().appSubUrl + '/login'}>
+            <LinkButton fill="text" href={getConfig().appSubUrl + '/login'}>
               Back to login
             </LinkButton>
           </HorizontalGroup>

--- a/public/app/features/alerting/components/NotificationChannelOptions.tsx
+++ b/public/app/features/alerting/components/NotificationChannelOptions.tsx
@@ -62,7 +62,7 @@ export const NotificationChannelOptions: FC<Props> = ({
                 suffix={
                   <Button
                     onClick={() => onResetSecureField(option.propertyName)}
-                    variant="link"
+                    buttonStyle="text"
                     type="button"
                     size="sm"
                   >

--- a/public/app/features/alerting/components/NotificationChannelOptions.tsx
+++ b/public/app/features/alerting/components/NotificationChannelOptions.tsx
@@ -60,12 +60,7 @@ export const NotificationChannelOptions: FC<Props> = ({
                 readOnly={true}
                 value="Configured"
                 suffix={
-                  <Button
-                    onClick={() => onResetSecureField(option.propertyName)}
-                    buttonStyle="text"
-                    type="button"
-                    size="sm"
-                  >
+                  <Button onClick={() => onResetSecureField(option.propertyName)} fill="text" type="button" size="sm">
                     Clear
                   </Button>
                 }

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
@@ -63,7 +63,7 @@ export const VisualizationSelectPane: FC<Props> = ({ panel }) => {
 
   const suffix =
     searchQuery !== '' ? (
-      <Button icon="times" variant="link" size="sm" onClick={() => setSearchQuery('')}>
+      <Button icon="times" buttonStyle="text" size="sm" onClick={() => setSearchQuery('')}>
         Clear
       </Button>
     ) : null;

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
@@ -63,7 +63,7 @@ export const VisualizationSelectPane: FC<Props> = ({ panel }) => {
 
   const suffix =
     searchQuery !== '' ? (
-      <Button icon="times" buttonStyle="text" size="sm" onClick={() => setSearchQuery('')}>
+      <Button icon="times" fill="text" size="sm" onClick={() => setSearchQuery('')}>
         Clear
       </Button>
     ) : null;

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -269,7 +269,7 @@ export class ShareSnapshot extends PureComponent<Props, State> {
 
         <div className="pull-right" style={{ padding: '5px' }}>
           Did you make a mistake?{' '}
-          <LinkButton variant="link" target="_blank" onClick={this.deleteSnapshot}>
+          <LinkButton buttonStyle="text" target="_blank" onClick={this.deleteSnapshot}>
             Delete snapshot.
           </LinkButton>
         </div>

--- a/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx
@@ -269,7 +269,7 @@ export class ShareSnapshot extends PureComponent<Props, State> {
 
         <div className="pull-right" style={{ padding: '5px' }}>
           Did you make a mistake?{' '}
-          <LinkButton buttonStyle="text" target="_blank" onClick={this.deleteSnapshot}>
+          <LinkButton fill="text" target="_blank" onClick={this.deleteSnapshot}>
             Delete snapshot.
           </LinkButton>
         </div>

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -39,7 +39,7 @@ const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest }) => {
       >
         Delete
       </Button>
-      <LinkButton variant="link" href={`${config.appSubUrl}/datasources`}>
+      <LinkButton buttonStyle="text" href={`${config.appSubUrl}/datasources`}>
         Back
       </LinkButton>
     </div>

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -39,7 +39,7 @@ const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest }) => {
       >
         Delete
       </Button>
-      <LinkButton buttonStyle="text" href={`${config.appSubUrl}/datasources`}>
+      <LinkButton fill="text" href={`${config.appSubUrl}/datasources`}>
         Back
       </LinkButton>
     </div>

--- a/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
+++ b/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
@@ -21,8 +21,8 @@ exports[`Render should render component 1`] = `
     Delete
   </Button>
   <LinkButton
+    buttonStyle="text"
     href="/datasources"
-    variant="link"
   >
     Back
   </LinkButton>
@@ -52,8 +52,8 @@ exports[`Render should render with buttons enabled 1`] = `
     Delete
   </Button>
   <LinkButton
+    buttonStyle="text"
     href="/datasources"
-    variant="link"
   >
     Back
   </LinkButton>

--- a/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
+++ b/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Render should render component 1`] = `
     Delete
   </Button>
   <LinkButton
-    buttonStyle="text"
+    fill="text"
     href="/datasources"
   >
     Back
@@ -52,7 +52,7 @@ exports[`Render should render with buttons enabled 1`] = `
     Delete
   </Button>
   <LinkButton
-    buttonStyle="text"
+    fill="text"
     href="/datasources"
   >
     Back

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -415,7 +415,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
         {!loading && !hasData && !scanning && (
           <div className={styles.noData}>
             No logs found.
-            <Button size="xs" variant="link" onClick={this.onClickScan}>
+            <Button size="xs" buttonStyle="text" onClick={this.onClickScan}>
               Scan for older logs
             </Button>
           </div>
@@ -424,7 +424,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
         {scanning && (
           <div className={styles.noData}>
             <span>{scanText}</span>
-            <Button size="xs" variant="link" onClick={this.onClickStopScan}>
+            <Button size="xs" buttonStyle="text" onClick={this.onClickStopScan}>
               Stop scan
             </Button>
           </div>

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -415,7 +415,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
         {!loading && !hasData && !scanning && (
           <div className={styles.noData}>
             No logs found.
-            <Button size="xs" buttonStyle="text" onClick={this.onClickScan}>
+            <Button size="xs" fill="text" onClick={this.onClickScan}>
               Scan for older logs
             </Button>
           </div>
@@ -424,7 +424,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
         {scanning && (
           <div className={styles.noData}>
             <span>{scanText}</span>
-            <Button size="xs" buttonStyle="text" onClick={this.onClickStopScan}>
+            <Button size="xs" fill="text" onClick={this.onClickStopScan}>
               Stop scan
             </Button>
           </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a buttonStyle type & prop to Buttons solid (default) | outline | text , and maps old `variant="link"` to ButtonStyle text and a deprecation message and replaces all usage of `variant="link"` in the grafana codebase.

| Before | After |
| --- | --- |
| <img width="928" alt="Screenshot 2021-04-26 at 14 15 49" src="https://user-images.githubusercontent.com/73201/116081118-245a3c80-a69a-11eb-92c1-04024b14b380.png"> | <img width="951" alt="Screenshot 2021-04-26 at 14 15 22" src="https://user-images.githubusercontent.com/73201/116081130-29b78700-a69a-11eb-849a-16bb7f3b6c56.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #32784

**Special notes for your reviewer**:
I noticed that the "link" storybook docs suggest adding a href to the button for links. This doesn't actually work as it always sends back a `<button>` so updated to include notice about using a `<LinkButton>` component.
