### PR TITLE
Access control: Add reporting permissions

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -77,7 +77,7 @@ export class ContextSrv {
   }
 
   // Checks whether user has required permission
-  hasPermission(action: AccessControlAction): boolean {
+  hasPermission(action: AccessControlAction | string): boolean {
     // Fallback if access control disabled
     if (!config.featureToggles['accesscontrol']) {
       return true;

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -33,4 +33,11 @@ export enum AccessControlAction {
   LDAPUsersRead = 'ldap.user:read',
   LDAPUsersSync = 'ldap.user:sync',
   LDAPStatusRead = 'ldap.status:read',
+
+  ReportingAdminWrite = 'reports.admin:write',
+  ReportingDelete = 'reports:delete',
+  ReportingRead = 'reports:read',
+  ReportingSend = 'reports:send',
+  ReportingSettingsWrite = 'reports.settings:write',
+  ReportingSettingsRead = 'reports.settings:read',
 }

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -33,11 +33,4 @@ export enum AccessControlAction {
   LDAPUsersRead = 'ldap.user:read',
   LDAPUsersSync = 'ldap.user:sync',
   LDAPStatusRead = 'ldap.status:read',
-
-  ReportingAdminWrite = 'reports.admin:write',
-  ReportingDelete = 'reports:delete',
-  ReportingRead = 'reports:read',
-  ReportingSend = 'reports:send',
-  ReportingSettingsWrite = 'reports.settings:write',
-  ReportingSettingsRead = 'reports.settings:read',
 }


### PR DESCRIPTION
This PR adds permissions for the reporting to the list of permissions.

Maybe it's better to keep enterprise-specific permissions separated from the OSS?