### PR TITLE
Library Panels: Reset config rev after saving changes

### DIFF
--- a/public/app/features/library-panels/utils.ts
+++ b/public/app/features/library-panels/utils.ts
@@ -40,7 +40,7 @@ function toPanelSaveModel(panel: PanelModel): any {
 function updatePanelModelWithUpdate(panel: PanelModel, updated: LibraryPanelDTO): void {
   panel.restoreModel({
     ...updated.model,
-    hasChanged: false, // reset dirty flag, since changes have been saved
+    configRev: 0, // reset config rev, since changes have been saved
     libraryPanel: toPanelModelLibraryPanel(updated),
   });
   panel.refresh();


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a small bug where `hasChanged` wasn't changed to `configRev`, which caused an error when adding a new library panel.

**Which issue(s) this PR fixes**:
Relates to #33133
