### PR TITLE
CUE: Add `cue fmt` to pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     ],
     "*pkg/**/*.go": [
       "gofmt -w -s"
+    ],
+    "*cue/**/*.cue": [
+      "cue fmt --simplify"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is responsible for adding CUE formatting to pre-commit hook.

**Which issue(s) this PR fixes**:

Resolves task in epic #33139
