### PR TITLE
Elasticsearch: Fix handling of inline scripts in different ES versions

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -124,6 +124,26 @@ datasources:
       timeField: "@timestamp"
       esVersion: 5
 
+  - name: gdev-elasticsearch-v56-metrics
+    type: elasticsearch
+    access: proxy
+    database: "[metrics-]YYYY.MM.DD"
+    url: http://localhost:13200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 56
+
+  - name: gdev-elasticsearch-v56-logs
+    type: elasticsearch
+    access: proxy
+    database: "[logs-]YYYY.MM.DD"
+    url: http://localhost:13200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 56
+
   - name: gdev-elasticsearch-v6-metrics
     type: elasticsearch
     access: proxy

--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -85,7 +85,7 @@ datasources:
     type: elasticsearch
     access: proxy
     database: "[metrics-]YYYY.MM.DD"
-    url: http://elasticsearch5:10200
+    url: http://elasticsearch5:9200
     jsonData:
       interval: Daily
       timeField: "@timestamp"
@@ -100,6 +100,26 @@ datasources:
       interval: Daily
       timeField: "@timestamp"
       esVersion: 5
+
+  - name: gdev-elasticsearch-v56-metrics
+    type: elasticsearch
+    access: proxy
+    database: "[metrics-]YYYY.MM.DD"
+    url: http://elasticsearch5:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 56
+
+  - name: gdev-elasticsearch-v56-logs
+    type: elasticsearch
+    access: proxy
+    database: "[logs-]YYYY.MM.DD"
+    url: http://elasticsearch5:9200
+    jsonData:
+      interval: Daily
+      timeField: "@timestamp"
+      esVersion: 56
 
   - name: gdev-elasticsearch-v6-metrics
     type: elasticsearch

--- a/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_compare.json
+++ b/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_compare.json
@@ -17,12 +17,16 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1610639791711,
+  "iteration": 1620904436360,
   "links": [
     {
       "asDropdown": true,
       "icon": "external link",
-      "tags": ["gdev", "elasticsearch", "datasource-test"],
+      "tags": [
+        "gdev",
+        "elasticsearch",
+        "datasource-test"
+      ],
       "title": "Dashboards",
       "type": "dashboards"
     }
@@ -45,19 +49,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_one",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 1
           },
           "hiddenSeries": false,
           "id": 2,
@@ -79,7 +77,7 @@
           },
           "paceLength": 10,
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -160,19 +158,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_two",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 1
           },
           "hiddenSeries": false,
           "id": 3,
@@ -194,7 +186,7 @@
           },
           "paceLength": 10,
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -275,19 +267,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_one",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 8,
@@ -309,7 +295,7 @@
           },
           "paceLength": 10,
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -390,19 +376,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_two",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 9,
@@ -424,7 +404,7 @@
           },
           "paceLength": 10,
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -505,19 +485,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_one",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 6,
@@ -539,7 +513,7 @@
           },
           "paceLength": 10,
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -620,19 +594,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_two",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 7,
@@ -654,7 +622,7 @@
           },
           "paceLength": 10,
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -750,12 +718,6 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_one",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -783,7 +745,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -869,12 +831,6 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_two",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -902,7 +858,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -988,12 +944,6 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_one",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1021,7 +971,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1107,12 +1057,6 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$version_two",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1140,7 +1084,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1227,12 +1171,6 @@
           "dashes": false,
           "datasource": "$version_one",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1261,7 +1199,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1346,12 +1284,6 @@
           "dashes": false,
           "datasource": "$version_two",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1380,7 +1312,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1465,12 +1397,6 @@
           "dashes": false,
           "datasource": "$version_one",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1499,7 +1425,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1584,12 +1510,6 @@
           "dashes": false,
           "datasource": "$version_two",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1618,7 +1538,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1703,12 +1623,6 @@
           "dashes": false,
           "datasource": "$version_one",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1740,7 +1654,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1834,12 +1748,6 @@
           "dashes": false,
           "datasource": "$version_two",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1871,7 +1779,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -1965,12 +1873,6 @@
           "dashes": false,
           "datasource": "$version_one",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2000,7 +1902,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2029,7 +1931,13 @@
                   "id": "1",
                   "meta": {},
                   "settings": {
-                    "percents": [25, 50, 75, 95, 99]
+                    "percents": [
+                      25,
+                      50,
+                      75,
+                      95,
+                      99
+                    ]
                   },
                   "type": "percentiles"
                 }
@@ -2087,12 +1995,6 @@
           "dashes": false,
           "datasource": "$version_two",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2122,7 +2024,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2152,7 +2054,13 @@
                   "meta": {},
                   "settings": {
                     "missing": null,
-                    "percents": [25, 50, 75, 95, 99]
+                    "percents": [
+                      25,
+                      50,
+                      75,
+                      95,
+                      99
+                    ]
                   },
                   "type": "percentiles"
                 }
@@ -2210,12 +2118,6 @@
           "dashes": false,
           "datasource": "$version_one",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2245,7 +2147,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -2330,12 +2232,6 @@
           "dashes": false,
           "datasource": "$version_two",
           "decimals": 3,
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2365,7 +2261,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
@@ -9050,19 +8946,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 86,
@@ -9082,7 +8972,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9183,19 +9073,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 94,
@@ -9215,7 +9099,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9316,19 +9200,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 87,
@@ -9348,7 +9226,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9449,19 +9327,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 95,
@@ -9481,7 +9353,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9582,19 +9454,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 88,
@@ -9614,7 +9480,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9715,19 +9581,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 96,
@@ -9747,7 +9607,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9848,19 +9708,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 89,
@@ -9880,7 +9734,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -9981,19 +9835,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 97,
@@ -10013,7 +9861,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -10114,19 +9962,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 90,
@@ -10146,7 +9988,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -10247,19 +10089,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 98,
@@ -10279,7 +10115,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -10380,19 +10216,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 91,
@@ -10412,7 +10242,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -10513,19 +10343,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 99,
@@ -10545,7 +10369,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -10646,19 +10470,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 92,
@@ -10678,7 +10496,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -10779,19 +10597,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 100,
@@ -10811,7 +10623,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -10912,19 +10724,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 73
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 93,
@@ -10944,7 +10750,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -11045,19 +10851,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 65
           },
           "hiddenSeries": false,
           "id": 101,
@@ -11077,7 +10877,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -11193,19 +10993,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 112,
@@ -11225,7 +11019,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -11262,7 +11056,9 @@
                   "field": "@value",
                   "id": "1",
                   "settings": {
-                    "percents": ["25"]
+                    "percents": [
+                      "25"
+                    ]
                   },
                   "type": "percentiles"
                 }
@@ -11319,19 +11115,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 114,
@@ -11351,7 +11141,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -11388,7 +11178,9 @@
                   "field": "@value",
                   "id": "1",
                   "settings": {
-                    "percents": ["25"]
+                    "percents": [
+                      "25"
+                    ]
                   },
                   "type": "percentiles"
                 }
@@ -11445,19 +11237,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_one}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 113,
@@ -11477,7 +11263,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -11514,7 +11300,9 @@
                   "field": "@value",
                   "id": "1",
                   "settings": {
-                    "percents": ["99"]
+                    "percents": [
+                      "99"
+                    ]
                   },
                   "type": "percentiles"
                 }
@@ -11571,19 +11359,13 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${version_two}",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 115,
@@ -11603,7 +11385,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.4.0-pre",
+          "pluginVersion": "7.5.0-pre",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -11640,7 +11422,9 @@
                   "field": "@value",
                   "id": "1",
                   "settings": {
-                    "percents": ["99"]
+                    "percents": [
+                      "99"
+                    ]
                   },
                   "type": "percentiles"
                 }
@@ -11694,17 +11478,293 @@
       ],
       "title": "Terms order by percentile",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 119,
+      "panels": [],
+      "title": "Inline scripts",
+      "type": "row"
+    },
+    {
+      "datasource": "${version_one}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 121,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "alias": "New Script Format",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "settings": {
+                "script": "_value * 2"
+              },
+              "type": "avg"
+            }
+          ],
+          "query": "",
+          "refId": "A",
+          "timeField": "@timestamp"
+        },
+        {
+          "alias": "Old Script Format",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "hide": false,
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "settings": {
+                "script": { 
+                  "inline": "_value * 1.5" 
+                }
+              },
+              "type": "avg"
+            }
+          ],
+          "query": "",
+          "refId": "B",
+          "timeField": "@timestamp"
+        }
+      ],
+      "title": "Old & new script format",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${version_two}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 122,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "alias": "New Script Format",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "settings": {
+                "script": "_value * 2"
+              },
+              "type": "avg"
+            }
+          ],
+          "query": "",
+          "refId": "A",
+          "timeField": "@timestamp"
+        },
+        {
+          "alias": "Old Script Format",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "hide": false,
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "settings": {
+                "script": { 
+                  "inline": "_value * 1.5" 
+                }
+              },
+              "type": "avg"
+            }
+          ],
+          "query": "",
+          "refId": "B",
+          "timeField": "@timestamp"
+        }
+      ],
+      "title": "Old & new script format",
+      "type": "timeseries"
     }
   ],
   "refresh": false,
-  "schemaVersion": 27,
+  "schemaVersion": 30,
   "style": "dark",
-  "tags": ["elasticsearch", "gdev", "datasource-test"],
+  "tags": [
+    "elasticsearch",
+    "gdev",
+    "datasource-test"
+  ],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "gdev-elasticsearch-v5-metrics",
           "value": "gdev-elasticsearch-v5-metrics"
         },
@@ -11725,9 +11785,9 @@
       },
       {
         "current": {
-          "selected": true,
-          "text": "gdev-elasticsearch-v7-metrics",
-          "value": "gdev-elasticsearch-v7-metrics"
+          "selected": false,
+          "text": "gdev-elasticsearch-v56-metrics",
+          "value": "gdev-elasticsearch-v56-metrics"
         },
         "description": null,
         "error": null,
@@ -11747,15 +11807,36 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "",
   "title": "Datasource tests - Elasticsearch comparison",
   "uid": "fuFWehBmk",
-  "version": 10
+  "version": 4
 }

--- a/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_v56.json
+++ b/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_v56.json
@@ -1,0 +1,737 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": false,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      },
+      {
+        "datasource": "Elastic 5 Logs",
+        "enable": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "test",
+        "query": "",
+        "showIn": 0,
+        "textField": "description",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1591027589702,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "tags": ["gdev", "elasticsearch", "datasource-test"],
+      "title": "Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "gdev-elasticsearch-v5-metrics",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@hostname",
+              "id": "3",
+              "settings": {
+                "min_doc_count": 1,
+                "order": "asc",
+                "orderBy": "1",
+                "size": "5"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "meta": {},
+              "settings": {},
+              "type": "max"
+            }
+          ],
+          "query": "*",
+          "refId": "A",
+          "target": "",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top 5 servers",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "Count": "#6ED0E0"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "gdev-elasticsearch-v56-metrics",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Count",
+          "lines": false,
+          "yaxis": 2,
+          "zindex": -1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "{{metric}}",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "5m",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "meta": {},
+              "settings": {
+                "percents": [25, 50, 75, 95, 99]
+              },
+              "type": "percentiles"
+            }
+          ],
+          "query": "@metric:cpu",
+          "refId": "A",
+          "target": "",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Percentiles & Metric filter",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "Count": "#6ED0E0"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "gdev-elasticsearch-v56-metrics",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Count",
+          "lines": false,
+          "yaxis": 2,
+          "zindex": -1
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "{{metric}}",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "meta": {
+                "std_deviation_bounds_lower": true,
+                "std_deviation_bounds_upper": true
+              },
+              "settings": {},
+              "type": "extended_stats"
+            }
+          ],
+          "query": "@metric:cpu",
+          "refId": "A",
+          "target": "",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Standard dev",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [
+        {
+          "text": "@hostname",
+          "value": "@hostname"
+        },
+        {
+          "text": "Average",
+          "value": "Average"
+        },
+        {
+          "text": "Max",
+          "value": "Max"
+        },
+        {
+          "text": "Sum",
+          "value": "Sum"
+        }
+      ],
+      "datasource": "gdev-elasticsearch-v56-metrics",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 6,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "@timestamp",
+          "type": "date"
+        },
+        {
+          "align": "auto",
+          "colorMode": null,
+          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "field": "@hostname",
+              "id": "2",
+              "settings": {
+                "min_doc_count": 1,
+                "order": "asc",
+                "orderBy": "_term",
+                "size": "0"
+              },
+              "type": "terms"
+            }
+          ],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            },
+            {
+              "field": "@value",
+              "id": "3",
+              "meta": {},
+              "settings": {},
+              "type": "max"
+            },
+            {
+              "field": "@value",
+              "id": "4",
+              "meta": {},
+              "settings": {},
+              "type": "sum"
+            }
+          ],
+          "refId": "B",
+          "timeField": "@timestamp"
+        }
+      ],
+      "title": "ES Metrics",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
+      "columns": [
+        {
+          "text": "@timestamp",
+          "value": "@timestamp"
+        },
+        {
+          "text": "@message",
+          "value": "@message"
+        },
+        {
+          "text": "tags",
+          "value": "tags"
+        },
+        {
+          "text": "description",
+          "value": "description"
+        }
+      ],
+      "datasource": "gdev-elasticsearch-v56-logs",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 5,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "@timestamp",
+          "type": "date"
+        }
+      ],
+      "targets": [
+        {
+          "bucketAggs": [],
+          "dsType": "elasticsearch",
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "meta": {},
+              "settings": {
+                "size": 500
+              },
+              "type": "raw_document"
+            }
+          ],
+          "refId": "A",
+          "target": "",
+          "timeField": "@timestamp"
+        }
+      ],
+      "title": "ES Log query",
+      "transform": "json",
+      "type": "table-old"
+    },
+    {
+      "circleMaxSize": 30,
+      "circleMinSize": 2,
+      "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
+      "datasource": "gdev-elasticsearch-v56-metrics",
+      "decimals": 0,
+      "esGeoPoint": "@location",
+      "esLocationName": "",
+      "esMetric": "Average",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "hideEmpty": false,
+      "hideZero": false,
+      "id": 8,
+      "initialZoom": 1,
+      "links": [],
+      "locationData": "geohash",
+      "mapCenter": "(0°, 0°)",
+      "mapCenterLatitude": 0,
+      "mapCenterLongitude": 0,
+      "maxDataPoints": 1,
+      "mouseWheelZoom": false,
+      "showLegend": true,
+      "stickyLabels": false,
+      "tableQueryOptions": {
+        "geohashField": "geohash",
+        "latitudeField": "latitude",
+        "longitudeField": "longitude",
+        "metricField": "metric",
+        "queryType": "geohash"
+      },
+      "targets": [
+        {
+          "bucketAggs": [
+            {
+              "fake": true,
+              "field": "@location",
+              "id": "3",
+              "settings": {
+                "precision": 2
+              },
+              "type": "geohash_grid"
+            }
+          ],
+          "metrics": [
+            {
+              "field": "@value",
+              "id": "1",
+              "meta": {},
+              "settings": {},
+              "type": "avg"
+            }
+          ],
+          "refId": "A",
+          "target": "",
+          "timeField": "@timestamp"
+        }
+      ],
+      "thresholds": "0,10",
+      "title": "World map panel",
+      "type": "grafana-worldmap-panel",
+      "unitPlural": "",
+      "unitSingle": "",
+      "valueName": "total"
+    }
+  ],
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": ["elasticsearch", "gdev", "datasource-test"],
+  "templating": {
+    "list": [
+      {
+        "datasource": "gdev-elasticsearch-v56-metrics",
+        "filters": [],
+        "hide": 0,
+        "label": "",
+        "name": "Filters",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "collapse": false,
+    "enable": true,
+    "notice": false,
+    "now": true,
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+    "status": "Stable",
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"],
+    "type": "timepicker"
+  },
+  "timezone": "browser",
+  "title": "Datasource tests - Elasticsearch v56",
+  "uid": "8HjT32BmO",
+  "version": 1
+}

--- a/devenv/docker/blocks/elastic5/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic5/docker-compose.yaml
@@ -1,5 +1,5 @@
   elasticsearch5:
-    image: elasticsearch:5
+    image: elasticsearch:5.0.2
     command: elasticsearch
     ports:
       - '10200:9200'

--- a/devenv/docker/blocks/elastic5/elasticsearch.yml
+++ b/devenv/docker/blocks/elastic5/elasticsearch.yml
@@ -1,2 +1,0 @@
-script.inline: on
-script.indexed: on

--- a/devenv/docker/blocks/elastic56/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic56/docker-compose.yaml
@@ -1,0 +1,15 @@
+  elasticsearch56:
+    image: elasticsearch:5.6.16
+    command: elasticsearch
+    ports:
+      - '13200:9200'
+      - '13300:9300'
+
+  fake-elastic56-data:
+    image: grafana/fake-data-gen
+    links:
+      - elasticsearch56
+    environment:
+      FD_SERVER: elasticsearch56
+      FD_DATASOURCE: elasticsearch
+      FD_PORT: 9200

--- a/pkg/tsdb/elasticsearch/models.go
+++ b/pkg/tsdb/elasticsearch/models.go
@@ -73,12 +73,29 @@ var pipelineAggType = map[string]string{
 	"bucket_script":  "bucket_script",
 }
 
+var scriptableAggType = map[string]string{
+	"avg":            "avg",
+	"sum":            "sum",
+	"max":            "max",
+	"min":            "min",
+	"extended_stats": "extended_stats",
+	"percentiles":    "percentiles",
+	"bucket_script":  "bucket_script",
+}
+
 var pipelineAggWithMultipleBucketPathsType = map[string]string{
 	"bucket_script": "bucket_script",
 }
 
 func isPipelineAgg(metricType string) bool {
 	if _, ok := pipelineAggType[metricType]; ok {
+		return true
+	}
+	return false
+}
+
+func isMetricAggregationWithInlineScriptSupport(metricType string) bool {
+	if _, ok := scriptableAggType[metricType]; ok {
 		return true
 	}
 	return false

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -933,6 +933,93 @@ func TestSettingsCasting(t *testing.T) {
 
 		assert.Equal(t, 1., serialDiffSettings["lag"])
 	})
+
+	t.Run("Inline Script", func(t *testing.T) {
+		t.Run("Correctly handles scripts for ES < 5.6", func(t *testing.T) {
+			c := newFakeClient("5.0.0")
+
+			for key := range scriptableAggType {
+				t.Run("Inline Script", func(t *testing.T) {
+					_, err := executeTsdbQuery(c, `{
+						"timeField": "@timestamp",
+						"bucketAggs": [
+							{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
+						],
+						"metrics": [
+							{
+								"id": "1",
+								"type": "`+key+`",
+								"settings": {
+									"script": "my_script"
+								}
+							},
+							{
+								"id": "3",
+								"type": "`+key+`",
+								"settings": {
+									"script": {
+										"inline": "my_script"
+									}
+								}
+							}
+						]
+					}`, from, to, 15*time.Second)
+
+					assert.Nil(t, err)
+					sr := c.multisearchRequests[0].Requests[0]
+
+					newFormatAggSettings := sr.Aggs[0].Aggregation.Aggs[0].Aggregation.Aggregation.(*es.MetricAggregation).Settings
+					oldFormatAggSettings := sr.Aggs[0].Aggregation.Aggs[1].Aggregation.Aggregation.(*es.MetricAggregation).Settings
+
+					assert.Equal(t, map[string]interface{}{"inline": "my_script"}, newFormatAggSettings["script"])
+					assert.Equal(t, map[string]interface{}{"inline": "my_script"}, oldFormatAggSettings["script"])
+				})
+			}
+		})
+
+		t.Run("Correctly handles scripts for ES >= 5.6", func(t *testing.T) {
+			c := newFakeClient("5.6.0")
+
+			for key := range scriptableAggType {
+				fmt.Println(key)
+				t.Run("Inline Script", func(t *testing.T) {
+					_, err := executeTsdbQuery(c, `{
+						"timeField": "@timestamp",
+						"bucketAggs": [
+							{ "type": "date_histogram", "field": "@timestamp", "id": "2" }
+						],
+						"metrics": [
+							{
+								"id": "1",
+								"type": "`+key+`",
+								"settings": {
+									"script": "my_script"
+								}
+							},
+							{ 
+								"id": "3",
+								"type": "`+key+`",
+								"settings": {
+									"script": {
+										"inline": "my_script"
+									}
+								}
+							}
+						]
+					}`, from, to, 15*time.Second)
+
+					assert.Nil(t, err)
+					sr := c.multisearchRequests[0].Requests[0]
+
+					newFormatAggSettings := sr.Aggs[0].Aggregation.Aggs[0].Aggregation.Aggregation.(*es.MetricAggregation).Settings
+					oldFormatAggSettings := sr.Aggs[0].Aggregation.Aggs[1].Aggregation.Aggregation.(*es.MetricAggregation).Settings
+
+					assert.Equal(t, "my_script", newFormatAggSettings["script"])
+					assert.Equal(t, "my_script", oldFormatAggSettings["script"])
+				})
+			}
+		})
+	})
 }
 
 type fakeClient struct {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -346,7 +346,8 @@ export class ElasticQueryBuilder {
         Object.entries(metric.settings || {})
           .filter(([_, v]) => v !== null)
           .forEach(([k, v]) => {
-            metricAgg[k] = k === 'script' ? getScriptValue(metric as MetricAggregationWithInlineScript) : v;
+            metricAgg[k] =
+              k === 'script' ? this.buildScript(getScriptValue(metric as MetricAggregationWithInlineScript)) : v;
           });
 
         // Elasticsearch isn't generally too picky about the data types in the request body,
@@ -386,6 +387,16 @@ export class ElasticQueryBuilder {
     }
 
     return query;
+  }
+
+  private buildScript(script: string) {
+    if (gte(this.esVersion, '5.6.0')) {
+      return script;
+    }
+
+    return {
+      inline: script,
+    };
   }
 
   private toNumber(stringValue: unknown): unknown | number {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Aggregations' Inline scripts prior to ES 5.6 had to be defined like (**VERSION B**)
```json
"script": {
  "inline": "script_value"
}
```

in 5.6, the former was deprecated in favor of:
```json
"script": {
  "source": "script_value"
}
```
or, as a shorthand: (**VERSION A**)
```json
"script": "script_value"
```

In Grafana < 7.4 we were storing the query model like **VERSION B**, in >=7.4 like **VERSION A**.

This PR fixes 2 things:
- Handling different Elasticsearch versions requirements for the script field (What the linked issue is about)
- Applying the same logic on the backend for alerting queries (it wasn't implemented before)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #34028
Closes #34030

**Special notes for your reviewer**:

I created a docker block in devenv for ES 5.0 and moved `elastic5` to `elastic56` as it was using elasticsearch 5.6. I'm not able to start both at the same time as somehow when starting both one of the nodes elects itself as master and shuts down the other. I tried working around this by setting different configurations but none of them did the job.

I also created a row in http://localhost:3000/d/fuFWehBmk/datasource-tests-elasticsearch-comparison (`Datasource tests -> Elasticsearch comparison`) that has queries using both the new and old script format.

as mentioned above, running 2 ES version at the same time doesn't work ATM, the best way I can think of to test this is therefore running  `make devenv sources=elastic5`, check that both series are being shown, then `make devenv sources=elastic56` and repeat.

![Screenshot 2021-05-13 at 15 46 01](https://user-images.githubusercontent.com/1170767/118142492-57266380-b402-11eb-877e-8013bfc58427.png)


Alerting as well works as expected with both formats and both ES version, testing is a bit more trickier as the datasource is templated, so make sure to pick the one you are testing against before testing the alerting rule:
![Screenshot 2021-05-13 at 15 52 49](https://user-images.githubusercontent.com/1170767/118143464-47f3e580-b403-11eb-916e-7452735a876a.png) -> ![Screenshot 2021-05-13 at 15 54 11](https://user-images.githubusercontent.com/1170767/118143625-783b8400-b403-11eb-8a6b-6ac9eacae04f.png)

## Alerting tests:

### ES 5.0
#### New Script format (**VERSION A**, **Query A**)
![Screenshot 2021-05-13 at 15 56 32](https://user-images.githubusercontent.com/1170767/118143952-cbadd200-b403-11eb-8083-47715291087f.png)

#### OLD Script format (**VERSION A**, **Query B**)
![Screenshot 2021-05-13 at 15 58 29](https://user-images.githubusercontent.com/1170767/118144204-14658b00-b404-11eb-9116-cbb561a74415.png)



### ES 5.6

#### New Script format (**VERSION A**, **Query A**)
![Screenshot 2021-05-13 at 16 00 05](https://user-images.githubusercontent.com/1170767/118144385-4b3ba100-b404-11eb-9a9c-8d142d2b2c00.png)

#### Old Script format (**VERSION B**, **Query B**)
![Screenshot 2021-05-13 at 16 00 37](https://user-images.githubusercontent.com/1170767/118144439-60183480-b404-11eb-86b6-e2a78bbeb74c.png)


**PS:** Don't forget to run `./setup.sh` in `devenv` to get updates to data sources and dashboard :)

