### PR TITLE
StatusGrid: show warning when too many points in status grid

### DIFF
--- a/public/app/plugins/panel/status-grid/StatusGridPanel.tsx
+++ b/public/app/plugins/panel/status-grid/StatusGridPanel.tsx
@@ -34,6 +34,18 @@ export const StatusGridPanel: React.FC<TimelinePanelProps> = ({
     );
   }
 
+  // Status grid requires some space between values
+  if (frames[0].length > width / 2) {
+    return (
+      <div className="panel-empty">
+        <p>
+          Too many points to visualize properly. <br />
+          Update the query to return fewer points. <br />({frames[0].length} points recieved)
+        </p>
+      </div>
+    );
+  }
+
   return (
     <TimelineChart
       theme={theme}


### PR DESCRIPTION
When the status grid is loaded with results that have 1 point/pixel, it does not display anything.  This replaces a funky view with funky warning message (at least not broken)

Before:
![image](https://user-images.githubusercontent.com/705951/118925187-26a76380-b8f3-11eb-9c02-f33e14aa7b7d.png)


After:
![image](https://user-images.githubusercontent.com/705951/118925078-ee078a00-b8f2-11eb-9d50-3dff51f73ba7.png)

OK:
![image](https://user-images.githubusercontent.com/705951/118925147-10010c80-b8f3-11eb-984e-cc017e7f7ef5.png)
