### PR TITLE
PagerDuty: Omit empty message

### DIFF
--- a/pkg/services/alerting/notifiers/pagerduty.go
+++ b/pkg/services/alerting/notifiers/pagerduty.go
@@ -168,7 +168,7 @@ func (pn *PagerdutyNotifier) buildEventPayload(evalContext *alerting.EvalContext
 	}
 
 	var summary string
-	if pn.MessageInDetails {
+	if pn.MessageInDetails || evalContext.Rule.Message == "" {
 		summary = evalContext.Rule.Name
 	} else {
 		summary = evalContext.Rule.Name + " - " + evalContext.Rule.Message


### PR DESCRIPTION
**What this PR does / why we need it**:
Make PagerDuty just use the rule name if the message is empty. Reintroduction of #31359, which was reverted due to introducing a test failure (that test has been fixed in this PR).

Co-authored by pkoenig10.