### PR TITLE
PanelEditor: leave table view when changing the other display modes

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -218,6 +218,9 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
 
   onDisplayModeChange = (mode?: DisplayMode) => {
     const { updatePanelEditorUIState } = this.props;
+    if (this.props.tableViewEnabled) {
+      this.props.toggleTableView();
+    }
     updatePanelEditorUIState({
       mode: mode,
     });


### PR DESCRIPTION
I really like the new table view option in the panel editor, but the other modes do not do anything when table mode is enabled.

There is an odd mix of toggle+radio.  As a simple fix, this PR disabled table view whenever a mode changes. 
![image](https://user-images.githubusercontent.com/705951/117604226-b0904900-b109-11eb-8336-338d242dec7e.png)
