### PR TITLE
Docs: Add Grafana basics card to landing page

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -48,6 +48,10 @@ aliases = ["/docs/grafana/v1.1", "/docs/grafana/latest/guides/reference/admin", 
         <h4>Getting started</h4>
         <p>Learn the basics of using Grafana.</p>
     </a>
+    <a href="{{< relref "basics/_index.md" >}}" class="nav-cards__item nav-cards__item--guide">
+        <h4>Grafana basics</h4>
+        <p>Learn basic observability.</p>
+    </a>  
     <a href="{{< relref "administration/configuration.md" >}}" class="nav-cards__item nav-cards__item--guide">
         <h4>Configure Grafana</h4>
         <p>Review the configuration and setup options.</p>


### PR DESCRIPTION
Added a Grafana basics card to the blank spot in the landing page.