### PR TITLE
FieldDisplay: remove auto min/max for percent units

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -150,23 +150,6 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
         }
       }
 
-      // Some units have an implied range
-      if (config.unit === 'percent') {
-        if (!isNumber(config.min)) {
-          config.min = 0;
-        }
-        if (!isNumber(config.max)) {
-          config.max = 100;
-        }
-      } else if (config.unit === 'percentunit') {
-        if (!isNumber(config.min)) {
-          config.min = 0;
-        }
-        if (!isNumber(config.max)) {
-          config.max = 1;
-        }
-      }
-
       // Set the Min/Max value automatically
       let range: NumericRange | undefined = undefined;
       if (field.type === FieldType.number) {

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
@@ -229,4 +229,22 @@ describe('sharedSingleStatMigrationHandler', () => {
     expect(panel.fieldConfig.defaults.min).toBe(undefined);
     expect(panel.fieldConfig.defaults.max).toBe(undefined);
   });
+
+  it('auto set min/max for percent units before 8.0', () => {
+    const panel = ({
+      options: {
+        fieldOptions: {
+          defaults: {
+            unit: 'percentunit',
+          },
+        },
+      },
+      title: 'Usage',
+      type: 'bargauge',
+    } as unknown) as PanelModel;
+    sharedSingleStatPanelChangedHandler(panel, 'singlestat', panel);
+    expect(panel.fieldConfig.defaults.unit).toBe('percentunit');
+    expect(panel.fieldConfig.defaults.min).toBe(0);
+    expect(panel.fieldConfig.defaults.max).toBe(1);
+  });
 });

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.test.ts
@@ -242,7 +242,7 @@ describe('sharedSingleStatMigrationHandler', () => {
       title: 'Usage',
       type: 'bargauge',
     } as unknown) as PanelModel;
-    sharedSingleStatPanelChangedHandler(panel, 'singlestat', panel);
+    sharedSingleStatMigrationHandler(panel as any);
     expect(panel.fieldConfig.defaults.unit).toBe('percentunit');
     expect(panel.fieldConfig.defaults.min).toBe(0);
     expect(panel.fieldConfig.defaults.max).toBe(1);

--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, omit } from 'lodash';
+import { cloneDeep, isNumber, omit } from 'lodash';
 
 import {
   fieldReducers,
@@ -213,6 +213,27 @@ export function sharedSingleStatMigrationHandler(panel: PanelModel<SingleStatBas
     if (oldTitle !== undefined && oldTitle !== null) {
       panel.fieldConfig.defaults.displayName = oldTitle;
       delete (panel.fieldConfig.defaults as any).title;
+    }
+  }
+
+  if (previousVersion < 8.0) {
+    // Explicit min/max was removed for percent/percentunit in 8.0
+    const config = panel.fieldConfig?.defaults;
+    let unit = config?.unit;
+    if (unit === 'percent') {
+      if (!isNumber(config.min)) {
+        config.min = 0;
+      }
+      if (!isNumber(config.max)) {
+        config.max = 100;
+      }
+    } else if (unit === 'percentunit') {
+      if (!isNumber(config.min)) {
+        config.min = 0;
+      }
+      if (!isNumber(config.max)) {
+        config.max = 1;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #31679

The fieldDisplayProcessor tries to use reasonable min/max values when they are not set.  This is usually fine, but also means that graphs can not be auto ranged and can not use the new softMin/Max features.

In 8.0, lets remove this automatic setting