### PR TITLE
Prometheus: Fix exemplars hover disappearing and broken link

### DIFF
--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -64,7 +64,6 @@ export function getFocusStyles(theme: GrafanaTheme2): CSSObject {
 
 // max-width is set up based on .grafana-tooltip class that's used in dashboard
 export const getTooltipContainerStyles = (theme: GrafanaTheme2) => `
-  pointer-events: none;
   overflow: hidden;
   background: ${theme.colors.background.secondary};
   box-shadow: ${theme.shadows.z2};

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -149,7 +149,7 @@ function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
       title: `Query with ${dsSettings?.name}`,
       url: '',
       internal: {
-        query: { query: '${__value.raw}', queryType: 'getTrace' },
+        query: { query: '${__value.raw}', queryType: 'traceId' },
         datasourceUid: options.datasourceUid,
         datasourceName: dsSettings?.name ?? 'Data source not found',
       },


### PR DESCRIPTION

**What this PR does / why we need it**:
This reverts commit e159985aa2907e2c2889853f9295183edc1032ac.

It causes exemplars window to be unusable.

https://user-images.githubusercontent.com/13729989/117692655-8730f500-b1bd-11eb-8aac-5d68acfcede2.mp4

