### PR TITLE
DashboardLink: Fixes double escaping of > in dashboard link

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useReducer } from 'react';
 import { Icon, IconName, Tooltip } from '@grafana/ui';
-import { sanitize, sanitizeUrl } from '@grafana/data/src/text/sanitize';
+import { sanitizeUrl } from '@grafana/data/src/text/sanitize';
 import { DashboardLinksDashboard } from './DashboardLinksDashboard';
 import { getLinkSrv } from '../../../panel/panellinks/link_srv';
 

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx
@@ -51,7 +51,7 @@ export const DashboardLinks: FC<Props> = ({ dashboard, links }) => {
             aria-label={selectors.components.DashboardLinks.link}
           >
             <Icon name={linkIconMap[link.icon] as IconName} style={{ marginRight: '4px' }} />
-            <span>{sanitize(linkInfo.title)}</span>
+            <span>{linkInfo.title}</span>
           </a>
         );
 


### PR DESCRIPTION
Fixes #33594
