### PR TITLE
CodeOwners: Set owners of unified alerting migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,9 @@ go.sum @grafana/backend-platform
 /pkg/tsdb/zipkin @grafana/observability-squad
 /pkg/tsdb/tempo @grafana/observability-squad
 
+# Unified Alerting
 /pkg/services/ngalert @grafana/alerting-squad
+ pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad
 
 # Database migrations
 /pkg/services/sqlstore/migrations @grafana/backend-platform @grafana/hosted-grafana-team


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets alerting squad to code owners for the migration code.

Annoy backend team less.

