### PR TITLE
Switch: prevent wrapping for InlineSwitch Label

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -150,6 +150,7 @@ const getSwitchStyles = stylesFactory((theme: GrafanaTheme2, transparent?: boole
       cursor: pointer;
       padding-right: ${theme.spacing(1)};
       color: ${theme.colors.text.secondary};
+      white-space: nowrap;
     `,
     inlineLabelEnabled: css`
       color: ${theme.colors.text.primary};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

when resizing the window, the inline switch label for the to "table view" toggle might wrap when there's not enough horizontal space. This PR prevents it.

Before:
![Screenshot 2021-05-13 at 17 05 36](https://user-images.githubusercontent.com/1170767/118153785-2f3cfd00-b40e-11eb-84d2-927ce154d8bd.png)

After:

![Screenshot 2021-05-13 at 17 05 44](https://user-images.githubusercontent.com/1170767/118153792-3106c080-b40e-11eb-923b-0061c1948777.png)


