### PR TITLE
Alerting: Avoid panic by not loading instances without rule

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -373,6 +373,7 @@ func (sch *schedule) WarmStateCache(st *state.Manager) {
 			ruleForEntry, ok := ruleByUID[entry.RuleDefinitionUID]
 			if !ok {
 				sch.log.Error("rule not found for instance, ignoring", "rule", entry.RuleDefinitionUID)
+				continue
 			}
 
 			lbs := map[string]string(entry.Labels)


### PR DESCRIPTION
**What this PR does / why we need it**:
If there are alert_instance entries in the DB, but the rule has been deleted, we would get this panic:

```
EROR[05-01|12:23:35] rule not found for instance, ignoring    logger=ngalert rule=mg0JWyrGz
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x21749a3]

goroutine 248 [running]:
github.com/grafana/grafana/pkg/services/ngalert/schedule.(*schedule).WarmStateCache(0xc000c3fe00, 0xc00040cc00)
	/home/kbrandt/go/github.com/grafana/grafana/pkg/services/ngalert/schedule/schedule.go:393 +0x483
github.com/grafana/grafana/pkg/services/ngalert.(*AlertNG).Run(0xc0000b9d00, 0x30cbf68, 0xc0009ba840, 0x0, 0x0)
	/home/kbrandt/go/github.com/grafana/grafana/pkg/services/ngalert/ngalert.go:100 +0x7e
github.com/grafana/grafana/pkg/server.(*Server).Run.func1(0x63ea5e6da70900e, 0x9fea3eadb1a94e4f)
	/home/kbrandt/go/github.com/grafana/grafana/pkg/server/server.go:203 +0xa6
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0009afe90, 0xc0009fbda0)
	/home/kbrandt/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	/home/kbrandt/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x66
```

This does not load alert instances on startup if the rule is missing. We should also look into how these may end up in there, but making fixing panic priority.

