### PR TITLE
Slack: Use image from disk if the image public url is empty

### DIFF
--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -294,7 +294,10 @@ func (sn *SlackNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"footer_icon": "https://grafana.com/assets/img/fav32.png",
 		"ts":          time.Now().Unix(),
 	}
-	if sn.NeedsImage() && imageURL != "" {
+	if sn.NeedsImage() {
+		if imageURL == "" {
+			imageURL = evalContext.ImageOnDiskPath
+		}
 		attachment["image_url"] = imageURL
 	}
 	body := map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:

In the slack notifications, if the `Include image` checkbox is checked, the image is not rendered when using `grafana-image-rendered`. This may be affected by the new `chat.postMessage` URL we introduced a while ago, to use Slack's latest api versions. 

This PR sets the `ImageOnDiskPath` as the imageURL, if there's no public url present fr the image.

**Which issue(s) this PR fixes**:

Fixes #33501