### PR TITLE
Azure: Expose Azure settings to external plugins

### DIFF
--- a/pkg/plugins/backendplugin/manager/manager.go
+++ b/pkg/plugins/backendplugin/manager/manager.go
@@ -81,6 +81,8 @@ func (m *manager) Register(pluginID string, factory backendplugin.PluginFactoryF
 	}
 
 	hostEnv = append(hostEnv, m.getAWSEnvironmentVariables()...)
+	hostEnv = append(hostEnv, m.getAzureEnvironmentVariables()...)
+
 	pluginSettings := getPluginSettings(pluginID, m.Cfg)
 	env := pluginSettings.ToEnv("GF_PLUGIN", hostEnv)
 
@@ -159,6 +161,21 @@ func (m *manager) getAWSEnvironmentVariables() []string {
 	}
 	if len(m.Cfg.AWSAllowedAuthProviders) > 0 {
 		variables = append(variables, awsds.AllowedAuthProvidersEnvVarKeyName+"="+strings.Join(m.Cfg.AWSAllowedAuthProviders, ","))
+	}
+
+	return variables
+}
+
+func (m *manager) getAzureEnvironmentVariables() []string {
+	variables := []string{}
+	if m.Cfg.Azure.Cloud != "" {
+		variables = append(variables, "AZURE_CLOUD="+m.Cfg.Azure.Cloud)
+	}
+	if m.Cfg.Azure.ManagedIdentityClientId != "" {
+		variables = append(variables, "AZURE_MANAGED_IDENTITY_CLIENT_ID="+m.Cfg.Azure.ManagedIdentityClientId)
+	}
+	if m.Cfg.Azure.ManagedIdentityEnabled {
+		variables = append(variables, "AZURE_MANAGED_IDENTITY_ENABLED=true")
 	}
 
 	return variables

--- a/pkg/plugins/backendplugin/manager/manager_test.go
+++ b/pkg/plugins/backendplugin/manager/manager_test.go
@@ -63,8 +63,16 @@ func TestManager(t *testing.T) {
 				})
 
 				t.Run("Should provide expected host environment variables", func(t *testing.T) {
-					require.Len(t, ctx.env, 4)
-					require.EqualValues(t, []string{"GF_VERSION=7.0.0", "GF_EDITION=Open Source", fmt.Sprintf("%s=true", awsds.AssumeRoleEnabledEnvVarKeyName), fmt.Sprintf("%s=keys,credentials", awsds.AllowedAuthProvidersEnvVarKeyName)}, ctx.env)
+					require.Len(t, ctx.env, 7)
+					require.EqualValues(t, []string{
+						"GF_VERSION=7.0.0",
+						"GF_EDITION=Open Source",
+						fmt.Sprintf("%s=true", awsds.AssumeRoleEnabledEnvVarKeyName),
+						fmt.Sprintf("%s=keys,credentials", awsds.AllowedAuthProvidersEnvVarKeyName),
+						"AZURE_CLOUD=AzureCloud",
+						"AZURE_MANAGED_IDENTITY_CLIENT_ID=client-id",
+						"AZURE_MANAGED_IDENTITY_ENABLED=true"},
+						ctx.env)
 				})
 
 				t.Run("When manager runs should start and stop plugin", func(t *testing.T) {
@@ -282,8 +290,18 @@ func TestManager(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("Should provide expected host environment variables", func(t *testing.T) {
-				require.Len(t, ctx.env, 6)
-				require.EqualValues(t, []string{"GF_VERSION=7.0.0", "GF_EDITION=Enterprise", "GF_ENTERPRISE_LICENSE_PATH=/license.txt", "GF_ENTERPRISE_LICENSE_TEXT=testtoken", fmt.Sprintf("%s=true", awsds.AssumeRoleEnabledEnvVarKeyName), fmt.Sprintf("%s=keys,credentials", awsds.AllowedAuthProvidersEnvVarKeyName)}, ctx.env)
+				require.Len(t, ctx.env, 9)
+				require.EqualValues(t, []string{
+					"GF_VERSION=7.0.0",
+					"GF_EDITION=Enterprise",
+					"GF_ENTERPRISE_LICENSE_PATH=/license.txt",
+					"GF_ENTERPRISE_LICENSE_TEXT=testtoken",
+					fmt.Sprintf("%s=true", awsds.AssumeRoleEnabledEnvVarKeyName),
+					fmt.Sprintf("%s=keys,credentials", awsds.AllowedAuthProvidersEnvVarKeyName),
+					"AZURE_CLOUD=AzureCloud",
+					"AZURE_MANAGED_IDENTITY_CLIENT_ID=client-id",
+					"AZURE_MANAGED_IDENTITY_ENABLED=true"},
+					ctx.env)
 			})
 		})
 	})
@@ -303,6 +321,10 @@ func newManagerScenario(t *testing.T, managed bool, fn func(t *testing.T, ctx *m
 	cfg := setting.NewCfg()
 	cfg.AWSAllowedAuthProviders = []string{"keys", "credentials"}
 	cfg.AWSAssumeRoleEnabled = true
+
+	cfg.Azure.ManagedIdentityEnabled = true
+	cfg.Azure.Cloud = "AzureCloud"
+	cfg.Azure.ManagedIdentityClientId = "client-id"
 
 	license := &testLicensingService{}
 	validator := &testPluginRequestValidator{}


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose the Azure settings that was added in [this](https://github.com/grafana/grafana/pull/33728) PR to external plugins using environment variables. 

**Which issue(s) this PR fixes**:

Fixes #33801

