### PR TITLE
InfluxDB: InfluxQL query editor: generate better HTML

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
@@ -176,11 +176,9 @@ export const Seg = ({
   const [isOpen, setOpen] = useState(false);
   if (!isOpen) {
     const className = cx(defaultButtonClass, buttonClassName);
-    // this should not be a label, this should be a button,
-    // but this is what is used inside a Segment, and i just
-    // want the same look
     return (
       <InlineLabel
+        as="button"
         className={className}
         onClick={() => {
           setOpen(true);

--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/TagsSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/TagsSection.test.tsx
@@ -31,7 +31,7 @@ async function assertSegmentSelect(
   callbackValue: unknown
 ) {
   // we find the segment
-  const segs = screen.getAllByText(segmentText, { selector: 'label' });
+  const segs = screen.getAllByRole('button', { name: segmentText });
   expect(segs.length).toBe(1);
   const seg = segs[0];
   expect(seg).toBeInTheDocument();


### PR DESCRIPTION
in the influxQL query editor, the "segments" are by-default represented as `<label/>` elements. having them buttons is more correct, and allows easier testing (should help with usability too in theory).
there is no visual change, just the underlying HTML is different.