### PR TITLE
DatasourceSettings: align Alert title

### DIFF
--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -200,6 +200,19 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
     return <div>Page not found: {page}</div>;
   }
 
+  renderAlertDetails() {
+    const { testingStatus } = this.props;
+
+    return (
+      <>
+        {testingStatus?.details?.message}
+        {testingStatus?.details?.verboseMessage ? (
+          <details style={{ whiteSpace: 'pre-wrap' }}>{testingStatus?.details?.verboseMessage}</details>
+        ) : null}
+      </>
+    );
+  }
+
   renderSettings() {
     const { dataSourceMeta, setDataSourceName, setIsDefault, dataSource, plugin, testingStatus } = this.props;
 
@@ -233,20 +246,17 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
           />
         )}
 
-        <div className="gf-form-group p-t-2">
-          {testingStatus?.message && (
+        {testingStatus?.message && (
+          <div className="gf-form-group p-t-2">
             <Alert
               severity={testingStatus.status === 'error' ? 'error' : 'success'}
               title={testingStatus.message}
               aria-label={selectors.pages.DataSource.alert}
             >
-              {testingStatus.details?.message ?? null}
-              {testingStatus.details?.verboseMessage ? (
-                <details style={{ whiteSpace: 'pre-wrap' }}>{testingStatus.details?.verboseMessage}</details>
-              ) : null}
+              {testingStatus.details && this.renderAlertDetails()}
             </Alert>
-          )}
-        </div>
+          </div>
+        )}
 
         <ButtonRow
           onSubmit={(event) => this.onSubmit(event)}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if the `Alert` component only has a `title` passed in and no children, the title won't be vertically aligned:

```
testingStatus: {
   message: "some-message"
}
```

![Screenshot 2021-05-11 at 11.41.12.png](https://images.zenhubusercontent.com/5fa00471317e5275d933a1a0/c1c66435-75b5-412c-8717-856902261ddd)

Because of the empty `div` here:

![Screenshot 2021-05-11 at 12 12 18](https://user-images.githubusercontent.com/36230812/117806440-42a36900-b252-11eb-9076-91d192adbfac.png)

Fine for:

```
testingStatus: {
   message: "some-message",
   details: {
      message: "some-detailed-message",
   }
}
```

![Screenshot 2021-05-11 at 11.45.50.png](https://images.zenhubusercontent.com/5fa00471317e5275d933a1a0/cd840c42-f8ea-4dad-bfff-6cc2a47832cc) 

Fine for:

```
testingStatus: {
   message: "some-message",
   details: {
      message: "some-detailed-message",
      verboseMessage: "some-detailed-verbose-message"
   }
}
```

![Screenshot 2021-05-11 at 11.40.35.png](https://images.zenhubusercontent.com/5fa00471317e5275d933a1a0/3f5c1be2-670a-403f-9153-5fe5f3dae56d)

**After**

The `title` is now vertically aligned:

![Screenshot 2021-05-11 at 11 45 36](https://user-images.githubusercontent.com/36230812/117805964-8d70b100-b251-11eb-98d4-70f592fb3fae.png)

There is no empty `div`:

![Screenshot 2021-05-11 at 12 16 51](https://user-images.githubusercontent.com/36230812/117806893-d2491780-b252-11eb-9c88-c8b083f39b32.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/integrations-team/issues/151

**Special notes for your reviewer**:

TIA 🙏 