### PR TITLE
Alerting/allow empty receiver

### DIFF
--- a/pkg/services/ngalert/api/forked_am.go
+++ b/pkg/services/ngalert/api/forked_am.go
@@ -117,22 +117,16 @@ func (am *ForkedAMSvc) RoutePostAlertingConfig(ctx *models.ReqContext, body apim
 		return response.Error(400, err.Error(), nil)
 	}
 
-	backendType, err := backendType(ctx, am.DatasourceCache)
+	b, err := backendType(ctx, am.DatasourceCache)
 	if err != nil {
 		return response.Error(400, err.Error(), nil)
 	}
 
-	payloadType := body.AlertmanagerConfig.Type()
-
-	if backendType != payloadType {
+	if err := body.AlertmanagerConfig.ReceiverType().MatchesBackend(b); err != nil {
 		return response.Error(
 			400,
-			fmt.Sprintf(
-				"unexpected backend type (%v) vs payload type (%v)",
-				backendType,
-				payloadType,
-			),
-			nil,
+			"bad match",
+			err,
 		)
 	}
 

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -496,6 +496,7 @@ type ReceiverType int
 const (
 	GrafanaReceiverType ReceiverType = iota
 	AlertmanagerReceiverType
+	EmptyReceiverType
 )
 
 type GettableApiReceiver struct {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -554,25 +554,14 @@ type PostableApiReceiver struct {
 }
 
 func (r *PostableApiReceiver) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var grafanaReceivers PostableGrafanaReceivers
-	if err := unmarshal(&grafanaReceivers); err != nil {
+	if err := unmarshal(&r.PostableGrafanaReceivers); err != nil {
 		return err
 	}
-	r.PostableGrafanaReceivers = grafanaReceivers
 
-	var cfg config.Receiver
-	if err := unmarshal(&cfg); err != nil {
+	if err := unmarshal(&r.Receiver); err != nil {
 		return err
 	}
-	r.Name = cfg.Name
-	r.EmailConfigs = cfg.EmailConfigs
-	r.PagerdutyConfigs = cfg.PagerdutyConfigs
-	r.SlackConfigs = cfg.SlackConfigs
-	r.WebhookConfigs = cfg.WebhookConfigs
-	r.OpsGenieConfigs = cfg.OpsGenieConfigs
-	r.WechatConfigs = cfg.WechatConfigs
-	r.PushoverConfigs = cfg.PushoverConfigs
-	r.VictorOpsConfigs = cfg.VictorOpsConfigs
+
 	return nil
 }
 

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -382,6 +382,8 @@ func (c *GettableApiAlertingConfig) validate() error {
 			hasGrafReceivers = true
 		case AlertmanagerReceiverType:
 			hasAMReceivers = true
+		default:
+			continue
 		}
 	}
 
@@ -436,6 +438,8 @@ func (c *PostableApiAlertingConfig) validate() error {
 			hasGrafReceivers = true
 		case AlertmanagerReceiverType:
 			hasAMReceivers = true
+		default:
+			continue
 		}
 	}
 
@@ -461,6 +465,8 @@ func (c *PostableApiAlertingConfig) ReceiverType() ReceiverType {
 			return GrafanaReceiverType
 		case AlertmanagerReceiverType:
 			return AlertmanagerReceiverType
+		default:
+			continue
 		}
 	}
 	return EmptyReceiverType
@@ -522,6 +528,7 @@ func (r ReceiverType) MatchesBackend(backend Backend) error {
 		ok = r.Can(GrafanaReceiverType)
 	case AlertmanagerBackend:
 		ok = r.Can(AlertmanagerReceiverType)
+	default:
 	}
 	if !ok {
 		return msg(backend, r)

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -69,6 +69,50 @@ func Test_ApiReceiver_Marshaling(t *testing.T) {
 	}
 }
 
+func Test_APIReceiverType(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		input    PostableApiReceiver
+		expected ReceiverType
+	}{
+		{
+			desc: "empty",
+			input: PostableApiReceiver{
+				Receiver: config.Receiver{
+					Name: "foo",
+				},
+			},
+			expected: EmptyReceiverType,
+		},
+		{
+			desc: "am",
+			input: PostableApiReceiver{
+				Receiver: config.Receiver{
+					Name:         "foo",
+					EmailConfigs: []*config.EmailConfig{{}},
+				},
+			},
+			expected: AlertmanagerReceiverType,
+		},
+		{
+			desc: "graf",
+			input: PostableApiReceiver{
+				Receiver: config.Receiver{
+					Name: "foo",
+				},
+				PostableGrafanaReceivers: PostableGrafanaReceivers{
+					GrafanaManagedReceivers: []*PostableGrafanaReceiver{{}},
+				},
+			},
+			expected: GrafanaReceiverType,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.input.Type())
+		})
+	}
+}
+
 func Test_AllReceivers(t *testing.T) {
 	input := &config.Route{
 		Receiver: "foo",
@@ -88,6 +132,10 @@ func Test_AllReceivers(t *testing.T) {
 	}
 
 	require.Equal(t, []string{"foo", "bar", "bazz", "buzz"}, AllReceivers(input))
+
+	// test empty
+	var empty []string
+	require.Equal(t, empty, AllReceivers(&config.Route{}))
 }
 
 func Test_ApiAlertingConfig_Marshaling(t *testing.T) {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -510,7 +510,6 @@ func Test_ReceiverCompatibility(t *testing.T) {
 }
 
 func Test_ReceiverMatchesBackend(t *testing.T) {
-
 	for _, tc := range []struct {
 		desc string
 		rec  ReceiverType


### PR DESCRIPTION
This PR allows sending receivers with a name only (valid) to either Alertmanager or Grafana backends.
