### PR TITLE
Scuemata: Add grafana-cli cue schema validation to CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -95,6 +95,15 @@ steps:
   - initialize
   - lint-backend
 
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - go run build.go build-cli
+  - chmod +x bin/linux-amd64/grafana-cli
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
+
 - name: gen-version
   image: grafana/build-container:1.4.1
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -98,8 +98,6 @@ steps:
 - name: validate-scuemata
   image: grafana/build-container:1.4.1
   commands:
-  - go run build.go build-cli
-  - chmod +x bin/linux-amd64/grafana-cli
   - ./bin/linux-amd64/grafana-cli cue validate-schema
   depends_on:
   - build-backend
@@ -363,6 +361,13 @@ steps:
   depends_on:
   - initialize
   - lint-backend
+
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
 
 - name: gen-version
   image: grafana/build-container:1.4.1
@@ -804,6 +809,13 @@ steps:
   - initialize
   - lint-backend
 
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
+
 - name: gen-version
   image: grafana/build-container:1.4.1
   commands:
@@ -1171,6 +1183,13 @@ steps:
   depends_on:
   - initialize
   - lint-backend
+
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
 
 - name: test-backend-enterprise2
   image: grafana/build-container:1.4.1
@@ -1739,6 +1758,13 @@ steps:
   - initialize
   - lint-backend
 
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
+
 - name: gen-version
   image: grafana/build-container:1.4.1
   commands:
@@ -2095,6 +2121,13 @@ steps:
   depends_on:
   - initialize
   - lint-backend
+
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
 
 - name: test-backend-enterprise2
   image: grafana/build-container:1.4.1
@@ -2653,6 +2686,13 @@ steps:
   - initialize
   - lint-backend
 
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
+
 - name: gen-version
   image: grafana/build-container:1.4.1
   commands:
@@ -2980,6 +3020,13 @@ steps:
   depends_on:
   - initialize
   - lint-backend
+
+- name: validate-scuemata
+  image: grafana/build-container:1.4.1
+  commands:
+  - ./bin/linux-amd64/grafana-cli cue validate-schema
+  depends_on:
+  - build-backend
 
 - name: test-backend-enterprise2
   image: grafana/build-container:1.4.1

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1118,8 +1118,6 @@ def validate_scuemata():
             'build-backend',
         ],
         'commands': [
-            'go run build.go build-cli',
-            'chmod +x bin/linux-amd64/grafana-cli',
             './bin/linux-amd64/grafana-cli cue validate-schema',
         ],
     }

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1109,3 +1109,17 @@ def integration_test_services(edition):
         }])
 
     return services
+
+def validate_scuemata():
+    return {
+        'name': 'validate-scuemata',
+        'image': build_image,
+        'depends_on': [
+            'build-backend',
+        ],
+        'commands': [
+            'go run build.go build-cli',
+            'chmod +x bin/linux-amd64/grafana-cli',
+            './bin/linux-amd64/grafana-cli cue validate-schema',
+        ],
+    }

--- a/scripts/main.star
+++ b/scripts/main.star
@@ -53,6 +53,7 @@ def get_steps(edition, is_downstream=False):
         build_backend_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
         build_frontend_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
         build_plugins_step(edition=edition, sign=True),
+        validate_scuemata(),
     ]
 
     # Have to insert Enterprise2 steps before they're depended on (in the gen-version step)

--- a/scripts/main.star
+++ b/scripts/main.star
@@ -33,7 +33,8 @@ load(
     'publish_packages_step',
     'notify_pipeline',
     'integration_test_services',
-    'upload_cdn'
+    'upload_cdn',
+    'validate_scuemata'
 )
 
 ver_mode = 'main'

--- a/scripts/pr.star
+++ b/scripts/pr.star
@@ -25,6 +25,7 @@ load(
     'benchmark_ldap_step',
     'ldap_service',
     'integration_test_services',
+    'validate_scuemata',
 )
 
 ver_mode = 'pr'
@@ -42,6 +43,7 @@ def pr_pipelines(edition):
         build_backend_step(edition=edition, ver_mode=ver_mode, variants=variants),
         build_frontend_step(edition=edition, ver_mode=ver_mode),
         build_plugins_step(edition=edition),
+        validate_scuemata(),
     ]
 
     # Have to insert Enterprise2 steps before they're depended on (in the gen-version step)

--- a/scripts/release.star
+++ b/scripts/release.star
@@ -77,6 +77,7 @@ def get_steps(edition, ver_mode):
         build_backend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_step(edition=edition, ver_mode=ver_mode),
         build_plugins_step(edition=edition, sign=True),
+        validate_scuemata(),
     ]
 
     # Have to insert Enterprise2 steps before they're depended on (in the gen-version step)

--- a/scripts/release.star
+++ b/scripts/release.star
@@ -32,7 +32,8 @@ load(
     'notify_pipeline',
     'integration_test_services',
     'publish_packages_step',
-    'upload_cdn'
+    'upload_cdn',
+    'validate_scuemata'
 )
 
 def release_npm_packages_step(edition, ver_mode):


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is responsible for adding the `grafana-cli` command to validate scuemata to the CI so it can validate the schemas in every PR or push to `main`.

