### PR TITLE
AlertMigration: remove alert_rule UID db check

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -49,13 +49,10 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 		For:             duration(da.For),
 		Updated:         time.Now().UTC(),
 		Annotations:     annotations,
-	}
-	var err error
-	ar.Uid, err = m.generateAlertRuleUID(ar.OrgId)
-	if err != nil {
-		return nil, err
+		Uid:             util.GenerateShortUID(),
 	}
 
+	var err error
 	ar.NoDataState, err = transNoData(da.ParsedSettings.NoDataState)
 	if err != nil {
 		return nil, err
@@ -68,25 +65,6 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 
 	return ar, nil
 }
-
-func (m *migration) generateAlertRuleUID(orgId int64) (string, error) {
-	for i := 0; i < 20; i++ {
-		uid := util.GenerateShortUID()
-
-		exists, err := m.sess.Where("org_id=? AND uid=?", orgId, uid).Get(&alertRule{})
-		if err != nil {
-			return "", err
-		}
-
-		if !exists {
-			return uid, nil
-		}
-	}
-
-	return "", fmt.Errorf("could not generate unique uid for alert rule")
-}
-
-// TODO: Do I need to create an initial alertRuleVersion as well?
 
 type alertQuery struct {
 	// RefID is the unique identifier of the query, set by the frontend call.


### PR DESCRIPTION
do not believe this is needed due to uniqueness promised by shortid lib
since there is no provisioning yet. https://github.com/teris-io/shortid


Fixes https://github.com/grafana/alerting-squad/issues/121

**Special notes for your reviewer**:
I am not sure if we want to remove the DB check from dashboard as well? Perhaps retry is not needed in the context of a migration (transaction, so single instance Grafana)? 

Not clear on why it was added to https://github.com/grafana/grafana/commit/58cfb236250e0d5b3bac72c1d261abcfb5572435#diff-9b8062a98126348a456e2b1a6f09d54537cf6021c6b1e370f511f7adde4a2b71R158

There could be a provisioning collision as well I guess in the context of dashboards, but not the case for alert_rules since they will not exist yet.
