### PR TITLE
LibraryElements: replaces `is_folder=1` usages with correct dialect string

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -660,7 +660,7 @@ func (l *LibraryElementService) deleteLibraryElementsInFolderUID(c *models.ReqCo
 		var folderUIDs []struct {
 			ID int64 `xorm:"id"`
 		}
-		err := session.SQL("SELECT id from dashboard WHERE uid=? AND org_id=? AND is_folder=1", folderUID, c.SignedInUser.OrgId).Find(&folderUIDs)
+		err := session.SQL("SELECT id from dashboard WHERE uid=? AND org_id=? AND is_folder=?", folderUID, c.SignedInUser.OrgId, l.SQLStore.Dialect.BooleanStr(true)).Find(&folderUIDs)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like `is_folder=1` won't work for postgres here:
https://github.com/grafana/grafana/blob/9237348076b1b610b008500cea8b9b1118cb8fb6/pkg/services/libraryelements/database.go#L663

This PR replaces that with the appropriate Dialect string.

**Which issue(s) this PR fixes**:
Fixes #34271

**Special notes for your reviewer**:

