### PR TITLE
Live: expose publish on live interfaces

### DIFF
--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -62,6 +62,13 @@ export interface GrafanaLiveSrv {
    * Join and leave messages will be sent to the open stream
    */
   getPresence(address: LiveChannelAddress): Promise<LiveChannelPresenceStatus>;
+
+  /**
+   * Publish into a channel
+   *
+   * @alpha -- experimental
+   */
+  publish(address: LiveChannelAddress, data: any): Promise<any>;
 }
 
 let singletonInstance: GrafanaLiveSrv;

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -6,6 +6,7 @@ import {
   config,
   LiveDataStreamOptions,
   toDataQueryError,
+  getBackendSrv,
 } from '@grafana/runtime';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import {
@@ -24,6 +25,7 @@ import {
   dataFrameToJSON,
   isLiveChannelMessageEvent,
   isLiveChannelStatusEvent,
+  toLiveChannelId,
 } from '@grafana/data';
 import { CentrifugeLiveChannel, getErrorChannel } from './channel';
 import {
@@ -312,6 +314,18 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
    */
   getPresence(address: LiveChannelAddress): Promise<LiveChannelPresenceStatus> {
     return this.getChannel(address).getPresence();
+  }
+
+  /**
+   * Publish into a channel
+   *
+   * @alpha -- experimental
+   */
+  publish(address: LiveChannelAddress, data: any): Promise<any> {
+    return getBackendSrv().post(`api/live/publish`, {
+      channel: toLiveChannelId(address),
+      data,
+    });
   }
 }
 

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -16,11 +16,10 @@ import {
   StreamingDataFrame,
   LiveChannelAddress,
   LiveChannelConfig,
-  toLiveChannelId,
 } from '@grafana/data';
 import { TablePanel } from '../table/TablePanel';
 import { LivePanelOptions, MessageDisplayMode } from './types';
-import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { config, getGrafanaLiveSrv } from '@grafana/runtime';
 import { css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
 

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -159,10 +159,7 @@ export class LivePanel extends PureComponent<Props, State> {
       return;
     }
 
-    const rsp = await getBackendSrv().post(`api/live/publish`, {
-      channel: toLiveChannelId(addr),
-      data,
-    });
+    const rsp = await getGrafanaLiveSrv().publish(addr, data);
     console.log('onPublishClicked (response from publish)', rsp);
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8571,6 +8571,11 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
+caniuse-db@1.0.30000772:
+  version "1.0.30000772"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000772.tgz#51aae891768286eade4a3d8319ea76d6a01b512b"
+  integrity sha1-UarokXaChureSj2DGep21qAbUSs=
+
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
   version "1.0.30001205"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz"


### PR DESCRIPTION
To simplify the interface, we previously removed `publish` and require that you send requets over HTTP:
```
getBackendSrv().post(`api/live/publish`, {
...
```
This works, but when trying to implement `publish` from a plugin/client, this is difficult to know the syntax.

This PR puts back the publish method and lets us keep the the raw HTTP request an implementation detail for now