### PR TITLE
RadioButtonGroup: Change background to background.primary

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
@@ -57,7 +57,7 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme2, size: RadioBut
 
   const textColor = theme.colors.text.secondary;
   const textColorHover = theme.colors.text.primary;
-  const bg = theme.components.input.background;
+  const bg = theme.colors.background.primary;
   // remove the group inner padding (set on RadioButtonGroup)
   const labelHeight = height * theme.spacing.gridSize - 4 - 2;
 


### PR DESCRIPTION
Does not impact light theme, this will make light & dark theme more similar. 

![Screenshot from 2021-05-04 10-44-13](https://user-images.githubusercontent.com/10999/116979959-ef676e80-acc5-11eb-8e3c-20e63065460a.png)
