### PR TITLE
Alerting/Chore: Move tests from tests package

### DIFF
--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1,4 +1,4 @@
-package tests
+package state_test
 
 import (
 	"testing"

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -1,6 +1,6 @@
 // +build integration
 
-package tests
+package store_test
 
 import (
 	"testing"
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/services/ngalert/tests"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,19 +26,19 @@ func mockTimeNow() {
 }
 
 func TestAlertInstanceOperations(t *testing.T) {
-	dbstore := SetupTestEnv(t, baseIntervalSeconds)
+	dbstore := tests.SetupTestEnv(t, baseIntervalSeconds)
 	t.Cleanup(registry.ClearOverrides)
 
-	alertRule1 := CreateTestAlertRule(t, dbstore, 60)
+	alertRule1 := tests.CreateTestAlertRule(t, dbstore, 60)
 	orgID := alertRule1.OrgID
 
-	alertRule2 := CreateTestAlertRule(t, dbstore, 60)
+	alertRule2 := tests.CreateTestAlertRule(t, dbstore, 60)
 	require.Equal(t, orgID, alertRule2.OrgID)
 
-	alertRule3 := CreateTestAlertRule(t, dbstore, 60)
+	alertRule3 := tests.CreateTestAlertRule(t, dbstore, 60)
 	require.Equal(t, orgID, alertRule3.OrgID)
 
-	alertRule4 := CreateTestAlertRule(t, dbstore, 60)
+	alertRule4 := tests.CreateTestAlertRule(t, dbstore, 60)
 	require.Equal(t, orgID, alertRule4.OrgID)
 
 	t.Run("can save and read new alert instance", func(t *testing.T) {

--- a/pkg/services/ngalert/tests/instance_database_test.go
+++ b/pkg/services/ngalert/tests/instance_database_test.go
@@ -25,19 +25,19 @@ func mockTimeNow() {
 }
 
 func TestAlertInstanceOperations(t *testing.T) {
-	dbstore := setupTestEnv(t, baseIntervalSeconds)
+	dbstore := SetupTestEnv(t, baseIntervalSeconds)
 	t.Cleanup(registry.ClearOverrides)
 
-	alertRule1 := createTestAlertRule(t, dbstore, 60)
+	alertRule1 := CreateTestAlertRule(t, dbstore, 60)
 	orgID := alertRule1.OrgID
 
-	alertRule2 := createTestAlertRule(t, dbstore, 60)
+	alertRule2 := CreateTestAlertRule(t, dbstore, 60)
 	require.Equal(t, orgID, alertRule2.OrgID)
 
-	alertRule3 := createTestAlertRule(t, dbstore, 60)
+	alertRule3 := CreateTestAlertRule(t, dbstore, 60)
 	require.Equal(t, orgID, alertRule3.OrgID)
 
-	alertRule4 := createTestAlertRule(t, dbstore, 60)
+	alertRule4 := CreateTestAlertRule(t, dbstore, 60)
 	require.Equal(t, orgID, alertRule4.OrgID)
 
 	t.Run("can save and read new alert instance", func(t *testing.T) {

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// setupTestEnv initializes a store to used by the tests.
-func setupTestEnv(t *testing.T, baseIntervalSeconds int64) *store.DBstore {
+// SetupTestEnv initializes a store to used by the tests.
+func SetupTestEnv(t *testing.T, baseIntervalSeconds int64) *store.DBstore {
 	cfg := setting.NewCfg()
 	// AlertNG is disabled by default and only if it's enabled
 	// its database migrations run and the relative database tables are created
@@ -65,7 +65,7 @@ func overrideAlertNGInRegistry(t *testing.T, cfg *setting.Cfg) ngalert.AlertNG {
 }
 
 // createTestAlertRule creates a dummy alert definition to be used by the tests.
-func createTestAlertRule(t *testing.T, dbstore *store.DBstore, intervalSeconds int64) *models.AlertRule {
+func CreateTestAlertRule(t *testing.T, dbstore *store.DBstore, intervalSeconds int64) *models.AlertRule {
 	d := rand.Intn(1000)
 	ruleGroup := fmt.Sprintf("ruleGroup-%d", d)
 	err := dbstore.UpdateRuleGroup(store.UpdateRuleGroupCmd{
@@ -118,7 +118,7 @@ func createTestAlertRule(t *testing.T, dbstore *store.DBstore, intervalSeconds i
 }
 
 // updateTestAlertRule update a dummy alert definition to be used by the tests.
-func updateTestAlertRuleIntervalSeconds(t *testing.T, dbstore *store.DBstore, existingRule *models.AlertRule, intervalSeconds int64) *models.AlertRule {
+func UpdateTestAlertRuleIntervalSeconds(t *testing.T, dbstore *store.DBstore, existingRule *models.AlertRule, intervalSeconds int64) *models.AlertRule {
 	cmd := store.UpdateRuleGroupCmd{
 		OrgID:        1,
 		NamespaceUID: "namespace",


### PR DESCRIPTION
**What this PR does / why we need it**:
Move tests from tests package, instead put in package folder but with package name suffixed with _test.

This enables code coverage within the pkg , another example is our sdk data package: https://github.com/grafana/grafana-plugin-sdk-go/blob/master/data/arrow_test.go

