### PR TITLE
FrameCompare: Name or label change is a structure change

### DIFF
--- a/packages/grafana-data/src/dataframe/frameComparisons.test.ts
+++ b/packages/grafana-data/src/dataframe/frameComparisons.test.ts
@@ -20,6 +20,7 @@ describe('test comparisons', () => {
         config: {
           decimals: 4,
         },
+        labels: { server: 'A' },
       },
     ],
   });
@@ -38,8 +39,25 @@ describe('test comparisons', () => {
     expect(compareArrayValues(null as any, [frameA], compareDataFrameStructures)).toBeFalsy();
   });
 
-  it('name change and field copy is not a structure change', () => {
-    expect(compareDataFrameStructures(frameB, { ...frameB, name: 'AA' })).toBeTruthy();
+  it('name change should be a structure change', () => {
+    expect(compareDataFrameStructures(frameB, { ...frameB, name: 'AA' })).toBeFalsy();
+  });
+
+  it('label change should be a structure change', () => {
+    const changedFrameB = {
+      ...frameB,
+      fields: [
+        frameB.fields[0],
+        {
+          ...frameB.fields[1],
+          labels: { server: 'B' },
+        },
+      ],
+    };
+    expect(compareDataFrameStructures(frameB, changedFrameB)).toBeFalsy();
+  });
+
+  it('Field copy should not be a structure change', () => {
     expect(compareDataFrameStructures(frameB, { ...frameB, fields: [field0, field1] })).toBeTruthy();
   });
 

--- a/packages/grafana-data/src/dataframe/frameComparisons.ts
+++ b/packages/grafana-data/src/dataframe/frameComparisons.ts
@@ -1,8 +1,7 @@
 import { DataFrame } from '../types/dataFrame';
 
 /**
- * Returns true if both frames have the same list of fields and configs.
- * Field may have diferent names, labels and values but share the same structure
+ * Returns true if both frames have the same name, fields, labels and configs.
  *
  * @example
  * To compare multiple frames use:
@@ -24,17 +23,26 @@ export function compareDataFrameStructures(a: DataFrame, b: DataFrame, skipConfi
     return false;
   }
 
+  if (a.name !== b.name) {
+    return false;
+  }
+
   for (let i = 0; i < a.fields.length; i++) {
     const fA = a.fields[i];
     const fB = b.fields[i];
 
-    if (fA.type !== fB.type) {
+    if (fA.type !== fB.type || fA.name !== fB.name) {
       return false;
     }
 
     // Do not check the config fields
     if (skipConfig) {
       continue;
+    }
+
+    // Check if labels are different
+    if (fA.labels && fB.labels && !shallowCompare(fA.labels, fB.labels)) {
+      return false;
     }
 
     const cfgA = fA.config as any;

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -62,6 +62,10 @@ export class TestDataDataSource extends DataSourceWithBackend<TestDataQuery> {
           streams.push(this.nodesQuery(target, options));
           break;
         default:
+          if (target.alias) {
+            target.alias = this.templateSrv.replace(target.alias, options.scopedVars);
+          }
+
           backendQueries.push(target);
       }
     }


### PR DESCRIPTION
Fixes #33896


The frame comparisions ignored frame name, field name and field label changes. All of these needs to be seen as structure changes as they impact
what field overrides are applied and what is shown in legend.
