### PR TITLE
Azure Monitor: Show loading indicators for dropdowns

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/AggregationField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/AggregationField.tsx
@@ -8,6 +8,7 @@ import { AzureQueryEditorFieldProps, AzureMonitorOption } from '../../types';
 
 interface AggregationFieldProps extends AzureQueryEditorFieldProps {
   aggregationOptions: AzureMonitorOption[];
+  isLoading: boolean;
 }
 
 const AggregationField: React.FC<AggregationFieldProps> = ({
@@ -15,6 +16,7 @@ const AggregationField: React.FC<AggregationFieldProps> = ({
   variableOptionGroup,
   onQueryChange,
   aggregationOptions,
+  isLoading,
 }) => {
   const handleChange = useCallback(
     (change: SelectableValue<string>) => {
@@ -46,6 +48,7 @@ const AggregationField: React.FC<AggregationFieldProps> = ({
         onChange={handleChange}
         options={options}
         width={38}
+        isLoading={isLoading}
       />
     </Field>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -103,6 +103,7 @@ const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({
           onQueryChange={onChange}
           setError={setError}
           aggregationOptions={metricsMetadata?.aggOptions ?? []}
+          isLoading={metricsMetadata.isLoading}
         />
         <TimeGrainField
           query={query}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
@@ -1,8 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 import Datasource from '../datasource';
-import { AzureMonitorOption, AzureMonitorQuery } from '../types';
-import { convertTimeGrainsToMs, toOption } from '../utils/common';
+import { AzureMonitorQuery } from '../types';
+import { convertTimeGrainsToMs } from '../utils/common';
 
 export interface MetricMetadata {
   aggOptions: Array<{ label: string; value: string }>;
@@ -91,46 +91,4 @@ export function useMetricsMetadata(
   ]);
 
   return metricMetadata;
-}
-
-export function useMetricDropdownOptions(
-  fetchFn: (...args: string[]) => Promise<Array<{ text: string; value: string }>>,
-  fetchArgs: Array<string | undefined>,
-  setError: (source: string, error: Error | undefined) => void,
-  errorSource: string,
-  afterSuccessfulFetch?: (results: Array<{ text: string; value: string }>) => void
-): [Array<AzureMonitorOption<string>>, boolean] {
-  const [metricOptions, setMetricOptions] = useState<AzureMonitorOption[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const lastFetchedWith = useRef('');
-
-  useEffect(() => {
-    const allArgsTruthy = fetchArgs.every((arg) => !!arg);
-    const argsHaveChanged = fetchArgs.toString() !== lastFetchedWith.current;
-    const shouldFetch = allArgsTruthy && argsHaveChanged;
-    if (!shouldFetch) {
-      return;
-    }
-
-    setIsLoading(true);
-    lastFetchedWith.current = fetchArgs.toString();
-    fetchFn(...(fetchArgs as string[]))
-      .then((results) => {
-        if (afterSuccessfulFetch) {
-          afterSuccessfulFetch(results);
-        }
-        return results;
-      })
-      .then((results) => {
-        setMetricOptions(results.map(toOption));
-        setError(errorSource, undefined);
-        setIsLoading(false);
-      })
-      .catch((err) => {
-        setError(errorSource, err);
-        setIsLoading(false);
-      });
-  }, [fetchFn, fetchArgs, lastFetchedWith, afterSuccessfulFetch, setError, errorSource]);
-
-  return [metricOptions, isLoading];
 }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/metrics.ts
@@ -21,7 +21,7 @@ export function useMetricsMetadata(
     aggOptions: [],
     timeGrains: [],
     dimensions: [],
-    isLoading: true,
+    isLoading: false,
   });
 
   useEffect(() => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds loading indicators for dropdowns

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/31083

**Special notes for your reviewer**:

I haven't added any tests, which feels a bit wrong to me. I wasn't entirely sure if we felt this sort of thing is worth testing as I don't see any tests currently for most of these components.

In looking at this, I also wonder if we should be memozing responses here as well? It seems a bit odd to make these requests more than once per page load. But again wasn't sure how far to pursue this if we have other competing priorities. 
