### PR TITLE
Variables: Refreshes all panels even if panel is full screen

### DIFF
--- a/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
+++ b/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`DashboardPage Dashboard init completed  Should render dashboard grid 1`
           "getVariablesFromState": [Function],
           "gnetId": null,
           "graphTooltip": 0,
+          "hasChangesThatAffectsAllPanels": false,
           "id": null,
           "links": Array [],
           "meta": Object {
@@ -175,6 +176,7 @@ exports[`DashboardPage Dashboard init completed  Should render dashboard grid 1`
                 "getVariablesFromState": [Function],
                 "gnetId": null,
                 "graphTooltip": 0,
+                "hasChangesThatAffectsAllPanels": false,
                 "id": null,
                 "links": Array [],
                 "meta": Object {
@@ -283,6 +285,7 @@ exports[`DashboardPage Dashboard init completed  Should render dashboard grid 1`
               "getVariablesFromState": [Function],
               "gnetId": null,
               "graphTooltip": 0,
+              "hasChangesThatAffectsAllPanels": false,
               "id": null,
               "links": Array [],
               "meta": Object {
@@ -413,6 +416,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
           "getVariablesFromState": [Function],
           "gnetId": null,
           "graphTooltip": 0,
+          "hasChangesThatAffectsAllPanels": false,
           "id": null,
           "links": Array [],
           "meta": Object {
@@ -551,6 +555,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
                 "getVariablesFromState": [Function],
                 "gnetId": null,
                 "graphTooltip": 0,
+                "hasChangesThatAffectsAllPanels": false,
                 "id": null,
                 "links": Array [],
                 "meta": Object {
@@ -659,6 +664,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
               "getVariablesFromState": [Function],
               "gnetId": null,
               "graphTooltip": 0,
+              "hasChangesThatAffectsAllPanels": false,
               "id": null,
               "links": Array [],
               "meta": Object {
@@ -771,6 +777,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
         "getVariablesFromState": [Function],
         "gnetId": null,
         "graphTooltip": 0,
+        "hasChangesThatAffectsAllPanels": false,
         "id": null,
         "links": Array [],
         "meta": Object {

--- a/public/app/features/dashboard/dashgrid/__snapshots__/DashboardGrid.test.tsx.snap
+++ b/public/app/features/dashboard/dashgrid/__snapshots__/DashboardGrid.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`DashboardGrid Can render dashboard grid Should render 1`] = `
           "getVariablesFromState": [Function],
           "gnetId": null,
           "graphTooltip": 0,
+          "hasChangesThatAffectsAllPanels": false,
           "id": null,
           "links": Array [],
           "meta": Object {
@@ -355,6 +356,7 @@ exports[`DashboardGrid Can render dashboard grid Should render 1`] = `
           "getVariablesFromState": [Function],
           "gnetId": null,
           "graphTooltip": 0,
+          "hasChangesThatAffectsAllPanels": false,
           "id": null,
           "links": Array [],
           "meta": Object {
@@ -626,6 +628,7 @@ exports[`DashboardGrid Can render dashboard grid Should render 1`] = `
           "getVariablesFromState": [Function],
           "gnetId": null,
           "graphTooltip": 0,
+          "hasChangesThatAffectsAllPanels": false,
           "id": null,
           "links": Array [],
           "meta": Object {
@@ -897,6 +900,7 @@ exports[`DashboardGrid Can render dashboard grid Should render 1`] = `
           "getVariablesFromState": [Function],
           "gnetId": null,
           "graphTooltip": 0,
+          "hasChangesThatAffectsAllPanels": false,
           "id": null,
           "links": Array [],
           "meta": Object {

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -804,7 +804,7 @@ describe('exitViewPanel', () => {
     describe('and there is a change that affects all panels', () => {
       it('then startRefresh is not called', () => {
         const { dashboard, panel } = getTestContext();
-        dashboard.changeAffectsAllPanels();
+        dashboard.setChangeAffectsAllPanels();
 
         dashboard.exitViewPanel(panel);
 
@@ -852,7 +852,7 @@ describe('exitPanelEditor', () => {
     describe('and there is a change that affects all panels', () => {
       it('then startRefresh is not called', () => {
         const { dashboard } = getTestContext();
-        dashboard.changeAffectsAllPanels();
+        dashboard.setChangeAffectsAllPanels();
 
         dashboard.exitPanelEditor();
 
@@ -862,7 +862,7 @@ describe('exitPanelEditor', () => {
   });
 });
 
-describe('changeAffectsAllPanels', () => {
+describe('setChangeAffectsAllPanels', () => {
   it.each`
     panelInEdit  | panelInView  | expected
     ${null}      | ${null}      | ${false}
@@ -879,7 +879,7 @@ describe('changeAffectsAllPanels', () => {
       dashboard.panelInEdit = panelInEdit;
       dashboard.panelInView = panelInView;
 
-      dashboard.changeAffectsAllPanels();
+      dashboard.setChangeAffectsAllPanels();
 
       expect(dashboard['hasChangesThatAffectsAllPanels']).toEqual(expected);
     }

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -6,6 +6,7 @@ import { variableAdapters } from '../../variables/adapters';
 import { createAdHocVariableAdapter } from '../../variables/adhoc/adapter';
 import { createQueryVariableAdapter } from '../../variables/query/adapter';
 import { createCustomVariableAdapter } from '../../variables/custom/adapter';
+import { expect } from '../../../../test/lib/common';
 
 jest.mock('app/core/services/context_srv', () => ({}));
 variableAdapters.setInit(() => [
@@ -763,4 +764,124 @@ describe('DashboardModel', () => {
       }
     );
   });
+});
+
+describe('exitViewPanel', () => {
+  function getTestContext() {
+    const panel: any = { setIsViewing: jest.fn() };
+    const dashboard = new DashboardModel({});
+    dashboard.startRefresh = jest.fn();
+    dashboard.panelInView = panel;
+
+    return { dashboard, panel };
+  }
+
+  describe('when called', () => {
+    it('then panelInView is set to undefined', () => {
+      const { dashboard, panel } = getTestContext();
+
+      dashboard.exitViewPanel(panel);
+
+      expect(dashboard.panelInView).toBeUndefined();
+    });
+
+    it('then setIsViewing is called on panel', () => {
+      const { dashboard, panel } = getTestContext();
+
+      dashboard.exitViewPanel(panel);
+
+      expect(panel.setIsViewing).toHaveBeenCalledWith(false);
+    });
+
+    it('then startRefresh is not called', () => {
+      const { dashboard, panel } = getTestContext();
+
+      dashboard.exitViewPanel(panel);
+
+      expect(dashboard.startRefresh).not.toHaveBeenCalled();
+    });
+
+    describe('and there is a change that affects all panels', () => {
+      it('then startRefresh is not called', () => {
+        const { dashboard, panel } = getTestContext();
+        dashboard.changeAffectsAllPanels();
+
+        dashboard.exitViewPanel(panel);
+
+        expect(dashboard.startRefresh).toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+describe('exitPanelEditor', () => {
+  function getTestContext() {
+    const panel: any = { destroy: jest.fn() };
+    const dashboard = new DashboardModel({});
+    dashboard.startRefresh = jest.fn();
+    dashboard.panelInEdit = panel;
+
+    return { dashboard, panel };
+  }
+
+  describe('when called', () => {
+    it('then panelInEdit is set to undefined', () => {
+      const { dashboard } = getTestContext();
+
+      dashboard.exitPanelEditor();
+
+      expect(dashboard.panelInEdit).toBeUndefined();
+    });
+
+    it('then destroy is called on panel', () => {
+      const { dashboard, panel } = getTestContext();
+
+      dashboard.exitPanelEditor();
+
+      expect(panel.destroy).toHaveBeenCalled();
+    });
+
+    it('then startRefresh is not called', () => {
+      const { dashboard } = getTestContext();
+
+      dashboard.exitPanelEditor();
+
+      expect(dashboard.startRefresh).not.toHaveBeenCalled();
+    });
+
+    describe('and there is a change that affects all panels', () => {
+      it('then startRefresh is not called', () => {
+        const { dashboard } = getTestContext();
+        dashboard.changeAffectsAllPanels();
+
+        dashboard.exitPanelEditor();
+
+        expect(dashboard.startRefresh).toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+describe('changeAffectsAllPanels', () => {
+  it.each`
+    panelInEdit  | panelInView  | expected
+    ${null}      | ${null}      | ${false}
+    ${undefined} | ${undefined} | ${false}
+    ${null}      | ${{}}        | ${true}
+    ${undefined} | ${{}}        | ${true}
+    ${{}}        | ${null}      | ${true}
+    ${{}}        | ${undefined} | ${true}
+    ${{}}        | ${{}}        | ${true}
+  `(
+    'when called and panelInEdit:{$panelInEdit} and panelInView:{$panelInView}',
+    ({ panelInEdit, panelInView, expected }) => {
+      const dashboard = new DashboardModel({});
+      dashboard.panelInEdit = panelInEdit;
+      dashboard.panelInView = panelInView;
+
+      dashboard.changeAffectsAllPanels();
+
+      expect(dashboard['hasChangesThatAffectsAllPanels']).toEqual(expected);
+    }
+  );
 });

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -116,8 +116,6 @@ export class DashboardModel {
     getVariablesFromState: true,
     formatDate: true,
     hasChangesThatAffectsAllPanels: true,
-    changeAffectsAllPanels: true,
-    refreshIfChangeAffectsAllPanels: true,
   };
 
   constructor(data: any, meta?: DashboardMeta, private getVariablesFromState: GetVariables = getVariables) {
@@ -379,12 +377,10 @@ export class DashboardModel {
     this.refreshIfChangeAffectsAllPanels();
   }
 
-  changeAffectsAllPanels() {
-    if (!this.panelInEdit && !this.panelInView) {
-      return;
+  setChangeAffectsAllPanels() {
+    if (this.panelInEdit || this.panelInView) {
+      this.hasChangesThatAffectsAllPanels = true;
     }
-
-    this.hasChangesThatAffectsAllPanels = true;
   }
 
   private refreshIfChangeAffectsAllPanels() {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -92,6 +92,7 @@ export class DashboardModel {
   panels: PanelModel[];
   panelInEdit?: PanelModel;
   panelInView?: PanelModel;
+  private hasChangesThatAffectsAllPanels: boolean;
 
   // ------------------
   // not persisted
@@ -114,6 +115,9 @@ export class DashboardModel {
     panelInView: true,
     getVariablesFromState: true,
     formatDate: true,
+    hasChangesThatAffectsAllPanels: true,
+    changeAffectsAllPanels: true,
+    refreshIfChangeAffectsAllPanels: true,
   };
 
   constructor(data: any, meta?: DashboardMeta, private getVariablesFromState: GetVariables = getVariables) {
@@ -154,6 +158,7 @@ export class DashboardModel {
 
     this.addBuiltInAnnotationQuery();
     this.sortPanelsByGridPos();
+    this.hasChangesThatAffectsAllPanels = false;
   }
 
   addBuiltInAnnotationQuery() {
@@ -365,11 +370,30 @@ export class DashboardModel {
   exitViewPanel(panel: PanelModel) {
     this.panelInView = undefined;
     panel.setIsViewing(false);
+    this.refreshIfChangeAffectsAllPanels();
   }
 
   exitPanelEditor() {
     this.panelInEdit!.destroy();
     this.panelInEdit = undefined;
+    this.refreshIfChangeAffectsAllPanels();
+  }
+
+  changeAffectsAllPanels() {
+    if (!this.panelInEdit && !this.panelInView) {
+      return;
+    }
+
+    this.hasChangesThatAffectsAllPanels = true;
+  }
+
+  private refreshIfChangeAffectsAllPanels() {
+    if (!this.hasChangesThatAffectsAllPanels) {
+      return;
+    }
+
+    this.hasChangesThatAffectsAllPanels = false;
+    this.startRefresh();
   }
 
   private ensureListExist(data: any) {

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -111,7 +111,7 @@ export const initDashboardTemplating = (list: VariableModel[]): ThunkResult<void
 };
 
 export const addSystemTemplateVariables = (dashboard: DashboardModel): ThunkResult<void> => {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     const dashboardModel: DashboardVariableModel = {
       ...initialVariableModelState,
       id: '__dashboard',
@@ -493,6 +493,7 @@ export const variableUpdated = (
     return Promise.all(promises).then(() => {
       if (emitChangeEvents) {
         const dashboard = getState().dashboard.getModel();
+        dashboard?.changeAffectsAllPanels();
         dashboard?.processRepeats();
         locationService.partial(getQueryWithVariables(getState));
         dashboard?.startRefresh();
@@ -526,6 +527,7 @@ export const onTimeRangeUpdated = (
   try {
     await Promise.all(promises);
     const dashboard = getState().dashboard.getModel();
+    dashboard?.changeAffectsAllPanels();
     dashboard?.startRefresh();
   } catch (error) {
     console.error(error);

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -493,7 +493,7 @@ export const variableUpdated = (
     return Promise.all(promises).then(() => {
       if (emitChangeEvents) {
         const dashboard = getState().dashboard.getModel();
-        dashboard?.changeAffectsAllPanels();
+        dashboard?.setChangeAffectsAllPanels();
         dashboard?.processRepeats();
         locationService.partial(getQueryWithVariables(getState));
         dashboard?.startRefresh();
@@ -527,7 +527,7 @@ export const onTimeRangeUpdated = (
   try {
     await Promise.all(promises);
     const dashboard = getState().dashboard.getModel();
-    dashboard?.changeAffectsAllPanels();
+    dashboard?.setChangeAffectsAllPanels();
     dashboard?.startRefresh();
   } catch (error) {
     console.error(error);

--- a/public/app/features/variables/state/onTimeRangeUpdated.test.ts
+++ b/public/app/features/variables/state/onTimeRangeUpdated.test.ts
@@ -54,11 +54,13 @@ const getTestContext = () => {
   const templateSrvMock = ({ updateTimeRange: updateTimeRangeMock } as unknown) as TemplateSrv;
   const dependencies: OnTimeRangeUpdatedDependencies = { templateSrv: templateSrvMock };
   const templateVariableValueUpdatedMock = jest.fn();
+  const changeAffectsAllPanelsMock = jest.fn();
   const dashboard = ({
     getModel: () =>
       (({
         templateVariableValueUpdated: templateVariableValueUpdatedMock,
         startRefresh: startRefreshMock,
+        changeAffectsAllPanels: changeAffectsAllPanelsMock,
       } as unknown) as DashboardModel),
   } as unknown) as DashboardState;
   const startRefreshMock = jest.fn();
@@ -82,6 +84,7 @@ const getTestContext = () => {
     updateTimeRangeMock,
     templateVariableValueUpdatedMock,
     startRefreshMock,
+    changeAffectsAllPanelsMock,
   };
 };
 
@@ -95,6 +98,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
         updateTimeRangeMock,
         templateVariableValueUpdatedMock,
         startRefreshMock,
+        changeAffectsAllPanelsMock,
       } = getTestContext();
 
       const tester = await reduxTester<RootReducerType>({ preloadedState })
@@ -117,6 +121,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
       expect(updateTimeRangeMock).toHaveBeenCalledWith(range);
       expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(1);
       expect(startRefreshMock).toHaveBeenCalledTimes(1);
+      expect(changeAffectsAllPanelsMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -130,6 +135,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
         updateTimeRangeMock,
         templateVariableValueUpdatedMock,
         startRefreshMock,
+        changeAffectsAllPanelsMock,
       } = getTestContext();
 
       const base = await reduxTester<RootReducerType>({ preloadedState })
@@ -154,6 +160,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
       expect(updateTimeRangeMock).toHaveBeenCalledWith(range);
       expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(0);
       expect(startRefreshMock).toHaveBeenCalledTimes(1);
+      expect(changeAffectsAllPanelsMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -168,6 +175,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
         updateTimeRangeMock,
         templateVariableValueUpdatedMock,
         startRefreshMock,
+        changeAffectsAllPanelsMock,
       } = getTestContext();
 
       adapter.updateOptions = jest.fn().mockRejectedValue(new Error('Something broke'));
@@ -196,6 +204,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
       expect(updateTimeRangeMock).toHaveBeenCalledWith(range);
       expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(0);
       expect(startRefreshMock).toHaveBeenCalledTimes(0);
+      expect(changeAffectsAllPanelsMock).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/public/app/features/variables/state/onTimeRangeUpdated.test.ts
+++ b/public/app/features/variables/state/onTimeRangeUpdated.test.ts
@@ -54,13 +54,13 @@ const getTestContext = () => {
   const templateSrvMock = ({ updateTimeRange: updateTimeRangeMock } as unknown) as TemplateSrv;
   const dependencies: OnTimeRangeUpdatedDependencies = { templateSrv: templateSrvMock };
   const templateVariableValueUpdatedMock = jest.fn();
-  const changeAffectsAllPanelsMock = jest.fn();
+  const setChangeAffectsAllPanelsMock = jest.fn();
   const dashboard = ({
     getModel: () =>
       (({
         templateVariableValueUpdated: templateVariableValueUpdatedMock,
         startRefresh: startRefreshMock,
-        changeAffectsAllPanels: changeAffectsAllPanelsMock,
+        setChangeAffectsAllPanels: setChangeAffectsAllPanelsMock,
       } as unknown) as DashboardModel),
   } as unknown) as DashboardState;
   const startRefreshMock = jest.fn();
@@ -84,7 +84,7 @@ const getTestContext = () => {
     updateTimeRangeMock,
     templateVariableValueUpdatedMock,
     startRefreshMock,
-    changeAffectsAllPanelsMock,
+    setChangeAffectsAllPanelsMock,
   };
 };
 
@@ -98,7 +98,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
         updateTimeRangeMock,
         templateVariableValueUpdatedMock,
         startRefreshMock,
-        changeAffectsAllPanelsMock,
+        setChangeAffectsAllPanelsMock,
       } = getTestContext();
 
       const tester = await reduxTester<RootReducerType>({ preloadedState })
@@ -121,7 +121,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
       expect(updateTimeRangeMock).toHaveBeenCalledWith(range);
       expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(1);
       expect(startRefreshMock).toHaveBeenCalledTimes(1);
-      expect(changeAffectsAllPanelsMock).toHaveBeenCalledTimes(1);
+      expect(setChangeAffectsAllPanelsMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -135,7 +135,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
         updateTimeRangeMock,
         templateVariableValueUpdatedMock,
         startRefreshMock,
-        changeAffectsAllPanelsMock,
+        setChangeAffectsAllPanelsMock,
       } = getTestContext();
 
       const base = await reduxTester<RootReducerType>({ preloadedState })
@@ -160,7 +160,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
       expect(updateTimeRangeMock).toHaveBeenCalledWith(range);
       expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(0);
       expect(startRefreshMock).toHaveBeenCalledTimes(1);
-      expect(changeAffectsAllPanelsMock).toHaveBeenCalledTimes(1);
+      expect(setChangeAffectsAllPanelsMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -175,7 +175,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
         updateTimeRangeMock,
         templateVariableValueUpdatedMock,
         startRefreshMock,
-        changeAffectsAllPanelsMock,
+        setChangeAffectsAllPanelsMock,
       } = getTestContext();
 
       adapter.updateOptions = jest.fn().mockRejectedValue(new Error('Something broke'));
@@ -204,7 +204,7 @@ describe('when onTimeRangeUpdated is dispatched', () => {
       expect(updateTimeRangeMock).toHaveBeenCalledWith(range);
       expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(0);
       expect(startRefreshMock).toHaveBeenCalledTimes(0);
-      expect(changeAffectsAllPanelsMock).toHaveBeenCalledTimes(0);
+      expect(setChangeAffectsAllPanelsMock).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a function called `changeAffectsAllPanels` to the DashboardModel that can be called for changes that affect all panels, such as variable changes. When the panel then exits fullscreen view or edit view all panels will be refreshed.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #17537

**Special notes for your reviewer**:

