### PR TITLE
Scue: make fieldConfig open for instant

### DIFF
--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -136,6 +136,7 @@ Family: scuemata.#Family & {
 
                     fieldConfig: {
                         defaults: {
+                            ...
                             // The display value for this field.  This supports template variables blank is auto
                             displayName?: string
 

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -133,7 +133,10 @@ Family: scuemata.#Family & {
 
                     // The values depend on panel type
                     options: {...}
-
+                    libraryPanel?: {
+                        name: string,
+                        uid: string
+                    }
                     fieldConfig: {
                         defaults: {
                             ...

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -71,7 +71,6 @@ func (hs *HTTPServer) TrimDashboard(c *models.ReqContext, cmd models.TrimDashboa
 func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
 	slug := c.Params(":slug")
 	uid := c.Params(":uid")
-	trimDefaults := c.QueryBoolWithDefault("trimdefaults", false)
 	dash, rsp := getDashboardHelper(c.OrgId, slug, 0, uid)
 	if rsp != nil {
 		return rsp
@@ -176,15 +175,6 @@ func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
 		return response.Error(500, "Error while loading library panels", err)
 	}
 
-	var trimedJson simplejson.Json
-	if trimDefaults && !hs.LoadSchemaService.IsDisabled() {
-		trimedJson, err = hs.LoadSchemaService.DashboardTrimDefaults(*dash.Data)
-		if err != nil {
-			return response.Error(500, "Error while trim default value from dashboard json", err)
-		}
-		dash.Data = &trimedJson
-	}
-
 	dto := dtos.DashboardFullWithMeta{
 		Dashboard: dash.Data,
 		Meta:      meta,
@@ -285,13 +275,6 @@ func (hs *HTTPServer) PostDashboard(c *models.ReqContext, cmd models.SaveDashboa
 	var err error
 	cmd.OrgId = c.OrgId
 	cmd.UserId = c.UserId
-	trimDefaults := c.QueryBoolWithDefault("trimdefaults", false)
-	if trimDefaults && !hs.LoadSchemaService.IsDisabled() {
-		cmd.Dashboard, err = hs.LoadSchemaService.DashboardApplyDefaults(cmd.Dashboard)
-		if err != nil {
-			return response.Error(500, "Error while applying default value to the dashboard json", err)
-		}
-	}
 	dash := cmd.GetDashboardModel()
 	newDashboard := dash.Id == 0 && dash.Uid == ""
 	if newDashboard {

--- a/pkg/cmd/grafana-cli/commands/scuemata_validation_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/scuemata_validation_command_test.go
@@ -110,7 +110,7 @@ func TestValidateScuemataBasics(t *testing.T) {
 					require.NoError(t, err, "failed to open dashboard file")
 
 					err = validateResources(b, baseLoadPaths, load.BaseDashboardFamily)
-					assert.EqualError(t, err, "failed validation: Family.lineages.0.0.panels.0.fieldConfig.defaults: field mappings not allowed")
+					assert.EqualError(t, err, "failed validation: Family.lineages.0.0.panels.0.type: incomplete value !=\"\"")
 				})
 			}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
before we get all panel schemas, we probably need to open fieldConfig, otherwise the validation fails for certain panel types. add panellibrary field because of the new feature. 
