### PR TITLE
Remove log about the need for Grafana restart after plugin installation

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -59,7 +59,6 @@ func runPluginCommand(command func(commandLine utils.CommandLine) error) func(co
 			return err
 		}
 
-		logger.Info(color.GreenString("Please restart Grafana after installing plugins. Refer to Grafana documentation for instructions if necessary.\n\n"))
 		return nil
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2376619/118126222-5688cf80-b3f8-11eb-9f66-648eccf605dd.png)


Time to remove the green log?  🤔 