### PR TITLE
Plugins: Ensure installer http client has correct timeout value

### DIFF
--- a/pkg/plugins/manager/installer/installer.go
+++ b/pkg/plugins/manager/installer/installer.go
@@ -59,7 +59,7 @@ func (e *BadRequestError) Error() string {
 func New(skipTLSVerify bool, grafanaVersion string, logger plugins.PluginInstallerLogger) *Installer {
 	return &Installer{
 		httpClient:          makeHttpClient(skipTLSVerify, 10*time.Second),
-		httpClientNoTimeout: makeHttpClient(skipTLSVerify, 10*time.Second),
+		httpClientNoTimeout: makeHttpClient(skipTLSVerify, 0),
 		log:                 logger,
 		grafanaVersion:      grafanaVersion,
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Some plugins need a long(er) time for fetching - this should have been zero but copy pasta 🤷 

Fixes the following problem seen when installing the `grafana-image-renderer`

```
./bin/grafana-cli --pluginUrl=https://github.com/grafana/grafana-image-renderer/releases/download/v2.0.1/plugin-linux-x64-glibc.zip plugins install grafana-image-renderer@2.0.1

Error: ✗ failed to download plugin archive: failed to compute SHA256 checksum: context deadline exceeded (Client.Timeout or context cancellation while reading body)
```