### PR TITLE
Documentation: Update Grafana Enterprise caching documentation

### DIFF
--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -330,7 +330,6 @@ A list of cookies that are stripped from the outgoing data source and alerting r
 ## [caching]
 
 > **Note:** Available in Grafana Enterprise v7.5 and later versions.
-> **Note:** The Memcached cache backend is unavailable in Grafana Enterprise v7.5.
 
 When query caching is enabled, Grafana temporarily stores the results of data source queries and serves cached responses to similar requests.
 
@@ -338,9 +337,13 @@ When query caching is enabled, Grafana temporarily stores the results of data so
 
 The caching backend to use when storing cached queries. Options: memory
 
+> **Note:** This setting enables the caching feature, and does not enable query caching for any data source. To enable query caching for a data source, visit the data source's configuration page.
+
 ### enabled
 
-Setting 'enabled' to true enables caching datasource queries for all data sources.
+Setting 'enabled' to true enables query caching for data sources with configured caching.
+
+This value is enabled by default.
 
 ### ttl
 
@@ -361,3 +364,9 @@ The full Redis URL of your Redis server. Example: `redis://localhost:6739/0`.
 ### prefix
 
 A string that prefixes all Redis keys. This value must be set if using a shared database in Redis. If `prefix` is empty, then one will not be used.
+
+## [caching.memcached]
+
+### memcached_servers
+
+A space-separated list of memcached servers. Example: `memcached-server-1:11211 memcached-server-2:11212 memcached-server-3:11211`. Or if there's only one server: `memcached-server:11211`

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -330,7 +330,6 @@ A list of cookies that are stripped from the outgoing data source and alerting r
 ## [caching]
 
 > **Note:** Available in Grafana Enterprise v7.5 and later versions.
-> **Note:** The Memcached cache backend is unavailable in Grafana Enterprise v7.5.
 
 When query caching is enabled, Grafana temporarily stores the results of data source queries and serves cached responses to similar requests.
 
@@ -338,9 +337,13 @@ When query caching is enabled, Grafana temporarily stores the results of data so
 
 The caching backend to use when storing cached queries. Options: memory
 
+> **Note:** This setting enables the caching feature, and does not enable query caching for any data source. To enable query caching for a data source, visit the data source's configuration page.
+
 ### enabled
 
-Setting 'enabled' to true enables caching datasource queries for all data sources.
+Setting 'enabled' to true enables query caching for data sources with configured caching.
+
+This value is enabled by default.
 
 ### ttl
 
@@ -361,3 +364,7 @@ The full Redis URL of your Redis server. Example: `redis://localhost:6739/0`.
 ### prefix
 
 A string that prefixes all Redis keys. This value must be set if using a shared database in Redis. If `prefix` is empty, then one will not be used.
+
+## [caching.memcached]
+
+

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -337,7 +337,7 @@ When query caching is enabled, Grafana temporarily stores the results of data so
 
 The caching backend to use when storing cached queries. Options: memory
 
-> **Note:** This setting enables the caching feature, and does not enable query caching for any data source. To enable query caching for a data source, visit the data source's configuration page.
+> **Note:** This setting enables the caching feature, and does not enable query caching for any data source. To enable query caching for a data source, refer to the data source’s configuration page.
 
 ### enabled
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -7,11 +7,9 @@ weight = 110
 
 # Query caching
 
-> **Note:** Query caching is available behind the `caching` feature flag in Grafana Enterprise 7.5+.
-
 When query caching is enabled, Grafana temporarily stores the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself.
 
-Query caching currently works for all backend data sources. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL). The cache can either be in-memory or in Redis.
+Query caching currently works for all backend data sources, and queries sent through the data source proxy. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL). The cache can either be in-memory or in Redis.
 
 ## Query caching benefits
 
@@ -21,7 +19,17 @@ Query caching currently works for all backend data sources. You can enable the c
 
 ## Enable query caching
 
+> **Note:** The query caching feature is enabled by default. To start caching data source queries, visit the data source's configuration page.
+
 To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#caching" >}}).
+
+Once caching is enabled in the Grafana instance, query caching can be enabled per-datasource in the data source settings.
+
+## Disable query caching
+
+To disable query caching for a single data source, visit the data source settings page.
+
+To unilaterally disable query caching for all data sources, edit the `enabled` flag in the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#caching" >}}).
 
 ## Sending a request without cache
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -7,11 +7,13 @@ weight = 110
 
 # Query caching
 
-> **Note:** Query caching is available behind the `caching` feature flag in Grafana Enterprise 7.5+.
-
 When query caching is enabled, Grafana temporarily stores the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself.
 
-Query caching currently works for all backend data sources. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL). The cache can either be in-memory or in Redis.
+Query caching currently works for all backend data sources, and queries sent through the data source proxy. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL).
+
+The following cache backends are available: in-memory, Redis, and Memcached.
+
+> **Note:** Storing cached queries in-memory can increase Grafana's memory footprint. In production environments, a Redis or Memcached backend is highly recommended.
 
 ## Query caching benefits
 
@@ -21,7 +23,17 @@ Query caching currently works for all backend data sources. You can enable the c
 
 ## Enable query caching
 
+> **Note:** The query caching feature is enabled by default. To start caching data source queries, visit the data source's configuration page.
+
 To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#caching" >}}).
+
+Once caching is enabled in the Grafana instance, query caching can be enabled per-datasource in the data source settings.
+
+## Disable query caching
+
+To disable query caching for a single data source, visit the data source settings page.
+
+To unilaterally disable query caching for all data sources, edit the `enabled` flag in the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#caching" >}}).
 
 ## Sending a request without cache
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -9,7 +9,7 @@ weight = 110
 
 When query caching is enabled, Grafana temporarily stores the results of data source queries. When you or another user submit the exact same query again, the results will come back from the cache instead of from the data source (like Splunk or ServiceNow) itself.
 
-Query caching currently works for all backend data sources, and queries sent through the data source proxy. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL).
+Query caching works for all backend data sources, and queries sent through the data source proxy. You can enable the cache globally and configure the cache duration (also called Time to Live, or TTL).
 
 The following cache backends are available: in-memory, Redis, and Memcached.
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -27,7 +27,7 @@ The following cache backends are available: in-memory, Redis, and Memcached.
 
 To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#caching" >}}).
 
-Once caching is enabled in the Grafana instance, query caching can be enabled per-data-source in the data source settings.
+Once caching is enabled in the Grafana instance, query caching can be enabled per data source in the data source settings.
 
 ## Disable query caching
 

--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -27,7 +27,7 @@ The following cache backends are available: in-memory, Redis, and Memcached.
 
 To enable and configure query caching, please refer the the [Query caching section of Enterprise Configuration]({{< relref "./enterprise-configuration.md#caching" >}}).
 
-Once caching is enabled in the Grafana instance, query caching can be enabled per-datasource in the data source settings.
+Once caching is enabled in the Grafana instance, query caching can be enabled per-data-source in the data source settings.
 
 ## Disable query caching
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some things relating to caching in the upcoming 8.0 release has changed.

1. The Memcached backend will be available in 8.0.
2. The `caching` feature toggle is no longer necessary
3. The caching feature is enabled by default, however, in order for queries to be cached in a data source, it must be enabled in that data source.
    * This allows users to unilaterally disable caching rather than having to go to each data source and disable it individually.
