### PR TITLE
Database: Add isolation level configuration parameter for MySQL

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -105,6 +105,11 @@ log_queries =
 # For "mysql", use either "true", "false", or "skip-verify".
 ssl_mode = disable
 
+# Database drivers may support different transaction isolation levels.
+# If the value is empty - driver's default isolation level is applied.
+# For "mysql" use "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
+isolation_level =
+
 ca_cert_path =
 client_key_path =
 client_cert_path =

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -106,6 +106,7 @@ log_queries =
 ssl_mode = disable
 
 # Database drivers may support different transaction isolation levels.
+# Currently, only "mysql" driver supports isolation levels.
 # If the value is empty - driver's default isolation level is applied.
 # For "mysql" use "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
 isolation_level =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -95,6 +95,7 @@
 ;ssl_mode = disable
 
 # Database drivers may support different transaction isolation levels.
+# Currently, only "mysql" driver supports isolation levels.
 # If the value is empty - driver's default isolation level is applied.
 # For "mysql" use "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
 ;isolation_level =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -94,6 +94,11 @@
 # For "postgres" only, either "disable", "require" or "verify-full"
 ;ssl_mode = disable
 
+# Database drivers may support different transaction isolation levels.
+# If the value is empty - driver's default isolation level is applied.
+# For "mysql" use "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
+;isolation_level =
+
 ;ca_cert_path =
 ;client_key_path =
 ;client_cert_path =

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -331,7 +331,7 @@ For MySQL, use either `true`, `false`, or `skip-verify`.
 
 ### isolation_level
 
-Database drivers may support different transaction isolation levels. Currently, only "mysql" driver supports isolation levels. If the value is empty - driver's default isolation level is applied. For "mysql" use "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
+Only the MySQL driver supports isolation levels in Grafana. In case the value is empty, the driver's default isolation level is applied. Available options are "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
 
 ### ca_cert_path
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -329,6 +329,10 @@ Set to `true` to log the sql calls and execution times.
 For Postgres, use either `disable`, `require` or `verify-full`.
 For MySQL, use either `true`, `false`, or `skip-verify`.
 
+### isolation_level
+
+Database drivers may support different transaction isolation levels. Currently, only "mysql" driver supports isolation levels. If the value is empty - driver's default isolation level is applied. For "mysql" use "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ" or "SERIALIZABLE".
+
 ### ca_cert_path
 
 The path to the CA certificate to use. On many Linux systems, certs can be found in `/etc/ssl/certs`.

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -233,6 +233,10 @@ func (ss *SQLStore) buildConnectionString() (string, error) {
 			cnnstr += "&tls=custom"
 		}
 
+		if isolation := ss.dbCfg.IsolationLevel; isolation != "" {
+			cnnstr += "&tx_isolation=" + isolation
+		}
+
 		cnnstr += ss.buildExtraConnectionString('&')
 	case migrator.Postgres:
 		addr, err := util.SplitHostPortDefault(ss.dbCfg.Host, "127.0.0.1", "5432")
@@ -379,6 +383,7 @@ func (ss *SQLStore) readConfig() {
 	ss.dbCfg.ClientCertPath = sec.Key("client_cert_path").String()
 	ss.dbCfg.ServerCertName = sec.Key("server_cert_name").String()
 	ss.dbCfg.Path = sec.Key("path").MustString("data/grafana.db")
+	ss.dbCfg.IsolationLevel = sec.Key("isolation_level").String()
 
 	ss.dbCfg.CacheMode = sec.Key("cache_mode").MustString("private")
 	ss.dbCfg.SkipMigrations = sec.Key("skip_migrations").MustBool()
@@ -531,6 +536,7 @@ type DatabaseConfig struct {
 	ClientCertPath   string
 	ServerCertName   string
 	ConnectionString string
+	IsolationLevel   string
 	MaxOpenConn      int
 	MaxIdleConn      int
 	ConnMaxLifetime  int


### PR DESCRIPTION
Hopefully closes #33556

This PR adds an `isolation_level` field to the database config and passes that value to the MySQL db.