### PR TITLE
InfluxDB: InfluxQL: handle empty tag values when generating query

### DIFF
--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -17,8 +17,8 @@ function renderTagCondition(tag: { operator: any; value: string; condition: any;
     }
   }
 
-  // quote value unless regex or number
-  if (operator !== '=~' && operator !== '!~' && isNaN(+value)) {
+  // quote value unless regex or number, or if empty-string
+  if (value === '' || (operator !== '=~' && operator !== '!~' && isNaN(+value))) {
     value = "'" + value + "'";
   }
 

--- a/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
@@ -159,5 +159,41 @@ describe('InfluxQueryBuilder', () => {
       const query = builder.buildExploreQuery('RETENTION POLICIES');
       expect(query).toBe('SHOW RETENTION POLICIES on "site"');
     });
+
+    it('should handle tag-value=number-ish when getting measurements', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: '42', operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('MEASUREMENTS');
+      expect(query).toBe(`SHOW MEASUREMENTS WHERE "app" == 42 LIMIT 100`);
+    });
+
+    it('should handle tag-value=number-ish getting tag-keys', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: '42', operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe(`SHOW TAG KEYS WHERE "app" == 42`);
+    });
+
+    it('should handle tag-value=emptry-string when getting measurements', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: '', operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('MEASUREMENTS');
+      expect(query).toBe(`SHOW MEASUREMENTS WHERE "app" == '' LIMIT 100`);
+    });
+
+    it('should handle tag-value=emptry-string when getting tag-keys', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: '', operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe(`SHOW TAG KEYS WHERE "app" == ''`);
+    });
   });
 });


### PR DESCRIPTION
This modifies the influxdb query generation to handle the case where the tag-value is an empty-string.

NOTE: currently it is not possible to achieve this using the query-editor. the issue was found when working on a related other issue. i just thought the code-generation-fix is valuable even without GUI support, and there are unit tests added to cover it.