### PR TITLE
LibraryPanels: Fixes connections after dashboard import

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1348,6 +1348,10 @@ func (m *mockLibraryPanelService) ConnectLibraryPanelsForDashboard(c *models.Req
 	return nil
 }
 
+func (m *mockLibraryPanelService) ImportDashboard(c *models.ReqContext, dashboard *simplejson.Json, importedID int64) error {
+	return nil
+}
+
 type mockLibraryElementService struct {
 }
 

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -226,6 +226,11 @@ func (hs *HTTPServer) ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDa
 		return hs.dashboardSaveErrorToApiResponse(err)
 	}
 
+	err = hs.LibraryPanelService.ImportDashboard(c, apiCmd.Dashboard, dashInfo.DashboardId)
+	if err != nil {
+		return response.Error(500, "Error while connecting library panels", err)
+	}
+
 	return response.JSON(200, dashInfo)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes so we add appropriate connections to the imported dashboard. 

**Which issue(s) this PR fixes**:
Fixes #34454

**Special notes for your reviewer**:

