### PR TITLE
Instrumentation: Instrument incoming HTTP request with histograms by default

### DIFF
--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -59,7 +59,11 @@ func RequestMetrics(cfg *setting.Cfg) func(handler string) macaron.Handler {
 			method := sanitizeMethod(req.Method)
 
 			// enable histogram and disable summaries + counters for http requests.
-			if cfg.IsHTTPRequestHistogramEnabled() {
+			if cfg.IsHTTPRequestHistogramDisabled() {
+				duration := time.Since(now).Nanoseconds() / int64(time.Millisecond)
+				metrics.MHttpRequestTotal.WithLabelValues(handler, code, method).Inc()
+				metrics.MHttpRequestSummary.WithLabelValues(handler, code, method).Observe(float64(duration))
+			} else {
 				// avoiding the sanitize functions for in the new instrumentation
 				// since they dont make much sense. We should remove them later.
 				histogram := httpRequestDurationHistogram.
@@ -74,10 +78,6 @@ func RequestMetrics(cfg *setting.Cfg) func(handler string) macaron.Handler {
 					return
 				}
 				histogram.Observe(time.Since(now).Seconds())
-			} else {
-				duration := time.Since(now).Nanoseconds() / int64(time.Millisecond)
-				metrics.MHttpRequestTotal.WithLabelValues(handler, code, method).Inc()
-				metrics.MHttpRequestSummary.WithLabelValues(handler, code, method).Observe(float64(duration))
 			}
 
 			switch {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -394,9 +394,11 @@ func (cfg Cfg) IsDatabaseMetricsEnabled() bool {
 	return cfg.FeatureToggles["database_metrics"]
 }
 
-// IsHTTPRequestHistogramEnabled returns whether the http_request_histogram feature is enabled.
-func (cfg Cfg) IsHTTPRequestHistogramEnabled() bool {
-	return cfg.FeatureToggles["http_request_histogram"]
+// IsHTTPRequestHistogramDisabled returns whether the request historgrams is disabled.
+// This feature toggle will be removed in Grafana 8.x but gives the operator
+// some graceperiod to update all the monitoring tools.
+func (cfg Cfg) IsHTTPRequestHistogramDisabled() bool {
+	return cfg.FeatureToggles["disable_http_request_histogram"]
 }
 
 // IsPanelLibraryEnabled returns whether the panel library feature is enabled.


### PR DESCRIPTION
Summaries are not really suitable for instrumenting HTTP request duration as its not possible to aggregate across instances or handlers. We had this enabled behind a feature toggle for quite some time but I think we should enable it by default in Grafana 8. While this is breaking we keep a feature toggle to expose the old metrics. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>
