### PR TITLE
PieChart: rename Pie chart v2 -> Pie chart

### DIFF
--- a/public/app/plugins/panel/piechart/plugin.json
+++ b/public/app/plugins/panel/piechart/plugin.json
@@ -1,6 +1,6 @@
 {
   "type": "panel",
-  "name": "Pie chart v2",
+  "name": "Pie chart",
   "id": "piechart",
   "state": "beta",
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The core pie chart plugin is currently using the working name Pie chart v2, this changes the name to just Pie chart