### PR TITLE
Theme: Fix for Graph tooltip background

### DIFF
--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -65,7 +65,8 @@ export function getFocusStyles(theme: GrafanaThemeV2): CSSObject {
 // max-width is set up based on .grafana-tooltip class that's used in dashboard
 export const getTooltipContainerStyles = (theme: GrafanaThemeV2) => `
   overflow: hidden;
-  background: ${theme.components.tooltip.background};
+  background: ${theme.colors.background.secondary};
+  box-shadow: ${theme.shadows.z2};
   max-width: 800px;
   padding: ${theme.spacing(1)};
   border-radius: ${theme.shape.borderRadius()};


### PR DESCRIPTION
The graph tooltip should not use the normal tooltip background, as that will result in very dark large tooltips. Think the secondary background works better.

Normal small: tooltip
![Screenshot from 2021-05-02 09-51-25](https://user-images.githubusercontent.com/10999/116806294-4d604e80-ab2c-11eb-85e0-fce0559854e3.png)
![Screenshot from 2021-05-02 09-51-09](https://user-images.githubusercontent.com/10999/116806297-4f2a1200-ab2c-11eb-8cff-190b1d1d3993.png)

Tooltip is an outlier in the light theme as it's using inverted colors not used anywhere else: 
handled that exception here: https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/themes/createComponents.ts#L72  with two hard coded colors, would like to get feedback on this from  @Ijin08 @hemdrup  

For a while we tested using background. secondary in boh themes but in the light theme having light background on tooltip did not work great, and seems to be very very uncommon.  Which is why I changed it back to use a special tooltip background & text color in light theme. But this also impact the graph tooltip, which I do not think works great with dark background in light theme since it so large and shows colors as well (series color). So think the graph tooltip should be seen more as a popover. Testing in this pr to use background.secondary & z2 shadow in both light and dark theme:

![Screenshot from 2021-05-02 09-59-35](https://user-images.githubusercontent.com/10999/116806412-25bdb600-ab2d-11eb-9d05-6c6a83de38e9.png)
![Screenshot from 2021-05-02 09-59-29](https://user-images.githubusercontent.com/10999/116806417-26eee300-ab2d-11eb-8628-2df8c02fef85.png)




