### PR TITLE
Alerting: Run table migrations regardless of feature flag and move out of service

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 )
@@ -111,20 +110,4 @@ func (ng *AlertNG) IsDisabled() bool {
 		return true
 	}
 	return !ng.Cfg.IsNgAlertEnabled()
-}
-
-// AddMigration defines database migrations.
-// If Alerting NG is not enabled does nothing.
-func (ng *AlertNG) AddMigration(mg *migrator.Migrator) {
-	if ng.IsDisabled() {
-		return
-	}
-	store.AddAlertDefinitionMigrations(mg, defaultIntervalSeconds)
-	store.AddAlertDefinitionVersionMigrations(mg)
-	// Create alert_instance table
-	store.AlertInstanceMigration(mg)
-
-	// Create alert_rule
-	store.AddAlertRuleMigrations(mg, defaultIntervalSeconds)
-	store.AddAlertRuleVersionMigrations(mg)
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -38,7 +38,8 @@ func AddMigrations(mg *Migrator) {
 	addUserAuthTokenMigrations(mg)
 	addCacheMigration(mg)
 	addShortURLMigrations(mg)
-	ualert.AddMigration(mg)
+	ualert.AddTablesMigrations(mg)
+	ualert.AddDashAlertMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -1,11 +1,26 @@
-package store
+package ualert
 
 import (
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
+
+// AddMigration defines database migrations.
+// If Alerting NG is not enabled does nothing.
+func AddTablesMigrations(mg *migrator.Migrator) {
+	if !mg.Cfg.IsNgAlertEnabled() {
+		return
+	}
+	AddAlertDefinitionMigrations(mg, 60)
+	AddAlertDefinitionVersionMigrations(mg)
+	// Create alert_instance table
+	AlertInstanceMigration(mg)
+
+	// Create alert_rule
+	AddAlertRuleMigrations(mg, 60)
+	AddAlertRuleVersionMigrations(mg)
+}
 
 // AddAlertDefinitionMigrations should not be modified.
 func AddAlertDefinitionMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64) {
@@ -151,8 +166,8 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			// the following fields will correspond to a dashboard (or folder) UIID
 			{Name: "namespace_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false},
 			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: fmt.Sprintf("'%s'", models.NoData.String())},
-			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: fmt.Sprintf("'%s'", models.AlertingErrState.String())},
+			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "NoData"},
+			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "Alerting"},
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"org_id", "title"}, Type: migrator.UniqueIndex},
@@ -199,8 +214,8 @@ func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {
 			{Name: "condition", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "data", Type: migrator.DB_Text, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false},
-			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: fmt.Sprintf("'%s'", models.NoData.String())},
-			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: fmt.Sprintf("'%s'", models.AlertingErrState.String())},
+			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "NoData"},
+			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "Alerting"},
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"rule_org_id", "rule_uid", "version"}, Type: migrator.UniqueIndex},

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -163,8 +163,8 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			// the following fields will correspond to a dashboard (or folder) UIID
 			{Name: "namespace_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false},
 			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "NoData"},
-			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "Alerting"},
+			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'NoData'"},
+			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'Alerting'"},
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"org_id", "title"}, Type: migrator.UniqueIndex},
@@ -211,8 +211,8 @@ func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {
 			{Name: "condition", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "data", Type: migrator.DB_Text, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false},
-			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "NoData"},
-			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "Alerting"},
+			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'NoData'"},
+			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'Alerting'"},
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"rule_org_id", "rule_uid", "version"}, Type: migrator.UniqueIndex},

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -9,9 +9,6 @@ import (
 // AddMigration defines database migrations.
 // If Alerting NG is not enabled does nothing.
 func AddTablesMigrations(mg *migrator.Migrator) {
-	if !mg.Cfg.IsNgAlertEnabled() {
-		return
-	}
 	AddAlertDefinitionMigrations(mg, 60)
 	AddAlertDefinitionVersionMigrations(mg)
 	// Create alert_instance table

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -30,7 +30,7 @@ func (e MigrationError) Error() string {
 
 func (e *MigrationError) Unwrap() error { return e.Err }
 
-func AddMigration(mg *migrator.Migrator) {
+func AddDashAlertMigration(mg *migrator.Migrator) {
 	if os.Getenv("UALERT_MIG") == "iDidBackup" {
 		// TODO: unified alerting DB needs to be extacted into ../migrations.go
 		// so it runs and creates the tables before this migration runs.

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -433,7 +433,7 @@ func InitTestDB(t ITestDB, opts ...InitTestDBOpt) *SQLStore {
 		}
 
 		// set test db config
-		testSQLStore.Cfg = setting.GetCfg()
+		testSQLStore.Cfg = setting.NewCfg()
 		sec, err := testSQLStore.Cfg.Raw.NewSection("database")
 		if err != nil {
 			t.Fatalf("Failed to create section: %s", err)

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -433,7 +433,7 @@ func InitTestDB(t ITestDB, opts ...InitTestDBOpt) *SQLStore {
 		}
 
 		// set test db config
-		testSQLStore.Cfg = setting.NewCfg()
+		testSQLStore.Cfg = setting.GetCfg()
 		sec, err := testSQLStore.Cfg.Raw.NewSection("database")
 		if err != nil {
 			t.Fatalf("Failed to create section: %s", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the unified alerting feature flag to run the migrations that create the tables.

Also moves the table migration code unified alerting out of the service and into sqlstore. This should not change any of the migrations, but rather just move them so the SQL migration order is not subject to the service loading order (see issue).

**Which issue(s) this PR fixes**:

Alerting side of https://github.com/grafana/grafana/issues/32912

**Special notes for your reviewer**:
Have trouble with the integration tests keeping the feature flag, and I think time to remove it from the migrations anyways.

These could possibly reduced, but that would mean: time and also possibly breaking people that have enabled the feature flag.
