### PR TITLE
JSON: make the dashboard JSON editor as big as possible

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -27,6 +27,7 @@ export interface SettingsPage {
   title: string;
   icon: IconName;
   render: () => React.ReactNode;
+  fullWidth?: boolean;
 }
 
 export class DashboardSettings extends PureComponent<Props> {
@@ -98,6 +99,7 @@ export class DashboardSettings extends PureComponent<Props> {
       title: 'JSON Model',
       id: 'dashboard_json',
       icon: 'arrow',
+      fullWidth: true,
       render: () => <JsonEditorSettings dashboard={dashboard} />,
     });
 
@@ -170,7 +172,9 @@ export class DashboardSettings extends PureComponent<Props> {
                   )}
                 </div>
               </aside>
-              <div className="dashboard-settings__content">{currentPage.render()}</div>
+              <div className={currentPage.fullWidth ? styles.settingsContentFullWidth : styles.settingsContent}>
+                {currentPage.render()}
+              </div>
             </div>
           </div>
         </CustomScrollbar>
@@ -189,5 +193,20 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => ({
     display: flex;
     min-height: 100%;
     width: 100%;
+  `,
+  settingsContent: css`
+    flex-grow: 1;
+    min-width: 0;
+    height: 100%;
+    padding: 32px;
+    max-width: 1100px;
+  `,
+  settingsContentFullWidth: css`
+    flex-grow: 1;
+    height: 100%;
+    padding: 32px;
+    min-width: 600px;
+    width: 100%;
+    height: 100%;
   `,
 }));

--- a/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/css';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { Button, CodeEditor, HorizontalGroup, stylesFactory } from '@grafana/ui';
+import { Button, CodeEditor, HorizontalGroup, useStyles2 } from '@grafana/ui';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { getDashboardSrv } from '../../services/DashboardSrv';
 import { DashboardModel } from '../../state/DashboardModel';
-import { GrafanaTheme } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { GrafanaThemeV2 } from '@grafana/data';
 
 interface Props {
   dashboard: DashboardModel;
@@ -24,7 +23,7 @@ export const JsonEditorSettings: React.FC<Props> = ({ dashboard }) => {
         dashboardWatcher.reloadPage();
       });
   };
-const styles = useStyles2(getStyles);
+  const styles = useStyles2(getStyles);
 
   return (
     <>
@@ -63,4 +62,4 @@ const getStyles = (theme: GrafanaThemeV2) => ({
     height: calc(100vh - 250px);
     margin-bottom: 10px;
   `,
-}));
+});

--- a/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
@@ -24,7 +24,7 @@ export const JsonEditorSettings: React.FC<Props> = ({ dashboard }) => {
         dashboardWatcher.reloadPage();
       });
   };
-  const styles = getStyles(config.theme);
+const styles = useStyles2(getStyles);
 
   return (
     <>

--- a/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
@@ -58,7 +58,7 @@ export const JsonEditorSettings: React.FC<Props> = ({ dashboard }) => {
   );
 };
 
-const getStyles = stylesFactory((theme: GrafanaTheme) => ({
+const getStyles = (theme: GrafanaThemeV2) => ({
   editWrapper: css`
     height: calc(100vh - 250px);
     margin-bottom: 10px;

--- a/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
+import { css } from '@emotion/css';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { Button, CodeEditor } from '@grafana/ui';
+import { Button, CodeEditor, HorizontalGroup, stylesFactory } from '@grafana/ui';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { getDashboardSrv } from '../../services/DashboardSrv';
 import { DashboardModel } from '../../state/DashboardModel';
+import { GrafanaTheme } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 interface Props {
   dashboard: DashboardModel;
@@ -21,6 +24,7 @@ export const JsonEditorSettings: React.FC<Props> = ({ dashboard }) => {
         dashboardWatcher.reloadPage();
       });
   };
+  const styles = getStyles(config.theme);
 
   return (
     <>
@@ -30,25 +34,33 @@ export const JsonEditorSettings: React.FC<Props> = ({ dashboard }) => {
         settings, layout, queries, and so on.
       </div>
 
-      <div>
-        <AutoSizer disableHeight>
-          {({ width }) => (
+      <div className={styles.editWrapper}>
+        <AutoSizer>
+          {({ width, height }) => (
             <CodeEditor
               value={dashboardJson}
               language="json"
               width={width}
-              height="500px"
-              showMiniMap={false}
+              height={height}
+              showMiniMap={true}
+              showLineNumbers={true}
               onBlur={onBlur}
             />
           )}
         </AutoSizer>
       </div>
       {dashboard.meta.canSave && (
-        <Button className="m-t-3" onClick={onClick}>
-          Save changes
-        </Button>
+        <HorizontalGroup>
+          <Button onClick={onClick}>Save changes</Button>
+        </HorizontalGroup>
       )}
     </>
   );
 };
+
+const getStyles = stylesFactory((theme: GrafanaTheme) => ({
+  editWrapper: css`
+    height: calc(100vh - 250px);
+    margin-bottom: 10px;
+  `,
+}));

--- a/public/sass/components/_dashboard_settings.scss
+++ b/public/sass/components/_dashboard_settings.scss
@@ -20,14 +20,6 @@
   background: $panel-bg;
 }
 
-.dashboard-settings__content {
-  flex-grow: 1;
-  min-width: 0;
-  height: 100%;
-  padding: 32px;
-  max-width: 1100px;
-}
-
 .dashboard-settings__aside {
   padding: 32px 0 0 32px;
   background: $dashboard-bg;


### PR DESCRIPTION
The dashboards-as-code project will use the JSON config pages extensively,  We should make sure they are as big as possible.

Before:
![image](https://user-images.githubusercontent.com/705951/116352476-14318280-a7aa-11eb-9133-555cac3f64ff.png)

After:
![image](https://user-images.githubusercontent.com/705951/116352398-ef3d0f80-a7a9-11eb-92a8-f4995960688d.png)

