### PR TITLE
Document customQueryParameters for prometheus datasource provisioning

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -153,6 +153,7 @@ Since not all datasources have the same configuration settings we only have the 
 | httpMode                | string  | Influxdb                                                         | HTTP Method. 'GET', 'POST', defaults to GET                                                 |
 | maxSeries               | number  | Influxdb                                                         | Max number of series/tables that Grafana processes                                          |
 | httpMethod              | string  | Prometheus                                                       | HTTP Method. 'GET', 'POST', defaults to GET                                                 |
+| customQueryParameters   | string  | Prometheus                                                       | Query parameters to add, as a url-encoded string.                                                 |
 | esVersion               | number  | Elasticsearch                                                    | Elasticsearch version as a number (2/5/56/60/70)                                            |
 | timeField               | string  | Elasticsearch                                                    | Which field that should be used as timestamp                                                |
 | interval                | string  | Elasticsearch                                                    | Index date time format. nil(No Pattern), 'Hourly', 'Daily', 'Weekly', 'Monthly' or 'Yearly' |

--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -153,7 +153,7 @@ Since not all datasources have the same configuration settings we only have the 
 | httpMode                | string  | Influxdb                                                         | HTTP Method. 'GET', 'POST', defaults to GET                                                 |
 | maxSeries               | number  | Influxdb                                                         | Max number of series/tables that Grafana processes                                          |
 | httpMethod              | string  | Prometheus                                                       | HTTP Method. 'GET', 'POST', defaults to GET                                                 |
-| customQueryParameters   | string  | Prometheus                                                       | Query parameters to add, as a url-encoded string.                                                 |
+| customQueryParameters   | string  | Prometheus                                                       | Query parameters to add, as a URL-encoded string.                                                 |
 | esVersion               | number  | Elasticsearch                                                    | Elasticsearch version as a number (2/5/56/60/70)                                            |
 | timeField               | string  | Elasticsearch                                                    | Which field that should be used as timestamp                                                |
 | interval                | string  | Elasticsearch                                                    | Index date time format. nil(No Pattern), 'Hourly', 'Daily', 'Weekly', 'Monthly' or 'Yearly' |


### PR DESCRIPTION
**What this PR does / why we need it**:

Document customQueryParameters for prometheus datasource provisioning

The customQueryParameters option was added to prometheus datasources in https://github.com/grafana/grafana/pull/19121.  This PR updates the "provisioning" documentation to contain a reference to this in the `jsonData` options for a prometheus datasource.


**Which issue(s) this PR fixes**:

none afaik -- just corrects a gap in the docs



