### PR TITLE
Removed type from find annotations example.

### DIFF
--- a/docs/sources/http_api/annotations.md
+++ b/docs/sources/http_api/annotations.md
@@ -53,7 +53,6 @@ Content-Type: application/json
         "timeEnd": 1507266395000,
         "text": "test",
         "metric": "",
-        "type": "event",
         "tags": [
             "tag1",
             "tag2"
@@ -72,7 +71,6 @@ Content-Type: application/json
         "time": 1507265111000,
         "text": "test",
         "metric": "",
-        "type": "event",
         "tags": [
             "tag1",
             "tag2"


### PR DESCRIPTION
PR based on Zendesk ticket 25877.

https://grafana.zendesk.com/agent/tickets/25877

Torlel clarifies that "the documentation is wrong, the type property has not been returned since forever as far as I can tell".

We do have type as an optional parameter for constructing a request, should that be removed as well? Thank you for any clarification @torkelo.

I checked with @zuchka, and this is what he says: "You can make a POST request with type specified as a parameter and it will still make the annotation, but pulling that annotation with GET doesn’t return the type value/field."