### PR TITLE
Chore: use background color for default/empty strings

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -346,6 +346,11 @@ describe('Date display options', () => {
         theme: createTheme(),
       });
       expect(processor('22.1122334455').text).toEqual('22.11');
+
+      // Support empty/missing strings
+      expect(processor(undefined).text).toEqual('');
+      expect(processor(null).text).toEqual('');
+      expect(processor('').text).toEqual('');
     });
   });
 });

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -137,6 +137,10 @@ export function getRawDisplayProcessor(): DisplayProcessor {
 function getDefaultColorFunc(field: Field, scaleFunc: ScaleCalculator, theme: GrafanaTheme2) {
   if (field.type === FieldType.string) {
     return (value: any) => {
+      if (!value) {
+        return { color: theme.colors.background.primary, percent: 0 };
+      }
+
       const hc = strHashCode(value as string);
       return {
         color: classicColors[Math.floor(hc % classicColors.length)],


### PR DESCRIPTION
improve #33965 so that empty strings give a consistent background color