### PR TITLE
CloudWatch: Fix AWS/Connect dimensions

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -158,7 +158,7 @@ var dimensionsMap = map[string][]string{
 	"AWS/CloudSearch":             {"ClientId", "DomainName"},
 	"AWS/CodeBuild":               {"ProjectName"},
 	"AWS/Cognito":                 {"Operation", "RiskLevel", "UserPoolId"},
-	"AWS/Connect":                 {"InstanceId", "MetricGroup", "Participant", "QueueName", "Stream Type", "Type of Connection"},
+	"AWS/Connect":                 {"InstanceId", "MetricGroup", "ContactFlowName", "SigningKeyId", "TypeOfConnection", "Participant", "QueueName", "StreamType"},
 	"AWS/DataSync":                {"AgentId", "TaskId"},
 	"AWS/DDoSProtection":          {"ResourceArn", "AttackVector", "MitigationAction", "Protocol", "SourcePort", "DestinationPort", "SourceIp", "SourceAsn", "TcpFlags"},
 	"AWS/DMS":                     {"ReplicationInstanceIdentifier", "ReplicationTaskIdentifier"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix broken dimension name and add two new dimensions for AWS/Connect. 

**Which issue(s) this PR fixes**:
Fixes #33730

**Special notes for your reviewer**:
We don't have data in AWS/Connect, so I've not been able to test this. 
