### PR TITLE
TraceViewer: fix hard to click trace to logs icon

### DIFF
--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBarRow.tsx
@@ -46,12 +46,6 @@ const getStyles = createStyle((theme: Theme) => {
       line-height: 27px;
       overflow: hidden;
       display: flex;
-      &:hover {
-        border-right: 1px solid ${autoColor(theme, '#bbb')};
-        float: left;
-        min-width: calc(100% + 1px);
-        overflow: visible;
-      }
     `,
     nameWrapperMatchingFilter: css`
       label: nameWrapperMatchingFilter;
@@ -401,6 +395,7 @@ export class UnthemedSpanBarRow extends React.PureComponent<SpanBarRowProps> {
             <a
               className={cx(styles.name, { [styles.nameDetailExpanded]: isDetailExpanded })}
               aria-checked={isDetailExpanded}
+              title={labelDetail}
               onClick={this._detailToggle}
               role="switch"
               style={{ borderColor: color }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes the issue when the operation name was too long it was not possible to press the trace to logs button.


https://user-images.githubusercontent.com/13729989/118677032-342df200-b7fc-11eb-8e93-7956629a6439.mp4



**Which issue(s) this PR fixes**:

Fixes #30888

**Special notes for your reviewer**:

