### PR TITLE
Elasticsearch: Add meta limit to data frames

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -936,6 +936,20 @@ describe('enhanceDataFrame', () => {
       },
     });
   });
+
+  it('adds limit to dataframe', () => {
+    const df = new MutableDataFrame({
+      fields: [
+        {
+          name: 'someField',
+          values: new ArrayVector([]),
+        },
+      ],
+    });
+    enhanceDataFrame(df, [], 10);
+
+    expect(df.meta?.limit).toBe(10);
+  });
 });
 
 const createElasticQuery = (): DataQueryRequest<ElasticsearchQuery> => {


### PR DESCRIPTION
Adds limit to datFrame meta info for ES logs queries

fixes #33318