### PR TITLE
Explore: Wrap each panel in separate error boundary

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -348,11 +348,13 @@ export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
                     <ErrorBoundaryAlert>
                       {showPanels && (
                         <>
-                          {showMetrics && graphResult && this.renderGraphPanel(width)}
-                          {showTable && this.renderTablePanel(width)}
-                          {showLogs && this.renderLogsPanel(width)}
-                          {showNodeGraph && this.renderNodeGraphPanel()}
-                          {showTrace && this.renderTraceViewPanel()}
+                          {showMetrics && graphResult && (
+                            <ErrorBoundaryAlert>{this.renderGraphPanel(width)}</ErrorBoundaryAlert>
+                          )}
+                          {showTable && <ErrorBoundaryAlert>{this.renderTablePanel(width)}</ErrorBoundaryAlert>}
+                          {showLogs && <ErrorBoundaryAlert>{this.renderLogsPanel(width)}</ErrorBoundaryAlert>}
+                          {showNodeGraph && <ErrorBoundaryAlert>{this.renderNodeGraphPanel()}</ErrorBoundaryAlert>}
+                          {showTrace && <ErrorBoundaryAlert>{this.renderTraceViewPanel()}</ErrorBoundaryAlert>}
                         </>
                       )}
                       {showRichHistory && (


### PR DESCRIPTION
When we show multiple panels it make sense not to break whole explore and just show error for each panel separately instead.