### PR TITLE
Timeline: Adds opacity & line width option

### DIFF
--- a/devenv/dev-dashboards/panel-timeline/timeline-demo.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-demo.json
@@ -1,0 +1,414 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "CRITICAL": {
+                  "color": "red",
+                  "index": 3
+                },
+                "HIGH": {
+                  "color": "orange",
+                  "index": 2
+                },
+                "LOW": {
+                  "color": "blue",
+                  "index": 0
+                },
+                "NORMAL": {
+                  "color": "green",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "alignValue": "center",
+        "colWidth": 0.9,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "mode": "changes",
+        "rowHeight": 0.98,
+        "showValue": "always"
+      },
+      "pluginVersion": "7.5.0-pre",
+      "targets": [
+        {
+          "alias": "SensorA",
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "LOW,HIGH,NORMAL,NORMAL,NORMAL,LOW,LOW,NORMAL,HIGH,CRITICAL"
+        },
+        {
+          "alias": "SensorB",
+          "hide": false,
+          "refId": "B",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "NORMAL,LOW,LOW,CRITICAL,CRITICAL,LOW,LOW,NORMAL,HIGH,CRITICAL"
+        },
+        {
+          "alias": "SensorA",
+          "hide": false,
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "NORMAL,NORMAL,NORMAL,NORMAL,CRITICAL,LOW,NORMAL,NORMAL,NORMAL,LOW"
+        }
+      ],
+      "title": "State changes strings",
+      "type": "timeline"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "true",
+                "result": {
+                  "color": "semi-dark-green",
+                  "index": 0,
+                  "text": "ON"
+                }
+              },
+              "type": "special"
+            },
+            {
+              "options": {
+                "match": "false",
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "OFF"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 13,
+        "x": 0,
+        "y": 8
+      },
+      "id": 13,
+      "options": {
+        "alignValue": "center",
+        "colWidth": 1,
+        "mode": "changes",
+        "rowHeight": 0.98,
+        "showValue": "always"
+      },
+      "targets": [
+        {
+          "alias": "",
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "true,false,true,true,true,true,false,false"
+        },
+        {
+          "hide": false,
+          "refId": "B",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "false,true,false,true,true,false,false,false,true,true"
+        },
+        {
+          "hide": false,
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "true,false,true,true"
+        },
+        {
+          "hide": false,
+          "refId": "D",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "false,true,false,true,true"
+        }
+      ],
+      "title": "State changes with boolean values",
+      "type": "timeline"
+    },
+    {
+      "datasource": null,
+      "description": "Should show gaps",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "true",
+                "result": {
+                  "color": "semi-dark-green",
+                  "index": 0,
+                  "text": "ON"
+                }
+              },
+              "type": "special"
+            },
+            {
+              "options": {
+                "match": "false",
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "OFF"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 11,
+        "x": 13,
+        "y": 8
+      },
+      "id": 12,
+      "options": {
+        "alignValue": "center",
+        "colWidth": 1,
+        "mode": "changes",
+        "rowHeight": 0.98,
+        "showValue": "always"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "true,false,true,true,true,true,false,false"
+        },
+        {
+          "hide": false,
+          "refId": "B",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "false,true,false,true,true,false,false,false,true,true"
+        },
+        {
+          "hide": false,
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "true,false,null,true,true"
+        },
+        {
+          "hide": false,
+          "refId": "D",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "false,null,null,false,true,true"
+        }
+      ],
+      "title": "State changes with nulls",
+      "type": "timeline"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "fillOpacity": 96,
+            "lineWidth": 0
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 30,
+          "min": -10,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 4,
+      "interval": null,
+      "maxDataPoints": 20,
+      "options": {
+        "alignValue": "center",
+        "colWidth": 0.96,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "mode": "samples",
+        "rowHeight": 0.98,
+        "showValue": "always"
+      },
+      "pluginVersion": "7.5.0-pre",
+      "targets": [
+        {
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "max": 30,
+          "min": -10,
+          "noise": 2,
+          "points": [],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 4,
+          "spread": 15,
+          "startValue": 5,
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
+        }
+      ],
+      "title": "\"Periodic samples\" Mode",
+      "type": "timeline"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [
+    "gdev",
+    "demo"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Timeline Demo",
+  "uid": "mIJjFy8Kz",
+  "version": 13
+}

--- a/devenv/dev-dashboards/panel-timeline/timeline-modes.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-modes.json
@@ -14,7 +14,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,  
+  "graphTooltip": 0,
   "links": [],
   "panels": [
     {
@@ -24,33 +24,7 @@
           "color": {
             "mode": "palette-classic"
           },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [
-            {
-              "options": {
-                "CRITICAL": {
-                  "color": "red",
-                  "index": 3
-                },
-                "HIGH": {
-                  "color": "orange",
-                  "index": 2
-                },
-                "LOW": {
-                  "color": "blue",
-                  "index": 0
-                },
-                "NORMAL": {
-                  "color": "green",
-                  "index": 1
-                }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -68,14 +42,13 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 9,
+      "id": 8,
       "options": {
-        "alignValue": "center",
         "colWidth": 0.9,
         "legend": {
           "calcs": [],
@@ -83,33 +56,138 @@
           "placement": "bottom"
         },
         "mode": "changes",
-        "rowHeight": 0.98,
+        "rowHeight": 0.9,
         "showValue": "always"
       },
       "pluginVersion": "7.5.0-pre",
       "targets": [
         {
-          "alias": "SensorA",
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
+          "lines": 10,
+          "points": [
+            [
+              0,
+              1616551651000
+            ],
+            [
+              1,
+              1616556554000
+            ],
+            [
+              2,
+              1616559873000
+            ],
+            [
+              0,
+              1616561077000
+            ],
+            [
+              3,
+              1616563090000
+            ]
+          ],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
           "refId": "A",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "LOW,HIGH,NORMAL,NORMAL,NORMAL,LOW,LOW,NORMAL,HIGH,CRITICAL"
+          "scenarioId": "manual_entry",
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
         },
         {
-          "alias": "SensorB",
+          "alias": "",
+          "csvWave": {
+            "timeStep": 60,
+            "valuesCSV": "0,0,2,2,1,1"
+          },
           "hide": false,
+          "lines": 10,
+          "points": [
+            [
+              4,
+              1616555060000
+            ],
+            [
+              5,
+              1616560081000
+            ],
+            [
+              4,
+              1616562217000
+            ],
+            [
+              5,
+              1616565458000
+            ]
+          ],
+          "pulseWave": {
+            "offCount": 3,
+            "offValue": 1,
+            "onCount": 3,
+            "onValue": 2,
+            "timeStep": 60
+          },
           "refId": "B",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "NORMAL,LOW,LOW,CRITICAL,CRITICAL,LOW,LOW,NORMAL,HIGH,CRITICAL"
+          "scenarioId": "manual_entry",
+          "stream": {
+            "bands": 1,
+            "noise": 2.2,
+            "speed": 250,
+            "spread": 3.5,
+            "type": "signal"
+          },
+          "stringInput": ""
         },
         {
-          "alias": "SensorA",
-          "hide": false,
+          "points": [
+            [
+              4,
+              1616557148000
+            ],
+            [
+              null,
+              1616558756000
+            ],
+            [
+              4,
+              1616561658000
+            ],
+            [
+              null,
+              1616562446000
+            ],
+            [
+              4,
+              1616564104000
+            ],
+            [
+              null,
+              1616564548000
+            ],
+            [
+              4,
+              1616564871000
+            ]
+          ],
           "refId": "C",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "NORMAL,NORMAL,NORMAL,NORMAL,CRITICAL,LOW,NORMAL,NORMAL,NORMAL,LOW"
+          "scenarioId": "manual_entry"
         }
       ],
-      "title": "State changes strings",
+      "title": "\"State changes\" Mode",
       "type": "timeline"
     },
     {
@@ -117,36 +195,9 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
-          "custom": {
-            "fillOpacity": 70,
-            "lineWidth": 1
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "true",
-                "result": {
-                  "color": "semi-dark-green",
-                  "index": 0,
-                  "text": "ON"
-                }
-              },
-              "type": "special"
-            },
-            {
-              "options": {
-                "match": "false",
-                "result": {
-                  "color": "semi-dark-red",
-                  "index": 1,
-                  "text": "OFF"
-                }
-              },
-              "type": "special"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -165,139 +216,43 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 13,
+        "w": 24,
         "x": 0,
-        "y": 7
+        "y": 10
       },
-      "id": 13,
+      "id": 9,
       "options": {
-        "alignValue": "center",
-        "colWidth": 1,
+        "colWidth": 0.9,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
         "mode": "changes",
-        "rowHeight": 0.98,
+        "rowHeight": 0.9,
         "showValue": "always"
       },
+      "pluginVersion": "7.5.0-pre",
       "targets": [
         {
           "alias": "",
           "refId": "A",
           "scenarioId": "csv_metric_values",
-          "stringInput": "true,false,true,true,true,true,false,false"
+          "stringInput": "a,a,b,b,b,b,c,a,a,d,d,d,d,d"
         },
         {
-          "hide": false,
+          "alias": "",
           "refId": "B",
           "scenarioId": "csv_metric_values",
-          "stringInput": "false,true,false,true,true,false,false,false,true,true"
+          "stringInput": "null,null,e,e,e,null,null,e,null,null,e,null,e,e,e,e"
         },
         {
-          "hide": false,
           "refId": "C",
           "scenarioId": "csv_metric_values",
-          "stringInput": "true,false,true,true"
-        },
-        {
-          "hide": false,
-          "refId": "D",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "false,true,false,true,true"
+          "stringInput": "true,null,false,null,true,false"
         }
       ],
-      "title": "State changes with boolean values",
-      "type": "timeline"
-    },
-    {
-      "datasource": null,
-      "description": "Should show gaps",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "true",
-                "result": {
-                  "color": "semi-dark-green",
-                  "index": 0,
-                  "text": "ON"
-                }
-              },
-              "type": "special"
-            },
-            {
-              "options": {
-                "match": "false",
-                "result": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "OFF"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 11,
-        "x": 13,
-        "y": 7
-      },
-      "id": 12,
-      "options": {
-        "alignValue": "center",
-        "colWidth": 1,
-        "mode": "changes",
-        "rowHeight": 0.98,
-        "showValue": "always"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "true,false,true,true,true,true,false,false"
-        },
-        {
-          "hide": false,
-          "refId": "B",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "false,true,false,true,true,false,false,false,true,true"
-        },
-        {
-          "hide": false,
-          "refId": "C",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "true,false,null,true,true"
-        },
-        {
-          "hide": false,
-          "refId": "D",
-          "scenarioId": "csv_metric_values",
-          "stringInput": "false,null,null,false,true,true"
-        }
-      ],
-      "title": "State changes with nulls",
+      "title": "\"State changes\" Mode (strings & booleans)",
       "type": "timeline"
     },
     {
@@ -305,16 +260,9 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "palette-classic"
           },
-          "custom": {
-            "fillOpacity": 96,
-            "lineWidth": 0
-          },
-          "decimals": 0,
           "mappings": [],
-          "max": 30,
-          "min": -10,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -333,24 +281,23 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
+        "h": 11,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 21
       },
       "id": 4,
       "interval": null,
       "maxDataPoints": 20,
       "options": {
-        "alignValue": "center",
-        "colWidth": 0.96,
+        "colWidth": 0.9,
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom"
         },
         "mode": "samples",
-        "rowHeight": 0.98,
+        "rowHeight": 0.9,
         "showValue": "always"
       },
       "pluginVersion": "7.5.0-pre",
@@ -362,9 +309,6 @@
             "valuesCSV": "0,0,2,2,1,1"
           },
           "lines": 10,
-          "max": 30,
-          "min": -10,
-          "noise": 2,
           "points": [],
           "pulseWave": {
             "offCount": 3,
@@ -376,8 +320,7 @@
           "refId": "A",
           "scenarioId": "random_walk",
           "seriesCount": 4,
-          "spread": 15,
-          "startValue": 5,
+          "spread": 14.9,
           "stream": {
             "bands": 1,
             "noise": 2.2,
@@ -393,19 +336,19 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 30,
+  "schemaVersion": 29,
   "style": "dark",
   "tags": ["gdev", "panel-tests"],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-1h",
-    "to": "now"
+    "from": "2021-03-24T03:00:00.000Z",
+    "to": "2021-03-24T07:00:00.000Z"
   },
   "timepicker": {},
   "timezone": "utc",
   "title": "Timeline Modes",
   "uid": "mIJjFy8Gz",
-  "version": 14
+  "version": 7
 }

--- a/devenv/dev-dashboards/panel-timeline/timeline-modes.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-modes.json
@@ -14,7 +14,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 0,  
   "links": [],
   "panels": [
     {
@@ -24,7 +24,33 @@
           "color": {
             "mode": "palette-classic"
           },
-          "mappings": [],
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "CRITICAL": {
+                  "color": "red",
+                  "index": 3
+                },
+                "HIGH": {
+                  "color": "orange",
+                  "index": 2
+                },
+                "LOW": {
+                  "color": "blue",
+                  "index": 0
+                },
+                "NORMAL": {
+                  "color": "green",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -42,13 +68,14 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 7,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 8,
+      "id": 9,
       "options": {
+        "alignValue": "center",
         "colWidth": 0.9,
         "legend": {
           "calcs": [],
@@ -56,138 +83,33 @@
           "placement": "bottom"
         },
         "mode": "changes",
-        "rowHeight": 0.9,
+        "rowHeight": 0.98,
         "showValue": "always"
       },
       "pluginVersion": "7.5.0-pre",
       "targets": [
         {
-          "alias": "",
-          "csvWave": {
-            "timeStep": 60,
-            "valuesCSV": "0,0,2,2,1,1"
-          },
-          "lines": 10,
-          "points": [
-            [
-              0,
-              1616551651000
-            ],
-            [
-              1,
-              1616556554000
-            ],
-            [
-              2,
-              1616559873000
-            ],
-            [
-              0,
-              1616561077000
-            ],
-            [
-              3,
-              1616563090000
-            ]
-          ],
-          "pulseWave": {
-            "offCount": 3,
-            "offValue": 1,
-            "onCount": 3,
-            "onValue": 2,
-            "timeStep": 60
-          },
+          "alias": "SensorA",
           "refId": "A",
-          "scenarioId": "manual_entry",
-          "stream": {
-            "bands": 1,
-            "noise": 2.2,
-            "speed": 250,
-            "spread": 3.5,
-            "type": "signal"
-          },
-          "stringInput": ""
+          "scenarioId": "csv_metric_values",
+          "stringInput": "LOW,HIGH,NORMAL,NORMAL,NORMAL,LOW,LOW,NORMAL,HIGH,CRITICAL"
         },
         {
-          "alias": "",
-          "csvWave": {
-            "timeStep": 60,
-            "valuesCSV": "0,0,2,2,1,1"
-          },
+          "alias": "SensorB",
           "hide": false,
-          "lines": 10,
-          "points": [
-            [
-              4,
-              1616555060000
-            ],
-            [
-              5,
-              1616560081000
-            ],
-            [
-              4,
-              1616562217000
-            ],
-            [
-              5,
-              1616565458000
-            ]
-          ],
-          "pulseWave": {
-            "offCount": 3,
-            "offValue": 1,
-            "onCount": 3,
-            "onValue": 2,
-            "timeStep": 60
-          },
           "refId": "B",
-          "scenarioId": "manual_entry",
-          "stream": {
-            "bands": 1,
-            "noise": 2.2,
-            "speed": 250,
-            "spread": 3.5,
-            "type": "signal"
-          },
-          "stringInput": ""
+          "scenarioId": "csv_metric_values",
+          "stringInput": "NORMAL,LOW,LOW,CRITICAL,CRITICAL,LOW,LOW,NORMAL,HIGH,CRITICAL"
         },
         {
-          "points": [
-            [
-              4,
-              1616557148000
-            ],
-            [
-              null,
-              1616558756000
-            ],
-            [
-              4,
-              1616561658000
-            ],
-            [
-              null,
-              1616562446000
-            ],
-            [
-              4,
-              1616564104000
-            ],
-            [
-              null,
-              1616564548000
-            ],
-            [
-              4,
-              1616564871000
-            ]
-          ],
+          "alias": "SensorA",
+          "hide": false,
           "refId": "C",
-          "scenarioId": "manual_entry"
+          "scenarioId": "csv_metric_values",
+          "stringInput": "NORMAL,NORMAL,NORMAL,NORMAL,CRITICAL,LOW,NORMAL,NORMAL,NORMAL,LOW"
         }
       ],
-      "title": "\"State changes\" Mode",
+      "title": "State changes strings",
       "type": "timeline"
     },
     {
@@ -195,9 +117,36 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
-          "mappings": [],
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "true",
+                "result": {
+                  "color": "semi-dark-green",
+                  "index": 0,
+                  "text": "ON"
+                }
+              },
+              "type": "special"
+            },
+            {
+              "options": {
+                "match": "false",
+                "result": {
+                  "color": "semi-dark-red",
+                  "index": 1,
+                  "text": "OFF"
+                }
+              },
+              "type": "special"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -216,43 +165,139 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 24,
+        "w": 13,
         "x": 0,
-        "y": 10
+        "y": 7
       },
-      "id": 9,
+      "id": 13,
       "options": {
-        "colWidth": 0.9,
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
+        "alignValue": "center",
+        "colWidth": 1,
         "mode": "changes",
-        "rowHeight": 0.9,
+        "rowHeight": 0.98,
         "showValue": "always"
       },
-      "pluginVersion": "7.5.0-pre",
       "targets": [
         {
           "alias": "",
           "refId": "A",
           "scenarioId": "csv_metric_values",
-          "stringInput": "a,a,b,b,b,b,c,a,a,d,d,d,d,d"
+          "stringInput": "true,false,true,true,true,true,false,false"
         },
         {
-          "alias": "",
+          "hide": false,
           "refId": "B",
           "scenarioId": "csv_metric_values",
-          "stringInput": "null,null,e,e,e,null,null,e,null,null,e,null,e,e,e,e"
+          "stringInput": "false,true,false,true,true,false,false,false,true,true"
         },
         {
+          "hide": false,
           "refId": "C",
           "scenarioId": "csv_metric_values",
-          "stringInput": "true,null,false,null,true,false"
+          "stringInput": "true,false,true,true"
+        },
+        {
+          "hide": false,
+          "refId": "D",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "false,true,false,true,true"
         }
       ],
-      "title": "\"State changes\" Mode (strings & booleans)",
+      "title": "State changes with boolean values",
+      "type": "timeline"
+    },
+    {
+      "datasource": null,
+      "description": "Should show gaps",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "true",
+                "result": {
+                  "color": "semi-dark-green",
+                  "index": 0,
+                  "text": "ON"
+                }
+              },
+              "type": "special"
+            },
+            {
+              "options": {
+                "match": "false",
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "OFF"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 11,
+        "x": 13,
+        "y": 7
+      },
+      "id": 12,
+      "options": {
+        "alignValue": "center",
+        "colWidth": 1,
+        "mode": "changes",
+        "rowHeight": 0.98,
+        "showValue": "always"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "true,false,true,true,true,true,false,false"
+        },
+        {
+          "hide": false,
+          "refId": "B",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "false,true,false,true,true,false,false,false,true,true"
+        },
+        {
+          "hide": false,
+          "refId": "C",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "true,false,null,true,true"
+        },
+        {
+          "hide": false,
+          "refId": "D",
+          "scenarioId": "csv_metric_values",
+          "stringInput": "false,null,null,false,true,true"
+        }
+      ],
+      "title": "State changes with nulls",
       "type": "timeline"
     },
     {
@@ -260,9 +305,16 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-GrYlRd"
           },
+          "custom": {
+            "fillOpacity": 96,
+            "lineWidth": 0
+          },
+          "decimals": 0,
           "mappings": [],
+          "max": 30,
+          "min": -10,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -281,23 +333,24 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
+        "h": 12,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 18
       },
       "id": 4,
       "interval": null,
       "maxDataPoints": 20,
       "options": {
-        "colWidth": 0.9,
+        "alignValue": "center",
+        "colWidth": 0.96,
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom"
         },
         "mode": "samples",
-        "rowHeight": 0.9,
+        "rowHeight": 0.98,
         "showValue": "always"
       },
       "pluginVersion": "7.5.0-pre",
@@ -309,6 +362,9 @@
             "valuesCSV": "0,0,2,2,1,1"
           },
           "lines": 10,
+          "max": 30,
+          "min": -10,
+          "noise": 2,
           "points": [],
           "pulseWave": {
             "offCount": 3,
@@ -320,7 +376,8 @@
           "refId": "A",
           "scenarioId": "random_walk",
           "seriesCount": 4,
-          "spread": 14.9,
+          "spread": 15,
+          "startValue": 5,
           "stream": {
             "bands": 1,
             "noise": 2.2,
@@ -336,19 +393,19 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 29,
+  "schemaVersion": 30,
   "style": "dark",
-  "tags": [],
+  "tags": ["gdev", "panel-tests"],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "2021-03-24T03:00:00.000Z",
-    "to": "2021-03-24T07:00:00.000Z"
+    "from": "now-1h",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "utc",
   "title": "Timeline Modes",
   "uid": "mIJjFy8Gz",
-  "version": 7
+  "version": 14
 }

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -257,7 +257,7 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
 
   function getContrastText(background: string, threshold: number = contrastThreshold) {
     const contrastText =
-      getContrastRatio(background, dark.text.maxContrast) >= threshold ? dark.text.maxContrast : light.text.maxContrast;
+      getContrastRatio(dark.text.maxContrast, background) >= threshold ? dark.text.maxContrast : light.text.maxContrast;
     // todo, need color framework
     return contrastText;
   }

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -1,6 +1,5 @@
 import { FieldConfigEditorProps, FieldConfigPropertyItem, FieldConfigEditorConfig } from '../types/fieldOverrides';
 import { OptionsUIRegistryBuilder } from '../types/OptionsUIRegistryBuilder';
-import { FieldType } from '../types/dataFrame';
 import { PanelOptionsEditorConfig, PanelOptionsEditorItem } from '../types/panel';
 import {
   numberOverrideProcessor,
@@ -33,7 +32,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
       override: standardEditorsRegistry.get('number').editor as any,
       editor: standardEditorsRegistry.get('number').editor as any,
       process: numberOverrideProcessor,
-      shouldApply: config.shouldApply ? config.shouldApply : (field) => field.type === FieldType.number,
+      shouldApply: config.shouldApply ?? (() => true),
       settings: config.settings || {},
     });
   }
@@ -45,7 +44,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
       override: standardEditorsRegistry.get('slider').editor as any,
       editor: standardEditorsRegistry.get('slider').editor as any,
       process: numberOverrideProcessor,
-      shouldApply: config.shouldApply ? config.shouldApply : (field) => field.type === FieldType.number,
+      shouldApply: config.shouldApply ?? (() => true),
       settings: config.settings || {},
     });
   }
@@ -57,7 +56,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
       override: standardEditorsRegistry.get('text').editor as any,
       editor: standardEditorsRegistry.get('text').editor as any,
       process: stringOverrideProcessor,
-      shouldApply: config.shouldApply ? config.shouldApply : (field) => field.type === FieldType.string,
+      shouldApply: config.shouldApply ?? (() => true),
       settings: config.settings || {},
     });
   }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -107,6 +107,7 @@ export class UPlotConfigBuilder {
   setStacking(enabled = true) {
     this.isStacking = enabled;
   }
+
   addSeries(props: SeriesProps) {
     this.series.push(new UPlotSeriesBuilder(props));
   }

--- a/public/app/plugins/panel/timeline/module.tsx
+++ b/public/app/plugins/panel/timeline/module.tsx
@@ -1,6 +1,6 @@
 import { FieldColorModeId, FieldConfigProperty, PanelPlugin } from '@grafana/data';
 import { TimelinePanel } from './TimelinePanel';
-import { TimelineOptions, TimelineFieldConfig, TimelineMode } from './types';
+import { TimelineOptions, TimelineFieldConfig, TimelineMode, defaultTimelineFieldConfig } from './types';
 import { BarValueVisibility } from '@grafana/ui';
 
 export const plugin = new PanelPlugin<TimelineOptions, TimelineFieldConfig>(TimelinePanel)
@@ -15,15 +15,12 @@ export const plugin = new PanelPlugin<TimelineOptions, TimelineFieldConfig>(Time
         },
       },
     },
-    /*
     useCustomConfig: (builder) => {
-      const cfg = defaultBarChartFieldConfig;
-
       builder
         .addSliderInput({
           path: 'lineWidth',
           name: 'Line width',
-          defaultValue: cfg.lineWidth,
+          defaultValue: defaultTimelineFieldConfig.lineWidth,
           settings: {
             min: 0,
             max: 10,
@@ -33,26 +30,14 @@ export const plugin = new PanelPlugin<TimelineOptions, TimelineFieldConfig>(Time
         .addSliderInput({
           path: 'fillOpacity',
           name: 'Fill opacity',
-          defaultValue: cfg.fillOpacity,
+          defaultValue: defaultTimelineFieldConfig.fillOpacity,
           settings: {
             min: 0,
             max: 100,
             step: 1,
           },
-        })
-        .addRadio({
-          path: 'gradientMode',
-          name: 'Gradient mode',
-          defaultValue: graphFieldOptions.fillGradient[0].value,
-          settings: {
-            options: graphFieldOptions.fillGradient,
-          },
         });
-
-      // addAxisConfig(builder, cfg, true);
-      addHideFrom(builder);
     },
-    */
   })
   .setPanelOptions((builder) => {
     builder

--- a/public/app/plugins/panel/timeline/types.ts
+++ b/public/app/plugins/panel/timeline/types.ts
@@ -1,4 +1,4 @@
-import { VizLegendOptions, GraphGradientMode, HideableFieldConfig, BarValueVisibility } from '@grafana/ui';
+import { VizLegendOptions, HideableFieldConfig, BarValueVisibility } from '@grafana/ui';
 
 /**
  * @alpha
@@ -20,7 +20,6 @@ export type TimelineValueAlignment = 'center' | 'left' | 'right';
 export interface TimelineFieldConfig extends HideableFieldConfig {
   lineWidth?: number; // 0
   fillOpacity?: number; // 100
-  gradientMode?: GraphGradientMode;
 }
 
 /**
@@ -28,8 +27,7 @@ export interface TimelineFieldConfig extends HideableFieldConfig {
  */
 export const defaultTimelineFieldConfig: TimelineFieldConfig = {
   lineWidth: 1,
-  fillOpacity: 80,
-  gradientMode: GraphGradientMode.None,
+  fillOpacity: 70,
 };
 
 /**

--- a/public/app/plugins/panel/timeline/utils.ts
+++ b/public/app/plugins/panel/timeline/utils.ts
@@ -11,20 +11,13 @@ import {
 } from '@grafana/data';
 import { UPlotConfigBuilder, FIXED_UNIT, SeriesVisibilityChangeMode, UPlotConfigPrepFn } from '@grafana/ui';
 import { TimelineCoreOptions, getConfig } from './timeline';
-import {
-  AxisPlacement,
-  GraphGradientMode,
-  ScaleDirection,
-  ScaleOrientation,
-} from '@grafana/ui/src/components/uPlot/config';
+import { AxisPlacement, ScaleDirection, ScaleOrientation } from '@grafana/ui/src/components/uPlot/config';
 import { measureText } from '@grafana/ui/src/utils/measureText';
-
 import { TimelineFieldConfig, TimelineOptions } from './types';
 
 const defaultConfig: TimelineFieldConfig = {
   lineWidth: 0,
   fillOpacity: 80,
-  gradientMode: GraphGradientMode.None,
 };
 
 export function mapMouseEventToMode(event: React.MouseEvent): SeriesVisibilityChangeMode {
@@ -61,7 +54,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
     return !(mode && field.display && mode.startsWith('continuous-'));
   };
 
-  const colorLookup = (seriesIdx: number, value: any) => {
+  const getValueColor = (seriesIdx: number, value: any) => {
     const field = frame.fields[seriesIdx];
 
     if (field.display) {
@@ -93,9 +86,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
     alignValue,
     theme,
     label: (seriesIdx) => getFieldDisplayName(frame.fields[seriesIdx], frame),
-    fill: colorLookup,
-    stroke: colorLookup,
-    colorLookup,
+    getFieldConfig: (seriesIdx) => frame.fields[seriesIdx].config.custom,
+    getValueColor,
     getTimeRange,
     // hardcoded formatter for state values
     formatValue: (seriesIdx, value) => formattedValueToString(frame.fields[seriesIdx].display!(value)),
@@ -170,17 +162,16 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
 
     field.state!.seriesIndex = seriesIndex++;
 
-    //const scaleKey = config.unit || FIXED_UNIT;
-    //const colorMode = getFieldColorModeForField(field);
-
-    let { fillOpacity } = customConfig;
+    // const scaleKey = config.unit || FIXED_UNIT;
+    // const colorMode = getFieldColorModeForField(field);
 
     builder.addSeries({
       scaleKey: FIXED_UNIT,
       pathBuilder: coreConfig.drawPaths,
       pointsBuilder: coreConfig.drawPoints,
       //colorMode,
-      fillOpacity,
+      lineWidth: customConfig.lineWidth,
+      fillOpacity: customConfig.fillOpacity,
       theme,
       show: !customConfig.hideFrom?.viz,
       thresholds: config.thresholds,


### PR DESCRIPTION

* [x] Minor refactorings to improve code readability, but struggling a lot with how to write tests for the timeline code and how to reduce nesting 
* [x] Adds fillOpacity option and lineWidth 
* [x] Tested a lot with a gradient modes but none impressed so skipping that option for now 
* [x] Updates the test dashboard 

 There is an issue with getContastText where it does not take into account opacity colors, created issue for that: https://github.com/grafana/grafana/issues/34117 

There is also an issue with line width does not actually work for "state changes" mode,  strokePaths map only contains style (color) and path not lineWidth, so in
https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/timeline/timeline.ts#L114 there is no access to stokeWidth 

![Screenshot from 2021-05-14 12-58-23](https://user-images.githubusercontent.com/10999/118261619-15ee8c00-b4b4-11eb-9f79-8d0f0c9d939b.png)
