### PR TITLE
Add link to release notes v7.5.7 (#34460)

### DIFF
--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,6 +8,8 @@ weight = 10000
 Here you can find detailed release notes that list everything that is included in every release as well as notices
 about deprecations, breaking changes as well as changes that relate to plugin development.
 
+- [Release notes for 8.0.0-beta1]({{< relref "release-notes-8-0-0-beta1" >}})
+- [Release notes for 7.5.7]({{< relref "release-notes-7-5-7" >}})
 - [Release notes for 7.5.6]({{< relref "release-notes-7-5-6" >}})
 - [Release notes for 7.5.5]({{< relref "release-notes-7-5-5" >}})
 - [Release notes for 7.5.4]({{< relref "release-notes-7-5-4" >}})

--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -8,7 +8,6 @@ weight = 10000
 Here you can find detailed release notes that list everything that is included in every release as well as notices
 about deprecations, breaking changes as well as changes that relate to plugin development.
 
-- [Release notes for 8.0.0-beta1]({{< relref "release-notes-8-0-0-beta1" >}})
 - [Release notes for 7.5.7]({{< relref "release-notes-7-5-7" >}})
 - [Release notes for 7.5.6]({{< relref "release-notes-7-5-6" >}})
 - [Release notes for 7.5.5]({{< relref "release-notes-7-5-5" >}})


### PR DESCRIPTION
(cherry picked from commit 07302faec2f2a7d0898ba87bec9b10b11e520d36)

Backport release notes v7.5.7.