### PR TITLE
Live: broadcast first event immediately

### DIFF
--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -214,23 +214,11 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
 
     return new Observable<DataQueryResponse>((subscriber) => {
       const channel = this.getChannel(options.addr);
+      const key = options.key ?? `xstr/${streamCounter++}`;
       let data: StreamingDataFrame | undefined = undefined;
       let filtered: DataFrame | undefined = undefined;
-      let state = LoadingState.Loading;
-      let { key } = options;
+      let state = LoadingState.Streaming;
       let last = perf.last;
-      if (options.frame) {
-        const msg = dataFrameToJSON(options.frame);
-        data = new StreamingDataFrame(msg, options.buffer);
-        state = LoadingState.Streaming;
-      }
-      if (channel.lastMessageWithSchema && !data) {
-        data = new StreamingDataFrame(channel.lastMessageWithSchema, options.buffer);
-      }
-
-      if (!key) {
-        key = `xstr/${streamCounter++}`;
-      }
 
       const process = (msg: DataFrameJSON) => {
         if (!data) {
@@ -261,6 +249,12 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
           last = perf.last;
         }
       };
+
+      if (options.frame) {
+        process(dataFrameToJSON(options.frame));
+      } else if (channel.lastMessageWithSchema) {
+        process(channel.lastMessageWithSchema);
+      }
 
       const sub = channel.getStream().subscribe({
         error: (err: any) => {


### PR DESCRIPTION
The current live query result waits for the first message to be received *after* initialization -- this updates the logic so we broadcast the first message also.