### PR TITLE
Grafana-UI: Make card figure honor align prop

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -145,8 +145,6 @@ export const getCardStyles = stylesFactory((theme: GrafanaTheme2) => {
     media: css`
       margin-right: ${theme.spacing(2)};
       width: 40px;
-      display: flex;
-      align-items: center;
 
       & > * {
         width: 100%;


### PR DESCRIPTION
`Card.Figure` has an `align` prop that defaults to `top`.
When using `align="center"` the following styles are applied:

https://github.com/grafana/grafana/blob/45402d02d6b1a2dc36ab91caf6d73281d059c267/packages/grafana-ui/src/components/Card/Card.tsx#L209-L214

The same css however is applied by default, making it impossible to align card figure to the top.

This PR removes the unneeded css from the static styles.
