### PR TITLE
Prometheus: Sanitize PromLink button

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromLink.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromLink.test.tsx
@@ -64,4 +64,16 @@ describe('PromLink', () => {
       'prom2/graph?g0.expr=up&g0.range_input=0s&g0.end_input=undefined&g0.step_input=15&g0.tab=0'
     );
   });
+  it('should create sanitized link', async () => {
+    render(
+      <div>
+        <PromLink
+          datasource={getDataSource({ directUrl: "javascript:300?1:2;alert('Hello');//" })}
+          panelData={getPanelData()}
+          query={{} as PromQuery}
+        />
+      </div>
+    );
+    expect(screen.getByText('Prometheus')).toHaveAttribute('href', 'about:blank');
+  });
 });

--- a/public/app/plugins/datasource/prometheus/components/PromLink.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromLink.tsx
@@ -3,7 +3,7 @@ import React, { FC, useEffect, useState, memo } from 'react';
 
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery } from '../types';
-import { DataQueryRequest, PanelData } from '@grafana/data';
+import { DataQueryRequest, PanelData, textUtil } from '@grafana/data';
 
 interface Props {
   datasource: PrometheusDatasource;
@@ -54,7 +54,7 @@ const PromLink: FC<Props> = ({ panelData, query, datasource }) => {
   }, [datasource, panelData, query]);
 
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
+    <a href={textUtil.sanitizeUrl(href)} target="_blank" rel="noopener noreferrer">
       Prometheus
     </a>
   );


### PR DESCRIPTION
**What this PR does / why we need it**:
PromLink button was missing URL sanitization. This PR sanitizes url and adds test.
To test this follow [this](https://github.com/grafana/grafana-private-mirror/pull/83).
