### PR TITLE
Spinner: Add @public release tag

### DIFF
--- a/packages/grafana-ui/src/components/Spinner/Spinner.tsx
+++ b/packages/grafana-ui/src/components/Spinner/Spinner.tsx
@@ -23,6 +23,10 @@ type Props = {
   inline?: boolean;
   size?: number;
 };
+
+/**
+ * @public
+ */
 export const Spinner: FC<Props> = (props: Props) => {
   const { className, inline = false, iconClassName, style, size = 16 } = props;
   const styles = getStyles(size, inline);


### PR DESCRIPTION
**What this PR does / why we need it**:

Drone builds are failing again on `API Extractor warnings/errors 1073 exceeded 1072 so failing build` even if the PRs are not touching @grafana/ui code.  This PR fixes 1 error so the build is passing for all PRs. 