### PR TITLE
Urls: Parsing key values will not convert to numbers

### DIFF
--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -51,7 +51,7 @@ describe('parseKeyValue', () => {
   });
 
   it('should parse number like params as strings', () => {
-    const obj = urlUtil.parseKeyValue('custom=&custom1=001&custom2=002');
-    expect(obj).toEqual({ custom: '', custom1: '001', custom2: '002' });
+    const obj = urlUtil.parseKeyValue('custom=&custom1=001&custom2=002&custom3');
+    expect(obj).toEqual({ custom: '', custom1: '001', custom2: '002', custom3: true });
   });
 });

--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -37,16 +37,21 @@ describe('parseKeyValue', () => {
 
   it('should parse numeric params', () => {
     const obj = urlUtil.parseKeyValue('num1=12&num2=12.2');
-    expect(obj).toEqual({ num1: 12, num2: 12.2 });
+    expect(obj).toEqual({ num1: '12', num2: '12.2' });
   });
 
-  it('should not parse empty strinhg as number', () => {
+  it('should not parse empty string as number', () => {
     const obj = urlUtil.parseKeyValue('num1=&num2=12.2');
-    expect(obj).toEqual({ num1: '', num2: 12.2 });
+    expect(obj).toEqual({ num1: '', num2: '12.2' });
   });
 
   it('should parse boolean params', () => {
     const obj = urlUtil.parseKeyValue('bool1&bool2=true&bool3=false');
     expect(obj).toEqual({ bool1: true, bool2: true, bool3: false });
+  });
+
+  it('should parse number like params as strings', () => {
+    const obj = urlUtil.parseKeyValue('custom=&custom1=001&custom2=002');
+    expect(obj).toEqual({ custom: '', custom1: '001', custom2: '002' });
   });
 });

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -2,7 +2,6 @@
  * @preserve jquery-param (c) 2015 KNOWLEDGECODE | MIT
  */
 
-import { toNumber } from 'lodash';
 import { ExploreUrlState } from '../types/explore';
 
 /**
@@ -156,7 +155,7 @@ export function parseKeyValue(keyValue: string) {
 
         let parsedVal: any;
         if (typeof val === 'string' && val !== '') {
-          parsedVal = val === 'true' || val === 'false' ? val === 'true' : toNumber(val);
+          parsedVal = val === 'true' || val === 'false' ? val === 'true' : val;
         } else {
           parsedVal = val;
         }

--- a/packages/grafana-runtime/src/services/LocationService.test.ts
+++ b/packages/grafana-runtime/src/services/LocationService.test.ts
@@ -7,7 +7,7 @@ describe('LocationService', () => {
 
       expect(locationService.getSearchObject()).toEqual({
         query1: false,
-        query2: 123,
+        query2: '123',
         query3: 'text',
       });
     });

--- a/public/app/angular/AngularLocationWrapper.test.ts
+++ b/public/app/angular/AngularLocationWrapper.test.ts
@@ -85,19 +85,19 @@ describe('AngularLocationWrapper', () => {
 
     it('search() should accept object', function () {
       locationService.push('/path/b');
-      wrapper.search({ one: 1, two: true });
-      expect(wrapper.search()).toEqual({ one: 1, two: true });
+      wrapper.search({ one: '1', two: true });
+      expect(wrapper.search()).toEqual({ one: '1', two: true });
       expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two');
     });
 
     it('should copy object', function () {
       locationService.push('/path/b');
-      const obj: Record<string, any> = { one: 1, two: true, three: null };
+      const obj: Record<string, any> = { one: '1', two: true, three: null };
       wrapper.search(obj);
-      expect(obj).toEqual({ one: 1, two: true, three: null });
+      expect(obj).toEqual({ one: '1', two: true, three: null });
       obj.one = 'changed';
 
-      expect(wrapper.search()).toEqual({ one: 1, two: true });
+      expect(wrapper.search()).toEqual({ one: '1', two: true });
       expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two');
     });
 
@@ -117,8 +117,8 @@ describe('AngularLocationWrapper', () => {
 
     it('should remove multiple parameters', function () {
       locationService.push('/path/b');
-      wrapper.search({ one: 1, two: true });
-      expect(wrapper.search()).toEqual({ one: 1, two: true });
+      wrapper.search({ one: '1', two: true });
+      expect(wrapper.search()).toEqual({ one: '1', two: true });
 
       wrapper.search({ one: null, two: null });
       expect(wrapper.search()).toEqual({});

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Wrapper from './Wrapper';
 import { configureStore } from '../../store/configureStore';
 import { Provider } from 'react-redux';
@@ -52,7 +52,7 @@ describe('Wrapper', () => {
 
     // At this point url should be initialised to some defaults
     expect(locationService.getSearchObject()).toEqual({
-      orgId: 1,
+      orgId: '1',
       left: JSON.stringify(['now-1h', 'now', 'loki', {}]),
     });
     expect(datasources.loki.query).not.toBeCalled();
@@ -74,7 +74,7 @@ describe('Wrapper', () => {
 
     // We did not change the url
     expect(locationService.getSearchObject()).toEqual({
-      orgId: 1,
+      orgId: '1',
       ...query,
     });
 
@@ -141,7 +141,7 @@ describe('Wrapper', () => {
     await screen.findByText('elastic Editor input:');
     expect(datasources.elastic.query).not.toBeCalled();
     expect(locationService.getSearchObject()).toEqual({
-      orgId: 1,
+      orgId: '1',
       left: JSON.stringify(['now-1h', 'now', 'elastic', {}]),
     });
   });
@@ -183,7 +183,7 @@ describe('Wrapper', () => {
 
     // We did not change the url
     expect(locationService.getSearchObject()).toEqual({
-      orgId: 1,
+      orgId: '1',
       ...query,
     });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the `toNumber` parsing of url params.

**Which issue(s) this PR fixes**:
Fixes #33890

**Special notes for your reviewer**:
Will create a follow up PR after v8 for cleaning up the variable system.
https://github.com/grafana/grafana/projects/14#card-60947877
