### PR TITLE
Access Control: Add histograms for evaluator and permissions checks

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -538,7 +538,6 @@ func init() {
 		Help:      "number of evaluation calls",
 		Namespace: ExporterName,
 	})
-
 }
 
 // SetBuildInformation sets the build information for this binary

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -12,6 +12,7 @@ import (
 const ExporterName = "grafana"
 
 var (
+
 	// MInstanceStart is a metric counter for started instances
 	MInstanceStart prometheus.Counter
 
@@ -104,6 +105,9 @@ var (
 
 	// MRenderingQueue is a metric gauge for image rendering queue size
 	MRenderingQueue prometheus.Gauge
+
+	// MAccessEvaluationCount is a metric gauge for total number of evaluation requests
+	MAccessEvaluationCount prometheus.Counter
 )
 
 // Timers
@@ -116,6 +120,12 @@ var (
 
 	// MRenderingSummary is a metric summary for image rendering request duration
 	MRenderingSummary *prometheus.SummaryVec
+
+	// MAccessPermissionsSummary is a metric summary for loading permissions request duration when evaluating access
+	MAccessPermissionsSummary prometheus.Histogram
+
+	// MAccessEvaluationsSummary is a metric summary for loading permissions request duration when evaluating access
+	MAccessEvaluationsSummary prometheus.Histogram
 )
 
 // StatTotals
@@ -510,6 +520,25 @@ func init() {
 		Help:      "total amount of annotations in the database",
 		Namespace: ExporterName,
 	})
+
+	MAccessPermissionsSummary = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "access_permissions_duration",
+		Help:    "Histogram for the runtime of permissions check function.",
+		Buckets: prometheus.ExponentialBuckets(0.00001, 4, 10),
+	})
+
+	MAccessEvaluationsSummary = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "access_evaluation_duration",
+		Help:    "Histogram for the runtime of evaluation function.",
+		Buckets: prometheus.ExponentialBuckets(0.00001, 4, 10),
+	})
+
+	MAccessEvaluationCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:      "access_evaluation_count",
+		Help:      "number of evaluation calls",
+		Namespace: ExporterName,
+	})
+
 }
 
 // SetBuildInformation sets the build information for this binary
@@ -582,6 +611,8 @@ func initMetricVars() {
 		MRenderingRequestTotal,
 		MRenderingSummary,
 		MRenderingQueue,
+		MAccessPermissionsSummary,
+		MAccessEvaluationsSummary,
 		MAlertingActiveAlerts,
 		MStatTotalDashboards,
 		MStatTotalFolders,
@@ -600,6 +631,7 @@ func initMetricVars() {
 		grafanaPluginBuildInfoDesc,
 		StatsTotalDashboardVersions,
 		StatsTotalAnnotations,
+		MAccessEvaluationCount,
 	)
 }
 
@@ -616,6 +648,5 @@ func newCounterVecStartingAtZero(opts prometheus.CounterOpts, labels []string, l
 func newCounterStartingAtZero(opts prometheus.CounterOpts, labelValues ...string) prometheus.Counter {
 	counter := prometheus.NewCounter(opts)
 	counter.Add(0)
-
 	return counter
 }

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/evaluator"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // OSSAccessControlService is the service implementing role based access control.
@@ -39,6 +41,9 @@ func (ac *OSSAccessControlService) Evaluate(ctx context.Context, user *models.Si
 
 // GetUserPermissions returns user permissions based on built-in roles
 func (ac *OSSAccessControlService) GetUserPermissions(ctx context.Context, user *models.SignedInUser) ([]*accesscontrol.Permission, error) {
+	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
+	defer timer.ObserveDuration()
+
 	builtinRoles := ac.GetUserBuiltInRoles(user)
 	permissions := make([]*accesscontrol.Permission, 0)
 	for _, builtin := range builtinRoles {


### PR DESCRIPTION
This patch adds metrics to support instrumenting the accesscontrols package.

It also isntruments the accesscontrol evaluator and the ossaccesscontrol permissions function.

Update pkg/infra/metrics/metrics.go

Co-authored-by: Vardan Torosyan <vardants@gmail.com>

Move enterprise only metrics to enterprise repo

Add separate counter for evaluation time

Whitespace changes

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/1247

**Special notes for your reviewer**:

