### PR TITLE
Alerting: Trim results when at processing instead of on ticker

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -92,8 +92,8 @@ func (c *cache) set(entry *State) {
 }
 
 func (c *cache) get(orgID int64, alertRuleUID, stateId string) (*State, error) {
-	c.mtxStates.Lock()
-	defer c.mtxStates.Unlock()
+	c.mtxStates.RLock()
+	defer c.mtxStates.RUnlock()
 	if state, ok := c.states[orgID][alertRuleUID][stateId]; ok {
 		return state, nil
 	}
@@ -102,8 +102,8 @@ func (c *cache) get(orgID int64, alertRuleUID, stateId string) (*State, error) {
 
 func (c *cache) getAll(orgID int64) []*State {
 	var states []*State
-	c.mtxStates.Lock()
-	defer c.mtxStates.Unlock()
+	c.mtxStates.RLock()
+	defer c.mtxStates.RUnlock()
 	for _, v1 := range c.states[orgID] {
 		for _, v2 := range v1 {
 			states = append(states, v2)
@@ -114,8 +114,8 @@ func (c *cache) getAll(orgID int64) []*State {
 
 func (c *cache) getStatesForRuleUID(orgID int64, alertRuleUID string) []*State {
 	var ruleStates []*State
-	c.mtxStates.Lock()
-	defer c.mtxStates.Unlock()
+	c.mtxStates.RLock()
+	defer c.mtxStates.RUnlock()
 	for _, state := range c.states[orgID][alertRuleUID] {
 		ruleStates = append(ruleStates, state)
 	}
@@ -136,8 +136,8 @@ func (c *cache) reset() {
 }
 
 func (c *cache) recordMetrics() {
-	c.mtxStates.Lock()
-	defer c.mtxStates.Unlock()
+	c.mtxStates.RLock()
+	defer c.mtxStates.RUnlock()
 
 	// Set default values to zero such that gauges are reset
 	// after all values from a single state disappear.

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -135,7 +135,7 @@ func (c *cache) reset() {
 	c.states = make(map[int64]map[string]map[string]*State)
 }
 
-func (c *cache) trim() {
+func (c *cache) recordMetrics() {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
 
@@ -153,13 +153,6 @@ func (c *cache) trim() {
 		c.metrics.GroupRules.WithLabelValues(fmt.Sprint(org)).Set(float64(len(orgMap)))
 		for _, rule := range orgMap {
 			for _, state := range rule {
-				if len(state.Results) > 100 {
-					newResults := make([]Evaluation, 100)
-					// Keep last 100 results
-					copy(newResults, state.Results[len(state.Results)-100:])
-					state.Results = newResults
-				}
-
 				n := ct[state.State]
 				ct[state.State] = n + 1
 			}

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -25,7 +24,7 @@ func NewManager(logger log.Logger, metrics *metrics.Metrics) *Manager {
 		Log:     logger,
 		metrics: metrics,
 	}
-	go manager.cleanUp()
+	go manager.recordMetrics()
 	return manager
 }
 
@@ -77,6 +76,7 @@ func (st *Manager) setNextState(alertRule *ngModels.AlertRule, result eval.Resul
 		EvaluationTime:  result.EvaluatedAt,
 		EvaluationState: result.State,
 	})
+	currentState.TrimResults(alertRule)
 
 	st.Log.Debug("setting alert state", "uid", alertRule.UID)
 	switch result.State {
@@ -103,19 +103,18 @@ func (st *Manager) GetStatesForRuleUID(orgID int64, alertRuleUID string) []*Stat
 	return st.cache.getStatesForRuleUID(orgID, alertRuleUID)
 }
 
-func (st *Manager) cleanUp() {
+func (st *Manager) recordMetrics() {
 	// TODO: parameterize?
 	// Setting to a reasonable default scrape interval for Prometheus.
 	dur := time.Duration(15) * time.Second
 	ticker := time.NewTicker(dur)
-	st.Log.Debug("starting cleanup process", "dur", fmt.Sprint(dur))
 	for {
 		select {
 		case <-ticker.C:
-			st.Log.Info("trimming alert state cache", "now", time.Now())
-			st.cache.trim()
+			st.Log.Info("recording state cache metrics", "now", time.Now())
+			st.cache.recordMetrics()
 		case <-st.quit:
-			st.Log.Debug("stopping cleanup process", "now", time.Now())
+			st.Log.Debug("stopping state cache metrics recording", "now", time.Now())
 			ticker.Stop()
 			return
 		}

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -124,3 +124,18 @@ func (a *State) Equals(b *State) bool {
 		a.LastEvaluationTime == b.LastEvaluationTime &&
 		data.Labels(a.Annotations).String() == data.Labels(b.Annotations).String()
 }
+
+func (a *State) TrimResults(alertRule *ngModels.AlertRule) {
+	numBuckets := 2 * (int64(alertRule.For.Seconds()) / alertRule.IntervalSeconds)
+	if numBuckets == 0 {
+		numBuckets = 10 // keep at least 10 evaluations in the event For is set to 0
+	}
+
+	if len(a.Results) < int(numBuckets) {
+		return
+	}
+	newResults := make([]Evaluation, numBuckets)
+	// Keep last 100 results
+	copy(newResults, a.Results[len(a.Results)-int(numBuckets):])
+	a.Results = newResults
+}

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -135,7 +135,6 @@ func (a *State) TrimResults(alertRule *ngModels.AlertRule) {
 		return
 	}
 	newResults := make([]Evaluation, numBuckets)
-	// Keep last 100 results
 	copy(newResults, a.Results[len(a.Results)-int(numBuckets):])
 	a.Results = newResults
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the way that Evaluation results are tracked and pruned. Instead of every cache entry having a set number of results, we will keep 2 * alertRule.For.Seconds / alertRule.IntervalSeconds or 10, in the case that For.Seconds is 0. 10 was chosen because it's a round, easy number but could easily be configurable. 

The trim method, previously used to keep results from growing without bounds, was already recording metrics and has been renamed to reflect that metric recording is now all it is used for. 