### PR TITLE
InfluxDB: InfluxQL always apply time interval end

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -530,11 +530,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
   getTimeFilter(options: any) {
     const from = this.getInfluxTime(options.rangeRaw.from, false, options.timezone);
     const until = this.getInfluxTime(options.rangeRaw.to, true, options.timezone);
-    const fromIsAbsolute = from[from.length - 1] === 'ms';
-
-    if (until === 'now()' && !fromIsAbsolute) {
-      return 'time >= ' + from;
-    }
 
     return 'time >= ' + from + ' and time <= ' + until;
   }


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/7071

currently, if you set up a time-range like from: `now - 15m` to : `now`, the generated influxql query will use this time-filter expression:  `WHERE time >= now() - 15m`. if the database contains data for in-the-future timestamps (for example, weather forecast data), those will get included in the query-result. we do not want this.

this happens because currently we special-case time-ranges that end with `now`.

this pull-request changes this and we always create the whole from-to expression, so the time-filter for the above-mentioned time-range will become: `WHERE time >= now() - 15m and time <= now()`.
