### PR TITLE
PieChart: Handle undefined custom.hideFrom in fieldConfig

### DIFF
--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -76,7 +76,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
   }
   const total = displayValues
     .filter((item) => {
-      return !item.field.custom.hideFrom.viz;
+      return !item.field.custom?.hideFrom?.viz;
     })
     .reduce((acc, item) => item.display.numeric + acc, 0);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This handles the case when swapping between visualizations and custom.hideFrom is not present in the fieldConfig.