### PR TITLE
Theme: Updating old theme variables to use the new theme higher contrast colors

### DIFF
--- a/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
@@ -84,9 +84,9 @@ $query-orange: ${theme.v1.palette.orange};
 
 // Status colors
 // -------------------------¨
-$online: ${theme.v1.palette.online};
-$warn: ${theme.v1.palette.warn};
-$critical: ${theme.v1.palette.critical};
+$online: ${theme.colors.success.text};
+$warn: ${theme.colors.warning.text};
+$critical: ${theme.colors.error.text};
 
 // Scaffolding
 // -------------------------

--- a/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
@@ -80,9 +80,10 @@ $query-orange: ${theme.v1.palette.orange};
 
 // Status colors
 // -------------------------
-$online: ${theme.v1.palette.online};
-$warn: ${theme.v1.palette.warn};
-$critical: ${theme.v1.palette.critical};
+$online: ${theme.colors.success.text};
+$warn: ${theme.colors.warning.text};
+$critical: ${theme.colors.error.text};
+
 
 // Scaffolding
 // -------------------------

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -87,9 +87,9 @@ $query-orange: #eb7b18;
 
 // Status colors
 // -------------------------¨
-$online: #1A7F4B;
-$warn: #1A7F4B;
-$critical: #1A7F4B;
+$online: #6CCF8E;
+$warn: #F8D06B;
+$critical: #FF5286;
 
 // Scaffolding
 // -------------------------

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -83,8 +83,9 @@ $query-orange: #eb7b18;
 // Status colors
 // -------------------------
 $online: #1A7F4B;
-$warn: #1A7F4B;
-$critical: #1A7F4B;
+$warn: #BD4B00;
+$critical: #CF0E5B;
+
 
 // Scaffolding
 // -------------------------

--- a/public/sass/pages/_alerting.scss
+++ b/public/sass/pages/_alerting.scss
@@ -1,18 +1,22 @@
 .alert-state-paused,
 .alert-state-pending {
   color: $text-muted;
+  font-weight: $font-weight-semi-bold;
 }
 
 .alert-state-ok {
   color: $online;
+  font-weight: $font-weight-semi-bold;
 }
 
 .alert-state-warning {
   color: $warn;
+  font-weight: $font-weight-semi-bold;
 }
 
 .alert-state-critical {
   color: $critical;
+  font-weight: $font-weight-semi-bold;
 }
 
 .alert-notify-emails {


### PR DESCRIPTION
Noticed that the old alerting list looked like this 
![Screenshot from 2021-05-18 17-11-33](https://user-images.githubusercontent.com/10999/118677133-4d36a300-b7fc-11eb-981c-1a8c4a163971.png)

After updated to use new theme colors:
![Screenshot from 2021-05-18 17-13-51](https://user-images.githubusercontent.com/10999/118677326-77886080-b7fc-11eb-8634-53c2bd1cb6e3.png)
