### PR TITLE
Add note to Snapshot API doc to specify that user has to provide the entire dashboard model 

### DIFF
--- a/docs/sources/http_api/snapshot.md
+++ b/docs/sources/http_api/snapshot.md
@@ -59,6 +59,8 @@ JSON Body schema:
 - **key** - Optional. Define the unique key. Required if **external** is `true`.
 - **deleteKey** - Optional. Unique key used to delete the snapshot. It is different from the **key** so that only the creator can delete the snapshot. Required if **external** is `true`.
 
+> **Note:** When creating a snapshot using the API you have to provide the full dashboard payload including snapshot data. This endpoint is essentially designed for the Grafana UI.
+
 **Example Response**:
 
 ```http

--- a/docs/sources/http_api/snapshot.md
+++ b/docs/sources/http_api/snapshot.md
@@ -59,7 +59,7 @@ JSON Body schema:
 - **key** - Optional. Define the unique key. Required if **external** is `true`.
 - **deleteKey** - Optional. Unique key used to delete the snapshot. It is different from the **key** so that only the creator can delete the snapshot. Required if **external** is `true`.
 
-> **Note:** When creating a snapshot using the API you have to provide the full dashboard payload including snapshot data. This endpoint is essentially designed for the Grafana UI.
+> **Note:** When creating a snapshot using the API, you have to provide the full dashboard payload including the snapshot data. This endpoint is designed for the Grafana UI.
 
 **Example Response**:
 


### PR DESCRIPTION
Updated topic: https://grafana.com/docs/grafana/latest/http_api/snapshot/#create-new-snapshot.

Fix for Grafana issue https://github.com/grafana/grafana/issues/32939.