### PR TITLE
Toolkit: update tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "testing-library-selector": "^0.1.3",
     "ts-jest": "26.4.4",
     "ts-node": "9.0.0",
-    "tslib": "2.1.0",
+    "tslib": "2.2.0",
     "typescript": "4.2.4",
     "webpack": "4.41.5",
     "webpack-bundle-analyzer": "3.6.0",

--- a/packages/grafana-toolkit/package.json
+++ b/packages/grafana-toolkit/package.json
@@ -103,7 +103,7 @@
     "ts-jest": "26.4.4",
     "ts-loader": "6.2.1",
     "ts-node": "9.0.0",
-    "tslib": "2.1.0",
+    "tslib": "2.2.0",
     "typescript": "4.2.4",
     "url-loader": "^2.0.1",
     "webpack": "4.41.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24380,15 +24380,20 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@2.1.0, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+tslib@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
When building plugins targeting `8.0.0-beta.1`, they fail with an error about `__spreadArray` this updates tslib to help avoid that problem:

![image](https://user-images.githubusercontent.com/705951/118195319-da928580-b3ff-11eb-8a2b-8a88bc56dbb1.png)

you can also fix by adding an explicit dependency on tslib version in the plugin, but we should aim to have an out-of-the-box build that works