### PR TITLE
Loki: fix label browser crashing when + typed

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiLabel.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabel.tsx
@@ -56,7 +56,12 @@ export const LokiLabel = forwardRef<HTMLElement, Props>(
         )}
         {...rest}
       >
-        <Highlighter textToHighlight={text} searchWords={searchWords} highlightClassName={styles.matchHighLight} />
+        <Highlighter
+          textToHighlight={text}
+          searchWords={searchWords}
+          autoEscape={true}
+          highlightClassName={styles.matchHighLight}
+        />
       </span>
     );
   }


### PR DESCRIPTION
searchWords description  is `The search terms are treated as RegExps unless autoEscape is set.` So setting the autoEscape true fixes the issue.
 
**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/support-escalations/issues/308