### PR TITLE
Docs: fix grafana/ui docsExtract REF_NOT_FOUND errors

### DIFF
--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -227,6 +227,7 @@ export { LegacyForms, LegacyInputStatus };
 
 // WIP, need renames and exports cleanup
 export * from './uPlot/config';
+export { ScaleDistribution } from './uPlot/models.gen';
 export { UPlotConfigBuilder } from './uPlot/config/UPlotConfigBuilder';
 export { UPlotChart } from './uPlot/Plot';
 export * from './uPlot/geometries';

--- a/packages/grafana-ui/src/components/uPlot/models.gen.ts
+++ b/packages/grafana-ui/src/components/uPlot/models.gen.ts
@@ -27,6 +27,9 @@ export enum LineInterpolation {
   StepAfter = 'stepAfter',
   StepBefore = 'stepBefore',
 }
+/**
+ * @alpha
+ */
 export enum ScaleDistribution {
   Linear = 'linear',
   Log = 'log',

--- a/packages/grafana-ui/src/options/index.ts
+++ b/packages/grafana-ui/src/options/index.ts
@@ -1,4 +1,5 @@
 // namespace is too big
-export * as commonOptionsBuilder from './builder';
+import * as commonOptionsBuilder from './builder';
+export { commonOptionsBuilder };
 
 export * from './models.gen';

--- a/packages/grafana-ui/src/options/models.gen.ts
+++ b/packages/grafana-ui/src/options/models.gen.ts
@@ -2,6 +2,9 @@
 
 import { VizLegendOptions } from '../components';
 
+/**
+ * @alpha
+ */
 export interface OptionsWithLegend {
   legend: VizLegendOptions;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Docs/website builds are failing due to grafana/ui docs script erroring when `docsExtract` script is run.

```bash
lerna info run Ran npm script 'docsExtract' in '@grafana/ui' in 5.3s:
$ mkdir -p ../../reports/docs && api-extractor run 2>&1 | tee ../../reports/docs/$(basename $(pwd)).log
api-extractor 7.10.1  - https://api-extractor.com/
Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 3.9.7
*** The target project appears to use TypeScript 4.2.4 which is newer than the bundled compiler engine; consider upgrading API Extractor.
ERROR: Internal Error: Unimplemented export declaration kind: * as commonOptionsBuilder
/Users/marcusandersson/development/go/src/github.com/grafana/grafana/packages/grafana-ui/dist/options/index.d.ts:1:8
You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
```
