### PR TITLE
Prometheus: Add info that using Loki as Prometheus data source is no longer supported and might stop working

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditorByApp.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditorByApp.test.tsx
@@ -12,6 +12,7 @@ import { testIds as regularTestIds } from './PromQueryEditor';
 function setup(app: CoreApp): RenderResult {
   const dataSource = ({
     createQuery: jest.fn((q) => q),
+    getInitHints: () => [],
     getPrometheusTime: jest.fn((date, roundup) => 123),
     languageProvider: {
       start: () => Promise.resolve([]),

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -3,7 +3,7 @@ import RCCascader from 'rc-cascader';
 import React from 'react';
 import PromQlLanguageProvider from '../language_provider';
 import PromQueryField from './PromQueryField';
-import { DataSourceInstanceSettings, PanelData } from '@grafana/data';
+import { DataSourceInstanceSettings, PanelData, LoadingState, DataFrame } from '@grafana/data';
 import { PromOptions } from '../types';
 import { render, screen } from '@testing-library/react';
 
@@ -105,7 +105,12 @@ describe('PromQueryField', () => {
         onRunQuery={() => {}}
         onChange={() => {}}
         history={[]}
-        data={{ series: ([1, 2] as unknown) as PanelData }}
+        data={
+          {
+            series: [{ name: 'test name' }] as DataFrame[],
+            state: LoadingState.Done,
+          } as PanelData
+        }
       />
     );
     expect(screen.getByText('Query hint')).toBeInTheDocument();

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.test.tsx
@@ -3,7 +3,7 @@ import RCCascader from 'rc-cascader';
 import React from 'react';
 import PromQlLanguageProvider from '../language_provider';
 import PromQueryField from './PromQueryField';
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataSourceInstanceSettings, PanelData } from '@grafana/data';
 import { PromOptions } from '../types';
 import { render, screen } from '@testing-library/react';
 
@@ -21,6 +21,7 @@ describe('PromQueryField', () => {
         getLabelKeys: () => [],
         metrics: [],
       },
+      getInitHints: () => [],
     } as unknown) as DataSourceInstanceSettings<PromOptions>;
 
     const queryField = render(
@@ -45,6 +46,7 @@ describe('PromQueryField', () => {
         getLabelKeys: () => [],
         metrics: [],
       },
+      getInitHints: () => [],
     } as unknown) as DataSourceInstanceSettings<PromOptions>;
     const queryField = render(
       <PromQueryField
@@ -61,6 +63,55 @@ describe('PromQueryField', () => {
     expect(bcButton).toBeDisabled();
   });
 
+  it('renders an initial hint if no data and initial hint provided', () => {
+    const datasource = ({
+      languageProvider: {
+        start: () => Promise.resolve([]),
+        syntax: () => {},
+        getLabelKeys: () => [],
+        metrics: [],
+      },
+      getInitHints: () => [{ label: 'Initial hint', type: 'INFO' }],
+    } as unknown) as DataSourceInstanceSettings<PromOptions>;
+    render(
+      <PromQueryField
+        // @ts-ignore
+        datasource={{ ...datasource, lookupsDisabled: true }}
+        query={{ expr: '', refId: '' }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+        history={[]}
+      />
+    );
+    expect(screen.getByText('Initial hint')).toBeInTheDocument();
+  });
+
+  it('renders query hint if data, query hint and initial hint provided', () => {
+    const datasource = ({
+      languageProvider: {
+        start: () => Promise.resolve([]),
+        syntax: () => {},
+        getLabelKeys: () => [],
+        metrics: [],
+      },
+      getInitHints: () => [{ label: 'Initial hint', type: 'INFO' }],
+      getQueryHints: () => [{ label: 'Query hint', type: 'INFO' }],
+    } as unknown) as DataSourceInstanceSettings<PromOptions>;
+    render(
+      <PromQueryField
+        // @ts-ignore
+        datasource={{ ...datasource }}
+        query={{ expr: '', refId: '' }}
+        onRunQuery={() => {}}
+        onChange={() => {}}
+        history={[]}
+        data={{ series: ([1, 2] as unknown) as PanelData }}
+      />
+    );
+    expect(screen.getByText('Query hint')).toBeInTheDocument();
+    expect(screen.queryByText('Initial hint')).not.toBeInTheDocument();
+  });
+
   it('refreshes metrics when the data source changes', async () => {
     const defaultProps = {
       query: { expr: '', refId: '' },
@@ -74,6 +125,7 @@ describe('PromQueryField', () => {
         // @ts-ignore
         datasource={{
           languageProvider: makeLanguageProvider({ metrics: [metrics] }),
+          getInitHints: () => [],
         }}
         {...defaultProps}
       />

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -155,7 +155,20 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     const { datasource, query, data } = this.props;
 
     if (!data || data.series.length === 0) {
-      this.setState({ hint: null });
+      /**
+       *  We are deprectating support for Loki as Prometheus data source in 8.0. If url includes "loki" and no metrics were found, we assume
+       *  that user is using Loki as Prometheus data source. To inform user, we are adding informational hint.
+       * */
+      if (datasource.directUrl.includes('/loki') && !datasource.languageProvider.metrics.length) {
+        this.setState({
+          hint: {
+            label: `Using Loki as Prometheus data source is no longer supported. Please use Loki data source for your Loki instance.`,
+            type: 'INFO',
+          },
+        });
+      } else {
+        this.setState({ hint: null });
+      }
       return;
     }
 

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -153,37 +153,21 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
   refreshHint = () => {
     const { datasource, query, data } = this.props;
+    const initHints = datasource.getInitHints();
+    const initHint = initHints.length > 0 ? initHints[0] : null;
 
     if (!data || data.series.length === 0) {
-      /**
-       *  We are deprectating support for Loki as Prometheus data source in 8.0. If url includes "loki" and no metrics were found, we assume
-       *  that user is using Loki as Prometheus data source. To inform user, we are adding informational hint.
-       * */
-      if (datasource.directUrl.includes('/loki') && !datasource.languageProvider.metrics.length) {
-        this.setState({
-          hint: {
-            label: `Using Loki as Prometheus data source is no longer supported. Please use Loki data source for your Loki instance.`,
-            type: 'INFO',
-          },
-        });
-      } else {
-        this.setState({ hint: null });
-      }
+      this.setState({
+        hint: initHint,
+      });
       return;
     }
 
     const result = isDataFrame(data.series[0]) ? data.series.map(toLegacyResponseData) : data.series;
-    const hints = datasource.getQueryHints(query, result);
-    let hint = hints.length > 0 ? hints[0] : null;
+    const queryHints = datasource.getQueryHints(query, result);
+    let queryHint = queryHints.length > 0 ? queryHints[0] : null;
 
-    // Hint for big disabled lookups
-    if (!hint && datasource.lookupsDisabled) {
-      hint = {
-        label: `Labels and metrics lookup was disabled in data source settings.`,
-        type: 'INFO',
-      };
-    }
-    this.setState({ hint });
+    this.setState({ hint: queryHint ?? initHint });
   };
 
   refreshMetrics = async () => {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -24,7 +24,7 @@ import { catchError, filter, map, tap } from 'rxjs/operators';
 import addLabelToQuery from './add_label_to_query';
 import PrometheusLanguageProvider from './language_provider';
 import { expandRecordingRules } from './language_utils';
-import { getQueryHints } from './query_hints';
+import { getQueryHints, getInitHints } from './query_hints';
 import { getOriginalMetricName, renderTemplate, transform } from './result_transformer';
 import {
   ExemplarTraceIdDestination,
@@ -732,6 +732,10 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
 
   getQueryHints(query: PromQuery, result: any[]) {
     return getQueryHints(query.expr ?? '', result, this);
+  }
+
+  getInitHints() {
+    return getInitHints(this);
   }
 
   async loadRules() {

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -119,7 +119,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
 
     // TODO #33976: make those requests parallel
     await this.fetchLabels();
-    this.metrics = await this.fetchLabelValues('__name__');
+    this.metrics = (await this.fetchLabelValues('__name__')) || [];
     this.metricsMetadata = fixSummariesMetadata(await this.request('/api/v1/metadata', {}));
     this.processHistogramMetrics(this.metrics);
 

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -128,12 +128,8 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
   return hints;
 }
 
-export function getInitHints(datasource?: PrometheusDatasource): QueryHint[] {
+export function getInitHints(datasource: PrometheusDatasource): QueryHint[] {
   const hints = [];
-  if (!datasource) {
-    return [];
-  }
-
   // Hint if using Loki as Prometheus data source
   if (datasource.directUrl.includes('/loki') && !datasource.languageProvider.metrics.length) {
     hints.push({

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -127,3 +127,28 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
 
   return hints;
 }
+
+export function getInitHints(datasource?: PrometheusDatasource): QueryHint[] {
+  const hints = [];
+  if (!datasource) {
+    return [];
+  }
+
+  // Hint if using Loki as Prometheus data source
+  if (datasource.directUrl.includes('/loki') && !datasource.languageProvider.metrics.length) {
+    hints.push({
+      label: `Using Loki as Prometheus data source is no longer supported and might stop working. Please use Loki data source for your Loki instance.`,
+      type: 'INFO',
+    });
+  }
+
+  // Hint for big disabled lookups
+  if (datasource.lookupsDisabled) {
+    hints.push({
+      label: `Labels and metrics lookup was disabled in data source settings.`,
+      type: 'INFO',
+    });
+  }
+
+  return hints;
+}

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -137,7 +137,7 @@ export function getInitHints(datasource?: PrometheusDatasource): QueryHint[] {
   // Hint if using Loki as Prometheus data source
   if (datasource.directUrl.includes('/loki') && !datasource.languageProvider.metrics.length) {
     hints.push({
-      label: `Using Loki as Prometheus data source is no longer supported and might stop working. Please use Loki data source for your Loki instance.`,
+      label: `Using Loki as a Prometheus data source is no longer supported. You must use the Loki data source for your Loki instance.`,
       type: 'INFO',
     });
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
In Grafana 8, we are introducing metrics browser for Prometheus and changing default http method to POST. These changes will affect our users who use Loki as Prometheus data source as Loki doesn't support POST at couple of endpoints and metric browser is not usable as well.

At this point, Loki supports alerting and therefore we have decided that we will not longer support Loki as Prometheus data source. In this PR, we are adding hint/info for users to use Loki data source for their Loki instance. 

However, it is still usable - I have fixed error due to no received metrics from Loki, but it is informing users that it can break anytime and they should change the data source to Loki. 

![image](https://user-images.githubusercontent.com/30407135/119495295-8faf3100-bd62-11eb-9353-7a570f41c64a.png)

Lastly, it slightly refactors the hinting logic. In the past, we always showed hints only after data were received. However, some of the hints (for example disabling of lookup) are helpful before we send the query. In the same way, this is helpful for this new Loki-related hint. Therefore now, we are showing initial hints (non-query related) even before we write a query. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/33657


