### PR TITLE
NewsPanel: Fixes rendering issue in Safari

### DIFF
--- a/public/app/plugins/panel/news/NewsPanel.tsx
+++ b/public/app/plugins/panel/news/NewsPanel.tsx
@@ -124,6 +124,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
     border-bottom: 2px solid ${theme.colors.border.weak};
     background: ${theme.colors.background.primary};
     flex-direction: column;
+    flex-shrink: 0;
   `,
   itemWide: css`
     flex-direction: row;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issue with rendering of the NewsPanel in safari so that it's now equivalent to Firefox/Chrome.

**Which issue(s) this PR fixes**:
Closes #34052
