### PR TITLE
Routing NG: persist state on partial updates

### DIFF
--- a/packages/grafana-runtime/src/services/LocationService.test.ts
+++ b/packages/grafana-runtime/src/services/LocationService.test.ts
@@ -35,5 +35,20 @@ describe('LocationService', () => {
 
       expect(locationService.getLocation().search).toBe('?servers=A&servers=B&servers=C');
     });
+
+    it('persist state', () => {
+      locationService.push({
+        pathname: '/d/123',
+        state: {
+          some: 'stateToPersist',
+        },
+      });
+      locationService.partial({ q: 1 });
+
+      expect(locationService.getLocation().search).toBe('?q=1');
+      expect(locationService.getLocation().state).toEqual({
+        some: 'stateToPersist',
+      });
+    });
   });
 });

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -67,9 +67,9 @@ export class HistoryWrapper implements LocationService {
     const updatedUrl = urlUtil.renderUrl(currentLocation.pathname, newQuery);
 
     if (replace) {
-      this.history.replace(updatedUrl);
+      this.history.replace(updatedUrl, this.history.location.state);
     } else {
-      this.history.push(updatedUrl);
+      this.history.push(updatedUrl, this.history.location.state);
     }
   }
 


### PR DESCRIPTION
On dashboard setting save we landed in situations when dashboard was not re-initialized after settings save. 

This was because the location state was cleared so the comparison in https://github.com/grafana/grafana/blob/master/public/app/features/dashboard/containers/DashboardPage.tsx#L139 indicated the reload is not needed (local value was 1, and the history state reload counter was also 1 as it was cleared after partial update).

cherrypicked from https://github.com/grafana/grafana/pull/33433