### PR TITLE
QueryRunner: update frame length when skipping processing

### DIFF
--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -113,6 +113,7 @@ export class PanelQueryRunner {
                 ...processedData,
                 series: lastData.map((frame, frameIndex) => ({
                   ...frame,
+                  length: data.series[frameIndex].length,
                   fields: frame.fields.map((field, fieldIndex) => ({
                     ...field,
                     values: data.series[frameIndex].fields[fieldIndex].values,


### PR DESCRIPTION
When the panelQueryRuner skips processing fields (because the config was the same) it also skipped updating the frame length