### PR TITLE
Instrumentation: Prefix metrics with grafana

### DIFF
--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -25,8 +25,9 @@ var (
 func init() {
 	httpRequestsInFlight = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "http_request_in_flight",
-			Help: "A gauge of requests currently being served by Grafana.",
+			Namespace: "grafana",
+			Name:      "http_request_in_flight",
+			Help:      "A gauge of requests currently being served by Grafana.",
 		},
 	)
 


### PR DESCRIPTION
By convention, metrics should be prefixed with the name of the application exporting them. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>


