### PR TITLE
Alerting: Copy secure settings only if they are missing

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -190,9 +190,6 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 		}
 	}
 
-	// dont do anything if its the default configuration or there no receivers
-	// copy over the secrets from the last known working configuration
-	// save it
 	currentConfig, err := notifier.Load([]byte(query.Result.AlertmanagerConfiguration))
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "failed to load lastest configuration", err)
@@ -201,6 +198,9 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 	// Copy the previously known secure settings
 	for i, r := range body.AlertmanagerConfig.Receivers {
 		for j, gr := range r.PostableGrafanaReceivers.GrafanaManagedReceivers {
+			if len(currentConfig.AlertmanagerConfig.Receivers) <= i { // if we don't have a receiver for this position - skip it.
+				continue
+			}
 			cr := currentConfig.AlertmanagerConfig.Receivers[i]
 			if cr != nil && len(cr.PostableGrafanaReceivers.GrafanaManagedReceivers) < j { //  if it's a newly introduced receiver it does not exist in the current configuration
 				cgmr := cr.PostableGrafanaReceivers.GrafanaManagedReceivers[j]

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -11,6 +13,7 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -177,10 +180,7 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 	if !c.HasUserRole(models.ROLE_EDITOR) {
 		return response.Error(http.StatusForbidden, "Permission denied", nil)
 	}
-	err := body.EncryptSecureSettings()
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "failed to encrypt receiver secrets", err)
-	}
+
 	// Get the last known working configuration
 	query := ngmodels.GetLatestAlertmanagerConfigurationQuery{}
 	if err := srv.store.GetLatestAlertmanagerConfiguration(&query); err != nil {
@@ -202,15 +202,35 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 	for i, r := range body.AlertmanagerConfig.Receivers {
 		for j, gr := range r.PostableGrafanaReceivers.GrafanaManagedReceivers {
 			cr := currentConfig.AlertmanagerConfig.Receivers[i]
-			if cr != nil {
+			if cr != nil && len(cr.PostableGrafanaReceivers.GrafanaManagedReceivers) < j { //  if it's a newly introduced receiver it does not exist in the current configuration
 				cgmr := cr.PostableGrafanaReceivers.GrafanaManagedReceivers[j]
 				if cgmr != nil {
 					if cgmr.Name == gr.Name && cgmr.Type == gr.Type {
-						body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings = cgmr.SecureSettings
+						// frontend sends only the secure settings that have to be updated
+						// therefore we have to copy from the last configuration only those secure settings not included in the request
+						// body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings = cgmr.SecureSettings
+						for key, storedValue := range cgmr.SecureSettings {
+							_, ok := body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings[key]
+							if !ok {
+								decodeValue, err := base64.StdEncoding.DecodeString(storedValue)
+								if err != nil {
+									return response.Error(http.StatusInternalServerError, fmt.Sprintf("failed to decode stored secure setting: %s", key), err)
+								}
+								decryptedValue, err := util.Decrypt([]byte(decodeValue), setting.SecretKey)
+								if err != nil {
+									return response.Error(http.StatusInternalServerError, fmt.Sprintf("failed to decrypt stored secure setting: %s", key), err)
+								}
+								body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings[key] = string(decryptedValue)
+							}
+						}
 					}
 				}
 			}
 		}
+	}
+
+	if err := body.EncryptSecureSettings(); err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to encrypt receiver secrets", err)
 	}
 
 	if err := srv.am.SaveAndApplyConfig(&body); err != nil {

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -208,7 +208,6 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 					if cgmr.Name == gr.Name && cgmr.Type == gr.Type {
 						// frontend sends only the secure settings that have to be updated
 						// therefore we have to copy from the last configuration only those secure settings not included in the request
-						// body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings = cgmr.SecureSettings
 						for key, storedValue := range cgmr.SecureSettings {
 							_, ok := body.AlertmanagerConfig.Receivers[i].PostableGrafanaReceivers.GrafanaManagedReceivers[j].SecureSettings[key]
 							if !ok {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Targets #33539
The frontend sends in the request only the secure settings that have to be updated. Therefore, we need copy from the latest configuration only those not included in the request.
There are two issues that need to address better in subsequent fixes:
- we identify the receivers using the name and the type but this is not safe because the name can change etc
- we assume that the receiver order is preserved (which is what the frontend does) but this is not necessarily true if users directly call the API.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
How to test:
- create a receiver and a secure setting (eg wrong password)
- update the receiver and provide the correct setting
- make sure that you receive a notification
