### PR TITLE
LibraryPanels: Adds Panels Page to Manage Folder tabs

### DIFF
--- a/public/app/features/folders/FolderLibraryPanelsPage.tsx
+++ b/public/app/features/folders/FolderLibraryPanelsPage.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { GrafanaRouteComponentProps } from '../../core/navigation/types';
+import { StoreState } from '../../types';
+import { getNavModel } from '../../core/selectors/navModel';
+import { getLoadingNav } from './state/navModel';
+import { LibraryPanelDTO } from '../library-panels/types';
+import Page from '../../core/components/Page/Page';
+import { LibraryPanelsSearch } from '../library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch';
+import { OpenLibraryPanelModal } from '../library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal';
+import { getFolderByUid } from './state/actions';
+
+export interface OwnProps extends GrafanaRouteComponentProps<{ uid: string }> {}
+
+const mapStateToProps = (state: StoreState, props: OwnProps) => {
+  const uid = props.match.params.uid;
+  return {
+    navModel: getNavModel(state.navIndex, `folder-library-panels-${uid}`, getLoadingNav(1)),
+    folderUid: uid,
+    folder: state.folder,
+  };
+};
+
+const mapDispatchToProps = {
+  getFolderByUid,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+export type Props = OwnProps & ConnectedProps<typeof connector>;
+
+export function FolderLibraryPanelsPage({ navModel, getFolderByUid, folderUid, folder }: Props): JSX.Element {
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<LibraryPanelDTO | undefined>(undefined);
+  useEffect(() => {
+    async function loadFolder() {
+      await getFolderByUid(folderUid);
+      setLoading(false);
+    }
+    loadFolder();
+  }, [getFolderByUid, folderUid]);
+
+  return (
+    <Page navModel={navModel}>
+      <Page.Contents isLoading={loading}>
+        <LibraryPanelsSearch
+          onClick={setSelected}
+          currentFolderId={folder.id}
+          showSecondaryActions
+          showSort
+          showPanelFilter
+        />
+        {selected ? <OpenLibraryPanelModal onDismiss={() => setSelected(undefined)} libraryPanel={selected} /> : null}
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default connector(FolderLibraryPanelsPage);

--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -1,5 +1,5 @@
 import { FolderDTO } from 'app/types';
-import { NavModelItem, NavModel } from '@grafana/data';
+import { NavModel, NavModelItem } from '@grafana/data';
 
 export function buildNavModel(folder: FolderDTO): NavModelItem {
   const model = {
@@ -37,6 +37,14 @@ export function buildNavModel(folder: FolderDTO): NavModelItem {
       id: `folder-settings-${folder.uid}`,
       text: 'Settings',
       url: `${folder.url}/settings`,
+    });
+
+    model.children.push({
+      active: false,
+      icon: 'reusable-panel',
+      id: `folder-library-panels-${folder.uid}`,
+      text: 'Panels',
+      url: `${folder.url}/library-panels`,
     });
   }
 

--- a/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.tsx
@@ -24,6 +24,7 @@ export interface LibraryPanelsSearchProps {
   showFolderFilter?: boolean;
   showSecondaryActions?: boolean;
   currentPanelId?: string;
+  currentFolderId?: number;
   perPage?: number;
 }
 
@@ -31,6 +32,7 @@ export const LibraryPanelsSearch = ({
   onClick,
   variant = LibraryPanelsSearchVariant.Spacious,
   currentPanelId,
+  currentFolderId,
   perPage = DEFAULT_PER_PAGE_PAGINATION,
   showPanelFilter = false,
   showFolderFilter = false,
@@ -40,7 +42,7 @@ export const LibraryPanelsSearch = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [sortDirection, setSortDirection] = useState<string | undefined>(undefined);
   const [panelFilter, setPanelFilter] = useState<string[]>([]);
-  const [folderFilter, setFolderFilter] = useState<string[]>([]);
+  const [folderFilter, setFolderFilter] = useState<string[]>(currentFolderId ? [currentFolderId.toString(10)] : []);
   const styles = useStyles2(getStyles);
   const onSortChange = useCallback((sort: SelectableValue<string>) => setSortDirection(sort.value), []);
   const onFilterChange = useCallback((plugins: PanelPluginMeta[]) => setPanelFilter(plugins.map((p) => p.id)), []);

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -150,6 +150,12 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/dashboards/f/:uid/:slug/library-panels',
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "FolderLibraryPanelsPage"*/ 'app/features/folders/FolderLibraryPanelsPage')
+      ),
+    },
+    {
       path: '/explore',
       pageClass: 'page-explore',
       roles: () => (config.viewersCanEdit ? [] : ['Editor', 'Admin']),


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Panels page to manage folder tabs
![image](https://user-images.githubusercontent.com/562238/116849206-9b3d8b00-abee-11eb-9f68-17154e72ce00.png)

**Which issue(s) this PR fixes**:
Relates #33530

**Special notes for your reviewer**:

