### PR TITLE
Alerting: Modify configuration apply and save semantics 

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -11,6 +13,7 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -177,13 +180,61 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 	if !c.HasUserRole(models.ROLE_EDITOR) {
 		return response.Error(http.StatusForbidden, "Permission denied", nil)
 	}
-	err := body.EncryptSecureSettings()
+
+	// Get the last known working configuration
+	query := ngmodels.GetLatestAlertmanagerConfigurationQuery{}
+	if err := srv.store.GetLatestAlertmanagerConfiguration(&query); err != nil {
+		// If we don't have a configuration there's nothing for us to know and we should just continue saving the new one
+		if !errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
+			return response.Error(http.StatusInternalServerError, "failed to get latest configuration", err)
+		}
+	}
+
+	currentConfig, err := notifier.Load([]byte(query.Result.AlertmanagerConfiguration))
 	if err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to load lastest configuration", err)
+	}
+
+	// Copy the previously known secure settings
+	for i, r := range body.AlertmanagerConfig.Receivers {
+		for j, gr := range r.PostableGrafanaReceivers.GrafanaManagedReceivers {
+			if len(currentConfig.AlertmanagerConfig.Receivers) <= i { // if we don't have a receiver for this position - skip it.
+				continue
+			}
+			cr := currentConfig.AlertmanagerConfig.Receivers[i]
+			if cr != nil && len(cr.PostableGrafanaReceivers.GrafanaManagedReceivers) < j { //  if it's a newly introduced receiver it does not exist in the current configuration
+				cgmr := cr.PostableGrafanaReceivers.GrafanaManagedReceivers[j]
+				if cgmr != nil {
+					if cgmr.Name == gr.Name && cgmr.Type == gr.Type {
+						// frontend sends only the secure settings that have to be updated
+						// therefore we have to copy from the last configuration only those secure settings not included in the request
+						for key, storedValue := range cgmr.SecureSettings {
+							_, ok := body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings[key]
+							if !ok {
+								decodeValue, err := base64.StdEncoding.DecodeString(storedValue)
+								if err != nil {
+									return response.Error(http.StatusInternalServerError, fmt.Sprintf("failed to decode stored secure setting: %s", key), err)
+								}
+								decryptedValue, err := util.Decrypt(decodeValue, setting.SecretKey)
+								if err != nil {
+									return response.Error(http.StatusInternalServerError, fmt.Sprintf("failed to decrypt stored secure setting: %s", key), err)
+								}
+								body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings[key] = string(decryptedValue)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if err := body.EncryptSecureSettings(); err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to encrypt receiver secrets", err)
 	}
 
 	if err := srv.am.SaveAndApplyConfig(&body); err != nil {
-		return response.Error(http.StatusInternalServerError, "failed to save and apply Alertmanager configuration", err)
+		srv.log.Error("unable to save and apply alertmanager configuration", "err", err)
+		return response.Error(http.StatusBadRequest, "failed to save and apply Alertmanager configuration", err)
 	}
 
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "configuration created"})

--- a/pkg/services/ngalert/models/alertmanager.go
+++ b/pkg/services/ngalert/models/alertmanager.go
@@ -11,6 +11,7 @@ type AlertConfiguration struct {
 	AlertmanagerConfiguration string
 	ConfigurationVersion      string
 	CreatedAt                 time.Time `xorm:"created"`
+	Default                   bool
 }
 
 // GetLatestAlertmanagerConfigurationQuery is the query to get the latest alertmanager configuration.
@@ -22,6 +23,7 @@ type GetLatestAlertmanagerConfigurationQuery struct {
 type SaveAlertmanagerConfigurationCmd struct {
 	AlertmanagerConfiguration string
 	ConfigurationVersion      string
+	Default                   bool
 }
 
 type DeleteAlertmanagerConfigurationCmd struct {

--- a/pkg/services/ngalert/store/database.go
+++ b/pkg/services/ngalert/store/database.go
@@ -18,6 +18,7 @@ const AlertDefinitionMaxTitleLength = 190
 type AlertingStore interface {
 	GetLatestAlertmanagerConfiguration(*models.GetLatestAlertmanagerConfigurationQuery) error
 	SaveAlertmanagerConfiguration(*models.SaveAlertmanagerConfigurationCmd) error
+	SaveAlertmanagerConfigurationWithCallback(*models.SaveAlertmanagerConfigurationCmd, SaveCallback) error
 }
 
 // DBstore stores the alert definitions and instances in the database.

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -251,4 +251,7 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 	}
 
 	mg.AddMigration("create_alert_configuration_table", migrator.NewAddTableMigration(alertConfiguration))
+	mg.AddMigration("Add column default in alert_configuration", migrator.NewAddColumnMigration(alertConfiguration, &migrator.Column{
+		Name: "default", Type: migrator.DB_Bool, Nullable: false, Default: "0",
+	}))
 }

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -123,7 +123,9 @@ func TestAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 				"settings": {
 					"recipient": "#unified-alerting-test-but-updated"
 				},
-				"secureSettings": {},
+				"secureFields": {
+					"url": true
+				},
 				"type": "slack",
 				"sendReminder": true,
 				"name": "slack.receiver",

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -1,0 +1,176 @@
+package alerting
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertmanagerConfigurationIsTransactional(t *testing.T) {
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{"ngalert"},
+		AnonymousUserRole:    models.ROLE_EDITOR,
+	})
+
+	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
+	alertConfigURL := fmt.Sprintf("http://%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
+
+	// On a blank start with no configuration, it saves and delivers the default configuration.
+	{
+		resp := getRequest(t, alertConfigURL, http.StatusOK) // nolint
+		require.JSONEq(t, defaultAlertmanagerConfigJSON, getBody(t, resp.Body))
+	}
+
+	// When creating new configuration, if it fails to apply - it does not save it.
+	{
+		payload := `
+{
+	"template_files": {},
+	"alertmanager_config": {
+		"route": {
+			"receiver": "slack.receiver"
+		},
+		"templates": null,
+		"receivers": [{
+			"name": "slack.receiver",
+			"grafana_managed_receiver_configs": [{
+				"settings": {
+					"iconEmoji": "",
+					"iconUrl": "",
+					"mentionGroups": "",
+					"mentionUsers": "",
+					"recipient": "#unified-alerting-test",
+					"username": ""
+				},
+				"secureSettings": {},
+				"type": "slack",
+				"sendReminder": true,
+				"name": "slack.receiver",
+				"disableResolveMessage": false,
+				"uid": ""
+			}]
+		}]
+	}
+}
+`
+		resp := postRequest(t, alertConfigURL, payload, http.StatusBadRequest) // nolint
+		require.JSONEq(t, "{\"error\":\"alert validation error: token must be specified when using the Slack chat API\", \"message\":\"failed to save and apply Alertmanager configuration\"}", getBody(t, resp.Body))
+
+		resp = getRequest(t, alertConfigURL, http.StatusOK) // nolint
+		require.JSONEq(t, defaultAlertmanagerConfigJSON, getBody(t, resp.Body))
+	}
+}
+
+func TestAlertmanagerConfigurationPersistSecrets(t *testing.T) {
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{"ngalert"},
+		AnonymousUserRole:    models.ROLE_EDITOR,
+	})
+
+	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
+	alertConfigURL := fmt.Sprintf("http://%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
+
+	// create a new configuration that has a secret
+	{
+		payload := `
+{
+	"template_files": {},
+	"alertmanager_config": {
+		"route": {
+			"receiver": "slack.receiver"
+		},
+		"templates": null,
+		"receivers": [{
+			"name": "slack.receiver",
+			"grafana_managed_receiver_configs": [{
+				"settings": {
+					"recipient": "#unified-alerting-test"
+				},
+				"secureSettings": {
+					"url": "http://averysecureurl.com/webhook"
+				},
+				"type": "slack",
+				"sendReminder": true,
+				"name": "slack.receiver",
+				"disableResolveMessage": false
+			}]
+		}]
+	}
+}
+`
+		resp := postRequest(t, alertConfigURL, payload, http.StatusAccepted) // nolint
+		require.JSONEq(t, `{"message":"configuration created"}`, getBody(t, resp.Body))
+	}
+	// Then, update the recipient
+	{
+		payload := `
+{
+	"template_files": {},
+	"alertmanager_config": {
+		"route": {
+			"receiver": "slack.receiver"
+		},
+		"templates": null,
+		"receivers": [{
+			"name": "slack.receiver",
+			"grafana_managed_receiver_configs": [{
+				"settings": {
+					"recipient": "#unified-alerting-test-but-updated"
+				},
+				"secureSettings": {},
+				"type": "slack",
+				"sendReminder": true,
+				"name": "slack.receiver",
+				"disableResolveMessage": false
+			}]
+		}]
+	}
+}
+`
+		resp := postRequest(t, alertConfigURL, payload, http.StatusAccepted) // nolint
+		require.JSONEq(t, `{"message": "configuration created"}`, getBody(t, resp.Body))
+	}
+
+	// The secure settings must be present
+	{
+		resp := getRequest(t, alertConfigURL, http.StatusOK) // nolint
+		require.JSONEq(t, `
+{
+	"template_files": {},
+	"alertmanager_config": {
+		"route": {
+			"receiver": "slack.receiver"
+		},
+		"templates": null,
+		"receivers": [{
+			"name": "slack.receiver",
+			"grafana_managed_receiver_configs": [{
+				"id": 0,
+				"uid": "",
+				"name": "slack.receiver",
+				"type": "slack",
+				"isDefault": false,
+				"sendReminder": true,
+				"disableResolveMessage": false,
+				"frequency": "",
+				"created": "0001-01-01T00:00:00Z",
+				"updated": "0001-01-01T00:00:00Z",
+				"settings": {
+					"recipient": "#unified-alerting-test-but-updated"
+				},
+				"secureFields": {
+					"url": true
+				}
+			}]
+		}]
+	}
+}
+`, getBody(t, resp.Body))
+	}
+}

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -1,0 +1,82 @@
+package alerting
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const defaultAlertmanagerConfigJSON = `
+{
+	"template_files": null,
+	"alertmanager_config": {
+		"route": {
+			"receiver": "grafana-default-email"
+		},
+		"templates": null,
+		"receivers": [{
+			"name": "grafana-default-email",
+			"grafana_managed_receiver_configs": [{
+				"id": 0,
+				"uid": "",
+				"name": "email receiver",
+				"type": "email",
+				"isDefault": true,
+				"sendReminder": false,
+				"disableResolveMessage": false,
+				"frequency": "",
+				"created": "0001-01-01T00:00:00Z",
+				"updated": "0001-01-01T00:00:00Z",
+				"settings": {
+					"addresses": "\u003cexample@email.com\u003e"
+				},
+				"secureFields": {}
+			}]
+		}]
+	}
+}
+`
+
+func getRequest(t *testing.T, url string, expStatusCode int) *http.Response {
+	t.Helper()
+	// nolint:gosec
+	resp, err := http.Get(url)
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+	require.NoError(t, err)
+	if expStatusCode != resp.StatusCode {
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		t.Fatal(string(b))
+	}
+	return resp
+}
+
+func postRequest(t *testing.T, url string, body string, expStatusCode int) *http.Response {
+	t.Helper()
+	buf := bytes.NewReader([]byte(body))
+	// nolint:gosec
+	resp, err := http.Post(url, "application/json", buf)
+	t.Cleanup(func() {
+		require.NoError(t, resp.Body.Close())
+	})
+	require.NoError(t, err)
+	if expStatusCode != resp.StatusCode {
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		t.Fatal(string(b))
+	}
+	return resp
+}
+
+func getBody(t *testing.T, body io.ReadCloser) string {
+	t.Helper()
+	b, err := ioutil.ReadAll(body)
+	require.NoError(t, err)
+	return string(b)
+}


### PR DESCRIPTION
In this PR, I'm changing the semantics of the alertmanager configuration endpoint for Grafana.

- When there's no config present in the database, it'll save the default configuration and use a boolean of default to represent it. This is useful for when we "change" the default configuration in the future - we can tell if it is the default and change it if need be.
- When we submit a new configuration and it fails to apply, we rollback the transaction to ensure we don't save a broken configuration.

TODO
- [x] fix & copy secure settings