### PR TITLE
Tooltip: eliminate flashing when repaint can't keep up

### DIFF
--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -64,6 +64,7 @@ export function getFocusStyles(theme: GrafanaThemeV2): CSSObject {
 
 // max-width is set up based on .grafana-tooltip class that's used in dashboard
 export const getTooltipContainerStyles = (theme: GrafanaThemeV2) => `
+  pointer-events: none;
   overflow: hidden;
   background: ${theme.colors.background.secondary};
   box-shadow: ${theme.shadows.z2};


### PR DESCRIPTION
this PR assumes that a tooltip cannot have interactive contents in it. if this does not hold, then we'll want to figure out a different approach.

noticed this when looking at the shared cursor PR (and previously when doing cursor and tooltip optimizations).

https://user-images.githubusercontent.com/43234/116821619-36c3f280-ab40-11eb-848d-4382f51d5832.mp4