### PR TITLE
Docs: Download logs as text update

### DIFF
--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -53,6 +53,8 @@ For logs where a **level** label is specified, we use the value of the label to 
 
 Logs navigation next to the log lines can be used to request more logs. You can do this by clicking on Older logs button on the bottom of navigation. This is especially useful when you hit the line limit and you want to see more logs. Each request that is run from the navigation is then displayed in the navigation as separate page. Every page is showing from and to timestamp of the incoming log lines. You can re-rerun the same request by clicking on the page.
 
+![Navigate logs in Explore](/img/docs/explore/navigate-logs-8-0.png)
+
 ### Visualization options
 
 You can customize how logs are displayed and select which columns are shown.

--- a/docs/sources/panels/inspect-panel.md
+++ b/docs/sources/panels/inspect-panel.md
@@ -67,9 +67,9 @@ Grafana generates a CSV file in your default browser download location. You can 
 
 To download a CSV file specifically formatted for Excel, expand the **Data options** panel and enable the **Download for Excel** toggle before clicking **Download CSV**.
 
-### Download log results as TXT
+### Download log results as text
 
-Grafana generates a text file in your default browser download location. You can open the log in the viewer of your choice.
+Grafana generates a text (.txt) file in your default browser download location. You can open the log in the viewer of your choice.
 
 1. Open the panel inspector.
 1. Inspect the log query results as described above.

--- a/docs/sources/panels/inspect-panel.md
+++ b/docs/sources/panels/inspect-panel.md
@@ -67,7 +67,7 @@ Grafana generates a CSV file in your default browser download location. You can 
 
 To download a CSV file specifically formatted for Excel, expand the **Data options** panel and enable the **Download for Excel** toggle before clicking **Download CSV**.
 
-### Download log results as text
+### Download log results
 
 Grafana generates a text (.txt) file in your default browser download location. You can open the log in the viewer of your choice.
 

--- a/docs/sources/whatsnew/whats-new-in-v8-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-0.md
@@ -36,17 +36,25 @@ New visualization that allows categorical data display. Following the new panel 
 - You can now search panel options.
 - Value mapping has been completely redesigned.
 
-### Download logs
+### Download logs from the panel inspector
 
-You can now download log results as a text (.txt) file. You can access this feature through the Data tab in the Panel inspector and Inspector in Explore.
+When you inspect a panel, you can now download log results as a text (.txt) file.
+
+[Download log results]({{< relref "../panels/inspect-panel.md#download-log-results" >}}) in [Inspect a panel]({{< relref "../panels/inspect-panel.md" >}}) was added as a result of this feature.
 
 ### Inspector in Explore
 
 The new Explore inspector helps you understand and troubleshoot your queries. You can inspect the raw data, export that data to a comma-separated values (CSV) file, export log results in text format, and view query requests.
 
-### Log improvements
+[Inspector in Explore]({{< relref "../explore/explore-inspector.md" >}}) was added as a result of this feature.
 
-Logs navigation next to the log lines can be used to request more logs. You can do this by clicking on the Older logs button on the bottom of navigation. This is especially useful when you hit the line limit and you want to see more logs. Each request that is run from the navigation is then displayed in the navigation as a separate page. Every page is showing from and to timestamp of the incoming log lines. You can re-rerun the same request by clicking on the page.
+### Explore log improvements
+
+Log navigation in Explore has been significantly improved. We added pagination to logs, so you can click through older or newer logs as needed.
+
+[Logs in Explore]({{< relref "../explore/logs-integration.md" >}}) was updated as a result of these changes.
+
+![Navigate logs in Explore](/img/docs/explore/navigate-logs-8-0.png)
 
 ### Tracing improvements
 


### PR DESCRIPTION
Updated What's new in Grafana 8.0 with links to content and images for the download logs updates.

Image is in https://github.com/grafana/website/pull/4427