### PR TITLE
NGAlert: Remove unwanted fields from notification channel config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace k8s.io/client-go => k8s.io/client-go v0.18.8
 require (
 	cloud.google.com/go/storage v1.14.0
 	cuelang.org/go v0.3.2
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.8.0
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/semver v1.5.0

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -89,13 +89,10 @@ func (srv AlertmanagerSrv) RouteGetAlertingConfig(c *models.ReqContext) response
 				secureFields[k] = true
 			}
 			gr := apimodels.GettableGrafanaReceiver{
-				Uid:                   pr.Uid,
+				UID:                   pr.UID,
 				Name:                  pr.Name,
 				Type:                  pr.Type,
-				IsDefault:             pr.IsDefault,
-				SendReminder:          pr.SendReminder,
 				DisableResolveMessage: pr.DisableResolveMessage,
-				Frequency:             pr.Frequency,
 				Settings:              pr.Settings,
 				SecureFields:          secureFields,
 			}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/grafana/grafana/pkg/api/dtos"
-	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util"
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/config"
 	"gopkg.in/yaml.v3"
 
-	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // swagger:route POST /api/alertmanager/{Recipient}/config/api/v1/alerts alertmanager RoutePostAlertingConfig
@@ -504,8 +503,23 @@ func AllReceivers(route *config.Route) (res []string) {
 	return res
 }
 
-type GettableGrafanaReceiver dtos.AlertNotification
-type PostableGrafanaReceiver models.CreateAlertNotificationCommand
+type GettableGrafanaReceiver struct {
+	UID                   string           `json:"uid"`
+	Name                  string           `json:"name"`
+	Type                  string           `json:"type"`
+	DisableResolveMessage bool             `json:"disableResolveMessage"`
+	Settings              *simplejson.Json `json:"settings"`
+	SecureFields          map[string]bool  `json:"secureFields"`
+}
+
+type PostableGrafanaReceiver struct {
+	UID                   string            `json:"uid"`
+	Name                  string            `json:"name"`
+	Type                  string            `json:"type"`
+	DisableResolveMessage bool              `json:"disableResolveMessage"`
+	Settings              *simplejson.Json  `json:"settings"`
+	SecureSettings        map[string]string `json:"secureSettings"`
+}
 
 type ReceiverType int
 

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/securejsondata"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/logging"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -397,12 +396,10 @@ func (am *Alertmanager) buildReceiverIntegrations(receiver *apimodels.PostableAp
 			secureSettings[k] = d
 		}
 		var (
-			cfg = &models.AlertNotification{
-				Uid:                   r.Uid,
+			cfg = &channels.NotificationChannelConfig{
+				UID:                   r.UID,
 				Name:                  r.Name,
 				Type:                  r.Type,
-				IsDefault:             r.IsDefault,
-				SendReminder:          r.SendReminder,
 				DisableResolveMessage: r.DisableResolveMessage,
 				Settings:              r.Settings,
 				SecureSettings:        secureSettings,

--- a/pkg/services/ngalert/notifier/channels/dingding.go
+++ b/pkg/services/ngalert/notifier/channels/dingding.go
@@ -23,7 +23,7 @@ import (
 const defaultDingdingMsgType = "link"
 
 // NewDingDingNotifier is the constructor for the Dingding notifier
-func NewDingDingNotifier(model *models.AlertNotification, t *template.Template) (*DingDingNotifier, error) {
+func NewDingDingNotifier(model *NotificationChannelConfig, t *template.Template) (*DingDingNotifier, error) {
 	if model.Settings == nil {
 		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
 	}
@@ -36,12 +36,18 @@ func NewDingDingNotifier(model *models.AlertNotification, t *template.Template) 
 	msgType := model.Settings.Get("msgType").MustString(defaultDingdingMsgType)
 
 	return &DingDingNotifier{
-		NotifierBase: old_notifiers.NewNotifierBase(model),
-		MsgType:      msgType,
-		URL:          url,
-		Message:      model.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
-		log:          log.New("alerting.notifier.dingding"),
-		tmpl:         t,
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		MsgType: msgType,
+		URL:     url,
+		Message: model.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		log:     log.New("alerting.notifier.dingding"),
+		tmpl:    t,
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/dingding_test.go
+++ b/pkg/services/ngalert/notifier/channels/dingding_test.go
@@ -104,7 +104,7 @@ func TestDingdingNotifier(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
 
-			m := &models.AlertNotification{
+			m := &NotificationChannelConfig{
 				Name:     "dingding_testing",
 				Type:     "dingding",
 				Settings: settingsJSON,

--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -32,7 +32,7 @@ type EmailNotifier struct {
 
 // NewEmailNotifier is the constructor function
 // for the EmailNotifier.
-func NewEmailNotifier(model *models.AlertNotification, t *template.Template) (*EmailNotifier, error) {
+func NewEmailNotifier(model *NotificationChannelConfig, t *template.Template) (*EmailNotifier, error) {
 	if model.Settings == nil {
 		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
 	}
@@ -48,12 +48,18 @@ func NewEmailNotifier(model *models.AlertNotification, t *template.Template) (*E
 	addresses := util.SplitEmails(addressesString)
 
 	return &EmailNotifier{
-		NotifierBase: old_notifiers.NewNotifierBase(model),
-		Addresses:    addresses,
-		SingleEmail:  singleEmail,
-		Message:      model.Settings.Get("message").MustString(),
-		log:          log.New("alerting.notifier.email"),
-		tmpl:         t,
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		Addresses:   addresses,
+		SingleEmail: singleEmail,
+		Message:     model.Settings.Get("message").MustString(),
+		log:         log.New("alerting.notifier.email"),
+		tmpl:        t,
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -26,7 +26,7 @@ func TestEmailNotifier(t *testing.T) {
 		json := `{ }`
 
 		settingsJSON, _ := simplejson.NewJson([]byte(json))
-		model := &models.AlertNotification{
+		model := &NotificationChannelConfig{
 			Name:     "ops",
 			Type:     "email",
 			Settings: settingsJSON,
@@ -44,7 +44,7 @@ func TestEmailNotifier(t *testing.T) {
 		settingsJSON, err := simplejson.NewJson([]byte(json))
 		require.NoError(t, err)
 
-		emailNotifier, err := NewEmailNotifier(&models.AlertNotification{
+		emailNotifier, err := NewEmailNotifier(&NotificationChannelConfig{
 			Name:     "ops",
 			Type:     "email",
 			Settings: settingsJSON,

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -45,7 +45,7 @@ type PagerdutyNotifier struct {
 }
 
 // NewPagerdutyNotifier is the constructor for the PagerDuty notifier
-func NewPagerdutyNotifier(model *models.AlertNotification, t *template.Template) (*PagerdutyNotifier, error) {
+func NewPagerdutyNotifier(model *NotificationChannelConfig, t *template.Template) (*PagerdutyNotifier, error) {
 	if model.Settings == nil {
 		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
 	}
@@ -56,8 +56,14 @@ func NewPagerdutyNotifier(model *models.AlertNotification, t *template.Template)
 	}
 
 	return &PagerdutyNotifier{
-		NotifierBase: old_notifiers.NewNotifierBase(model),
-		Key:          key,
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		Key: key,
 		CustomDetails: map[string]string{
 			"firing":       `{{ template "__text_alert_list" .Alerts.Firing }}`,
 			"resolved":     `{{ template "__text_alert_list" .Alerts.Resolved }}`,

--- a/pkg/services/ngalert/notifier/channels/pagerduty_test.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty_test.go
@@ -139,7 +139,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
 
-			m := &models.AlertNotification{
+			m := &NotificationChannelConfig{
 				Name:     "pageduty_testing",
 				Type:     "pagerduty",
 				Settings: settingsJSON,

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -54,7 +54,7 @@ var reRecipient *regexp.Regexp = regexp.MustCompile("^((@[a-z0-9][a-zA-Z0-9._-]*
 var SlackAPIEndpoint = "https://slack.com/api/chat.postMessage"
 
 // NewSlackNotifier is the constructor for the Slack notifier
-func NewSlackNotifier(model *models.AlertNotification, t *template.Template) (*SlackNotifier, error) {
+func NewSlackNotifier(model *NotificationChannelConfig, t *template.Template) (*SlackNotifier, error) {
 	if model.Settings == nil {
 		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
 	}
@@ -112,7 +112,13 @@ func NewSlackNotifier(model *models.AlertNotification, t *template.Template) (*S
 	}
 
 	return &SlackNotifier{
-		NotifierBase:   old_notifiers.NewNotifierBase(model),
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
 		URL:            apiURL,
 		Recipient:      recipient,
 		MentionUsers:   mentionUsers,

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 )
 
@@ -176,7 +175,7 @@ func TestSlackNotifier(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
 
-			m := &models.AlertNotification{
+			m := &NotificationChannelConfig{
 				Name:     "slack_testing",
 				Type:     "slack",
 				Settings: settingsJSON,

--- a/pkg/services/ngalert/notifier/channels/teams.go
+++ b/pkg/services/ngalert/notifier/channels/teams.go
@@ -30,7 +30,7 @@ type TeamsNotifier struct {
 }
 
 // NewTeamsNotifier is the constructor for Teams notifier.
-func NewTeamsNotifier(model *models.AlertNotification, t *template.Template) (*TeamsNotifier, error) {
+func NewTeamsNotifier(model *NotificationChannelConfig, t *template.Template) (*TeamsNotifier, error) {
 	if model.Settings == nil {
 		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
 	}
@@ -41,11 +41,17 @@ func NewTeamsNotifier(model *models.AlertNotification, t *template.Template) (*T
 	}
 
 	return &TeamsNotifier{
-		NotifierBase: old_notifiers.NewNotifierBase(model),
-		URL:          u,
-		Message:      model.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
-		log:          log.New("alerting.notifier.teams"),
-		tmpl:         t,
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		URL:     u,
+		Message: model.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		log:     log.New("alerting.notifier.teams"),
+		tmpl:    t,
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/teams_test.go
+++ b/pkg/services/ngalert/notifier/channels/teams_test.go
@@ -128,7 +128,7 @@ func TestTeamsNotifier(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
 
-			m := &models.AlertNotification{
+			m := &NotificationChannelConfig{
 				Name:     "teams_testing",
 				Type:     "teams",
 				Settings: settingsJSON,

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -35,7 +35,7 @@ type TelegramNotifier struct {
 }
 
 // NewTelegramNotifier is the constructor for the Telegram notifier
-func NewTelegramNotifier(model *models.AlertNotification, t *template.Template) (*TelegramNotifier, error) {
+func NewTelegramNotifier(model *NotificationChannelConfig, t *template.Template) (*TelegramNotifier, error) {
 	if model.Settings == nil {
 		return nil, alerting.ValidationError{Reason: "No Settings Supplied"}
 	}
@@ -53,12 +53,18 @@ func NewTelegramNotifier(model *models.AlertNotification, t *template.Template) 
 	}
 
 	return &TelegramNotifier{
-		NotifierBase: old_notifiers.NewNotifierBase(model),
-		BotToken:     botToken,
-		ChatID:       chatID,
-		Message:      message,
-		tmpl:         t,
-		log:          log.New("alerting.notifier.telegram"),
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		BotToken: botToken,
+		ChatID:   chatID,
+		Message:  message,
+		tmpl:     t,
+		log:      log.New("alerting.notifier.telegram"),
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/telegram_test.go
+++ b/pkg/services/ngalert/notifier/channels/telegram_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 )
 
@@ -101,7 +100,7 @@ func TestTelegramNotifier(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
 
-			m := &models.AlertNotification{
+			m := &NotificationChannelConfig{
 				Name:     "telegram_testing",
 				Type:     "telegram",
 				Settings: settingsJSON,

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -2,6 +2,9 @@ package channels
 
 import (
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/grafana/pkg/components/securejsondata"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
 const (
@@ -15,4 +18,21 @@ func getAlertStatusColor(status model.AlertStatus) string {
 		return ColorAlertFiring
 	}
 	return ColorAlertResolved
+}
+
+type NotificationChannelConfig struct {
+	UID                   string                        `json:"uid"`
+	Name                  string                        `json:"name"`
+	Type                  string                        `json:"type"`
+	DisableResolveMessage bool                          `json:"disableResolveMessage"`
+	Settings              *simplejson.Json              `json:"settings"`
+	SecureSettings        securejsondata.SecureJsonData `json:"secureSettings"`
+}
+
+// DecryptedValue returns decrypted value from secureSettings
+func (an *NotificationChannelConfig) DecryptedValue(field string, fallback string) string {
+	if value, ok := an.SecureSettings.DecryptedValue(field); ok {
+		return value
+	}
+	return fallback
 }

--- a/pkg/services/ngalert/notifier/channels/webhook.go
+++ b/pkg/services/ngalert/notifier/channels/webhook.go
@@ -34,20 +34,26 @@ type WebhookNotifier struct {
 
 // NewWebHookNotifier is the constructor for
 // the WebHook notifier.
-func NewWebHookNotifier(model *models.AlertNotification, t *template.Template) (*WebhookNotifier, error) {
+func NewWebHookNotifier(model *NotificationChannelConfig, t *template.Template) (*WebhookNotifier, error) {
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find url property in settings"}
 	}
 	return &WebhookNotifier{
-		NotifierBase: old_notifiers.NewNotifierBase(model),
-		URL:          url,
-		User:         model.Settings.Get("username").MustString(),
-		Password:     model.DecryptedValue("password", model.Settings.Get("password").MustString()),
-		HTTPMethod:   model.Settings.Get("httpMethod").MustString("POST"),
-		MaxAlerts:    model.Settings.Get("maxAlerts").MustInt(0),
-		log:          log.New("alerting.notifier.webhook"),
-		tmpl:         t,
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		URL:        url,
+		User:       model.Settings.Get("username").MustString(),
+		Password:   model.DecryptedValue("password", model.Settings.Get("password").MustString()),
+		HTTPMethod: model.Settings.Get("httpMethod").MustString("POST"),
+		MaxAlerts:  model.Settings.Get("maxAlerts").MustInt(0),
+		log:        log.New("alerting.notifier.webhook"),
+		tmpl:       t,
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/webhook_test.go
+++ b/pkg/services/ngalert/notifier/channels/webhook_test.go
@@ -175,7 +175,7 @@ func TestWebhookNotifier(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
 
-			m := &models.AlertNotification{
+			m := &NotificationChannelConfig{
 				Name:     "webhook_testing",
 				Type:     "webhook",
 				Settings: settingsJSON,

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -49,7 +49,6 @@ func TestAlertmanagerConfigurationIsTransactional(t *testing.T) {
 				},
 				"secureSettings": {},
 				"type": "slack",
-				"sendReminder": true,
 				"name": "slack.receiver",
 				"disableResolveMessage": false,
 				"uid": ""
@@ -96,7 +95,6 @@ func TestAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 					"url": "http://averysecureurl.com/webhook"
 				},
 				"type": "slack",
-				"sendReminder": true,
 				"name": "slack.receiver",
 				"disableResolveMessage": false
 			}]
@@ -127,7 +125,6 @@ func TestAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 					"url": true
 				},
 				"type": "slack",
-				"sendReminder": true,
 				"name": "slack.receiver",
 				"disableResolveMessage": false
 			}]
@@ -153,16 +150,10 @@ func TestAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 		"receivers": [{
 			"name": "slack.receiver",
 			"grafana_managed_receiver_configs": [{
-				"id": 0,
 				"uid": "",
 				"name": "slack.receiver",
 				"type": "slack",
-				"isDefault": false,
-				"sendReminder": true,
 				"disableResolveMessage": false,
-				"frequency": "",
-				"created": "0001-01-01T00:00:00Z",
-				"updated": "0001-01-01T00:00:00Z",
 				"settings": {
 					"recipient": "#unified-alerting-test-but-updated"
 				},

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -67,7 +67,8 @@ func TestNotificationChannels(t *testing.T) {
 		alertsURL := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
 		resp := getRequest(t, alertsURL, http.StatusOK) // nolint
 		b := getBody(t, resp.Body)
-		require.JSONEq(t, getExpAlertmanagerConfigFromAPI(mockChannel.server.Addr), b)
+		e := getExpAlertmanagerConfigFromAPI(mockChannel.server.Addr)
+		require.JSONEq(t, e, b)
 	}
 
 	{
@@ -584,16 +585,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "email_recv",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "email_test",
             "type": "email",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "addresses": "test@email.com",
               "singleEmail": true
@@ -606,16 +601,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "dingding_recv",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "dingding_test",
             "type": "dingding",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "url": "http://CHANNEL_ADDR/dingding_recv/dingding_test"
             },
@@ -627,16 +616,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "teams_recv",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "teams_test",
             "type": "teams",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "url": "http://CHANNEL_ADDR/teams_recv/teams_test"
             },
@@ -648,16 +631,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "webhook_recv",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "webhook_test",
             "type": "webhook",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "url": "http://CHANNEL_ADDR/webhook_recv/webhook_test",
               "username": "my_username",
@@ -674,16 +651,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "telegram_recv",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "telegram_test",
             "type": "telegram",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "chatid": "telegram_chat_id"
             },
@@ -697,16 +668,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "slack_recv1",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "slack_test_without_token",
             "type": "slack",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "fallback": "Integration Test {{ template \"slack.default.title\" . }}",
               "icon_emoji": "🚀",
@@ -729,16 +694,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "slack_recv2",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "slack_test_with_token",
             "type": "slack",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "mentionUsers": "user1, user2",
               "recipient": "#test-channel",
@@ -754,16 +713,10 @@ var expAlertmanagerConfigFromAPI = `
         "name": "pagerduty_recv",
         "grafana_managed_receiver_configs": [
           {
-            "id": 0,
             "uid": "",
             "name": "pagerduty_test",
             "type": "pagerduty",
-            "isDefault": false,
-            "sendReminder": false,
             "disableResolveMessage": false,
-            "frequency": "",
-            "created": "0001-01-01T00:00:00Z",
-            "updated": "0001-01-01T00:00:00Z",
             "settings": {
               "class": "testclass",
               "component": "Integration Test",

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -21,16 +21,10 @@ const defaultAlertmanagerConfigJSON = `
 		"receivers": [{
 			"name": "grafana-default-email",
 			"grafana_managed_receiver_configs": [{
-				"id": 0,
 				"uid": "",
 				"name": "email receiver",
 				"type": "email",
-				"isDefault": true,
-				"sendReminder": false,
 				"disableResolveMessage": false,
-				"frequency": "",
-				"created": "0001-01-01T00:00:00Z",
-				"updated": "0001-01-01T00:00:00Z",
 				"settings": {
 					"addresses": "\u003cexample@email.com\u003e"
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we used old config structs for the new channels, we have a bunch of fields that are not needed that appear in the API and the config. In this PR I am proposing to remove those fields before we cut beta for ngalert.