### PR TITLE
Replace numerical status codes with http constants

### DIFF
--- a/contribute/style-guides/backend.md
+++ b/contribute/style-guides/backend.md
@@ -98,3 +98,7 @@ drop-in alternative to the standard [encoding/json](https://golang.org/pkg/encod
 is a fine choice, profiling shows that json-iterator may be 3-4 times more efficient for encoding. We haven't profiled
 its parsing performance yet, but according to json-iterator's own benchmarks, it appears even more superior in this
 department.
+
+## HTTP
+
+For status codes prefer using http package constants rather than magic numbers, i.e. `http.StatusNotFound` instead of `404`. Constants are more descriptive, provide correct semantics and context of use.

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
@@ -20,15 +22,15 @@ func AdminGetSettings(c *models.ReqContext) response.Response {
 		}
 	}
 
-	return response.JSON(200, settings)
+	return response.JSON(http.StatusOK, settings)
 }
 
 func AdminGetStats(c *models.ReqContext) response.Response {
 	statsQuery := models.GetAdminStatsQuery{}
 
 	if err := bus.Dispatch(&statsQuery); err != nil {
-		return response.Error(500, "Failed to get admin stats from database", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get admin stats from database", err)
 	}
 
-	return response.JSON(200, statsQuery.Result)
+	return response.JSON(http.StatusOK, statsQuery.Result)
 }

--- a/pkg/api/admin_provisioning.go
+++ b/pkg/api/admin_provisioning.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
@@ -11,7 +12,7 @@ import (
 func (hs *HTTPServer) AdminProvisioningReloadDashboards(c *models.ReqContext) response.Response {
 	err := hs.ProvisioningService.ProvisionDashboards()
 	if err != nil && !errors.Is(err, context.Canceled) {
-		return response.Error(500, "", err)
+		return response.Error(http.StatusInternalServerError, "", err)
 	}
 	return response.Success("Dashboards config reloaded")
 }
@@ -19,7 +20,7 @@ func (hs *HTTPServer) AdminProvisioningReloadDashboards(c *models.ReqContext) re
 func (hs *HTTPServer) AdminProvisioningReloadDatasources(c *models.ReqContext) response.Response {
 	err := hs.ProvisioningService.ProvisionDatasources()
 	if err != nil {
-		return response.Error(500, "", err)
+		return response.Error(http.StatusInternalServerError, "", err)
 	}
 	return response.Success("Datasources config reloaded")
 }
@@ -27,7 +28,7 @@ func (hs *HTTPServer) AdminProvisioningReloadDatasources(c *models.ReqContext) r
 func (hs *HTTPServer) AdminProvisioningReloadPlugins(c *models.ReqContext) response.Response {
 	err := hs.ProvisioningService.ProvisionPlugins()
 	if err != nil {
-		return response.Error(500, "Failed to reload plugins config", err)
+		return response.Error(http.StatusInternalServerError, "Failed to reload plugins config", err)
 	}
 	return response.Success("Plugins config reloaded")
 }
@@ -35,7 +36,7 @@ func (hs *HTTPServer) AdminProvisioningReloadPlugins(c *models.ReqContext) respo
 func (hs *HTTPServer) AdminProvisioningReloadNotifications(c *models.ReqContext) response.Response {
 	err := hs.ProvisioningService.ProvisionNotifications()
 	if err != nil {
-		return response.Error(500, "", err)
+		return response.Error(http.StatusInternalServerError, "", err)
 	}
 	return response.Success("Notifications config reloaded")
 }

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -423,7 +423,6 @@ func DeleteAlertNotificationByUID(c *models.ReqContext) response.Response {
 		"message": "Notification deleted",
 		"id":      cmd.DeletedAlertNotificationId,
 	})
-
 }
 
 // POST /api/alert-notifications/test

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -89,7 +89,6 @@ func PostAnnotation(c *models.ReqContext, cmd dtos.PostAnnotationsCmd) response.
 		"message": "Annotation added",
 		"id":      startID,
 	})
-
 }
 
 func formatGraphiteAnnotation(what string, data string) string {
@@ -149,7 +148,6 @@ func PostGraphiteAnnotation(c *models.ReqContext, cmd dtos.PostGraphiteAnnotatio
 		"message": "Graphite annotation added",
 		"id":      item.Id,
 	})
-
 }
 
 func UpdateAnnotation(c *models.ReqContext, cmd dtos.UpdateAnnotationsCmd) response.Response {

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -280,7 +280,6 @@ func (hs *HTTPServer) deleteDashboard(c *models.ReqContext) response.Response {
 		"message": fmt.Sprintf("Dashboard %s deleted", dash.Title),
 		"id":      dash.Id,
 	})
-
 }
 
 func (hs *HTTPServer) PostDashboard(c *models.ReqContext, cmd models.SaveDashboardCommand) response.Response {
@@ -351,7 +350,6 @@ func (hs *HTTPServer) PostDashboard(c *models.ReqContext, cmd models.SaveDashboa
 				"status":  "pending",
 				"message": "changes were broadcast to the gitops listener",
 			})
-
 		}
 
 		if liveerr != nil {
@@ -386,7 +384,6 @@ func (hs *HTTPServer) PostDashboard(c *models.ReqContext, cmd models.SaveDashboa
 		"uid":     dashboard.Uid,
 		"url":     dashboard.GetUrl(),
 	})
-
 }
 
 func (hs *HTTPServer) dashboardSaveErrorToApiResponse(err error) response.Response {

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -237,7 +237,6 @@ func DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) response.Response 
 		"message": "Snapshot deleted. It might take an hour before it's cleared from any CDN caches.",
 		"id":      query.Result.Id,
 	})
-
 }
 
 // DELETE /api/snapshots/:key
@@ -287,7 +286,6 @@ func DeleteDashboardSnapshot(c *models.ReqContext) response.Response {
 		"message": "Snapshot deleted. It might take an hour before it's cleared from any CDN caches.",
 		"id":      query.Result.Id,
 	})
-
 }
 
 // GET /api/dashboard/snapshots

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -187,7 +187,6 @@ func DeleteDataSourceByName(c *models.ReqContext) response.Response {
 		"message": "Data source deleted",
 		"id":      getCmd.Result.Id,
 	})
-
 }
 
 func validateURL(tp string, u string) response.Response {
@@ -224,7 +223,6 @@ func AddDataSource(c *models.ReqContext, cmd models.AddDataSourceCommand) respon
 		"name":       cmd.Result.Name,
 		"datasource": ds,
 	})
-
 }
 
 func UpdateDataSource(c *models.ReqContext, cmd models.UpdateDataSourceCommand) response.Response {
@@ -268,7 +266,6 @@ func UpdateDataSource(c *models.ReqContext, cmd models.UpdateDataSourceCommand) 
 		"name":       cmd.Name,
 		"datasource": dtos,
 	})
-
 }
 
 func fillWithSecureJSONData(cmd *models.UpdateDataSourceCommand) error {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -106,7 +106,6 @@ func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // 
 		"message": fmt.Sprintf("Folder %s deleted", f.Title),
 		"id":      f.Id,
 	})
-
 }
 
 func toFolderDto(g guardian.DashboardGuardian, folder *models.Folder) dtos.Folder {

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -131,5 +131,4 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *models.ReqContext, apiCmd dtos.
 		"id":      folder.Id,
 		"title":   folder.Title,
 	})
-
 }

--- a/pkg/api/frontend_metrics.go
+++ b/pkg/api/frontend_metrics.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -17,5 +18,5 @@ func (hs *HTTPServer) PostFrontendMetrics(c *models.ReqContext, cmd metrics.Post
 			c.Logger.Debug("Received unknown frontend metric", "metric", name)
 		}
 	}
-	return response.Empty(200)
+	return response.Empty(http.StatusOK)
 }

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -167,20 +167,20 @@ func (hs *HTTPServer) PostSyncUserWithLDAP(c *models.ReqContext) response.Respon
 
 	if err := bus.Dispatch(&query); err != nil { // validate the userId exists
 		if errors.Is(err, models.ErrUserNotFound) {
-			return response.Error(404, models.ErrUserNotFound.Error(), nil)
+			return response.Error(http.StatusNotFound, models.ErrUserNotFound.Error(), nil)
 		}
 
-		return response.Error(500, "Failed to get user", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
 	}
 
 	authModuleQuery := &models.GetAuthInfoQuery{UserId: query.Result.Id, AuthModule: models.AuthModuleLDAP}
 
 	if err := bus.Dispatch(authModuleQuery); err != nil { // validate the userId comes from LDAP
 		if errors.Is(err, models.ErrUserNotFound) {
-			return response.Error(404, models.ErrUserNotFound.Error(), nil)
+			return response.Error(http.StatusNotFound, models.ErrUserNotFound.Error(), nil)
 		}
 
-		return response.Error(500, "Failed to get user", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
 	}
 
 	ldapServer := newLDAP(ldapConfig.Servers)
@@ -313,7 +313,7 @@ func (hs *HTTPServer) GetUserFromLDAP(c *models.ReqContext) response.Response {
 
 	u.Teams = cmd.Result
 
-	return response.JSON(200, u)
+	return response.JSON(http.StatusOK, u)
 }
 
 // splitName receives the full name of a user and splits it into two parts: A name and a surname.

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -163,10 +163,10 @@ func (hs *HTTPServer) tryOAuthAutoLogin(c *models.ReqContext) bool {
 
 func (hs *HTTPServer) LoginAPIPing(c *models.ReqContext) response.Response {
 	if c.IsSignedIn || c.IsAnonymous {
-		return response.JSON(200, "Logged in")
+		return response.JSON(http.StatusOK, "Logged in")
 	}
 
-	return response.Error(401, "Unauthorized", nil)
+	return response.Error(http.StatusUnauthorized, "Unauthorized", nil)
 }
 
 func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) response.Response {
@@ -204,7 +204,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) res
 	err := bus.Dispatch(authQuery)
 	authModule = authQuery.AuthModule
 	if err != nil {
-		resp = response.Error(401, "Invalid username or password", err)
+		resp = response.Error(http.StatusUnauthorized, "Invalid username or password", err)
 		if errors.Is(err, login.ErrInvalidCredentials) || errors.Is(err, login.ErrTooManyLoginAttempts) || errors.Is(err,
 			models.ErrUserNotFound) {
 			return resp
@@ -217,7 +217,7 @@ func (hs *HTTPServer) LoginPost(c *models.ReqContext, cmd dtos.LoginCommand) res
 			return resp
 		}
 
-		resp = response.Error(500, "Error while trying to authenticate user", err)
+		resp = response.Error(http.StatusInternalServerError, "Error while trying to authenticate user", err)
 		return resp
 	}
 

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -27,10 +28,10 @@ func (hs *HTTPServer) GetOrgByName(c *models.ReqContext) response.Response {
 	org, err := hs.SQLStore.GetOrgByName(c.Params(":name"))
 	if err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
-			return response.Error(404, "Organization not found", err)
+			return response.Error(http.StatusNotFound, "Organization not found", err)
 		}
 
-		return response.Error(500, "Failed to get organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get organization", err)
 	}
 	result := models.OrgDetailsDTO{
 		Id:   org.Id,
@@ -45,7 +46,7 @@ func (hs *HTTPServer) GetOrgByName(c *models.ReqContext) response.Response {
 		},
 	}
 
-	return response.JSON(200, &result)
+	return response.JSON(http.StatusOK, &result)
 }
 
 func getOrgHelper(orgID int64) response.Response {
@@ -53,10 +54,10 @@ func getOrgHelper(orgID int64) response.Response {
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
-			return response.Error(404, "Organization not found", err)
+			return response.Error(http.StatusNotFound, "Organization not found", err)
 		}
 
-		return response.Error(500, "Failed to get organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get organization", err)
 	}
 
 	org := query.Result
@@ -73,29 +74,30 @@ func getOrgHelper(orgID int64) response.Response {
 		},
 	}
 
-	return response.JSON(200, &result)
+	return response.JSON(http.StatusOK, &result)
 }
 
 // POST /api/orgs
 func CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Response {
 	if !c.IsSignedIn || (!setting.AllowUserOrgCreate && !c.IsGrafanaAdmin) {
-		return response.Error(403, "Access denied", nil)
+		return response.Error(http.StatusForbidden, "Access denied", nil)
 	}
 
 	cmd.UserId = c.UserId
 	if err := bus.Dispatch(&cmd); err != nil {
 		if errors.Is(err, models.ErrOrgNameTaken) {
-			return response.Error(409, "Organization name taken", err)
+			return response.Error(http.StatusConflict, "Organization name taken", err)
 		}
-		return response.Error(500, "Failed to create organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to create organization", err)
 	}
 
 	metrics.MApiOrgCreate.Inc()
 
-	return response.JSON(200, &util.DynMap{
+	return response.JSON(http.StatusOK, &util.DynMap{
 		"orgId":   cmd.Result.Id,
 		"message": "Organization created",
 	})
+
 }
 
 // PUT /api/org
@@ -112,9 +114,9 @@ func updateOrgHelper(form dtos.UpdateOrgForm, orgID int64) response.Response {
 	cmd := models.UpdateOrgCommand{Name: form.Name, OrgId: orgID}
 	if err := bus.Dispatch(&cmd); err != nil {
 		if errors.Is(err, models.ErrOrgNameTaken) {
-			return response.Error(400, "Organization name taken", err)
+			return response.Error(http.StatusBadRequest, "Organization name taken", err)
 		}
-		return response.Error(500, "Failed to update organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update organization", err)
 	}
 
 	return response.Success("Organization updated")
@@ -144,7 +146,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgID int64) respons
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to update org address", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update org address", err)
 	}
 
 	return response.Success("Address updated")
@@ -154,9 +156,9 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgID int64) respons
 func DeleteOrgByID(c *models.ReqContext) response.Response {
 	if err := bus.Dispatch(&models.DeleteOrgCommand{Id: c.ParamsInt64(":orgId")}); err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
-			return response.Error(404, "Failed to delete organization. ID not found", nil)
+			return response.Error(http.StatusNotFound, "Failed to delete organization. ID not found", nil)
 		}
-		return response.Error(500, "Failed to update organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update organization", err)
 	}
 	return response.Success("Organization deleted")
 }
@@ -177,8 +179,8 @@ func SearchOrgs(c *models.ReqContext) response.Response {
 	}
 
 	if err := bus.Dispatch(&query); err != nil {
-		return response.Error(500, "Failed to search orgs", err)
+		return response.Error(http.StatusInternalServerError, "Failed to search orgs", err)
 	}
 
-	return response.JSON(200, query.Result)
+	return response.JSON(http.StatusOK, query.Result)
 }

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -97,7 +97,6 @@ func CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Respo
 		"orgId":   cmd.Result.Id,
 		"message": "Organization created",
 	})
-
 }
 
 // PUT /api/org

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -129,7 +129,6 @@ func inviteExistingUserToOrg(c *models.ReqContext, user *models.User, inviteDto 
 		"message": fmt.Sprintf("Existing Grafana user %s added to org %s", user.NameOrFallback(), c.OrgName),
 		"userId":  user.Id,
 	})
-
 }
 
 func RevokeInvite(c *models.ReqContext) response.Response {
@@ -163,7 +162,6 @@ func GetInviteInfoByCode(c *models.ReqContext) response.Response {
 		Username:  invite.Email,
 		InvitedBy: util.StringsFallback3(invite.InvitedByName, invite.InvitedByLogin, invite.InvitedByEmail),
 	})
-
 }
 
 func (hs *HTTPServer) CompleteInvite(c *models.ReqContext, completeInvite dtos.CompleteInviteForm) response.Response {
@@ -221,7 +219,6 @@ func (hs *HTTPServer) CompleteInvite(c *models.ReqContext, completeInvite dtos.C
 		"message": "User created and logged in",
 		"id":      user.Id,
 	})
-
 }
 
 func updateTempUserStatus(code string, status models.TempUserStatus) (bool, response.Response) {

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -44,7 +44,6 @@ func addOrgUserHelper(cmd models.AddOrgUserCommand) response.Response {
 				"message": "User is already member of this organization",
 				"userId":  cmd.UserId,
 			})
-
 		}
 		return response.Error(http.StatusInternalServerError, "Could not add user to organization", err)
 	}
@@ -53,7 +52,6 @@ func addOrgUserHelper(cmd models.AddOrgUserCommand) response.Response {
 		"message": "User added to organization",
 		"userId":  cmd.UserId,
 	})
-
 }
 
 // GET /api/org/users

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -13,22 +14,22 @@ import (
 
 func SendResetPasswordEmail(c *models.ReqContext, form dtos.SendResetPasswordEmailForm) response.Response {
 	if setting.LDAPEnabled || setting.AuthProxyEnabled {
-		return response.Error(401, "Not allowed to reset password when LDAP or Auth Proxy is enabled", nil)
+		return response.Error(http.StatusUnauthorized, "Not allowed to reset password when LDAP or Auth Proxy is enabled", nil)
 	}
 	if setting.DisableLoginForm {
-		return response.Error(401, "Not allowed to reset password when login form is disabled", nil)
+		return response.Error(http.StatusUnauthorized, "Not allowed to reset password when login form is disabled", nil)
 	}
 
 	userQuery := models.GetUserByLoginQuery{LoginOrEmail: form.UserOrEmail}
 
 	if err := bus.Dispatch(&userQuery); err != nil {
 		c.Logger.Info("Requested password reset for user that was not found", "user", userQuery.LoginOrEmail)
-		return response.Error(200, "Email sent", err)
+		return response.Error(http.StatusOK, "Email sent", err)
 	}
 
 	emailCmd := models.SendResetPasswordEmailCommand{User: userQuery.Result}
 	if err := bus.Dispatch(&emailCmd); err != nil {
-		return response.Error(500, "Failed to send email", err)
+		return response.Error(http.StatusInternalServerError, "Failed to send email", err)
 	}
 
 	return response.Success("Email sent")
@@ -39,13 +40,13 @@ func ResetPassword(c *models.ReqContext, form dtos.ResetUserPasswordForm) respon
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrInvalidEmailCode) {
-			return response.Error(400, "Invalid or expired reset password code", nil)
+			return response.Error(http.StatusBadRequest, "Invalid or expired reset password code", nil)
 		}
-		return response.Error(500, "Unknown error validating email code", err)
+		return response.Error(http.StatusInternalServerError, "Unknown error validating email code", err)
 	}
 
 	if form.NewPassword != form.ConfirmPassword {
-		return response.Error(400, "Passwords do not match", nil)
+		return response.Error(http.StatusBadRequest, "Passwords do not match", nil)
 	}
 
 	cmd := models.ChangeUserPasswordCommand{}
@@ -53,11 +54,11 @@ func ResetPassword(c *models.ReqContext, form dtos.ResetUserPasswordForm) respon
 	var err error
 	cmd.NewPassword, err = util.EncodePassword(form.NewPassword, query.Result.Salt)
 	if err != nil {
-		return response.Error(500, "Failed to encode password", err)
+		return response.Error(http.StatusInternalServerError, "Failed to encode password", err)
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to change user password", err)
+		return response.Error(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 
 	return response.Success("User password changed")

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
@@ -43,10 +45,10 @@ func SearchPlaylists(c *models.ReqContext) response.Response {
 
 	err := bus.Dispatch(&searchQuery)
 	if err != nil {
-		return response.Error(500, "Search failed", err)
+		return response.Error(http.StatusInternalServerError, "Search failed", err)
 	}
 
-	return response.JSON(200, searchQuery.Result)
+	return response.JSON(http.StatusOK, searchQuery.Result)
 }
 
 func GetPlaylist(c *models.ReqContext) response.Response {
@@ -54,7 +56,7 @@ func GetPlaylist(c *models.ReqContext) response.Response {
 	cmd := models.GetPlaylistByIdQuery{Id: id}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Playlist not found", err)
+		return response.Error(http.StatusInternalServerError, "Playlist not found", err)
 	}
 
 	playlistDTOs, _ := LoadPlaylistItemDTOs(id)
@@ -67,7 +69,7 @@ func GetPlaylist(c *models.ReqContext) response.Response {
 		Items:    playlistDTOs,
 	}
 
-	return response.JSON(200, dto)
+	return response.JSON(http.StatusOK, dto)
 }
 
 func LoadPlaylistItemDTOs(id int64) ([]models.PlaylistItemDTO, error) {
@@ -108,10 +110,10 @@ func GetPlaylistItems(c *models.ReqContext) response.Response {
 	playlistDTOs, err := LoadPlaylistItemDTOs(id)
 
 	if err != nil {
-		return response.Error(500, "Could not load playlist items", err)
+		return response.Error(http.StatusInternalServerError, "Could not load playlist items", err)
 	}
 
-	return response.JSON(200, playlistDTOs)
+	return response.JSON(http.StatusOK, playlistDTOs)
 }
 
 func GetPlaylistDashboards(c *models.ReqContext) response.Response {
@@ -119,10 +121,10 @@ func GetPlaylistDashboards(c *models.ReqContext) response.Response {
 
 	playlists, err := LoadPlaylistDashboards(c.OrgId, c.SignedInUser, playlistID)
 	if err != nil {
-		return response.Error(500, "Could not load dashboards", err)
+		return response.Error(http.StatusInternalServerError, "Could not load dashboards", err)
 	}
 
-	return response.JSON(200, playlists)
+	return response.JSON(http.StatusOK, playlists)
 }
 
 func DeletePlaylist(c *models.ReqContext) response.Response {
@@ -130,20 +132,20 @@ func DeletePlaylist(c *models.ReqContext) response.Response {
 
 	cmd := models.DeletePlaylistCommand{Id: id, OrgId: c.OrgId}
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to delete playlist", err)
+		return response.Error(http.StatusInternalServerError, "Failed to delete playlist", err)
 	}
 
-	return response.JSON(200, "")
+	return response.JSON(http.StatusOK, "")
 }
 
 func CreatePlaylist(c *models.ReqContext, cmd models.CreatePlaylistCommand) response.Response {
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to create playlist", err)
+		return response.Error(http.StatusInternalServerError, "Failed to create playlist", err)
 	}
 
-	return response.JSON(200, cmd.Result)
+	return response.JSON(http.StatusOK, cmd.Result)
 }
 
 func UpdatePlaylist(c *models.ReqContext, cmd models.UpdatePlaylistCommand) response.Response {
@@ -151,14 +153,14 @@ func UpdatePlaylist(c *models.ReqContext, cmd models.UpdatePlaylistCommand) resp
 	cmd.Id = c.ParamsInt64(":id")
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to save playlist", err)
+		return response.Error(http.StatusInternalServerError, "Failed to save playlist", err)
 	}
 
 	playlistDTOs, err := LoadPlaylistItemDTOs(cmd.Id)
 	if err != nil {
-		return response.Error(500, "Failed to save playlist", err)
+		return response.Error(http.StatusInternalServerError, "Failed to save playlist", err)
 	}
 
 	cmd.Result.Items = playlistDTOs
-	return response.JSON(200, cmd.Result)
+	return response.JSON(http.StatusOK, cmd.Result)
 }

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
@@ -13,7 +15,7 @@ func SetHomeDashboard(c *models.ReqContext, cmd models.SavePreferencesCommand) r
 	cmd.OrgId = c.OrgId
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to set home dashboard", err)
+		return response.Error(http.StatusInternalServerError, "Failed to set home dashboard", err)
 	}
 
 	return response.Success("Home dashboard set")
@@ -28,7 +30,7 @@ func getPreferencesFor(orgID, userID, teamID int64) response.Response {
 	prefsQuery := models.GetPreferencesQuery{UserId: userID, OrgId: orgID, TeamId: teamID}
 
 	if err := bus.Dispatch(&prefsQuery); err != nil {
-		return response.Error(500, "Failed to get preferences", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get preferences", err)
 	}
 
 	dto := dtos.Prefs{
@@ -37,7 +39,7 @@ func getPreferencesFor(orgID, userID, teamID int64) response.Response {
 		Timezone:        prefsQuery.Result.Timezone,
 	}
 
-	return response.JSON(200, &dto)
+	return response.JSON(http.StatusOK, &dto)
 }
 
 // PUT /api/user/preferences
@@ -56,7 +58,7 @@ func updatePreferencesFor(orgID, userID, teamId int64, dtoCmd *dtos.UpdatePrefsC
 	}
 
 	if err := bus.Dispatch(&saveCmd); err != nil {
-		return response.Error(500, "Failed to save preferences", err)
+		return response.Error(http.StatusInternalServerError, "Failed to save preferences", err)
 	}
 
 	return response.Success("Preferences updated")

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
@@ -9,60 +11,60 @@ import (
 
 func GetOrgQuotas(c *models.ReqContext) response.Response {
 	if !setting.Quota.Enabled {
-		return response.Error(404, "Quotas not enabled", nil)
+		return response.Error(http.StatusNotFound, "Quotas not enabled", nil)
 	}
 	query := models.GetOrgQuotasQuery{OrgId: c.ParamsInt64(":orgId")}
 
 	if err := bus.Dispatch(&query); err != nil {
-		return response.Error(500, "Failed to get org quotas", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get org quotas", err)
 	}
 
-	return response.JSON(200, query.Result)
+	return response.JSON(http.StatusOK, query.Result)
 }
 
 func UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response.Response {
 	if !setting.Quota.Enabled {
-		return response.Error(404, "Quotas not enabled", nil)
+		return response.Error(http.StatusNotFound, "Quotas not enabled", nil)
 	}
 	cmd.OrgId = c.ParamsInt64(":orgId")
 	cmd.Target = c.Params(":target")
 
 	if _, ok := setting.Quota.Org.ToMap()[cmd.Target]; !ok {
-		return response.Error(404, "Invalid quota target", nil)
+		return response.Error(http.StatusNotFound, "Invalid quota target", nil)
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to update org quotas", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update org quotas", err)
 	}
 	return response.Success("Organization quota updated")
 }
 
 func GetUserQuotas(c *models.ReqContext) response.Response {
 	if !setting.Quota.Enabled {
-		return response.Error(404, "Quotas not enabled", nil)
+		return response.Error(http.StatusNotFound, "Quotas not enabled", nil)
 	}
 	query := models.GetUserQuotasQuery{UserId: c.ParamsInt64(":id")}
 
 	if err := bus.Dispatch(&query); err != nil {
-		return response.Error(500, "Failed to get org quotas", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get org quotas", err)
 	}
 
-	return response.JSON(200, query.Result)
+	return response.JSON(http.StatusOK, query.Result)
 }
 
 func UpdateUserQuota(c *models.ReqContext, cmd models.UpdateUserQuotaCmd) response.Response {
 	if !setting.Quota.Enabled {
-		return response.Error(404, "Quotas not enabled", nil)
+		return response.Error(http.StatusNotFound, "Quotas not enabled", nil)
 	}
 	cmd.UserId = c.ParamsInt64(":id")
 	cmd.Target = c.Params(":target")
 
 	if _, ok := setting.Quota.User.ToMap()[cmd.Target]; !ok {
-		return response.Error(404, "Invalid quota target", nil)
+		return response.Error(http.StatusNotFound, "Invalid quota target", nil)
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to update org quotas", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update org quotas", err)
 	}
 	return response.Success("Organization quota updated")
 }

--- a/pkg/api/routing/routing.go
+++ b/pkg/api/routing/routing.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
 	"gopkg.in/macaron.v1"
@@ -8,7 +10,7 @@ import (
 
 var (
 	ServerError = func(err error) response.Response {
-		return response.Error(500, "Server error", err)
+		return response.Error(http.StatusInternalServerError, "Server error", err)
 	}
 )
 

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -24,7 +24,7 @@ func Search(c *models.ReqContext) response.Response {
 	permission := models.PERMISSION_VIEW
 
 	if limit > 5000 {
-		return response.Error(422, "Limit is above maximum allowed (5000), use page parameter to access hits beyond limit", nil)
+		return response.Error(http.StatusUnprocessableEntity, "Limit is above maximum allowed (5000), use page parameter to access hits beyond limit", nil)
 	}
 
 	if c.Query("permission") == "Edit" {
@@ -64,11 +64,11 @@ func Search(c *models.ReqContext) response.Response {
 
 	err := bus.Dispatch(&searchQuery)
 	if err != nil {
-		return response.Error(500, "Search failed", err)
+		return response.Error(http.StatusInternalServerError, "Search failed", err)
 	}
 
 	c.TimeRequest(metrics.MApiDashboardSearch)
-	return response.JSON(200, searchQuery.Result)
+	return response.JSON(http.StatusOK, searchQuery.Result)
 }
 
 func (hs *HTTPServer) ListSortOptions(c *models.ReqContext) response.Response {

--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"path"
 	"strings"
 
@@ -21,12 +22,12 @@ func (hs *HTTPServer) createShortURL(c *models.ReqContext, cmd dtos.CreateShortU
 
 	if path.IsAbs(cmd.Path) {
 		hs.log.Error("Invalid short URL path", "path", cmd.Path)
-		return response.Error(400, "Path should be relative", nil)
+		return response.Error(http.StatusBadRequest, "Path should be relative", nil)
 	}
 
 	shortURL, err := hs.ShortURLService.CreateShortURL(c.Req.Context(), c.SignedInUser, cmd.Path)
 	if err != nil {
-		return response.Error(500, "Failed to create short URL", err)
+		return response.Error(http.StatusInternalServerError, "Failed to create short URL", err)
 	}
 
 	url := fmt.Sprintf("%s/goto/%s", strings.TrimSuffix(setting.AppUrl, "/"), shortURL.Uid)
@@ -37,7 +38,7 @@ func (hs *HTTPServer) createShortURL(c *models.ReqContext, cmd dtos.CreateShortU
 		URL: url,
 	}
 
-	return response.JSON(200, dto)
+	return response.JSON(http.StatusOK, dto)
 }
 
 func (hs *HTTPServer) redirectFromShortURL(c *models.ReqContext) {

--- a/pkg/api/signup.go
+++ b/pkg/api/signup.go
@@ -20,7 +20,6 @@ func GetSignUpOptions(c *models.ReqContext) response.Response {
 		"verifyEmailEnabled": setting.VerifyEmailEnabled,
 		"autoAssignOrg":      setting.AutoAssignOrg,
 	})
-
 }
 
 // POST /api/user/signup

--- a/pkg/api/stars.go
+++ b/pkg/api/stars.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
@@ -10,11 +12,11 @@ func StarDashboard(c *models.ReqContext) response.Response {
 	cmd := models.StarDashboardCommand{UserId: c.UserId, DashboardId: c.ParamsInt64(":id")}
 
 	if cmd.DashboardId <= 0 {
-		return response.Error(400, "Missing dashboard id", nil)
+		return response.Error(http.StatusBadRequest, "Missing dashboard id", nil)
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to star dashboard", err)
+		return response.Error(http.StatusInternalServerError, "Failed to star dashboard", err)
 	}
 
 	return response.Success("Dashboard starred!")
@@ -24,11 +26,11 @@ func UnstarDashboard(c *models.ReqContext) response.Response {
 	cmd := models.UnstarDashboardCommand{UserId: c.UserId, DashboardId: c.ParamsInt64(":id")}
 
 	if cmd.DashboardId <= 0 {
-		return response.Error(400, "Missing dashboard id", nil)
+		return response.Error(http.StatusBadRequest, "Missing dashboard id", nil)
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to unstar dashboard", err)
+		return response.Error(http.StatusInternalServerError, "Failed to unstar dashboard", err)
 	}
 
 	return response.Success("Dashboard unstarred")

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -45,7 +45,6 @@ func (hs *HTTPServer) CreateTeam(c *models.ReqContext, cmd models.CreateTeamComm
 		"teamId":  team.Id,
 		"message": "Team created",
 	})
-
 }
 
 // PUT /api/teams/:teamId

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -17,7 +18,7 @@ func (hs *HTTPServer) GetTeamMembers(c *models.ReqContext) response.Response {
 	query := models.GetTeamMembersQuery{OrgId: c.OrgId, TeamId: c.ParamsInt64(":teamId")}
 
 	if err := bus.Dispatch(&query); err != nil {
-		return response.Error(500, "Failed to get Team Members", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get Team Members", err)
 	}
 
 	filteredMembers := make([]*models.TeamMemberDTO, 0, len(query.Result))
@@ -37,7 +38,7 @@ func (hs *HTTPServer) GetTeamMembers(c *models.ReqContext) response.Response {
 		filteredMembers = append(filteredMembers, member)
 	}
 
-	return response.JSON(200, filteredMembers)
+	return response.JSON(http.StatusOK, filteredMembers)
 }
 
 // POST /api/teams/:teamId/members
@@ -46,25 +47,26 @@ func (hs *HTTPServer) AddTeamMember(c *models.ReqContext, cmd models.AddTeamMemb
 	cmd.TeamId = c.ParamsInt64(":teamId")
 
 	if err := teamguardian.CanAdmin(hs.Bus, cmd.OrgId, cmd.TeamId, c.SignedInUser); err != nil {
-		return response.Error(403, "Not allowed to add team member", err)
+		return response.Error(http.StatusForbidden, "Not allowed to add team member", err)
 	}
 
 	err := addTeamMember(hs.SQLStore, cmd.UserId, cmd.OrgId, cmd.TeamId, cmd.External, cmd.Permission)
 	if err != nil {
 		if errors.Is(err, models.ErrTeamNotFound) {
-			return response.Error(404, "Team not found", nil)
+			return response.Error(http.StatusNotFound, "Team not found", nil)
 		}
 
 		if errors.Is(err, models.ErrTeamMemberAlreadyAdded) {
-			return response.Error(400, "User is already added to this team", nil)
+			return response.Error(http.StatusBadRequest, "User is already added to this team", nil)
 		}
 
-		return response.Error(500, "Failed to add Member to Team", err)
+		return response.Error(http.StatusInternalServerError, "Failed to add Member to Team", err)
 	}
 
-	return response.JSON(200, &util.DynMap{
+	return response.JSON(http.StatusOK, &util.DynMap{
 		"message": "Member added to Team",
 	})
+
 }
 
 // PUT /:teamId/members/:userId
@@ -73,7 +75,7 @@ func (hs *HTTPServer) UpdateTeamMember(c *models.ReqContext, cmd models.UpdateTe
 	orgId := c.OrgId
 
 	if err := teamguardian.CanAdmin(hs.Bus, orgId, teamId, c.SignedInUser); err != nil {
-		return response.Error(403, "Not allowed to update team member", err)
+		return response.Error(http.StatusForbidden, "Not allowed to update team member", err)
 	}
 
 	if c.OrgRole != models.ROLE_ADMIN {
@@ -86,9 +88,9 @@ func (hs *HTTPServer) UpdateTeamMember(c *models.ReqContext, cmd models.UpdateTe
 
 	if err := hs.Bus.Dispatch(&cmd); err != nil {
 		if errors.Is(err, models.ErrTeamMemberNotFound) {
-			return response.Error(404, "Team member not found.", nil)
+			return response.Error(http.StatusNotFound, "Team member not found.", nil)
 		}
-		return response.Error(500, "Failed to update team member.", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update team member.", err)
 	}
 	return response.Success("Team member updated")
 }
@@ -100,7 +102,7 @@ func (hs *HTTPServer) RemoveTeamMember(c *models.ReqContext) response.Response {
 	userId := c.ParamsInt64(":userId")
 
 	if err := teamguardian.CanAdmin(hs.Bus, orgId, teamId, c.SignedInUser); err != nil {
-		return response.Error(403, "Not allowed to remove team member", err)
+		return response.Error(http.StatusForbidden, "Not allowed to remove team member", err)
 	}
 
 	protectLastAdmin := false
@@ -110,14 +112,14 @@ func (hs *HTTPServer) RemoveTeamMember(c *models.ReqContext) response.Response {
 
 	if err := hs.Bus.Dispatch(&models.RemoveTeamMemberCommand{OrgId: orgId, TeamId: teamId, UserId: userId, ProtectLastAdmin: protectLastAdmin}); err != nil {
 		if errors.Is(err, models.ErrTeamNotFound) {
-			return response.Error(404, "Team not found", nil)
+			return response.Error(http.StatusNotFound, "Team not found", nil)
 		}
 
 		if errors.Is(err, models.ErrTeamMemberNotFound) {
-			return response.Error(404, "Team member not found", nil)
+			return response.Error(http.StatusNotFound, "Team member not found", nil)
 		}
 
-		return response.Error(500, "Failed to remove Member from Team", err)
+		return response.Error(http.StatusInternalServerError, "Failed to remove Member from Team", err)
 	}
 	return response.Success("Team Member removed")
 }

--- a/pkg/api/team_members.go
+++ b/pkg/api/team_members.go
@@ -66,7 +66,6 @@ func (hs *HTTPServer) AddTeamMember(c *models.ReqContext, cmd models.AddTeamMemb
 	return response.JSON(http.StatusOK, &util.DynMap{
 		"message": "Member added to Team",
 	})
-
 }
 
 // PUT /:teamId/members/:userId

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -26,9 +27,9 @@ func getUserUserProfile(userID int64) response.Response {
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrUserNotFound) {
-			return response.Error(404, models.ErrUserNotFound.Error(), nil)
+			return response.Error(http.StatusNotFound, models.ErrUserNotFound.Error(), nil)
 		}
-		return response.Error(500, "Failed to get user", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
 	}
 
 	getAuthQuery := models.GetAuthInfoQuery{UserId: userID}
@@ -41,7 +42,7 @@ func getUserUserProfile(userID int64) response.Response {
 
 	query.Result.AvatarUrl = dtos.GetGravatarUrl(query.Result.Email)
 
-	return response.JSON(200, query.Result)
+	return response.JSON(http.StatusOK, query.Result)
 }
 
 // GET /api/users/lookup
@@ -49,9 +50,9 @@ func GetUserByLoginOrEmail(c *models.ReqContext) response.Response {
 	query := models.GetUserByLoginQuery{LoginOrEmail: c.Query("loginOrEmail")}
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrUserNotFound) {
-			return response.Error(404, models.ErrUserNotFound.Error(), nil)
+			return response.Error(http.StatusNotFound, models.ErrUserNotFound.Error(), nil)
 		}
-		return response.Error(500, "Failed to get user", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get user", err)
 	}
 	user := query.Result
 	result := models.UserProfileDTO{
@@ -65,17 +66,17 @@ func GetUserByLoginOrEmail(c *models.ReqContext) response.Response {
 		UpdatedAt:      user.Updated,
 		CreatedAt:      user.Created,
 	}
-	return response.JSON(200, &result)
+	return response.JSON(http.StatusOK, &result)
 }
 
 // POST /api/user
 func UpdateSignedInUser(c *models.ReqContext, cmd models.UpdateUserCommand) response.Response {
 	if setting.AuthProxyEnabled {
 		if setting.AuthProxyHeaderProperty == "email" && cmd.Email != c.Email {
-			return response.Error(400, "Not allowed to change email when auth proxy is using email property", nil)
+			return response.Error(http.StatusBadRequest, "Not allowed to change email when auth proxy is using email property", nil)
 		}
 		if setting.AuthProxyHeaderProperty == "username" && cmd.Login != c.Login {
-			return response.Error(400, "Not allowed to change username when auth proxy is using username property", nil)
+			return response.Error(http.StatusBadRequest, "Not allowed to change username when auth proxy is using username property", nil)
 		}
 	}
 	cmd.UserId = c.UserId
@@ -94,13 +95,13 @@ func UpdateUserActiveOrg(c *models.ReqContext) response.Response {
 	orgID := c.ParamsInt64(":orgId")
 
 	if !validateUsingOrg(userID, orgID) {
-		return response.Error(401, "Not a valid organization", nil)
+		return response.Error(http.StatusUnauthorized, "Not a valid organization", nil)
 	}
 
 	cmd := models.SetUsingOrgCommand{UserId: userID, OrgId: orgID}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to change active organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to change active organization", err)
 	}
 
 	return response.Success("Active organization changed")
@@ -110,12 +111,12 @@ func handleUpdateUser(cmd models.UpdateUserCommand) response.Response {
 	if len(cmd.Login) == 0 {
 		cmd.Login = cmd.Email
 		if len(cmd.Login) == 0 {
-			return response.Error(400, "Validation error, need to specify either username or email", nil)
+			return response.Error(http.StatusBadRequest, "Validation error, need to specify either username or email", nil)
 		}
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to update user", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update user", err)
 	}
 
 	return response.Success("User updated")
@@ -140,13 +141,13 @@ func getUserTeamList(orgID int64, userID int64) response.Response {
 	query := models.GetTeamsByUserQuery{OrgId: orgID, UserId: userID}
 
 	if err := bus.Dispatch(&query); err != nil {
-		return response.Error(500, "Failed to get user teams", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get user teams", err)
 	}
 
 	for _, team := range query.Result {
 		team.AvatarUrl = dtos.GetGravatarUrlWithDefault(team.Email, team.Name)
 	}
-	return response.JSON(200, query.Result)
+	return response.JSON(http.StatusOK, query.Result)
 }
 
 // GET /api/users/:id/orgs
@@ -158,10 +159,10 @@ func getUserOrgList(userID int64) response.Response {
 	query := models.GetUserOrgListQuery{UserId: userID}
 
 	if err := bus.Dispatch(&query); err != nil {
-		return response.Error(500, "Failed to get user organizations", err)
+		return response.Error(http.StatusInternalServerError, "Failed to get user organizations", err)
 	}
 
-	return response.JSON(200, query.Result)
+	return response.JSON(http.StatusOK, query.Result)
 }
 
 func validateUsingOrg(userID int64, orgID int64) bool {
@@ -187,13 +188,13 @@ func UserSetUsingOrg(c *models.ReqContext) response.Response {
 	orgID := c.ParamsInt64(":id")
 
 	if !validateUsingOrg(c.UserId, orgID) {
-		return response.Error(401, "Not a valid organization", nil)
+		return response.Error(http.StatusUnauthorized, "Not a valid organization", nil)
 	}
 
 	cmd := models.SetUsingOrgCommand{UserId: c.UserId, OrgId: orgID}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to change active organization", err)
+		return response.Error(http.StatusInternalServerError, "Failed to change active organization", err)
 	}
 
 	return response.Success("Active organization changed")
@@ -218,36 +219,36 @@ func (hs *HTTPServer) ChangeActiveOrgAndRedirectToHome(c *models.ReqContext) {
 
 func ChangeUserPassword(c *models.ReqContext, cmd models.ChangeUserPasswordCommand) response.Response {
 	if setting.LDAPEnabled || setting.AuthProxyEnabled {
-		return response.Error(400, "Not allowed to change password when LDAP or Auth Proxy is enabled", nil)
+		return response.Error(http.StatusBadRequest, "Not allowed to change password when LDAP or Auth Proxy is enabled", nil)
 	}
 
 	userQuery := models.GetUserByIdQuery{Id: c.UserId}
 
 	if err := bus.Dispatch(&userQuery); err != nil {
-		return response.Error(500, "Could not read user from database", err)
+		return response.Error(http.StatusInternalServerError, "Could not read user from database", err)
 	}
 
 	passwordHashed, err := util.EncodePassword(cmd.OldPassword, userQuery.Result.Salt)
 	if err != nil {
-		return response.Error(500, "Failed to encode password", err)
+		return response.Error(http.StatusInternalServerError, "Failed to encode password", err)
 	}
 	if passwordHashed != userQuery.Result.Password {
-		return response.Error(401, "Invalid old password", nil)
+		return response.Error(http.StatusUnauthorized, "Invalid old password", nil)
 	}
 
 	password := models.Password(cmd.NewPassword)
 	if password.IsWeak() {
-		return response.Error(400, "New password is too short", nil)
+		return response.Error(http.StatusBadRequest, "New password is too short", nil)
 	}
 
 	cmd.UserId = c.UserId
 	cmd.NewPassword, err = util.EncodePassword(cmd.NewPassword, userQuery.Result.Salt)
 	if err != nil {
-		return response.Error(500, "Failed to encode password", err)
+		return response.Error(http.StatusInternalServerError, "Failed to encode password", err)
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to change user password", err)
+		return response.Error(http.StatusInternalServerError, "Failed to change user password", err)
 	}
 
 	return response.Success("User password changed")
@@ -262,20 +263,20 @@ func redirectToChangePassword(c *models.ReqContext) {
 func SearchUsers(c *models.ReqContext) response.Response {
 	query, err := searchUser(c)
 	if err != nil {
-		return response.Error(500, "Failed to fetch users", err)
+		return response.Error(http.StatusInternalServerError, "Failed to fetch users", err)
 	}
 
-	return response.JSON(200, query.Result.Users)
+	return response.JSON(http.StatusOK, query.Result.Users)
 }
 
 // GET /api/users/search
 func SearchUsersWithPaging(c *models.ReqContext) response.Response {
 	query, err := searchUser(c)
 	if err != nil {
-		return response.Error(500, "Failed to fetch users", err)
+		return response.Error(http.StatusInternalServerError, "Failed to fetch users", err)
 	}
 
-	return response.JSON(200, query.Result)
+	return response.JSON(http.StatusOK, query.Result)
 }
 
 func searchUser(c *models.ReqContext) (*models.SearchUsersQuery, error) {
@@ -324,10 +325,10 @@ func SetHelpFlag(c *models.ReqContext) response.Response {
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to update help flag", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update help flag", err)
 	}
 
-	return response.JSON(200, &util.DynMap{"message": "Help flag set", "helpFlags1": cmd.HelpFlags1})
+	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": cmd.HelpFlags1})
 }
 
 func ClearHelpFlags(c *models.ReqContext) response.Response {
@@ -337,10 +338,10 @@ func ClearHelpFlags(c *models.ReqContext) response.Response {
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
-		return response.Error(500, "Failed to update help flag", err)
+		return response.Error(http.StatusInternalServerError, "Failed to update help flag", err)
 	}
 
-	return response.JSON(200, &util.DynMap{"message": "Help flag set", "helpFlags1": cmd.HelpFlags1})
+	return response.JSON(http.StatusOK, &util.DynMap{"message": "Help flag set", "helpFlags1": cmd.HelpFlags1})
 }
 
 func GetAuthProviderLabel(authModule string) string {

--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -42,7 +42,6 @@ func (hs *HTTPServer) logoutUserFromAllDevicesInternal(ctx context.Context, user
 	return response.JSON(http.StatusOK, util.DynMap{
 		"message": "User logged out",
 	})
-
 }
 
 func (hs *HTTPServer) getUserAuthTokensInternal(c *models.ReqContext, userID int64) response.Response {
@@ -145,5 +144,4 @@ func (hs *HTTPServer) revokeUserAuthTokenInternal(c *models.ReqContext, userID i
 	return response.JSON(http.StatusOK, util.DynMap{
 		"message": "User auth token revoked",
 	})
-
 }

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -2,6 +2,7 @@ package libraryelements
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/go-macaron/binding"
 
@@ -30,7 +31,7 @@ func (l *LibraryElementService) createHandler(c *models.ReqContext, cmd CreateLi
 		return toLibraryElementError(err, "Failed to create library element")
 	}
 
-	return response.JSON(200, util.DynMap{"result": element})
+	return response.JSON(http.StatusOK, util.DynMap{"result": element})
 }
 
 // deleteHandler handles DELETE /api/library-elements/:uid.
@@ -50,7 +51,7 @@ func (l *LibraryElementService) getHandler(c *models.ReqContext) response.Respon
 		return toLibraryElementError(err, "Failed to get library element")
 	}
 
-	return response.JSON(200, util.DynMap{"result": element})
+	return response.JSON(http.StatusOK, util.DynMap{"result": element})
 }
 
 // getAllHandler handles GET /api/library-elements/.
@@ -70,7 +71,7 @@ func (l *LibraryElementService) getAllHandler(c *models.ReqContext) response.Res
 		return toLibraryElementError(err, "Failed to get library elements")
 	}
 
-	return response.JSON(200, util.DynMap{"result": elementsResult})
+	return response.JSON(http.StatusOK, util.DynMap{"result": elementsResult})
 }
 
 // patchHandler handles PATCH /api/library-elements/:uid
@@ -80,7 +81,7 @@ func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibr
 		return toLibraryElementError(err, "Failed to update library element")
 	}
 
-	return response.JSON(200, util.DynMap{"result": element})
+	return response.JSON(http.StatusOK, util.DynMap{"result": element})
 }
 
 // getConnectionsHandler handles GET /api/library-panels/:uid/connections/.
@@ -90,30 +91,30 @@ func (l *LibraryElementService) getConnectionsHandler(c *models.ReqContext) resp
 		return toLibraryElementError(err, "Failed to get connections")
 	}
 
-	return response.JSON(200, util.DynMap{"result": connections})
+	return response.JSON(http.StatusOK, util.DynMap{"result": connections})
 }
 
 func toLibraryElementError(err error, message string) response.Response {
 	if errors.Is(err, errLibraryElementAlreadyExists) {
-		return response.Error(400, errLibraryElementAlreadyExists.Error(), err)
+		return response.Error(http.StatusBadRequest, errLibraryElementAlreadyExists.Error(), err)
 	}
 	if errors.Is(err, errLibraryElementNotFound) {
-		return response.Error(404, errLibraryElementNotFound.Error(), err)
+		return response.Error(http.StatusNotFound, errLibraryElementNotFound.Error(), err)
 	}
 	if errors.Is(err, errLibraryElementDashboardNotFound) {
-		return response.Error(404, errLibraryElementDashboardNotFound.Error(), err)
+		return response.Error(http.StatusNotFound, errLibraryElementDashboardNotFound.Error(), err)
 	}
 	if errors.Is(err, errLibraryElementVersionMismatch) {
-		return response.Error(412, errLibraryElementVersionMismatch.Error(), err)
+		return response.Error(http.StatusPreconditionFailed, errLibraryElementVersionMismatch.Error(), err)
 	}
 	if errors.Is(err, models.ErrFolderNotFound) {
-		return response.Error(404, models.ErrFolderNotFound.Error(), err)
+		return response.Error(http.StatusNotFound, models.ErrFolderNotFound.Error(), err)
 	}
 	if errors.Is(err, models.ErrFolderAccessDenied) {
-		return response.Error(403, models.ErrFolderAccessDenied.Error(), err)
+		return response.Error(http.StatusForbidden, models.ErrFolderAccessDenied.Error(), err)
 	}
 	if errors.Is(err, errLibraryElementHasConnections) {
-		return response.Error(403, errLibraryElementHasConnections.Error(), err)
+		return response.Error(http.StatusForbidden, errLibraryElementHasConnections.Error(), err)
 	}
-	return response.Error(500, message, err)
+	return response.Error(http.StatusInternalServerError, message, err)
 }

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -619,10 +619,8 @@ func (g *GrafanaLive) HandleInfoHTTP(ctx *models.ReqContext) response.Response {
 		return response.JSON(http.StatusOK, util.DynMap{
 			"active": g.GrafanaScope.Dashboards.HasGitOpsObserver(ctx.SignedInUser.OrgId),
 		})
-
 	}
 	return response.JSONStreaming(http.StatusNotFound, util.DynMap{
 		"message": "Info is not supported for this channel",
 	})
-
 }

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -609,18 +609,20 @@ func (g *GrafanaLive) HandleListHTTP(c *models.ReqContext) response.Response {
 	})
 
 	info["channels"] = channels
-	return response.JSONStreaming(200, info)
+	return response.JSONStreaming(http.StatusOK, info)
 }
 
 // HandleInfoHTTP special http response for
 func (g *GrafanaLive) HandleInfoHTTP(ctx *models.ReqContext) response.Response {
 	path := ctx.Params("*")
 	if path == "grafana/dashboards/gitops" {
-		return response.JSON(200, util.DynMap{
+		return response.JSON(http.StatusOK, util.DynMap{
 			"active": g.GrafanaScope.Dashboards.HasGitOpsObserver(ctx.SignedInUser.OrgId),
 		})
+
 	}
-	return response.JSONStreaming(404, util.DynMap{
+	return response.JSONStreaming(http.StatusNotFound, util.DynMap{
 		"message": "Info is not supported for this channel",
 	})
+
 }

--- a/pkg/services/ngalert/api/fork_ruler.go
+++ b/pkg/services/ngalert/api/fork_ruler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
@@ -27,7 +28,7 @@ func NewForkedRuler(datasourceCache datasources.CacheService, lotex, grafana Rul
 func (r *ForkedRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
@@ -35,14 +36,14 @@ func (r *ForkedRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) re
 	case apimodels.LoTexRulerBackend:
 		return r.LotexRuler.RouteDeleteNamespaceRulesConfig(ctx)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", t), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", t), nil)
 	}
 }
 
 func (r *ForkedRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
@@ -50,14 +51,14 @@ func (r *ForkedRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) respons
 	case apimodels.LoTexRulerBackend:
 		return r.LotexRuler.RouteDeleteRuleGroupConfig(ctx)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", t), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", t), nil)
 	}
 }
 
 func (r *ForkedRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
@@ -65,14 +66,14 @@ func (r *ForkedRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respo
 	case apimodels.LoTexRulerBackend:
 		return r.LotexRuler.RouteGetNamespaceRulesConfig(ctx)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", t), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", t), nil)
 	}
 }
 
 func (r *ForkedRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
@@ -80,14 +81,14 @@ func (r *ForkedRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.
 	case apimodels.LoTexRulerBackend:
 		return r.LotexRuler.RouteGetRulegGroupConfig(ctx)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", t), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", t), nil)
 	}
 }
 
 func (r *ForkedRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
@@ -95,27 +96,27 @@ func (r *ForkedRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Respo
 	case apimodels.LoTexRulerBackend:
 		return r.LotexRuler.RouteGetRulesConfig(ctx)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", t), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", t), nil)
 	}
 }
 
 func (r *ForkedRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimodels.PostableRuleGroupConfig) response.Response {
 	backendType, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 	payloadType := conf.Type()
 
 	if backendType != payloadType {
-		return response.Error(
-			400,
+		return response.Error(http.StatusBadRequest,
+
 			fmt.Sprintf(
 				"unexpected backend type (%v) vs payload type (%v)",
 				backendType,
 				payloadType,
 			),
-			nil,
-		)
+			nil)
+
 	}
 
 	switch backendType {
@@ -124,6 +125,6 @@ func (r *ForkedRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apim
 	case apimodels.LoTexRulerBackend:
 		return r.LotexRuler.RoutePostNameRulesConfig(ctx, conf)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", backendType), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", backendType), nil)
 	}
 }

--- a/pkg/services/ngalert/api/fork_ruler.go
+++ b/pkg/services/ngalert/api/fork_ruler.go
@@ -116,7 +116,6 @@ func (r *ForkedRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apim
 				payloadType,
 			),
 			nil)
-
 	}
 
 	switch backendType {

--- a/pkg/services/ngalert/api/forked_am.go
+++ b/pkg/services/ngalert/api/forked_am.go
@@ -124,11 +124,7 @@ func (am *ForkedAMSvc) RoutePostAlertingConfig(ctx *models.ReqContext, body apim
 	}
 
 	if err := body.AlertmanagerConfig.ReceiverType().MatchesBackend(b); err != nil {
-		return response.Error(http.StatusBadRequest,
-
-			"bad match",
-			err)
-
+		return response.Error(http.StatusBadRequest, "bad match", err)
 	}
 
 	return s.RoutePostAlertingConfig(ctx, body)

--- a/pkg/services/ngalert/api/forked_am.go
+++ b/pkg/services/ngalert/api/forked_am.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
@@ -42,7 +43,7 @@ func (am *ForkedAMSvc) getService(ctx *models.ReqContext) (AlertmanagerApiServic
 func (am *ForkedAMSvc) RouteCreateSilence(ctx *models.ReqContext, body apimodels.PostableSilence) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteCreateSilence(ctx, body)
@@ -51,7 +52,7 @@ func (am *ForkedAMSvc) RouteCreateSilence(ctx *models.ReqContext, body apimodels
 func (am *ForkedAMSvc) RouteDeleteAlertingConfig(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteDeleteAlertingConfig(ctx)
@@ -60,7 +61,7 @@ func (am *ForkedAMSvc) RouteDeleteAlertingConfig(ctx *models.ReqContext) respons
 func (am *ForkedAMSvc) RouteDeleteSilence(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteDeleteSilence(ctx)
@@ -69,7 +70,7 @@ func (am *ForkedAMSvc) RouteDeleteSilence(ctx *models.ReqContext) response.Respo
 func (am *ForkedAMSvc) RouteGetAlertingConfig(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteGetAlertingConfig(ctx)
@@ -78,7 +79,7 @@ func (am *ForkedAMSvc) RouteGetAlertingConfig(ctx *models.ReqContext) response.R
 func (am *ForkedAMSvc) RouteGetAMAlertGroups(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteGetAMAlertGroups(ctx)
@@ -87,7 +88,7 @@ func (am *ForkedAMSvc) RouteGetAMAlertGroups(ctx *models.ReqContext) response.Re
 func (am *ForkedAMSvc) RouteGetAMAlerts(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteGetAMAlerts(ctx)
@@ -96,7 +97,7 @@ func (am *ForkedAMSvc) RouteGetAMAlerts(ctx *models.ReqContext) response.Respons
 func (am *ForkedAMSvc) RouteGetSilence(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteGetSilence(ctx)
@@ -105,7 +106,7 @@ func (am *ForkedAMSvc) RouteGetSilence(ctx *models.ReqContext) response.Response
 func (am *ForkedAMSvc) RouteGetSilences(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RouteGetSilences(ctx)
@@ -114,20 +115,20 @@ func (am *ForkedAMSvc) RouteGetSilences(ctx *models.ReqContext) response.Respons
 func (am *ForkedAMSvc) RoutePostAlertingConfig(ctx *models.ReqContext, body apimodels.PostableUserConfig) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	b, err := backendType(ctx, am.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	if err := body.AlertmanagerConfig.ReceiverType().MatchesBackend(b); err != nil {
-		return response.Error(
-			400,
+		return response.Error(http.StatusBadRequest,
+
 			"bad match",
-			err,
-		)
+			err)
+
 	}
 
 	return s.RoutePostAlertingConfig(ctx, body)
@@ -136,7 +137,7 @@ func (am *ForkedAMSvc) RoutePostAlertingConfig(ctx *models.ReqContext, body apim
 func (am *ForkedAMSvc) RoutePostAMAlerts(ctx *models.ReqContext, body apimodels.PostableAlerts) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	return s.RoutePostAMAlerts(ctx, body)

--- a/pkg/services/ngalert/api/forked_prom.go
+++ b/pkg/services/ngalert/api/forked_prom.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
@@ -26,7 +27,7 @@ func NewForkedProm(datasourceCache datasources.CacheService, proxy, grafana Prom
 func (p *ForkedPromSvc) RouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, p.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	switch t {
@@ -35,14 +36,14 @@ func (p *ForkedPromSvc) RouteGetAlertStatuses(ctx *models.ReqContext) response.R
 	case apimodels.LoTexRulerBackend:
 		return p.ProxySvc.RouteGetAlertStatuses(ctx)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", t), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", t), nil)
 	}
 }
 
 func (p *ForkedPromSvc) RouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, p.DatasourceCache)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
 	switch t {
@@ -51,6 +52,6 @@ func (p *ForkedPromSvc) RouteGetRuleStatuses(ctx *models.ReqContext) response.Re
 	case apimodels.LoTexRulerBackend:
 		return p.ProxySvc.RouteGetRuleStatuses(ctx)
 	default:
-		return response.Error(400, fmt.Sprintf("unexpected backend type (%v)", t), nil)
+		return response.Error(http.StatusBadRequest, fmt.Sprintf("unexpected backend type (%v)", t), nil)
 	}
 }

--- a/pkg/services/ngalert/api/lotex_am.go
+++ b/pkg/services/ngalert/api/lotex_am.go
@@ -36,7 +36,7 @@ func NewLotexAM(proxy *AlertingProxy, log log.Logger) *LotexAM {
 func (am *LotexAM) RouteCreateSilence(ctx *models.ReqContext, silenceBody apimodels.PostableSilence) response.Response {
 	blob, err := json.Marshal(silenceBody)
 	if err != nil {
-		return response.Error(500, "Failed marshal silence", err)
+		return response.Error(http.StatusInternalServerError, "Failed marshal silence", err)
 	}
 	return am.withReq(
 		ctx,
@@ -149,7 +149,7 @@ func (am *LotexAM) RouteGetSilences(ctx *models.ReqContext) response.Response {
 func (am *LotexAM) RoutePostAlertingConfig(ctx *models.ReqContext, config apimodels.PostableUserConfig) response.Response {
 	yml, err := yaml.Marshal(&config)
 	if err != nil {
-		return response.Error(500, "Failed marshal alert manager configuration ", err)
+		return response.Error(http.StatusInternalServerError, "Failed marshal alert manager configuration ", err)
 	}
 
 	return am.withReq(
@@ -165,7 +165,7 @@ func (am *LotexAM) RoutePostAlertingConfig(ctx *models.ReqContext, config apimod
 func (am *LotexAM) RoutePostAMAlerts(ctx *models.ReqContext, alerts apimodels.PostableAlerts) response.Response {
 	yml, err := yaml.Marshal(alerts)
 	if err != nil {
-		return response.Error(500, "Failed marshal postable alerts", err)
+		return response.Error(http.StatusInternalServerError, "Failed marshal postable alerts", err)
 	}
 
 	return am.withReq(

--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -40,7 +40,7 @@ func NewLotexProm(proxy *AlertingProxy, log log.Logger) *LotexProm {
 func (p *LotexProm) RouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
 	endpoints, err := p.getEndpoints(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 
 	return p.withReq(
@@ -59,7 +59,7 @@ func (p *LotexProm) RouteGetAlertStatuses(ctx *models.ReqContext) response.Respo
 func (p *LotexProm) RouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
 	endpoints, err := p.getEndpoints(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 
 	return p.withReq(

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -34,7 +34,7 @@ func NewLotexRuler(proxy *AlertingProxy, log log.Logger) *LotexRuler {
 func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
 	legacyRulerPrefix, err := r.getPrefix(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 	return r.withReq(
 		ctx,
@@ -52,7 +52,7 @@ func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) res
 func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
 	legacyRulerPrefix, err := r.getPrefix(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 	return r.withReq(
 		ctx,
@@ -75,7 +75,7 @@ func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response
 func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
 	legacyRulerPrefix, err := r.getPrefix(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 	return r.withReq(
 		ctx,
@@ -97,7 +97,7 @@ func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respon
 func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
 	legacyRulerPrefix, err := r.getPrefix(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 	return r.withReq(
 		ctx,
@@ -120,7 +120,7 @@ func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.R
 func (r *LotexRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Response {
 	legacyRulerPrefix, err := r.getPrefix(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 	return r.withReq(
 		ctx,
@@ -138,11 +138,11 @@ func (r *LotexRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Respon
 func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimodels.PostableRuleGroupConfig) response.Response {
 	legacyRulerPrefix, err := r.getPrefix(ctx)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 	yml, err := yaml.Marshal(conf)
 	if err != nil {
-		return response.Error(500, "Failed marshal rule group", err)
+		return response.Error(http.StatusInternalServerError, "Failed marshal rule group", err)
 	}
 	ns := ctx.Params("Namespace")
 	u := withPath(*ctx.Req.URL, fmt.Sprintf("%s/%s", legacyRulerPrefix, ns))

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -93,7 +93,7 @@ func (p *AlertingProxy) withReq(
 ) response.Response {
 	req, err := http.NewRequest(method, u.String(), body)
 	if err != nil {
-		return response.Error(400, err.Error(), nil)
+		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 	for h, v := range headers {
 		req.Header.Add(h, v)
@@ -121,12 +121,12 @@ func (p *AlertingProxy) withReq(
 
 	t, err := extractor(resp.Body())
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 
 	b, err := json.Marshal(t)
 	if err != nil {
-		return response.Error(500, err.Error(), nil)
+		return response.Error(http.StatusInternalServerError, err.Error(), nil)
 	}
 
 	return response.JSON(status, b)
@@ -214,7 +214,7 @@ func conditionEval(c *models.ReqContext, cmd ngmodels.EvalAlertConditionCommand,
 		Data:      cmd.Data,
 	}
 	if err := validateCondition(evalCond, c.SignedInUser, c.SkipCache, datasourceCache); err != nil {
-		return response.Error(400, "invalid condition", err)
+		return response.Error(http.StatusBadRequest, "invalid condition", err)
 	}
 
 	now := cmd.Now

--- a/pkg/services/sqlstore/user_auth_test.go
+++ b/pkg/services/sqlstore/user_auth_test.go
@@ -5,9 +5,10 @@ package sqlstore
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/models"
 	"golang.org/x/oauth2"


### PR DESCRIPTION
Closes #34154 

Automatic `gofmt` replacement of status code numbers with http package constants.