### PR TITLE
grafana/ui: Add invalid prop to the TagsInput

### DIFF
--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.mdx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.mdx
@@ -1,11 +1,11 @@
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { Meta, Props } from '@storybook/addon-docs/blocks';
 import { TagsInput } from './TagsInput';
 
 <Meta title="MDX|TagsInput" component={TagsInput} />
 
 # TagsInput
 
-A set of an input field and a button next to it that allows the user to add new tags. The added tags are previewed under the input and can be removed there by clicking the "X" icon. You can customize the width of the input.
+A set of an input field and a button next to it that allows the user to add new tags. The added tags are previewed next to the input and can be removed by clicking the "X" icon. You can customize the width of the input.
 
 ### Props
 <Props of={TagsInput} />

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.story.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.story.tsx
@@ -31,3 +31,25 @@ export const WithManyTags = () => {
     </VerticalGroup>
   );
 };
+
+export const WithAddOnBlur = () => {
+  const [tags, setTags] = useState<string[]>([]);
+  return (
+    <VerticalGroup>
+      <StoryExample name="Tags are added when input loses focus">
+        <TagsInput tags={tags} onChange={setTags} addOnBlur />
+      </StoryExample>
+    </VerticalGroup>
+  );
+};
+
+export const WithInvalidState = () => {
+  const [tags, setTags] = useState<string[]>([]);
+  return (
+    <VerticalGroup>
+      <StoryExample name="Invalid state">
+        <TagsInput tags={tags} onChange={setTags} invalid />
+      </StoryExample>
+    </VerticalGroup>
+  );
+};

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.story.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.story.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
+import { Meta, Story } from '@storybook/react';
+import { TagsInput, Props } from './TagsInput';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
-import { TagsInput } from '@grafana/ui';
-import mdx from './TagsInput.mdx';
 import { StoryExample } from '../../utils/storybook/StoryExample';
 import { VerticalGroup } from '../Layout/Layout';
+import mdx from './TagsInput.mdx';
 
 export default {
   title: 'Forms/TagsInput',
@@ -13,12 +14,20 @@ export default {
     docs: {
       page: mdx,
     },
+    knobs: {
+      disable: true,
+    },
+    controls: {
+      exclude: ['onChange', 'className', 'tags'],
+    },
   },
-};
+} as Meta;
 
-export const Basic = () => {
+type StoryProps = Omit<Props, 'onChange' | 'className' | 'tags'>;
+
+export const Basic: Story<StoryProps> = (props) => {
   const [tags, setTags] = useState<string[]>([]);
-  return <TagsInput tags={tags} onChange={setTags} />;
+  return <TagsInput {...props} tags={tags} onChange={setTags} />;
 };
 
 export const WithManyTags = () => {
@@ -27,28 +36,6 @@ export const WithManyTags = () => {
     <VerticalGroup>
       <StoryExample name="With many tags">
         <TagsInput tags={tags} onChange={setTags} />
-      </StoryExample>
-    </VerticalGroup>
-  );
-};
-
-export const WithAddOnBlur = () => {
-  const [tags, setTags] = useState<string[]>([]);
-  return (
-    <VerticalGroup>
-      <StoryExample name="Tags are added when input loses focus">
-        <TagsInput tags={tags} onChange={setTags} addOnBlur />
-      </StoryExample>
-    </VerticalGroup>
-  );
-};
-
-export const WithInvalidState = () => {
-  const [tags, setTags] = useState<string[]>([]);
-  return (
-    <VerticalGroup>
-      <StoryExample name="Invalid state">
-        <TagsInput tags={tags} onChange={setTags} invalid />
       </StoryExample>
     </VerticalGroup>
   );

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -14,6 +14,7 @@ export interface Props {
   className?: string;
   disabled?: boolean;
   addOnBlur?: boolean;
+  invalid?: boolean;
 }
 
 export const TagsInput: FC<Props> = ({
@@ -24,6 +25,7 @@ export const TagsInput: FC<Props> = ({
   className,
   disabled,
   addOnBlur,
+  invalid,
 }) => {
   const [newTagName, setNewName] = useState('');
   const styles = useStyles(getStyles);
@@ -77,6 +79,7 @@ export const TagsInput: FC<Props> = ({
           value={newTagName}
           onKeyUp={onKeyboardAdd}
           onBlur={onBlur}
+          invalid={invalid}
           suffix={
             newTagName.length > 0 && (
               <Button fill="text" className={styles.addButtonStyle} onClick={onAdd} size="md">

--- a/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
+++ b/packages/grafana-ui/src/components/TagsInput/TagsInput.tsx
@@ -8,12 +8,16 @@ import { Input } from '../Input/Input';
 
 export interface Props {
   placeholder?: string;
+  /** Array of selected tags */
   tags?: string[];
   onChange: (tags: string[]) => void;
   width?: number;
   className?: string;
+  /** Toggle disabled state */
   disabled?: boolean;
+  /** Enable adding new tags when input loses focus */
   addOnBlur?: boolean;
+  /** Toggle invalid state */
   invalid?: boolean;
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds the `invalid` prop to `TagsInput`, so its styling can be consistent with other input elements. 
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

