### PR TITLE
Alerting: Lower the default timerange

### DIFF
--- a/packages/grafana-data/src/types/time.ts
+++ b/packages/grafana-data/src/types/time.ts
@@ -67,7 +67,7 @@ export function getDefaultTimeRange(): TimeRange {
  */
 export function getDefaultRelativeTimeRange(): RelativeTimeRange {
   return {
-    from: 21600,
+    from: 600,
     to: 0,
   };
 }

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -22,6 +22,7 @@ import { isGrafanaRulesSource } from './datasource';
 import { arrayToRecord, recordToArray } from './misc';
 import { isAlertingRulerRule, isGrafanaRulerRule } from './rules';
 import { parseInterval } from './time';
+import { getDefaultRelativeTimeRange } from '../../../../../../packages/grafana-data';
 
 export const getDefaultFormValues = (): RuleFormValues =>
   Object.freeze({
@@ -136,7 +137,7 @@ export const getDefaultQueries = (): GrafanaQuery[] => {
   if (!dataSource) {
     return [getDefaultExpression('A')];
   }
-  const relativeTimeRange = { from: 600, to: 0 };
+  const relativeTimeRange = getDefaultRelativeTimeRange();
 
   return [
     {

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -1,4 +1,4 @@
-import { DataQuery, getDefaultTimeRange, rangeUtil, RelativeTimeRange } from '@grafana/data';
+import { DataQuery, rangeUtil, RelativeTimeRange } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getNextRefIdChar } from 'app/core/utils/query';
@@ -136,9 +136,7 @@ export const getDefaultQueries = (): GrafanaQuery[] => {
   if (!dataSource) {
     return [getDefaultExpression('A')];
   }
-
-  const timeRange = getDefaultTimeRange();
-  const relativeTimeRange = rangeUtil.timeRangeToRelative(timeRange);
+  const relativeTimeRange = { from: 600, to: 0 };
 
   return [
     {


### PR DESCRIPTION
**What this PR does / why we need it**:
Lowers the default timerange from `now-6h - now` to `now-10m - now`


**Special notes for your reviewer**:

