### PR TITLE
Graphite: Pass date range to auto-complete for metrics

### DIFF
--- a/public/app/features/explore/QueryEditor.tsx
+++ b/public/app/features/explore/QueryEditor.tsx
@@ -29,7 +29,7 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
       return;
     }
 
-    const { datasource, initialQuery, exploreEvents } = this.props;
+    const { datasource, initialQuery, exploreEvents, range } = this.props;
 
     const loader = getAngularLoader();
     const template = '<plugin-component type="query-ctrl"> </plugin-component>';
@@ -38,6 +38,7 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
       ctrl: {
         datasource,
         target,
+        range,
         refresh: () => {
           setTimeout(() => {
             // the "hide" attribute of the quries can be changed from the "outside",
@@ -77,6 +78,10 @@ export default class QueryEditor extends PureComponent<QueryEditorProps, any> {
     if (this.component) {
       if (hasToggledEditorMode && this.angularScope && this.angularScope.toggleEditorMode) {
         this.angularScope.toggleEditorMode();
+      }
+
+      if (this.angularScope) {
+        this.angularScope.range = this.props.range;
       }
 
       if (hasNewError || hasToggledEditorMode) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently selected date range should be passed in the URL when getting auto-complete list for available metrics. It's passed in the query editor in dashboards but not in Explore. This PR ensures the range is passed down to the controller for Explore editor as well.

Please check #33583 for more details and how to reproduce/test it. The only way to verify it is by checking the network tab. In Graphite with Whisper database (used in devenv) it will have no effect but still - from/until should be passed in the URL all times as some clients could run Graphite on a storage that uses these parameters (Ceres or a remote one).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #33583

**Special notes for your reviewer**:

