### PR TITLE
Chore: Fix alerting migration code owners typo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@ go.sum @grafana/backend-platform
 
 # Unified Alerting
 /pkg/services/ngalert @grafana/alerting-squad
- pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad
+/pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad
 
 # Database migrations
 /pkg/services/sqlstore/migrations @grafana/backend-platform @grafana/hosted-grafana-team


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/grafana/grafana/pull/33571/files was missing leading forward slash, which is I think the reason changes for this folder still going to backend team. 


