### PR TITLE
Grafana-UI: Fix options margin when spanning on multiple lines

### DIFF
--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -90,7 +90,7 @@ export const getSelectStyles = stylesFactory((theme: GrafanaThemeV2) => {
       line-height: 1;
       background: ${theme.colors.background.secondary};
       border-radius: ${theme.shape.borderRadius()};
-      margin: ${theme.spacing(0, 1, 0, 0)};
+      margin: ${theme.spacing(0.25, 1, 0.25, 0)};
       padding: ${theme.spacing(0.25, 0, 0.25, 1)};
       color: ${theme.colors.text.primary};
       font-size: ${theme.typography.size.sm};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When a multiselect has items that span on multiple lines there's no vertical spacing between them:

![Screenshot 2021-04-27 at 15 25 01](https://user-images.githubusercontent.com/1170767/116267512-635cc080-a774-11eb-8b9e-5221cca099d2.png)

As discussed offline with @hemdrup, this PR changes the styles of the items to look like:
![Screenshot 2021-04-27 at 15 31 38](https://user-images.githubusercontent.com/1170767/116267889-b46cb480-a774-11eb-9a23-00561bdffdc1.png)
![Screenshot 2021-04-27 at 15 32 02](https://user-images.githubusercontent.com/1170767/116267894-b5054b00-a774-11eb-99f6-bbc0f10469b4.png)
![Screenshot 2021-04-27 at 15 32 11](https://user-images.githubusercontent.com/1170767/116267897-b59de180-a774-11eb-892e-0707a9e708de.png)
