### PR TITLE
Alerting: Remove datasource (name) from migration

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/datasource.go
+++ b/pkg/services/sqlstore/migrations/ualert/datasource.go
@@ -1,24 +1,30 @@
 package ualert
 
-// slurpDSIDs returns a map of [orgID, dataSourceId] -> [UID, Name].
-func (m *migration) slurpDSIDs() (map[[2]int64][2]string, error) {
+type dsUIDLookup map[[2]int64]string
+
+// GetUID fetch thes datasource UID based on orgID+datasourceID
+func (d dsUIDLookup) GetUID(orgID, datasourceID int64) string {
+	return d[[2]int64{orgID, datasourceID}]
+}
+
+// slurpDSIDs returns a map of [orgID, dataSourceId] -> UID.
+func (m *migration) slurpDSIDs() (dsUIDLookup, error) {
 	dsIDs := []struct {
 		OrgID int64  `xorm:"org_id"`
 		ID    int64  `xorm:"id"`
 		UID   string `xorm:"uid"`
-		Name  string
 	}{}
 
-	err := m.sess.SQL(`SELECT org_id, id, uid, name FROM data_source`).Find(&dsIDs)
+	err := m.sess.SQL(`SELECT org_id, id, uid FROM data_source`).Find(&dsIDs)
 
 	if err != nil {
 		return nil, err
 	}
 
-	idToUID := make(map[[2]int64][2]string, len(dsIDs))
+	idToUID := make(dsUIDLookup, len(dsIDs))
 
 	for _, ds := range dsIDs {
-		idToUID[[2]int64{ds.OrgID, ds.ID}] = [2]string{ds.UID, ds.Name}
+		idToUID[[2]int64{ds.OrgID, ds.ID}] = ds.UID
 	}
 
 	return idToUID, nil

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -50,7 +50,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 		return err
 	}
 
-	// [orgID, dataSourceId] -> [UID, Name]
+	// [orgID, dataSourceId] -> UID
 	dsIDMap, err := m.slurpDSIDs()
 	if err != nil {
 		return err


### PR DESCRIPTION
I believe with the merging of grafana/grafana#33416 (cc @mckn) the `"datasource"` (name) property no longer needs to be included in the `model` of each query.

Fixes https://github.com/grafana/alerting-squad/issues/126

**Special notes for your reviewer**:

