### PR TITLE
Access Control: Fix side menu links

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -323,7 +323,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 			HideFromTabs: true,
 			Id:           "admin",
 			Icon:         "shield",
-			Url:          hs.Cfg.AppSubURL + "/admin/users",
+			Url:          adminNavLinks[0].Url,
 			SortWeight:   dtos.WeightAdmin,
 			Children:     adminNavLinks,
 		})


### PR DESCRIPTION
This PR fixes bug with access control: when user has no access to the `/admin/users` page, but has to, for example, `admin/ldap`, then admin menu is added to the sidebar, but link still refers to the `/admin/users` and it causes 404 error when navigating to the admin menu.