### PR TITLE
InfluxDB datasource: RE substitutions in alias names

### DIFF
--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -20,7 +20,7 @@ var (
 )
 
 func init() {
-	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$\s*([\@\/\w-]+?)*`)
+	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$(\$|\s*([\@\/\w-]+?)*)`)
 }
 
 // nolint:staticcheck // plugins.DataQueryResult deprecated
@@ -105,6 +105,10 @@ func formatFrameName(row Row, column string, query *Query) string {
 		aliasFormat = strings.Replace(aliasFormat, "[[", "", 1)
 		aliasFormat = strings.Replace(aliasFormat, "]]", "", 1)
 		aliasFormat = strings.Replace(aliasFormat, "$", "", 1)
+
+		if aliasFormat == "$" {
+			return "$"
+		}
 
 		if aliasFormat == "m" || aliasFormat == "measurement" {
 			return []byte(query.Measurement)

--- a/public/app/plugins/datasource/influxdb/influx_series.ts
+++ b/public/app/plugins/datasource/influxdb/influx_series.ts
@@ -59,13 +59,16 @@ export default class InfluxSeries {
   }
 
   _getSeriesName(series: any, index: number) {
-    const regex = /\$(\w+)|\[\[([\s\S]+?)\]\]/g;
+    const regex = /\$(\$|\w+)|\[\[([\s\S]+?)\]\]/g;
     const segments = series.name.split('.');
 
     return this.alias.replace(regex, (match: any, g1: any, g2: any) => {
       const group = g1 || g2;
       const segIndex = parseInt(group, 10);
 
+      if (group === '$') {
+        return '$';
+      }
       if (group === 'm' || group === 'measurement') {
         return series.name;
       }


### PR DESCRIPTION
I needed some sort of substitution in Grafana legends. For instance, I want to cut off redundant domain suffices from host names, shorten switch names like `sw-u05-0.math.uni-bonn.de` to just `u05`, replace switch:port combinations like `ea62:16` with something more descriptive etc.

I first thought of implementing BSD-make-like modifiers on the `$tag_foo` expansions (i.e. `${tag_instance:C/foo/bar}`) but then went for something simpler.

What I now implemented are RE substitutions by specifying `$/foo/bar/` anyplace inside the alias string. You can combine several substitutions into one as in `$/foo/bar//ding/dong/`, where only the first successful substitution takes place. This means `$/0/foo1//1/foo2/` will not turn 0 into foofoo2; substituting somethinmg with itself does count as a substitution so `$/foobar/foobar//foo/bar/` will leave foobar unchanged while turning foo into bar.
I also implemented some other RE delimiters (`$[foo|bar]`, `$(foo|bar)` and `${foo|bar}`) as a PoC.

As I exclusively use InfluxDB as a data source, I tackled the code path in there, but it probably makes sense to apply it more generally.

I identified the Go code handling InfluxDB legends in pkg/tsdb/influxdb/response_parser.go, spent a week learning Go and implemented my idea in Go just to find out nothing happened since that code seems to be dead and there's some parallel TypeScript code (using a different quoting style for `"tag_"` so I didn't find it) and pkgsrc just pulls in the generated JS from a Linux binary distribution.

So I spent some more days learning TypeScript (well, first JavaScript), transformed my Go code to JavaScript, then TypeScript, then back to JavaScript, and patched that into app.$hash.js, which works (I'm developing on NetBSD, and, for reasons to complicated to explain here, use Grafana 6.2.2). I couldn't find my way through the maze of grunt, yarn, webpack, node.js, phantomjs (which seems to need X11) and whatnot to figure out how to programatically generate app.$hash.js.

So here's my code, intended as a PoC to base discussion on. I never wrote anything in Go, TypeScript or JavaScript before. Pulling one character from a string seems to be severly involved in JavaScript (at least if you want to correctly handle code points not fitting into 16 bits), but i may have failed to research deeply enough.

I first had to slightly modify the existing expansion algorithm to allow `$$` passing the substitutions as `$`, so you can use `$$1` to specify backreferences in the RE substitution (before, the `$1` would have been substituted by the second element of the series name, so `$$1` would have turned into `$undefined`). I explicitly handled the $ case in the code (while strictly unnecessary due to fall-through) for the sake of clarity.

I'm also unsure how to handle errors like incomplete REs, end-of-string in escape sequences, incorrect REs and the like. I (hope to) catch them all only to skip the whole substitution on error. Some logging would be preferrable.

I don't know whether the Go code I first worked on is actually dead or any improvements need to go into both Go and TypeScript code in parallel.

There's also a number of open design questions:

- should a substitution be global (as in `/foo/bar/g`) or not?

- should a `$/foo/bar/` start substituting from the beginning of the string or after the last substitution command?

- which delimiters to implement?

- does it make sense to additionally implement a simpler (non-RE) substitution (bmake has :S and :C for that)?

- should it be possible to specify flags to select global/start-of-string behaviour etc.?

- I could also think of an alternate, more extensible syntax like `$:C/foo/bar/` for RE and `$:S/foo/bar/` for non-RE substitutions.

Opinions?