### PR TITLE
Auth Proxy: Support setting Organization roles via HTTP headers

### DIFF
--- a/docs/sources/auth/auth-proxy.md
+++ b/docs/sources/auth/auth-proxy.md
@@ -30,7 +30,7 @@ sync_ttl = 60
 # Example `whitelist = 192.168.1.1, 192.168.1.0/24, 2001::23, 2001::0/120`
 whitelist =
 # Optionally define more headers to sync other user attributes
-# Example `headers = Name:X-WEBAUTH-NAME Email:X-WEBAUTH-EMAIL Groups:X-WEBAUTH-GROUPS`
+# Example `headers = Name:X-WEBAUTH-NAME Email:X-WEBAUTH-EMAIL Groups:X-WEBAUTH-GROUPS Orgs:X-WEBAUTH-ORGS`
 headers =
 # Check out docs on this for more details on the below setting
 enable_login_token = false
@@ -293,6 +293,33 @@ With this, the user `leonard` will be automatically placed into the Loki team as
 
 [Learn more about Team Sync]({{< relref "team-sync.md" >}})
 
+## Organization roles
+Roles can be set via the headers configuration. The specific attribute to support this feature is called 'Orgs'. e.g. 
+
+```bash
+# Optionally define more headers to sync other user attributes
+headers: 'Orgs:X-WEBAUTH-ORGS'
+```
+
+The value is something in the lines of:
+
+```bash
+X-WEBAUTH-ORGS: 1,2,3
+```
+or 
+```bash
+X-WEBAUTH-ORGS: 1:Admin,2:Viewer,3:Editor
+```
+or anything in between
+```bash
+X-WEBAUTH-ORGS: 1:Admin,2,3:Editor
+```
+
+Where 1, 2 & 3 are the IDs of existing organizations. Behind the (optional) colon (:), you can put the role assigned to this organization. You can only choose between Admin, Editor or Viewer.
+If nothing is provided or a typo is made (it is case-sensitive as well), it will default to having only viewing rights for that organization.
+
+The first organization ID listed, will also be made that users default organization.
+It should be noted that this header overwrites any organization assigned to that user via other means (API, web interface, ...).
 
 ## Login token and session cookie
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -356,11 +356,12 @@ func TestMiddlewareContext(t *testing.T) {
 			cfg.LDAPEnabled = true
 			cfg.AuthProxyHeaderName = "X-WEBAUTH-USER"
 			cfg.AuthProxyHeaderProperty = "username"
-			cfg.AuthProxyHeaders = map[string]string{"Groups": "X-WEBAUTH-GROUPS"}
+			cfg.AuthProxyHeaders = map[string]string{"Groups": "X-WEBAUTH-GROUPS", "Orgs": "X-WEBAUTH-ORGS"}
 		}
 
 		const hdrName = "markelog"
 		const group = "grafana-core-team"
+		const orgs = "1:Admin,2"
 
 		middlewareScenario(t, "Should not sync the user if it's in the cache", func(t *testing.T, sc *scenarioContext) {
 			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
@@ -403,6 +404,37 @@ func TestMiddlewareContext(t *testing.T) {
 			configure(cfg)
 			cfg.LDAPEnabled = false
 			cfg.AuthProxyAutoSignUp = false
+		})
+
+		middlewareScenario(t, "Should create an user from headers and assign organizations", func(t *testing.T, sc *scenarioContext) {
+			var orgRoles = map[int64]models.RoleType{}
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+				if query.UserId > 0 {
+					query.Result = &models.SignedInUser{OrgId: query.OrgId, UserId: userID}
+					return nil
+				}
+				return models.ErrUserNotFound
+			})
+
+			bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+				orgRoles = cmd.ExternalUser.OrgRoles
+				cmd.Result = &models.User{Id: userID}
+				return nil
+			})
+
+			sc.fakeReq("GET", "/")
+			sc.req.Header.Set(sc.cfg.AuthProxyHeaderName, hdrName)
+			sc.req.Header.Set("X-WEBAUTH-ORGS", orgs)
+			sc.exec()
+
+			assert.True(t, sc.context.IsSignedIn)
+			assert.Equal(t, map[int64]models.RoleType{1: models.ROLE_ADMIN, 2: models.ROLE_VIEWER}, orgRoles)
+			assert.Equal(t, userID, sc.context.UserId)
+			assert.Equal(t, int64(1), sc.context.OrgId)
+		}, func(cfg *setting.Cfg) {
+			configure(cfg)
+			cfg.LDAPEnabled = false
+			cfg.AuthProxyAutoSignUp = true
 		})
 
 		middlewareScenario(t, "Should create an user from a header", func(t *testing.T, sc *scenarioContext) {

--- a/pkg/services/contexthandler/authproxy/authproxy.go
+++ b/pkg/services/contexthandler/authproxy/authproxy.go
@@ -10,6 +10,8 @@ import (
 	"net/mail"
 	"path"
 	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,7 +47,7 @@ var isLDAPEnabled = func(cfg *setting.Cfg) bool {
 var newLDAP = multildap.New
 
 // supportedHeaders states the supported headers configuration fields
-var supportedHeaderFields = []string{"Name", "Email", "Login", "Groups"}
+var supportedHeaderFields = []string{"Name", "Email", "Login", "Groups", "Orgs"}
 
 // AuthProxy struct
 type AuthProxy struct {
@@ -278,9 +280,35 @@ func (auth *AuthProxy) LoginViaHeader() (int64, error) {
 	}
 
 	auth.headersIterator(func(field string, header string) {
-		if field == "Groups" {
+		switch field {
+		case "Groups":
 			extUser.Groups = util.SplitString(header)
-		} else {
+		case "Orgs":
+			var err error
+			var orgID int64
+			var organizations = util.SplitString(header)
+
+			extUser.OrgRoles = map[int64]models.RoleType{}
+
+			for i := 0; i < len(organizations); i++ {
+				var organization = organizations[i]
+				var splitOrganization = regexp.MustCompile("[:]+").Split(organization, -1)
+				orgID, err = strconv.ParseInt(splitOrganization[0], 10, 64)
+
+				if err == nil {
+					if len(splitOrganization) == 1 || !models.RoleType.IsValid(models.RoleType(splitOrganization[1])) {
+						extUser.OrgRoles[orgID] = models.ROLE_VIEWER
+					} else {
+						extUser.OrgRoles[orgID] = models.RoleType(splitOrganization[1])
+					}
+
+					// Assign the first organization id as the primary organization to which this user should belong
+					if auth.orgID == 0 {
+						auth.orgID = orgID
+					}
+				}
+			}
+		default:
 			reflect.ValueOf(extUser).Elem().FieldByName(field).SetString(header)
 		}
 	})


### PR DESCRIPTION
This PR gives the ability to set the roles for each organization and registers the user to these in the process.
One has the ability to set it via X-WEBAUTH-ORGS headers as: "1,2,3" or "1:Admin,2,3:Editor". If no role is provided, viewer role is assumed.
Once this header is used, it overwrites all existing organization data for that user
_It should be noted that only the IDs can be used._

I've:
- Added a test
- Updated documentation
- Did a manual UI test to double-check

References issues:
 - https://github.com/grafana/grafana/issues/19943
 - https://github.com/grafana/grafana/issues/8816
 - https://github.com/grafana/grafana/issues/6083