### PR TITLE
AccessControl : Permission for provisioning reloading

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -75,12 +75,18 @@ const (
 	ActionLDAPUsersSync  = "ldap.user:sync"
 	ActionLDAPStatusRead = "ldap.status:read"
 
+	// Provisioning actions
+	ActionProvisioningReload = "provisioning:reload"
+
 	// Global Scopes
 	ScopeUsersAll  = "users:*"
 	ScopeUsersSelf = "users:self"
 
 	ScopeOrgAllUsersAll     = "org:*/users:*"
 	ScopeOrgCurrentUsersAll = "org:current/users:*"
+
+	// Services Scopes
+	ScopeServiceAccessControl = "service:access-control"
 )
 
 const RoleGrafanaAdmin = "Grafana Admin"


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to add permissions that allow a user to target the provisioning reload endpoints
We also need a scope describing the access-control service.

**Which issue(s) this PR fixes**:

Relates to https://github.com/grafana/grafana-enterprise/issues/1260

**Special notes for your reviewer**:
Do you think we should as well add this permissions to the predefined roles?
