### PR TITLE
IconButton: Introduce variant for red and blue icon buttons

### DIFF
--- a/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/css';
-import { IconButton } from '@grafana/ui';
+import { IconButton, IconButtonVariant } from './IconButton';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { useTheme2 } from '../../themes';
 import { IconSize, IconName } from '../../types';
@@ -35,6 +35,7 @@ const RenderScenario = ({ background }: ScenarioProps) => {
   const theme = useTheme2();
   const sizes: IconSize[] = ['sm', 'md', 'lg', 'xl', 'xxl'];
   const icons: IconName[] = ['search', 'trash-alt', 'arrow-left', 'times'];
+  const variants: IconButtonVariant[] = ['primary', 'destructive'];
 
   return (
     <div
@@ -49,6 +50,15 @@ const RenderScenario = ({ background }: ScenarioProps) => {
       `}
     >
       <div>{background}</div>
+      {variants.map((variant) => {
+        return icons.map((icon) => {
+          return sizes.map((size) => (
+            <span key={icon + size}>
+              <IconButton name={icon} size={size} variant={variant} />
+            </span>
+          ));
+        });
+      })}
       {icons.map((icon) => {
         return sizes.map((size) => (
           <span key={icon + size}>

--- a/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
@@ -36,7 +36,7 @@ const RenderScenario = ({ background }: ScenarioProps) => {
   const theme = useTheme2();
   const sizes: IconSize[] = ['sm', 'md', 'lg', 'xl', 'xxl'];
   const icons: IconName[] = ['search', 'trash-alt', 'arrow-left', 'times'];
-  const variants: IconButtonVariant[] = [undefined, 'primary', 'destructive'];
+  const variants: IconButtonVariant[] = ['secondary', 'primary', 'destructive'];
 
   return (
     <div

--- a/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.story.tsx
@@ -5,6 +5,7 @@ import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { useTheme2 } from '../../themes';
 import { IconSize, IconName } from '../../types';
 import mdx from './IconButton.mdx';
+import { VerticalGroup } from '../Layout/Layout';
 
 export default {
   title: 'Buttons/IconButton',
@@ -35,7 +36,7 @@ const RenderScenario = ({ background }: ScenarioProps) => {
   const theme = useTheme2();
   const sizes: IconSize[] = ['sm', 'md', 'lg', 'xl', 'xxl'];
   const icons: IconName[] = ['search', 'trash-alt', 'arrow-left', 'times'];
-  const variants: IconButtonVariant[] = ['primary', 'destructive'];
+  const variants: IconButtonVariant[] = [undefined, 'primary', 'destructive'];
 
   return (
     <div
@@ -49,23 +50,22 @@ const RenderScenario = ({ background }: ScenarioProps) => {
         }
       `}
     >
-      <div>{background}</div>
-      {variants.map((variant) => {
-        return icons.map((icon) => {
-          return sizes.map((size) => (
-            <span key={icon + size}>
-              <IconButton name={icon} size={size} variant={variant} />
-            </span>
-          ));
-        });
-      })}
-      {icons.map((icon) => {
-        return sizes.map((size) => (
-          <span key={icon + size}>
-            <IconButton name={icon} size={size} />
-          </span>
-        ));
-      })}
+      <VerticalGroup spacing="md">
+        <div>{background}</div>
+        {variants.map((variant) => {
+          return (
+            <div key={variant}>
+              {icons.map((icon) => {
+                return sizes.map((size) => (
+                  <span key={icon + size}>
+                    <IconButton name={icon} size={size} variant={variant} />
+                  </span>
+                ));
+              })}
+            </div>
+          );
+        })}
+      </VerticalGroup>
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/IconButton/IconButton.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.tsx
@@ -9,6 +9,8 @@ import { Tooltip } from '../Tooltip/Tooltip';
 import { TooltipPlacement } from '../Tooltip/PopoverController';
 import { getFocusStyles, getMouseFocusStyles } from '../../themes/mixins';
 
+export type IconButtonVariant = 'primary' | 'destructive' | undefined;
+
 export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Name of the icon **/
   name: IconName;
@@ -22,14 +24,16 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   tooltip?: string;
   /** Position of the tooltip */
   tooltipPlacement?: TooltipPlacement;
+  /** Color of  */
+  variant?: IconButtonVariant;
 }
 
 type SurfaceType = 'dashboard' | 'panel' | 'header';
 
 export const IconButton = React.forwardRef<HTMLButtonElement, Props>(
-  ({ name, size = 'md', iconType, tooltip, tooltipPlacement, className, ...restProps }, ref) => {
+  ({ name, size = 'md', iconType, tooltip, tooltipPlacement, className, variant, ...restProps }, ref) => {
     const theme = useTheme2();
-    const styles = getStyles(theme, size);
+    const styles = getStyles(theme, size, variant);
 
     const button = (
       <button ref={ref} {...restProps} className={cx(styles.button, className)}>
@@ -51,10 +55,17 @@ export const IconButton = React.forwardRef<HTMLButtonElement, Props>(
 
 IconButton.displayName = 'IconButton';
 
-const getStyles = stylesFactory((theme: GrafanaThemeV2, size: IconSize) => {
+const getStyles = stylesFactory((theme: GrafanaThemeV2, size: IconSize, variant: IconButtonVariant) => {
   const hoverColor = theme.colors.action.hover;
   const pixelSize = getSvgSize(size);
   const hoverSize = Math.max(pixelSize / 3, 8);
+  let iconColor = theme.colors.text.primary;
+
+  if (variant === 'primary') {
+    iconColor = theme.colors.primary.main;
+  } else if (variant === 'destructive') {
+    iconColor = theme.colors.error.main;
+  }
 
   return {
     button: css`
@@ -62,6 +73,7 @@ const getStyles = stylesFactory((theme: GrafanaThemeV2, size: IconSize) => {
       height: ${pixelSize}px;
       background: transparent;
       border: none;
+      color: ${iconColor};
       padding: 0;
       margin: 0;
       outline: none;
@@ -77,6 +89,7 @@ const getStyles = stylesFactory((theme: GrafanaThemeV2, size: IconSize) => {
       &[disabled],
       &:disabled {
         cursor: not-allowed;
+        color: ${theme.colors.action.disabledText};
         opacity: 0.65;
         box-shadow: none;
       }
@@ -110,7 +123,7 @@ const getStyles = stylesFactory((theme: GrafanaThemeV2, size: IconSize) => {
       }
 
       &:hover {
-        color: ${theme.colors.text.primary};
+        color: ${iconColor};
 
         &:before {
           background-color: ${hoverColor};

--- a/packages/grafana-ui/src/components/IconButton/IconButton.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.tsx
@@ -4,7 +4,7 @@ import { IconName, IconSize, IconType } from '../../types/icon';
 import { stylesFactory } from '../../themes/stylesFactory';
 import { css, cx } from '@emotion/css';
 import { useTheme2 } from '../../themes/ThemeContext';
-import { GrafanaThemeV2 } from '@grafana/data';
+import { GrafanaThemeV2, colorManipulator } from '@grafana/data';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { TooltipPlacement } from '../Tooltip/PopoverController';
 import { getFocusStyles, getMouseFocusStyles } from '../../themes/mixins';
@@ -56,7 +56,6 @@ export const IconButton = React.forwardRef<HTMLButtonElement, Props>(
 IconButton.displayName = 'IconButton';
 
 const getStyles = stylesFactory((theme: GrafanaThemeV2, size: IconSize, variant: IconButtonVariant) => {
-  const hoverColor = theme.colors.action.hover;
   const pixelSize = getSvgSize(size);
   const hoverSize = Math.max(pixelSize / 3, 8);
   let iconColor = theme.colors.text.primary;
@@ -126,7 +125,9 @@ const getStyles = stylesFactory((theme: GrafanaThemeV2, size: IconSize, variant:
         color: ${iconColor};
 
         &:before {
-          background-color: ${hoverColor};
+          background-color: ${variant === 'secondary'
+            ? theme.colors.action.hover
+            : colorManipulator.alpha(iconColor, 0.12)};
           border: none;
           box-shadow: none;
           opacity: 1;

--- a/packages/grafana-ui/src/components/IconButton/IconButton.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.tsx
@@ -24,7 +24,7 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   tooltip?: string;
   /** Position of the tooltip */
   tooltipPlacement?: TooltipPlacement;
-  /** Color of  */
+  /** Variant to change the color of the Icon */
   variant?: IconButtonVariant;
 }
 

--- a/packages/grafana-ui/src/components/IconButton/IconButton.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from '../Tooltip/Tooltip';
 import { TooltipPlacement } from '../Tooltip/PopoverController';
 import { getFocusStyles, getMouseFocusStyles } from '../../themes/mixins';
 
-export type IconButtonVariant = 'primary' | 'destructive' | undefined;
+export type IconButtonVariant = 'primary' | 'secondary' | 'destructive';
 
 export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Name of the icon **/
@@ -31,7 +31,7 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 type SurfaceType = 'dashboard' | 'panel' | 'header';
 
 export const IconButton = React.forwardRef<HTMLButtonElement, Props>(
-  ({ name, size = 'md', iconType, tooltip, tooltipPlacement, className, variant, ...restProps }, ref) => {
+  ({ name, size = 'md', iconType, tooltip, tooltipPlacement, className, variant = 'secondary', ...restProps }, ref) => {
     const theme = useTheme2();
     const styles = getStyles(theme, size, variant);
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a `variant` prop to the `<IconButton />` so it can be coloured red or blue.


<img width="811" alt="Screenshot 2021-04-29 at 10 24 55" src="https://user-images.githubusercontent.com/73201/116522214-383db280-a8d5-11eb-92c4-9324d36af2ac.png">

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #32784

**Special notes for your reviewer**:

