### PR TITLE
Graph: Fixes threshold handles not rendering when graph thresholds section is open 

### DIFF
--- a/public/app/plugins/panel/graph/threshold_manager.ts
+++ b/public/app/plugins/panel/graph/threshold_manager.ts
@@ -87,7 +87,8 @@ export class ThresholdManager {
 
   renderHandle(handleIndex: number, defaultHandleTopPos: number) {
     const model = this.thresholds[handleIndex];
-    if (!model.visible) {
+    // alerting defines
+    if (!model.visible && (this.panelCtrl as any).alert) {
       return;
     }
 


### PR DESCRIPTION
Fixes issue with threshold handles not rendering for graph thresholds, introduced by https://github.com/grafana/grafana/pull/30431 