### PR TITLE
Docs: remove character from release notes

### DIFF
--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,7 +8,7 @@ weight = 10000
 Here you can find detailed release notes that list everything that is included in every release as well as notices
 about deprecations, breaking changes as well as changes that relate to plugin development.
 
-- [Release notes for 8.0.0-beta16]({{< relref "release-notes-8-0-0-beta1" >}})
+- [Release notes for 8.0.0-beta1]({{< relref "release-notes-8-0-0-beta1" >}})
 - [Release notes for 7.5.6]({{< relref "release-notes-7-5-6" >}})
 - [Release notes for 7.5.5]({{< relref "release-notes-7-5-5" >}})
 - [Release notes for 7.5.4]({{< relref "release-notes-7-5-4" >}})


### PR DESCRIPTION
Remove stray `6` from release notes index.