### PR TITLE
Unredact/secret

### DIFF
--- a/pkg/services/ngalert/api/lotex_am_test.go
+++ b/pkg/services/ngalert/api/lotex_am_test.go
@@ -1,0 +1,1 @@
+package api

--- a/pkg/services/ngalert/api/lotex_am_test.go
+++ b/pkg/services/ngalert/api/lotex_am_test.go
@@ -1,1 +1,0 @@
-package api

--- a/pkg/services/ngalert/api/tooling/Makefile
+++ b/pkg/services/ngalert/api/tooling/Makefile
@@ -2,11 +2,19 @@
 
 API_DIR = definitions
 GO_PKG_FILES = $(shell find $(API_DIR) -name *.go -print)
+SWAGGER_TAG ?= latest
+
+PATH_DOWN = pkg/services/ngalert/api/tooling
+PATH_UP = ../../../../..
 
 spec.json: $(GO_PKG_FILES)
 	# this is slow because this image does not use the cache
 	# https://github.com/go-swagger/go-swagger/blob/v0.27.0/Dockerfile#L5
-	docker run --rm -it -e GOPATH=${GOPATH} -v ${GOPATH}:${GOPATH} -w $$(pwd) go-swagger generate spec -m -o $@
+	docker run --rm -it \
+		-w /src/$(PATH_DOWN) \
+		-v $$(pwd)/$(PATH_UP):/src \
+		quay.io/goswagger/swagger:$(SWAGGER_TAG) \
+		generate spec -m -o $@
 
 post.json: spec.json
 	go run cmd/clean-swagger/main.go -if $(<) -of $@

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -201,7 +201,6 @@ type PostableUserConfig struct {
 }
 
 func (c *PostableUserConfig) UnmarshalJSON(b []byte) error {
-
 	type plain PostableUserConfig
 	if err := json.Unmarshal(b, (*plain)(c)); err != nil {
 		return err

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -372,6 +372,9 @@ alertmanager_config: |
 				return
 			}
 			require.Nil(t, err)
+			// Override the map[string]interface{} field for test simplicity.
+			// It's tested in Test_GettableUserConfigRoundtrip.
+			out.amSimple = nil
 			require.Equal(t, tc.output, out)
 		})
 	}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test_artifact.json
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test_artifact.json
@@ -1,0 +1,36 @@
+{
+  "template_files": {
+    "foo": "bar"
+  },
+  "alertmanager_config": {
+    "receivers": [
+      {
+        "email_configs": [
+          {
+            "auth_password": "shh",
+            "auth_username": "admin",
+            "from": "bar",
+            "headers": {
+              "Bazz": "buzz"
+            },
+            "html": "there",
+            "text": "hi",
+            "to": "foo"
+          }
+        ],
+        "name": "am"
+      }
+    ],
+    "route": {
+      "continue": false,
+      "receiver": "am",
+      "routes": [
+        {
+          "continue": false,
+          "receiver": "am"
+        }
+      ]
+    },
+    "templates": []
+  }
+}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test_artifact.yaml
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test_artifact.yaml
@@ -1,0 +1,21 @@
+template_files:
+    foo: bar
+alertmanager_config: |
+    receivers:
+        - email_configs:
+            - auth_password: shh
+              auth_username: admin
+              from: bar
+              headers:
+                Bazz: buzz
+              html: there
+              text: hi
+              to: foo
+          name: am
+    route:
+        continue: false
+        receiver: am
+        routes:
+            - continue: false
+              receiver: am
+    templates: []

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -141,7 +141,7 @@
   "AlertQuery": {
    "properties": {
     "datasourceUid": {
-     "description": "Grafana data source unique identifer; it should be '-100' for a Server Side Expression operation.",
+     "description": "Grafana data source unique identifier; it should be '-100' for a Server Side Expression operation.",
      "type": "string",
      "x-go-name": "DatasourceUID"
     },
@@ -584,12 +584,8 @@
   "Failure": {
    "$ref": "#/definitions/ResponseDetails"
   },
-  "GettableAlert": {
-   "$ref": "#/definitions/gettableAlert"
-  },
-  "GettableAlerts": {
-   "$ref": "#/definitions/gettableAlerts"
-  },
+  "GettableAlert": {},
+  "GettableAlerts": {},
   "GettableApiAlertingConfig": {
    "properties": {
     "global": {
@@ -856,9 +852,7 @@
   "GettableSilence": {
    "$ref": "#/definitions/gettableSilence"
   },
-  "GettableSilences": {
-   "$ref": "#/definitions/gettableSilences"
-  },
+  "GettableSilences": {},
   "GettableUserConfig": {
    "properties": {
     "alertmanager_config": {
@@ -895,6 +889,10 @@
     },
     "slack_api_url": {
      "$ref": "#/definitions/SecretURL"
+    },
+    "slack_api_url_file": {
+     "type": "string",
+     "x-go-name": "SlackAPIURLFile"
     },
     "smtp_auth_identity": {
      "type": "string",
@@ -963,6 +961,9 @@
     "FollowRedirects": {
      "description": "FollowRedirects specifies whether the client should follow HTTP 3xx redirects.\nThe omitempty flag is not set, because it would be hidden from the\nmarshalled configuration when set to false.",
      "type": "boolean"
+    },
+    "OAuth2": {
+     "$ref": "#/definitions/OAuth2"
     },
     "ProxyURL": {
      "$ref": "#/definitions/URL"
@@ -1119,6 +1120,37 @@
    "title": "NotifierConfig contains base options common across all notifier configurations.",
    "type": "object",
    "x-go-package": "github.com/prometheus/alertmanager/config"
+  },
+  "OAuth2": {
+   "properties": {
+    "ClientID": {
+     "type": "string"
+    },
+    "ClientSecret": {
+     "$ref": "#/definitions/Secret"
+    },
+    "ClientSecretFile": {
+     "type": "string"
+    },
+    "EndpointParams": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
+    "Scopes": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "TokenURL": {
+     "type": "string"
+    }
+   },
+   "title": "OAuth2 is the oauth2 client configuration.",
+   "type": "object",
+   "x-go-package": "github.com/prometheus/common/config"
   },
   "OpsGenieConfig": {
    "properties": {
@@ -2012,6 +2044,10 @@
     "api_url": {
      "$ref": "#/definitions/SecretURL"
     },
+    "api_url_file": {
+     "type": "string",
+     "x-go-name": "APIURLFile"
+    },
     "callback_id": {
      "type": "string",
      "x-go-name": "CallbackID"
@@ -2206,7 +2242,6 @@
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2239,9 +2274,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object",
-   "x-go-package": "net/url"
+   "x-go-package": "github.com/prometheus/common/config"
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -2269,6 +2304,9 @@
   "VictorOpsConfig": {
    "properties": {
     "api_key": {
+     "$ref": "#/definitions/Secret"
+    },
+    "api_key_file": {
      "$ref": "#/definitions/Secret"
     },
     "api_url": {
@@ -2410,7 +2448,7 @@
     "alerts": {
      "description": "alerts",
      "items": {
-      "$ref": "#/definitions/gettableAlert"
+      "$ref": "#/definitions/GettableAlert"
      },
      "type": "array",
      "x-go-name": "Alerts"
@@ -2419,7 +2457,7 @@
      "$ref": "#/definitions/labelSet"
     },
     "receiver": {
-     "$ref": "#/definitions/Receiver"
+     "$ref": "#/definitions/receiver"
     }
    },
    "required": [
@@ -3166,7 +3204,7 @@
      "200": {
       "description": "AlertGroups",
       "schema": {
-       "$ref": "#/definitions/alertGroups"
+       "$ref": "#/definitions/AlertGroups"
       }
      },
      "400": {
@@ -3281,7 +3319,7 @@
      "200": {
       "description": "GettableSilences",
       "schema": {
-       "$ref": "#/definitions/gettableSilences"
+       "$ref": "#/definitions/GettableSilences"
       }
      },
      "400": {
@@ -3303,7 +3341,7 @@
       "in": "body",
       "name": "Silence",
       "schema": {
-       "$ref": "#/definitions/postableSilence"
+       "$ref": "#/definitions/PostableSilence"
       }
      },
      {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -190,7 +190,7 @@
           "200": {
             "description": "AlertGroups",
             "schema": {
-              "$ref": "#/definitions/alertGroups"
+              "$ref": "#/definitions/AlertGroups"
             }
           },
           "400": {
@@ -305,7 +305,7 @@
           "200": {
             "description": "GettableSilences",
             "schema": {
-              "$ref": "#/definitions/gettableSilences"
+              "$ref": "#/definitions/GettableSilences"
             }
           },
           "400": {
@@ -327,7 +327,7 @@
             "name": "Silence",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/postableSilence"
+              "$ref": "#/definitions/PostableSilence"
             }
           },
           {
@@ -982,7 +982,7 @@
       "title": "AlertQuery represents a single query associated with an alert definition.",
       "properties": {
         "datasourceUid": {
-          "description": "Grafana data source unique identifer; it should be '-100' for a Server Side Expression operation.",
+          "description": "Grafana data source unique identifier; it should be '-100' for a Server Side Expression operation.",
           "type": "string",
           "x-go-name": "DatasourceUID"
         },
@@ -1427,10 +1427,10 @@
       "$ref": "#/definitions/ResponseDetails"
     },
     "GettableAlert": {
-      "$ref": "#/definitions/gettableAlert"
+      "$ref": "#/definitions/GettableAlert"
     },
     "GettableAlerts": {
-      "$ref": "#/definitions/gettableAlerts"
+      "$ref": "#/definitions/GettableAlerts"
     },
     "GettableApiAlertingConfig": {
       "type": "object",
@@ -1699,7 +1699,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "GettableSilences": {
-      "$ref": "#/definitions/gettableSilences"
+      "$ref": "#/definitions/GettableSilences"
     },
     "GettableUserConfig": {
       "type": "object",
@@ -1738,6 +1738,10 @@
         },
         "slack_api_url": {
           "$ref": "#/definitions/SecretURL"
+        },
+        "slack_api_url_file": {
+          "type": "string",
+          "x-go-name": "SlackAPIURLFile"
         },
         "smtp_auth_identity": {
           "type": "string",
@@ -1807,6 +1811,9 @@
         "FollowRedirects": {
           "description": "FollowRedirects specifies whether the client should follow HTTP 3xx redirects.\nThe omitempty flag is not set, because it would be hidden from the\nmarshalled configuration when set to false.",
           "type": "boolean"
+        },
+        "OAuth2": {
+          "$ref": "#/definitions/OAuth2"
         },
         "ProxyURL": {
           "$ref": "#/definitions/URL"
@@ -1962,6 +1969,37 @@
         }
       },
       "x-go-package": "github.com/prometheus/alertmanager/config"
+    },
+    "OAuth2": {
+      "type": "object",
+      "title": "OAuth2 is the oauth2 client configuration.",
+      "properties": {
+        "ClientID": {
+          "type": "string"
+        },
+        "ClientSecret": {
+          "$ref": "#/definitions/Secret"
+        },
+        "ClientSecretFile": {
+          "type": "string"
+        },
+        "EndpointParams": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "Scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "TokenURL": {
+          "type": "string"
+        }
+      },
+      "x-go-package": "github.com/prometheus/common/config"
     },
     "OpsGenieConfig": {
       "type": "object",
@@ -2859,6 +2897,10 @@
         "api_url": {
           "$ref": "#/definitions/SecretURL"
         },
+        "api_url_file": {
+          "type": "string",
+          "x-go-name": "APIURLFile"
+        },
         "callback_id": {
           "type": "string",
           "x-go-name": "CallbackID"
@@ -3051,9 +3093,8 @@
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -3086,7 +3127,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "net/url"
+      "x-go-package": "github.com/prometheus/common/config"
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3116,6 +3157,9 @@
       "title": "VictorOpsConfig configures notifications via VictorOps.",
       "properties": {
         "api_key": {
+          "$ref": "#/definitions/Secret"
+        },
+        "api_key_file": {
           "$ref": "#/definitions/Secret"
         },
         "api_url": {
@@ -3262,7 +3306,7 @@
           "description": "alerts",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/gettableAlert"
+            "$ref": "#/definitions/GettableAlert"
           },
           "x-go-name": "Alerts"
         },
@@ -3270,7 +3314,7 @@
           "$ref": "#/definitions/labelSet"
         },
         "receiver": {
-          "$ref": "#/definitions/Receiver"
+          "$ref": "#/definitions/receiver"
         }
       },
       "x-go-name": "AlertGroup",


### PR DESCRIPTION
Better automates the openAPI spec generation and does some marshaling trickery to unredact proxied AM secrets.