### PR TITLE
Access control: Add a role for provisioning admins

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -42,6 +42,10 @@ func (p RoleDTO) Role() Role {
 const (
 	// Permission actions
 
+	// Actions
+	// Provisioning actions
+	ActionProvisioningReload = "provisioning:reload"
+
 	// Users actions
 	ActionUsersRead     = "users:read"
 	ActionUsersWrite    = "users:write"
@@ -80,6 +84,9 @@ const (
 
 	ScopeUsersSelf = "users:self"
 	ScopeUsersAll  = "users:*"
+
+	// Services Scopes
+	ScopeServicesAll = "service:*"
 )
 
 const RoleGrafanaAdmin = "Grafana Admin"

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -124,6 +124,17 @@ var usersAdminEditRole = RoleDTO{
 	}),
 }
 
+var provisioningAdminRole = RoleDTO{
+	Name:    provisioningAdmin,
+	Version: 1,
+	Permissions: []Permission{
+		{
+			Action: ActionProvisioningReload,
+			Scope:  ScopeServicesAll,
+		},
+	},
+}
+
 // PredefinedRoles provides a map of permission sets/roles which can be
 // assigned to a set of users. When adding a new resource protected by
 // Grafana access control the default permissions should be added to a
@@ -139,6 +150,8 @@ var PredefinedRoles = map[string]RoleDTO{
 
 	ldapAdminRead: ldapAdminReadRole,
 	ldapAdminEdit: ldapAdminEditRole,
+
+	provisioningAdmin: provisioningAdminRole,
 }
 
 const (
@@ -150,6 +163,8 @@ const (
 
 	ldapAdminEdit = "grafana:roles:ldap:admin:edit"
 	ldapAdminRead = "grafana:roles:ldap:admin:read"
+
+	provisioningAdmin = "grafana:roles:provisioning:admin"
 )
 
 // PredefinedRoleGrants specifies which organization roles are assigned
@@ -158,6 +173,7 @@ var PredefinedRoleGrants = map[string][]string{
 	RoleGrafanaAdmin: {
 		ldapAdminEdit,
 		ldapAdminRead,
+		provisioningAdmin,
 		usersAdminEdit,
 		usersAdminRead,
 		usersOrgEdit,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a predefined role which allows Grafana Admins to reload provisioning files. The only endpoint with access control is in the enterprise for the access control itself.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/1327

**Special notes for your reviewer**:

