### PR TITLE
Chore: improve the "Actual" size calculation

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/utils.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.ts
@@ -9,12 +9,15 @@ export function calculatePanelSize(mode: DisplayMode, width: number, height: num
   if (mode === DisplayMode.Fill) {
     return { width, height };
   }
-  const colWidth = (window.innerWidth - GRID_CELL_VMARGIN * 4) / GRID_COLUMN_COUNT;
+  const panelPadding = 8 * 6;
+  const sidebarWidth = 60;
+
+  const colWidth = (window.innerWidth - sidebarWidth - GRID_CELL_VMARGIN * 4) / GRID_COLUMN_COUNT;
   const pWidth = colWidth * panel.gridPos.w;
-  const pHeight = GRID_CELL_HEIGHT * panel.gridPos.h;
+  const pHeight = GRID_CELL_HEIGHT * panel.gridPos.h + panelPadding;
   const scale = Math.min(width / pWidth, height / pHeight);
 
-  if (mode === DisplayMode.Exact && pWidth <= width && pHeight <= height) {
+  if (pWidth <= width && pHeight <= height) {
     return {
       width: pWidth,
       height: pHeight,

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -147,7 +147,6 @@ class DashboardWatcher {
           }
         }
       }
-      console.log('DashboardEvent EVENT', event);
     },
   };
 


### PR DESCRIPTION
When selecting "Actual" size the panel is shorter than it should be.  This updates the calculation (trial and error :man_shrugging: )

![image](https://user-images.githubusercontent.com/705951/118768753-390e9800-b834-11eb-825b-c22abd858696.png)
