### PR TITLE
Temporarily extend default jest timeout to alleviate stress on drone

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testRegex: '(\\.|/)(test)\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   setupFiles: ['jest-canvas-mock', './public/test/jest-shim.ts', './public/test/jest-setup.ts'],
+  testTimeout: 30000,
   setupFilesAfterEnv: ['./public/test/setupTests.ts'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   globals: {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently drone is under heavy load and async tests are failing due to timeouts. This is an attempt to reduce the number of failing tests and thus reduce the number of re-runs.