### PR TITLE
Elasticsearch Query Builder: Fix script payload for versions prior to 5.2

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -346,7 +346,13 @@ export class ElasticQueryBuilder {
         Object.entries(metric.settings || {})
           .filter(([_, v]) => v !== null)
           .forEach(([k, v]) => {
-            metricAgg[k] = k === 'script' ? getScriptValue(metric as MetricAggregationWithInlineScript) : v;
+            let value = v;
+            if (k === 'script') {
+              const scriptValue = getScriptValue(metric as MetricAggregationWithInlineScript);
+              value = lt(this.esVersion, '5.2.0') ? { inline: scriptValue } : scriptValue;
+            }
+
+            metricAgg[k] = value;
           });
 
         // Elasticsearch isn't generally too picky about the data types in the request body,


### PR DESCRIPTION
**What this PR does / why we need it**:
Regression between a working dashboard between grafana 6.4.2 and 7.5.6. The payload sent to elasticsearch for the use of script options in aggregates is incompatible with earlier versions.

**Which issue(s) this PR fixes**:
Fixes #34028

**Special notes for your reviewer**:

There are zero tests for the query_builder that exist, so nothing to really build off of. I also understand this may not be how you want to fix this, but I wanted to submit it to show one solution to the linked bug. Looking at the ES docs, this may actually be broken in other versions (https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-script-query.html shows the same syntax as earlier versions, with only the latest (https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-query.html) having support for the raw script -- you would know a lot better than me the quirks of ES though.)