### PR TITLE
Timeline: Add 1px gap on right side

### DIFF
--- a/public/app/plugins/panel/state-timeline/timeline.ts
+++ b/public/app/plugins/panel/state-timeline/timeline.ts
@@ -233,7 +233,7 @@ export function getConfig(opts: TimelineCoreOptions) {
                   yOff,
                   left,
                   round(yOff + y0),
-                  right - left,
+                  right - left - 1,
                   round(height),
                   strokeWidth,
                   iy,


### PR DESCRIPTION
Propose a 1px gap on right side of box so the edge line strokes does not line up next to each other.

Alternative is wait with this and a proper gap option (that controls both gaps between boxes and rows, so they are the same) 

Before:
![Screenshot from 2021-05-20 07-51-13](https://user-images.githubusercontent.com/10999/118926214-3bf6af00-b940-11eb-8665-2205ab133456.png)

After:
![Screenshot from 2021-05-20 07-50-49](https://user-images.githubusercontent.com/10999/118926216-3d27dc00-b940-11eb-8390-a9dffee56df1.png)