### PR TITLE
grafana/u: Move stacking config to common options builder

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config.ts
+++ b/packages/grafana-ui/src/components/uPlot/config.ts
@@ -196,6 +196,13 @@ export interface StackingConfig {
 /**
  * @alpha
  */
+export interface StackableFieldConfig {
+  stacking?: StackingConfig;
+}
+
+/**
+ * @alpha
+ */
 export enum GraphTresholdsStyleMode {
   Off = 'off',
   Line = 'line',
@@ -220,10 +227,10 @@ export interface GraphFieldConfig
     PointsConfig,
     AxisConfig,
     BarConfig,
+    StackableFieldConfig,
     HideableFieldConfig {
   drawStyle?: DrawStyle;
   gradientMode?: GraphGradientMode;
-  stacking?: StackingConfig;
   thresholdsStyle?: GraphThresholdsStyleConfig;
 }
 

--- a/packages/grafana-ui/src/options/builder/index.ts
+++ b/packages/grafana-ui/src/options/builder/index.ts
@@ -2,3 +2,4 @@ export * from './axis';
 export * from './hideSeries';
 export * from './legend';
 export * from './tooltip';
+export * from './stacking';

--- a/packages/grafana-ui/src/options/builder/stacking.tsx
+++ b/packages/grafana-ui/src/options/builder/stacking.tsx
@@ -1,6 +1,12 @@
-import React from 'react';
-import { FieldOverrideEditorProps } from '@grafana/data';
 import {
+  FieldConfigEditorBuilder,
+  FieldOverrideEditorProps,
+  FieldType,
+  identityOverrideProcessor,
+} from '@grafana/data';
+import React from 'react';
+import {
+  graphFieldOptions,
   HorizontalGroup,
   IconButton,
   Input,
@@ -8,7 +14,7 @@ import {
   StackingConfig,
   StackingMode,
   Tooltip,
-} from '@grafana/ui';
+} from '../..';
 
 export const StackingEditor: React.FC<FieldOverrideEditorProps<StackingConfig, any>> = ({
   value,
@@ -49,3 +55,24 @@ export const StackingEditor: React.FC<FieldOverrideEditorProps<StackingConfig, a
     </HorizontalGroup>
   );
 };
+
+export function addStackingConfig(
+  builder: FieldConfigEditorBuilder<{ stacking: StackingConfig }>,
+  defaultConfig?: StackingConfig,
+  category = ['Graph styles']
+) {
+  builder.addCustomEditor({
+    id: 'stacking',
+    path: 'stacking',
+    name: 'Stack series',
+    category: category,
+    defaultValue: defaultConfig,
+    editor: StackingEditor,
+    override: StackingEditor,
+    settings: {
+      options: graphFieldOptions.stacking,
+    },
+    process: identityOverrideProcessor,
+    shouldApply: (f) => f.type === FieldType.number,
+  });
+}

--- a/public/app/plugins/panel/timeseries/config.ts
+++ b/public/app/plugins/panel/timeseries/config.ts
@@ -1,6 +1,5 @@
 import {
   FieldColorModeId,
-  FieldConfigEditorBuilder,
   FieldConfigProperty,
   FieldType,
   identityOverrideProcessor,
@@ -16,14 +15,12 @@ import {
   LineInterpolation,
   LineStyle,
   PointVisibility,
-  StackingConfig,
   StackingMode,
   commonOptionsBuilder,
 } from '@grafana/ui';
 import { LineStyleEditor } from './LineStyleEditor';
 import { FillBellowToEditor } from './FillBelowToEditor';
 import { SpanNullsEditor } from './SpanNullsEditor';
-import { StackingEditor } from './StackingEditor';
 
 export const defaultGraphConfig: GraphFieldConfig = {
   drawStyle: DrawStyle.Line,
@@ -176,7 +173,7 @@ export function getGraphFieldConfig(cfg: GraphFieldConfig): SetFieldConfigOption
           showIf: (c) => c.showPoints !== PointVisibility.Never || c.drawStyle === DrawStyle.Points,
         });
 
-      addStackingConfig(builder, cfg.stacking);
+      commonOptionsBuilder.addStackingConfig(builder, cfg.stacking, categoryStyles);
       commonOptionsBuilder.addAxisConfig(builder, cfg);
       commonOptionsBuilder.addHideFrom(builder);
 
@@ -191,24 +188,4 @@ export function getGraphFieldConfig(cfg: GraphFieldConfig): SetFieldConfigOption
       });
     },
   };
-}
-
-export function addStackingConfig(
-  builder: FieldConfigEditorBuilder<{ stacking: StackingConfig }>,
-  defaultConfig?: StackingConfig
-) {
-  builder.addCustomEditor({
-    id: 'stacking',
-    path: 'stacking',
-    name: 'Stack series',
-    category: categoryStyles,
-    defaultValue: defaultConfig,
-    editor: StackingEditor,
-    override: StackingEditor,
-    settings: {
-      options: graphFieldOptions.stacking,
-    },
-    process: identityOverrideProcessor,
-    shouldApply: (f) => f.type === FieldType.number,
-  });
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves stacking to common options to support stacking in bar chart.