### PR TITLE
Annotations panel: Remove subpath from dashboard links

### DIFF
--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -55,7 +55,7 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
 
   constructor() {
     const baseURL = window.location.origin.replace('http', 'ws');
-    const liveUrl = `${baseURL}/${config.appSubUrl}api/live/ws`;
+    const liveUrl = `${baseURL}${config.appSubUrl}/api/live/ws`;
     this.orgId = (window as any).grafanaBootData.user.orgId;
     this.centrifuge = new Centrifuge(liveUrl, {
       debug: true,

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -2,8 +2,8 @@
 import React, { PureComponent } from 'react';
 // Types
 import { AnnoOptions } from './types';
-import { AnnotationEvent, AppEvents, dateTime, DurationUnit, PanelProps } from '@grafana/data';
-import { getBackendSrv, getLocationSrv } from '@grafana/runtime';
+import { AnnotationEvent, AppEvents, dateTime, DurationUnit, locationUtil, PanelProps } from '@grafana/data';
+import { getBackendSrv, locationService } from '@grafana/runtime';
 import { AbstractList } from '@grafana/ui/src/components/List/AbstractList';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import appEvents from 'app/core/app_events';
@@ -121,10 +121,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     }
 
     if (current?.id === anno.dashboardId) {
-      getLocationSrv().update({
-        query: params,
-        partial: true,
-      });
+      locationService.partial(params);
       return;
     }
 
@@ -133,10 +130,8 @@ export class AnnoListPanel extends PureComponent<Props, State> {
       .then((res: any[]) => {
         if (res && res.length && res[0].id === anno.dashboardId) {
           const dash = res[0];
-          getLocationSrv().update({
-            query: params,
-            path: dash.url,
-          });
+          const newUrl = locationUtil.stripBaseFromUrl(dash.url);
+          locationService.push(newUrl);
           return;
         }
         appEvents.emit(AppEvents.alertWarning, ['Unknown Dashboard: ' + anno.dashboardId]);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The annotation panel doesn't strip the baseUrl from links to dashboards. This causes `localhost:3000/grafana/grafana` to be prepended when clicking annotation links in the panel if a subpath has been defined in the `.ini`.

I also updated the centrifuge liveUrl as it wasn't able to connect when a subpath is defined as it was trying to connect to `ws:localhost:3000/grafanaapi/live/ws`. From testing it appears the `appSubUrl` has the trailing slash removed regardless of setting it in the `.ini` config. Would appreciate your eyes on this @ryantxu as I'm not familiar with the service.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #33917

**Special notes for your reviewer**:

