### PR TITLE
AccessControl: Add provisioning folder to the packaging process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ public/css/*.min.css
 conf/custom.ini
 /conf/provisioning/**/custom.yaml
 /conf/provisioning/**/dev.yaml
-/conf/provisioning/access-control/
 /conf/ldap_dev.toml
 /conf/ldap_freeipa.toml
 profile.cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN export GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_PROVISIONING/notifiers" \
              "$GF_PATHS_PROVISIONING/plugins" \
+             "$GF_PATHS_PROVISIONING/access-control" \
              "$GF_PATHS_LOGS" \
              "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -62,6 +62,7 @@ RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_PROVISIONING/notifiers" \
              "$GF_PATHS_PROVISIONING/plugins" \
+             "$GF_PATHS_PROVISIONING/access-control" \
              "$GF_PATHS_LOGS" \
              "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \

--- a/conf/provisioning/access-control/sample.yaml
+++ b/conf/provisioning/access-control/sample.yaml
@@ -1,0 +1,56 @@
+# # config file version
+# apiVersion: 1
+
+# # list of default built-in role assignments that should be removed
+# removeDefaultAssignments:
+#   # <string, required>, must be one of the Organization roles (`Viewer`, `Editor`, `Admin`) or `Grafana Admin`
+#   - builtInRole: "Grafana Admin"
+#     # <string, required>, must be one of the existing predefined roles
+#     predefinedRole: "grafana:roles:permissions:admin"
+
+# # list of default built-in role assignments that should be added back
+# addDefaultAssignments:
+#   # <string, required>, must be one of the Organization roles (`Viewer`, `Editor`, `Admin`) or `Grafana Admin`
+#   - builtInRole: "Admin"
+#     # <string, required>, must be one of the existing predefined roles
+#     predefinedRole: "grafana:roles:reporting:admin:read"
+    
+# # list of roles that should be deleted
+# deleteRoles:
+#   # <string> name of the role you want to create. Required if no uid is set
+#   - name: "custom:roles:reporting:admin:edit"
+#     # <string> uid of the role. Required if no name
+#     uid: customrolesreportingadminedit
+#     # <int> org id. will default to Grafana's default if not specified
+#     orgId: 1
+#     # <bool> force deletion revoking all grants of the role
+#     force: true
+
+# # list of roles to insert/update depending on what is available in the database
+# roles:
+#   # <string, required> name of the role you want to create. Required
+#   - name: custom:roles:users:editor
+#     # <string> uid of the role. Has to be unique for all orgs.
+#     uid: customrolesuserseditor
+#     # <string> description of the role, informative purpose only.
+#     description: "Role to allow users to create/read/write users"
+#     # <int> version of the role, Grafana will update the role when increased
+#     version: 2
+#     # <int> org id. will default to Grafana's default if not specified
+#     orgId: 1    
+#     # <list> list of the permissions granted by this role
+#     permissions:
+#       # <string, required> action allowed
+#       - action: "users:read"
+#         #<string> scope it applies to
+#         scope: "users:*"
+#       - action: "users:write"
+#         scope: "users:*"
+#       - action: "users:create"
+#         scope: "users:*"
+#     # <list> list of builtIn roles the role should be assigned to
+#     builtInRoles:
+#       # <string, required> name of the builtin role you want to assign the role to
+#       - name: "Admin"
+#         # <int> org id. will default to the role org id
+#         orgId: 1

--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -47,6 +47,11 @@ case "$1" in
     cp /usr/share/grafana/conf/provisioning/plugins/sample.yaml $PROVISIONING_CFG_DIR/plugins/sample.yaml
   fi
 
+  if [ ! -d $PROVISIONING_CFG_DIR/access-control ]; then
+    mkdir -p $PROVISIONING_CFG_DIR/access-control
+    cp /usr/share/grafana/conf/provisioning/access-control/sample.yaml $PROVISIONING_CFG_DIR/access-control/sample.yaml
+  fi
+
 	# configuration files should not be modifiable by grafana user, as this can be a security issue
 	chown -Rh root:$GRAFANA_GROUP /etc/grafana/*
 	chmod 755 /etc/grafana

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -57,6 +57,7 @@ RUN export GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_PROVISIONING/notifiers" \
              "$GF_PATHS_PROVISIONING/plugins" \
+             "$GF_PATHS_PROVISIONING/access-control" \
              "$GF_PATHS_LOGS" \
              "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \

--- a/packaging/docker/ubuntu.Dockerfile
+++ b/packaging/docker/ubuntu.Dockerfile
@@ -44,6 +44,7 @@ RUN export GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
              "$GF_PATHS_PROVISIONING/dashboards" \
              "$GF_PATHS_PROVISIONING/notifiers" \
              "$GF_PATHS_PROVISIONING/plugins" \
+             "$GF_PATHS_PROVISIONING/access-control" \
              "$GF_PATHS_LOGS" \
              "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -61,6 +61,11 @@ if [ $1 -eq 1 ] ; then
     cp /usr/share/grafana/conf/provisioning/plugins/sample.yaml $PROVISIONING_CFG_DIR/plugins/sample.yaml
   fi
 
+  if [ ! -d $PROVISIONING_CFG_DIR/access-control ]; then
+    mkdir -p $PROVISIONING_CFG_DIR/access-control
+    cp /usr/share/grafana/conf/provisioning/access-control/sample.yaml $PROVISIONING_CFG_DIR/access-control/sample.yaml
+  fi
+
  	# Set user permissions on /var/log/grafana, /var/lib/grafana
 	mkdir -p /var/log/grafana /var/lib/grafana
 	chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
Enterprise access-control provisioning folder is not created at start up. Resulting in an error log, when using the downloadable archive for [beta-1](https://grafana.com/grafana/download/8.0.0-beta1?pg=get&platform=linux&plcmt=selfmanaged-box1-cta1&edition=enterprise)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/1320

**Special notes for your reviewer**:

