### PR TITLE
AlertingMigration: Separate info into multiple annos

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -72,18 +72,31 @@ func (a *alertRule) makeVersion() *alertRuleVersion {
 	}
 }
 
-func getMigrationInfo(da dashAlert) string {
+func addMigrationInfo(da *dashAlert) map[string]string {
+	annotations := da.ParsedSettings.AlertRuleTags
+	if annotations == nil {
+		annotations = make(map[string]string, 3)
+	}
+
+	annotations["__dashboardUid__"] = da.DashboardUID
+	annotations["__panelId__"] = fmt.Sprintf("%v", da.PanelId)
+	annotations["__alertId__"] = fmt.Sprintf("%v", da.Id)
+
+	return annotations
+}
+
+type migInfo struct {
+	dashboardUid string
+	panelId      int
+	alertId      int
+}
+
+func getMigrationString(da *dashAlert) string {
 	return fmt.Sprintf(`{"dashboardUid": "%v", "panelId": %v, "alertId": %v}`, da.DashboardUID, da.PanelId, da.Id)
 }
 
 func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string) (*alertRule, error) {
-	migAnnotation := getMigrationInfo(da)
-
-	annotations := da.ParsedSettings.AlertRuleTags
-	if annotations == nil {
-		annotations = make(map[string]string, 1)
-	}
-	annotations["__migration__info__"] = migAnnotation
+	annotations := addMigrationInfo(&da)
 
 	ar := &alertRule{
 		OrgId:           da.OrgId,

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -85,13 +85,7 @@ func addMigrationInfo(da *dashAlert) map[string]string {
 	return annotations
 }
 
-type migInfo struct {
-	dashboardUid string
-	panelId      int
-	alertId      int
-}
-
-func getMigrationString(da *dashAlert) string {
+func getMigrationString(da dashAlert) string {
 	return fmt.Sprintf(`{"dashboardUid": "%v", "panelId": %v, "alertId": %v}`, da.DashboardUID, da.PanelId, da.Id)
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -113,7 +113,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 		switch {
 		case dash.HasAcl:
 			// create folder and assign the permissions of the dashboard (included default and inherited)
-			ptr, err := m.createFolder(dash.OrgId, fmt.Sprintf(DASHBOARD_FOLDER, getMigrationInfo(da)))
+			ptr, err := m.createFolder(dash.OrgId, fmt.Sprintf(DASHBOARD_FOLDER, getMigrationString(&da)))
 			if err != nil {
 				return MigrationError{
 					Err:     fmt.Errorf("failed to create folder: %w", err),

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -113,7 +113,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 		switch {
 		case dash.HasAcl:
 			// create folder and assign the permissions of the dashboard (included default and inherited)
-			ptr, err := m.createFolder(dash.OrgId, fmt.Sprintf(DASHBOARD_FOLDER, getMigrationString(&da)))
+			ptr, err := m.createFolder(dash.OrgId, fmt.Sprintf(DASHBOARD_FOLDER, getMigrationString(da)))
 			if err != nil {
 				return MigrationError{
 					Err:     fmt.Errorf("failed to create folder: %w", err),


### PR DESCRIPTION
**What this PR does / why we need it**:
Migration info annotations are separate instead of one json(ish) string, as requested by @domasx2 

Exampled migrated alert in edit view:
![image](https://user-images.githubusercontent.com/1692624/116885706-2f5f2080-abf6-11eb-9ff5-7551fc487261.png)


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/alerting-squad/issues/134

**Special notes for your reviewer**:

