### PR TITLE
Docs: delete from high availability docs references to removed configurations related to session storage

### DIFF
--- a/docs/sources/administration/set-up-for-high-availability.md
+++ b/docs/sources/administration/set-up-for-high-availability.md
@@ -26,22 +26,4 @@ Currently alerting supports a limited form of high availability. [Alert notifica
 
 ## User sessions
 
-> **Note:** You don't need to configure session storage, because the database will be used by default.
-> If you want to offload the login session data from the database, then you can configure [remote_cache]({{< relref "../administration/configuration.md" >}}#remote-cache).
-
-The second thing to consider is how to deal with user sessions and how to configure your load balancer in front of Grafana.
-Grafana supports two ways of storing session data: locally on disk or in a database/cache-server.
-If you want to store sessions on disk you can use `sticky sessions` in your load balancer. If you prefer to store session data in a database/cache-server
-you can use any stateless routing strategy in your load balancer (ex round robin or least connections).
-
-### Sticky sessions
-
-Using sticky sessions, all traffic for one user will always be sent to the same server. Which means that session related data can be
-stored on disk rather than on a shared database. This is the default behavior for Grafana and if you only want multiple servers for fail over this is a good solution since it requires the least amount of work.
-
-### Stateless sessions
-
-You can also choose to store session data in a Redis/Memcache/Postgres/MySQL which means that the load balancer can send a user to any Grafana server without having to log in on each server. This requires a little bit more work from the operator but enables you to remove/add grafana servers without impacting the user experience.
-If you use MySQL/Postgres for session storage, you first need a table to store the session data in. More details about that in [[sessions]]({{< relref "../administration/configuration.md" >}}#session)
-
-For Grafana itself it doesn't really matter if you store the session data on disk or database/redis/memcache. But we recommend using a database/redis/memcache since it makes it easier to manage the grafana servers.
+You don't need to configure session storage, because the database will be used by default. This means that a load balancer can send a user to any Grafana server without having to log in on each server. If you want to offload the login session data from the database, then you can configure [remote_cache]({{< relref "../administration/configuration.md" >}}#remote-cache).

--- a/docs/sources/administration/set-up-for-high-availability.md
+++ b/docs/sources/administration/set-up-for-high-availability.md
@@ -26,4 +26,4 @@ Currently alerting supports a limited form of high availability. [Alert notifica
 
 ## User sessions
 
-You don't need to configure session storage, because the database will be used by default. This means that a load balancer can send a user to any Grafana server without having to log in on each server. If you want to offload the login session data from the database, then you can configure [remote_cache]({{< relref "../administration/configuration.md" >}}#remote-cache).
+Grafana uses auth token strategy with database by default. This means that a load balancer can send a user to any Grafana server without having to log in on each server. If you want to offload the login session data from the database, then you can configure [remote_cache]({{< relref "../administration/configuration.md" >}}#remote-cache).


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the documentation
**Which issue(s) this PR fixes**:

Fixes #33822

**Special notes for your reviewer**:

The issue describes the problem well. So after some time I fount that the docs are kind of outdated. You updated (b3ac63d) it saying that

> **Note:** You don't need to configure session storage, because the database will be used by default.
> If you want to offload the login session data from the database, then you can configure [remote_cache]({{< relref "../administration/configuration.md" >}}#remote-cache).

But  the `Sticky sessions` was not removed from the docs since it is not available anymore (as you will see below, this should have been removed way before this commit). The reason is the following (445b427):

> ### Auth and session token improvements
> The previous session storage implementation in Grafana was causing problems in larger HA setups due to too many write requests to the database. The remember me token also have several security issues which is why we decided to rewrite auth middleware in Grafana and remove the session storage since most operations using the session storage could be rewritten to use cookies or data already made available earlier in the request. 
If you are using `Auth proxy` for authentication the session storage will still be used but our goal is to remove this ASAP as well.
> This release will force all users to log in again since their previous token is not valid anymore.

This docs update (de2f3db) confirms:

> Grafana 6.0 removes the need of configuring and setup of additional storage for [user sessions](/tutorials/ha_setup/#user-sessions). This should make it easier to deploy and operate Grafana in a
high availability setup and/or if you're using a stateless user session storage like Redis, Memcache, Postgres or MySQL.

This commit (db584b3d) forgot to remove the discussed details from the docs. Just to really make sure we dont need [session] anymore:

> ## [session]
>**Removed starting from Grafana v6.2. Please use [remote_cache](#remote-cache) option instead.**

I think that 7899651 is the commit that missed this detail. Therefore this PR fix the doc that and closes #33822
