### PR TITLE
Plugins: AuthType in route configuration and params interpolation

### DIFF
--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -54,7 +54,7 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 	}
 
 	if tokenProvider, err := getTokenProvider(ctx, ds, route, data); err != nil {
-		logger.Error("Failed resolve auth token provider", "error", err)
+		logger.Error("Failed to resolve auth token provider", "error", err)
 	} else if tokenProvider != nil {
 		if token, err := tokenProvider.getAccessToken(); err != nil {
 			logger.Error("Failed to get access token", "error", err)

--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -53,7 +53,9 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		logger.Error("Failed to set plugin route body content", "error", err)
 	}
 
-	if tokenProvider := getTokenProvider(ctx, ds, route, data); tokenProvider != nil {
+	if tokenProvider, err := getTokenProvider(ctx, ds, route, data); err != nil {
+		logger.Error("Failed resolve auth token provider", "error", err)
+	} else if tokenProvider != nil {
 		if token, err := tokenProvider.getAccessToken(); err != nil {
 			logger.Error("Failed to get access token", "error", err)
 		} else {
@@ -65,7 +67,7 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 }
 
 func getTokenProvider(ctx context.Context, ds *models.DataSource, pluginRoute *plugins.AppPluginRoute,
-	data templateData) accessTokenProvider {
+	data templateData) (accessTokenProvider, error) {
 	authType := pluginRoute.AuthType
 
 	// Plugin can override authentication type specified in route configuration
@@ -73,22 +75,72 @@ func getTokenProvider(ctx context.Context, ds *models.DataSource, pluginRoute *p
 		authType = authTypeOverride
 	}
 
-	switch authType {
-	case "gce":
-		return newGceAccessTokenProvider(ctx, ds, pluginRoute)
-	case "jwt":
-		if pluginRoute.JwtTokenAuth != nil {
-			return newJwtAccessTokenProvider(ctx, ds, pluginRoute, data)
-		}
-	default:
-		// Fallback to authentication options when authentication type isn't explicitly configured
-		if pluginRoute.TokenAuth != nil {
-			return newGenericAccessTokenProvider(ds, pluginRoute, data)
-		}
-		if pluginRoute.JwtTokenAuth != nil {
-			return newJwtAccessTokenProvider(ctx, ds, pluginRoute, data)
-		}
+	tokenAuth, err := interpolateAuthParams(pluginRoute.TokenAuth, data)
+	if err != nil {
+		return nil, err
+	}
+	jwtTokenAuth, err := interpolateAuthParams(pluginRoute.JwtTokenAuth, data)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	switch authType {
+	case "gce":
+		if jwtTokenAuth == nil {
+			return nil, fmt.Errorf("'jwtTokenAuth' not configured for authentication type '%s'", authType)
+		}
+		provider := newGceAccessTokenProvider(ctx, ds, pluginRoute, jwtTokenAuth)
+		return provider, nil
+
+	case "jwt":
+		if jwtTokenAuth == nil {
+			return nil, fmt.Errorf("'jwtTokenAuth' not configured for authentication type '%s'", authType)
+		}
+		provider := newJwtAccessTokenProvider(ctx, ds, pluginRoute, jwtTokenAuth)
+		return provider, nil
+
+	case "":
+		// Fallback to authentication methods when authentication type isn't explicitly configured
+		if tokenAuth != nil {
+			provider := newGenericAccessTokenProvider(ds, pluginRoute, tokenAuth)
+			return provider, nil
+		}
+		if jwtTokenAuth != nil {
+			provider := newJwtAccessTokenProvider(ctx, ds, pluginRoute, jwtTokenAuth)
+			return provider, nil
+		}
+
+		// No authentication
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("authentication type '%s' not supported", authType)
+	}
+}
+
+func interpolateAuthParams(tokenAuth *plugins.JwtTokenAuth, data templateData) (*plugins.JwtTokenAuth, error) {
+	if tokenAuth == nil {
+		// Nothing to interpolate
+		return nil, nil
+	}
+
+	interpolatedUrl, err := interpolateString(tokenAuth.Url, data)
+	if err != nil {
+		return nil, err
+	}
+
+	interpolatedParams := make(map[string]string)
+	for key, value := range tokenAuth.Params {
+		interpolatedParam, err := interpolateString(value, data)
+		if err != nil {
+			return nil, err
+		}
+		interpolatedParams[key] = interpolatedParam
+	}
+
+	return &plugins.JwtTokenAuth{
+		Url:    interpolatedUrl,
+		Scopes: tokenAuth.Scopes,
+		Params: interpolatedParams,
+	}, nil
 }

--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -66,9 +66,14 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 
 func getTokenProvider(ctx context.Context, ds *models.DataSource, pluginRoute *plugins.AppPluginRoute,
 	data templateData) accessTokenProvider {
-	authenticationType := ds.JsonData.Get("authenticationType").MustString()
+	authType := pluginRoute.AuthType
 
-	switch authenticationType {
+	// Plugin can override authentication type specified in route configuration
+	if authTypeOverride := ds.JsonData.Get("authenticationType").MustString(); authTypeOverride != "" {
+		authType = authTypeOverride
+	}
+
+	switch authType {
 	case "gce":
 		return newGceAccessTokenProvider(ctx, ds, pluginRoute)
 	case "jwt":

--- a/pkg/api/pluginproxy/ds_auth_provider_test.go
+++ b/pkg/api/pluginproxy/ds_auth_provider_test.go
@@ -1,0 +1,62 @@
+package pluginproxy
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyRoute_interpolateAuthParams(t *testing.T) {
+	pluginRoute := &plugins.AppPluginRoute{
+		Path:   "pathwithjwttoken1",
+		URL:    "https://api.jwt.io/some/path",
+		Method: "GET",
+		TokenAuth: &plugins.JwtTokenAuth{
+			Url: "https://login.server.com/{{.JsonData.tenantId}}/oauth2/token",
+			Scopes: []string{
+				"https://www.testapi.com/auth/Read.All",
+				"https://www.testapi.com/auth/Write.All",
+			},
+			Params: map[string]string{
+				"token_uri":    "{{.JsonData.tokenUri}}",
+				"client_email": "{{.JsonData.clientEmail}}",
+				"private_key":  "{{.SecureJsonData.privateKey}}",
+			},
+		},
+	}
+
+	templateData := templateData{
+		JsonData: map[string]interface{}{
+			"clientEmail": "test@test.com",
+			"tokenUri":    "login.url.com/token",
+			"tenantId":    "f09c86ac",
+		},
+		SecureJsonData: map[string]string{
+			"privateKey": "testkey",
+		},
+	}
+
+	t.Run("should interpolate JwtTokenAuth struct using given JsonData", func(t *testing.T) {
+		interpolated, err := interpolateAuthParams(pluginRoute.TokenAuth, templateData)
+		require.NoError(t, err)
+		require.NotNil(t, interpolated)
+
+		assert.Equal(t, "https://login.server.com/f09c86ac/oauth2/token", interpolated.Url)
+
+		assert.Equal(t, 2, len(interpolated.Scopes))
+		assert.Equal(t, "https://www.testapi.com/auth/Read.All", interpolated.Scopes[0])
+		assert.Equal(t, "https://www.testapi.com/auth/Write.All", interpolated.Scopes[1])
+
+		assert.Equal(t, "login.url.com/token", interpolated.Params["token_uri"])
+		assert.Equal(t, "test@test.com", interpolated.Params["client_email"])
+		assert.Equal(t, "testkey", interpolated.Params["private_key"])
+	})
+
+	t.Run("should return Nil if given JwtTokenAuth is Nil", func(t *testing.T) {
+		interpolated, err := interpolateAuthParams(pluginRoute.JwtTokenAuth, templateData)
+		require.NoError(t, err)
+		require.Nil(t, interpolated)
+	})
+}

--- a/pkg/api/pluginproxy/token_provider_gce.go
+++ b/pkg/api/pluginproxy/token_provider_gce.go
@@ -13,19 +13,22 @@ type gceAccessTokenProvider struct {
 	datasourceVersion int
 	ctx               context.Context
 	route             *plugins.AppPluginRoute
+	authParams        *plugins.JwtTokenAuth
 }
 
-func newGceAccessTokenProvider(ctx context.Context, ds *models.DataSource, pluginRoute *plugins.AppPluginRoute) *gceAccessTokenProvider {
+func newGceAccessTokenProvider(ctx context.Context, ds *models.DataSource, pluginRoute *plugins.AppPluginRoute,
+	authParams *plugins.JwtTokenAuth) *gceAccessTokenProvider {
 	return &gceAccessTokenProvider{
 		datasourceId:      ds.Id,
 		datasourceVersion: ds.Version,
 		ctx:               ctx,
 		route:             pluginRoute,
+		authParams:        authParams,
 	}
 }
 
 func (provider *gceAccessTokenProvider) getAccessToken() (string, error) {
-	tokenSrc, err := google.DefaultTokenSource(provider.ctx, provider.route.JwtTokenAuth.Scopes...)
+	tokenSrc, err := google.DefaultTokenSource(provider.ctx, provider.authParams.Scopes...)
 	if err != nil {
 		logger.Error("Failed to get default token from meta data server", "error", err)
 		return "", err

--- a/pkg/api/pluginproxy/token_provider_jwt.go
+++ b/pkg/api/pluginproxy/token_provider_jwt.go
@@ -28,17 +28,17 @@ type jwtAccessTokenProvider struct {
 	datasourceVersion int
 	ctx               context.Context
 	route             *plugins.AppPluginRoute
-	data              templateData
+	authParams        *plugins.JwtTokenAuth
 }
 
 func newJwtAccessTokenProvider(ctx context.Context, ds *models.DataSource, pluginRoute *plugins.AppPluginRoute,
-	data templateData) *jwtAccessTokenProvider {
+	authParams *plugins.JwtTokenAuth) *jwtAccessTokenProvider {
 	return &jwtAccessTokenProvider{
 		datasourceId:      ds.Id,
 		datasourceVersion: ds.Version,
 		ctx:               ctx,
 		route:             pluginRoute,
-		data:              data,
+		authParams:        authParams,
 	}
 }
 
@@ -54,31 +54,19 @@ func (provider *jwtAccessTokenProvider) getAccessToken() (string, error) {
 
 	conf := &jwt.Config{}
 
-	if val, ok := provider.route.JwtTokenAuth.Params["client_email"]; ok {
-		interpolatedVal, err := interpolateString(val, provider.data)
-		if err != nil {
-			return "", err
-		}
-		conf.Email = interpolatedVal
+	if val, ok := provider.authParams.Params["client_email"]; ok {
+		conf.Email = val
 	}
 
-	if val, ok := provider.route.JwtTokenAuth.Params["private_key"]; ok {
-		interpolatedVal, err := interpolateString(val, provider.data)
-		if err != nil {
-			return "", err
-		}
-		conf.PrivateKey = []byte(interpolatedVal)
+	if val, ok := provider.authParams.Params["private_key"]; ok {
+		conf.PrivateKey = []byte(val)
 	}
 
-	if val, ok := provider.route.JwtTokenAuth.Params["token_uri"]; ok {
-		interpolatedVal, err := interpolateString(val, provider.data)
-		if err != nil {
-			return "", err
-		}
-		conf.TokenURL = interpolatedVal
+	if val, ok := provider.authParams.Params["token_uri"]; ok {
+		conf.TokenURL = val
 	}
 
-	conf.Scopes = provider.route.JwtTokenAuth.Scopes
+	conf.Scopes = provider.authParams.Scopes
 
 	token, err := getTokenSource(conf, provider.ctx)
 	if err != nil {

--- a/pkg/plugins/app_plugin.go
+++ b/pkg/plugins/app_plugin.go
@@ -33,6 +33,7 @@ type AppPluginRoute struct {
 	URL          string                   `json:"url"`
 	URLParams    []AppPluginRouteURLParam `json:"urlParams"`
 	Headers      []AppPluginRouteHeader   `json:"headers"`
+	AuthType     string                   `json:"authType"`
 	TokenAuth    *JwtTokenAuth            `json:"tokenAuth"`
 	JwtTokenAuth *JwtTokenAuth            `json:"jwtTokenAuth"`
 	Body         json.RawMessage          `json:"body"`


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds optional `authType` property directly into the route configuration, so authentication method (and token provider implementation) can be explicitly defined for each route.
This is useful for routes which require a custom (non-generic) implementation of token provider, e.g. Azure data sources.

Another change is template interpolation of auth parameters (`tokenAuth` and `jwtTokenAuth`) has been moved from token providers to common code, so individual token providers do not need to re-implement interpolation anymore.

This PR doesn't break existing authentication behavior when `authType` isn't explicitly provided.




See also #33669
