### PR TITLE
AzureMonitor: Azure Resource Graph routes fix

### DIFF
--- a/pkg/tsdb/azuremonitor/routes.go
+++ b/pkg/tsdb/azuremonitor/routes.go
@@ -52,6 +52,8 @@ func getResourceGraphApiRoute(azureCloud string) (string, error) {
 		return "chinaazureresourcegraph", nil
 	case azureMonitorUSGovernment:
 		return "govazureresourcegraph", nil
+	case azureMonitorGermany:
+		return "germanyazureresourcegraph", nil
 	default:
 		err := fmt.Errorf("the cloud '%s' not supported", azureCloud)
 		return "", err

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/plugin.json
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/plugin.json
@@ -105,11 +105,11 @@
       "tokenAuth": {
         "scopes": ["https://management.azure.com/.default"],
         "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType}}",
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
           "azure_cloud": "AzureCloud",
-          "tenant_id": "{{.JsonData.tenantId}}",
-          "client_id": "{{.JsonData.clientId}}",
-          "client_secret": "{{.SecureJsonData.clientSecret}}"
+          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
+          "client_id": "{{.JsonData.clientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
         }
       },
       "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
@@ -122,11 +122,11 @@
       "tokenAuth": {
         "scopes": ["https://management.chinacloudapi.cn/.default"],
         "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType}}",
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
           "azure_cloud": "AzureChinaCloud",
-          "tenant_id": "{{.JsonData.tenantId}}",
-          "client_id": "{{.JsonData.clientId}}",
-          "client_secret": "{{.SecureJsonData.clientSecret}}"
+          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
+          "client_id": "{{.JsonData.clientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
         }
       },
       "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
@@ -139,11 +139,11 @@
       "tokenAuth": {
         "scopes": ["https://management.usgovcloudapi.net/.default"],
         "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType}}",
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
           "azure_cloud": "AzureUSGovernment",
-          "tenant_id": "{{.JsonData.tenantId}}",
-          "client_id": "{{.JsonData.clientId}}",
-          "client_secret": "{{.SecureJsonData.clientSecret}}"
+          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
+          "client_id": "{{.JsonData.clientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
         }
       },
       "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
@@ -156,11 +156,11 @@
       "tokenAuth": {
         "scopes": ["https://management.microsoftazure.de/.default"],
         "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType}}",
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
           "azure_cloud": "AzureGermanCloud",
-          "tenant_id": "{{.JsonData.tenantId}}",
-          "client_id": "{{.JsonData.clientId}}",
-          "client_secret": "{{.SecureJsonData.clientSecret}}"
+          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
+          "client_id": "{{.JsonData.clientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
         }
       },
       "headers": [{ "name": "x-ms-app", "content": "Grafana" }]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix resolution of a cloud and routes for Azure Resource Graph queries.

**Which issue(s) this PR fixes**:

Related to: #33293, #34342

**Special notes for your reviewer**:

The logic is the same as for other datasources in the Azure Monitor plugin.