### PR TITLE
NGAlert: Add GoogleChat notification channel

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -430,6 +430,8 @@ func (am *Alertmanager) buildReceiverIntegrations(receiver *apimodels.PostableAp
 			n, err = channels.NewDiscordNotifier(cfg, tmpl)
 		case "alertmanager":
 			n, err = channels.NewAlertmanagerNotifier(cfg, tmpl)
+		case "googlechat":
+			n, err = channels.NewGoogleChatNotifier(cfg, tmpl)
 		default:
 			return nil, fmt.Errorf("notifier %s is not supported", r.Type)
 		}

--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -620,5 +620,21 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 				},
 			},
 		},
+		{
+			Type:        "googlechat",
+			Name:        "Google Hangouts Chat",
+			Description: "Sends notifications to Google Hangouts Chat via webhooks based on the official JSON message format",
+			Heading:     "Google Hangouts Chat settings",
+			Options: []alerting.NotifierOption{
+				{
+					Label:        "Url",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					Placeholder:  "Google Hangouts Chat incoming webhook url",
+					PropertyName: "url",
+					Required:     true,
+				},
+			},
+		},
 	}
 }

--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -1,0 +1,194 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"time"
+
+	gokit_log "github.com/go-kit/kit/log"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	old_notifiers "github.com/grafana/grafana/pkg/services/alerting/notifiers"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// GoogleChatNotifier is responsible for sending
+// alert notifications to Google chat.
+type GoogleChatNotifier struct {
+	old_notifiers.NotifierBase
+	URL  string
+	log  log.Logger
+	tmpl *template.Template
+}
+
+func NewGoogleChatNotifier(model *NotificationChannelConfig, t *template.Template) (*GoogleChatNotifier, error) {
+	url := model.Settings.Get("url").MustString()
+	if url == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find url property in settings"}
+	}
+
+	return &GoogleChatNotifier{
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		URL:  url,
+		log:  log.New("alerting.notifier.googlechat"),
+		tmpl: t,
+	}, nil
+}
+
+// Notify send an alert notification to Google Chat.
+func (gcn *GoogleChatNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+	gcn.log.Debug("Executing Google Chat notification")
+
+	data := notify.GetTemplateData(ctx, gcn.tmpl, as, gokit_log.NewNopLogger())
+	var tmplErr error
+	tmpl := notify.TmplText(gcn.tmpl, data, &tmplErr)
+
+	widgets := []widget{}
+
+	if msg := tmpl(`{{ template "default.message" . }}`); msg != "" {
+		// Add a text paragraph widget for the message if there is a message.
+		// Google Chat API doesn't accept an empty text property.
+		widgets = append(widgets, textParagraphWidget{
+			Text: text{
+				Text: msg,
+			},
+		})
+	}
+
+	// Add a button widget (link to Grafana).
+	widgets = append(widgets, buttonWidget{
+		Buttons: []button{
+			{
+				TextButton: textButton{
+					Text: "OPEN IN GRAFANA",
+					OnClick: onClick{
+						OpenLink: openLink{
+							URL: path.Join(gcn.tmpl.ExternalURL.String(), "/alerting/list"),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// Add text paragraph widget for the build version and timestamp.
+	widgets = append(widgets, textParagraphWidget{
+		Text: text{
+			Text: "Grafana v" + setting.BuildVersion + " | " + (time.Now()).Format(time.RFC822),
+		},
+	})
+
+	// Nest the required structs.
+	res := &outerStruct{
+		PreviewText:  tmpl(`{{ template "default.title" . }}`),
+		FallbackText: tmpl(`{{ template "default.title" . }}`),
+		Cards: []card{
+			{
+				Header: header{
+					Title: tmpl(`{{ template "default.title" . }}`),
+				},
+				Sections: []section{
+					{
+						Widgets: widgets,
+					},
+				},
+			},
+		},
+	}
+
+	if tmplErr != nil {
+		return false, fmt.Errorf("failed to template GoogleChat message: %w", tmplErr)
+	}
+
+	body, err := json.Marshal(res)
+	if err != nil {
+		return false, fmt.Errorf("marshal json: %w", err)
+	}
+
+	cmd := &models.SendWebhookSync{
+		Url:        gcn.URL,
+		HttpMethod: "POST",
+		HttpHeader: map[string]string{
+			"Content-Type": "application/json; charset=UTF-8",
+		},
+		Body: string(body),
+	}
+
+	if err := bus.DispatchCtx(ctx, cmd); err != nil {
+		gcn.log.Error("Failed to send Google Hangouts Chat alert", "error", err, "webhook", gcn.Name)
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (gcn *GoogleChatNotifier) SendResolved() bool {
+	return !gcn.GetDisableResolveMessage()
+}
+
+// Structs used to build a custom Google Hangouts Chat message card.
+// See: https://developers.google.com/hangouts/chat/reference/message-formats/cards
+type outerStruct struct {
+	PreviewText  string `json:"previewText"`
+	FallbackText string `json:"fallbackText"`
+	Cards        []card `json:"cards"`
+}
+
+type card struct {
+	Header   header    `json:"header"`
+	Sections []section `json:"sections"`
+}
+
+type header struct {
+	Title string `json:"title"`
+}
+
+type section struct {
+	Widgets []widget `json:"widgets"`
+}
+
+// "generic" widget used to add different types of widgets (buttonWidget, textParagraphWidget, imageWidget)
+type widget interface{}
+
+type buttonWidget struct {
+	Buttons []button `json:"buttons"`
+}
+
+type textParagraphWidget struct {
+	Text text `json:"textParagraph"`
+}
+
+type text struct {
+	Text string `json:"text"`
+}
+
+type button struct {
+	TextButton textButton `json:"textButton"`
+}
+
+type textButton struct {
+	Text    string  `json:"text"`
+	OnClick onClick `json:"onClick"`
+}
+
+type onClick struct {
+	OpenLink openLink `json:"openLink"`
+}
+
+type openLink struct {
+	URL string `json:"url"`
+}

--- a/pkg/services/ngalert/notifier/channels/googlechat_test.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat_test.go
@@ -1,0 +1,207 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestGoogleChatNotifier(t *testing.T) {
+	tmpl := templateForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	cases := []struct {
+		name         string
+		settings     string
+		alerts       []*types.Alert
+		expMsg       *outerStruct
+		expInitError error
+		expMsgError  error
+	}{
+		{
+			name:     "One alert",
+			settings: `{"url": "http://localhost"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				},
+			},
+			expMsg: &outerStruct{
+				PreviewText:  "[FIRING:1]  (val1)",
+				FallbackText: "[FIRING:1]  (val1)",
+				Cards: []card{
+					{
+						Header: header{
+							Title: "[FIRING:1]  (val1)",
+						},
+						Sections: []section{
+							{
+								Widgets: []widget{
+									textParagraphWidget{
+										Text: text{
+											Text: "\n**Firing**\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: \n\n\n\n\n",
+										},
+									},
+									buttonWidget{
+										Buttons: []button{
+											{
+												TextButton: textButton{
+													Text: "OPEN IN GRAFANA",
+													OnClick: onClick{
+														OpenLink: openLink{
+															URL: "http:/localhost/alerting/list",
+														},
+													},
+												},
+											},
+										},
+									},
+									textParagraphWidget{
+										Text: text{
+											// RFC822 only has the minute, hence it works in most cases.
+											Text: "Grafana v" + setting.BuildVersion + " | " + (time.Now()).Format(time.RFC822),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name:     "Multiple alerts",
+			settings: `{"url": "http://localhost"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: &outerStruct{
+				PreviewText:  "[FIRING:2]  ",
+				FallbackText: "[FIRING:2]  ",
+				Cards: []card{
+					{
+						Header: header{
+							Title: "[FIRING:2]  ",
+						},
+						Sections: []section{
+							{
+								Widgets: []widget{
+									textParagraphWidget{
+										Text: text{
+											Text: "\n**Firing**\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSource: \nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSource: \n\n\n\n\n",
+										},
+									},
+									buttonWidget{
+										Buttons: []button{
+											{
+												TextButton: textButton{
+													Text: "OPEN IN GRAFANA",
+													OnClick: onClick{
+														OpenLink: openLink{
+															URL: "http:/localhost/alerting/list",
+														},
+													},
+												},
+											},
+										},
+									},
+									textParagraphWidget{
+										Text: text{
+											Text: "Grafana v" + setting.BuildVersion + " | " + (time.Now()).Format(time.RFC822),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name:         "Error in initing",
+			settings:     `{}`,
+			expInitError: alerting.ValidationError{Reason: "Could not find url property in settings"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
+			require.NoError(t, err)
+
+			m := &NotificationChannelConfig{
+				Name:     "googlechat_testing",
+				Type:     "googlechat",
+				Settings: settingsJSON,
+			}
+
+			pn, err := NewGoogleChatNotifier(m, tmpl)
+			if c.expInitError != nil {
+				require.Error(t, err)
+				require.Equal(t, c.expInitError.Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			body := ""
+			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+				body = webhook.Body
+				return nil
+			})
+
+			if time.Now().Second() == 59 {
+				// The notification payload has a time component with a precision
+				// of minute. So if we are at the edge of a minute, we delay for 1 second
+				// to avoid any flakiness.
+				time.Sleep(1 * time.Second)
+			}
+			ctx := notify.WithGroupKey(context.Background(), "alertname")
+			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+			ok, err := pn.Notify(ctx, c.alerts...)
+			if c.expMsgError != nil {
+				require.False(t, ok)
+				require.Error(t, err)
+				require.Equal(t, c.expMsgError.Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			expBody, err := json.Marshal(c.expMsg)
+			require.NoError(t, err)
+
+			require.JSONEq(t, string(expBody), body)
+		})
+	}
+}

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -1264,6 +1264,31 @@ var expAvailableChannelJsonOutput = `
 		"secure": false
 	  }
 	]
+  },
+  {
+    "type": "googlechat",
+    "name": "Google Hangouts Chat",
+    "heading": "Google Hangouts Chat settings",
+    "description": "Sends notifications to Google Hangouts Chat via webhooks based on the official JSON message format",
+    "info": "",
+    "options": [
+      {
+        "element": "input",
+        "inputType": "text",
+        "label": "Url",
+        "description": "",
+        "placeholder": "Google Hangouts Chat incoming webhook url",
+        "propertyName": "url",
+        "selectOptions": null,
+        "showWhen": {
+          "field": "",
+          "is": ""
+        },
+        "required": true,
+        "validationRule": "",
+        "secure": false
+      }
+    ]
   }
 ]
 `


### PR DESCRIPTION
**What this PR does / why we need it**:

Ports GoogleChat to ngalert.

I plan to add integration tests all at once later when we have a bunch of new channels in.