### PR TITLE
Respect hour12 settings when formatting local date

### DIFF
--- a/packages/grafana-data/src/datetime/formats.test.ts
+++ b/packages/grafana-data/src/datetime/formats.test.ts
@@ -18,7 +18,7 @@ describe('Date Formats', () => {
   });
 });
 
-describe('Date Formats with hour12', () => {
+describe('Date Formats without hour12', () => {
   it('localTimeFormat', () => {
     const format = localTimeFormat(
       {

--- a/packages/grafana-data/src/datetime/formats.test.ts
+++ b/packages/grafana-data/src/datetime/formats.test.ts
@@ -14,6 +14,25 @@ describe('Date Formats', () => {
       ''
     );
 
-    expect(format).toBe('MM/DD/YYYY, HH:mm:ss A');
+    expect(format).toBe('MM/DD/YYYY, hh:mm:ss A');
+  });
+});
+
+describe('Date Formats with hour12', () => {
+  it('localTimeFormat', () => {
+    const format = localTimeFormat(
+      {
+        year: '2-digit',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      },
+      ''
+    );
+
+    expect(format).toBe('MM/DD/YYYY, HH:mm:ss');
   });
 });

--- a/packages/grafana-data/src/datetime/formats.ts
+++ b/packages/grafana-data/src/datetime/formats.ts
@@ -97,8 +97,9 @@ export function localTimeFormat(
   }
 
   // https://momentjs.com/docs/#/displaying/format/
-  const parts = new Intl.DateTimeFormat(locale, options).formatToParts(new Date());
-  const hour12 = !!parts.filter((part) => part.type === 'dayPeriod').pop();
+  const dateTimeFormat = new Intl.DateTimeFormat(locale, options);
+  const parts = dateTimeFormat.formatToParts(new Date());
+  const hour12 = dateTimeFormat.resolvedOptions().hour12;
 
   const mapping: { [key: string]: string } = {
     year: 'YYYY',

--- a/packages/grafana-data/src/datetime/formats.ts
+++ b/packages/grafana-data/src/datetime/formats.ts
@@ -98,11 +98,13 @@ export function localTimeFormat(
 
   // https://momentjs.com/docs/#/displaying/format/
   const parts = new Intl.DateTimeFormat(locale, options).formatToParts(new Date());
+  const hour12 = !!parts.filter((part) => part.type === 'dayPeriod').pop();
+
   const mapping: { [key: string]: string } = {
     year: 'YYYY',
     month: 'MM',
     day: 'DD',
-    hour: 'HH',
+    hour: hour12 ? 'hh' : 'HH',
     minute: 'mm',
     second: 'ss',
     weekday: 'ddd',


### PR DESCRIPTION
Hi!
Following https://github.com/grafana/grafana/pull/25602#issuecomment-687655554

This PR will make local date formatting to respect `hour12` option, and properly translate format to momentjs