### PR TITLE
Alerting: Fix state cache getOrCreate panic

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -47,6 +47,8 @@ func (c *cache) getOrCreate(alertRule *ngModels.AlertRule, result eval.Result) *
 
 	if _, ok := c.states[alertRule.OrgID]; !ok {
 		c.states[alertRule.OrgID] = make(map[string]map[string]*State)
+	}
+	if _, ok := c.states[alertRule.OrgID][alertRule.UID]; !ok {
 		c.states[alertRule.OrgID][alertRule.UID] = make(map[string]*State)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes panic, taken from https://github.com/grafana/grafana/pull/33722 to merge no-panic faster.

**Special notes for your reviewer**:

