### PR TITLE
devenv: slow_proxy_mac: make configurable and smaller

### DIFF
--- a/devenv/docker/blocks/slow_proxy_mac/.env
+++ b/devenv/docker/blocks/slow_proxy_mac/.env
@@ -1,0 +1,2 @@
+ORIGIN_SERVER=http://host.docker.internal:9090/
+SLEEP_DURATION=60s

--- a/devenv/docker/blocks/slow_proxy_mac/Dockerfile
+++ b/devenv/docker/blocks/slow_proxy_mac/Dockerfile
@@ -1,7 +1,10 @@
-
-FROM golang:latest
+FROM golang:latest as builder
 ADD main.go /
 WORKDIR /
-RUN GO111MODULE=off go build -o main .
+RUN GO111MODULE=off CGO_ENABLED=0 go build -o main .
+
+FROM scratch
+WORKDIR /
 EXPOSE 3011
+COPY --from=builder /main /main
 ENTRYPOINT ["/main"]

--- a/devenv/docker/blocks/slow_proxy_mac/docker-compose.yaml
+++ b/devenv/docker/blocks/slow_proxy_mac/docker-compose.yaml
@@ -3,4 +3,5 @@
     ports:
       - '3011:3011'
     environment:
-      ORIGIN_SERVER: 'http://host.docker.internal:9090/'
+      ORIGIN_SERVER: ${ORIGIN_SERVER}
+      SLEEP_DURATION: ${SLEEP_DURATION}


### PR DESCRIPTION
i tried to use the `devenv` block `slow_proxy_mac`, but could not find a way to configure it. so i updated it with code from `slow_proxy` to make it configurable, so now something like:
`make devenv sources=influxdb,slow_proxy_mac ORIGIN_SERVER=http;//host.dockeer.internal:8086 SLEEP_DURATION=4s` works.
i also used a two-step dockerfile to make the final docer-image smaller.