### PR TITLE
Timeline: Fix y-axis being cropped

### DIFF
--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -25,7 +25,6 @@ import {
 } from '@grafana/ui';
 import { TimelineCoreOptions, getConfig } from './timeline';
 import { AxisPlacement, ScaleDirection, ScaleOrientation } from '@grafana/ui/src/components/uPlot/config';
-import { measureText } from '@grafana/ui/src/utils/measureText';
 import { TimelineFieldConfig, TimelineOptions } from './types';
 
 const defaultConfig: TimelineFieldConfig = {
@@ -79,14 +78,6 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
 
     return FALLBACK_COLOR;
   };
-
-  const yAxisWidth =
-    frame.fields.reduce((maxWidth, field) => {
-      return Math.max(
-        maxWidth,
-        measureText(getFieldDisplayName(field, frame), Math.round(10 * devicePixelRatio)).width
-      );
-    }, 0) + 24;
 
   const opts: TimelineCoreOptions = {
     // should expose in panel config
@@ -154,7 +145,6 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
     values: coreConfig.yValues,
     grid: false,
     ticks: false,
-    size: yAxisWidth,
     gap: 16,
     theme,
   });


### PR DESCRIPTION
Noticed the y-axis was cut of. But the function calculateAxisSize in UPlotAxisBuilder was not being called as there was a similar calculation done
in timeline config. Removing this config and relying on the code in calculateAxisSize fixed the issue.

Fixes this
![Screenshot from 2021-05-20 15-35-25](https://user-images.githubusercontent.com/10999/118993035-76366f80-b985-11eb-86a5-6eda72688581.png)

