### PR TITLE
Explore: Convert nodes with "*" to regular expressions when a Graphite query is mapped to Loki

### DIFF
--- a/public/app/plugins/datasource/loki/importing/importing.test.ts
+++ b/public/app/plugins/datasource/loki/importing/importing.test.ts
@@ -34,7 +34,7 @@ describe('importing from Graphite queries', () => {
 
   beforeEach(() => {});
 
-  it('test', () => {
+  it('test matching mappings', () => {
     mockSettings(['servers.(cluster).(server).*']);
     const lokiQueries = fromGraphiteQueries(
       [
@@ -45,6 +45,8 @@ describe('importing from Graphite queries', () => {
         // tags: captured
         mockGraphiteQuery("interpolate(seriesByTag('cluster=west', 'server=002'), inf))"),
         mockGraphiteQuery("interpolate(seriesByTag('foo=bar', 'server=002'), inf))"),
+        // regexp
+        mockGraphiteQuery('interpolate(alias(servers.eas*.{001,002}.request.POST.200,1,2))'),
         // not captured
         mockGraphiteQuery('interpolate(alias(test.west.001.cpu))'),
         mockGraphiteQuery('interpolate(alias(servers.west.001))'),
@@ -56,8 +58,12 @@ describe('importing from Graphite queries', () => {
       { refId: 'A', expr: '{cluster="west", server="001"}' },
       { refId: 'A', expr: '{cluster="east", server="001"}' },
       { refId: 'A', expr: '{server="002"}' },
+
       { refId: 'A', expr: '{cluster="west", server="002"}' },
       { refId: 'A', expr: '{foo="bar", server="002"}' },
+
+      { refId: 'A', expr: '{cluster=~"^eas.*", server=~"^(001|002)"}' },
+
       { refId: 'A', expr: '' },
       { refId: 'A', expr: '' },
     ]);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Graphite uses glob-like pattern for queries. When queries are mapped to Loki such patterns can be converted to regular expressions. First implementation handled only `{}` from glob patterns. This PR adds support for `*`.

How to test it?

* Use mapping configuration and sample data from #33405
* Run a Graphite query in Explore: `servers.eas*.{001,002}.request.*`
* Switch to Loki, you should see: `{cluster=~"^eas.*", server=~"^(001|002)"}` and some tasty data

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #34007 

**Special notes for your reviewer**: 

The parser does not correctly handle `{}` used inside the node, e.g. if you wrote `servers.east.00{1,2}.request.*` in raw editor, it wouldn't be possible to switch back to the visual editor. This is becuase the parser cannot handle this scenario, even though it's a valid query. It's a separate issue I'll try to tackle soon.

