### PR TITLE
Alerting: fix rule editor remounting issue

### DIFF
--- a/public/app/features/alerting/unified/RuleEditor.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.tsx
@@ -22,7 +22,7 @@ const ExistingRuleEditor: FC<ExistingRuleEditorProps> = ({ identifier }) => {
   useCleanup((state) => state.unifiedAlerting.ruleForm.existingRule);
   const { loading, result, error, dispatched } = useUnifiedAlertingSelector((state) => state.ruleForm.existingRule);
   const dispatch = useDispatch();
-  const { isEditable, loading: loadingEditableStatus } = useIsRuleEditable(result?.rule);
+  const { isEditable } = useIsRuleEditable(result?.rule);
 
   useEffect(() => {
     if (!dispatched) {
@@ -30,7 +30,7 @@ const ExistingRuleEditor: FC<ExistingRuleEditorProps> = ({ identifier }) => {
     }
   }, [dispatched, dispatch, identifier]);
 
-  if (loading || loadingEditableStatus) {
+  if (loading || isEditable === undefined) {
     return (
       <Page.Contents>
         <LoadingPlaceholder text="Loading rule..." />


### PR DESCRIPTION
When opening rule editor, it would mount, unmount and then mount the form component again.

This was because it first loads the rule via API, then in case of grafana managed rule, loads folder via API to check if user can edit it. Folder can only be loaded after loading the rule. However in between finishing loading rule and starting loading folder it would briefly render the form. So it went spinner -> form -> spinner -> form.
This fixes it so we don't show the rule until both folder and rule are loaded.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

