### PR TITLE
Live: disable gzip for ws endpoints

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -14,7 +14,8 @@ var gzipIgnoredPathPrefixes = []string{
 	"/api/datasources/proxy", // Ignore datasource proxy requests.
 	"/api/plugin-proxy/",
 	"/metrics",
-	"/live/ws", // WebSocket does not support gzip compression.
+	"/api/live/ws",   // WebSocket does not support gzip compression.
+	"/api/live/push", // WebSocket does not support gzip compression.
 }
 
 func Gziper() macaron.Handler {


### PR DESCRIPTION
**What this PR does / why we need it**:

WS can't be compressed, + causes `http: response.Write on hijacked connection` errors in logs.