### PR TITLE
Migrate timeseries hideFrom graph->viz (#33806)

### DIFF
--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -49,6 +49,15 @@ describe('Graph Migrations', () => {
     expect(panel).toMatchSnapshot();
   });
 
+  it('hides series', () => {
+    const old: any = {
+      angular: legend,
+    };
+    const panel = {} as PanelModel;
+    panel.options = graphPanelChangedHandler(panel, 'graph', old);
+    expect(panel).toMatchSnapshot();
+  });
+
   describe('stacking', () => {
     test('simple', () => {
       const old: any = {
@@ -189,6 +198,48 @@ describe('Graph Migrations', () => {
           },
         ]
       `);
+    });
+
+    test('hide series', () => {
+      const panel = {} as PanelModel;
+      panel.fieldConfig = {
+        defaults: {
+          custom: {
+            hideFrom: {
+              tooltip: false,
+              graph: false,
+              legend: false,
+            },
+          },
+        },
+        overrides: [
+          {
+            matcher: {
+              id: 'byNames',
+              options: {
+                mode: 'exclude',
+                names: ['Bedroom'],
+                prefix: 'All except:',
+                readOnly: true,
+              },
+            },
+            properties: [
+              {
+                id: 'custom.hideFrom',
+                value: {
+                  graph: true,
+                  legend: false,
+                  tooltip: false,
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      panel.options = graphPanelChangedHandler(panel, 'graph', {});
+      expect(panel.fieldConfig.defaults.custom.hideFrom).toEqual({ viz: false, legend: false, tooltip: false });
+      expect(panel.fieldConfig.overrides[0].properties[0].value).toEqual({ viz: true, legend: false, tooltip: false });
     });
   });
 });

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -49,15 +49,6 @@ describe('Graph Migrations', () => {
     expect(panel).toMatchSnapshot();
   });
 
-  it('hides series', () => {
-    const old: any = {
-      angular: legend,
-    };
-    const panel = {} as PanelModel;
-    panel.options = graphPanelChangedHandler(panel, 'graph', old);
-    expect(panel).toMatchSnapshot();
-  });
-
   describe('stacking', () => {
     test('simple', () => {
       const old: any = {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -44,6 +44,7 @@ export const graphPanelChangedHandler = (
     return options;
   }
 
+  //fixes graph -> viz renaming in custom.hideFrom field config by mutation.
   migrateHideFrom(panel);
 
   return {};

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -44,6 +44,8 @@ export const graphPanelChangedHandler = (
     return options;
   }
 
+  migrateHideFrom(panel);
+
   return {};
 };
 
@@ -512,4 +514,25 @@ function getReducersFromLegend(obj: Record<string, any>): string[] {
     }
   }
   return ids;
+}
+
+function migrateHideFrom(panel: {
+  fieldConfig?: { defaults?: { custom?: { hideFrom?: any } }; overrides: ConfigOverrideRule[] };
+}) {
+  if (panel.fieldConfig?.defaults?.custom?.hideFrom?.graph !== undefined) {
+    panel.fieldConfig.defaults.custom.hideFrom.viz = panel.fieldConfig.defaults.custom.hideFrom.graph;
+    delete panel.fieldConfig.defaults.custom.hideFrom.graph;
+  }
+  if (panel.fieldConfig?.overrides) {
+    panel.fieldConfig.overrides = panel.fieldConfig.overrides.map((fr) => {
+      fr.properties = fr.properties.map((p) => {
+        if (p.id === 'custom.hideFrom' && p.value.graph) {
+          p.value.viz = p.value.graph;
+          delete p.value.graph;
+        }
+        return p;
+      });
+      return fr;
+    });
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
hideFrom.graph changed name to the more generic name viz. This migrates old timeseries panels.

**Which issue(s) this PR fixes**:
Fixes #33806