### PR TITLE
Elasticsearch: automatically set date_histogram field in query model based on data source configuration

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -15,7 +15,7 @@ import {
 import { bucketAggregationConfig } from '../utils';
 import { removeEmpty } from '../../../../utils';
 
-export const reducer = (
+export const createReducer = (defaultTimeField: string) => (
   state: ElasticsearchQuery['bucketAggs'],
   action: BucketAggregationAction | ChangeMetricTypeAction | InitAction
 ): ElasticsearchQuery['bucketAggs'] => {
@@ -78,7 +78,7 @@ export const reducer = (
         // Else, if there are no bucket aggregations we restore a default one.
         // This happens when switching from a metric that requires the absence of bucket aggregations to
         // one that requires it.
-        return [defaultBucketAgg()];
+        return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
       }
       return state;
 
@@ -105,7 +105,8 @@ export const reducer = (
       if (state?.length || 0 > 0) {
         return state;
       }
-      return [defaultBucketAgg('2')];
+
+      return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
 
     default:
       return state;

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -4,7 +4,7 @@ import { combineReducers, useStatelessReducer, DispatchContext } from '../../hoo
 import { ElasticsearchQuery } from '../../types';
 
 import { reducer as metricsReducer } from './MetricAggregationsEditor/state/reducer';
-import { reducer as bucketAggsReducer } from './BucketAggregationsEditor/state/reducer';
+import { createReducer as createBucketAggsReducer } from './BucketAggregationsEditor/state/reducer';
 import { aliasPatternReducer, queryReducer, initQuery } from './state';
 import { TimeRange } from '@grafana/data';
 
@@ -40,7 +40,7 @@ export const ElasticsearchProvider = ({
     query: queryReducer,
     alias: aliasPatternReducer,
     metrics: metricsReducer,
-    bucketAggs: bucketAggsReducer,
+    bucketAggs: createBucketAggsReducer(datasource.timeField),
   });
 
   const dispatch = useStatelessReducer(

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -1,4 +1,4 @@
-import { BucketAggregation } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
+import { DateHistogram } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 import {
   ExtendedStat,
   MetricAggregation,
@@ -36,7 +36,7 @@ export function defaultMetricAgg(id = '1'): MetricAggregation {
   return { type: 'count', id };
 }
 
-export function defaultBucketAgg(id = '1'): BucketAggregation {
+export function defaultBucketAgg(id = '1'): DateHistogram {
   return { type: 'date_histogram', id, settings: { interval: 'auto' } };
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When creating a new Elasticsearch query, a `Date Histogram` bucket aggregation is automatically created with no time field.
The front-end query builder adds the configured default time field to the query automatically if no `field` for a `date_histogram` is selected, however, this doesn't happen in the backend.

This leads to some confusion when users create an alert without selecting a field for the date histogram as the query used to generate the graph and the alerting query will be different.

This PR changes the query editor so that when creating a new ES query (or, for instance, when switching from `raw_data` to another metric where a `date_histogram` is automatically created) the aggregation's `field` in the query model is automatically populated with the configured default time field from the data source settings.

![Screenshot 2021-05-10 at 11 06 16](https://user-images.githubusercontent.com/1170767/117642905-c2143800-b17f-11eb-9fb6-27b8b1dd3d69.png)

I decided to not go for a backend implementation that mimics the front-end (automatically falling back to the configured time field) for the following reasons:
- It's "magic" and not clear that this happens anywhere
- the UI state does not reflect the query being executed
- we'll (hopefully) get rid of the frontend implementation soon.


**Which issue(s) this PR fixes**:

~Fixes~ (it doesn't) #33701, we'll probably either tackle it when removing the FE implementation of the query builder.


**Special notes for your reviewer**:

Not introducing the same behavior in the BE should be considered then a breaking change (in the future) as it will most likely break some panels, but on quest to reduce complexity and have less magic it might be worth it.

