### PR TITLE
Alerting: Disable dashboard alerting if NG enabled

### DIFF
--- a/pkg/services/alerting/engine.go
+++ b/pkg/services/alerting/engine.go
@@ -28,6 +28,7 @@ type AlertEngine struct {
 	Bus              bus.Bus                       `inject:""`
 	RequestValidator models.PluginRequestValidator `inject:""`
 	DataService      plugins.DataRequestHandler    `inject:""`
+	Cfg              *setting.Cfg                  `inject:""`
 
 	execQueue     chan *Job
 	ticker        *Ticker
@@ -44,7 +45,7 @@ func init() {
 
 // IsDisabled returns true if the alerting service is disable for this instance.
 func (e *AlertEngine) IsDisabled() bool {
-	return !setting.AlertingEnabled || !setting.ExecuteAlerts
+	return !setting.AlertingEnabled || !setting.ExecuteAlerts || e.Cfg.IsNgAlertEnabled()
 }
 
 // Init initializes the AlertingService.


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes NG/Unified Alerting and dashboard alerting exlusive, by setting the dash alerting service to disabled

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/alerting-squad/issues/97

**Special notes for your reviewer**:
Only Backend, also I think the dashboard extractor "service" (I think it is a hook actually?) is not disabled. But I'm thinking perhaps we don't care, and we can just let it run until the code is removed.

