### PR TITLE
Explore: Implement caching of logs result from navigation

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -2,6 +2,7 @@ import { Labels } from './data';
 import { GraphSeriesXY } from './graph';
 import { DataFrame } from './dataFrame';
 import { AbsoluteTimeRange } from './time';
+import { DataQuery } from './datasource';
 
 /**
  * Mapping of log level abbreviation to canonical log level.
@@ -85,6 +86,7 @@ export interface LogsModel {
   rows: LogRowModel[];
   series?: GraphSeriesXY[];
   visibleRange?: AbsoluteTimeRange;
+  queries?: DataQuery[];
 }
 
 export interface LogSearchMatch {

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -30,6 +30,7 @@ import {
   AbsoluteTimeRange,
   sortInAscendingOrder,
   rangeUtil,
+  DataQuery,
 } from '@grafana/data';
 import { getThemeColor } from 'app/core/utils/colors';
 import { config } from '@grafana/runtime';
@@ -202,7 +203,8 @@ export function dataFrameToLogsModel(
   dataFrame: DataFrame[],
   intervalMs: number | undefined,
   timeZone: TimeZone,
-  absoluteRange?: AbsoluteTimeRange
+  absoluteRange?: AbsoluteTimeRange,
+  queries?: DataQuery[]
 ): LogsModel {
   const { logSeries } = separateLogsAndMetrics(dataFrame);
   const logsModel = logSeriesToLogsModel(logSeries);
@@ -218,6 +220,7 @@ export function dataFrameToLogsModel(
       );
       logsModel.visibleRange = visibleRange;
       logsModel.series = makeSeriesForLogs(sortedRows, bucketSize, timeZone);
+      logsModel.queries = queries;
 
       if (logsModel.meta) {
         logsModel.meta = adjustMetaInfo(logsModel, visibleRangeMs, requestedRangeMs);

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -220,7 +220,6 @@ export function dataFrameToLogsModel(
       );
       logsModel.visibleRange = visibleRange;
       logsModel.series = makeSeriesForLogs(sortedRows, bucketSize, timeZone);
-      logsModel.queries = queries;
 
       if (logsModel.meta) {
         logsModel.meta = adjustMetaInfo(logsModel, visibleRangeMs, requestedRangeMs);
@@ -228,6 +227,7 @@ export function dataFrameToLogsModel(
     } else {
       logsModel.series = [];
     }
+    logsModel.queries = queries;
     return logsModel;
   }
 
@@ -236,6 +236,7 @@ export function dataFrameToLogsModel(
     rows: [],
     meta: [],
     series: [],
+    queries,
   };
 }
 

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -57,7 +57,7 @@ interface Props {
   timeZone: TimeZone;
   scanning?: boolean;
   scanRange?: RawTimeRange;
-  queries: DataQuery[];
+  logsQueries?: DataQuery[];
   showContextToggle?: (row?: LogRowModel) => boolean;
   onChangeTime: (range: AbsoluteTimeRange, checkForCaching?: boolean) => void;
   onClickFilterLabel?: (key: string, value: string) => void;
@@ -241,7 +241,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
       onChangeTime,
       getFieldLinks,
       theme,
-      queries,
+      logsQueries,
     } = this.props;
 
     const {
@@ -356,7 +356,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
             timeZone={timeZone}
             onChangeTime={onChangeTime}
             loading={loading}
-            queries={queries}
+            queries={logsQueries || []}
           />
         </div>
         {!loading && !hasData && !scanning && (

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -351,7 +351,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
           </CustomScrollbar>
           <LogsNavigation
             logsSortOrder={logsSortOrder}
-            visibleRange={visibleRange}
+            visibleRange={visibleRange || absoluteRange}
             absoluteRange={absoluteRange}
             timeZone={timeZone}
             onChangeTime={onChangeTime}

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -59,7 +59,7 @@ interface Props {
   scanRange?: RawTimeRange;
   queries: DataQuery[];
   showContextToggle?: (row?: LogRowModel) => boolean;
-  onChangeTime: (range: AbsoluteTimeRange) => void;
+  onChangeTime: (range: AbsoluteTimeRange, checkForCaching?: boolean) => void;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
   onStartScanning?: () => void;

--- a/public/app/features/explore/LogsContainer.test.tsx
+++ b/public/app/features/explore/LogsContainer.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { dateTime, MutableDataFrame, DataFrame, FieldType } from '@grafana/data';
+import { ExploreId } from 'app/types/explore';
+import { dataFrameToLogsModel } from 'app/core/logs_model';
+import { LogsContainerProps, LogsContainer } from './LogsContainer';
+
+const setup = (propOverrides?: object) => {
+  const props: LogsContainerProps = {
+    exploreId: ExploreId.left,
+    width: 500,
+    syncedTimes: false,
+    loading: false,
+    splitOpen: jest.fn(),
+    onStartScanning: jest.fn(),
+    onStopScanning: jest.fn(),
+    updateTimeRange: jest.fn(),
+    logsResult: null,
+    scanning: false,
+    timeZone: 'utc',
+    datasourceInstance: null,
+    isLive: false,
+    isPaused: false,
+    logsHighlighterExpressions: [],
+    absoluteRange: { from: 1546297200000, to: 1546383600000 },
+    range: { from: dateTime('2019-01-01'), to: dateTime('2019-01-02'), raw: { from: 'now-1d', to: 'now' } },
+    ...propOverrides,
+  };
+
+  return render(<LogsContainer {...props} />);
+};
+
+describe('LogsNavigation', () => {
+  it('should render empty div if null logsResult', () => {
+    const { container } = setup();
+    expect(container.firstChild).toBeNull();
+  });
+  it('should render "No logs found" if empty logs model passed', () => {
+    const emptyLogsModel: any = {
+      hasUniqueLabels: false,
+      rows: [],
+      meta: [],
+      series: [],
+    };
+    setup({ logsResult: emptyLogsModel });
+    expect(screen.getByText(/no logs found/i)).toBeInTheDocument();
+  });
+  it('should render logs when logsModel containes logs', () => {
+    const logsModel = dataFrameToLogsModel(testSeries, 1, 'utc');
+    setup({ logsResult: logsModel });
+    expect(screen.getAllByText('test_log_entry1')).toHaveLength(1);
+  });
+});
+
+const testSeries: DataFrame[] = [
+  new MutableDataFrame({
+    fields: [
+      {
+        name: 'time',
+        type: FieldType.time,
+        values: ['2019-04-26T09:28:11.352440161Z', '2019-04-26T14:42:50.991981292Z'],
+      },
+      {
+        name: 'message',
+        type: FieldType.string,
+        values: ['test_log_entry1', 'test_log_entry2'],
+        labels: {
+          label1: 'value1',
+          label2: 'value2',
+        },
+      },
+      {
+        name: 'id',
+        type: FieldType.string,
+        values: ['foo', 'bar'],
+      },
+    ],
+    meta: {
+      limit: 10,
+    },
+  }),
+];

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -32,7 +32,9 @@ type LogsContainerState = {
   absoluteRangeToShow: AbsoluteTimeRange;
 };
 export class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState> {
-  private logRowsCache = new LRU<string, { cacheLogsResult: LogsModel; cacheAbsoluteRange: AbsoluteTimeRange }>(5);
+  private logRowsCache = new LRU<string, { cacheLogsResult: LogsModel | null; cacheAbsoluteRange: AbsoluteTimeRange }>(
+    5
+  );
 
   constructor(props: LogsContainerProps) {
     super(props);
@@ -53,9 +55,9 @@ export class LogsContainer extends PureComponent<LogsContainerProps, LogsContain
   componentDidUpdate(prevProps: LogsContainerProps) {
     const { logsResult, absoluteRange } = this.props;
     // If new results, update cache
-    if (logsResult && !isEqual(logsResult, prevProps.logsResult)) {
+    if (!isEqual(logsResult, prevProps.logsResult) || !isEqual(absoluteRange, prevProps.absoluteRange)) {
       // If queries were changed, reset cache and start fresh
-      if (!isEqual(logsResult.queries, prevProps.logsResult?.queries)) {
+      if (!isEqual(logsResult?.queries, prevProps.logsResult?.queries)) {
         this.logRowsCache.reset();
       }
       // Update state and add to logResults and absolutRange to cache
@@ -64,7 +66,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps, LogsContain
     }
   }
 
-  setCacheLogResults(logsResult: LogsModel, absoluteRange: AbsoluteTimeRange) {
+  setCacheLogResults(logsResult: LogsModel | null, absoluteRange: AbsoluteTimeRange) {
     const cacheKey = this.createCacheKey(absoluteRange);
     this.logRowsCache.set(cacheKey, { cacheLogsResult: logsResult, cacheAbsoluteRange: absoluteRange });
   }
@@ -143,7 +145,6 @@ export class LogsContainer extends PureComponent<LogsContainerProps, LogsContain
     } = this.props;
 
     const { logsToShow, absoluteRangeToShow } = this.state;
-
     const { rows: logRows, meta: logsMeta, series: logsSeries, queries: logsQueries, visibleRange } = logsToShow || {};
 
     if (!logRows) {

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -4,7 +4,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { isEqual } from 'lodash';
 import LRU from 'lru-cache';
 import { Collapse } from '@grafana/ui';
-import { AbsoluteTimeRange, DataQuery, Field, LogRowModel, LogsModel, RawTimeRange } from '@grafana/data';
+import { AbsoluteTimeRange, Field, LogRowModel, LogsModel, RawTimeRange } from '@grafana/data';
 import { ExploreId, ExploreItemState } from 'app/types/explore';
 import { StoreState } from 'app/types';
 import { splitOpen } from './state/main';

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -58,7 +58,7 @@ export class LogsContainer extends PureComponent<LogsContainerProps, LogsContain
       if (!isEqual(logsResult.queries, prevProps.logsResult?.queries)) {
         this.logRowsCache.reset();
       }
-      // Update state and add to logResults and absolutRange to chache
+      // Update state and add to logResults and absolutRange to cache
       this.setState({ logsToShow: this.props.logsResult, absoluteRangeToShow: this.props.absoluteRange });
       this.setCacheLogResults(logsResult, absoluteRange);
     }

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -32,7 +32,7 @@ type LogsContainerState = {
   absoluteRangeToShow: AbsoluteTimeRange;
 };
 export class LogsContainer extends PureComponent<LogsContainerProps, LogsContainerState> {
-  private logRowsCache = new LRU<string, { cacheLogsResult: LogsModel; cacheAbsoluteRange: AbsoluteTimeRange }>(10);
+  private logRowsCache = new LRU<string, { cacheLogsResult: LogsModel; cacheAbsoluteRange: AbsoluteTimeRange }>(5);
 
   constructor(props: LogsContainerProps) {
     super(props);

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -16,7 +16,7 @@ import { LogsCrossFadeTransition } from './utils/LogsCrossFadeTransition';
 import { LiveTailControls } from './useLiveTailControls';
 import { getFieldLinksForExplore } from './utils/links';
 
-interface LogsContainerProps extends PropsFromRedux {
+export interface LogsContainerProps extends PropsFromRedux {
   exploreId: ExploreId;
   scanRange?: RawTimeRange;
   width: number;

--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -15,10 +15,10 @@ import { Button, Icon, Spinner, useTheme, stylesFactory, CustomScrollbar } from 
 
 type Props = {
   absoluteRange: AbsoluteTimeRange;
+  visibleRange: AbsoluteTimeRange;
   timeZone: TimeZone;
   queries: DataQuery[];
   loading: boolean;
-  visibleRange?: AbsoluteTimeRange;
   logsSortOrder?: LogsSortOrder | null;
   onChangeTime: (range: AbsoluteTimeRange, runFromNavigation?: boolean) => void;
 };
@@ -34,8 +34,8 @@ function LogsNavigation({
   timeZone,
   loading,
   onChangeTime,
-  visibleRange = absoluteRange,
-  queries = [],
+  visibleRange,
+  queries,
 }: Props) {
   const [pages, setPages] = useState<LogsPage[]>([]);
   const [currentPageIndex, setCurrentPageIndex] = useState(0);

--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -20,7 +20,7 @@ type Props = {
   loading: boolean;
   visibleRange?: AbsoluteTimeRange;
   logsSortOrder?: LogsSortOrder | null;
-  onChangeTime: (range: AbsoluteTimeRange) => void;
+  onChangeTime: (range: AbsoluteTimeRange, runFromNavigation?: boolean) => void;
 };
 
 type LogsPage = {
@@ -76,7 +76,7 @@ function LogsNavigation({
 
   const changeTime = ({ from, to }: AbsoluteTimeRange) => {
     expectedRangeRef.current = { from, to };
-    onChangeTime({ from, to });
+    onChangeTime({ from, to }, true);
   };
 
   const sortPages = (a: LogsPage, b: LogsPage, logsSortOrder?: LogsSortOrder | null) => {
@@ -94,9 +94,6 @@ function LogsNavigation({
   };
 
   const createPageContent = (page: LogsPage, index: number) => {
-    if (currentPageIndex === index && loading) {
-      return <Spinner />;
-    }
     const topContent = formatTime(oldestLogsFirst ? page.logsRange.from : page.logsRange.to);
     const bottomContent = formatTime(oldestLogsFirst ? page.logsRange.to : page.logsRange.from);
     return `${topContent} — ${bottomContent}`;

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -357,7 +357,7 @@ export const runQueries = (exploreId: ExploreId, options?: { replaceUrl?: boolea
         map((data: PanelData) => preProcessPanelData(data, queryResponse)),
         map(decorateWithFrameTypeMetadata),
         map(decorateWithGraphResult),
-        map(decorateWithLogsResult({ absoluteRange, refreshInterval })),
+        map(decorateWithLogsResult({ absoluteRange, refreshInterval, queries })),
         mergeMap(decorateWithTableResult)
       )
       .subscribe(

--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -6,6 +6,7 @@ import {
   PanelData,
   sortLogsResult,
   standardTransformers,
+  DataQuery,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { groupBy } from 'lodash';
@@ -129,7 +130,7 @@ export const decorateWithTableResult = (data: ExplorePanelData): Observable<Expl
 };
 
 export const decorateWithLogsResult = (
-  options: { absoluteRange?: AbsoluteTimeRange; refreshInterval?: string } = {}
+  options: { absoluteRange?: AbsoluteTimeRange; refreshInterval?: string; queries?: DataQuery[] } = {}
 ) => (data: ExplorePanelData): ExplorePanelData => {
   if (data.logsFrames.length === 0) {
     return { ...data, logsResult: null };
@@ -137,7 +138,13 @@ export const decorateWithLogsResult = (
 
   const timeZone = data.request?.timezone ?? 'browser';
   const intervalMs = data.request?.intervalMs;
-  const newResults = dataFrameToLogsModel(data.logsFrames, intervalMs, timeZone, options.absoluteRange);
+  const newResults = dataFrameToLogsModel(
+    data.logsFrames,
+    intervalMs,
+    timeZone,
+    options.absoluteRange,
+    options.queries
+  );
   const sortOrder = refreshIntervalToSortOrder(options.refreshInterval);
   const sortedNewResults = sortLogsResult(newResults, sortOrder);
   const rows = sortedNewResults.rows;


### PR DESCRIPTION
**What this PR does / why we need it**:
The next PR from **Logs navigation** series. This ones implements caching of the last 10 results run from navigation. The scope of this PR is only caching and functionality, not UI (more UI changes coming).

1. I had to update logsModel to store queries it was run with. This way we can reliable reset navigation and logsResultCache when the queries that we run change. Otherwise, we could use only absoluteRange. Previously we used queries object, but this was buggy as it did reset navigation and cache when you just edited query (without running it). 
2. I am caching last 5 sets of results. We can do in the future/polishing phase some benchmarking of how many results should we save. 

3. I still need to finish writing tests, but I think it is ready for functionality/code review and testing. 


https://user-images.githubusercontent.com/30407135/117171563-43a84680-adcb-11eb-8bbf-190cf565ed02.mov


https://user-images.githubusercontent.com/30407135/117173020-a3ebb800-adcc-11eb-8d51-e5e9116b6808.mov

