### PR TITLE
Alerting: remove State cache entries on Ruler DEL

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -73,7 +73,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.Metrics) {
 	api.RegisterRulerApiEndpoints(NewForkedRuler(
 		api.DatasourceCache,
 		NewLotexRuler(proxy, logger),
-		RulerSrv{DatasourceCache: api.DatasourceCache, store: api.RuleStore, log: logger},
+		RulerSrv{DatasourceCache: api.DatasourceCache, manager: api.StateManager, store: api.RuleStore, log: logger},
 	), m)
 	api.RegisterTestingApiEndpoints(TestingApiSrv{
 		AlertingProxy:   proxy,

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 
 	coreapi "github.com/grafana/grafana/pkg/api"
@@ -22,6 +23,7 @@ import (
 type RulerSrv struct {
 	store           store.RuleStore
 	DatasourceCache datasources.CacheService
+	manager         *state.Manager
 	log             log.Logger
 }
 
@@ -32,9 +34,15 @@ func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) respon
 		return toNamespaceErrorResponse(err)
 	}
 
-	if err := srv.store.DeleteNamespaceAlertRules(c.SignedInUser.OrgId, namespace.Uid); err != nil {
+	uids, err := srv.store.DeleteNamespaceAlertRules(c.SignedInUser.OrgId, namespace.Uid)
+	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to delete namespace alert rules", err)
 	}
+
+	for _, uid := range uids {
+		srv.manager.RemoveByRuleUID(c.SignedInUser.OrgId, uid)
+	}
+
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "namespace rules deleted"})
 }
 
@@ -45,11 +53,17 @@ func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Re
 		return toNamespaceErrorResponse(err)
 	}
 	ruleGroup := c.Params(":Groupname")
-	if err := srv.store.DeleteRuleGroupAlertRules(c.SignedInUser.OrgId, namespace.Uid, ruleGroup); err != nil {
+	uids, err := srv.store.DeleteRuleGroupAlertRules(c.SignedInUser.OrgId, namespace.Uid, ruleGroup)
+
+	if err != nil {
 		if errors.Is(err, ngmodels.ErrRuleGroupNamespaceNotFound) {
 			return response.Error(http.StatusNotFound, "failed to delete rule group", err)
 		}
 		return response.Error(http.StatusInternalServerError, "failed to delete rule group", err)
+	}
+
+	for _, uid := range uids {
+		srv.manager.RemoveByRuleUID(c.SignedInUser.OrgId, uid)
 	}
 
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "rule group deleted"})

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -113,6 +113,17 @@ func (c *cache) getStatesByRuleUID() map[string][]*State {
 	return ruleMap
 }
 
+// removeByRuleUID deletes all entries in the state cache that match the given UID.
+func (c *cache) removeByRuleUID(orgID int64, uid string) {
+	c.mtxStates.Lock()
+	defer c.mtxStates.Unlock()
+	for k, state := range c.states {
+		if state.AlertRuleUID == uid && state.OrgID == orgID {
+			delete(c.states, k)
+		}
+	}
+}
+
 func (c *cache) reset() {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -50,9 +50,9 @@ func (st *Manager) ResetCache() {
 	st.cache.reset()
 }
 
-// RemoveByRuleUID deletes all entries in the state manager that match the given UID.
-func (st *Manager) RemoveByRuleUID(orgID int64, uid string) {
-	st.cache.removeByRuleUID(orgID, uid)
+// RemoveByRuleUID deletes all entries in the state manager that match the given rule UID.
+func (st *Manager) RemoveByRuleUID(orgID int64, ruleUID string) {
+	st.cache.removeByRuleUID(orgID, ruleUID)
 }
 
 func (st *Manager) ProcessEvalResults(alertRule *ngModels.AlertRule, results eval.Results) []*State {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -45,9 +45,14 @@ func (st *Manager) Get(id string) (*State, error) {
 	return st.cache.get(id)
 }
 
-//Used to ensure a clean cache on startup
+// ResetCache is used to ensure a clean cache on startup.
 func (st *Manager) ResetCache() {
 	st.cache.reset()
+}
+
+// RemoveByRuleUID deletes all entries in the state manager that match the given UID.
+func (st *Manager) RemoveByRuleUID(orgID int64, uid string) {
+	st.cache.removeByRuleUID(orgID, uid)
 }
 
 func (st *Manager) ProcessEvalResults(alertRule *ngModels.AlertRule, results eval.Results) []*State {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -119,7 +119,7 @@ func (st DBstore) DeleteNamespaceAlertRules(orgID int64, namespaceUID string) ([
 	return ruleUIDs, err
 }
 
-// DeleteRuleGroupAlertRules is a handler for deleting rule group alert rules.
+// DeleteRuleGroupAlertRules is a handler for deleting rule group alert rules. A list of deleted rule UIDs are returned.
 func (st DBstore) DeleteRuleGroupAlertRules(orgID int64, namespaceUID string, ruleGroup string) ([]string, error) {
 	ruleUIDs := []string{}
 
@@ -339,20 +339,6 @@ func (st DBstore) GetNamespaceAlertRules(query *ngmodels.ListNamespaceAlertRules
 		return nil
 	})
 }
-
-// GetNamespaceAlertRuleUIDs is a handler for retrieving namespace alert rules UIDs of specific organisation.
-// func (st DBstore) GetNamespaceAlertRuleUIDs(orgID string, namespace string) ([]string, error) {
-// 	alertRuleUIDs := make([]*ngmodels.AlertRule, 0)
-// 	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-// 		// TODO rewrite using group by namespace_uid, rule_group
-// 		q := "SELECT * FROM alert_rule WHERE org_id = ? and namespace_uid = ?"
-// 		if err := sess.SQL(q, orgID, query.NamespaceUID).Find(&alertRules); err != nil {
-// 			return err
-// 		}
-
-// 		return nil
-// 	})
-// }
 
 // GetRuleGroupAlertRules is a handler for retrieving rule group alert rules of specific organisation.
 func (st DBstore) GetRuleGroupAlertRules(query *ngmodels.ListRuleGroupAlertRulesQuery) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes entries in the State cache when an alert rule namespace or group is deleted via the ruler api.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/alerting-squad/issues/133

**Special notes for your reviewer**:

