### PR TITLE
Timeline: use full row height with one series

### DIFF
--- a/public/app/plugins/panel/state-timeline/TimelineChart.tsx
+++ b/public/app/plugins/panel/state-timeline/TimelineChart.tsx
@@ -42,6 +42,9 @@ export class TimelineChart extends React.Component<TimelineProps> {
       getTimeRange,
       eventBus,
       ...this.props,
+
+      // When there is only one row, use the full space
+      rowHeight: alignedFrame.fields.length > 2 ? this.props.rowHeight : 1,
     });
   };
 


### PR DESCRIPTION
Timeline has row height setting to control spacing between rows - it defaults to 0.9.  This makes sense when there are multiple rows, but awkward when there are not. 

Before:
![image](https://user-images.githubusercontent.com/705951/119045390-42048400-b970-11eb-950a-941996300009.png)


After:
![image](https://user-images.githubusercontent.com/705951/119045216-023d9c80-b970-11eb-8441-2cc435408229.png)
