### PR TITLE
POC: use react-router in AppPlugins

### DIFF
--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -30,6 +30,7 @@ export * from './legacyEvents';
 export * from './live';
 export * from './variables';
 export * from './geometry';
+export * from './navigation';
 export { isUnsignedPluginSignature } from './pluginSignature';
 export { GrafanaConfig, BuildInfo, FeatureToggles, LicenseInfo } from './config';
 export * from './alerts';

--- a/packages/grafana-data/src/types/navigation.ts
+++ b/packages/grafana-data/src/types/navigation.ts
@@ -1,6 +1,6 @@
-import { UrlQueryMap } from '@grafana/data';
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import { UrlQueryMap } from '../utils';
 
 export interface GrafanaRouteComponentProps<T = {}, Q = UrlQueryMap> extends RouteComponentProps<T> {
   route: RouteDescriptor;
@@ -16,4 +16,5 @@ export interface RouteDescriptor {
   pageClass?: string;
   /** Can be used like an id for the route if the same component is used by many routes */
   routeName?: string;
+  soft?: boolean;
 }

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -154,6 +154,5 @@ const navigationLog = createLogger('Router');
 
 /** @internal */
 export const navigationLogger = navigationLog.logger;
-
 // For debugging purposes the location service is attached to global _debug variable
 attachDebugger('location', locationService, navigationLog);

--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -8,6 +8,7 @@ export * from './types';
 export * from './utils';
 export * from './themes';
 export * from './slate-plugins';
+export { Route } from 'react-router-dom';
 
 // Exposes standard editors for registries of optionsUi config and panel options UI
 export { getStandardFieldConfigs, getStandardOptionEditors } from './utils/standardEditors';

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -7,13 +7,13 @@ import { ErrorBoundaryAlert, GlobalStyles, ModalRoot, ModalsProvider } from '@gr
 import { GrafanaApp } from './app';
 import { getAppRoutes } from 'app/routes/routes';
 import { ConfigContext, ThemeProvider } from './core/utils/ConfigProvider';
-import { RouteDescriptor } from './core/navigation/types';
 import { contextSrv } from './core/services/context_srv';
 import { SideMenu } from './core/components/sidemenu/SideMenu';
 import { GrafanaRoute } from './core/navigation/GrafanaRoute';
 import { AppNotificationList } from './core/components/AppNotifications/AppNotificationList';
 import { SearchWrapper } from 'app/features/search';
 import { LiveConnectionCorner } from './features/live/LiveConnectionCorner';
+import { RouteDescriptor } from '@grafana/data';
 
 interface AppWrapperProps {
   app: GrafanaApp;
@@ -59,7 +59,7 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
 
     return (
       <Route
-        exact
+        exact={!route.soft}
         path={route.path}
         key={route.path}
         render={(props) => {

--- a/public/app/core/components/DynamicImports/SafeDynamicImport.tsx
+++ b/public/app/core/components/DynamicImports/SafeDynamicImport.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Loadable from 'react-loadable';
 import { LoadingChunkPlaceHolder } from './LoadingChunkPlaceHolder';
 import { ErrorLoadingChunk } from './ErrorLoadingChunk';
-import { GrafanaRouteComponent } from 'app/core/navigation/types';
+import { GrafanaRouteComponent } from '@grafana/data';
 
 export const loadComponentHandler = (props: { error: Error; pastDelay: boolean }) => {
   const { error, pastDelay } = props;

--- a/public/app/core/components/ForgottenPassword/ChangePasswordPage.tsx
+++ b/public/app/core/components/ForgottenPassword/ChangePasswordPage.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { LoginLayout, InnerBox } from '../Login/LoginLayout';
 import { ChangePassword } from './ChangePassword';
 import LoginCtrl from '../Login/LoginCtrl';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 interface Props extends GrafanaRouteComponentProps<{}, { code: string }> {}
 

--- a/public/app/core/components/Signup/SignupPage.tsx
+++ b/public/app/core/components/Signup/SignupPage.tsx
@@ -3,8 +3,7 @@ import { Form, Field, Input, Button, HorizontalGroup, LinkButton } from '@grafan
 import { getConfig } from 'app/core/config';
 import { getBackendSrv } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
-import { AppEvents } from '@grafana/data';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { AppEvents, GrafanaRouteComponentProps } from '@grafana/data';
 import { InnerBox, LoginLayout } from '../Login/LoginLayout';
 
 interface SignupDTO {

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 // @ts-ignore
 import Drop from 'tether-drop';
-import { GrafanaRouteComponentProps } from './types';
 import { locationSearchToObject, navigationLogger } from '@grafana/runtime';
 import { keybindingSrv } from '../services/keybindingSrv';
 import { analyticsService } from '../services/analytics';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 export interface Props extends Omit<GrafanaRouteComponentProps, 'queryParams'> {}
 
-export class GrafanaRoute extends React.Component<Props> {
+export class GrafanaRoute<T extends Props> extends React.Component<T> {
   componentDidMount() {
     this.updateBodyClassNames();
     this.cleanupDOM();

--- a/public/app/core/navigation/RouterDebugger.tsx
+++ b/public/app/core/navigation/RouterDebugger.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { getAppRoutes } from '../../routes/routes';
 import { PageContents } from '../components/Page/PageContents';
-import { RouteDescriptor } from './types';
+import { RouteDescriptor } from '@grafana/data';
 
 export const RouterDebugger: React.FC<any> = () => {
   const manualRoutes: RouteDescriptor[] = [];

--- a/public/app/core/navigation/__mocks__/routeProps.ts
+++ b/public/app/core/navigation/__mocks__/routeProps.ts
@@ -1,6 +1,6 @@
-import { GrafanaRouteComponentProps } from '../types';
 import { createMemoryHistory } from 'history';
 import { merge } from 'lodash';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 export function getRouteComponentProps<T = {}, Q extends Record<string, string | null | undefined> = {}>(
   overrides: Partial<GrafanaRouteComponentProps> = {}

--- a/public/app/core/navigation/testRoutes.tsx
+++ b/public/app/core/navigation/testRoutes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { RouterDebugger } from './RouterDebugger';
-import { RouteDescriptor } from './types';
+import { RouteDescriptor } from '@grafana/data';
 
 export const testRoutes: RouteDescriptor[] = [
   {

--- a/public/app/features/admin/AdminEditOrgPage.tsx
+++ b/public/app/features/admin/AdminEditOrgPage.tsx
@@ -6,10 +6,9 @@ import { getNavModel } from 'app/core/selectors/navModel';
 import UsersTable from '../users/UsersTable';
 import { useAsyncFn } from 'react-use';
 import { getBackendSrv } from '@grafana/runtime';
-import { UrlQueryValue } from '@grafana/data';
+import { GrafanaRouteComponentProps, UrlQueryValue } from '@grafana/data';
 import { Form, Field, Input, Button, Legend } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
 interface OrgNameDTO {
   orgName: string;

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
-import { NavModel } from '@grafana/data';
+import { GrafanaRouteComponentProps, NavModel } from '@grafana/data';
 import { getNavModel } from 'app/core/selectors/navModel';
 import config from 'app/core/config';
 import Page from 'app/core/components/Page/Page';
@@ -26,7 +26,6 @@ import {
   syncLdapUser,
 } from './state/actions';
 import { UserOrgs } from './UserOrgs';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { contextSrv } from 'app/core/core';
 
 interface Props extends GrafanaRouteComponentProps<{ id: string }> {

--- a/public/app/features/admin/ldap/LdapPage.tsx
+++ b/public/app/features/admin/ldap/LdapPage.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
-import { NavModel } from '@grafana/data';
+import { GrafanaRouteComponentProps, NavModel } from '@grafana/data';
 import { Alert, Button, LegacyForms } from '@grafana/ui';
 const { FormField } = LegacyForms;
 import { getNavModel } from 'app/core/selectors/navModel';
@@ -26,7 +26,6 @@ import {
   clearUserError,
   clearUserMappingInfo,
 } from '../state/actions';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { contextSrv } from 'app/core/core';
 
 interface Props extends GrafanaRouteComponentProps<{}, { username: string }> {

--- a/public/app/features/alerting/AlertRuleList.tsx
+++ b/public/app/features/alerting/AlertRuleList.tsx
@@ -9,12 +9,11 @@ import { AlertDefinition, AlertRule, StoreState } from 'app/types';
 import { getAlertRulesAsync, togglePauseAlertRule } from './state/actions';
 import { getAlertRuleItems, getSearchQuery } from './state/selectors';
 import { FilterInput } from 'app/core/components/FilterInput/FilterInput';
-import { SelectableValue } from '@grafana/data';
+import { GrafanaRouteComponentProps, SelectableValue } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { setSearchQuery } from './state/reducers';
 import { Button, LinkButton, Select, VerticalGroup } from '@grafana/ui';
 import { AlertDefinitionItem } from './components/AlertDefinitionItem';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { ShowModalReactEvent } from '../../types/events';
 import { AlertHowToModal } from './AlertHowToModal';
 

--- a/public/app/features/alerting/EditNotificationChannelPage.tsx
+++ b/public/app/features/alerting/EditNotificationChannelPage.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { MapDispatchToProps, MapStateToProps } from 'react-redux';
-import { NavModel } from '@grafana/data';
+import { GrafanaRouteComponentProps, NavModel } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Form, Spinner } from '@grafana/ui';
 import Page from 'app/core/components/Page/Page';
@@ -11,7 +11,6 @@ import { getNavModel } from 'app/core/selectors/navModel';
 import { mapChannelsToSelectableValue, transformSubmitData, transformTestData } from './utils/notificationChannels';
 import { NotificationChannelType, NotificationChannelDTO, StoreState } from 'app/types';
 import { resetSecureField } from './state/reducers';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
 interface OwnProps extends GrafanaRouteComponentProps<{ id: string }> {}
 

--- a/public/app/features/alerting/NextGenAlertingPage.tsx
+++ b/public/app/features/alerting/NextGenAlertingPage.tsx
@@ -2,7 +2,7 @@ import React, { FormEvent, PureComponent } from 'react';
 import { hot } from 'react-hot-loader';
 import { connect, ConnectedProps } from 'react-redux';
 import { css } from '@emotion/css';
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { GrafanaRouteComponentProps, GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { PageToolbar, stylesFactory, ToolbarButton, withTheme2, Themeable2 } from '@grafana/ui';
 import { config } from 'app/core/config';
@@ -21,7 +21,6 @@ import {
   updateAlertDefinitionUiState,
 } from './state/actions';
 import { StoreState } from 'app/types';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { GrafanaQuery } from '../../types/unified-alerting-dto';
 
 function mapStateToProps(state: StoreState, props: RouteProps) {

--- a/public/app/features/alerting/unified/RuleEditor.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.tsx
@@ -1,7 +1,6 @@
 import { Alert, Button, LoadingPlaceholder } from '@grafana/ui';
 import Page from 'app/core/components/Page/Page';
 import { useCleanup } from 'app/core/hooks/useCleanup';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { RuleIdentifier } from 'app/types/unified-alerting';
 import React, { FC, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
@@ -9,6 +8,7 @@ import { AlertRuleForm } from './components/rule-editor/AlertRuleForm';
 import { useUnifiedAlertingSelector } from './hooks/useUnifiedAlertingSelector';
 import { fetchExistingRuleAction } from './state/actions';
 import { parseRuleIdentifier } from './utils/rules';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 interface ExistingRuleEditorProps {
   identifier: RuleIdentifier;

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -23,10 +23,9 @@ import { cleanUpDashboardAndVariables } from '../state/actions';
 import { cancelVariables, templateVarsChangedInUrl } from '../../variables/state/actions';
 import { findTemplateVarChanges } from '../../variables/utils';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { getTimeSrv } from '../services/TimeSrv';
 import { getKioskMode } from 'app/core/navigation/kiosk';
-import { GrafanaTheme2, UrlQueryValue } from '@grafana/data';
+import { GrafanaRouteComponentProps, GrafanaTheme2, UrlQueryValue } from '@grafana/data';
 import { DashboardLoading } from '../components/DashboardLoading/DashboardLoading';
 import { DashboardFailed } from '../components/DashboardLoading/DashboardFailed';
 

--- a/public/app/features/dashboard/containers/SoloPanelPage.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.tsx
@@ -9,7 +9,7 @@ import { initDashboard } from '../state/initDashboard';
 // Types
 import { StoreState } from 'app/types';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 export interface DashboardPageRouteParams {
   uid?: string;

--- a/public/app/features/datasources/DataSourceDashboards.tsx
+++ b/public/app/features/datasources/DataSourceDashboards.tsx
@@ -15,7 +15,7 @@ import { getDataSource } from './state/selectors';
 
 // Types
 import { PluginDashboard, StoreState } from 'app/types';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 export interface OwnProps extends GrafanaRouteComponentProps<{ id: string }> {}
 

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -20,14 +20,13 @@ import { getNavModel } from 'app/core/selectors/navModel';
 
 // Types
 import { StoreState } from 'app/types/';
-import { DataSourceSettings } from '@grafana/data';
+import { DataSourceSettings, GrafanaRouteComponentProps } from '@grafana/data';
 import { Alert, Button, LinkButton } from '@grafana/ui';
 import { getDataSourceLoadingNav } from '../state/navModel';
 import PluginStateinfo from 'app/features/plugins/PluginStateInfo';
 import { dataSourceLoaded, setDataSourceName, setIsDefault } from '../state/reducers';
 import { selectors } from '@grafana/e2e-selectors';
 import { CloudInfoBox } from './CloudInfoBox';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { connect, ConnectedProps } from 'react-redux';
 import { cleanUpAction } from 'app/core/actions/cleanUp';
 import { ShowConfirmModalEvent } from '../../../types/events';

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundaryAlert } from '@grafana/ui';
 import { lastSavedUrl, resetExploreAction, richHistoryUpdatedAction } from './state/main';
 import { getRichHistory } from '../../core/utils/richHistory';
 import { ExplorePaneContainer } from './ExplorePaneContainer';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 interface WrapperProps extends GrafanaRouteComponentProps<{}, ExploreQueryParams> {
   resetExploreAction: typeof resetExploreAction;

--- a/public/app/features/folders/FolderLibraryPanelsPage.tsx
+++ b/public/app/features/folders/FolderLibraryPanelsPage.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { useAsync } from 'react-use';
-
-import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { StoreState } from '../../types';
 import { getNavModel } from '../../core/selectors/navModel';
 import { getLoadingNav } from './state/navModel';
@@ -11,6 +9,7 @@ import Page from '../../core/components/Page/Page';
 import { LibraryPanelsSearch } from '../library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch';
 import { OpenLibraryPanelModal } from '../library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal';
 import { getFolderByUid } from './state/actions';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 export interface OwnProps extends GrafanaRouteComponentProps<{ uid: string }> {}
 

--- a/public/app/features/folders/FolderPermissions.tsx
+++ b/public/app/features/folders/FolderPermissions.tsx
@@ -17,7 +17,7 @@ import { getLoadingNav } from './state/navModel';
 import PermissionList from 'app/core/components/PermissionList/PermissionList';
 import AddPermission from 'app/core/components/PermissionList/AddPermission';
 import PermissionsInfo from 'app/core/components/PermissionList/PermissionsInfo';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 export interface OwnProps extends GrafanaRouteComponentProps<{ uid: string }> {}
 

--- a/public/app/features/folders/FolderSettingsPage.tsx
+++ b/public/app/features/folders/FolderSettingsPage.tsx
@@ -10,7 +10,7 @@ import { deleteFolder, getFolderByUid, saveFolder } from './state/actions';
 import { getLoadingNav } from './state/navModel';
 import { setFolderTitle } from './state/reducers';
 import { ShowConfirmModalEvent } from '../../types/events';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 export interface OwnProps extends GrafanaRouteComponentProps<{ uid: string }> {}
 

--- a/public/app/features/library-panels/LibraryPanelsPage.tsx
+++ b/public/app/features/library-panels/LibraryPanelsPage.tsx
@@ -1,13 +1,12 @@
 import React, { FC, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-
-import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { StoreState } from '../../types';
 import { getNavModel } from '../../core/selectors/navModel';
 import Page from '../../core/components/Page/Page';
 import { LibraryPanelsSearch } from './components/LibraryPanelsSearch/LibraryPanelsSearch';
 import { LibraryPanelDTO } from './types';
 import { OpenLibraryPanelModal } from './components/OpenLibraryPanelModal/OpenLibraryPanelModal';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 const mapStateToProps = (state: StoreState) => ({
   navModel: getNavModel(state.navIndex, 'library-panels'),

--- a/public/app/features/manage-dashboards/SnapshotListPage.tsx
+++ b/public/app/features/manage-dashboards/SnapshotListPage.tsx
@@ -1,10 +1,9 @@
 import React, { FC } from 'react';
 import { MapStateToProps, connect } from 'react-redux';
-import { NavModel } from '@grafana/data';
+import { GrafanaRouteComponentProps, NavModel } from '@grafana/data';
 import Page from 'app/core/components/Page/Page';
 import { StoreState } from 'app/types';
 import { SnapshotListTable } from './components/SnapshotListTable';
-import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
 
 interface ConnectedProps {

--- a/public/app/features/playlist/PlaylistEditPage.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { NavModel } from '@grafana/data';
+import { GrafanaRouteComponentProps, NavModel } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 
 import Page from 'app/core/components/Page/Page';
 import { StoreState } from 'app/types';
-import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { PlaylistForm } from './PlaylistForm';
 import { updatePlaylist } from './api';

--- a/public/app/features/playlist/PlaylistNewPage.tsx
+++ b/public/app/features/playlist/PlaylistNewPage.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { NavModel } from '@grafana/data';
+import { GrafanaRouteComponentProps, NavModel } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 
 import Page from 'app/core/components/Page/Page';
 import { StoreState } from 'app/types';
-import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { PlaylistForm } from './PlaylistForm';
 import { createPlaylist } from './api';

--- a/public/app/features/playlist/PlaylistPage.tsx
+++ b/public/app/features/playlist/PlaylistPage.tsx
@@ -1,9 +1,8 @@
 import React, { FC, useState } from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { NavModel, SelectableValue, urlUtil } from '@grafana/data';
+import { GrafanaRouteComponentProps, NavModel, SelectableValue, urlUtil } from '@grafana/data';
 import Page from 'app/core/components/Page/Page';
 import { StoreState } from 'app/types';
-import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { useAsync } from 'react-use';
 import { getBackendSrv, locationService } from '@grafana/runtime';

--- a/public/app/features/playlist/PlaylistStartPage.tsx
+++ b/public/app/features/playlist/PlaylistStartPage.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
-import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 import { playlistSrv } from './PlaylistSrv';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 interface Props extends GrafanaRouteComponentProps<{ id: string }> {}
 

--- a/public/app/features/plugins/PluginPage.tsx
+++ b/public/app/features/plugins/PluginPage.tsx
@@ -5,6 +5,7 @@ import { capitalize, find } from 'lodash';
 import {
   AppPlugin,
   GrafanaPlugin,
+  GrafanaRouteComponentProps,
   GrafanaTheme2,
   NavModel,
   NavModelItem,
@@ -34,7 +35,6 @@ import { contextSrv } from '../../core/services/context_srv';
 import { css } from '@emotion/css';
 import { selectors } from '@grafana/e2e-selectors';
 import { ShowModalReactEvent } from 'app/types/events';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { UpdatePluginModal } from './UpdatePluginModal';
 
 interface Props extends GrafanaRouteComponentProps<{ pluginId: string }, UrlQueryMap> {}

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -1,14 +1,13 @@
 import React, { FC, memo } from 'react';
 import { useAsync } from 'react-use';
 import { connect, MapStateToProps } from 'react-redux';
-import { NavModel, locationUtil } from '@grafana/data';
+import { NavModel, locationUtil, GrafanaRouteComponentProps } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { FolderDTO, StoreState } from 'app/types';
 import { getNavModel } from 'app/core/selectors/navModel';
 import Page from 'app/core/components/Page/Page';
 import { loadFolderPage } from '../loaders';
 import ManageDashboards from './ManageDashboards';
-import { GrafanaRouteComponentProps } from '../../../core/navigation/types';
 
 export interface DashboardListPageRouteParams {
   uid?: string;

--- a/public/app/features/teams/TeamPages.tsx
+++ b/public/app/features/teams/TeamPages.tsx
@@ -12,8 +12,7 @@ import { getTeam, getTeamMembers, isSignedInUserTeamAdmin } from './state/select
 import { getTeamLoadingNav } from './state/navModel';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { contextSrv } from 'app/core/services/context_srv';
-import { NavModel } from '@grafana/data';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps, NavModel } from '@grafana/data';
 
 interface TeamPageRouteParams {
   id: string;

--- a/public/app/features/users/SignupInvited.tsx
+++ b/public/app/features/users/SignupInvited.tsx
@@ -5,7 +5,7 @@ import { useAsync } from 'react-use';
 import Page from 'app/core/components/Page/Page';
 import { contextSrv } from 'app/core/core';
 import { getConfig } from 'app/core/config';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { GrafanaRouteComponentProps } from '@grafana/data';
 
 interface FormModel {
   email: string;

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -5,10 +5,10 @@ import { LoginPage } from 'app/core/components/Login/LoginPage';
 import config from 'app/core/config';
 import { DashboardRoutes } from 'app/types';
 import { SafeDynamicImport } from '../core/components/DynamicImports/SafeDynamicImport';
-import { RouteDescriptor } from '../core/navigation/types';
 import { SignupPage } from 'app/core/components/Signup/SignupPage';
 import { Redirect } from 'react-router-dom';
 import ErrorPage from 'app/core/components/ErrorPage/ErrorPage';
+import { RouteDescriptor } from '@grafana/data';
 
 export const extraRoutes: RouteDescriptor[] = [];
 export const featureToggledRoutes: RouteDescriptor[] = [];
@@ -158,6 +158,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/a/:pluginId/',
+      soft: true,
       // Someday * and will get a ReactRouter under that path!
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "AppRootPage" */ 'app/features/plugins/AppRootPage')


### PR DESCRIPTION
This is a POC of exposing router to AppPlugins.

It adds a new method to AppPlugin API:

`addPage(page: AppRouteDescriptor)` which enables routes definition in plugin module. 

Alternative solution would be to just expose Route component via grafana/ui, but then the app root url will always have to be defined in the path definition of the route - this means someone can render anything in arbitrary core route. With the API, we have a control over the app segment of the url (`/a/:pluginid`) and all app routes are rendered under that path.


TODO:
- [ ] Figure out how to build the nav model - do we need to build it on the backend?
- [ ] Make sure roles defined in RouteDescriptor are honored in app routes
- [ ] Move GrafanaRouteComponent to grafana/ui or grafana/data and reuse in AppRootPage
- [ ] tests
- [ ] and some more probably

You can test this PR against  the MArketplace App https://github.com/grafana/marketplace-app/pull/3 - **make sure you link grafana/ui, grafana/data and grafana/runtime** when running marketplace app