### PR TITLE
[BUG] Correct value mapping for hex formatted strings

### DIFF
--- a/packages/grafana-data/src/utils/valueMappings.test.ts
+++ b/packages/grafana-data/src/utils/valueMappings.test.ts
@@ -106,6 +106,8 @@ describe('Format value with value mappings', () => {
       ${'192.168'}     | ${undefined}
       ${'192.168.1'}   | ${undefined}
       ${'9.90'}        | ${{ id: 5, text: 'OK', type: MappingType.ValueToText, value: '9.9' }}
+      ${'0x12'}        | ${{ id: 6, text: 'mapped hexstring', type: MappingType.ValueToText, value: '0x12' }}
+      ${'0x15'}        | ${undefined}
     `('numeric-like text mapping, value:${value', ({ value, expected }) => {
       const valueMappings: ValueMapping[] = [
         { id: 1, text: 'mapped value 1', type: MappingType.ValueToText, value: '2/0/12' },
@@ -113,6 +115,7 @@ describe('Format value with value mappings', () => {
         { id: 3, text: 'mapped value 3', type: MappingType.ValueToText, value: '2:0' },
         { id: 4, text: 'mapped value ip', type: MappingType.ValueToText, value: '192.168.1.1' },
         { id: 5, text: 'OK', type: MappingType.ValueToText, value: '9.9' },
+        { id: 6, text: 'mapped hexstring', type: MappingType.ValueToText, value: '0x12' },
       ];
       expect(getMappedValue(valueMappings, value)).toEqual(expected);
     });

--- a/packages/grafana-data/src/utils/valueMappings.ts
+++ b/packages/grafana-data/src/utils/valueMappings.ts
@@ -18,8 +18,13 @@ const addValueToTextMappingText = (
   let valueAsNumber, valueToTextMappingAsNumber;
 
   if (isNumeric(value as string) && isNumeric(valueToTextMapping.value)) {
-    valueAsNumber = parseFloat(value as string);
-    valueToTextMappingAsNumber = parseFloat(valueToTextMapping.value as string);
+    if (isHexString(value as string)) {
+      valueToTextMappingAsNumber = parseInt(valueToTextMapping.value as string, 16);
+      valueAsNumber = parseInt(value as string, 16);
+    } else {
+      valueAsNumber = parseFloat(value as string);
+      valueToTextMappingAsNumber = parseFloat(valueToTextMapping.value as string);
+    }
 
     if (valueAsNumber === valueToTextMappingAsNumber) {
       return allValueMappings.concat(valueToTextMapping);
@@ -101,4 +106,8 @@ const isNullValueMap = (mapping: ValueMap): boolean => {
 
 export function isNumeric(num: any) {
   return (typeof num === 'number' || (typeof num === 'string' && num.trim() !== '')) && !isNaN(num as number);
+}
+
+export function isHexString(num: any) {
+  return Boolean(typeof num === 'string' && num.match(/^0x[0-9a-f]+$/i));
 }


### PR DESCRIPTION
Fixes #34131 for Grafana v7.5.x