### PR TITLE
build.go: Switch 32bits compilation to default mode

### DIFF
--- a/build.go
+++ b/build.go
@@ -342,9 +342,6 @@ func setBuildEnv() {
 	} else {
 		os.Setenv("GOARCH", goarch)
 	}
-	if goarch == "386" {
-		os.Setenv("GO386", "softfloat")
-	}
 	if cgo {
 		os.Setenv("CGO_ENABLED", "1")
 	}

--- a/build.go
+++ b/build.go
@@ -343,7 +343,7 @@ func setBuildEnv() {
 		os.Setenv("GOARCH", goarch)
 	}
 	if goarch == "386" {
-		os.Setenv("GO386", "387")
+		os.Setenv("GO386", "softfloat")
 	}
 	if cgo {
 		os.Setenv("CGO_ENABLED", "1")


### PR DESCRIPTION
On the compilation in 32 bits system (or with GOARCH=386), build.go returns error "unsupported setting GO386=387. Consider using GO386=softfloat instead."

This PR is tested on grafana compilation.
