### PR TITLE
devenv: InfluxDB: fix version mismatch

### DIFF
--- a/devenv/docker/blocks/influxdb/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb/docker-compose.yaml
@@ -12,7 +12,7 @@
   influxdb_cli:
     links:
       - influxdb
-    image: influxdb:2.0.4
+    image: influxdb:latest
     # The following long command does 2 things:
     #   1. It initializes the bucket
     #   2. Maps bucket to database to enable backward-compatible access (influxql queries)


### PR DESCRIPTION
the docker-image version for the inflxudb database, and for invoking command-line tools, should be the same.

some time ago, the database-docker-image-version was switched to `latest` but the version for the command-line tools was not.