### PR TITLE
CI: Lint backend after testing, to let the test step catch build failures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,15 +27,6 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition oss
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -59,7 +50,16 @@ steps:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition oss
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -273,15 +273,6 @@ steps:
     token:
       from_secret: drone_token
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition oss
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -305,7 +296,16 @@ steps:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition oss
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -721,15 +721,6 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition oss
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -753,7 +744,16 @@ steps:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition oss
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -1089,15 +1089,6 @@ steps:
   depends_on:
   - clone
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition enterprise
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -1121,7 +1112,16 @@ steps:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition enterprise
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -1163,15 +1163,6 @@ steps:
   - initialize
   - lint-backend
 
-- name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition enterprise2
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: test-backend-enterprise2
   image: grafana/build-container:1.4.1
   commands:
@@ -1180,7 +1171,16 @@ steps:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - initialize
-  - lint-backend-enterprise2
+
+- name: lint-backend-enterprise2
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition enterprise2
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend-enterprise2
 
 - name: build-backend-enterprise2
   image: grafana/build-container:1.4.1
@@ -1656,15 +1656,6 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition oss
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -1688,7 +1679,16 @@ steps:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition oss
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -2013,15 +2013,6 @@ steps:
   depends_on:
   - clone
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition enterprise
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -2045,7 +2036,16 @@ steps:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition enterprise
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -2087,15 +2087,6 @@ steps:
   - initialize
   - lint-backend
 
-- name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition enterprise2
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: test-backend-enterprise2
   image: grafana/build-container:1.4.1
   commands:
@@ -2104,7 +2095,16 @@ steps:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - initialize
-  - lint-backend-enterprise2
+
+- name: lint-backend-enterprise2
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition enterprise2
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend-enterprise2
 
 - name: build-backend-enterprise2
   image: grafana/build-container:1.4.1
@@ -2573,15 +2573,6 @@ steps:
   environment:
     DOCKERIZE_VERSION: 0.6.1
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition oss
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -2605,7 +2596,16 @@ steps:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition oss
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -2901,15 +2901,6 @@ steps:
   depends_on:
   - clone
 
-- name: lint-backend
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition enterprise
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: codespell
   image: grafana/build-container:1.4.1
   commands:
@@ -2933,7 +2924,16 @@ steps:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - initialize
-  - lint-backend
+
+- name: lint-backend
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition enterprise
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend
 
 - name: test-frontend
   image: grafana/build-container:1.4.1
@@ -2972,15 +2972,6 @@ steps:
   - initialize
   - lint-backend
 
-- name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.1
-  commands:
-  - ./bin/grabpl lint-backend --edition enterprise2
-  environment:
-    CGO_ENABLED: 1
-  depends_on:
-  - initialize
-
 - name: test-backend-enterprise2
   image: grafana/build-container:1.4.1
   commands:
@@ -2989,7 +2980,16 @@ steps:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - initialize
-  - lint-backend-enterprise2
+
+- name: lint-backend-enterprise2
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/grabpl lint-backend --edition enterprise2
+  environment:
+    CGO_ENABLED: 1
+  depends_on:
+  - initialize
+  - test-backend-enterprise2
 
 - name: build-backend-enterprise2
   image: grafana/build-container:1.4.1

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -215,6 +215,7 @@ def lint_backend_step(edition):
         },
         'depends_on': [
             'initialize',
+            'test-backend' + enterprise2_sfx(edition),
         ],
         'commands': [
             # Don't use Make since it will re-download the linters
@@ -451,7 +452,6 @@ def test_backend_step(edition):
         'image': build_image,
         'depends_on': [
             'initialize',
-            'lint-backend' + enterprise2_sfx(edition),
         ],
         'commands': [
             # First make sure that there are no tests with FocusConvey

--- a/scripts/master.star
+++ b/scripts/master.star
@@ -43,10 +43,10 @@ def get_steps(edition, is_downstream=False):
     include_enterprise2 = edition == 'enterprise'
     steps = [
         enterprise_downstream_step(edition=edition),
-        lint_backend_step(edition=edition),
         codespell_step(),
         shellcheck_step(),
         test_backend_step(edition=edition),
+        lint_backend_step(edition=edition),
         test_frontend_step(),
         frontend_metrics_step(edition=edition),
         build_backend_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
@@ -58,8 +58,8 @@ def get_steps(edition, is_downstream=False):
     if include_enterprise2:
         edition2 = 'enterprise2'
         steps.extend([
-            lint_backend_step(edition=edition2),
             test_backend_step(edition=edition2),
+            lint_backend_step(edition=edition2),
             build_backend_step(edition=edition2, ver_mode=ver_mode, variants=['linux-x64'], is_downstream=is_downstream),
         ])
 

--- a/scripts/pr.star
+++ b/scripts/pr.star
@@ -34,10 +34,10 @@ def pr_pipelines(edition):
     variants = ['linux-x64', 'linux-x64-musl', 'osx64', 'win64',]
     include_enterprise2 = edition == 'enterprise'
     steps = [
-        lint_backend_step(edition=edition),
         codespell_step(),
         shellcheck_step(),
         test_backend_step(edition=edition),
+        lint_backend_step(edition=edition),
         test_frontend_step(),
         build_backend_step(edition=edition, ver_mode=ver_mode, variants=variants),
         build_frontend_step(edition=edition, ver_mode=ver_mode),
@@ -50,8 +50,8 @@ def pr_pipelines(edition):
         steps.append(benchmark_ldap_step())
         services.append(ldap_service())
         steps.extend([
-            lint_backend_step(edition=edition2),
             test_backend_step(edition=edition2),
+            lint_backend_step(edition=edition2),
             build_backend_step(edition=edition2, ver_mode=ver_mode, variants=['linux-x64']),
         ])
 

--- a/scripts/release.star
+++ b/scripts/release.star
@@ -68,10 +68,10 @@ def get_steps(edition, ver_mode):
     include_enterprise2 = edition == 'enterprise'
 
     steps = [
-        lint_backend_step(edition=edition),
         codespell_step(),
         shellcheck_step(),
         test_backend_step(edition=edition),
+        lint_backend_step(edition=edition),
         test_frontend_step(),
         build_backend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_step(edition=edition, ver_mode=ver_mode),
@@ -82,8 +82,8 @@ def get_steps(edition, ver_mode):
     if include_enterprise2:
         edition2 = 'enterprise2'
         steps.extend([
-            lint_backend_step(edition=edition2),
             test_backend_step(edition=edition2),
+            lint_backend_step(edition=edition2),
             build_backend_step(edition=edition2, ver_mode=ver_mode, variants=['linux-x64']),
         ])
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Change CI pipelines to lint backend _after_ testing, to let the latter step catch build failures in a more informative way (build failures when linting are really opaque).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #32155

**Special notes for your reviewer**:

