### PR TITLE
GraphNG: uPlot 1.6.9

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -78,7 +78,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.8"
+    "uplot": "1.6.9"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24746,10 +24746,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.8:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.8.tgz#0a7920018de24fa9aa0ba78ab59c99b4a23f8322"
-  integrity sha512-Hqg7iv/3fJlD9nockD7heaUj28RhrIwzugXglnoX//W27wgRAJIJMV2VFMZ5oRVM0RIchByAle1ylf/GdnXgjA==
+uplot@1.6.9:
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.9.tgz#0f10e10b5882cb80eb58d63f870b8a77e8d95962"
+  integrity sha512-uWIegRdqbqJwnB5SDBt29lyJIgHLIqt5AnwlLGxuA3gKKXGtY7d68RR6oDF2u5pK9jpIb1djrQnm5n0BiAnUgA==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
- includes `cursor.sync` changes needed for https://github.com/grafana/grafana/pull/33433
- improves smooth spline interpolation to avoid exceeding local y min/max datapoints (see https://github.com/leeoniya/uPlot/issues/504)

https://github.com/leeoniya/uPlot/releases/tag/1.6.9

![image](https://user-images.githubusercontent.com/43234/116796715-6c1b0280-aaa4-11eb-9027-d1988fb1750f.png)
