### PR TITLE
Table: Fix issue with cell border not showing with colored background cells

### DIFF
--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -25,6 +25,7 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
 
       ${color ? `color: ${color};` : ''};
       ${background ? `background: ${background};` : ''};
+      background-clip: padding-box;
 
       &:last-child:not(:only-child) {
         border-right: none;


### PR DESCRIPTION
Fixes issue with cell border not showing when cells have background color
Before: 
![Screenshot from 2021-05-17 18-21-01](https://user-images.githubusercontent.com/10999/118522709-a808c580-b73c-11eb-8551-eeca45efcafa.png)

After:

![Screenshot from 2021-05-17 18-20-16](https://user-images.githubusercontent.com/10999/118522723-ab03b600-b73c-11eb-98d7-ac23cb847e79.png)
