### PR TITLE
Datasource: Fix dataproxy timeout should always be applied for outgoing data source HTTP requests

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -139,12 +139,12 @@ connstr =
 # This enables data proxy logging, default is false
 logging = false
 
-# How long the data proxy waits to read the headers of the response before timing out, default is 10 seconds.
+# How long the data proxy waits to read the headers of the response before timing out, default is 30 seconds.
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
-timeout = 10
+timeout = 30
 
-# How long the data proxy waits to establish a TCP connection before timing out, default is 30 seconds.
-dialTimeout = 30
+# How long the data proxy waits to establish a TCP connection before timing out, default is 10 seconds.
+dialTimeout = 10
 
 # How many seconds the data proxy waits before sending a keepalive request.
 keep_alive_seconds = 30

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -139,9 +139,12 @@ connstr =
 # This enables data proxy logging, default is false
 logging = false
 
-# How long the data proxy waits before timing out, default is 30 seconds.
+# How long the data proxy waits to read the headers of the response before timing out, default is 10 seconds.
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
-timeout = 30
+timeout = 10
+
+# How long the data proxy waits to establish a TCP connection before timing out, default is 30 seconds.
+dialTimeout = 30
 
 # How many seconds the data proxy waits before sending a keepalive request.
 keep_alive_seconds = 30

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -145,9 +145,12 @@
 # This enables data proxy logging, default is false
 ;logging = false
 
-# How long the data proxy waits before timing out, default is 30 seconds.
+# How long the data proxy waits to read the headers of the response before timing out, default is 10 seconds.
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
-;timeout = 30
+;timeout = 10
+
+# How long the data proxy waits to establish a TCP connection before timing out, default is 30 seconds.
+;dialTimeout = 30
 
 # How many seconds the data proxy waits before sending a keepalive probe request.
 ;keep_alive_seconds = 30

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -145,12 +145,12 @@
 # This enables data proxy logging, default is false
 ;logging = false
 
-# How long the data proxy waits to read the headers of the response before timing out, default is 10 seconds.
+# How long the data proxy waits to read the headers of the response before timing out, default is 30 seconds.
 # This setting also applies to core backend HTTP data sources where query requests use an HTTP client with timeout set.
-;timeout = 10
+;timeout = 30
 
-# How long the data proxy waits to establish a TCP connection before timing out, default is 30 seconds.
-;dialTimeout = 30
+# How long the data proxy waits to establish a TCP connection before timing out, default is 10 seconds.
+;dialTimeout = 10
 
 # How many seconds the data proxy waits before sending a keepalive probe request.
 ;keep_alive_seconds = 30

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/gosimple/slug v1.9.0
 	github.com/grafana/grafana-aws-sdk v0.4.0
 	github.com/grafana/grafana-live-sdk v0.0.6
-	github.com/grafana/grafana-plugin-sdk-go v0.99.0
+	github.com/grafana/grafana-plugin-sdk-go v0.99.1-0.20210524132954-f5c0098028e0
 	github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-hclog v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/gosimple/slug v1.9.0
 	github.com/grafana/grafana-aws-sdk v0.4.0
 	github.com/grafana/grafana-live-sdk v0.0.6
-	github.com/grafana/grafana-plugin-sdk-go v0.99.1-0.20210524132954-f5c0098028e0
+	github.com/grafana/grafana-plugin-sdk-go v0.100.0
 	github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-hclog v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -922,8 +922,8 @@ github.com/grafana/grafana-live-sdk v0.0.6 h1:P1QFn0ZradOJp3zVpfG0STZMP+pgZrW0e0
 github.com/grafana/grafana-live-sdk v0.0.6/go.mod h1:f15hHmWyLdFjmuWLsjeKeZnq/HnNQ3QkoPcaEww45AY=
 github.com/grafana/grafana-plugin-sdk-go v0.79.0/go.mod h1:NvxLzGkVhnoBKwzkst6CFfpMFKwAdIUZ1q8ssuLeF60=
 github.com/grafana/grafana-plugin-sdk-go v0.91.0/go.mod h1:Ot3k7nY7P6DXmUsDgKvNB7oG1v7PRyTdmnYVoS554bU=
-github.com/grafana/grafana-plugin-sdk-go v0.99.0 h1:pEmoSSYw7VsF+rhRgG4z+azE3eLwznomxVg9Ezppqzo=
-github.com/grafana/grafana-plugin-sdk-go v0.99.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
+github.com/grafana/grafana-plugin-sdk-go v0.99.1-0.20210524132954-f5c0098028e0 h1:TWHm4j45TRpGQX7cWQQCIcH6Fby0Nvi/+MhHfT2Se40=
+github.com/grafana/grafana-plugin-sdk-go v0.99.1-0.20210524132954-f5c0098028e0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103 h1:qCmofFVwQR9QnsinstVqI1NPLMVl33jNCnOCXEAVn6E=
 github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103/go.mod h1:GHIsn+EohCChsdu5YouNZewqLeV9L2FNw4DEJU3P9qE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/go.sum
+++ b/go.sum
@@ -922,8 +922,8 @@ github.com/grafana/grafana-live-sdk v0.0.6 h1:P1QFn0ZradOJp3zVpfG0STZMP+pgZrW0e0
 github.com/grafana/grafana-live-sdk v0.0.6/go.mod h1:f15hHmWyLdFjmuWLsjeKeZnq/HnNQ3QkoPcaEww45AY=
 github.com/grafana/grafana-plugin-sdk-go v0.79.0/go.mod h1:NvxLzGkVhnoBKwzkst6CFfpMFKwAdIUZ1q8ssuLeF60=
 github.com/grafana/grafana-plugin-sdk-go v0.91.0/go.mod h1:Ot3k7nY7P6DXmUsDgKvNB7oG1v7PRyTdmnYVoS554bU=
-github.com/grafana/grafana-plugin-sdk-go v0.99.1-0.20210524132954-f5c0098028e0 h1:TWHm4j45TRpGQX7cWQQCIcH6Fby0Nvi/+MhHfT2Se40=
-github.com/grafana/grafana-plugin-sdk-go v0.99.1-0.20210524132954-f5c0098028e0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
+github.com/grafana/grafana-plugin-sdk-go v0.100.0 h1:BryvIFdx/HrsKMt2hkxN7cJ0WrCgKpgjdJW8y8TSol0=
+github.com/grafana/grafana-plugin-sdk-go v0.100.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103 h1:qCmofFVwQR9QnsinstVqI1NPLMVl33jNCnOCXEAVn6E=
 github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103/go.mod h1:GHIsn+EohCChsdu5YouNZewqLeV9L2FNw4DEJU3P9qE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -75,7 +75,8 @@ func (ds *DataSource) HTTPClientOptions() sdkhttpclient.Options {
 	tlsOptions := ds.TLSOptions()
 	opts := sdkhttpclient.Options{
 		Timeouts: &sdkhttpclient.TimeoutOptions{
-			Timeout:               ds.getTimeout(),
+			Timeout:               time.Duration(setting.DataProxyTimeout) * time.Second,
+			DialTimeout:           time.Duration(setting.DataProxyDialTimeout) * time.Second,
 			KeepAlive:             time.Duration(setting.DataProxyKeepAlive) * time.Second,
 			TLSHandshakeTimeout:   time.Duration(setting.DataProxyTLSHandshakeTimeout) * time.Second,
 			ExpectContinueTimeout: time.Duration(setting.DataProxyExpectContinueTimeout) * time.Second,

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -75,7 +75,7 @@ func (ds *DataSource) HTTPClientOptions() sdkhttpclient.Options {
 	tlsOptions := ds.TLSOptions()
 	opts := sdkhttpclient.Options{
 		Timeouts: &sdkhttpclient.TimeoutOptions{
-			Timeout:               time.Duration(setting.DataProxyTimeout) * time.Second,
+			Timeout:               ds.getTimeout(),
 			DialTimeout:           time.Duration(setting.DataProxyDialTimeout) * time.Second,
 			KeepAlive:             time.Duration(setting.DataProxyKeepAlive) * time.Second,
 			TLSHandshakeTimeout:   time.Duration(setting.DataProxyTLSHandshakeTimeout) * time.Second,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -78,6 +78,7 @@ var (
 	// HTTP server options
 	DataProxyLogging               bool
 	DataProxyTimeout               int
+	DataProxyDialTimeout           int
 	DataProxyTLSHandshakeTimeout   int
 	DataProxyExpectContinueTimeout int
 	DataProxyMaxIdleConns          int
@@ -823,7 +824,8 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	// read data proxy settings
 	dataproxy := iniFile.Section("dataproxy")
 	DataProxyLogging = dataproxy.Key("logging").MustBool(false)
-	DataProxyTimeout = dataproxy.Key("timeout").MustInt(30)
+	DataProxyTimeout = dataproxy.Key("timeout").MustInt(10)
+	DataProxyDialTimeout = dataproxy.Key("dialTimeout").MustInt(30)
 	DataProxyKeepAlive = dataproxy.Key("keep_alive_seconds").MustInt(30)
 	DataProxyTLSHandshakeTimeout = dataproxy.Key("tls_handshake_timeout_seconds").MustInt(10)
 	DataProxyExpectContinueTimeout = dataproxy.Key("expect_continue_timeout_seconds").MustInt(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

`ResponseHeaderTimeout` is now set for the http.Transport via https://github.com/grafana/grafana-plugin-sdk-go/pull/358 which should guarantee that outgoing data source HTTP requests that do not directly use a `http.Client`, rather a `http.Transport`, will get the `ResponseHeaderTimeout` set to the configured dataproxy timeout. The Grafana data source proxy and the Prometheus data source (when queries comes from Grafana alerting) are two examples where the dataproxy timeout was not properly enforced, but this change should fix this.

In addition, a new data proxy setting named `dialTimeout` was introduced.

![image](https://user-images.githubusercontent.com/1668778/119574313-d417ec80-bdb5-11eb-90c8-1e410a437c33.png) 

**Which issue(s) this PR fixes**:

Fixes #34177
Fixes #29457

