### PR TITLE
WIP InfluxDB: InfluxQL: allow setting tag-value to empty-string

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/AddButton.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/AddButton.tsx
@@ -16,7 +16,7 @@ export const AddButton = ({ loadOptions, allowCustomValue, onAdd }: Props): JSX.
       loadOptions={loadOptions}
       allowCustomValue={allowCustomValue}
       onChange={(v) => {
-        onAdd(unwrap(v.value));
+        onAdd(unwrap(v));
       }}
     />
   );

--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/FromSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/FromSection.tsx
@@ -52,7 +52,7 @@ export const FromSection = ({
         value={policy ?? 'using default policy'}
         loadOptions={handlePolicyLoadOptions}
         onChange={(v) => {
-          onChange(v.value, measurement);
+          onChange(v, measurement);
         }}
       />
       <Seg
@@ -61,7 +61,7 @@ export const FromSection = ({
         loadOptions={handleMeasurementLoadOptions}
         filterByLoadOptions
         onChange={(v) => {
-          onChange(policy, v.value);
+          onChange(policy, v);
         }}
       />
     </>

--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/PartListSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/PartListSection.tsx
@@ -100,7 +100,7 @@ const Part = ({ name, params, onChange, onRemove }: PartProps): JSX.Element => {
               buttonClassName={noHorizMarginPaddingClass}
               loadOptions={loadOptions}
               onChange={(v) => {
-                onParamChange(unwrap(v.value), i);
+                onParamChange(unwrap(v), i);
               }}
             />
             {!isLast && ','}

--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
@@ -15,12 +15,11 @@ import { useShadowedState } from '../useShadowedState';
 
 // NOTE: maybe these changes could be migrated into the SegmentAsync later
 
-type SelVal = SelectableValue<string>;
-
 // when allowCustomValue is true, there is no way to enforce the selectableValue
 // enum-type, so i just go with `string`
 
-type LoadOptions = (filter: string) => Promise<SelVal[]>;
+type LoadOptions = (filter: string) => Promise<Array<SelectableValue<string>>>;
+type Value = string | undefined;
 
 type Props = {
   value: string;
@@ -35,7 +34,7 @@ type Props = {
   // as you write the loadOptions is executed again and again,
   // and it is relied on to filter the results.
   filterByLoadOptions?: boolean;
-  onChange: (v: SelVal) => void;
+  onChange: (v: Value) => void;
   allowCustomValue?: boolean;
 };
 
@@ -47,14 +46,14 @@ type SelProps = {
   loadOptions: LoadOptions;
   filterByLoadOptions?: boolean;
   onClose: () => void;
-  onChange: (v: SelVal) => void;
+  onChange: (v: Value) => void;
   allowCustomValue?: boolean;
 };
 
 type SelReloadProps = {
-  loadOptions: (filter: string) => Promise<SelVal[]>;
+  loadOptions: LoadOptions;
   onClose: () => void;
-  onChange: (v: SelVal) => void;
+  onChange: (v: Value) => void;
   allowCustomValue?: boolean;
 };
 
@@ -83,16 +82,19 @@ const SelReload = ({ loadOptions, allowCustomValue, onChange, onClose }: SelRelo
         onCloseMenu={onClose}
         allowCustomValue={allowCustomValue}
         loadOptions={debouncedLoadOptions}
-        onChange={onChange}
+        onChange={(v) => {
+          onChange(v.value);
+        }}
+        onCreateOption={onChange}
       />
     </div>
   );
 };
 
 type SelSingleLoadProps = {
-  loadOptions: (filter: string) => Promise<SelVal[]>;
+  loadOptions: LoadOptions;
   onClose: () => void;
-  onChange: (v: SelVal) => void;
+  onChange: (v: Value) => void;
   allowCustomValue?: boolean;
 };
 
@@ -112,7 +114,10 @@ const SelSingleLoad = ({ loadOptions, allowCustomValue, onChange, onClose }: Sel
         onCloseMenu={onClose}
         allowCustomValue={allowCustomValue}
         options={loadState.value ?? []}
-        onChange={onChange}
+        onChange={(v) => {
+          onChange(v.value);
+        }}
+        onCreateOption={onChange}
       />
     </div>
   );
@@ -211,7 +216,7 @@ export const Seg = ({
           initialValue={value}
           onChange={(v) => {
             setOpen(false);
-            onChange({ value: v, label: v });
+            onChange(v);
           }}
         />
       );

--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/TagsSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/TagsSection.test.tsx
@@ -129,7 +129,7 @@ describe('InfluxDB InfluxQL Editor tags section', () => {
       ...tags,
       {
         key: 't5',
-        value: 'select tag value',
+        value: '',
         operator: '=',
         condition: 'AND',
       },


### PR DESCRIPTION
[NOTE: this pull-request is currently on hold. i need to re-think the UI for this feature]

in the influxdb influxql query editor, you cannot represent this situation:
`FROM ... SELECT .. WHERE tag1<>""`

you cannot set the tag-value to empty-string. this pull-request tries to fix this. there is a new option "-- empty --" in the tag-value select-box, you can choose it to set the value to empty-string.

NOTE there are 2 "unrelated" changes in this one:
- i switched the rendering of `<InlineLabel/>` to button-elements. i think it is more correct, and visually there is no change
- the `<Seg onChange/>` `onChange` prop was returning `SelectableValue` objects, now it simply returns `string|undefined`. the code becomes simpler

fixes https://github.com/grafana/grafana/issues/5600