### PR TITLE
Elasticsearch: don't add bucket aggregations when importing log queries

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -82,4 +82,41 @@ describe('QueryEditor', () => {
       expect(screen.getByLabelText('Alias')).toBeEnabled();
     });
   });
+
+  it('Should NOT show Bucket Aggregations Editor if query contains a "singleMetric" metric', () => {
+    const query: ElasticsearchQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [
+        {
+          id: '1',
+          type: 'logs',
+        },
+      ],
+      // Even if present, this shouldn't be shown in the UI
+      bucketAggs: [{ id: '2', type: 'date_histogram' }],
+    };
+
+    render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={noop} onRunQuery={noop} />);
+
+    expect(screen.queryByLabelText('Group By')).not.toBeInTheDocument();
+  });
+
+  it('Should show Bucket Aggregations Editor if query does NOT contains a "singleMetric" metric', () => {
+    const query: ElasticsearchQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [
+        {
+          id: '1',
+          type: 'avg',
+        },
+      ],
+      bucketAggs: [{ id: '2', type: 'date_histogram' }],
+    };
+
+    render(<QueryEditor query={query} datasource={{} as ElasticDatasource} onChange={noop} onRunQuery={noop} />);
+
+    expect(screen.getByText('Group By')).toBeInTheDocument();
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -9,6 +9,7 @@ import { MetricAggregationsEditor } from './MetricAggregationsEditor';
 import { BucketAggregationsEditor } from './BucketAggregationsEditor';
 import { useDispatch } from '../../hooks/useStatelessReducer';
 import { useNextId } from '../../hooks/useNextId';
+import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions>;
 
@@ -34,6 +35,10 @@ const QueryEditorForm = ({ value }: Props) => {
 
   // To be considered a time series query, the last bucked aggregation must be a Date Histogram
   const isTimeSeriesQuery = value.bucketAggs?.slice(-1)[0]?.type === 'date_histogram';
+
+  const showBucketAggregationsEditor = value.metrics?.every(
+    (metric) => !metricAggregationConfig[metric.type].isSingleMetric
+  );
 
   return (
     <>
@@ -65,7 +70,7 @@ const QueryEditorForm = ({ value }: Props) => {
       </InlineFieldRow>
 
       <MetricAggregationsEditor nextId={nextId} />
-      <BucketAggregationsEditor nextId={nextId} />
+      {showBucketAggregationsEditor && <BucketAggregationsEditor nextId={nextId} />}
     </>
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/language_provider.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/language_provider.test.ts
@@ -4,8 +4,6 @@ import { ElasticDatasource } from './datasource';
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { ElasticsearchOptions, ElasticsearchQuery } from './types';
 import { TemplateSrv } from '../../../features/templating/template_srv';
-import { defaultBucketAgg } from './query_def';
-import { DateHistogram } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 
 const templateSrvStub = {
   getAdhocFilters: jest.fn(() => [] as any[]),
@@ -27,7 +25,6 @@ const dataSource = new ElasticDatasource(
 
 const baseLogsQuery: Partial<ElasticsearchQuery> = {
   metrics: [{ type: 'logs', id: '1' }],
-  bucketAggs: [{ ...defaultBucketAgg('2'), field: dataSource.timeField } as DateHistogram],
 };
 
 describe('transform prometheus query to elasticsearch query', () => {

--- a/public/app/plugins/datasource/elasticsearch/language_provider.ts
+++ b/public/app/plugins/datasource/elasticsearch/language_provider.ts
@@ -7,7 +7,6 @@ import { PromQuery } from '../prometheus/types';
 
 import Prism, { Token } from 'prismjs';
 import grammar from '../prometheus/promql';
-import { defaultBucketAgg } from './query_def';
 
 function getNameLabelValue(promQuery: string, tokens: any): string {
   let nameLabelValue = '';
@@ -122,7 +121,6 @@ export default class ElasticsearchLanguageProvider extends LanguageProvider {
               type: 'logs',
             },
           ],
-          bucketAggs: [{ ...defaultBucketAgg('2'), field: this.datasource.timeField }],
           query: expr,
           refId: query.refId,
         };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When importing log queries from Prometheus/Loki, a date histogram bucket aggregation was being added to the query. That bucket aggregation is actually being ignored by the query builder.
We previously changed the editor to remove all bucket aggregations when a single metric was added, but when importing log queries we still added one.

Also, this PR forces the UI to not render the bucket aggregation editor if one of the metric aggregations is "single metric" (like logs, raw_document, raw_data) even if the query model contains a bucket aggregation.
This can happen for example when manually editing the JSON schema

**Special notes for your reviewer**:

This is basically just a UI change, as it doesn't affect in any way how the query is being built