### PR TITLE
Library Panels: Fix error when changing viz of panel with multiple instances

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -107,7 +107,7 @@ function updateDuplicateLibraryPanels(modifiedPanel: PanelModel, dashboard: Dash
     const pluginChanged = panel.plugin?.meta.id !== modifiedPanel.plugin?.meta.id;
     panel.plugin = modifiedPanel.plugin;
 
-    if (panel.type !== modifiedPanel.type || pluginChanged) {
+    if (pluginChanged) {
       dispatch(panelModelAndPluginReady({ panelId: panel.id, plugin: panel.plugin! }));
     }
 

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -106,6 +106,7 @@ function updateDuplicateLibraryPanels(modifiedPanel: PanelModel, dashboard: Dash
     // So is not handled by restoreModel
     const pluginChanged = panel.plugin?.meta.id !== modifiedPanel.plugin?.meta.id;
     panel.plugin = modifiedPanel.plugin;
+    panel.configRev++;
 
     if (pluginChanged) {
       dispatch(panelModelAndPluginReady({ panelId: panel.id, plugin: panel.plugin! }));

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -104,9 +104,10 @@ function updateDuplicateLibraryPanels(modifiedPanel: PanelModel, dashboard: Dash
 
     // Loaded plugin is not included in the persisted properties
     // So is not handled by restoreModel
-    panel.plugin = modifiedSaveModel.plugin;
+    const pluginChanged = panel.plugin?.meta.id !== modifiedPanel.plugin?.meta.id;
+    panel.plugin = modifiedPanel.plugin;
 
-    if (panel.type !== modifiedPanel.type) {
+    if (panel.type !== modifiedPanel.type || pluginChanged) {
       dispatch(panelModelAndPluginReady({ panelId: panel.id, plugin: panel.plugin! }));
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where changing the visualization type of a library panel with multiple instances on the same dashboard could cause an error resulting in one of the panels not rendering.


