### PR TITLE
devenv: influxdb: create a "slow" influxdb server

### DIFF
--- a/devenv/docker/blocks/influxdb/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb/docker-compose.yaml
@@ -33,3 +33,11 @@
       - ./docker/blocks/influxdb/telegraf.conf:/etc/telegraf/telegraf.conf:ro
       - /var/log:/var/log
       - ../data/log:/var/log/grafana
+
+  influxdb_slow:
+    build: docker/blocks/influxdb/influxdb_slow
+    ports:
+      - '8096:8096'
+    environment:
+      ORIGIN_SERVER: 'http://influxdb:8086'
+      SLEEP_DURATION: '2s'

--- a/devenv/docker/blocks/influxdb/influxdb_slow/Dockerfile
+++ b/devenv/docker/blocks/influxdb/influxdb_slow/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:latest as builder
+ADD main.go /
+WORKDIR /
+RUN GO111MODULE=off CGO_ENABLED=0 go build -o main .
+
+FROM scratch
+WORKDIR /
+EXPOSE 8096
+COPY --from=builder /main /main
+CMD ["/main"]

--- a/devenv/docker/blocks/influxdb/influxdb_slow/main.go
+++ b/devenv/docker/blocks/influxdb/influxdb_slow/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"time"
+)
+
+func main() {
+	origin := os.Getenv("ORIGIN_SERVER")
+	if origin == "" {
+		log.Fatalf("ORIGIN_SERVER env-variable missing")
+	}
+
+	sleepStr := os.Getenv("SLEEP_DURATION")
+	if sleepStr == "" {
+		log.Fatalf("SLEEP_DURATION env-variable missing")
+	}
+
+	sleep, err := time.ParseDuration(sleepStr)
+	if err != nil {
+		log.Fatalf("Invalid SLEEP_DURATION env-variable: %v", err)
+	}
+
+	originURL, _ := url.Parse(origin)
+	proxy := httputil.NewSingleHostReverseProxy(originURL)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("sleeping for %s then proxying request: %s", sleep.String(), r.RequestURI)
+		<-time.After(sleep)
+		proxy.ServeHTTP(w, r)
+	})
+
+	log.Fatal(http.ListenAndServe(":8096", nil))
+}


### PR DESCRIPTION
i've found out that because i use a local influxdb database with a minimal amount of data, it is always responding immediately. this way i cannot really see how the system behaves when the response takes a little while to arrive. for this reason i created this pull-request, which, when running `make devenv sources=influxdb`, it provides a "slow" influxdb on port 8096.

it is basically a copy of the slow_proxy devenv-block, but that one is basically created for prometheus it seems, and i do not see an easy way to customize it for other server-ports. 

this is a draft PR, i'd like to get some feedback, like:

- is this a good idea?
- maybe achieve this in a different way?
- should we go further and even add to devenv-setup.sh to provision additional datasources like "gdev-influxdb-flux-slow" ? 
- should i make the sleep-duration configurable with something like `make devenv sources=influxdb influxdb_slow_sleep=3s`?