### PR TITLE
Access control: Add metrics

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -12,9 +12,6 @@ import (
 const ExporterName = "grafana"
 
 var (
-	// MUserPermission is a metric counter for user permission queries
-	MUserPermission prometheus.Counter
-
 	// MInstanceStart is a metric counter for started instances
 	MInstanceStart prometheus.Counter
 
@@ -108,9 +105,6 @@ var (
 	// MRenderingQueue is a metric gauge for image rendering queue size
 	MRenderingQueue prometheus.Gauge
 
-	// MAccessUserCount is a metric gauge for image rendering queue size
-	MAccessUserCount prometheus.Gauge
-
 	// MAccessRoleCount is a metric gauge for image rendering queue size
 	MAccessRoleCount prometheus.Gauge
 
@@ -201,12 +195,6 @@ var (
 func init() {
 	httpStatusCodes := []string{"200", "404", "500", "unknown"}
 	objectiveMap := map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001}
-
-	MUserPermission = prometheus.NewCounter(prometheus.CounterOpts{
-		Name:      "user_permission_total",
-		Help:      "counter for user permission requests",
-		Namespace: ExporterName,
-	})
 
 	MInstanceStart = prometheus.NewCounter(prometheus.CounterOpts{
 		Name:      "instance_start_total",
@@ -414,7 +402,7 @@ func init() {
 	)
 
 	MAccessSummary = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "access",
+		Name:    "access_request_duration",
 		Help:    "Histogram for the runtime of access functions.",
 		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 	})
@@ -422,12 +410,6 @@ func init() {
 	MRenderingQueue = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rendering_queue_size",
 		Help:      "size of image rendering queue",
-		Namespace: ExporterName,
-	})
-
-	MAccessUserCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name:      "access_user_count",
-		Help:      "number of users",
 		Namespace: ExporterName,
 	})
 
@@ -620,7 +602,6 @@ func SetPluginBuildInformation(pluginID, pluginType, version string) {
 
 func initMetricVars() {
 	prometheus.MustRegister(
-		MUserPermission,
 		MInstanceStart,
 		MPageStatus,
 		MApiStatus,
@@ -659,7 +640,6 @@ func initMetricVars() {
 		MAccessRoleCount,
 		MAccessTeamRoleCount,
 		MAccessTeamCount,
-		MAccessUserCount,
 		MAccessPermissionCount,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -117,6 +117,9 @@ var (
 
 	// MAccessPermissionCount is a metric gauge for total number of permissions
 	MAccessPermissionCount prometheus.Gauge
+
+	// MAccessEvaluationCount is a metric gauge for total number of evaluation requests
+	MAccessEvaluationCount prometheus.Gauge
 )
 
 // Timers
@@ -132,6 +135,9 @@ var (
 
 	// MAccessSummary is a metric summary for access request duration
 	MAccessSummary prometheus.Histogram
+
+	// MAccessSummary is a metric summary for access request duration
+	MAccessPermissionsSummary prometheus.Histogram
 )
 
 // StatTotals
@@ -405,6 +411,12 @@ func init() {
 		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 	})
 
+	MAccessPermissionsSummary = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "access_permissions_duration",
+		Help:    "Histogram for the runtime of permissions check function.",
+		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
+	})
+
 	MRenderingQueue = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rendering_queue_size",
 		Help:      "size of image rendering queue",
@@ -414,6 +426,12 @@ func init() {
 	MAccessPermissionCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "access_permission_count",
 		Help:      "number of permissions",
+		Namespace: ExporterName,
+	})
+
+	MAccessEvaluationCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "access_evaluation_count",
+		Help:      "number of evaluation calls",
 		Namespace: ExporterName,
 	})
 
@@ -629,10 +647,12 @@ func initMetricVars() {
 		MRenderingSummary,
 		MRenderingQueue,
 		MAccessSummary,
+		MAccessPermissionsSummary,
 		MAccessRoleCount,
 		MAccessTeamRoleCount,
 		MAccessUserRoleCount,
 		MAccessPermissionCount,
+		MAccessEvaluationCount,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,
 		MStatTotalFolders,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -145,17 +145,8 @@ var (
 	// MAccessSummary is a metric summary for access request duration
 	MAccessPermissionsSummary prometheus.Histogram
 
-	// MAccessSummary is a metric summary for access request duration
-	MProvisionDatasourcesSummary *prometheus.HistogramVec
-
-	// MProvisionAlertsSummary is a metric summary for access request duration
-	MProvisionAlertsSummary *prometheus.HistogramVec
-
 	// MProvisionRolesSummary is a metric summary for access request duration
 	MProvisionRolesSummary *prometheus.HistogramVec
-
-	// MAccessSummary is a metric summary for access request duration
-	MProvisionPluginsSummary *prometheus.HistogramVec
 )
 
 // StatTotals
@@ -435,30 +426,6 @@ func init() {
 		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 	})
 
-	MProvisionDatasourcesSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "provision_datasource_duration",
-		Help:    "Histogram for the runtime of datasource provisioning.",
-		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
-	},
-		[]string{"datasource"},
-	)
-
-	MProvisionPluginsSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "provision_plugin_duration",
-		Help:    "Histogram for the runtime of plugin provisioning.",
-		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
-	},
-		[]string{"plugin"},
-	)
-
-	MProvisionAlertsSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "provision_alert_duration",
-		Help:    "Histogram for the runtime of alert provisioning.",
-		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
-	},
-		[]string{"alert"},
-	)
-
 	MProvisionRolesSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "provision_role_duration",
 		Help:    "Histogram for the runtime of role provisioning.",
@@ -710,12 +677,9 @@ func initMetricVars() {
 		MRenderingQueue,
 		MAccessSummary,
 		MAccessPermissionsSummary,
-		MProvisionDatasourcesSummary,
-		MProvisionAlertsSummary,
+		MProvisionRolesSummary,
 		MProvisionRolesCount,
 		MProvisionRolesDeleteCount,
-		MProvisionRolesSummary,
-		MProvisionPluginsSummary,
 		MAccessRoleCount,
 		MAccessTeamRoleCount,
 		MAccessUserRoleCount,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -120,6 +120,12 @@ var (
 
 	// MAccessEvaluationCount is a metric gauge for total number of evaluation requests
 	MAccessEvaluationCount prometheus.Gauge
+
+	// MProvisionRolesCount is a metric gauge for total number of roles provisioned
+	MProvisionRolesCount prometheus.Gauge
+
+	// MProvisionRolesDeleteCount is a metric gauge for total number of roles provisioned
+	MProvisionRolesDeleteCount prometheus.Gauge
 )
 
 // Timers
@@ -138,6 +144,18 @@ var (
 
 	// MAccessSummary is a metric summary for access request duration
 	MAccessPermissionsSummary prometheus.Histogram
+
+	// MAccessSummary is a metric summary for access request duration
+	MProvisionDatasourcesSummary *prometheus.HistogramVec
+
+	// MProvisionAlertsSummary is a metric summary for access request duration
+	MProvisionAlertsSummary *prometheus.HistogramVec
+
+	// MProvisionRolesSummary is a metric summary for access request duration
+	MProvisionRolesSummary *prometheus.HistogramVec
+
+	// MAccessSummary is a metric summary for access request duration
+	MProvisionPluginsSummary *prometheus.HistogramVec
 )
 
 // StatTotals
@@ -417,6 +435,38 @@ func init() {
 		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 	})
 
+	MProvisionDatasourcesSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "provision_datasource_duration",
+		Help:    "Histogram for the runtime of datasource provisioning.",
+		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
+	},
+		[]string{"datasource"},
+	)
+
+	MProvisionPluginsSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "provision_plugin_duration",
+		Help:    "Histogram for the runtime of plugin provisioning.",
+		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
+	},
+		[]string{"plugin"},
+	)
+
+	MProvisionAlertsSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "provision_alert_duration",
+		Help:    "Histogram for the runtime of alert provisioning.",
+		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
+	},
+		[]string{"alert"},
+	)
+
+	MProvisionRolesSummary = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "provision_role_duration",
+		Help:    "Histogram for the runtime of role provisioning.",
+		Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
+	},
+		[]string{"role"},
+	)
+
 	MRenderingQueue = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rendering_queue_size",
 		Help:      "size of image rendering queue",
@@ -432,6 +482,18 @@ func init() {
 	MAccessEvaluationCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "access_evaluation_count",
 		Help:      "number of evaluation calls",
+		Namespace: ExporterName,
+	})
+
+	MProvisionRolesCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "provision_roles_count",
+		Help:      "number of roles provisioned",
+		Namespace: ExporterName,
+	})
+
+	MProvisionRolesDeleteCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:      "provision_roles_delete_count",
+		Help:      "number of roles deleted",
 		Namespace: ExporterName,
 	})
 
@@ -648,6 +710,12 @@ func initMetricVars() {
 		MRenderingQueue,
 		MAccessSummary,
 		MAccessPermissionsSummary,
+		MProvisionDatasourcesSummary,
+		MProvisionAlertsSummary,
+		MProvisionRolesCount,
+		MProvisionRolesDeleteCount,
+		MProvisionRolesSummary,
+		MProvisionPluginsSummary,
 		MAccessRoleCount,
 		MAccessTeamRoleCount,
 		MAccessUserRoleCount,

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -12,6 +12,7 @@ import (
 const ExporterName = "grafana"
 
 var (
+
 	// MInstanceStart is a metric counter for started instances
 	MInstanceStart prometheus.Counter
 
@@ -105,19 +106,16 @@ var (
 	// MRenderingQueue is a metric gauge for image rendering queue size
 	MRenderingQueue prometheus.Gauge
 
-	// MAccessRoleCount is a metric gauge for image rendering queue size
+	// MAccessRoleCount is a metric gauge for total number of roles
 	MAccessRoleCount prometheus.Gauge
 
-	// MAccessBuiltinRoleCount is a metric gauge for image rendering queue size
+	// MAccessBuiltinRoleCount is a metric gauge for number of role assignments to teams
 	MAccessTeamRoleCount prometheus.Gauge
 
-	// MAccessUserRoleCount is a metric gauge for image rendering queue size
+	// MAccessUserRoleCount is a metric gauge for number of role assignments to users
 	MAccessUserRoleCount prometheus.Gauge
 
-	// MAccessTeamCount is a metric gauge for image rendering queue size
-	MAccessTeamCount prometheus.Gauge
-
-	// MAccessPermissionCount is a metric gauge for image rendering queue size
+	// MAccessPermissionCount is a metric gauge for total number of permissions
 	MAccessPermissionCount prometheus.Gauge
 )
 
@@ -419,12 +417,6 @@ func init() {
 		Namespace: ExporterName,
 	})
 
-	MAccessTeamCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name:      "access_team_count",
-		Help:      "number of team",
-		Namespace: ExporterName,
-	})
-
 	MDataSourceProxyReqTimer = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:       "api_dataproxy_request_all_milliseconds",
 		Help:       "summary for dataproxy request duration",
@@ -635,11 +627,11 @@ func initMetricVars() {
 		LDAPUsersSyncExecutionTime,
 		MRenderingRequestTotal,
 		MRenderingSummary,
-		MAccessSummary,
 		MRenderingQueue,
+		MAccessSummary,
 		MAccessRoleCount,
 		MAccessTeamRoleCount,
-		MAccessTeamCount,
+		MAccessUserRoleCount,
 		MAccessPermissionCount,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -15,6 +15,8 @@ import (
 // Scopes are evaluated with an `OR` relationship.
 func Evaluate(ctx context.Context, ac accesscontrol.AccessControl, user *models.SignedInUser, action string, scope ...string) (bool, error) {
 	timer := prometheus.NewTimer(metrics.MAccessSummary)
+	defer timer.ObserveDuration()
+	metrics.MAccessEvaluationCount.Inc()
 	userPermissions, err := ac.GetUserPermissions(ctx, user)
 	if err != nil {
 		return false, err
@@ -26,7 +28,6 @@ func Evaluate(ctx context.Context, ac accesscontrol.AccessControl, user *models.
 	}
 
 	res, err := evaluateScope(dbScopes, scope...)
-	timer.ObserveDuration()
 	return res, err
 }
 

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/gobwas/glob"
 
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Evaluate evaluates access to the given resource, using provided AccessControl instance.

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/evaluator"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // OSSAccessControlService is the service implementing role based access control.

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -39,6 +39,9 @@ func (ac *OSSAccessControlService) Evaluate(ctx context.Context, user *models.Si
 
 // GetUserPermissions returns user permissions based on built-in roles
 func (ac *OSSAccessControlService) GetUserPermissions(ctx context.Context, user *models.SignedInUser) ([]*accesscontrol.Permission, error) {
+	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
+	defer timer.ObserveDuration()
+
 	builtinRoles := ac.GetUserBuiltInRoles(user)
 	permissions := make([]*accesscontrol.Permission, 0)
 	for _, builtin := range builtinRoles {


### PR DESCRIPTION

**What this PR does / why we need it**:

This adds support for enterprise metrics in the access control package

**Which issue(s) this PR fixes**:

Fixes #1247(Enterprise)

**Special notes for your reviewer**:

