### PR TITLE
grafana/ui: Enable adding tags on blur in TagsInput

### DIFF
--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -49,7 +49,7 @@ export const TagsInput: FC<Props> = ({
   };
 
   const onBlur = () => {
-    if (addOnBlur) {
+    if (addOnBlur && newTagName) {
       onAdd();
     }
   };

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -13,6 +13,7 @@ export interface Props {
   width?: number;
   className?: string;
   disabled?: boolean;
+  addOnBlur?: boolean;
 }
 
 export const TagsInput: FC<Props> = ({
@@ -22,6 +23,7 @@ export const TagsInput: FC<Props> = ({
   width,
   className,
   disabled,
+  addOnBlur,
 }) => {
   const [newTagName, setNewName] = useState('');
   const styles = useStyles(getStyles);
@@ -38,12 +40,18 @@ export const TagsInput: FC<Props> = ({
     onChange(tags?.filter((x) => x !== tagToRemove));
   };
 
-  const onAdd = (event: React.MouseEvent) => {
-    event.preventDefault();
+  const onAdd = (event?: React.MouseEvent) => {
+    event?.preventDefault();
     if (!tags.includes(newTagName)) {
       onChange(tags.concat(newTagName));
     }
     setNewName('');
+  };
+
+  const onBlur = () => {
+    if (addOnBlur) {
+      onAdd();
+    }
   };
 
   const onKeyboardAdd = (event: KeyboardEvent) => {
@@ -68,6 +76,7 @@ export const TagsInput: FC<Props> = ({
           onChange={onNameChange}
           value={newTagName}
           onKeyUp={onKeyboardAdd}
+          onBlur={onBlur}
           suffix={
             newTagName.length > 0 && (
               <Button fill="text" className={styles.addButtonStyle} onClick={onAdd} size="md">


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Enable `addOnBlur` toggle that will automatically add tags when the input is blurred. 
