### PR TITLE
ValueMappings: Add duplicate action, and disable dismiss on backdrop click

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -141,8 +141,12 @@ function getDefaultColorFunc(field: Field, scaleFunc: ScaleCalculator, theme: Gr
       }
 
       const hc = strHashCode(value as string);
+      const color = theme.visualization.getColorByName(
+        theme.visualization.palette[Math.floor(hc % theme.visualization.palette.length)]
+      );
+
       return {
-        color: theme.visualization.palette[Math.floor(hc % theme.visualization.palette.length)],
+        color: color,
         percent: 0,
       };
     };

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -18,6 +18,7 @@ export interface Props {
   className?: string;
   contentClassName?: string;
   closeOnEscape?: boolean;
+  closeOnBackdropClick?: boolean;
 
   isOpen?: boolean;
   onDismiss?: () => void;
@@ -32,6 +33,7 @@ export function Modal(props: PropsWithChildren<Props>) {
     children,
     isOpen = false,
     closeOnEscape = true,
+    closeOnBackdropClick = true,
     className,
     contentClassName,
     onDismiss: propsOnDismiss,
@@ -79,7 +81,10 @@ export function Modal(props: PropsWithChildren<Props>) {
         </div>
         <div className={cx(styles.modalContent, contentClassName)}>{children}</div>
       </div>
-      <div className={styles.modalBackdrop} onClick={onClickBackdrop || onDismiss} />
+      <div
+        className={styles.modalBackdrop}
+        onClick={onClickBackdrop || (closeOnBackdropClick ? onDismiss : undefined)}
+      />
     </Portal>
   );
 }

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingEditRow.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingEditRow.tsx
@@ -26,9 +26,10 @@ interface Props {
   index: number;
   onChange: (index: number, mapping: ValueMappingEditRowModel) => void;
   onRemove: (index: number) => void;
+  onDuplicate: (index: number) => void;
 }
 
-export function ValueMappingEditRow({ mapping, index, onChange, onRemove }: Props) {
+export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDuplicate: onDupliate }: Props) {
   const { key, result } = mapping;
   const styles = useStyles2(getStyles);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -175,6 +176,7 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove }: Prop
           </td>
           <td className={styles.textAlignCenter}>
             <HorizontalGroup spacing="sm">
+              <IconButton name="copy" onClick={() => onDupliate(index)} data-testid="duplicate-value-mapping" />
               <IconButton name="trash-alt" onClick={() => onRemove(index)} data-testid="remove-value-mapping" />
             </HorizontalGroup>
           </td>
@@ -197,6 +199,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   typeColumn: css({
     textTransform: 'capitalize',
     textAlign: 'center',
+    width: '1%',
   }),
   textAlignCenter: css({
     textAlign: 'center',

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.tsx
@@ -73,15 +73,13 @@ export const ValueMappingsEditor = React.memo(({ value, onChange }: Props) => {
         title="Value mappings"
         onDismiss={onCloseEditor}
         className={styles.modal}
-        onClickBackdrop={DoNothingBackdropClickFunction}
+        closeOnBackdropClick={false}
       >
         <ValueMappingsEditorModal value={value} onChange={onChange} onClose={onCloseEditor} />
       </Modal>
     </VerticalGroup>
   );
 });
-
-function DoNothingBackdropClickFunction() {}
 
 ValueMappingsEditor.displayName = 'ValueMappingsEditor';
 

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditor.tsx
@@ -68,12 +68,20 @@ export const ValueMappingsEditor = React.memo(({ value, onChange }: Props) => {
         {rows.length > 0 && <span>Edit value mappings</span>}
         {rows.length === 0 && <span>Add value mappings</span>}
       </Button>
-      <Modal isOpen={isEditorOpen} title="Value mappings" onDismiss={onCloseEditor} className={styles.modal}>
+      <Modal
+        isOpen={isEditorOpen}
+        title="Value mappings"
+        onDismiss={onCloseEditor}
+        className={styles.modal}
+        onClickBackdrop={DoNothingBackdropClickFunction}
+      >
         <ValueMappingsEditorModal value={value} onChange={onChange} onClose={onCloseEditor} />
       </Modal>
     </VerticalGroup>
   );
 });
+
+function DoNothingBackdropClickFunction() {}
 
 ValueMappingsEditor.displayName = 'ValueMappingsEditor';
 

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.tsx
@@ -63,6 +63,18 @@ export function ValueMappingsEditorModal({ value, onChange, onClose }: Props) {
     ]);
   };
 
+  const onDuplicateMapping = (index: number) => {
+    const sourceRow = rows[index];
+    const copy = [...rows];
+    copy.splice(index, 0, { ...sourceRow });
+
+    for (let i = index; i < rows.length; i++) {
+      copy[i].result.index = i;
+    }
+
+    updateRows(copy);
+  };
+
   const onUpdate = () => {
     onChange(editModelToSaveModel(rows));
     onClose();
@@ -93,6 +105,7 @@ export function ValueMappingsEditorModal({ value, onChange, onClose }: Props) {
                     index={index}
                     onChange={onChangeMapping}
                     onRemove={onRemoveRow}
+                    onDuplicate={onDuplicateMapping}
                   />
                 ))}
                 {provided.placeholder}


### PR DESCRIPTION
* After having lost many edits to accidental clicks on the backdrop I figured disabling this is a good thing.
* Adds duplicate action to make adding a new mapping of the same type quicker 

![Screenshot from 2021-05-14 09-57-45](https://user-images.githubusercontent.com/10999/118240280-1cbcd500-b49b-11eb-9c69-ea2155221629.png)


