### PR TITLE
Alerting: Remove UALERT_MIG env guard from dashboard rule migration

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -31,34 +31,30 @@ func (e MigrationError) Error() string {
 func (e *MigrationError) Unwrap() error { return e.Err }
 
 func AddDashAlertMigration(mg *migrator.Migrator) {
-	if os.Getenv("UALERT_MIG") == "iDidBackup" {
-		// TODO: unified alerting DB needs to be extacted into ../migrations.go
-		// so it runs and creates the tables before this migration runs.
-		logs, err := mg.GetMigrationLog()
+	logs, err := mg.GetMigrationLog()
+	if err != nil {
+		mg.Logger.Crit("alert migration failure: could not get migration log", "error", err)
+		os.Exit(1)
+	}
+
+	_, migrationRun := logs[migTitle]
+
+	ngEnabled := mg.Cfg.IsNgAlertEnabled()
+
+	switch {
+	case ngEnabled && !migrationRun:
+		// clear the entry of the migration that
+		err = mg.ClearMigrationEntry(rmMigTitle)
 		if err != nil {
-			mg.Logger.Crit("alert migration failure: could not get migration log", "error", err)
-			os.Exit(1)
+			mg.Logger.Error("alert migration error: could not clear alert migration for removing data", "error", err)
 		}
-
-		_, migrationRun := logs[migTitle]
-
-		ngEnabled := mg.Cfg.IsNgAlertEnabled()
-
-		switch {
-		case ngEnabled && !migrationRun:
-			// clear the entry of the migration that
-			err = mg.ClearMigrationEntry(rmMigTitle)
-			if err != nil {
-				mg.Logger.Error("alert migration error: could not clear alert migration for removing data", "error", err)
-			}
-			mg.AddMigration(migTitle, &migration{})
-		case !ngEnabled && migrationRun:
-			err = mg.ClearMigrationEntry(migTitle)
-			if err != nil {
-				mg.Logger.Error("alert migration error: could not clear alert migration", "error", err)
-			}
-			mg.AddMigration(rmMigTitle, &rmMigration{})
+		mg.AddMigration(migTitle, &migration{})
+	case !ngEnabled && migrationRun:
+		err = mg.ClearMigrationEntry(migTitle)
+		if err != nil {
+			mg.Logger.Error("alert migration error: could not clear alert migration", "error", err)
 		}
+		mg.AddMigration(rmMigTitle, &rmMigration{})
 	}
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -43,16 +43,19 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 
 	switch {
 	case ngEnabled && !migrationRun:
-		// clear the entry of the migration that
+		// Remove the migration entry that removes all unified alerting data. This is so when the feature
+		// flag is removed in future the "remove unified alerting data" migration will be run again.
 		err = mg.ClearMigrationEntry(rmMigTitle)
 		if err != nil {
 			mg.Logger.Error("alert migration error: could not clear alert migration for removing data", "error", err)
 		}
 		mg.AddMigration(migTitle, &migration{})
 	case !ngEnabled && migrationRun:
+		// Remove the migration entry that creates unified alerting data. This is so when the feature
+		// flag is enabled in the future the migration "move dashboard alerts to unified alerting" will be run again.
 		err = mg.ClearMigrationEntry(migTitle)
 		if err != nil {
-			mg.Logger.Error("alert migration error: could not clear alert migration", "error", err)
+			mg.Logger.Error("alert migration error: could not clear dashboard alert migration", "error", err)
 		}
 		mg.AddMigration(rmMigTitle, &rmMigration{})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Runs the migration of dashboard alert rules into unified alerting if the feature flag is enabled.

Before you also had to provide the `UALERT_MIG=iDidBackup`

**Special notes for your reviewer**:

Blurb:

The `ngalert` feature toggle enables the beta version of our new alerting system.

It is recommended to backup Grafana's database before enabling this feature.

When the feature flag is enabled, dashboard alerting is disabled and dashboard alerts are migrated into the system. Going to "Alert List" will take you to the new system.

When the feature flag is removed, all migrated and newly created alerts in the new system are deleted, and dashboard alerting will be enabled again.

During beta, the migration of existing dashboard rules may change.

