### PR TITLE
chore: refactor Datasource Cache arguments

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -354,7 +354,7 @@ func GetDataSourceIdByName(c *models.ReqContext) response.Response {
 // /api/datasources/:id/resources/*
 func (hs *HTTPServer) CallDatasourceResource(c *models.ReqContext) {
 	datasourceID := c.ParamsInt64(":id")
-	ds, err := hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser, c.SkipCache)
+	ds, err := hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser.OrgId, c.SkipCache)
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceAccessDenied) {
 			c.JsonApiErr(403, "Access denied to datasource", err)
@@ -422,7 +422,7 @@ func convertModelToDtos(ds *models.DataSource) dtos.DataSource {
 func (hs *HTTPServer) CheckDatasourceHealth(c *models.ReqContext) response.Response {
 	datasourceID := c.ParamsInt64("id")
 
-	ds, err := hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser, c.SkipCache)
+	ds, err := hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser.OrgId, c.SkipCache)
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceAccessDenied) {
 			return response.Error(403, "Access denied to datasource", err)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -53,7 +53,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricReq
 		// So only the datasource from the first query is needed. As all requests
 		// should be the same data source.
 		if i == 0 {
-			ds, err = hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser, c.SkipCache)
+			ds, err = hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser.OrgId, c.SkipCache)
 			if err != nil {
 				return hs.handleGetDataSourceError(err, datasourceID)
 			}
@@ -123,7 +123,7 @@ func (hs *HTTPServer) handleExpressions(c *models.ReqContext, reqDTO dtos.Metric
 		if name != expr.DatasourceName {
 			// Expression requests have everything in one request, so need to check
 			// all data source queries for possible permission / not found issues.
-			if _, err = hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser, c.SkipCache); err != nil {
+			if _, err = hs.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser.OrgId, c.SkipCache); err != nil {
 				return hs.handleGetDataSourceError(err, datasourceID)
 			}
 		}
@@ -171,7 +171,7 @@ func (hs *HTTPServer) QueryMetrics(c *models.ReqContext, reqDto dtos.MetricReque
 		return response.Error(http.StatusBadRequest, "Query missing datasourceId", nil)
 	}
 
-	ds, err := hs.DatasourceCache.GetDatasource(datasourceId, c.SignedInUser, c.SkipCache)
+	ds, err := hs.DatasourceCache.GetDatasource(datasourceId, c.SignedInUser.OrgId, c.SkipCache)
 	if err != nil {
 		return hs.handleGetDataSourceError(err, datasourceId)
 	}

--- a/pkg/plugins/plugincontext/plugincontext.go
+++ b/pkg/plugins/plugincontext/plugincontext.go
@@ -81,7 +81,7 @@ func (p *Provider) Get(pluginID string, datasourceUID string, user *models.Signe
 	}
 
 	if datasourceUID != "" {
-		ds, err := p.DatasourceCache.GetDatasourceByUID(datasourceUID, user, false)
+		ds, err := p.DatasourceCache.GetDatasourceByUID(datasourceUID, user.OrgId, false)
 		if err != nil {
 			return pc, false, errutil.Wrap("Failed to get datasource", err)
 		}

--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -38,7 +38,7 @@ func (p *DatasourceProxyService) ProxyDataSourceRequest(c *models.ReqContext) {
 func (p *DatasourceProxyService) ProxyDatasourceRequestWithID(c *models.ReqContext, dsID int64) {
 	c.TimeRequest(metrics.MDataSourceProxyReqTimer)
 
-	ds, err := p.DatasourceCache.GetDatasource(dsID, c.SignedInUser, c.SkipCache)
+	ds, err := p.DatasourceCache.GetDatasource(dsID, c.SignedInUser.OrgId, c.SkipCache)
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceAccessDenied) {
 			c.JsonApiErr(http.StatusForbidden, "Access denied to datasource", err)

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -509,12 +509,12 @@ func (g *GrafanaLive) handleStreamScope(u *models.SignedInUser, namespace string
 }
 
 func (g *GrafanaLive) handleDatasourceScope(user *models.SignedInUser, namespace string) (models.ChannelHandlerFactory, error) {
-	ds, err := g.DatasourceCache.GetDatasourceByUID(namespace, user, false)
+	ds, err := g.DatasourceCache.GetDatasourceByUID(namespace, user.OrgId, false)
 	if err != nil {
 		// the namespace may be an ID
 		id, _ := strconv.ParseInt(namespace, 10, 64)
 		if id > 0 {
-			ds, err = g.DatasourceCache.GetDatasource(id, user, false)
+			ds, err = g.DatasourceCache.GetDatasource(id, user.OrgId, false)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("error getting datasource: %w", err)

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -45,7 +45,7 @@ func (srv TestingApiSrv) RouteTestRuleConfig(c *models.ReqContext, body apimodel
 
 	var path string
 	if datasourceID, err := strconv.ParseInt(recipient, 10, 64); err == nil {
-		ds, err := srv.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser, c.SkipCache)
+		ds, err := srv.DatasourceCache.GetDatasource(datasourceID, c.SignedInUser.OrgId, c.SkipCache)
 		if err != nil {
 			return response.Error(http.StatusInternalServerError, "failed to get datasource", err)
 		}

--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -76,7 +76,7 @@ func (p *LotexProm) RouteGetRuleStatuses(ctx *models.ReqContext) response.Respon
 }
 
 func (p *LotexProm) getEndpoints(ctx *models.ReqContext) (*promEndpoints, error) {
-	ds, err := p.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
+	ds, err := p.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser.OrgId, ctx.SkipCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -150,7 +150,7 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 }
 
 func (r *LotexRuler) getPrefix(ctx *models.ReqContext) (string, error) {
-	ds, err := r.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
+	ds, err := r.DataProxy.DatasourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser.OrgId, ctx.SkipCache)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -41,7 +41,7 @@ func backendType(ctx *models.ReqContext, cache datasources.CacheService) (apimod
 		return apimodels.GrafanaBackend, nil
 	}
 	if datasourceID, err := strconv.ParseInt(recipient, 10, 64); err == nil {
-		if ds, err := cache.GetDatasource(datasourceID, ctx.SignedInUser, ctx.SkipCache); err == nil {
+		if ds, err := cache.GetDatasource(datasourceID, ctx.SignedInUser.OrgId, ctx.SkipCache); err == nil {
 			switch ds.Type {
 			case "loki", "prometheus":
 				return apimodels.LoTexRulerBackend, nil
@@ -198,7 +198,7 @@ func validateQueriesAndExpressions(data []ngmodels.AlertQuery, user *models.Sign
 			continue
 		}
 
-		_, err = datasourceCache.GetDatasourceByUID(datasourceUID, user, skipCache)
+		_, err = datasourceCache.GetDatasourceByUID(datasourceUID, user.OrgId, skipCache)
 		if err != nil {
 			return nil, fmt.Errorf("invalid query %s: %w: %s", query.RefID, err, datasourceUID)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

In #33695 we have to use fake user to use Datasource Cache methods, since it only requires orgID internally I think it's reasonable to refactor a bit to avoid faking user (we aim to send requests from plugins where no user context exist).