### PR TITLE
Fix dockerfiles to use embed.go and Go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,12 @@ RUN apk add --no-cache gcc g++
 
 WORKDIR $GOPATH/src/github.com/grafana/grafana
 
-COPY go.mod go.sum ./
+COPY go.mod go.sum embed.go ./
 
 RUN go mod verify
 
+COPY cue cue
+COPY public/app/plugins public/app/plugins
 COPY pkg pkg
 COPY build.go package.json ./
 
@@ -74,7 +76,7 @@ RUN export GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
     chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
-COPY --from=go-builder /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-server /go/src/github.com/grafana/grafana/bin/linux-amd64/grafana-cli ./bin/
+COPY --from=go-builder /go/src/github.com/grafana/grafana/bin/*/grafana-server /go/src/github.com/grafana/grafana/bin/*/grafana-cli ./bin/
 COPY --from=js-builder /usr/src/app/public ./public
 COPY --from=js-builder /usr/src/app/tools ./tools
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -17,16 +17,18 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.15.1 AS go-builder
+FROM golang:1.16 AS go-builder
 
 WORKDIR /src/grafana
 
-COPY go.mod go.sum ./
+COPY go.mod go.sum embed.go ./
 
 RUN go mod verify
 
 COPY build.go package.json ./
 COPY pkg pkg/
+COPY cue cue/
+COPY public/app/plugins public/app/plugins/
 
 RUN go run build.go build
 
@@ -68,7 +70,7 @@ RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
-COPY --from=go-builder /src/grafana/bin/linux-amd64/grafana-server /src/grafana/bin/linux-amd64/grafana-cli bin/
+COPY --from=go-builder /src/grafana/bin/*/grafana-server /src/grafana/bin/*/grafana-cli bin/
 COPY --from=js-builder /usr/src/app/public public
 COPY --from=js-builder /usr/src/app/tools tools
 


### PR DESCRIPTION
Closes #33636 

Adds `embed.go` and the embeddable files to the builder image, fixes the builds.
Also, copies _any available_ GOOS/GOARCH binaries to the final binaries folder (should work on `linux-amd64`, `linux-arm64` for RPi fans and `darwin-arm64` for M1 owners).