### PR TITLE
Azure Monitor: Migrate from workspace to resource uri for log analytics

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/datasource.ts
@@ -37,6 +37,7 @@ export default function createMockDatasource() {
     resourcePickerData: {
       getResourcePickerData: () => ({}),
       getResourcesForResourceGroup: () => ({}),
+      getResourceURIFromWorkspace: () => '',
     },
   };
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { AzureMonitorErrorish, AzureMonitorOption, AzureMonitorQuery } from '../../types';
 import Datasource from '../../datasource';
 import { InlineFieldRow } from '@grafana/ui';
@@ -23,6 +23,26 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
   onChange,
   setError,
 }) => {
+  const migrateWorkspaceQueriesToResourceQueries = useCallback(async () => {
+    if (query.azureLogAnalytics.workspace !== undefined && !query.azureLogAnalytics.resource) {
+      const resourceURI = await datasource.resourcePickerData.getResourceURIFromWorkspace(
+        query.azureLogAnalytics.workspace
+      );
+      onChange({
+        ...query,
+        azureLogAnalytics: {
+          ...query.azureLogAnalytics,
+          resource: resourceURI,
+          workspace: undefined,
+        },
+      });
+    }
+  }, [datasource, onChange, query]);
+
+  useEffect(() => {
+    migrateWorkspaceQueriesToResourceQueries();
+  }, [query, migrateWorkspaceQueriesToResourceQueries]);
+
   return (
     <div data-testid="azure-monitor-logs-query-editor">
       <InlineFieldRow>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/QueryField.tsx
@@ -31,26 +31,28 @@ const QueryField: React.FC<AzureQueryEditorFieldProps> = ({ query, datasource, o
   }
 
   useEffect(() => {
-    const promises = [
-      datasource.azureLogAnalyticsDatasource.getKustoSchema(query.azureLogAnalytics.workspace),
-      getPromise(),
-    ] as const;
+    if (query.azureLogAnalytics.resource) {
+      const promises = [
+        datasource.azureLogAnalyticsDatasource.getKustoSchema(query.azureLogAnalytics.resource),
+        getPromise(),
+      ] as const;
 
-    // the kusto schema call might fail, but its okay for that to happen silently
-    Promise.all(promises).then(([schema, { monaco, editor }]) => {
-      const languages = (monaco.languages as unknown) as MonacoLanguages;
+      // the kusto schema call might fail, but its okay for that to happen silently
+      Promise.all(promises).then(([schema, { monaco, editor }]) => {
+        const languages = (monaco.languages as unknown) as MonacoLanguages;
 
-      languages.kusto.getKustoWorker().then((kusto) => {
-        const model = editor.getModel();
-        if (!model) {
-          return;
-        }
-        kusto(model.uri).then((worker) => {
-          worker.setSchema(schema, 'https://help.kusto.windows.net', 'Samples');
+        languages.kusto.getKustoWorker().then((kusto) => {
+          const model = editor.getModel();
+          if (!model) {
+            return;
+          }
+          kusto(model.uri).then((worker) => {
+            worker.setSchema(schema, 'https://help.kusto.windows.net', 'Samples');
+          });
         });
       });
-    });
-  }, [datasource.azureLogAnalyticsDatasource, query.azureLogAnalytics.workspace]);
+    }
+  }, [datasource.azureLogAnalyticsDatasource, query.azureLogAnalytics.resource]);
 
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {
     monacoPromiseRef.current?.resolve?.({ editor, monaco });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/index.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/index.tsx
@@ -86,8 +86,6 @@ const ResourcePicker = ({ resourcePickerData, resourceURI, onApply, onCancel }: 
     return {};
   }, [internalSelected, rows, requestNestedRows]);
 
-  const hasSelection = Object.keys(selectedResource).length > 0;
-
   const handleApply = useCallback(() => {
     onApply(internalSelected);
   }, [internalSelected, onApply]);

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -77,6 +77,20 @@ export default class ResourcePickerData {
     return this.formatResourceGroupChildren(response.data as RawAzureResourceItem[]);
   }
 
+  async getResourceURIFromWorkspace(workspace: string) {
+    const { ok, data: response } = await this.makeResourceGraphRequest(`
+      resources
+      | where properties['customerId'] == "${workspace}"
+    `);
+
+    // TODO: figure out desired error handling strategy
+    if (!ok) {
+      throw new Error('unable to fetch resource containers');
+    }
+
+    return (response.data[0] as RawAzureResourceItem).id;
+  }
+
   formatResourceGroupData(rawData: RawAzureResourceGroupItem[]) {
     const formatedSubscriptionsAndResourceGroups: RowGroup = {};
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/index.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/index.ts
@@ -91,7 +91,7 @@ export interface AzureLogsQuery {
   resource?: string;
 
   /** @deprecated Queries should be migrated to use Resource instead */
-  workspace: string;
+  workspace?: string;
 }
 
 export interface ApplicationInsightsQuery {


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrates old log analytics queries from workspace queries to queries made with a resource url
This pr is based off of https://github.com/grafana/grafana/pull/33879

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/34287

**Special notes for your reviewer**:
So a thing I haven't quite figured out here yet is that when I'm in the editor and click settings and then click JSON Model it adds some kind of incorrect default workspace property to the query (or at least that's what I think might be happening). However this doesn't happen in the Dashboard json model. I've looked and seen a few places that seem relevant but I can't seem to get it to stop doing it, so I must be looking in the wrong place. But I don't want that bug to block anything so I figured better to make a PR now. 
