### PR TITLE
TestData: use new format for random walk endpoint

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -251,5 +251,9 @@ func (hs *HTTPServer) GetTestDataRandomWalk(c *models.ReqContext) response.Respo
 		return response.Error(500, "Metric request error", err)
 	}
 
-	return response.JSON(200, &resp)
+	qdr, err := resp.ToBackendDataResponse()
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "error converting results", err)
+	}
+	return toMacronResponse(qdr)
 }


### PR DESCRIPTION
The special endpoint for random-walk was using the "old" json format with base64 encoded arrow.  This updates the endpoint so the testdata query works:

http://localhost:3000/api/tsdb/testdata/random-walk?intervalMs=60000&maxDataPoints=407&from=1621423277532&to=1621444877532

![image](https://user-images.githubusercontent.com/705951/118856747-232cc180-b88c-11eb-8a16-dc3b99194669.png)
