### PR TITLE
Alerting: Remove back end logic for supporting KeepLastState

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -279,18 +279,16 @@ func (n *GettableExtendedRuleNode) validate() error {
 type NoDataState string
 
 const (
-	Alerting      NoDataState = "Alerting"
-	NoData        NoDataState = "NoData"
-	KeepLastState NoDataState = "KeepLastState"
-	OK            NoDataState = "OK"
+	Alerting NoDataState = "Alerting"
+	NoData   NoDataState = "NoData"
+	OK       NoDataState = "OK"
 )
 
 // swagger:enum ExecutionErrorState
 type ExecutionErrorState string
 
 const (
-	AlertingErrState      ExecutionErrorState = "Alerting"
-	KeepLastStateErrState ExecutionErrorState = "KeepLastState"
+	AlertingErrState ExecutionErrorState = "Alerting"
 )
 
 // swagger:model

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -26,10 +26,9 @@ func (noDataState NoDataState) String() string {
 }
 
 const (
-	Alerting      NoDataState = "Alerting"
-	NoData        NoDataState = "NoData"
-	KeepLastState NoDataState = "KeepLastState"
-	OK            NoDataState = "OK"
+	Alerting NoDataState = "Alerting"
+	NoData   NoDataState = "NoData"
+	OK       NoDataState = "OK"
 )
 
 type ExecutionErrorState string
@@ -39,8 +38,7 @@ func (executionErrorState ExecutionErrorState) String() string {
 }
 
 const (
-	AlertingErrState      ExecutionErrorState = "Alerting"
-	KeepLastStateErrState ExecutionErrorState = "KeepLastState"
+	AlertingErrState ExecutionErrorState = "Alerting"
 )
 
 const (

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -652,7 +652,7 @@ func TestProcessEvalResults(t *testing.T) {
 			},
 		},
 		{
-			desc: "normal -> normal when result is NoData and NoDataState is KeepLastState",
+			desc: "normal -> alerting when result is Error and ExecErrState is Alerting",
 			alertRule: &models.AlertRule{
 				OrgID:           1,
 				Title:           "test_title",
@@ -662,7 +662,7 @@ func TestProcessEvalResults(t *testing.T) {
 				Labels:          map[string]string{"label": "test"},
 				IntervalSeconds: 10,
 				For:             1 * time.Minute,
-				NoDataState:     models.KeepLastState,
+				ExecErrState:    models.AlertingErrState,
 			},
 			evalResults: []eval.Results{
 				{
@@ -676,7 +676,7 @@ func TestProcessEvalResults(t *testing.T) {
 				{
 					eval.Result{
 						Instance:           data.Labels{"instance_label": "test"},
-						State:              eval.NoData,
+						State:              eval.Error,
 						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
 						EvaluationDuration: evaluationDuration,
 					},
@@ -694,7 +694,7 @@ func TestProcessEvalResults(t *testing.T) {
 						"label":                        "test",
 						"instance_label":               "test",
 					},
-					State: eval.Normal,
+					State: eval.Alerting,
 					Results: []state.Evaluation{
 						{
 							EvaluationTime:  evaluationTime,
@@ -702,69 +702,7 @@ func TestProcessEvalResults(t *testing.T) {
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
-							EvaluationState: eval.NoData,
-						},
-					},
-					StartsAt:           evaluationTime.Add(10 * time.Second),
-					EndsAt:             evaluationTime.Add(10 * time.Second).Add(1 * time.Minute),
-					LastEvaluationTime: evaluationTime.Add(10 * time.Second),
-					EvaluationDuration: evaluationDuration,
-					Annotations:        map[string]string{"annotation": "test"},
-				},
-			},
-		},
-		{
-			desc: "normal -> normal when result is NoData and NoDataState is KeepLastState",
-			alertRule: &models.AlertRule{
-				OrgID:           1,
-				Title:           "test_title",
-				UID:             "test_alert_rule_uid_2",
-				NamespaceUID:    "test_namespace_uid",
-				Annotations:     map[string]string{"annotation": "test"},
-				Labels:          map[string]string{"label": "test"},
-				IntervalSeconds: 10,
-				For:             1 * time.Minute,
-				NoDataState:     models.KeepLastState,
-			},
-			evalResults: []eval.Results{
-				{
-					eval.Result{
-						Instance:           data.Labels{"instance_label": "test"},
-						State:              eval.Normal,
-						EvaluatedAt:        evaluationTime,
-						EvaluationDuration: evaluationDuration,
-					},
-				},
-				{
-					eval.Result{
-						Instance:           data.Labels{"instance_label": "test"},
-						State:              eval.NoData,
-						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
-						EvaluationDuration: evaluationDuration,
-					},
-				},
-			},
-			expectedStates: map[string]*state.State{
-				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
-					AlertRuleUID: "test_alert_rule_uid_2",
-					OrgID:        1,
-					CacheId:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
-					Labels: data.Labels{
-						"__alert_rule_namespace_uid__": "test_namespace_uid",
-						"__alert_rule_uid__":           "test_alert_rule_uid_2",
-						"alertname":                    "test_title",
-						"label":                        "test",
-						"instance_label":               "test",
-					},
-					State: eval.Normal,
-					Results: []state.Evaluation{
-						{
-							EvaluationTime:  evaluationTime,
-							EvaluationState: eval.Normal,
-						},
-						{
-							EvaluationTime:  evaluationTime.Add(10 * time.Second),
-							EvaluationState: eval.NoData,
+							EvaluationState: eval.Error,
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -86,7 +86,6 @@ func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) *
 	switch alertRule.ExecErrState {
 	case ngModels.AlertingErrState:
 		a.State = eval.Alerting
-	case ngModels.KeepLastStateErrState:
 	}
 	return a
 }
@@ -106,7 +105,6 @@ func (a *State) resultNoData(alertRule *ngModels.AlertRule, result eval.Result) 
 		a.State = eval.Alerting
 	case ngModels.NoData:
 		a.State = eval.NoData
-	case ngModels.KeepLastState:
 	case ngModels.OK:
 		a.State = eval.Normal
 	}

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -188,8 +188,6 @@ func transNoData(s string) (string, error) {
 		return "NoData", nil
 	case "alerting":
 		return "Alerting", nil
-	case "keep_state":
-		return "KeepLastState", nil
 	}
 	return "", fmt.Errorf("unrecognized No Data setting %v", s)
 }
@@ -198,8 +196,6 @@ func transExecErr(s string) (string, error) {
 	switch s {
 	case "", "alerting":
 		return "Alerting", nil
-	case "KeepLastState":
-		return "KeepLastState", nil
 	}
 	return "", fmt.Errorf("unrecognized Execution Error setting %v", s)
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -188,6 +188,8 @@ func transNoData(s string) (string, error) {
 		return "NoData", nil
 	case "alerting":
 		return "Alerting", nil
+	case "keep_state":
+		return "Alerting", nil
 	}
 	return "", fmt.Errorf("unrecognized No Data setting %v", s)
 }
@@ -195,6 +197,8 @@ func transNoData(s string) (string, error) {
 func transExecErr(s string) (string, error) {
 	switch s {
 	case "", "alerting":
+		return "Alerting", nil
+	case "keep_state":
 		return "Alerting", nil
 	}
 	return "", fmt.Errorf("unrecognized Execution Error setting %v", s)

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -781,7 +781,7 @@ func TestAlertRuleCRUD(t *testing.T) {
 							},
 						},
 						NoDataState:  apimodels.NoDataState(ngmodels.Alerting),
-						ExecErrState: apimodels.ExecutionErrorState(ngmodels.KeepLastStateErrState),
+						ExecErrState: apimodels.ExecutionErrorState(ngmodels.AlertingErrState),
 					},
 				},
 			},
@@ -911,7 +911,7 @@ func TestAlertRuleCRUD(t *testing.T) {
 						  "namespace_id":1,
 						  "rule_group":"arulegroup",
 						  "no_data_state":"Alerting",
-						  "exec_err_state":"KeepLastState"
+						  "exec_err_state":"Alerting"
 					   }
 					}
 				 ]
@@ -960,7 +960,7 @@ func TestAlertRuleCRUD(t *testing.T) {
 							},
 						},
 						NoDataState:  apimodels.NoDataState(ngmodels.Alerting),
-						ExecErrState: apimodels.ExecutionErrorState(ngmodels.KeepLastStateErrState),
+						ExecErrState: apimodels.ExecutionErrorState(ngmodels.AlertingErrState),
 					},
 				},
 			},
@@ -1044,7 +1044,7 @@ func TestAlertRuleCRUD(t *testing.T) {
 							},
 						},
 						NoDataState:  apimodels.NoDataState(ngmodels.Alerting),
-						ExecErrState: apimodels.ExecutionErrorState(ngmodels.KeepLastStateErrState),
+						ExecErrState: apimodels.ExecutionErrorState(ngmodels.AlertingErrState),
 					},
 				},
 			},
@@ -1135,7 +1135,7 @@ func TestAlertRuleCRUD(t *testing.T) {
 		                  "namespace_id":1,
 		                  "rule_group":"arulegroup",
 		                  "no_data_state":"Alerting",
-		                  "exec_err_state":"KeepLastState"
+		                  "exec_err_state":"Alerting"
 		               }
 		            }
 		         ]

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -119,7 +119,7 @@ func TestPrometheusRules(t *testing.T) {
 							},
 						},
 						NoDataState:  apimodels.NoDataState(ngmodels.Alerting),
-						ExecErrState: apimodels.ExecutionErrorState(ngmodels.KeepLastStateErrState),
+						ExecErrState: apimodels.ExecutionErrorState(ngmodels.AlertingErrState),
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes Keep Last State as an alerting rule configuration option for No Data and Error cases. Evaluations that return an error will now only have Alerting as a possible state. Evaluations that result in No Data can still be set to Normal, Alerting, and No Data

**Which issue(s) this PR fixes**:
BE half of https://github.com/grafana/alerting-squad/issues/132

**Special notes for your reviewer**:
Do not merge until the front end team has been able to remove KeepLastState from the UI
