### PR TITLE
Alerting: Eval pkg tests and more specific error handling

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -255,7 +255,7 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 		}
 
 		if f.Fields[0].Type() != data.FieldTypeNullableFloat64 {
-			appendErrRes(&invalidEvalResultFormatError{refID: f.RefID, reason: fmt.Sprintf("invalid field type: %d", f.Fields[0].Type())})
+			appendErrRes(&invalidEvalResultFormatError{refID: f.RefID, reason: fmt.Sprintf("invalid field type: %s", f.Fields[0].Type())})
 			continue
 		}
 
@@ -290,7 +290,7 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 					Instance:           res.Instance,
 					EvaluatedAt:        ts,
 					EvaluationDuration: time.Since(ts),
-					Error:              &invalidEvalResultFormatError{reason: fmt.Sprintf("frame cannot uniquely be identified by its labels: %s", labelsStr)},
+					Error:              &invalidEvalResultFormatError{reason: fmt.Sprintf("frame cannot uniquely be identified by its labels: has duplicate results with labels {%s}", labelsStr)},
 				},
 			}
 		}

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -46,8 +46,6 @@ func (e *invalidEvalResultFormatError) Unwrap() error {
 // ExecutionResults contains the unevaluated results from executing
 // a condition.
 type ExecutionResults struct {
-	AlertDefinitionID int64
-
 	Error error
 
 	Results data.Frames
@@ -181,10 +179,13 @@ func executeQueriesAndExpressions(ctx AlertExecCtx, data []models.AlertQuery, no
 
 // evaluateExecutionResult takes the ExecutionResult, and returns a frame where
 // each column is a string type that holds a string representing its State.
-func evaluateExecutionResult(results *ExecutionResults, ts time.Time) (Results, error) {
+func evaluateExecutionResult(execResults *ExecutionResults, ts time.Time) (Results, error) {
+	if execResults != nil && execResults.Error != nil {
+		return Results{{State: Error}}, nil
+	}
 	evalResults := make([]Result, 0)
 	labels := make(map[string]bool)
-	for _, f := range results.Results {
+	for _, f := range execResults.Results {
 		rowLen, err := f.RowLen()
 		if err != nil {
 			return nil, &invalidEvalResultFormatError{refID: f.RefID, reason: "unable to get frame row length", err: err}

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -228,6 +228,11 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 			continue
 		}
 
+		if len(f.TypeIndices(data.FieldTypeTime, data.FieldTypeNullableTime)) > 0 {
+			appendErrRes(&invalidEvalResultFormatError{refID: f.RefID, reason: "looks like time series data, only reduced data can be alerted on."})
+			continue
+		}
+
 		if rowLen == 0 {
 			if len(f.Fields) == 0 {
 				appendNoData(nil)

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -246,7 +246,8 @@ func TestEvaluateExecutionResult(t *testing.T) {
 					State: Error,
 				},
 				{
-					State: Alerting,
+					State:    Alerting,
+					Instance: data.Labels{"a": "b"},
 				},
 			},
 		},
@@ -260,6 +261,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 
 			for i, r := range res {
 				require.Equal(t, tc.expectResults[i].State, r.State)
+				require.Equal(t, tc.expectResults[i].Instance, r.Instance)
 			}
 		})
 	}

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -159,11 +159,27 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			},
 		},
 		{
-			desc: "more than one row (e.g. time series) Error state result",
+			desc: "more than one row Error state result",
 			execResults: ExecutionResults{
 				Results: []*data.Frame{
 					data.NewFrame("",
 						data.NewField("", nil, []*float64{ptr.Float64(2), ptr.Float64(3)}),
+					),
+				},
+			},
+			expectResultLength: 1,
+			expectResults: Results{
+				{
+					State: Error,
+				},
+			},
+		},
+		{
+			desc: "time fields (looks like time series) returns error",
+			execResults: ExecutionResults{
+				Results: []*data.Frame{
+					data.NewFrame("",
+						data.NewField("", nil, []time.Time{}),
 					),
 				},
 			},

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -1,0 +1,88 @@
+package eval
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+	ptr "github.com/xorcare/pointer"
+)
+
+func TestEvaluateExecutionResult(t *testing.T) {
+	cases := []struct {
+		desc               string
+		execResults        *ExecutionResults
+		expectResultLength int
+		expectResults      Results
+	}{
+		{
+			desc: "zero valued single instance is single Normal state result",
+			execResults: &ExecutionResults{
+				Results: []*data.Frame{
+					data.NewFrame("", data.NewField("", nil, []*float64{ptr.Float64(0)})),
+				},
+			},
+			expectResultLength: 1,
+			expectResults: Results{
+				{
+					State: Normal,
+				},
+			},
+		},
+		{
+			desc: "non-zero valued single instance is single Alerting state result",
+			execResults: &ExecutionResults{
+				Results: []*data.Frame{
+					data.NewFrame("", data.NewField("", nil, []*float64{ptr.Float64(1)})),
+				},
+			},
+			expectResultLength: 1,
+			expectResults: Results{
+				{
+					State: Alerting,
+				},
+			},
+		},
+		{
+			desc: "nil value single instance is single a NoData state result",
+			execResults: &ExecutionResults{
+				Results: []*data.Frame{
+					data.NewFrame("", data.NewField("", nil, []*float64{nil})),
+				},
+			},
+			expectResultLength: 1,
+			expectResults: Results{
+				{
+					State: NoData,
+				},
+			},
+		},
+		{
+			desc: "an execution error produces a single Error state result",
+			execResults: &ExecutionResults{
+				Error: fmt.Errorf("an execution error"),
+			},
+			expectResultLength: 1,
+			expectResults: Results{
+				{
+					State: Error,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res, err := evaluateExecutionResult(tc.execResults, time.Time{})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectResultLength, len(res))
+
+			for i, r := range res {
+				require.Equal(t, tc.expectResults[i].State, r.State)
+			}
+		})
+	}
+}

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -68,6 +68,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("an execution error"),
 				},
 			},
 		},
@@ -138,6 +139,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : unable to get frame row length: frame has different field lengths, field 0 is len 1 but field 1 is len 0"),
 				},
 			},
 		},
@@ -155,11 +157,12 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : unexpected field length: 2 instead of 1"),
 				},
 			},
 		},
 		{
-			desc: "more than one row Error state result",
+			desc: "more than one row produces Error state result",
 			execResults: ExecutionResults{
 				Results: []*data.Frame{
 					data.NewFrame("",
@@ -171,6 +174,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : unexpected row length: 2 instead of 0 or 1"),
 				},
 			},
 		},
@@ -187,6 +191,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : looks like time series data, only reduced data can be alerted on."),
 				},
 			},
 		},
@@ -203,6 +208,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : invalid field type: []float64"),
 				},
 			},
 		},
@@ -222,6 +228,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : frame cannot uniquely be identified by its labels: has duplicate results with labels {}"),
 				},
 			},
 		},
@@ -241,6 +248,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : frame cannot uniquely be identified by its labels: has duplicate results with labels {}"),
 				},
 			},
 		},
@@ -260,6 +268,7 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			expectResults: Results{
 				{
 					State: Error,
+					Error: fmt.Errorf("invalid format of evaluation results for the alert definition : invalid field type: []float64"),
 				},
 				{
 					State:    Alerting,
@@ -278,6 +287,9 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			for i, r := range res {
 				require.Equal(t, tc.expectResults[i].State, r.State)
 				require.Equal(t, tc.expectResults[i].Instance, r.Instance)
+				if tc.expectResults[i].State == Error {
+					require.EqualError(t, tc.expectResults[i].Error, r.Error.Error())
+				}
 			}
 		})
 	}

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -228,6 +228,28 @@ func TestEvaluateExecutionResult(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "certain errors will produce multiple mixed Error and other state results",
+			execResults: ExecutionResults{
+				Results: []*data.Frame{
+					data.NewFrame("",
+						data.NewField("", nil, []float64{3}),
+					),
+					data.NewFrame("",
+						data.NewField("", data.Labels{"a": "b"}, []*float64{ptr.Float64(2)}),
+					),
+				},
+			},
+			expectResultLength: 2,
+			expectResults: Results{
+				{
+					State: Error,
+				},
+				{
+					State: Alerting,
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**:
Backend tests for ngeval package and change to when an Error state result in returned (more specificity).

Also adds `Error error` field to each `Result` so a message can be passed when the State is an Error (which kind of relates to https://github.com/grafana/alerting-squad/issues/108). Although this has some error cases where some instances could error and other can't. Although we could change that so if there is any error - everything errors (since we process all the results together).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

