### PR TITLE
Fix tooltip not closing

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { Portal } from '../../Portal/Portal';
 import { usePlotContext } from '../context';
 import {
@@ -47,23 +47,21 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
     pluginLog(pluginId, true, `Focused series: ${focusedSeriesIdx}, focused point: ${focusedPointIdx}`);
   }, [focusedPointIdx, focusedSeriesIdx]);
 
-  const plotMouseLeave = useCallback(
-    (e) => {
-      setCoords(null);
-    },
-    [setCoords]
-  );
-
   useEffect(() => {
+    const plotMouseLeave = () => {
+      setCoords(null);
+    };
+
     if (plotCtx && plotCtx.plot) {
       plotCtx.plot.root.querySelector('.u-over')!.addEventListener('mouseleave', plotMouseLeave);
     }
+
     return () => {
       if (plotCtx && plotCtx.plot) {
         plotCtx.plot.root.querySelector('.u-over')!.removeEventListener('mouseleave', plotMouseLeave);
       }
     };
-  }, [plotCtx.plot?.root]);
+  }, [plotCtx.plot?.root, setCoords]);
 
   // Add uPlot hooks to the config, or re-add when the config changed
   useLayoutEffect(() => {

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -55,7 +55,6 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
   );
 
   useEffect(() => {
-    console.log('running');
     if (plotCtx && plotCtx.plot) {
       plotCtx.plot.root.querySelector('.u-over')!.addEventListener('mouseleave', plotMouseLeave);
     }

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -55,6 +55,7 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
   );
 
   useEffect(() => {
+    console.log('running');
     if (plotCtx && plotCtx.plot) {
       plotCtx.plot.root.querySelector('.u-over')!.addEventListener('mouseleave', plotMouseLeave);
     }
@@ -63,7 +64,7 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
         plotCtx.plot.root.querySelector('.u-over')!.removeEventListener('mouseleave', plotMouseLeave);
       }
     };
-  });
+  }, [plotCtx.plot?.root]);
 
   // Add uPlot hooks to the config, or re-add when the config changed
   useLayoutEffect(() => {

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import { Portal } from '../../Portal/Portal';
 import { usePlotContext } from '../context';
 import {
@@ -47,13 +47,26 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
     pluginLog(pluginId, true, `Focused series: ${focusedSeriesIdx}, focused point: ${focusedPointIdx}`);
   }, [focusedPointIdx, focusedSeriesIdx]);
 
+  const plotMouseLeave = useCallback(
+    (e) => {
+      setCoords(null);
+    },
+    [setCoords]
+  );
+
+  useEffect(() => {
+    if (plotCtx && plotCtx.plot) {
+      plotCtx.plot.root.addEventListener('mouseleave', plotMouseLeave);
+    }
+    return () => {
+      if (plotCtx && plotCtx.plot) {
+        plotCtx.plot.root.removeEventListener('mouseleave', plotMouseLeave);
+      }
+    };
+  });
+
   // Add uPlot hooks to the config, or re-add when the config changed
   useLayoutEffect(() => {
-    if (plotCtx && plotCtx.plot) {
-      plotCtx.plot.root.onmouseleave = (event) => {
-        setCoords(null);
-      };
-    }
     if (config.tooltipInterpolator) {
       // Custom toolitp positioning
       config.addHook('setCursor', (u) => {

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -56,11 +56,11 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
 
   useEffect(() => {
     if (plotCtx && plotCtx.plot) {
-      plotCtx.plot.root.addEventListener('mouseleave', plotMouseLeave);
+      plotCtx.plot.root.querySelector('.u-over')!.addEventListener('mouseleave', plotMouseLeave);
     }
     return () => {
       if (plotCtx && plotCtx.plot) {
-        plotCtx.plot.root.removeEventListener('mouseleave', plotMouseLeave);
+        plotCtx.plot.root.querySelector('.u-over')!.removeEventListener('mouseleave', plotMouseLeave);
       }
     };
   });

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -49,6 +49,11 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
 
   // Add uPlot hooks to the config, or re-add when the config changed
   useLayoutEffect(() => {
+    if (plotCtx && plotCtx.plot) {
+      plotCtx.plot.root.onmouseleave = (event) => {
+        setCoords(null);
+      };
+    }
     if (config.tooltipInterpolator) {
       // Custom toolitp positioning
       config.addHook('setCursor', (u) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where the tooltip on the bar graph stays open when the mouse leaves the plot.
