### PR TITLE
enforce receivers align with backend type when posting AM config

### DIFF
--- a/pkg/services/ngalert/api/forked_am.go
+++ b/pkg/services/ngalert/api/forked_am.go
@@ -117,6 +117,25 @@ func (am *ForkedAMSvc) RoutePostAlertingConfig(ctx *models.ReqContext, body apim
 		return response.Error(400, err.Error(), nil)
 	}
 
+	backendType, err := backendType(ctx, am.DatasourceCache)
+	if err != nil {
+		return response.Error(400, err.Error(), nil)
+	}
+
+	payloadType := body.AlertmanagerConfig.Type()
+
+	if backendType != payloadType {
+		return response.Error(
+			400,
+			fmt.Sprintf(
+				"unexpected backend type (%v) vs payload type (%v)",
+				backendType,
+				payloadType,
+			),
+			nil,
+		)
+	}
+
 	return s.RoutePostAlertingConfig(ctx, body)
 }
 


### PR DESCRIPTION
This PR should align payload and backend types when POSTing Alertmanager configs. Below is an example when using upstream AM receivers against the grafana AM backend.

```
$ curl -s -H 'Content-Type: application/json' -XPOST -d "$(cat /tmp/am_config.json)" admin:admin@localhost:3000/api/alertmanager/grafana/config/api/v1/alerts
{"message":"unexpected backend type (grafana) vs payload type (alertmanager)"}
```