### PR TITLE
Instrumentation: Enable tracing when Jaeger host and port are set

### DIFF
--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -53,16 +53,11 @@ func (ts *TracingService) Init() error {
 
 func (ts *TracingService) parseSettings() {
 	var section, err = ts.Cfg.Raw.GetSection("tracing.jaeger")
-	if err == nil {
-		ts.address = section.Key("address").MustString("")
-		ts.customTags = splitTagSettings(section.Key("always_included_tag").MustString(""))
-		ts.samplerType = section.Key("sampler_type").MustString("")
-		ts.samplerParam = section.Key("sampler_param").MustFloat64(1)
-		ts.zipkinPropagation = section.Key("zipkin_propagation").MustBool(false)
-		ts.disableSharedZipkinSpans = section.Key("disable_shared_zipkin_spans").MustBool(false)
-		ts.samplingServerURL = section.Key("sampling_server_url").MustString("")
+	if err != nil {
+		return
 	}
 
+	ts.address = section.Key("address").MustString("")
 	if ts.address == "" {
 		host := os.Getenv(envJaegerAgentHost)
 		port := os.Getenv(envJaegerAgentPort)
@@ -73,6 +68,13 @@ func (ts *TracingService) parseSettings() {
 	if ts.address != "" {
 		ts.enabled = true
 	}
+
+	ts.customTags = splitTagSettings(section.Key("always_included_tag").MustString(""))
+	ts.samplerType = section.Key("sampler_type").MustString("")
+	ts.samplerParam = section.Key("sampler_param").MustFloat64(1)
+	ts.zipkinPropagation = section.Key("zipkin_propagation").MustBool(false)
+	ts.disableSharedZipkinSpans = section.Key("disable_shared_zipkin_spans").MustBool(false)
+	ts.samplingServerURL = section.Key("sampling_server_url").MustString("")
 }
 
 func (ts *TracingService) initJaegerCfg() (jaegercfg.Configuration, error) {

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -66,7 +66,7 @@ func (ts *TracingService) parseSettings() {
 	if ts.address == "" {
 		host := os.Getenv(envJaegerAgentHost)
 		port := os.Getenv(envJaegerAgentPort)
-		if host != "" {
+		if host != "" || port != "" {
 			ts.address = fmt.Sprintf("%s:%s", host, port)
 		}
 	}

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -42,7 +42,9 @@ type TracingService struct {
 
 func (ts *TracingService) Init() error {
 	ts.log = log.New("tracing")
-	ts.parseSettings()
+	if err := ts.parseSettings(); err != nil {
+		return err
+	}
 
 	if ts.enabled {
 		return ts.initGlobalTracer()
@@ -51,10 +53,10 @@ func (ts *TracingService) Init() error {
 	return nil
 }
 
-func (ts *TracingService) parseSettings() {
+func (ts *TracingService) parseSettings() error {
 	var section, err = ts.Cfg.Raw.GetSection("tracing.jaeger")
 	if err != nil {
-		return
+		return err
 	}
 
 	ts.address = section.Key("address").MustString("")
@@ -75,6 +77,7 @@ func (ts *TracingService) parseSettings() {
 	ts.zipkinPropagation = section.Key("zipkin_propagation").MustBool(false)
 	ts.disableSharedZipkinSpans = section.Key("disable_shared_zipkin_spans").MustBool(false)
 	ts.samplingServerURL = section.Key("sampling_server_url").MustString("")
+	return nil
 }
 
 func (ts *TracingService) initJaegerCfg() (jaegercfg.Configuration, error) {

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -13,6 +14,11 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
 	"github.com/uber/jaeger-client-go/zipkin"
+)
+
+const (
+	envJaegerAgentHost = "JAEGER_AGENT_HOST"
+	envJaegerAgentPort = "JAEGER_AGENT_PORT"
 )
 
 func init() {
@@ -52,6 +58,13 @@ func (ts *TracingService) parseSettings() {
 	}
 
 	ts.address = section.Key("address").MustString("")
+	if ts.address == "" {
+		host := os.Getenv(envJaegerAgentHost)
+		port := os.Getenv(envJaegerAgentPort)
+		if host != "" && port != "" {
+			ts.address = fmt.Sprintf("%s:%s", host, port)
+		}
+	}
 	if ts.address != "" {
 		ts.enabled = true
 	}

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -53,28 +53,26 @@ func (ts *TracingService) Init() error {
 
 func (ts *TracingService) parseSettings() {
 	var section, err = ts.Cfg.Raw.GetSection("tracing.jaeger")
-	if err != nil {
-		return
+	if err == nil {
+		ts.address = section.Key("address").MustString("")
+		ts.customTags = splitTagSettings(section.Key("always_included_tag").MustString(""))
+		ts.samplerType = section.Key("sampler_type").MustString("")
+		ts.samplerParam = section.Key("sampler_param").MustFloat64(1)
+		ts.zipkinPropagation = section.Key("zipkin_propagation").MustBool(false)
+		ts.disableSharedZipkinSpans = section.Key("disable_shared_zipkin_spans").MustBool(false)
+		ts.samplingServerURL = section.Key("sampling_server_url").MustString("")
 	}
 
-	ts.address = section.Key("address").MustString("")
 	if ts.address == "" {
 		host := os.Getenv(envJaegerAgentHost)
 		port := os.Getenv(envJaegerAgentPort)
-		if host != "" && port != "" {
+		if host != "" {
 			ts.address = fmt.Sprintf("%s:%s", host, port)
 		}
 	}
 	if ts.address != "" {
 		ts.enabled = true
 	}
-
-	ts.customTags = splitTagSettings(section.Key("always_included_tag").MustString(""))
-	ts.samplerType = section.Key("sampler_type").MustString("")
-	ts.samplerParam = section.Key("sampler_param").MustFloat64(1)
-	ts.zipkinPropagation = section.Key("zipkin_propagation").MustBool(false)
-	ts.disableSharedZipkinSpans = section.Key("disable_shared_zipkin_spans").MustBool(false)
-	ts.samplingServerURL = section.Key("sampling_server_url").MustString("")
 }
 
 func (ts *TracingService) initJaegerCfg() (jaegercfg.Configuration, error) {

--- a/pkg/infra/tracing/tracing_test.go
+++ b/pkg/infra/tracing/tracing_test.go
@@ -108,6 +108,7 @@ func TestInitJaegerCfg_EnabledViaHost(t *testing.T) {
 	}()
 
 	ts := &TracingService{Cfg: setting.NewCfg()}
+	ts.Cfg.Raw.NewSection("tracing.jaeger")
 	ts.parseSettings()
 	cfg, err := ts.initJaegerCfg()
 	require.NoError(t, err)
@@ -125,6 +126,7 @@ func TestInitJaegerCfg_EnabledViaHostPort(t *testing.T) {
 	}()
 
 	ts := &TracingService{Cfg: setting.NewCfg()}
+	ts.Cfg.Raw.NewSection("tracing.jaeger")
 	ts.parseSettings()
 	cfg, err := ts.initJaegerCfg()
 	require.NoError(t, err)

--- a/pkg/infra/tracing/tracing_test.go
+++ b/pkg/infra/tracing/tracing_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,4 +99,36 @@ func TestInitJaegerCfg_InvalidEnvVar(t *testing.T) {
 	ts := &TracingService{}
 	_, err = ts.initJaegerCfg()
 	require.EqualError(t, err, "cannot parse env var JAEGER_DISABLED=totallybogus: strconv.ParseBool: parsing \"totallybogus\": invalid syntax")
+}
+
+func TestInitJaegerCfg_EnabledViaHost(t *testing.T) {
+	require.NoError(t, os.Setenv("JAEGER_AGENT_HOST", "example.com"))
+	defer func() {
+		require.NoError(t, os.Unsetenv("JAEGER_AGENT_HOST"))
+	}()
+
+	ts := &TracingService{Cfg: setting.NewCfg()}
+	ts.parseSettings()
+	cfg, err := ts.initJaegerCfg()
+	require.NoError(t, err)
+
+	assert.False(t, cfg.Disabled)
+	assert.Equal(t, "example.com:6831", cfg.Reporter.LocalAgentHostPort)
+}
+
+func TestInitJaegerCfg_EnabledViaHostPort(t *testing.T) {
+	require.NoError(t, os.Setenv("JAEGER_AGENT_HOST", "example.com"))
+	require.NoError(t, os.Setenv("JAEGER_AGENT_PORT", "12345"))
+	defer func() {
+		require.NoError(t, os.Unsetenv("JAEGER_AGENT_HOST"))
+		require.NoError(t, os.Unsetenv("JAEGER_AGENT_PORT"))
+	}()
+
+	ts := &TracingService{Cfg: setting.NewCfg()}
+	ts.parseSettings()
+	cfg, err := ts.initJaegerCfg()
+	require.NoError(t, err)
+
+	assert.False(t, cfg.Disabled)
+	assert.Equal(t, "example.com:12345", cfg.Reporter.LocalAgentHostPort)
 }

--- a/pkg/infra/tracing/tracing_test.go
+++ b/pkg/infra/tracing/tracing_test.go
@@ -108,7 +108,8 @@ func TestInitJaegerCfg_EnabledViaHost(t *testing.T) {
 	}()
 
 	ts := &TracingService{Cfg: setting.NewCfg()}
-	ts.Cfg.Raw.NewSection("tracing.jaeger")
+	_, err := ts.Cfg.Raw.NewSection("tracing.jaeger")
+	require.NoError(t, err)
 	ts.parseSettings()
 	cfg, err := ts.initJaegerCfg()
 	require.NoError(t, err)
@@ -126,7 +127,8 @@ func TestInitJaegerCfg_EnabledViaHostPort(t *testing.T) {
 	}()
 
 	ts := &TracingService{Cfg: setting.NewCfg()}
-	ts.Cfg.Raw.NewSection("tracing.jaeger")
+	_, err := ts.Cfg.Raw.NewSection("tracing.jaeger")
+	require.NoError(t, err)
 	ts.parseSettings()
 	cfg, err := ts.initJaegerCfg()
 	require.NoError(t, err)

--- a/pkg/infra/tracing/tracing_test.go
+++ b/pkg/infra/tracing/tracing_test.go
@@ -110,7 +110,7 @@ func TestInitJaegerCfg_EnabledViaHost(t *testing.T) {
 	ts := &TracingService{Cfg: setting.NewCfg()}
 	_, err := ts.Cfg.Raw.NewSection("tracing.jaeger")
 	require.NoError(t, err)
-	ts.parseSettings()
+	require.NoError(t, ts.parseSettings())
 	cfg, err := ts.initJaegerCfg()
 	require.NoError(t, err)
 
@@ -129,7 +129,7 @@ func TestInitJaegerCfg_EnabledViaHostPort(t *testing.T) {
 	ts := &TracingService{Cfg: setting.NewCfg()}
 	_, err := ts.Cfg.Raw.NewSection("tracing.jaeger")
 	require.NoError(t, err)
-	ts.parseSettings()
+	require.NoError(t, ts.parseSettings())
 	cfg, err := ts.initJaegerCfg()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes #32667 

Tracing would be enabled when one of the following is true:

* `address` is set in the INI configuration
* `GF_TRACING_JAEGER_ADDRESS` env variable is set
* `JAEGER_AGENT_HOST` and `JAEGER_AGENT_PORT` are both set.

We have to look into Jaeger env variables, because the client library does not tell if the values are from the env or if they are the defaults.