### PR TITLE
Revert "Omit empty message in PagerDuty notifier (#31359)"

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -168,7 +168,7 @@ func (pn *PagerdutyNotifier) buildEventPayload(evalContext *alerting.EvalContext
 	}
 
 	var summary string
-	if pn.MessageInDetails || evalContext.Rule.Message == "" {
+	if pn.MessageInDetails {
 		summary = evalContext.Rule.Name
 	} else {
 		summary = evalContext.Rule.Name + " - " + evalContext.Rule.Message

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -173,60 +173,6 @@ func TestPagerdutyNotifier(t *testing.T) {
 				So(diff, ShouldBeEmpty)
 			})
 
-			Convey("should return properly formatted default v2 event payload with empty message", func() {
-				json := `{
-					"integrationKey": "abcdefgh0123456789",
-					"autoResolve": false
-				}`
-
-				settingsJSON, err := simplejson.NewJson([]byte(json))
-				So(err, ShouldBeNil)
-
-				model := &models.AlertNotification{
-					Name:     "pagerduty_testing",
-					Type:     "pagerduty",
-					Settings: settingsJSON,
-				}
-
-				not, err := NewPagerdutyNotifier(model)
-				So(err, ShouldBeNil)
-
-				pagerdutyNotifier := not.(*PagerdutyNotifier)
-				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
-					ID:    0,
-					Name:  "someRule",
-					State: models.AlertStateAlerting,
-				}, &validations.OSSPluginRequestValidator{})
-				evalContext.IsTestRun = true
-
-				payloadJSON, err := pagerdutyNotifier.buildEventPayload(evalContext)
-				So(err, ShouldBeNil)
-				payload, err := simplejson.NewJson(payloadJSON)
-				So(err, ShouldBeNil)
-
-				diff := cmp.Diff(map[string]interface{}{
-					"client":       "Grafana",
-					"client_url":   "",
-					"dedup_key":    "alertId-0",
-					"event_action": "trigger",
-					"links": []interface{}{
-						map[string]interface{}{
-							"href": "",
-						},
-					},
-					"payload": map[string]interface{}{
-						"component":      "Grafana",
-						"source":         "<<PRESENCE>>",
-						"custom_details": map[string]interface{}{},
-						"severity":       "critical",
-						"summary":        "someRule",
-						"timestamp":      "<<PRESENCE>>",
-					},
-					"routing_key": "abcdefgh0123456789",
-				}, payload.Interface(), cmp.Comparer(presenceComparer))
-				So(diff, ShouldBeEmpty)
-			})
-
 			Convey("should return properly formatted payload with message moved to details", func() {
 				json := `{
 					"integrationKey": "abcdefgh0123456789",


### PR DESCRIPTION
This reverts commit d652d035abaa923a17e4bad0bfd4134a7bdf8ed5.

Reverts https://github.com/grafana/grafana/pull/31359 as it caused broken builds in master

