### PR TITLE
PanelChrome: Fix queries being issued again when scrolling in and out of view

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
@@ -3,7 +3,7 @@ import { ReplaySubject } from 'rxjs';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import { act, render, screen } from '@testing-library/react';
-import { getDefaultTimeRange, LoadingState, PanelData, PanelPlugin, PanelProps } from '@grafana/data';
+import { EventBusSrv, getDefaultTimeRange, LoadingState, PanelData, PanelPlugin, PanelProps } from '@grafana/data';
 
 import { PanelChrome, Props } from './PanelChrome';
 import { DashboardModel, PanelModel } from '../state';
@@ -43,6 +43,7 @@ function setupTestContext(options: Partial<Props>) {
     dashboard: ({
       panelInitialized: jest.fn(),
       getTimezone: () => 'browser',
+      events: new EventBusSrv(),
     } as unknown) as DashboardModel,
     plugin: ({
       meta: { skipDataQuery: false },


### PR DESCRIPTION
Customer noticed that panels issued the same query again when scrolling in and out of view. Was able to replicate it, we never reset the refreshWhenInView state property
