### PR TITLE
App plugins: use existing queryparams prop in AppRootPage

### DIFF
--- a/public/app/features/plugins/AppRootPage.tsx
+++ b/public/app/features/plugins/AppRootPage.tsx
@@ -10,8 +10,6 @@ import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/nav_mod
 import { appEvents } from 'app/core/core';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
-import { locationSearchToObject } from '@grafana/runtime';
-
 interface RouteParams {
   pluginId: string;
 }
@@ -107,7 +105,7 @@ class AppRootPage extends Component<Props, State> {
               meta={plugin.meta}
               basename={this.props.match.url}
               onNavChanged={this.onNavChanged}
-              query={locationSearchToObject(this.props.location.search) as KeyValue}
+              query={this.props.queryParams as KeyValue}
               path={this.props.location.pathname}
             />
           )}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Hi,

With last change, `AppRootPage` would create new `queryParams` object on every rerender, which puts some existing plugins that use that in hook dependencies into infinite update loops. This change uses the `queryParams` provided by route component via props instead, which is stable between location changes


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

