### PR TITLE
CloudWatch: Make it possible to use with query caching

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -15,14 +15,13 @@ import {
   takeWhile,
   tap,
 } from 'rxjs/operators';
-import { getBackendSrv, getGrafanaLiveSrv, toDataQueryResponse } from '@grafana/runtime';
+import { getBackendSrv, getGrafanaLiveSrv, toDataQueryResponse, DataSourceWithBackend } from '@grafana/runtime';
 import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
 import {
   DataFrame,
   DataQueryErrorType,
   DataQueryRequest,
   DataQueryResponse,
-  DataSourceApi,
   DataSourceInstanceSettings,
   dateMath,
   LiveChannelEvent,
@@ -88,7 +87,7 @@ const displayCustomError = (title: string, message: string) =>
 
 export const MAX_ATTEMPTS = 5;
 
-export class CloudWatchDatasource extends DataSourceApi<CloudWatchQuery, CloudWatchJsonData> {
+export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery, CloudWatchJsonData> {
   proxyUrl: any;
   defaultRegion: any;
   datasourceName: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment, query caching doesn't work with CloudWatch. This is because the CloudWatch data source doesn't extend DataSourceWithBackend. 

Even though the CloudWatch data source did not already extend DataSourceWithBackend, it was still using the latest plugin api:s - all DataQuery requests went through `/api/ds/query`. Therefore there should be no need to make more changes to get query caching to work. 

**Special notes for your reviewer**:
In the future I'd like to do more refactoring in the CloudWatch datasource.ts. For example, call `super.query` instead of handling the request and response prep and parsing internally. However, we don't have time to do that for 8.0 and also I'm not able to test CloudWatch logs properly due to lack of test data.   


@ryantxu - just extending the DataSourceWithBackend should not have any other side effects right? 