### PR TITLE
Azure Monitor: Fix Resource Picker UI overflow

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/ResourceField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/ResourceField.tsx
@@ -1,4 +1,6 @@
-import { Button, Icon, Modal } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, Icon, Modal, useStyles2 } from '@grafana/ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { AzureQueryEditorFieldProps, AzureResourceSummaryItem } from '../../types';
 import { Field } from '../Field';
@@ -22,6 +24,7 @@ function parseResourceDetails(resourceURI: string) {
 }
 
 const ResourceField: React.FC<AzureQueryEditorFieldProps> = ({ query, datasource, onQueryChange }) => {
+  const styles = useStyles2(getStyles);
   const { resource } = query.azureLogAnalytics;
 
   const [resourceComponents, setResourceComponents] = useState(parseResourceDetails(resource ?? ''));
@@ -59,7 +62,7 @@ const ResourceField: React.FC<AzureQueryEditorFieldProps> = ({ query, datasource
 
   return (
     <>
-      <Modal title="Select a resource" isOpen={pickerIsOpen} onDismiss={closePicker}>
+      <Modal className={styles.modal} title="Select a resource" isOpen={pickerIsOpen} onDismiss={closePicker}>
         <ResourcePicker
           resourcePickerData={datasource.resourcePickerData}
           resourceURI={query.azureLogAnalytics.resource!}
@@ -105,3 +108,9 @@ const Separator = () => (
 );
 
 export default ResourceField;
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  modal: css({
+    width: theme.breakpoints.values.lg,
+  }),
+});

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import { Checkbox, HorizontalGroup, Icon, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
+import { Checkbox, Icon, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import getStyles from './styles';
 import { EntryType, Row, RowGroup } from './types';
@@ -169,10 +169,10 @@ const NestedEntry: React.FC<NestedEntryProps> = ({
   );
 
   return (
-    <div className={styles.flexRowWithTruncatedText} style={{ marginLeft: level * (3 * theme.spacing.gridSize) }}>
-      <HorizontalGroup align="center" spacing="sm">
-        {/* When groups are selectable, I *think* we will want to show a 2-wide space instead
+    <div className={styles.nestedEntry} style={{ marginLeft: level * (3 * theme.spacing.gridSize) }}>
+      {/* When groups are selectable, I *think* we will want to show a 2-wide space instead
             of the collapse button for leaf rows that have no children to get them to align */}
+      <span className={styles.entryContentItem}>
         {hasChildren && (
           <IconButton
             className={styles.collapseButton}
@@ -183,11 +183,13 @@ const NestedEntry: React.FC<NestedEntryProps> = ({
         )}
 
         {isSelectable && <Checkbox onChange={handleSelectedChanged} disabled={isDisabled} value={isSelected} />}
+      </span>
 
+      <span className={styles.entryContentItem}>
         <EntryIcon entry={entry} isOpen={isOpen} />
+      </span>
 
-        <div>{entry.name}</div>
-      </HorizontalGroup>
+      <span className={styles.entryContentItem + ' ' + styles.truncated}>{entry.name}</span>
     </div>
   );
 };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import { Checkbox, Icon, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
+import { Checkbox, Icon, IconButton, LoadingPlaceholder, useStyles2, useTheme2, FadeTransition } from '@grafana/ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import getStyles from './styles';
 import { EntryType, Row, RowGroup } from './types';
@@ -100,13 +100,13 @@ const NestedRow: React.FC<NestedRowProps> = ({ row, selectedRows, level, request
         />
       )}
 
-      {openStatus === 'loading' && (
+      <FadeTransition visible={openStatus === 'loading'}>
         <tr>
           <td className={cx(styles.cell, styles.loadingCell)} colSpan={3}>
-            Loading...
+            <LoadingPlaceholder text="Loading..." className={styles.spinner} />
           </td>
         </tr>
-      )}
+      </FadeTransition>
     </>
   );
 };
@@ -189,7 +189,7 @@ const NestedEntry: React.FC<NestedEntryProps> = ({
         <EntryIcon entry={entry} isOpen={isOpen} />
       </span>
 
-      <span className={styles.entryContentItem + ' ' + styles.truncated}>{entry.name}</span>
+      <span className={cx(styles.entryContentItem, styles.truncated)}>{entry.name}</span>
     </div>
   );
 };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
@@ -169,7 +169,7 @@ const NestedEntry: React.FC<NestedEntryProps> = ({
   );
 
   return (
-    <div style={{ marginLeft: level * (3 * theme.spacing.gridSize) }}>
+    <div className={styles.flexRowWithTruncatedText} style={{ marginLeft: level * (3 * theme.spacing.gridSize) }}>
       <HorizontalGroup align="center" spacing="sm">
         {/* When groups are selectable, I *think* we will want to show a 2-wide space instead
             of the collapse button for leaf rows that have no children to get them to align */}
@@ -186,7 +186,7 @@ const NestedEntry: React.FC<NestedEntryProps> = ({
 
         <EntryIcon entry={entry} isOpen={isOpen} />
 
-        {entry.name}
+        <div>{entry.name}</div>
       </HorizontalGroup>
     </div>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
@@ -45,13 +45,19 @@ const getStyles = (theme: GrafanaTheme2) => ({
     textAlign: 'center',
   }),
 
-  flexRowWithTruncatedText: css({
-    'div:last-child': {
-      minWidth: 0,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-    },
+  nestedEntry: css({
+    display: 'flex',
+  }),
+
+  entryContentItem: css({
+    margin: theme.spacing(0, 1, 0, 0),
+  }),
+
+  truncated: css({
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   }),
 });
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
@@ -4,6 +4,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 const getStyles = (theme: GrafanaTheme2) => ({
   table: css({
     width: '100%',
+    tableLayout: 'fixed',
   }),
 
   tableScroller: css({
@@ -30,7 +31,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   cell: css({
     padding: theme.spacing(1, 0),
     width: '25%',
-
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
     '&:first-of-type': {
       width: '50%',
       padding: theme.spacing(1, 0, 1, 2),
@@ -41,6 +43,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
   loadingCell: css({
     textAlign: 'center',
+  }),
+
+  flexRowWithTruncatedText: css({
+    'div:last-child': {
+      minWidth: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
   }),
 });
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
@@ -45,6 +45,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     textAlign: 'center',
   }),
 
+  spinner: css({
+    marginBottom: 0,
+  }),
+
   nestedEntry: css({
     display: 'flex',
   }),


### PR DESCRIPTION
**What this PR does / why we need it**:

Truncates text and ensures resource picker doesn't overflow the modal
<img width="743" alt="Screen Shot 2021-05-19 at 3 55 02 PM" src="https://user-images.githubusercontent.com/6620164/118876190-f80d9680-b8ba-11eb-9b6b-5c8f64772869.png">


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/34430 

**Special notes for your reviewer**:

~I don't love this solution of `div:last-child` but it seems to work for me. The issue is with HorizontalGroup which sets all its children into flex divs, which autosets a minWidth of auto. Items with a min width of auto are not truncate-able.~ 

~Some other ideas I considered:~
~- Updating HorizontalGroup in someway. Honestly it mostly just felt beyond the scope of this pr and I'm not sure how common a need this is. But we could do something where we pass in props to identify which child elements will be truncate-able or something. Definitely if this is a common enough issue we could look into it for the future.~
~- Manually specifying a width on the text we want truncatable. This seems the most desirable option to me. Unfortunately we'd need to specify multiple values for it to resize properly, which is a pain to calculate, but doable. But then I wasn't sure how that would work with other theme's spacing though.~

~I don't know this felt the least-worst option to me, but open to suggestions!~

UPDATE: got rid of HorizontalGroup, added in a loading spinner
