### PR TITLE
Alerting/metrics

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -55,7 +55,7 @@ type API struct {
 }
 
 // RegisterAPIEndpoints registers API handlers
-func (api *API) RegisterAPIEndpoints() {
+func (api *API) RegisterAPIEndpoints(m *metrics.Metrics) {
 	logger := log.New("ngalert.api")
 	proxy := &AlertingProxy{
 		DataProxy: api.DataProxy,
@@ -66,26 +66,26 @@ func (api *API) RegisterAPIEndpoints() {
 		api.DatasourceCache,
 		NewLotexAM(proxy, logger),
 		AlertmanagerSrv{store: api.AlertingStore, am: api.Alertmanager, log: logger},
-	), metrics.GlobalMetrics)
+	), m)
 	// Register endpoints for proxing to Prometheus-compatible backends.
 	api.RegisterPrometheusApiEndpoints(NewForkedProm(
 		api.DatasourceCache,
 		NewLotexProm(proxy, logger),
 		PrometheusSrv{log: logger, manager: api.StateManager, store: api.RuleStore},
-	), metrics.GlobalMetrics)
+	), m)
 	// Register endpoints for proxing to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkedRuler(
 		api.DatasourceCache,
 		NewLotexRuler(proxy, logger),
 		RulerSrv{DatasourceCache: api.DatasourceCache, store: api.RuleStore, log: logger},
-	), metrics.GlobalMetrics)
+	), m)
 	api.RegisterTestingApiEndpoints(TestingApiSrv{
 		AlertingProxy:   proxy,
 		Cfg:             api.Cfg,
 		DataService:     api.DataService,
 		DatasourceCache: api.DatasourceCache,
 		log:             logger,
-	}, metrics.GlobalMetrics)
+	}, m)
 
 	// Legacy routes; they will be removed in v8
 	api.RouteRegister.Group("/api/alert-definitions", func(alertDefinitions routing.RouteRegister) {

--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
 
 type AlertmanagerApiService interface {
@@ -32,99 +33,99 @@ type AlertmanagerApiService interface {
 	RoutePostAlertingConfig(*models.ReqContext, apimodels.PostableUserConfig) response.Response
 }
 
-func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApiService, metrics *Metrics) {
+func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApiService, m *metrics.Metrics) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Post(
 			toMacaronPath("/api/alertmanager/{Recipient}/api/v2/silences"),
 			binding.Bind(apimodels.PostableSilence{}),
-			Instrument(
+			metrics.Instrument(
 				http.MethodPost,
 				"/api/alertmanager/{Recipient}/api/v2/silences",
 				srv.RouteCreateSilence,
-				metrics,
+				m,
 			),
 		)
 		group.Delete(
 			toMacaronPath("/api/alertmanager/{Recipient}/config/api/v1/alerts"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodDelete,
 				"/api/alertmanager/{Recipient}/config/api/v1/alerts",
 				srv.RouteDeleteAlertingConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Delete(
 			toMacaronPath("/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodDelete,
 				"/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}",
 				srv.RouteDeleteSilence,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{Recipient}/api/v2/alerts/groups"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/alertmanager/{Recipient}/api/v2/alerts/groups",
 				srv.RouteGetAMAlertGroups,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{Recipient}/api/v2/alerts"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/alertmanager/{Recipient}/api/v2/alerts",
 				srv.RouteGetAMAlerts,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{Recipient}/config/api/v1/alerts"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/alertmanager/{Recipient}/config/api/v1/alerts",
 				srv.RouteGetAlertingConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}",
 				srv.RouteGetSilence,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/alertmanager/{Recipient}/api/v2/silences"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/alertmanager/{Recipient}/api/v2/silences",
 				srv.RouteGetSilences,
-				metrics,
+				m,
 			),
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/{Recipient}/api/v2/alerts"),
 			binding.Bind(apimodels.PostableAlerts{}),
-			Instrument(
+			metrics.Instrument(
 				http.MethodPost,
 				"/api/alertmanager/{Recipient}/api/v2/alerts",
 				srv.RoutePostAMAlerts,
-				metrics,
+				m,
 			),
 		)
 		group.Post(
 			toMacaronPath("/api/alertmanager/{Recipient}/config/api/v1/alerts"),
 			binding.Bind(apimodels.PostableUserConfig{}),
-			Instrument(
+			metrics.Instrument(
 				http.MethodPost,
 				"/api/alertmanager/{Recipient}/config/api/v1/alerts",
 				srv.RoutePostAlertingConfig,
-				metrics,
+				m,
 			),
 		)
 	}, middleware.ReqSignedIn)

--- a/pkg/services/ngalert/api/generated_base_api_prometheus.go
+++ b/pkg/services/ngalert/api/generated_base_api_prometheus.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
 
 type PrometheusApiService interface {
@@ -21,24 +22,24 @@ type PrometheusApiService interface {
 	RouteGetRuleStatuses(*models.ReqContext) response.Response
 }
 
-func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApiService, metrics *Metrics) {
+func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApiService, m *metrics.Metrics) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Get(
 			toMacaronPath("/api/prometheus/{Recipient}/api/v1/alerts"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/prometheus/{Recipient}/api/v1/alerts",
 				srv.RouteGetAlertStatuses,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/prometheus/{Recipient}/api/v1/rules"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/prometheus/{Recipient}/api/v1/rules",
 				srv.RouteGetRuleStatuses,
-				metrics,
+				m,
 			),
 		)
 	}, middleware.ReqSignedIn)

--- a/pkg/services/ngalert/api/generated_base_api_ruler.go
+++ b/pkg/services/ngalert/api/generated_base_api_ruler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
 
 type RulerApiService interface {
@@ -28,61 +29,61 @@ type RulerApiService interface {
 	RoutePostNameRulesConfig(*models.ReqContext, apimodels.PostableRuleGroupConfig) response.Response
 }
 
-func (api *API) RegisterRulerApiEndpoints(srv RulerApiService, metrics *Metrics) {
+func (api *API) RegisterRulerApiEndpoints(srv RulerApiService, m *metrics.Metrics) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules/{Namespace}"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodDelete,
 				"/api/ruler/{Recipient}/api/v1/rules/{Namespace}",
 				srv.RouteDeleteNamespaceRulesConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Delete(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodDelete,
 				"/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}",
 				srv.RouteDeleteRuleGroupConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules/{Namespace}"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/ruler/{Recipient}/api/v1/rules/{Namespace}",
 				srv.RouteGetNamespaceRulesConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}",
 				srv.RouteGetRulegGroupConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Get(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules"),
-			Instrument(
+			metrics.Instrument(
 				http.MethodGet,
 				"/api/ruler/{Recipient}/api/v1/rules",
 				srv.RouteGetRulesConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Post(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules/{Namespace}"),
 			binding.Bind(apimodels.PostableRuleGroupConfig{}),
-			Instrument(
+			metrics.Instrument(
 				http.MethodPost,
 				"/api/ruler/{Recipient}/api/v1/rules/{Namespace}",
 				srv.RoutePostNameRulesConfig,
-				metrics,
+				m,
 			),
 		)
 	}, middleware.ReqSignedIn)

--- a/pkg/services/ngalert/api/generated_base_api_testing.go
+++ b/pkg/services/ngalert/api/generated_base_api_testing.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
 
 type TestingApiService interface {
@@ -25,36 +26,36 @@ type TestingApiService interface {
 	RouteTestRuleConfig(*models.ReqContext, apimodels.TestRulePayload) response.Response
 }
 
-func (api *API) RegisterTestingApiEndpoints(srv TestingApiService, metrics *Metrics) {
+func (api *API) RegisterTestingApiEndpoints(srv TestingApiService, m *metrics.Metrics) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Post(
 			toMacaronPath("/api/v1/eval"),
 			binding.Bind(apimodels.EvalQueriesPayload{}),
-			Instrument(
+			metrics.Instrument(
 				http.MethodPost,
 				"/api/v1/eval",
 				srv.RouteEvalQueries,
-				metrics,
+				m,
 			),
 		)
 		group.Post(
 			toMacaronPath("/api/v1/receiver/test/{Recipient}"),
 			binding.Bind(apimodels.ExtendedReceiver{}),
-			Instrument(
+			metrics.Instrument(
 				http.MethodPost,
 				"/api/v1/receiver/test/{Recipient}",
 				srv.RouteTestReceiverConfig,
-				metrics,
+				m,
 			),
 		)
 		group.Post(
 			toMacaronPath("/api/v1/rule/test/{Recipient}"),
 			binding.Bind(apimodels.TestRulePayload{}),
-			Instrument(
+			metrics.Instrument(
 				http.MethodPost,
 				"/api/v1/rule/test/{Recipient}",
 				srv.RouteTestRuleConfig,
-				metrics,
+				m,
 			),
 		)
 	}, middleware.ReqSignedIn)

--- a/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
+++ b/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/middleware"
 )
 
@@ -16,16 +17,16 @@ type {{classname}}Service interface { {{#operation}}
 	{{nickname}}(*models.ReqContext{{#bodyParams}}, apimodels.{{dataType}}{{/bodyParams}}) response.Response{{/operation}}
 }
 
-func (api *API) Register{{classname}}Endpoints(srv {{classname}}Service, metrics *Metrics) {
+func (api *API) Register{{classname}}Endpoints(srv {{classname}}Service, m *metrics.Metrics) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister){ {{#operations}}{{#operation}}
 	group.{{httpMethod}}(
 		toMacaronPath("{{{path}}}"){{#bodyParams}},
 		binding.Bind(apimodels.{{dataType}}{}){{/bodyParams}},
-		Instrument(
+		metrics.Instrument(
 			http.Method{{httpMethod}},
 			"{{{path}}}",
 			srv.{{nickname}},
-			metrics,
+			m,
 		),
   ){{/operation}}{{/operations}}
 	}, middleware.ReqSignedIn)

--- a/pkg/services/ngalert/metrics/metrics.go
+++ b/pkg/services/ngalert/metrics/metrics.go
@@ -31,7 +31,6 @@ type Metrics struct {
 	*metrics.Alerts
 	AlertState      *prometheus.GaugeVec
 	RequestDuration *prometheus.HistogramVec
-	Silences        *prometheus.GaugeVec
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
@@ -53,12 +52,6 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			},
 			[]string{"method", "route", "status_code", "backend"},
 		),
-		Silences: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "grafana",
-			Subsystem: "alerting",
-			Name:      "silences",
-			Help:      "The total number of silences by state.",
-		}, []string{"state"}),
 	}
 }
 

--- a/pkg/services/ngalert/metrics/metrics.go
+++ b/pkg/services/ngalert/metrics/metrics.go
@@ -17,11 +17,6 @@ import (
 	"gopkg.in/macaron.v1"
 )
 
-// GlobalMetrics are a globally registered metric suite for alerting.
-// TODO: refactor testware to allow these to be created without
-// panicking on duplicate registration, thus enabling non-global vars.
-var GlobalMetrics = NewMetrics(prometheus.DefaultRegisterer)
-
 const (
 	GrafanaBackend = "grafana"
 	ProxyBackend   = "proxy"

--- a/pkg/services/ngalert/metrics/metrics.go
+++ b/pkg/services/ngalert/metrics/metrics.go
@@ -15,62 +15,67 @@ import (
 	"gopkg.in/macaron.v1"
 )
 
+// metrics are a globally registered metric suite for alerting.
+// TODO: refactor testware to allow these to be created without
+// panicking on duplicate registration, thus enabling non-global vars.
+var GlobalMetrics = NewMetrics(prometheus.DefaultRegisterer)
+
 const (
 	GrafanaBackend = "grafana"
 	ProxyBackend   = "proxy"
 )
 
 type Metrics struct {
-	alerts              *prometheus.GaugeVec
-	alertsInvalid       prometheus.Counter
-	alertsReceived      prometheus.Counter
-	notificationLatency prometheus.Histogram
-	notifications       *prometheus.CounterVec
-	notificationsFailed *prometheus.CounterVec
-	requestDuration     *prometheus.HistogramVec
-	silences            *prometheus.GaugeVec
+	Alerts              *prometheus.GaugeVec
+	AlertsInvalid       prometheus.Counter
+	AlertsReceived      prometheus.Counter
+	NotificationLatency prometheus.Histogram
+	Notifications       *prometheus.CounterVec
+	NotificationsFailed *prometheus.CounterVec
+	RequestDuration     *prometheus.HistogramVec
+	Silences            *prometheus.GaugeVec
 }
 
 func NewMetrics(r prometheus.Registerer) *Metrics {
 	return &Metrics{
-		alerts: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+		Alerts: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "alerts",
 			Help:      "How many alerts by state.",
 		}, []string{"state"}),
-		alertsInvalid: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		AlertsInvalid: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "alerts_invalid_total",
 			Help:      "The total number of invalid received alerts.",
 		}),
-		alertsReceived: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		AlertsReceived: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "alerts_received_total",
 			Help:      "The total number of received alerts.",
 		}),
-		notificationLatency: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+		NotificationLatency: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "notification_latency_seconds",
 			Help:      "Histogram of notification deliveries",
 			Buckets:   prometheus.DefBuckets,
 		}),
-		notifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Notifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "notifications_total",
 			Help:      "The total number of attempted notfications by integration.",
 		}, []string{"integration"}),
-		notificationsFailed: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		NotificationsFailed: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "notifications_failed_total",
 			Help:      "The total number of failed notfications by integration.",
 		}, []string{"integration"}),
-		requestDuration: promauto.With(r).NewHistogramVec(
+		RequestDuration: promauto.With(r).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: "grafana",
 				Subsystem: "alerting",
@@ -80,7 +85,7 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			},
 			[]string{"method", "route", "status_code", "backend"},
 		),
-		silences: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+		Silences: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "silences",
@@ -124,7 +129,7 @@ func Instrument(
 			"backend":     backend,
 		}
 		res.WriteTo(c)
-		metrics.requestDuration.With(ls).Observe(time.Since(start).Seconds())
+		metrics.RequestDuration.With(ls).Observe(time.Since(start).Seconds())
 	}
 }
 

--- a/pkg/services/ngalert/metrics/metrics.go
+++ b/pkg/services/ngalert/metrics/metrics.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/macaron.v1"
 )
 
-// metrics are a globally registered metric suite for alerting.
+// GlobalMetrics are a globally registered metric suite for alerting.
 // TODO: refactor testware to allow these to be created without
 // panicking on duplicate registration, thus enabling non-global vars.
 var GlobalMetrics = NewMetrics(prometheus.DefaultRegisterer)

--- a/pkg/services/ngalert/metrics/metrics.go
+++ b/pkg/services/ngalert/metrics/metrics.go
@@ -28,7 +28,7 @@ const (
 type Metrics struct {
 	Alerts              *prometheus.GaugeVec
 	AlertsInvalid       prometheus.Counter
-	AlertsReceived      prometheus.Counter
+	AlertsReceived      *prometheus.CounterVec
 	NotificationLatency prometheus.Histogram
 	Notifications       *prometheus.CounterVec
 	NotificationsFailed *prometheus.CounterVec
@@ -50,12 +50,12 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 			Name:      "alerts_invalid_total",
 			Help:      "The total number of invalid received alerts.",
 		}),
-		AlertsReceived: promauto.With(r).NewCounter(prometheus.CounterOpts{
+		AlertsReceived: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",
 			Name:      "alerts_received_total",
 			Help:      "The total number of received alerts.",
-		}),
+		}, []string{"state"}),
 		NotificationLatency: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Namespace: "grafana",
 			Subsystem: "alerting",

--- a/pkg/services/ngalert/metrics/metrics.go
+++ b/pkg/services/ngalert/metrics/metrics.go
@@ -1,4 +1,4 @@
-package api
+package metrics
 
 import (
 	"fmt"

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/benbjohnson/clock"
 
@@ -57,8 +58,9 @@ func init() {
 
 // Init initializes the AlertingService.
 func (ng *AlertNG) Init() error {
+	m := metrics.NewMetrics(prometheus.DefaultRegisterer)
 	ng.Log = log.New("ngalert")
-	ng.stateManager = state.NewManager(ng.Log, metrics.GlobalMetrics)
+	ng.stateManager = state.NewManager(ng.Log, m)
 	baseInterval := baseIntervalSeconds * time.Second
 
 	store := store.DBstore{BaseInterval: baseInterval, DefaultIntervalSeconds: defaultIntervalSeconds, SQLStore: ng.SQLStore}
@@ -88,7 +90,7 @@ func (ng *AlertNG) Init() error {
 		Alertmanager:    ng.Alertmanager,
 		StateManager:    ng.stateManager,
 	}
-	api.RegisterAPIEndpoints()
+	api.RegisterAPIEndpoints(m)
 
 	return nil
 }

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 
 	"github.com/benbjohnson/clock"
@@ -57,7 +58,7 @@ func init() {
 // Init initializes the AlertingService.
 func (ng *AlertNG) Init() error {
 	ng.Log = log.New("ngalert")
-	ng.stateManager = state.NewManager(ng.Log)
+	ng.stateManager = state.NewManager(ng.Log, metrics.GlobalMetrics)
 	baseInterval := baseIntervalSeconds * time.Second
 
 	store := store.DBstore{BaseInterval: baseInterval, DefaultIntervalSeconds: defaultIntervalSeconds, SQLStore: ng.SQLStore}

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -460,9 +460,9 @@ func (am *Alertmanager) PutAlerts(postableAlerts apimodels.PostableAlerts) error
 		}
 
 		if alert.EndsAt.After(now) {
-			am.ngMetrics.AlertsReceived.WithLabelValues("firing").Inc()
+			am.ngMetrics.Firing().Inc()
 		} else {
-			am.ngMetrics.AlertsReceived.WithLabelValues("resolved").Inc()
+			am.ngMetrics.Resolved().Inc()
 		}
 
 		if err := alert.Validate(); err != nil {
@@ -471,7 +471,7 @@ func (am *Alertmanager) PutAlerts(postableAlerts apimodels.PostableAlerts) error
 			}
 			validationErr.Alerts = append(validationErr.Alerts, a)
 			validationErr.Errors = append(validationErr.Errors, err)
-			am.ngMetrics.AlertsInvalid.Inc()
+			am.ngMetrics.Invalid().Inc()
 			continue
 		}
 

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -128,7 +128,7 @@ func (am *Alertmanager) InitWithRegisterer(r prometheus.Registerer) (err error) 
 	am.marker = types.NewMarker(r)
 	am.stageMetrics = notify.NewMetrics(r)
 	am.dispatcherMetrics = dispatch.NewDispatcherMetrics(r)
-	am.ngMetrics = metrics.GlobalMetrics
+	am.ngMetrics = metrics.NewMetrics(r)
 	am.Store = store.DBstore{SQLStore: am.SQLStore}
 
 	// Initialize the notification log

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -40,6 +40,11 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+// allow overriding in tests to avoid duplicate registration
+var getDefaultRegisterer = func() prometheus.Registerer {
+	return prometheus.DefaultRegisterer
+}
+
 const (
 	pollInterval = 1 * time.Minute
 	workingDir   = "alerting"
@@ -140,6 +145,7 @@ func (am *Alertmanager) Init() (err error) {
 	}
 	// Initialize silences
 	am.silences, err = silence.New(silence.Options{
+		Metrics:      getDefaultRegisterer(),
 		SnapshotFile: filepath.Join(am.WorkingDirPath(), "silences"),
 		Retention:    retentionNotificationsAndSilences,
 	})

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -23,17 +23,11 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-// hijack init fn in tests to override default prom registerer
-// to prevent panics on duplicate registering.
-func init() {
-	getDefaultRegisterer = func() prometheus.Registerer { return nil }
-}
-
 func TestAlertmanager_ShouldUseDefaultConfigurationWhenNoConfiguration(t *testing.T) {
 	am := &Alertmanager{}
 	am.Settings = &setting.Cfg{}
 	am.SQLStore = sqlstore.InitTestDB(t)
-	require.NoError(t, am.Init())
+	require.NoError(t, am.InitWithRegisterer(prometheus.NewRegistry()))
 	require.NoError(t, am.SyncAndApplyConfigFromDatabase())
 	require.NotNil(t, am.config)
 }

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -23,6 +23,12 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+// hijack init fn in tests to override default prom registerer
+// to prevent panics on duplicate registering.
+func init() {
+	getDefaultRegisterer = func() prometheus.Registerer { return nil }
+}
+
 func TestAlertmanager_ShouldUseDefaultConfigurationWhenNoConfiguration(t *testing.T) {
 	am := &Alertmanager{}
 	am.Settings = &setting.Cfg{}

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -27,7 +28,7 @@ func TestAlertmanager_ShouldUseDefaultConfigurationWhenNoConfiguration(t *testin
 	am := &Alertmanager{}
 	am.Settings = &setting.Cfg{}
 	am.SQLStore = sqlstore.InitTestDB(t)
-	require.NoError(t, am.InitWithRegisterer(prometheus.NewRegistry()))
+	require.NoError(t, am.InitWithMetrics(metrics.NewMetrics(prometheus.NewRegistry())))
 	require.NoError(t, am.SyncAndApplyConfigFromDatabase())
 	require.NotNil(t, am.config)
 }
@@ -44,7 +45,7 @@ func TestPutAlert(t *testing.T) {
 		DataPath: dir,
 	}
 
-	require.NoError(t, am.InitWithRegisterer(prometheus.NewRegistry()))
+	require.NoError(t, am.InitWithMetrics(metrics.NewMetrics(prometheus.NewRegistry())))
 
 	startTime := time.Now()
 	endTime := startTime.Add(2 * time.Hour)

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -44,7 +44,7 @@ func TestPutAlert(t *testing.T) {
 		DataPath: dir,
 	}
 
-	require.NoError(t, am.Init())
+	require.NoError(t, am.InitWithRegisterer(prometheus.NewRegistry()))
 
 	startTime := time.Now()
 	endTime := startTime.Add(2 * time.Hour)

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -2,12 +2,14 @@ package state
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	prometheusModel "github.com/prometheus/common/model"
 )
@@ -16,12 +18,14 @@ type cache struct {
 	states    map[string]*State
 	mtxStates sync.RWMutex
 	log       log.Logger
+	metrics   *metrics.Metrics
 }
 
-func newCache(logger log.Logger) *cache {
+func newCache(logger log.Logger, metrics *metrics.Metrics) *cache {
 	return &cache{
-		states: make(map[string]*State),
-		log:    logger,
+		states:  make(map[string]*State),
+		log:     logger,
+		metrics: metrics,
 	}
 }
 
@@ -118,13 +122,23 @@ func (c *cache) reset() {
 func (c *cache) trim() {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
+
+	ct := make(map[eval.State]int)
+
 	for _, v := range c.states {
 		if len(v.Results) > 100 {
 			newResults := make([]Evaluation, 100)
-			copy(newResults, v.Results[100:])
+			// Keep last 100 results
+			copy(newResults, v.Results[len(v.Results)-100:])
 			v.Results = newResults
-			c.set(v)
 		}
+
+		n := ct[v.State]
+		ct[v.State] = n + 1
+	}
+
+	for k, n := range ct {
+		c.metrics.Alerts.WithLabelValues(strings.ToLower(k.String())).Set(float64(n))
 	}
 }
 

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -138,7 +138,7 @@ func (c *cache) trim() {
 	}
 
 	for k, n := range ct {
-		c.metrics.Alerts.WithLabelValues(strings.ToLower(k.String())).Set(float64(n))
+		c.metrics.AlertState.WithLabelValues(strings.ToLower(k.String())).Set(float64(n))
 	}
 }
 

--- a/pkg/services/ngalert/tests/manager_test.go
+++ b/pkg/services/ngalert/tests/manager_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var NilMetrics = metrics.NewMetrics(nil)
+var nilMetrics = metrics.NewMetrics(nil)
 
 func TestProcessEvalResults(t *testing.T) {
 	evaluationTime, err := time.Parse("2006-01-02", "2021-03-25")
@@ -778,7 +778,7 @@ func TestProcessEvalResults(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		st := state.NewManager(log.New("test_state_manager"), NilMetrics)
+		st := state.NewManager(log.New("test_state_manager"), nilMetrics)
 		t.Run(tc.desc, func(t *testing.T) {
 			for _, res := range tc.evalResults {
 				_ = st.ProcessEvalResults(tc.alertRule, res)

--- a/pkg/services/ngalert/tests/manager_test.go
+++ b/pkg/services/ngalert/tests/manager_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -15,6 +16,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/stretchr/testify/assert"
 )
+
+var NilMetrics = metrics.NewMetrics(nil)
 
 func TestProcessEvalResults(t *testing.T) {
 	evaluationTime, err := time.Parse("2006-01-02", "2021-03-25")
@@ -775,7 +778,7 @@ func TestProcessEvalResults(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		st := state.NewManager(log.New("test_state_manager"))
+		st := state.NewManager(log.New("test_state_manager"), NilMetrics)
 		t.Run(tc.desc, func(t *testing.T) {
 			for _, res := range tc.evalResults {
 				_ = st.ProcessEvalResults(tc.alertRule, res)

--- a/pkg/services/ngalert/tests/schedule_test.go
+++ b/pkg/services/ngalert/tests/schedule_test.go
@@ -94,7 +94,7 @@ func TestWarmStateCache(t *testing.T) {
 		Store:        dbstore,
 	}
 	sched := schedule.NewScheduler(schedCfg, nil)
-	st := state.NewManager(schedCfg.Logger, NilMetrics)
+	st := state.NewManager(schedCfg.Logger, nilMetrics)
 	sched.WarmStateCache(st)
 
 	t.Run("instance cache has expected entries", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestAlertingTicker(t *testing.T) {
 
 	ctx := context.Background()
 
-	st := state.NewManager(schedCfg.Logger, NilMetrics)
+	st := state.NewManager(schedCfg.Logger, nilMetrics)
 	go func() {
 		err := sched.Ticker(ctx, st)
 		require.NoError(t, err)

--- a/pkg/services/ngalert/tests/schedule_test.go
+++ b/pkg/services/ngalert/tests/schedule_test.go
@@ -94,7 +94,7 @@ func TestWarmStateCache(t *testing.T) {
 		Store:        dbstore,
 	}
 	sched := schedule.NewScheduler(schedCfg, nil)
-	st := state.NewManager(schedCfg.Logger)
+	st := state.NewManager(schedCfg.Logger, NilMetrics)
 	sched.WarmStateCache(st)
 
 	t.Run("instance cache has expected entries", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestAlertingTicker(t *testing.T) {
 
 	ctx := context.Background()
 
-	st := state.NewManager(schedCfg.Logger)
+	st := state.NewManager(schedCfg.Logger, NilMetrics)
 	go func() {
 		err := sched.Ticker(ctx, st)
 		require.NoError(t, err)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/server"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -26,12 +27,11 @@ import (
 // StartGrafana starts a Grafana server.
 // The server address is returned.
 func StartGrafana(t *testing.T, grafDir, cfgPath string, sqlStore *sqlstore.SQLStore) string {
-	// Grafana uses some global metric registration. Clear the
-	// registry between tests.
-	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	t.Helper()
-
 	ctx := context.Background()
+	// Prevent duplicate registration errors between tests by replacing
+	// the registry used.
+	metrics.GlobalMetrics.SwapRegisterer(prometheus.NewRegistry())
 
 	origSQLStore := registry.GetService(sqlstore.ServiceName)
 	t.Cleanup(func() {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
@@ -25,6 +26,9 @@ import (
 // StartGrafana starts a Grafana server.
 // The server address is returned.
 func StartGrafana(t *testing.T, grafDir, cfgPath string, sqlStore *sqlstore.SQLStore) string {
+	// Grafana uses some global metric registration. Clear the
+	// registry between tests.
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 	t.Helper()
 
 	ctx := context.Background()


### PR DESCRIPTION
This PR adds a bunch of new metrics to the ngalert package and refactors it a bit. It reuses alertmanager libraries where possible.

Additionally, it fixes a mutex deadlock condition in the state iteration code and trims the active alert history to 100 _total_ on each iteration rather than removing the first 100. It also  moves the cleanup interval to 15s (prometheus scrape config) and includes metric reporting there.