### PR TITLE
AzureMonitor: Update Logs workspace() template variable query to return resource URIs

### DIFF
--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -19,6 +19,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 	datasource := &AzureLogAnalyticsDatasource{}
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
 
+	timeRange := plugins.DataTimeRange{
+		From: fmt.Sprintf("%v", fromStart.Unix()*1000),
+		To:   fmt.Sprintf("%v", fromStart.Add(34*time.Minute).Unix()*1000),
+	}
+
 	tests := []struct {
 		name                     string
 		queryModel               []plugins.DataSubQuery
@@ -27,11 +32,8 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 		Err                      require.ErrorAssertionFunc
 	}{
 		{
-			name: "Query with macros should be interpolated",
-			timeRange: plugins.DataTimeRange{
-				From: fmt.Sprintf("%v", fromStart.Unix()*1000),
-				To:   fmt.Sprintf("%v", fromStart.Add(34*time.Minute).Unix()*1000),
-			},
+			name:      "Query with macros should be interpolated",
+			timeRange: timeRange,
 			queryModel: []plugins.DataSubQuery{
 				{
 					DataSource: &models.DataSource{
@@ -65,12 +67,11 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 				},
 			},
 			Err: require.NoError,
-		}, {
-			name: "Legacy workspace queries should use workspace query endpoint",
-			timeRange: plugins.DataTimeRange{
-				From: fmt.Sprintf("%v", fromStart.Unix()*1000),
-				To:   fmt.Sprintf("%v", fromStart.Add(34*time.Minute).Unix()*1000),
-			},
+		},
+
+		{
+			name:      "Legacy queries with a workspace GUID should use workspace-centric url",
+			timeRange: timeRange,
 			queryModel: []plugins.DataSubQuery{
 				{
 					DataSource: &models.DataSource{
@@ -80,7 +81,7 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 						"queryType": "Azure Log Analytics",
 						"azureLogAnalytics": map[string]interface{}{
 							"workspace":    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-							"query":        "query=Perf | where $__timeFilter() | where $__contains(Computer, 'comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer",
+							"query":        "query=Perf",
 							"resultFormat": timeSeries,
 						},
 					}),
@@ -94,13 +95,89 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 					URL:          "v1/workspaces/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/query",
 					Model: simplejson.NewFromAny(map[string]interface{}{
 						"azureLogAnalytics": map[string]interface{}{
-							"query":        "query=Perf | where $__timeFilter() | where $__contains(Computer, 'comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer",
-							"resultFormat": timeSeries,
 							"workspace":    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+							"query":        "query=Perf",
+							"resultFormat": timeSeries,
 						},
 					}),
-					Params: url.Values{"query": {"query=Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer"}},
-					Target: "query=query%3DPerf+%7C+where+%5B%27TimeGenerated%27%5D+%3E%3D+datetime%28%272018-03-15T13%3A00%3A00Z%27%29+and+%5B%27TimeGenerated%27%5D+%3C%3D+datetime%28%272018-03-15T13%3A34%3A00Z%27%29+%7C+where+%5B%27Computer%27%5D+in+%28%27comp1%27%2C%27comp2%27%29+%7C+summarize+avg%28CounterValue%29+by+bin%28TimeGenerated%2C+34000ms%29%2C+Computer",
+					Params: url.Values{"query": {"query=Perf"}},
+					Target: "query=query%3DPerf",
+				},
+			},
+			Err: require.NoError,
+		},
+
+		{
+			name:      "Legacy workspace queries with a resource URI (from a template variable) should use resource-centric url",
+			timeRange: timeRange,
+			queryModel: []plugins.DataSubQuery{
+				{
+					DataSource: &models.DataSource{
+						JsonData: simplejson.NewFromAny(map[string]interface{}{}),
+					},
+					Model: simplejson.NewFromAny(map[string]interface{}{
+						"queryType": "Azure Log Analytics",
+						"azureLogAnalytics": map[string]interface{}{
+							"workspace":    "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
+							"query":        "query=Perf",
+							"resultFormat": timeSeries,
+						},
+					}),
+					RefID: "A",
+				},
+			},
+			azureLogAnalyticsQueries: []*AzureLogAnalyticsQuery{
+				{
+					RefID:        "A",
+					ResultFormat: timeSeries,
+					URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
+					Model: simplejson.NewFromAny(map[string]interface{}{
+						"azureLogAnalytics": map[string]interface{}{
+							"workspace":    "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
+							"query":        "query=Perf",
+							"resultFormat": timeSeries,
+						},
+					}),
+					Params: url.Values{"query": {"query=Perf"}},
+					Target: "query=query%3DPerf",
+				},
+			},
+			Err: require.NoError,
+		},
+
+		{
+			name:      "Queries with a Resource should use resource-centric url",
+			timeRange: timeRange,
+			queryModel: []plugins.DataSubQuery{
+				{
+					DataSource: &models.DataSource{
+						JsonData: simplejson.NewFromAny(map[string]interface{}{}),
+					},
+					Model: simplejson.NewFromAny(map[string]interface{}{
+						"queryType": "Azure Log Analytics",
+						"azureLogAnalytics": map[string]interface{}{
+							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
+							"query":        "query=Perf",
+							"resultFormat": timeSeries,
+						},
+					}),
+					RefID: "A",
+				},
+			},
+			azureLogAnalyticsQueries: []*AzureLogAnalyticsQuery{
+				{
+					RefID:        "A",
+					ResultFormat: timeSeries,
+					URL:          "v1/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace/query",
+					Model: simplejson.NewFromAny(map[string]interface{}{
+						"azureLogAnalytics": map[string]interface{}{
+							"resource":     "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.OperationalInsights/workspaces/AppInsightsTestDataWorkspace",
+							"query":        "query=Perf",
+							"resultFormat": timeSeries,
+						},
+					}),
+					Params: url.Values{"query": {"query=Perf"}},
+					Target: "query=query%3DPerf",
 				},
 			},
 			Err: require.NoError,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -14,6 +14,13 @@ jest.mock('@grafana/runtime', () => ({
   getTemplateSrv: () => templateSrv,
 }));
 
+const makeResourceURI = (
+  resourceName: string,
+  resourceGroup = 'test-resource-group',
+  subscriptionID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+) =>
+  `/subscriptions/${subscriptionID}/resourceGroups/${resourceGroup}/providers/Microsoft.OperationalInsights/workspaces/${resourceName}`;
+
 describe('AzureLogAnalyticsDatasource', () => {
   const datasourceRequestMock = jest.spyOn(backendSrv, 'datasourceRequest');
 
@@ -53,6 +60,7 @@ describe('AzureLogAnalyticsDatasource', () => {
       value: [
         {
           name: 'aworkspace',
+          id: makeResourceURI('a-workspace'),
           properties: {
             source: 'Azure',
             customerId: 'abc1b44e-3e57-4410-b027-6cc0ae6dee67',
@@ -72,7 +80,7 @@ describe('AzureLogAnalyticsDatasource', () => {
       ctx.ds = new AzureMonitorDatasource(ctx.instanceSettings);
 
       datasourceRequestMock.mockImplementation((options: { url: string }) => {
-        if (options.url.indexOf('Microsoft.OperationalInsights/workspaces') > -1) {
+        if (options.url.indexOf('Microsoft.OperationalInsights/workspaces?api-version') > -1) {
           workspacesUrl = options.url;
           return Promise.resolve({ data: workspaceResponse, status: 200 });
         } else {
@@ -80,11 +88,11 @@ describe('AzureLogAnalyticsDatasource', () => {
           return Promise.resolve({ data: tableResponseWithOneColumn, status: 200 });
         }
       });
-
-      await ctx.ds.metricFindQuery('workspace("aworkspace").AzureActivity  | distinct Category');
     });
 
-    it('should use the loganalyticsazure plugin route', () => {
+    it('should use the loganalyticsazure plugin route', async () => {
+      await ctx.ds.metricFindQuery('workspace("aworkspace").AzureActivity  | distinct Category');
+
       expect(workspacesUrl).toContain('workspacesloganalytics');
       expect(azureLogAnalyticsUrl).toContain('loganalyticsazure');
     });
@@ -168,12 +176,14 @@ describe('AzureLogAnalyticsDatasource', () => {
       value: [
         {
           name: 'workspace1',
+          id: makeResourceURI('workspace-1'),
           properties: {
             customerId: 'eeee4fde-1aaa-4d60-9974-eeee562ffaa1',
           },
         },
         {
           name: 'workspace2',
+          id: makeResourceURI('workspace-2'),
           properties: {
             customerId: 'eeee4fde-1aaa-4d60-9974-eeee562ffaa2',
           },
@@ -192,11 +202,10 @@ describe('AzureLogAnalyticsDatasource', () => {
       });
 
       it('should return a list of workspaces', () => {
-        expect(queryResults.length).toBe(2);
-        expect(queryResults[0].text).toBe('workspace1');
-        expect(queryResults[0].value).toBe('eeee4fde-1aaa-4d60-9974-eeee562ffaa1');
-        expect(queryResults[1].text).toBe('workspace2');
-        expect(queryResults[1].value).toBe('eeee4fde-1aaa-4d60-9974-eeee562ffaa2');
+        expect(queryResults).toEqual([
+          { text: 'workspace1', value: makeResourceURI('workspace-1') },
+          { text: 'workspace2', value: makeResourceURI('workspace-2') },
+        ]);
       });
     });
 
@@ -211,11 +220,10 @@ describe('AzureLogAnalyticsDatasource', () => {
       });
 
       it('should return a list of workspaces', () => {
-        expect(queryResults.length).toBe(2);
-        expect(queryResults[0].text).toBe('workspace1');
-        expect(queryResults[0].value).toBe('eeee4fde-1aaa-4d60-9974-eeee562ffaa1');
-        expect(queryResults[1].text).toBe('workspace2');
-        expect(queryResults[1].value).toBe('eeee4fde-1aaa-4d60-9974-eeee562ffaa2');
+        expect(queryResults).toEqual([
+          { text: 'workspace1', value: makeResourceURI('workspace-1') },
+          { text: 'workspace2', value: makeResourceURI('workspace-2') },
+        ]);
       });
     });
 
@@ -230,11 +238,10 @@ describe('AzureLogAnalyticsDatasource', () => {
       });
 
       it('should return a list of workspaces', () => {
-        expect(queryResults.length).toBe(2);
-        expect(queryResults[0].text).toBe('workspace1');
-        expect(queryResults[0].value).toBe('eeee4fde-1aaa-4d60-9974-eeee562ffaa1');
-        expect(queryResults[1].text).toBe('workspace2');
-        expect(queryResults[1].value).toBe('eeee4fde-1aaa-4d60-9974-eeee562ffaa2');
+        expect(queryResults).toEqual([
+          { text: 'workspace1', value: makeResourceURI('workspace-1') },
+          { text: 'workspace2', value: makeResourceURI('workspace-2') },
+        ]);
       });
     });
 
@@ -258,6 +265,7 @@ describe('AzureLogAnalyticsDatasource', () => {
         value: [
           {
             name: 'aworkspace',
+            id: makeResourceURI('a-workspace'),
             properties: {
               source: 'Azure',
               customerId: 'abc1b44e-3e57-4410-b027-6cc0ae6dee67',
@@ -268,22 +276,22 @@ describe('AzureLogAnalyticsDatasource', () => {
 
       beforeEach(async () => {
         datasourceRequestMock.mockImplementation((options: { url: string }) => {
-          if (options.url.indexOf('Microsoft.OperationalInsights/workspaces') > -1) {
+          if (options.url.indexOf('OperationalInsights/workspaces?api-version=') > -1) {
             return Promise.resolve({ data: workspaceResponse, status: 200 });
           } else {
             return Promise.resolve({ data: tableResponseWithOneColumn, status: 200 });
           }
         });
-
-        queryResults = await ctx.ds.metricFindQuery('workspace("aworkspace").AzureActivity  | distinct Category');
       });
 
-      it('should return a list of categories in the correct format', () => {
-        expect(queryResults.length).toBe(2);
-        expect(queryResults[0].text).toBe('Administrative');
-        expect(queryResults[0].value).toBe('Administrative');
-        expect(queryResults[1].text).toBe('Policy');
-        expect(queryResults[1].value).toBe('Policy');
+      it('should return a list of categories in the correct format', async () => {
+        const results = await ctx.ds.metricFindQuery('workspace("aworkspace").AzureActivity  | distinct Category');
+
+        expect(results.length).toBe(2);
+        expect(results[0].text).toBe('Administrative');
+        expect(results[0].value).toBe('Administrative');
+        expect(results[1].text).toBe('Policy');
+        expect(results[1].value).toBe('Policy');
       });
     });
   });
@@ -319,6 +327,7 @@ describe('AzureLogAnalyticsDatasource', () => {
       value: [
         {
           name: 'aworkspace',
+          id: makeResourceURI('a-workspace'),
           properties: {
             source: 'Azure',
             customerId: 'abc1b44e-3e57-4410-b027-6cc0ae6dee67',

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -61,7 +61,7 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
 
     return (
       map(response.data.value, (val: any) => {
-        return { text: val.name, value: val.properties.customerId };
+        return { text: val.name, value: val.id };
       }) || []
     );
   }
@@ -218,8 +218,9 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
       return this.getWorkspaces((workspacesQueryWithSub[1] || '').trim());
     }
 
-    return this.getDefaultOrFirstWorkspace().then((workspace: any) => {
-      const queries: any[] = this.buildQuery(query, null, workspace);
+    // TODO: what's this??
+    return this.getDefaultOrFirstWorkspace().then((resourceURI) => {
+      const queries: any[] = this.buildQuery(query, null, resourceURI);
 
       const promises = this.doQueries(queries);
 
@@ -288,8 +289,9 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
       return Promise.resolve(this.defaultOrFirstWorkspace);
     }
 
-    return this.getWorkspaces(this.subscriptionId).then((workspaces: any[]) => {
+    return this.getWorkspaces(this.subscriptionId).then((workspaces) => {
       this.defaultOrFirstWorkspace = workspaces[0].value;
+
       return this.defaultOrFirstWorkspace;
     });
   }
@@ -362,8 +364,8 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
     }
 
     return this.getDefaultOrFirstWorkspace()
-      .then((ws: any) => {
-        const url = `${this.baseUrl}/v1/workspaces/${ws}/metadata`;
+      .then((resourceURI) => {
+        const url = `${this.baseUrl}/v1${resourceURI}/metadata`;
 
         return this.doRequest(url);
       })

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -240,6 +240,8 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
           } else if (err.error && err.error.data && err.error.data.error) {
             throw { message: err.error.data.error.message };
           }
+
+          throw err;
         });
     }) as Promise<MetricFindValue[]>;
   }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { AzureMonitorErrorish, AzureMonitorOption, AzureMonitorQuery } from '../../types';
 import Datasource from '../../datasource';
-import { InlineFieldRow } from '@grafana/ui';
+import { Alert, InlineFieldRow } from '@grafana/ui';
 import QueryField from './QueryField';
 import FormatAsField from './FormatAsField';
 import ResourceField from './ResourceField';
@@ -24,7 +24,7 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
   onChange,
   setError,
 }) => {
-  useMigrations(datasource, query, onChange);
+  const migrationError = useMigrations(datasource, query, onChange);
 
   return (
     <div data-testid="azure-monitor-logs-query-editor">
@@ -56,6 +56,8 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
         onQueryChange={onChange}
         setError={setError}
       />
+
+      {migrationError && <Alert title={migrationError.title}>{migrationError.message}</Alert>}
     </div>
   );
 };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/ResourceField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/ResourceField.tsx
@@ -28,7 +28,7 @@ const ResourceField: React.FC<AzureQueryEditorFieldProps> = ({ query, datasource
   const [pickerIsOpen, setPickerIsOpen] = useState(false);
 
   useEffect(() => {
-    if (resource) {
+    if (resource && parseResourceDetails(resource)) {
       datasource.resourcePickerData.getResource(resource).then(setResourceComponents);
     } else {
       setResourceComponents(undefined);

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/utils.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/utils.ts
@@ -10,3 +10,7 @@ export function parseResourceURI(resourceURI: string) {
   const { subscriptionID, resourceGroup, resource } = matches.groups;
   return { subscriptionID, resourceGroup, resource };
 }
+
+export function isGUIDish(input: string) {
+  return !!input.match(/^[A-Z0-9]+/i);
+}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -107,6 +107,10 @@ export default class ResourcePickerData {
       throw new Error('unable to fetch resource containers');
     }
 
+    if (!response.data.length) {
+      throw new Error('unable to find resource for workspace ' + workspace);
+    }
+
     return response.data[0].id;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bunch of issues with template variables in the new Logs experience:

 - The (undocumented) `workspaces()` template variable query function now returns resource URIs as the value, so they can be compatible with the new resource picker for Logs
 - Handles migrating `workspace` -> `resource` when the value is a variable - it is just moved straight into the resource field. 
 - Updates backend to handle resource URI in the `workspace` field - this can happen with legacy workspace queries with template variables
 - Updates the Logs `testDatasource` function to work with resource URIs, and it shares some internals with the template variable query function.
 - Add error reporting for when `workspace` -> `resource` migrations fail in the query editor.

**Which issue(s) this PR fixes**:

Fixes #33708

**Special notes for your reviewer**:

This PR does not include template variables in the resource picker


# Release notice breaking change

The `workspaces()` template variable, mainly for use with Azure Monitor Logs, has been changed to return resource URIs instead of Log Analytics Workspaces GUIDs. This should not impact Azure Monitor Logs queries, but if the variables are being used in other data sources which expect a Workspace GUID may no longer be compatible.

Custom template variables used in the workspace or resource field in Azure Monitor Logs queries should resolve to an Azure Resource URI in the format `/subscriptions/{guid}/resourceGroups/{resource-group-name}/{resource-provider-namespace}/{resource-type}/{resource-name}`
