### PR TITLE
PieChart: Always show the calculation options dropdown in the editor.

### DIFF
--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,4 +1,4 @@
-import { FieldColorModeId, FieldConfigProperty, PanelPlugin, ReducerID, standardEditorsRegistry } from '@grafana/data';
+import { FieldColorModeId, FieldConfigProperty, PanelPlugin, standardEditorsRegistry } from '@grafana/data';
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions, PieChartType, PieChartLabels, PieChartLegendValues } from './types';
 import { LegendDisplayMode, commonOptionsBuilder } from '@grafana/ui';
@@ -32,9 +32,6 @@ export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
         name: 'Calculation',
         description: 'Choose a reducer function / calculation',
         editor: standardEditorsRegistry.get('stats-picker').editor as any,
-        defaultValue: [ReducerID.lastNotNull],
-        // Hides it when all values mode is on
-        showIf: (currentConfig) => currentConfig.reduceOptions.values === false,
       })
       .addRadio({
         name: 'Piechart type',

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,4 +1,4 @@
-import { FieldColorModeId, FieldConfigProperty, PanelPlugin, standardEditorsRegistry } from '@grafana/data';
+import { FieldColorModeId, FieldConfigProperty, PanelPlugin, ReducerID, standardEditorsRegistry } from '@grafana/data';
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartOptions, PieChartType, PieChartLabels, PieChartLegendValues } from './types';
 import { LegendDisplayMode, commonOptionsBuilder } from '@grafana/ui';
@@ -32,6 +32,7 @@ export const plugin = new PanelPlugin<PieChartOptions>(PieChartPanel)
         name: 'Calculation',
         description: 'Choose a reducer function / calculation',
         editor: standardEditorsRegistry.get('stats-picker').editor as any,
+        defaultValue: [ReducerID.lastNotNull],
       })
       .addRadio({
         name: 'Piechart type',


### PR DESCRIPTION
**What this PR does / why we need it**:
When cleaning up the options for the piechart the all/calculated option was removed. The option for selecting calculations depended on that being there and would not be visible. This changes it so it's always displayed.

**Which issue(s) this PR fixes**:
Fixes #34258
