### PR TITLE
Grafana-UI: Create Grafana themes for Monaco

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/theme.ts
+++ b/packages/grafana-ui/src/components/Monaco/theme.ts
@@ -1,0 +1,23 @@
+import { GrafanaTheme2 } from '@grafana/data';
+import { Monaco } from './types';
+
+export default function defineThemes(monaco: Monaco, theme: GrafanaTheme2) {
+  const colors = {
+    'editor.background': theme.components.input.background,
+    'minimap.background': theme.colors.background.secondary,
+  };
+
+  monaco.editor.defineTheme('grafana-dark', {
+    base: 'vs-dark',
+    inherit: true,
+    colors: colors,
+    rules: [],
+  });
+
+  monaco.editor.defineTheme('grafana-light', {
+    base: 'vs',
+    inherit: true,
+    colors: colors,
+    rules: [],
+  });
+}

--- a/packages/grafana-ui/src/components/Monaco/theme.ts
+++ b/packages/grafana-ui/src/components/Monaco/theme.ts
@@ -2,6 +2,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Monaco } from './types';
 
 export default function defineThemes(monaco: Monaco, theme: GrafanaTheme2) {
+  // color tokens are defined here https://github.com/microsoft/vscode/blob/main/src/vs/platform/theme/common/colorRegistry.ts#L174
   const colors = {
     'editor.background': theme.components.input.background,
     'minimap.background': theme.colors.background.secondary,

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -76,20 +76,20 @@ $purple: #9933cc;
 $variable: #6E9FFF;
 
 $brand-primary: #eb7b18;
-$brand-success: #299c46;
-$brand-warning: #eb7b18;
-$brand-danger: #e02f44;
+$brand-success: #1A7F4B;
+$brand-warning: #F5B73D;
+$brand-danger: #D10E5C;
 
-$query-red: #e02f44;
-$query-green: #74e680;
+$query-red: #FF5286;
+$query-green: #6CCF8E;
 $query-purple: #fe85fc;
 $query-orange: #eb7b18;
 
 // Status colors
 // -------------------------¨
-$online: #299c46;
-$warn: #f79520;
-$critical: #e02f44;
+$online: #1A7F4B;
+$warn: #1A7F4B;
+$critical: #1A7F4B;
 
 // Scaffolding
 // -------------------------

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -71,20 +71,20 @@ $purple: #9933cc;
 $variable: #0465d7;
 
 $brand-primary: #eb7b18;
-$brand-success: #299c46;
-$brand-warning: #eb7b18;
-$brand-danger: #e02f44;
+$brand-success: #1A7F4B;
+$brand-warning: #E56F00;
+$brand-danger: #E0226E;
 
-$query-red: #e02f44;
-$query-green: #74e680;
+$query-red: #CF0E5B;
+$query-green: #1A7F4B;
 $query-purple: #fe85fc;
 $query-orange: #eb7b18;
 
 // Status colors
 // -------------------------
-$online: #299c46;
-$warn: #f79520;
-$critical: #e02f44;
+$online: #1A7F4B;
+$warn: #1A7F4B;
+$critical: #1A7F4B;
 
 // Scaffolding
 // -------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates a slightly custom Monaco theme to make the <CodeEditor /> POP with our Grafana colours.

![chrome_K0IoLMtVjf](https://user-images.githubusercontent.com/46142/117058430-83612680-ad16-11eb-8bcd-649a9d5cd3d2.png)
![chrome_Rn3nKcjaAw](https://user-images.githubusercontent.com/46142/117058437-84925380-ad16-11eb-9954-0ef3590426ff.png)


The top/bottom borders are clipped off in the JSON Models view of Dashboard settings, and I'm unsure why - the "Code editor container" doesn't have a proper height or width like it does elsewhere...

![chrome_a4jOPI3dtC](https://user-images.githubusercontent.com/46142/117058915-2023c400-ad17-11eb-9878-f91c3589c646.png)
