### PR TITLE
NGAlert: Add Line notification channel

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -432,6 +432,8 @@ func (am *Alertmanager) buildReceiverIntegrations(receiver *apimodels.PostableAp
 			n, err = channels.NewAlertmanagerNotifier(cfg, tmpl)
 		case "googlechat":
 			n, err = channels.NewGoogleChatNotifier(cfg, tmpl)
+		case "line":
+			n, err = channels.NewLineNotifier(cfg, tmpl)
 		default:
 			return nil, fmt.Errorf("notifier %s is not supported", r.Type)
 		}

--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -636,5 +636,21 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 				},
 			},
 		},
+		{
+			Type:        "LINE",
+			Name:        "LINE",
+			Description: "Send notifications to LINE notify",
+			Heading:     "LINE notify settings",
+			Options: []alerting.NotifierOption{
+				{
+					Label:        "Token",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					Placeholder:  "LINE notify token key",
+					PropertyName: "token",
+					Required:     true,
+					Secure:       true,
+				}},
+		},
 	}
 }

--- a/pkg/services/ngalert/notifier/channels/line.go
+++ b/pkg/services/ngalert/notifier/channels/line.go
@@ -1,0 +1,98 @@
+package channels
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+
+	gokit_log "github.com/go-kit/kit/log"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	old_notifiers "github.com/grafana/grafana/pkg/services/alerting/notifiers"
+)
+
+const (
+	LineNotifyURL string = "https://notify-api.line.me/api/notify"
+)
+
+// NewLineNotifier is the constructor for the LINE notifier
+func NewLineNotifier(model *NotificationChannelConfig, t *template.Template) (*LineNotifier, error) {
+	token := model.DecryptedValue("token", model.Settings.Get("token").MustString())
+	if token == "" {
+		return nil, alerting.ValidationError{Reason: "Could not find token in settings"}
+	}
+
+	return &LineNotifier{
+		NotifierBase: old_notifiers.NewNotifierBase(&models.AlertNotification{
+			Uid:                   model.UID,
+			Name:                  model.Name,
+			Type:                  model.Type,
+			DisableResolveMessage: model.DisableResolveMessage,
+			Settings:              model.Settings,
+		}),
+		Token: token,
+		log:   log.New("alerting.notifier.line"),
+		tmpl:  t,
+	}, nil
+}
+
+// LineNotifier is responsible for sending
+// alert notifications to LINE.
+type LineNotifier struct {
+	old_notifiers.NotifierBase
+	Token string
+	log   log.Logger
+	tmpl  *template.Template
+}
+
+// Notify send an alert notification to LINE
+func (ln *LineNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+	ln.log.Debug("Executing line notification", "notification", ln.Name)
+
+	ruleURL := path.Join(ln.tmpl.ExternalURL.String(), "/alerting/list")
+
+	data := notify.GetTemplateData(ctx, ln.tmpl, as, gokit_log.NewNopLogger())
+	var tmplErr error
+	tmpl := notify.TmplText(ln.tmpl, data, &tmplErr)
+
+	body := fmt.Sprintf(
+		"%s\n%s\n\n%s",
+		tmpl(`{{ template "default.title" . }}`),
+		ruleURL,
+		tmpl(`{{ template "default.message" . }}`),
+	)
+	if tmplErr != nil {
+		return false, fmt.Errorf("failed to template Line message: %w", tmplErr)
+	}
+
+	form := url.Values{}
+	form.Add("message", body)
+
+	cmd := &models.SendWebhookSync{
+		Url:        LineNotifyURL,
+		HttpMethod: "POST",
+		HttpHeader: map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", ln.Token),
+			"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
+		},
+		Body: form.Encode(),
+	}
+
+	if err := bus.DispatchCtx(ctx, cmd); err != nil {
+		ln.log.Error("Failed to send notification to LINE", "error", err, "body", body)
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (ln *LineNotifier) SendResolved() bool {
+	return !ln.GetDisableResolveMessage()
+}

--- a/pkg/services/ngalert/notifier/channels/line_test.go
+++ b/pkg/services/ngalert/notifier/channels/line_test.go
@@ -1,0 +1,126 @@
+package channels
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+func TestLineNotifier(t *testing.T) {
+	tmpl := templateForTests(t)
+
+	externalURL, err := url.Parse("http://localhost")
+	require.NoError(t, err)
+	tmpl.ExternalURL = externalURL
+
+	cases := []struct {
+		name         string
+		settings     string
+		alerts       []*types.Alert
+		expHeaders   map[string]string
+		expMsg       string
+		expInitError error
+		expMsgError  error
+	}{
+		{
+			name:     "One alert",
+			settings: `{"token": "sometoken"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				},
+			},
+			expHeaders: map[string]string{
+				"Authorization": "Bearer sometoken",
+				"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
+			},
+			expMsg:       "message=%5BFIRING%3A1%5D++%28val1%29%0Ahttp%3A%2Flocalhost%2Falerting%2Flist%0A%0A%0A%2A%2AFiring%2A%2A%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val1%0AAnnotations%3A%0A+-+ann1+%3D+annv1%0ASource%3A+%0A%0A%0A%0A%0A",
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name:     "Multiple alerts",
+			settings: `{"token": "sometoken"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expHeaders: map[string]string{
+				"Authorization": "Bearer sometoken",
+				"Content-Type":  "application/x-www-form-urlencoded;charset=UTF-8",
+			},
+			expMsg:       "message=%5BFIRING%3A2%5D++%0Ahttp%3A%2Flocalhost%2Falerting%2Flist%0A%0A%0A%2A%2AFiring%2A%2A%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val1%0AAnnotations%3A%0A+-+ann1+%3D+annv1%0ASource%3A+%0ALabels%3A%0A+-+alertname+%3D+alert1%0A+-+lbl1+%3D+val2%0AAnnotations%3A%0A+-+ann1+%3D+annv2%0ASource%3A+%0A%0A%0A%0A%0A",
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
+			name:         "Token missing",
+			settings:     `{}`,
+			expInitError: alerting.ValidationError{Reason: "Could not find token in settings"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
+			require.NoError(t, err)
+
+			m := &NotificationChannelConfig{
+				Name:     "line_testing",
+				Type:     "line",
+				Settings: settingsJSON,
+			}
+
+			pn, err := NewLineNotifier(m, tmpl)
+			if c.expInitError != nil {
+				require.Error(t, err)
+				require.Equal(t, c.expInitError.Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			body := ""
+			var headers map[string]string
+			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+				body = webhook.Body
+				headers = webhook.HttpHeader
+				return nil
+			})
+
+			ctx := notify.WithGroupKey(context.Background(), "alertname")
+			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
+			ok, err := pn.Notify(ctx, c.alerts...)
+			if c.expMsgError != nil {
+				require.False(t, ok)
+				require.Error(t, err)
+				require.Equal(t, c.expMsgError.Error(), err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			require.Equal(t, c.expHeaders, headers)
+			require.Equal(t, c.expMsg, body)
+		})
+	}
+}

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -1289,6 +1289,31 @@ var expAvailableChannelJsonOutput = `
         "secure": false
       }
     ]
+  },
+  {
+    "type": "LINE",
+    "name": "LINE",
+    "heading": "LINE notify settings",
+    "description": "Send notifications to LINE notify",
+    "info": "",
+    "options": [
+      {
+        "element": "input",
+        "inputType": "text",
+        "label": "Token",
+        "description": "",
+        "placeholder": "LINE notify token key",
+        "propertyName": "token",
+        "selectOptions": null,
+        "showWhen": {
+          "field": "",
+          "is": ""
+        },
+        "required": true,
+        "validationRule": "",
+        "secure": true
+      }
+    ]
   }
 ]
 `


### PR DESCRIPTION
**What this PR does / why we need it**:

Ports Line channel to ngalert.

I plan to add integration tests all at once later when we have a bunch of new channels in.