### PR TITLE
API: Use SettingsProvider when fetching current settings

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -4,23 +4,10 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
-func AdminGetSettings(c *models.ReqContext) response.Response {
-	settings := make(map[string]interface{})
-
-	for _, section := range setting.Raw.Sections() {
-		jsonSec := make(map[string]interface{})
-		settings[section.Name()] = jsonSec
-
-		for _, key := range section.Keys() {
-			keyName := key.Name()
-			jsonSec[keyName] = setting.RedactedValue(keyName, key.Value())
-		}
-	}
-
-	return response.JSON(200, settings)
+func (hs *HTTPServer) AdminGetSettings(_ *models.ReqContext) response.Response {
+	return response.JSON(200, hs.SettingsProvider.Current())
 }
 
 func AdminGetStats(c *models.ReqContext) response.Response {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -440,7 +440,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 	// admin api
 	r.Group("/api/admin", func(adminRoute routing.RouteRegister) {
-		adminRoute.Get("/settings", reqGrafanaAdmin, routing.Wrap(AdminGetSettings))
+		adminRoute.Get("/settings", reqGrafanaAdmin, routing.Wrap(hs.AdminGetSettings))
 		adminRoute.Get("/stats", reqGrafanaAdmin, routing.Wrap(AdminGetStats))
 		adminRoute.Post("/pause-all-alerts", reqGrafanaAdmin, bind(dtos.PauseAllAlertsCommand{}), routing.Wrap(PauseAllAlerts))
 

--- a/pkg/setting/provider.go
+++ b/pkg/setting/provider.go
@@ -32,7 +32,13 @@ func (v ValidationError) Error() string {
 // Provider is a settings provider abstraction
 // with thread-safety and runtime updates.
 type Provider interface {
-	// Update
+	// Current returns a SettingsBag with a static copy of
+	// the current configured pairs of key/values for each
+	// configuration section.
+	Current() SettingsBag
+	// Update receives a SettingsBag with the pairs of key/values
+	// to be updated per section and a SettingsRemovals with the
+	// section keys to be removed.
 	Update(updates SettingsBag, removals SettingsRemovals) error
 	// KeyValue returns a key-value abstraction
 	// for the given pair of section and key.
@@ -92,6 +98,19 @@ type OSSImpl struct {
 
 func (o OSSImpl) Init() error {
 	return nil
+}
+
+func (o OSSImpl) Current() SettingsBag {
+	settingsCopy := make(SettingsBag)
+
+	for _, section := range o.Cfg.Raw.Sections() {
+		settingsCopy[section.Name()] = make(map[string]string)
+		for _, key := range section.Keys() {
+			settingsCopy[section.Name()][key.Name()] = RedactedValue(key.Name(), key.Value())
+		}
+	}
+
+	return settingsCopy
 }
 
 func (OSSImpl) Update(SettingsBag, SettingsRemovals) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

At [this PR](https://github.com/grafana/grafana/pull/32219) we introduced a new extensible settings abstraction but didn't update the `GET /api/admin/settings` handler, so for those set-ups where that abstraction is being extended, the endpoint (and the related UI view) is not returning the actual settings.

So, this PR adds a new method as part of the abstraction definition (interface) to fetch the current settings and uses it within the `GET /api/admin/settings` handler to return the actual settings. Also, it includes the straightforward implementation of that method for the OSS settings provider (the default one).