### PR TITLE
CSP backward compatible with older browsers

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -243,7 +243,7 @@ content_security_policy = false
 
 # Set Content Security Policy template used when adding the Content-Security-Policy header to your requests.
 # $NONCE in the template includes a random nonce.
-content_security_policy_template = """script-src 'unsafe-eval' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data:;base-uri 'self';connect-src 'self' grafana.com;manifest-src 'self';media-src 'none';form-action 'self';"""
+content_security_policy_template = """script-src http: https: 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data:;base-uri 'self';connect-src 'self' grafana.com;manifest-src 'self';media-src 'none';form-action 'self';"""
 
 #################################### Snapshots ###########################
 [snapshots]


### PR DESCRIPTION
Included `http:`, `https:` & `unsafe-inline` entry in `script-src `
- unsafe-inline (ignored by browsers supporting nonces/hashes) add backward compatible with older browsers.
- https: and http: url schemes (ignored by browsers supporting 'strict-dynamic') add backward compatible with older browsers.
