### PR TITLE
QueryField: Remove carriage return character from pasted text

### DIFF
--- a/packages/grafana-ui/src/components/QueryField/QueryField.test.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.test.tsx
@@ -33,7 +33,7 @@ describe('<QueryField />', () => {
   it('should run onChange with clean text', () => {
     const onChange = jest.fn();
     const wrapper = shallow(
-      <QueryField query="my\r clean query" onTypeahead={jest.fn()} onChange={onChange} portalOrigin="mock-origin" />
+      <QueryField query={`my\r clean query`} onTypeahead={jest.fn()} onChange={onChange} portalOrigin="mock-origin" />
     );
     const field = wrapper.instance() as QueryField;
     field.runOnChange();

--- a/packages/grafana-ui/src/components/QueryField/QueryField.test.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.test.tsx
@@ -30,6 +30,17 @@ describe('<QueryField />', () => {
     expect(onRun.mock.calls.length).toBe(1);
   });
 
+  it('should run onChange with clean text', () => {
+    const onChange = jest.fn();
+    const wrapper = shallow(
+      <QueryField query="my\r clean query" onTypeahead={jest.fn()} onChange={onChange} portalOrigin="mock-origin" />
+    );
+    const field = wrapper.instance() as QueryField;
+    field.runOnChange();
+    expect(onChange.mock.calls.length).toBe(1);
+    expect(onChange.mock.calls[0][0]).toBe('my clean query');
+  });
+
   it('should run custom on blur, but not necessarily execute query', () => {
     const onBlur = jest.fn();
     const onRun = jest.fn();

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -148,9 +148,11 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
 
   runOnChange = () => {
     const { onChange } = this.props;
-
+    const value = Plain.serialize(this.state.value);
+    console.log(value);
+    console.log(this.cleanText(value));
     if (onChange) {
-      onChange(Plain.serialize(this.state.value));
+      onChange(this.cleanText(value));
     }
   };
 
@@ -189,6 +191,12 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
     }
     return next();
   };
+
+  cleanText(text: string) {
+    // RegExp with characters we want to remove - currently only carriage return
+    const regExp = /\\r/g;
+    return text.replace(regExp, '');
+  }
 
   render() {
     const { disabled } = this.props;

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -149,8 +149,6 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
   runOnChange = () => {
     const { onChange } = this.props;
     const value = Plain.serialize(this.state.value);
-    console.log(value);
-    console.log(this.cleanText(value));
     if (onChange) {
       onChange(this.cleanText(value));
     }
@@ -193,9 +191,9 @@ export class QueryField extends React.PureComponent<QueryFieldProps, QueryFieldS
   };
 
   cleanText(text: string) {
-    // RegExp with characters we want to remove - currently only carriage return
-    const regExp = /\\r/g;
-    return text.replace(regExp, '');
+    // RegExp with invisible characters we want to remove - currently only carriage return (newlines are visible)
+    const newText = text.trim().replace(/[\r]/g, '');
+    return newText;
   }
 
   render() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR **removes carriage return from copy-pasted values that contain carriage return** as carriage return is invisible character and therefore user's can't detect what is wrong with their query. This PR solves the problem on QueryField component level so we don't have to deal with each data source/query individually. 

I have tested also newline and newline is visible character, therefore I have decided to don't remove that one.

I don't think we need to remove carriage return when parsing url (on Explore AND Dashboard level), because if we don't let user create invalid query, we won't have invalid url. 

**Which issue(s) this PR fixes**:

Fixes  #32159

**Special notes for your reviewer**:

How to test this:
1. Run `make devenv sources=prometheus` to start prometheus data source
2. Open this URL that contains query with carriage return. Query is not going to work, but we are going to use this to create text with carriage return character:
```
http://localhost:3000/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22gdev-prometheus%22,%7B%22expr%22:%22ALERTS%7Bjob%3D%5C%22prometheus%5Cr%5C%22%7D%22,%22requestId%22:%22Q-65a9909a-bc25-4fa2-8f94-a91d2385dbc9-0A%22%7D%5D
```

3. Cut the query `ALERTS{job="prometheus"}` or copy it and clean query input.
4. Paste the query `ALERTS{job="prometheus"}`. Query should return data.
5. Test this on play. Do the same and the query won' return the data, cause carriage return is not removed:
```
http://play.grafana.org/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22demo.robustperception.io%22,%7B%22expr%22:%22ALERTS%7Bjob%3D%5C%22prometheus%5Cr%5C%22%7D%22,%22requestId%22:%22Q-65a9909a-bc25-4fa2-8f94-a91d2385dbc9-0A%22%7D%5D
```
