### PR TITLE
Explore: Match queries that are longer than defined Graphite/Loki mapping

### DIFF
--- a/public/app/plugins/datasource/loki/importing/fromGraphite.ts
+++ b/public/app/plugins/datasource/loki/importing/fromGraphite.ts
@@ -49,7 +49,7 @@ function fromGraphite(graphiteQuery: GraphiteQueryModel, config: GraphiteToLokiQ
     });
   } else {
     const targetNodes = graphiteQuery.segments.map((segment) => segment.value);
-    let mappings = config.mappings.filter((mapping) => mapping.matchers.length === targetNodes.length);
+    let mappings = config.mappings.filter((mapping) => mapping.matchers.length <= targetNodes.length);
 
     for (let mapping of mappings) {
       const matchers = mapping.matchers.concat();

--- a/public/app/plugins/datasource/loki/importing/importing.test.ts
+++ b/public/app/plugins/datasource/loki/importing/importing.test.ts
@@ -40,6 +40,7 @@ describe('importing from Graphite queries', () => {
       [
         // metrics: captured
         mockGraphiteQuery('interpolate(alias(servers.west.001.cpu,1,2))'),
+        mockGraphiteQuery('interpolate(alias(servers.east.001.request.POST.200,1,2))'),
         mockGraphiteQuery('interpolate(alias(servers.*.002.*,1,2))'),
         // tags: captured
         mockGraphiteQuery("interpolate(seriesByTag('cluster=west', 'server=002'), inf))"),
@@ -53,6 +54,7 @@ describe('importing from Graphite queries', () => {
 
     expect(lokiQueries).toMatchObject([
       { refId: 'A', expr: '{cluster="west", server="001"}' },
+      { refId: 'A', expr: '{cluster="east", server="001"}' },
       { refId: 'A', expr: '{server="002"}' },
       { refId: 'A', expr: '{cluster="west", server="002"}' },
       { refId: 'A', expr: '{foo="bar", server="002"}' },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

A small bug fix for Graphite/Loki mappings. At the moment a mapping has to define exactly as many node levels as the query that is being run. This is really cumbersome because Graphite metrics usually have different length. Imagine having metrics like:

```
stats.server001.app001.request.POST.count (6 levels)
stats.server001.app001.memory.used (5 levels) 
```

To capture level for both, you would need to define two mappings for each number of levels: 

```
stats.(server).(app).request.POST.count (6 levels)
stats.(server).(app).memory.used (5 levels) 
```

or

```
stats.(server).(app).*.*.* (6 levels)
stats.(server).(app).*.* (5 levels) 
```

while in practice only one mapping should be needed, e.g. `stats.(server).(app).*` or even `stats.(server).(app)` is enough. This PR changes the matching so the requirement for the same number of levels is lifted.

*How to test it?*

Use the same steps, same example and same sample data as in #33405.  The test data has been amended to track additional (longer) metrics. 

 Try running a query for: `servers.west.002.request.*`. Previously such query wouldn't be captured with the mapping from the example (`servers.(cluster).(server).*`) because it's longer than mapping itself.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes N/A

**Special notes for your reviewer**: N/A
