### PR TITLE
Toolkit: add deprecation notice to toolkit/ci commands

### DIFF
--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -15,7 +15,6 @@ import { closeMilestoneTask } from './tasks/closeMilestone';
 import { pluginDevTask } from './tasks/plugin.dev';
 import { githubPublishTask } from './tasks/plugin.utils';
 import { pluginUpdateTask } from './tasks/plugin.update';
-// DEPRECATED
 import { ciBuildPluginTask, ciPackagePluginTask, ciPluginReportTask } from './tasks/plugin.ci';
 import { buildPackageTask } from './tasks/package.build';
 import { pluginCreateTask } from './tasks/plugin.create';

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -15,7 +15,8 @@ import { closeMilestoneTask } from './tasks/closeMilestone';
 import { pluginDevTask } from './tasks/plugin.dev';
 import { githubPublishTask } from './tasks/plugin.utils';
 import { pluginUpdateTask } from './tasks/plugin.update';
-import { ciBuildPluginDocsTask, ciBuildPluginTask, ciPackagePluginTask, ciPluginReportTask } from './tasks/plugin.ci';
+// DEPRECATED
+import { ciBuildPluginTask, ciPackagePluginTask, ciPluginReportTask } from './tasks/plugin.ci';
 import { buildPackageTask } from './tasks/package.build';
 import { pluginCreateTask } from './tasks/plugin.create';
 import { pluginSignTask } from './tasks/plugin.sign';
@@ -210,7 +211,7 @@ export const run = (includeInternalScripts = false) => {
     .command('plugin:ci-build')
     .option('--finish', 'move all results to the jobs folder', false)
     .option('--maxJestWorkers <num>|<string>', 'Limit number of Jest workers spawned')
-    .description('Build the plugin, leaving results in /dist and /coverage')
+    .description('[deprecated] Build the plugin, leaving results in /dist and /coverage')
     .action(async (cmd) => {
       await execTask(ciBuildPluginTask)({
         finish: cmd.finish,
@@ -219,18 +220,11 @@ export const run = (includeInternalScripts = false) => {
     });
 
   program
-    .command('plugin:ci-docs')
-    .description('Build the HTML docs')
-    .action(async (cmd) => {
-      await execTask(ciBuildPluginDocsTask)({});
-    });
-
-  program
     .command('plugin:ci-package')
     .option('--signatureType <type>', 'Signature Type')
     .option('--rootUrls <urls...>', 'Root URLs')
     .option('--signing-admin', 'Use the admin API endpoint for signing the manifest. (deprecated)', false)
-    .description('Create a zip packages for the plugin')
+    .description('[deprecated] Create a zip packages for the plugin')
     .action(async (cmd) => {
       await execTask(ciPackagePluginTask)({
         signatureType: cmd.signatureType,
@@ -240,7 +234,7 @@ export const run = (includeInternalScripts = false) => {
 
   program
     .command('plugin:ci-report')
-    .description('Build a report for this whole process')
+    .description('[deprecated] Build a report for this whole process')
     .option('--upload', 'upload packages also')
     .action(async (cmd) => {
       await execTask(ciPluginReportTask)({

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.ci.ts
@@ -41,6 +41,10 @@ export interface PluginCIOptions {
  *
  *  Anything that should be put into the final zip file should be put in:
  *   ~/ci/jobs/build_xxx/dist
+ *
+ * @deprecated -- this task was written with a specific circle-ci build in mind.  That system
+ * has been replaced with Drone, and this is no longer the best practice.  Any new work
+ * should be defined in the grafana build pipeline tool or drone configs directly.
  */
 const buildPluginRunner: TaskRunner<PluginCIOptions> = async ({ finish, maxJestWorkers }) => {
   const start = Date.now();
@@ -67,43 +71,17 @@ const buildPluginRunner: TaskRunner<PluginCIOptions> = async ({ finish, maxJestW
 export const ciBuildPluginTask = new Task<PluginCIOptions>('Build Plugin', buildPluginRunner);
 
 /**
- * 2. Build Docs
- *
- *  Take /docs/* and format it into /ci/docs/HTML site
- *
- */
-const buildPluginDocsRunner: TaskRunner<PluginCIOptions> = async () => {
-  const docsSrc = path.resolve(process.cwd(), 'docs');
-  if (!fs.existsSync(docsSrc)) {
-    console.log('No docs src');
-    return;
-  }
-
-  const start = Date.now();
-  const workDir = getJobFolder();
-  await execa('rimraf', [workDir]);
-  fs.mkdirSync(workDir);
-
-  const docsDest = path.resolve(process.cwd(), 'ci', 'docs');
-  fs.mkdirSync(docsDest);
-
-  const exe = await execa('cp', ['-rv', docsSrc + '/.', docsDest]);
-  console.log(exe.stdout);
-
-  fs.writeFileSync(path.resolve(docsDest, 'index.html'), `TODO... actually build docs`, { encoding: 'utf-8' });
-
-  writeJobStats(start, workDir);
-};
-
-export const ciBuildPluginDocsTask = new Task<PluginCIOptions>('Build Plugin Docs', buildPluginDocsRunner);
-
-/**
  * 2. Package
  *
  *  Take everything from `~/ci/job/{any}/dist` and
  *  1. merge it into: `~/ci/dist`
  *  2. zip it into packages in `~/ci/packages`
  *  3. prepare grafana environment in: `~/ci/grafana-test-env`
+ *
+ *
+ * @deprecated -- this task was written with a specific circle-ci build in mind.  That system
+ * has been replaced with Drone, and this is no longer the best practice.  Any new work
+ * should be defined in the grafana build pipeline tool or drone configs directly.
  */
 const packagePluginRunner: TaskRunner<PluginCIOptions> = async ({ signatureType, rootUrls }) => {
   const start = Date.now();
@@ -224,6 +202,10 @@ export const ciPackagePluginTask = new Task<PluginCIOptions>('Bundle Plugin', pa
  * 4. Report
  *
  *  Create a report from all the previous steps
+ *
+ * @deprecated -- this task was written with a specific circle-ci build in mind.  That system
+ * has been replaced with Drone, and this is no longer the best practice.  Any new work
+ * should be defined in the grafana build pipeline tool or drone configs directly.
  */
 const pluginReportRunner: TaskRunner<PluginCIOptions> = async ({ upload }) => {
   const ciDir = path.resolve(process.cwd(), 'ci');


### PR DESCRIPTION
We have migrated most things from circle to drone, however there remain a few (confusing) steps left in toolkit.

We want to remove toolkit from the ci process entirely, but that will be a bigger task.  This PR adds warnings to the toolkit code just in case anyone is looking there :shrug: 