### PR TITLE
CustomScrollbar: Invoke setScrollTop callback only after scrolling finishes

### DIFF
--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -2,9 +2,11 @@ import React, { FC, useCallback, useEffect, useRef } from 'react';
 import { isNil } from 'lodash';
 import classNames from 'classnames';
 import { css } from '@emotion/css';
-import Scrollbars from 'react-custom-scrollbars';
+import Scrollbars, { positionValues } from 'react-custom-scrollbars';
 import { useStyles2 } from '../../themes';
 import { GrafanaTheme2 } from '@grafana/data';
+
+export type ScrollbarPosition = positionValues;
 
 interface Props {
   className?: string;
@@ -15,7 +17,7 @@ interface Props {
   hideHorizontalTrack?: boolean;
   hideVerticalTrack?: boolean;
   scrollTop?: number;
-  setScrollTop?: (event: any) => void;
+  setScrollTop?: (position: ScrollbarPosition) => void;
   autoHeightMin?: number | string;
   updateAfterMountMs?: number;
 }
@@ -105,7 +107,9 @@ export const CustomScrollbar: FC<Props> = ({
     <Scrollbars
       ref={ref}
       className={classNames(styles.customScrollbar, className)}
-      onScroll={setScrollTop}
+      onScrollStop={() => {
+        ref.current && setScrollTop && setScrollTop(ref.current.getValues());
+      }}
       autoHeight={true}
       autoHide={autoHide}
       autoHideTimeout={autoHideTimeout}

--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -103,13 +103,15 @@ export const CustomScrollbar: FC<Props> = ({
     return <div {...passedProps} className="scrollbar-view" />;
   }, []);
 
+  const onScrollStop = useCallback(() => {
+    ref.current && setScrollTop && setScrollTop(ref.current.getValues());
+  }, [setScrollTop]);
+
   return (
     <Scrollbars
       ref={ref}
       className={classNames(styles.customScrollbar, className)}
-      onScrollStop={() => {
-        ref.current && setScrollTop && setScrollTop(ref.current.getValues());
-      }}
+      onScrollStop={onScrollStop}
       autoHeight={true}
       autoHide={autoHide}
       autoHideTimeout={autoHideTimeout}

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -6,7 +6,7 @@ export { Tooltip, PopoverContent } from './Tooltip/Tooltip';
 export { PopoverController } from './Tooltip/PopoverController';
 export { Popover } from './Tooltip/Popover';
 export { Portal } from './Portal/Portal';
-export { CustomScrollbar } from './CustomScrollbar/CustomScrollbar';
+export { CustomScrollbar, ScrollbarPosition } from './CustomScrollbar/CustomScrollbar';
 export { TabbedContainer, TabConfig } from './TabbedContainer/TabbedContainer';
 
 export { ClipboardButton } from './ClipboardButton/ClipboardButton';

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -1,11 +1,11 @@
 import $ from 'jquery';
-import React, { MouseEvent, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import { css } from 'emotion';
 import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
 import { locationService } from '@grafana/runtime';
 import { selectors } from '@grafana/e2e-selectors';
-import { CustomScrollbar, stylesFactory, Themeable2, withTheme2 } from '@grafana/ui';
+import { CustomScrollbar, ScrollbarPosition, stylesFactory, Themeable2, withTheme2 } from '@grafana/ui';
 
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { Branding } from 'app/core/components/Branding/Branding';
@@ -241,9 +241,8 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
     $('body').toggleClass('panel-in-fullscreen', isFullscreen);
   }
 
-  setScrollTop = (e: MouseEvent<HTMLElement>): void => {
-    const target = e.target as HTMLElement;
-    this.setState({ scrollTop: target.scrollTop, updateScrollTop: undefined });
+  setScrollTop = ({ scrollTop }: ScrollbarPosition): void => {
+    this.setState({ scrollTop, updateScrollTop: undefined });
   };
 
   onAddPanel = () => {

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -1,7 +1,16 @@
 // Libraries
 import React, { PureComponent } from 'react';
 // Components
-import { Button, CustomScrollbar, HorizontalGroup, Icon, Modal, stylesFactory, Tooltip } from '@grafana/ui';
+import {
+  Button,
+  CustomScrollbar,
+  HorizontalGroup,
+  Icon,
+  Modal,
+  ScrollbarPosition,
+  stylesFactory,
+  Tooltip,
+} from '@grafana/ui';
 import { getDataSourceSrv, DataSourcePicker } from '@grafana/runtime';
 import { QueryEditorRows } from './QueryEditorRows';
 // Services
@@ -275,9 +284,8 @@ export class QueryGroup extends PureComponent<Props, State> {
     this.onScrollBottom();
   };
 
-  setScrollTop = (event: React.MouseEvent<HTMLElement>) => {
-    const target = event.target as HTMLElement;
-    this.setState({ scrollTop: target.scrollTop });
+  setScrollTop = ({ scrollTop }: ScrollbarPosition) => {
+    this.setState({ scrollTop: scrollTop });
   };
 
   onQueriesChange = (queries: DataQuery[]) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

*Problem*

Firefox (Gecko) supports smooth scrolling meaning that when it's enabled...

> (...) then the view doesn't scroll immediately but schedules a series of small-step scroll events to be processed over time. 

Gecko docs: https://wiki.mozilla.org/Gecko:How_Scrolling_Works

QueryGroup listens to scroll events and updates the scroll back to the dispatched value ([here](https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryGroup.tsx#L278)). However, the scrollTop value is set in [CustomScrollbar with useEffect()](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx#L49) meaning it's set only after the render. At that point the scroll might haven already been moved farther by the next small-step event. This causes the scroll to be reset to a lower value and stop after the first small-step event. 

Example:
- native scroll event is dispatched { scrollTop: 101 }
- QueryGroup passes scrollTop=101 to CustomScrollbar 
- CustomScrollbar schedules setting the scrollTop with useEffect
- another native scroll event is dispatched { scrollTop: 102 }
- useEffect is triggered setting the scroll back to 101

*Fix*

The PR changes that `setScrollTop` callback is triggered only on the scroll end. This is a breaking change in API. Should I instead introduce a new method `onScrollStop`?

Note that DashboardPage is not affected by this bug because the scrollTop value is not being passed back to CustomScrollbar. It could also be a solution for QueryGroup but feels clunky as it's not really needed. I also tried disabling smooth scrolling with `scroll-behavior` CSS but it didn't work.

*How to test it?*

I was able to test it on a Mac using a mouse. A single roll triggers multiple scroll events. Not sure if there's a way to reproduce it with a trackpad.

UX wise it feels like the scroll is extremely slow:

https://user-images.githubusercontent.com/745532/118611612-55bbb900-b7bd-11eb-9880-462ac307aed9.mov

Here's how it looks in Chrome (but Chrome dispatches only single scroll event with bigger delta):

https://user-images.githubusercontent.com/745532/118610958-9c5ce380-b7bc-11eb-81f8-219d19742d25.mov


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #34165 
Fixes #33815

**Special notes for your reviewer**: N/A
