### PR TITLE
Live: streamId in path for ws push endpoint

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -248,6 +248,7 @@ func (g *GrafanaLive) Init() error {
 		user := ctx.SignedInUser
 		newCtx := livecontext.SetContextSignedUser(ctx.Req.Context(), user)
 		newCtx = livecontext.SetContextValues(newCtx, ctx.Req.URL.Query())
+		newCtx = livecontext.SetContextStreamID(newCtx, ctx.Params(":streamId"))
 		r := ctx.Req.Request
 		r = r.WithContext(newCtx)
 		pushWSHandler.ServeHTTP(ctx.Resp, r)
@@ -258,7 +259,7 @@ func (g *GrafanaLive) Init() error {
 	}, middleware.ReqSignedIn)
 
 	g.RouteRegister.Group("/api/live", func(group routing.RouteRegister) {
-		group.Get("/push", g.pushWebsocketHandler)
+		group.Get("/push/:streamId", g.pushWebsocketHandler)
 	}, middleware.ReqOrgAdmin)
 
 	return nil

--- a/pkg/services/live/livecontext/context.go
+++ b/pkg/services/live/livecontext/context.go
@@ -38,3 +38,18 @@ func GetContextValues(ctx context.Context) (url.Values, bool) {
 	}
 	return nil, false
 }
+
+type streamIDContextKey struct{}
+
+func SetContextStreamID(ctx context.Context, streamID string) context.Context {
+	ctx = context.WithValue(ctx, streamIDContextKey{}, streamID)
+	return ctx
+}
+
+func GetContextStreamID(ctx context.Context) (string, bool) {
+	if val := ctx.Value(streamIDContextKey{}); val != nil {
+		values, ok := val.(string)
+		return values, ok
+	}
+	return "", false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Since stream ID is required better to put it into path.