### PR TITLE
Datasource: Use intervalMs field of query model in GetIntervalFrom if interval field is not set

### DIFF
--- a/pkg/tsdb/interval/interval.go
+++ b/pkg/tsdb/interval/interval.go
@@ -69,6 +69,15 @@ func (ic *intervalCalculator) Calculate(timerange plugins.DataTimeRange, minInte
 func GetIntervalFrom(dsInfo *models.DataSource, queryModel *simplejson.Json, defaultInterval time.Duration) (time.Duration, error) {
 	interval := queryModel.Get("interval").MustString("")
 
+	// intervalMs field appears in the v2 plugins API and should be preferred
+	// if 'interval' isn't present.
+	if interval == "" {
+		intervalMS := queryModel.Get("intervalMs").MustInt(0)
+		if intervalMS != 0 {
+			return time.Duration(intervalMS) * time.Millisecond, nil
+		}
+	}
+
 	if interval == "" && dsInfo != nil && dsInfo.JsonData != nil {
 		dsInterval := dsInfo.JsonData.Get("timeInterval").MustString("")
 		if dsInterval != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

The /api/ds/query and /api/tsdb/query endpoints extract this field from each query in the request, but it currently seems to be ignored, at least for queries to a Prometheus datasource. This PR changes GetIntervalFrom function to check for the presence of intervalMs in the query JSON (as well as just checking for 'interval'). This is then picked up by the Prometheus datasource.

The reason for the PR is that I'm attempting to use the /api/ds/query endpoint as a unified interface to many Grafana datasources, so I expected Grafana to translate the (documented) `intervalMs` field to the relevant parameter for whichever backend datasource I queried. This doesn't seem to be happening currently, but hopefully this PR is a step in that direction!

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Discussed on Grafana internal Slack in #grafana-backend.