### PR TITLE
Variables: Filters out builtin variables from unknown list

### DIFF
--- a/public/app/features/variables/inspect/utils.ts
+++ b/public/app/features/variables/inspect/utils.ts
@@ -3,7 +3,7 @@ import { DashboardModel } from '../../dashboard/state';
 import { isAdHoc } from '../guard';
 import { safeStringifyValue } from '../../../core/utils/explore';
 import { VariableModel } from '../types';
-import { containsVariable, variableRegex } from '../utils';
+import { containsVariable, variableRegex, variableRegexExec } from '../utils';
 
 export interface GraphNode {
   id: string;
@@ -50,8 +50,7 @@ export const createDependencyEdges = (variables: VariableModel[]): GraphEdge[] =
 };
 
 function getVariableName(expression: string) {
-  variableRegex.lastIndex = 0;
-  const match = variableRegex.exec(expression);
+  const match = variableRegexExec(expression);
   if (!match) {
     return null;
   }
@@ -60,6 +59,7 @@ function getVariableName(expression: string) {
 }
 
 export const getUnknownVariableStrings = (variables: VariableModel[], model: any) => {
+  variableRegex.lastIndex = 0;
   const unknownVariableNames: string[] = [];
   const modelAsString = safeStringifyValue(model, 2);
   const matches = modelAsString.match(variableRegex);
@@ -74,6 +74,11 @@ export const getUnknownVariableStrings = (variables: VariableModel[], model: any
     }
 
     if (match.indexOf('$__') !== -1) {
+      // ignore builtin variables
+      continue;
+    }
+
+    if (match.indexOf('${__') !== -1) {
       // ignore builtin variables
       continue;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Data links create variables with the pattern ${__xyz} so the Unknown variables section should filter these out to avoid showing false positives.

**Which issue(s) this PR fixes**:
Fixes #33429

**Special notes for your reviewer**:

