### PR TITLE
Alerting: fix maching loki prom rules to rule rules, rename "Inactive" to "Normal"

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -244,16 +244,16 @@ describe('RuleList', () => {
     let ruleRows = table.querySelectorAll<HTMLTableRowElement>(':scope > tbody > tr');
     expect(ruleRows).toHaveLength(4);
 
-    expect(ruleRows[0]).toHaveTextContent('n/a');
+    expect(ruleRows[0]).toHaveTextContent('Recording rule');
     expect(ruleRows[0]).toHaveTextContent('recordingrule');
 
-    expect(ruleRows[1]).toHaveTextContent('firing');
+    expect(ruleRows[1]).toHaveTextContent('Firing');
     expect(ruleRows[1]).toHaveTextContent('alertingrule');
 
-    expect(ruleRows[2]).toHaveTextContent('pending');
+    expect(ruleRows[2]).toHaveTextContent('Pending');
     expect(ruleRows[2]).toHaveTextContent('p-rule');
 
-    expect(ruleRows[3]).toHaveTextContent('inactive');
+    expect(ruleRows[3]).toHaveTextContent('Normal');
     expect(ruleRows[3]).toHaveTextContent('i-rule');
 
     expect(byText('Labels').query()).not.toBeInTheDocument();
@@ -277,8 +277,8 @@ describe('RuleList', () => {
     let instanceRows = instancesTable?.querySelectorAll<HTMLTableRowElement>(':scope > tbody > tr');
     expect(instanceRows).toHaveLength(2);
 
-    expect(instanceRows![0]).toHaveTextContent('firingfoo=barseverity=warning2021-03-18 13:47:05');
-    expect(instanceRows![1]).toHaveTextContent('firingfoo=bazseverity=error2021-03-18 13:47:05');
+    expect(instanceRows![0]).toHaveTextContent('Firingfoo=barseverity=warning2021-03-18 13:47:05');
+    expect(instanceRows![1]).toHaveTextContent('Firingfoo=bazseverity=error2021-03-18 13:47:05');
 
     // expand details of an instance
     userEvent.click(ui.alertCollapseToggle.get(instanceRows![0]));

--- a/public/app/features/alerting/unified/components/rules/AlertStateTag.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertStateTag.tsx
@@ -1,5 +1,6 @@
 import { GrafanaAlertState, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 import React, { FC } from 'react';
+import { alertStateToReadable } from '../../utils/rules';
 import { State, StateTag } from '../StateTag';
 
 const alertStateToState: Record<PromAlertingRuleState | GrafanaAlertState, State> = {
@@ -17,4 +18,6 @@ interface Props {
   state: PromAlertingRuleState | GrafanaAlertState;
 }
 
-export const AlertStateTag: FC<Props> = ({ state }) => <StateTag state={alertStateToState[state]}>{state}</StateTag>;
+export const AlertStateTag: FC<Props> = ({ state }) => (
+  <StateTag state={alertStateToState[state]}>{alertStateToReadable(state)}</StateTag>
+);

--- a/public/app/features/alerting/unified/components/rules/RuleListSateSection.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListSateSection.tsx
@@ -3,8 +3,8 @@ import { GrafanaTheme } from '@grafana/data';
 import { useStyles } from '@grafana/ui';
 import { CombinedRule } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
-import { capitalize } from 'lodash';
 import React, { FC, useState } from 'react';
+import { promRuleStateToReadable } from '../../utils/rules';
 import { CollapseToggle } from '../CollapseToggle';
 import { RulesTable } from './RulesTable';
 
@@ -26,7 +26,7 @@ export const RuleListStateSection: FC<Props> = ({ rules, state, defaultCollapsed
           isCollapsed={collapsed}
           onToggle={() => setCollapsed(!collapsed)}
         />
-        {capitalize(state)} ({rules.length})
+        {promRuleStateToReadable(state)} ({rules.length})
       </h4>
       {!collapsed && <RulesTable rules={rules} showGroupColumn={true} />}
     </>

--- a/public/app/features/alerting/unified/components/rules/RuleListStateSection.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateSection.tsx
@@ -4,7 +4,7 @@ import { useStyles } from '@grafana/ui';
 import { CombinedRule } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 import React, { FC, useState } from 'react';
-import { promRuleStateToReadable } from '../../utils/rules';
+import { alertStateToReadable } from '../../utils/rules';
 import { CollapseToggle } from '../CollapseToggle';
 import { RulesTable } from './RulesTable';
 
@@ -26,7 +26,7 @@ export const RuleListStateSection: FC<Props> = ({ rules, state, defaultCollapsed
           isCollapsed={collapsed}
           onToggle={() => setCollapsed(!collapsed)}
         />
-        {promRuleStateToReadable(state)} ({rules.length})
+        {alertStateToReadable(state)} ({rules.length})
       </h4>
       {!collapsed && <RulesTable rules={rules} showGroupColumn={true} />}
     </>

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -4,7 +4,7 @@ import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 import React, { FC, useMemo } from 'react';
 import { getFiltersFromUrlParams } from '../../utils/misc';
 import { isAlertingRule } from '../../utils/rules';
-import { RuleListStateSection } from './RuleListSateSection';
+import { RuleListStateSection } from './RuleListStateSection';
 
 interface Props {
   namespaces: CombinedRuleNamespace[];

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
@@ -8,6 +8,7 @@ import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { getFiltersFromUrlParams } from '../../utils/misc';
 import { DataSourcePicker } from '@grafana/runtime';
+import { alertStateToReadable } from '../../utils/rules';
 
 const RulesFilter = () => {
   const [queryParams, setQueryParams] = useQueryParams();
@@ -19,7 +20,10 @@ const RulesFilter = () => {
   const { dataSource, alertState, queryString } = getFiltersFromUrlParams(queryParams);
 
   const styles = useStyles(getStyles);
-  const stateOptions = Object.entries(PromAlertingRuleState).map(([key, value]) => ({ label: key, value }));
+  const stateOptions = Object.entries(PromAlertingRuleState).map(([key, value]) => ({
+    label: alertStateToReadable(value),
+    value,
+  }));
 
   const handleDataSourceChange = (dataSourceValue: DataSourceInstanceSettings) => {
     setQueryParams({ dataSource: dataSourceValue.name });

--- a/public/app/features/alerting/unified/components/rules/RulesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.tsx
@@ -1,7 +1,7 @@
 import { GrafanaTheme2 } from '@grafana/data';
 import { ConfirmModal, useStyles2 } from '@grafana/ui';
 import React, { FC, Fragment, useState } from 'react';
-import { getRuleIdentifier, isAlertingRule, stringifyRuleIdentifier } from '../../utils/rules';
+import { getRuleIdentifier, isAlertingRule, isRecordingRule, stringifyRuleIdentifier } from '../../utils/rules';
 import { CollapseToggle } from '../CollapseToggle';
 import { css, cx } from '@emotion/css';
 import { RuleDetails } from './RuleDetails';
@@ -126,7 +126,15 @@ export const RulesTable: FC<Props> = ({
                         data-testid="rule-collapse-toggle"
                       />
                     </td>
-                    <td>{promRule && isAlertingRule(promRule) ? <AlertStateTag state={promRule.state} /> : 'n/a'}</td>
+                    <td>
+                      {promRule && isAlertingRule(promRule) ? (
+                        <AlertStateTag state={promRule.state} />
+                      ) : promRule && isRecordingRule(promRule) ? (
+                        'Recording rule'
+                      ) : (
+                        'n/a'
+                      )}
+                    </td>
                     <td>{rule.name}</td>
                     {showGroupColumn && (
                       <td>{isCloudRulesSource(rulesSource) ? `${namespace.name} > ${group.name}` : namespace.name}</td>

--- a/public/app/features/alerting/unified/utils/rules.ts
+++ b/public/app/features/alerting/unified/utils/rules.ts
@@ -1,6 +1,8 @@
 import {
   Annotations,
+  GrafanaAlertState,
   Labels,
+  PromAlertingRuleState,
   PromRuleType,
   RulerAlertingRuleDTO,
   RulerGrafanaRuleDTO,
@@ -20,6 +22,7 @@ import {
 import { AsyncRequestState } from './redux';
 import { RULER_NOT_SUPPORTED_MSG } from './constants';
 import { hash } from './misc';
+import { capitalize } from 'lodash';
 
 export function isAlertingRule(rule: Rule): rule is AlertingRule {
   return rule.type === PromRuleType.Alerting;
@@ -131,4 +134,11 @@ export function ruleWithLocationToRuleIdentifier(ruleWithLocation: RuleWithLocat
     ruleWithLocation.group.name,
     ruleWithLocation.rule
   );
+}
+
+export function alertStateToReadable(state: PromAlertingRuleState | GrafanaAlertState): string {
+  if (state === PromAlertingRuleState.Inactive) {
+    return 'Normal';
+  }
+  return capitalize(state);
 }


### PR DESCRIPTION
Double feature:
* Fixes matching Loki prom rules to ruler rules. It would on occasion falsly show rules stuck in `creating` or `deleting`.  It seems Loki sometimes rewrite the query tht was submitted to ruler, eg `2 > 1` becomes `1`, and then we'd fail to match ruler rules to prom rules. Now if it fails to find a matching rule, it will attempt to match just by name and labels + annoations, disregarding query. 
* Display "inactive" state as "normal" in frontend to avoid confusion. "inactive" means it's not firing in prometheus world, but ppl would sometimes think it means it's nor working.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

