### PR TITLE
Access control: Allow empty scope requirement lists

### DIFF
--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -26,6 +26,10 @@ func Evaluate(ctx context.Context, ac accesscontrol.AccessControl, user *models.
 }
 
 func evaluateScope(dbScopes map[string]struct{}, targetScopes ...string) (bool, error) {
+	if len(targetScopes) == 0 {
+		return true, nil
+	}
+
 	for _, s := range targetScopes {
 		var match bool
 		for dbScope := range dbScopes {


### PR DESCRIPTION
**What this PR does / why we need it**:

#33393 removed the behavior where empty scope lists would be permitted for anyone with access to the given action regardless of what scopes they have access to.

**Special notes for your reviewer**:

Restructured tests to be table tests as well + added a base case and a case to test the new behavior with empty target scopes but a list of scopes from the database.
