### PR TITLE
App plugin: Use UID in dashboard navlinks

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -109,8 +109,14 @@ func (hs *HTTPServer) getAppLinks(c *models.ReqContext) ([]*dtos.NavLink, error)
 			}
 
 			if include.Type == "dashboard" && include.AddToNav {
+				var url string
+				if len(include.Uid) > 0 {
+					url = hs.Cfg.AppSubURL + "/d/" + include.Uid
+				} else {
+					url = hs.Cfg.AppSubURL + "/dashboard/db/" + include.Slug
+				}
 				link := &dtos.NavLink{
-					Url:  hs.Cfg.AppSubURL + "/dashboard/db/" + include.Slug,
+					Url:  url,
 					Text: include.Name,
 				}
 				appLink.Children = append(appLink.Children, link)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -109,14 +109,8 @@ func (hs *HTTPServer) getAppLinks(c *models.ReqContext) ([]*dtos.NavLink, error)
 			}
 
 			if include.Type == "dashboard" && include.AddToNav {
-				var url string
-				if len(include.Uid) > 0 {
-					url = hs.Cfg.AppSubURL + "/d/" + include.Uid
-				} else {
-					url = hs.Cfg.AppSubURL + "/dashboard/db/" + include.Slug
-				}
 				link := &dtos.NavLink{
-					Url:  url,
+					Url:  hs.Cfg.AppSubURL + "/d/" + include.GetSlugOrUid(),
 					Text: include.Name,
 				}
 				appLink.Children = append(appLink.Children, link)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -110,7 +110,7 @@ func (hs *HTTPServer) getAppLinks(c *models.ReqContext) ([]*dtos.NavLink, error)
 
 			if include.Type == "dashboard" && include.AddToNav {
 				link := &dtos.NavLink{
-					Url:  hs.Cfg.AppSubURL + "/d/" + include.GetSlugOrUid(),
+					Url:  hs.Cfg.AppSubURL + include.GetSlugOrUidLink(),
 					Text: include.Name,
 				}
 				appLink.Children = append(appLink.Children, link)

--- a/pkg/plugins/app_plugin.go
+++ b/pkg/plugins/app_plugin.go
@@ -116,7 +116,11 @@ func (app *AppPlugin) InitApp(panels map[string]*PanelPlugin, dataSources map[st
 			app.DefaultNavUrl = cfg.AppSubURL + "/plugins/" + app.Id + "/page/" + include.Slug
 		}
 		if include.Type == "dashboard" && include.DefaultNav {
-			app.DefaultNavUrl = cfg.AppSubURL + "/dashboard/db/" + include.Slug
+			if len(include.Uid) > 0 {
+				app.DefaultNavUrl = cfg.AppSubURL + "/d/" + include.Uid
+			} else {
+				app.DefaultNavUrl = cfg.AppSubURL + "/dashboard/db/" + include.Slug
+			}
 		}
 	}
 

--- a/pkg/plugins/app_plugin.go
+++ b/pkg/plugins/app_plugin.go
@@ -116,11 +116,7 @@ func (app *AppPlugin) InitApp(panels map[string]*PanelPlugin, dataSources map[st
 			app.DefaultNavUrl = cfg.AppSubURL + "/plugins/" + app.Id + "/page/" + include.Slug
 		}
 		if include.Type == "dashboard" && include.DefaultNav {
-			if len(include.Uid) > 0 {
-				app.DefaultNavUrl = cfg.AppSubURL + "/d/" + include.Uid
-			} else {
-				app.DefaultNavUrl = cfg.AppSubURL + "/dashboard/db/" + include.Slug
-			}
+			app.DefaultNavUrl = cfg.AppSubURL + "/d/" + include.GetSlugOrUid()
 		}
 	}
 

--- a/pkg/plugins/app_plugin.go
+++ b/pkg/plugins/app_plugin.go
@@ -116,7 +116,7 @@ func (app *AppPlugin) InitApp(panels map[string]*PanelPlugin, dataSources map[st
 			app.DefaultNavUrl = cfg.AppSubURL + "/plugins/" + app.Id + "/page/" + include.Slug
 		}
 		if include.Type == "dashboard" && include.DefaultNav {
-			app.DefaultNavUrl = cfg.AppSubURL + "/d/" + include.GetSlugOrUid()
+			app.DefaultNavUrl = cfg.AppSubURL + include.GetSlugOrUidLink()
 		}
 	}
 

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -101,6 +101,14 @@ func (e PluginInclude) GetSlugOrUid() string {
 	}
 }
 
+func (e PluginInclude) GetSlugOrUidLink() string {
+	if len(e.Uid) > 0 {
+		return "/d/" + e.Uid
+	} else {
+		return "/dashboard/db/" + e.Slug
+	}
+}
+
 type PluginDependencyItem struct {
 	Type    string `json:"type"`
 	Id      string `json:"id"`

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -88,6 +88,7 @@ type PluginInclude struct {
 	DefaultNav bool            `json:"defaultNav"`
 	Slug       string          `json:"slug"`
 	Icon       string          `json:"icon"`
+	Uid        string          `json:"uid"`
 
 	Id string `json:"-"`
 }

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -93,6 +93,14 @@ type PluginInclude struct {
 	Id string `json:"-"`
 }
 
+func (e PluginInclude) GetSlugOrUid() string {
+	if len(e.Uid) > 0 {
+		return e.Uid
+	} else {
+		return e.Slug
+	}
+}
+
 type PluginDependencyItem struct {
 	Type    string `json:"type"`
 	Id      string `json:"id"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with dashboard links in app plugins.
These still use the slug to select dashboards, but builds the slug from the link title.

Added functinality where setting Uid in plugin.json would use the new Uid link.

**Which issue(s) this PR fixes**:

Fixes #33808 

**Special notes for your reviewer**:

