### PR TITLE
Routing: refresh plugin module when pluginId changes

### DIFF
--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -13,7 +13,7 @@ import { css, cx } from '@emotion/css';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
-  navModel: NavModel;
+  navModel?: NavModel;
 }
 
 export interface PageType extends FC<Props> {
@@ -25,15 +25,19 @@ export const Page: PageType = ({ navModel, children, className, ...otherProps })
   const styles = useStyles2(getStyles);
 
   useEffect(() => {
-    const title = getTitleFromNavModel(navModel);
-    document.title = title ? `${title} - ${Branding.AppTitle}` : Branding.AppTitle;
+    if (navModel) {
+      const title = getTitleFromNavModel(navModel);
+      document.title = title ? `${title} - ${Branding.AppTitle}` : Branding.AppTitle;
+    } else {
+      document.title = Branding.AppTitle;
+    }
   }, [navModel]);
 
   return (
     <div {...otherProps} className={cx(styles.wrapper, className)}>
       <CustomScrollbar autoHeightMin={'100%'}>
         <div className="page-scrollbar-content">
-          <PageHeader model={navModel} />
+          {navModel && <PageHeader model={navModel} />}
           {children}
           <Footer />
         </div>

--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -77,7 +77,7 @@ class AppRootPage extends Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     const { params } = this.props.match;
-    console.log(prevProps.match.params.pluginId !== params.pluginId);
+
     if (prevProps.match.params.pluginId !== params.pluginId) {
       this.setState({
         loading: true,
@@ -118,10 +118,10 @@ class AppRootPage extends Component<Props, State> {
             </Page.Contents>
           </Page>
         ) : (
-          <>
+          <Page>
             <OutPortal node={portalNode} />
             {loading && <PageLoader />}
-          </>
+          </Page>
         )}
       </>
     );

--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -49,8 +49,7 @@ class AppRootPage extends Component<Props, State> {
   shouldComponentUpdate(nextProps: Props) {
     return nextProps.location.pathname.startsWith('/a/');
   }
-
-  async componentDidMount() {
+  async loadPluginSettings() {
     const { params } = this.props.match;
     try {
       const app = await getPluginSettings(params.pluginId).then((info) => {
@@ -62,13 +61,28 @@ class AppRootPage extends Component<Props, State> {
         }
         return importAppPlugin(info);
       });
-      this.setState({ plugin: app, loading: false });
+      this.setState({ plugin: app, loading: false, nav: undefined });
     } catch (err) {
       this.setState({
         plugin: null,
         loading: false,
         nav: process.env.NODE_ENV === 'development' ? getExceptionNav(err) : getNotFoundNav(),
       });
+    }
+  }
+
+  componentDidMount() {
+    this.loadPluginSettings();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const { params } = this.props.match;
+    console.log(prevProps.match.params.pluginId !== params.pluginId);
+    if (prevProps.match.params.pluginId !== params.pluginId) {
+      this.setState({
+        loading: true,
+      });
+      this.loadPluginSettings();
     }
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This is a WIP as I'd appreciate some feedback on the approach I've taken. 

This PR fixes an issue where switching between two app custom pages doesn't update the UI. 

It also fixes a problem where the app crashes when the dashboard search is opened on a plugin custom page if the plugin doesn't declare a navModel. I traced this back to a lack `<Page/>` component being rendered. The [marketplace-app](https://github.com/grafana/marketplace-app) is one plugin I've noticed this occurring with.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #33493

**Special notes for your reviewer**:

