### PR TITLE
Alerting: improve error presentation in forms

### DIFF
--- a/public/app/features/alerting/unified/AmRoutes.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.tsx
@@ -97,11 +97,6 @@ const AmRoutes: FC = () => {
   return (
     <AlertingPageWrapper pageId="am-routes">
       <AlertManagerPicker current={alertManagerSourceName} onChange={setAlertManagerSourceName} />
-      {savingError && !saving && (
-        <Alert severity="error" title="Error saving alert manager config">
-          {savingError.message || 'Unknown error.'}
-        </Alert>
-      )}
       {resultError && !resultLoading && (
         <Alert severity="error" title="Error loading alert manager config">
           {resultError.message || 'Unknown error.'}

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -71,10 +71,15 @@ export async function createOrUpdateSilence(
   alertmanagerSourceName: string,
   payload: SilenceCreatePayload
 ): Promise<Silence> {
-  const result = await getBackendSrv().post(
-    `/api/alertmanager/${getDatasourceAPIId(alertmanagerSourceName)}/api/v2/silences`,
-    payload
-  );
+  const result = await getBackendSrv()
+    .fetch<Silence>({
+      url: `/api/alertmanager/${getDatasourceAPIId(alertmanagerSourceName)}/api/v2/silences`,
+      data: payload,
+      showErrorAlert: false,
+      showSuccessAlert: false,
+      method: 'POST',
+    })
+    .toPromise();
   return result.data;
 }
 

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -51,11 +51,16 @@ export async function fetchRulerRulesGroup(
 }
 
 export async function deleteRulerRulesGroup(dataSourceName: string, namespace: string, groupName: string) {
-  return getBackendSrv().delete(
-    `/api/ruler/${getDatasourceAPIId(dataSourceName)}/api/v1/rules/${encodeURIComponent(
-      namespace
-    )}/${encodeURIComponent(groupName)}`
-  );
+  return getBackendSrv()
+    .fetch({
+      url: `/api/ruler/${getDatasourceAPIId(dataSourceName)}/api/v1/rules/${encodeURIComponent(
+        namespace
+      )}/${encodeURIComponent(groupName)}`,
+      method: 'DELETE',
+      showSuccessAlert: false,
+      showErrorAlert: false,
+    })
+    .toPromise();
 }
 
 // false in case ruler is not supported. this is weird, but we'll work on it

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
@@ -70,6 +70,7 @@ const RulesFilter = () => {
               prefix={searchIcon}
               onChange={handleQueryStringChange}
               defaultValue={queryString}
+              placeholder="Search"
             />
           </div>
           <div className={styles.rowChild}>

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -1,6 +1,6 @@
 import { Silence, SilenceCreatePayload } from 'app/plugins/datasource/alertmanager/types';
 import React, { FC, useState } from 'react';
-import { Alert, Button, Field, FieldSet, Input, LinkButton, TextArea, useStyles } from '@grafana/ui';
+import { Button, Field, FieldSet, Input, LinkButton, TextArea, useStyles } from '@grafana/ui';
 import {
   DefaultTimeZone,
   GrafanaTheme,
@@ -75,7 +75,7 @@ export const SilencesEditor: FC<Props> = ({ silence, alertManagerSourceName }) =
   const dispatch = useDispatch();
   const styles = useStyles(getStyles);
 
-  const { loading, error } = useUnifiedAlertingSelector((state) => state.updateSilence);
+  const { loading } = useUnifiedAlertingSelector((state) => state.updateSilence);
 
   useCleanup((state) => state.unifiedAlerting.updateSilence);
 
@@ -138,11 +138,6 @@ export const SilencesEditor: FC<Props> = ({ silence, alertManagerSourceName }) =
     <FormProvider {...formAPI}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <FieldSet label={`${silence ? 'Recreate silence' : 'Create silence'}`}>
-          {error && (
-            <Alert severity="error" title="Error saving silence">
-              {error.message || (error as any)?.data?.message || String(error)}
-            </Alert>
-          )}
           <div className={styles.flexRow}>
             <SilencePeriod />
             <Field

--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -1,6 +1,8 @@
 import { AnyAction, AsyncThunk, createSlice, Draft, isAsyncThunkAction, SerializedError } from '@reduxjs/toolkit';
 import { FetchError } from '@grafana/runtime';
 import { isArray } from 'angular';
+import { appEvents } from 'app/core/core';
+import { AppEvents } from '@grafana/data';
 export interface AsyncRequestState<T> {
   result?: T;
   loading: boolean;
@@ -106,14 +108,36 @@ export function withSerializedError<T>(p: Promise<T>): Promise<T> {
   });
 }
 
+export function withAppEvents<T>(
+  p: Promise<T>,
+  options: { successMessage?: string; errorMessage?: string }
+): Promise<T> {
+  return p
+    .then((v) => {
+      if (options.successMessage) {
+        appEvents.emit(AppEvents.alertSuccess, [options.successMessage]);
+      }
+      return v;
+    })
+    .catch((e) => {
+      const msg = messageFromError(e);
+      appEvents.emit(AppEvents.alertError, [`${options.errorMessage ?? 'Error'}: ${msg}`]);
+      throw e;
+    });
+}
+
 function isFetchError(e: unknown): e is FetchError {
   return typeof e === 'object' && e !== null && 'status' in e && 'data' in e;
 }
 
-function messageFromError(e: Error | FetchError): string {
+function messageFromError(e: Error | FetchError | SerializedError): string {
   if (isFetchError(e)) {
     if (e.data?.message) {
-      return e.data?.message;
+      let msg = e.data?.message;
+      if (typeof e.data?.error === 'string') {
+        msg += `; ${e.data.error}`;
+      }
+      return msg;
     } else if (isArray(e.data) && e.data.length && e.data[0]?.message) {
       return e.data
         .map((d) => d?.message)


### PR DESCRIPTION
**What this PR does / why we need it**:

 * Form submit errors will show up as top-right pop-up toast instead of inline `<Alert/>`, as everywhere else in grafana. Inline <Alert> was easy to miss.
* Improved error message extraction from backend response. Sometimes backend returns both `error` and `message` properties , both with relevant text :shrug: 


https://user-images.githubusercontent.com/847684/118689684-f3d86f00-b80f-11eb-91b5-81fffd94da01.mp4
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/alerting-squad/issues/119







**Special notes for your reviewer**:

