### PR TITLE
Dashboard: prevent error when sharing a dashboard.

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -71,10 +71,10 @@ export class ShareModal extends React.Component<Props, State> {
     this.state = getInitialState(props);
   }
 
-  onDismiss = () => {
-    this.setState(getInitialState(this.props));
-    this.props.onDismiss();
-  };
+  // onDismiss = () => {
+  //   //this.setState(getInitialState(this.props));
+  //   this.props.onDismiss();
+  // };
 
   onSelectTab = (t: any) => {
     this.setState({ activeTab: t.value });
@@ -112,9 +112,9 @@ export class ShareModal extends React.Component<Props, State> {
     const ActiveTab = activeTabModel.component;
 
     return (
-      <Modal isOpen={true} title={this.renderTitle()} onDismiss={this.onDismiss}>
+      <Modal isOpen={true} title={this.renderTitle()} onDismiss={this.props.onDismiss}>
         <TabContent>
-          <ActiveTab dashboard={dashboard} panel={panel} onDismiss={this.onDismiss} />
+          <ActiveTab dashboard={dashboard} panel={panel} onDismiss={this.props.onDismiss} />
         </TabContent>
       </Modal>
     );


### PR DESCRIPTION
**What this PR does / why we need it**:
When exporting a dashboard and using the `trimmed` dashboard json settings we get the following issue in the console. I have tracked it down to the `this.setState(getInitialState(this.props));` in the `ShareModal`. I don't understand why we would want to reset the state on a component that will be unmounted since it is just local state. Feel free to comment on this if you know why or see any reason why we should keep this line.

```
react_devtools_backend.js:2557 Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    at ShareLink (http://localhost:3000/public/build/default~app.94c4703c7ba6755bcc0f.js:96857:5)
    at div
    at TabContent (http://localhost:3000/public/build/default~app.94c4703c7ba6755bcc0f.js:50837:5)
    at div
    at div
    at div
    at Portal (http://localhost:3000/public/build/default~app.94c4703c7ba6755bcc0f.js:45317:5)
    at Modal (http://localhost:3000/public/build/default~app.94c4703c7ba6755bcc0f.js:40480:5)
    at ShareModal (http://localhost:3000/public/build/default~app.94c4703c7ba6755bcc0f.js:97113:5)
overrideMethod @ react_devtools_backend.js:2557
printWarning @ react-dom.development.js:67
error @ react-dom.development.js:43
warnAboutUpdateOnUnmountedFiberInDEV @ react-dom.development.js:23914
scheduleUpdateOnFiber @ react-dom.development.js:21840
enqueueSetState @ react-dom.development.js:12467
push../node_modules/react/cjs/react.development.js.Component.setState @ react.development.js:365
ShareLink.buildUrl @ ShareLink.tsx:63
async function (async)
ShareLink.buildUrl @ ShareLink.tsx:60
componentDidMount @ ShareLink.tsx:42
commitLifeCycles @ react-dom.development.js:20663
commitLayoutEffects @ react-dom.development.js:23426
callCallback @ react-dom.development.js:3945
invokeGuardedCallbackDev @ react-dom.development.js:3994
invokeGuardedCallback @ react-dom.development.js:4056
commitRootImpl @ react-dom.development.js:23151
unstable_runWithPriority @ scheduler.development.js:646
runWithPriority$1 @ react-dom.development.js:11276
commitRoot @ react-dom.development.js:22990
performSyncWorkOnRoot @ react-dom.development.js:22329
(anonymous) @ react-dom.development.js:11327
unstable_runWithPriority @ scheduler.development.js:646
runWithPriority$1 @ react-dom.development.js:11276
flushSyncCallbackQueueImpl @ react-dom.development.js:11322
flushSyncCallbackQueue @ react-dom.development.js:11309
scheduleUpdateOnFiber @ react-dom.development.js:21893
enqueueSetState @ react-dom.development.js:12467
push../node_modules/react/cjs/react.development.js.Component.setState @ react.development.js:365
ShareModal.onDismiss @ ShareModal.tsx:75
ShareExport.openJsonModal @ ShareExport.tsx:127
(anonymous) @ ShareExport.tsx:100
Promise.then (async)
ShareExport.onViewJson @ ShareExport.tsx:99
callCallback @ react-dom.development.js:3945
invokeGuardedCallbackDev @ react-dom.development.js:3994
invokeGuardedCallback @ react-dom.development.js:4056
invokeGuardedCallbackAndCatchFirstError @ react-dom.development.js:4070
executeDispatch @ react-dom.development.js:8243
processDispatchQueueItemsInOrder @ react-dom.development.js:8275
processDispatchQueue @ react-dom.development.js:8288
dispatchEventsForPlugins @ react-dom.development.js:8299
(anonymous) @ react-dom.development.js:8508
batchedEventUpdates$1 @ react-dom.development.js:22396
batchedEventUpdates @ react-dom.development.js:3745
dispatchEventForPluginEventSystem @ react-dom.development.js:8507
attemptToDispatchEvent @ react-dom.development.js:6005
dispatchEvent @ react-dom.development.js:5924
unstable_runWithPriority @ scheduler.development.js:646
runWithPriority$1 @ react-dom.development.js:11276
discreteUpdates$1 @ react-dom.development.js:22413
discreteUpdates @ react-dom.development.js:3756
dispatchDiscreteEvent @ react-dom.development.js:5889

```

**Which issue(s) this PR fixes**:
Fixes this error introduced by #33561

**Special notes for your reviewer**:
You need to have the `trimDefaults` feature toggle enabled to test this.
