### PR TITLE
Explore: Fix running of duplicit queries when clicking on Older logs button

### DIFF
--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -98,9 +98,10 @@ function LogsNavigation({
             from: pages[currentPageIndex + 1].queryRange.from,
             to: pages[currentPageIndex + 1].queryRange.to,
           });
+        } else {
+          //If we are on the last page, create new range
+          changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
         }
-        //If we are on the last page, create new range
-        changeTime({ from: visibleRange.from - rangeSpanRef.current, to: visibleRange.from });
       }}
       disabled={loading}
     >


### PR DESCRIPTION
**What this PR does / why we need it**:
When clicking on Older logs, we've been changing time range twice. This is because I didn't add `else` clause and we are not returning anything. Therefore both changeTime were run. 🤦‍♀️ 🤦‍♀️ 🤦‍♀️ 