### PR TITLE
Live: use the browser url to build websocket url, not appUrl

### DIFF
--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -55,7 +55,11 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
 
   constructor() {
     // build live url replacing scheme in appUrl.
-    const liveUrl = `${config.appUrl.replace('http', 'ws')}api/live/ws`;
+    let baseURL = config.appUrl;
+    if (baseURL === 'http://localhost:3000/') {
+      baseURL = window.location.origin + '/'; // match the request
+    }
+    const liveUrl = `${baseURL.replace('http', 'ws')}api/live/ws`;
     this.orgId = (window as any).grafanaBootData.user.orgId;
     this.centrifuge = new Centrifuge(liveUrl, {
       debug: true,

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -54,12 +54,8 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
   private orgId: number;
 
   constructor() {
-    // build live url replacing scheme in appUrl.
-    let baseURL = config.appUrl;
-    if (baseURL === 'http://localhost:3000/') {
-      baseURL = window.location.origin + '/'; // match the request
-    }
-    const liveUrl = `${baseURL.replace('http', 'ws')}api/live/ws`;
+    const baseURL = window.location.origin.replace('http', 'ws');
+    const liveUrl = `${baseURL}/${config.appSubUrl}api/live/ws`;
     this.orgId = (window as any).grafanaBootData.user.orgId;
     this.centrifuge = new Centrifuge(liveUrl, {
       debug: true,


### PR DESCRIPTION
Since many people do not properly configure `root_url`, it is easy to get stuck figuring out why the websocket is trying to connect to ws://localhost:3000 -- this uses the browser url settings to build the URL.

I believe `appSubUrl` will have the proper subpath if required. 