### PR TITLE
NGAlert: Add integration tests for remaining notification channels

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -432,8 +432,6 @@ func (am *Alertmanager) buildReceiverIntegrations(receiver *apimodels.PostableAp
 			n, err = channels.NewSensuGoNotifier(cfg, tmpl)
 		case "discord":
 			n, err = channels.NewDiscordNotifier(cfg, tmpl)
-		case "alertmanager":
-			n, err = channels.NewAlertmanagerNotifier(cfg, tmpl)
 		case "googlechat":
 			n, err = channels.NewGoogleChatNotifier(cfg, tmpl)
 		case "line":

--- a/pkg/services/ngalert/notifier/channels/kafka.go
+++ b/pkg/services/ngalert/notifier/channels/kafka.go
@@ -3,6 +3,7 @@ package channels
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	gokit_log "github.com/go-kit/kit/log"
 	"github.com/prometheus/alertmanager/notify"
@@ -103,7 +104,7 @@ func (kn *KafkaNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 		return false, err
 	}
 
-	topicURL := kn.Endpoint + "/topics/" + kn.Topic
+	topicURL := strings.TrimRight(kn.Endpoint, "/") + "/topics/" + kn.Topic
 
 	cmd := &models.SendWebhookSync{
 		Url:        topicURL,

--- a/pkg/services/ngalert/notifier/channels/line.go
+++ b/pkg/services/ngalert/notifier/channels/line.go
@@ -18,7 +18,7 @@ import (
 	old_notifiers "github.com/grafana/grafana/pkg/services/alerting/notifiers"
 )
 
-const (
+var (
 	LineNotifyURL string = "https://notify-api.line.me/api/notify"
 )
 

--- a/pkg/services/ngalert/notifier/channels/pushover_test.go
+++ b/pkg/services/ngalert/notifier/channels/pushover_test.go
@@ -133,13 +133,13 @@ func TestPushoverNotifier(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		origGetBoundary := getBoundary
+		origGetBoundary := GetBoundary
 		boundary := "abcd"
-		getBoundary = func() string {
+		GetBoundary = func() string {
 			return boundary
 		}
 		t.Cleanup(func() {
-			getBoundary = origGetBoundary
+			GetBoundary = origGetBoundary
 		})
 
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -82,6 +82,13 @@ func (tn *TelegramNotifier) Notify(ctx context.Context, as ...*types.Alert) (boo
 			tn.log.Warn("Failed to close writer", "err", err)
 		}
 	}()
+	boundary := GetBoundary()
+	if boundary != "" {
+		err = w.SetBoundary(boundary)
+		if err != nil {
+			return false, err
+		}
+	}
 
 	for k, v := range msg {
 		if err := writeField(w, k, v); err != nil {

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -122,3 +122,9 @@ func joinUrlPath(base, additionalPath string) (string, error) {
 
 	return u.String(), nil
 }
+
+// GetBoundary is used for overriding the behaviour for tests
+// and set a boundary for multipart body. DO NOT set this outside tests.
+var GetBoundary = func() string {
+	return ""
+}

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -39,9 +39,21 @@ func TestNotificationChannels(t *testing.T) {
 	amConfig := getAlertmanagerConfig(mockChannel.server.Addr)
 
 	// Overriding some URLs to send to the mock channel.
+	os, opa, ot, opu, ogb, ol, oth := channels.SlackAPIEndpoint, channels.PagerdutyEventAPIURL,
+		channels.TelegramAPIURL, channels.PushoverEndpoint, channels.GetBoundary,
+		channels.LineNotifyURL, channels.ThreemaGwBaseURL
+	t.Cleanup(func() {
+		channels.SlackAPIEndpoint, channels.PagerdutyEventAPIURL,
+			channels.TelegramAPIURL, channels.PushoverEndpoint, channels.GetBoundary,
+			channels.LineNotifyURL, channels.ThreemaGwBaseURL = os, opa, ot, opu, ogb, ol, oth
+	})
 	channels.SlackAPIEndpoint = fmt.Sprintf("http://%s/slack_recvX/slack_testX", mockChannel.server.Addr)
 	channels.PagerdutyEventAPIURL = fmt.Sprintf("http://%s/pagerduty_recvX/pagerduty_testX", mockChannel.server.Addr)
 	channels.TelegramAPIURL = fmt.Sprintf("http://%s/telegram_recv/bot%%s", mockChannel.server.Addr)
+	channels.PushoverEndpoint = fmt.Sprintf("http://%s/pushover_recv/pushover_test", mockChannel.server.Addr)
+	channels.LineNotifyURL = fmt.Sprintf("http://%s/line_recv/line_test", mockChannel.server.Addr)
+	channels.ThreemaGwBaseURL = fmt.Sprintf("http://%s/threema_recv/threema_test", mockChannel.server.Addr)
+	channels.GetBoundary = func() string { return "abcd" }
 
 	// Create a user to make authenticated requests
 	require.NoError(t, createUser(t, s, models.ROLE_EDITOR, "grafana", "password"))
@@ -111,7 +123,25 @@ func getExpAlertmanagerConfigFromAPI(channelAddr string) string {
 // the routes that we define in Alertmanager config.
 // EmailAlert and TelegramAlert are missing because they don't
 // send a JSON. Email and POST body are yet to be supported in the tests.
-var alertNames = []string{"DingDingAlert", "SlackAlert1", "SlackAlert2", "PagerdutyAlert", "TeamsAlert", "WebhookAlert"}
+var alertNames = []string{
+	"AlertmanagerAlert",
+	"OpsGenieAlert",
+	"VictorOpsAlert",
+	"ThreemaAlert",
+	"LineAlert",
+	"DiscordAlert",
+	"KafkaAlert",
+	"GoogleChatAlert",
+	"PushoverAlert",
+	"SensuGoAlert",
+	"TelegramAlert",
+	"DingDingAlert",
+	"SlackAlert1",
+	"SlackAlert2",
+	"PagerdutyAlert",
+	"TeamsAlert",
+	"WebhookAlert",
+}
 
 func getRulesConfig(t *testing.T) string {
 	t.Helper()
@@ -220,31 +250,60 @@ func (nc *mockNotificationChannel) matchesExpNotifications(exp map[string][]stri
 		}
 		for i := range expVals {
 			expVal := expVals[i]
-			var r *regexp.Regexp
+			var r1, r2 *regexp.Regexp
 			switch expKey {
 			case "webhook_recv/webhook_test":
 				// It has a time component "startsAt".
-				r = regexp.MustCompile(`.*"startsAt"\s*:\s*"([^"]+)"`)
+				r1 = regexp.MustCompile(`.*"startsAt"\s*:\s*"([^"]+)"`)
 			case "slack_recvX/slack_testX":
 				fallthrough
 			case "slack_recv1/slack_test_without_token":
 				// It has a time component "ts".
-				r = regexp.MustCompile(`.*"ts"\s*:\s*([0-9]{10})`)
+				r1 = regexp.MustCompile(`.*"ts"\s*:\s*([0-9]{10})`)
+			case "sensugo/events":
+				// It has a time component "ts".
+				r1 = regexp.MustCompile(`.*"issued"\s*:\s*([0-9]{10})`)
 			case "pagerduty_recvX/pagerduty_testX":
 				// It has a changing "source".
-				r = regexp.MustCompile(`.*"source"\s*:\s*"([^"]+)"`)
+				r1 = regexp.MustCompile(`.*"source"\s*:\s*"([^"]+)"`)
+			case "googlechat_recv/googlechat_test":
+				// "Grafana v | 25 May 21 17:44 IST"
+				r1 = regexp.MustCompile(`.*"text"\s*:\s*"(Grafana v[^"]+)"`)
+			case "victorops_recv/victorops_test":
+				// It has a time component "timestamp".
+				r1 = regexp.MustCompile(`.*"timestamp"\s*:\s*([0-9]{10})`)
+			case "v1/alerts":
+				// It has a changing time fields.
+				r1 = regexp.MustCompile(`.*"startsAt"\s*:\s*"([^"]+)"`)
+				r2 = regexp.MustCompile(`.*"UpdatedAt"\s*:\s*"([^"]+)"`)
 			}
-			if r != nil {
-				parts := r.FindStringSubmatch(actVals[i])
+			if r1 != nil {
+				parts := r1.FindStringSubmatch(actVals[i])
 				require.Equal(nc.t, 2, len(parts))
-				expVal = fmt.Sprintf(expVal, parts[1])
+				if expKey == "v1/alerts" {
+					// 2 fields for Prometheus Alertmanager.
+					parts2 := r2.FindStringSubmatch(actVals[i])
+					require.Equal(nc.t, 2, len(parts2))
+					expVal = fmt.Sprintf(expVal, parts[1], parts2[1])
+				} else {
+					expVal = fmt.Sprintf(expVal, parts[1])
+				}
 			}
 
-			var expJson, actJson interface{}
-			require.NoError(nc.t, json.Unmarshal([]byte(expVal), &expJson))
-			require.NoError(nc.t, json.Unmarshal([]byte(actVals[i]), &actJson))
-			if !assert.ObjectsAreEqual(expJson, actJson) {
-				return false
+			switch expKey {
+			case "pushover_recv/pushover_test", "telegram_recv/bot6sh027hs034h",
+				"line_recv/line_test", "threema_recv/threema_test":
+				// Multipart data or POST parameters.
+				if expVal != actVals[i] {
+					return false
+				}
+			default:
+				var expJson, actJson interface{}
+				require.NoError(nc.t, json.Unmarshal([]byte(expVal), &expJson))
+				require.NoError(nc.t, json.Unmarshal([]byte(actVals[i]), &actJson))
+				if !assert.ObjectsAreEqual(expJson, actJson) {
+					return false
+				}
 			}
 		}
 	}
@@ -321,6 +380,106 @@ const alertmanagerConfig = `
           ]
         },
         {
+          "receiver": "discord_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"DiscordAlert\""
+          ]
+        },
+        {
+          "receiver": "sensugo_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"SensuGoAlert\""
+          ]
+        },
+        {
+          "receiver": "pushover_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"PushoverAlert\""
+          ]
+        },
+        {
+          "receiver": "googlechat_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"GoogleChatAlert\""
+          ]
+        },
+        {
+          "receiver": "kafka_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"KafkaAlert\""
+          ]
+        },
+        {
+          "receiver": "line_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"LineAlert\""
+          ]
+        },
+        {
+          "receiver": "threema_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"ThreemaAlert\""
+          ]
+        },
+        {
+          "receiver": "opsgenie_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"OpsGenieAlert\""
+          ]
+        },
+        {
+          "receiver": "alertmanager_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"AlertmanagerAlert\""
+          ]
+        },
+        {
+          "receiver": "victorops_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"VictorOpsAlert\""
+          ]
+        },
+        {
           "receiver": "teams_recv",
           "group_wait": "0s",
           "group_by": [
@@ -379,6 +538,55 @@ const alertmanagerConfig = `
         ]
       },
       {
+        "name": "discord_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "discord_test",
+            "type": "discord",
+            "settings": {
+              "url": "http://CHANNEL_ADDR/discord_recv/discord_test"
+            }
+          }
+        ]
+      },
+      {
+        "name": "googlechat_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "googlechat_test",
+            "type": "googlechat",
+            "settings": {
+              "url": "http://CHANNEL_ADDR/googlechat_recv/googlechat_test"
+            }
+          }
+        ]
+      },
+      {
+        "name": "kafka_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "kafka_test",
+            "type": "kafka",
+            "settings": {
+              "kafkaRestProxy": "http://CHANNEL_ADDR",
+              "kafkaTopic": "my_kafka_topic"
+            }
+          }
+        ]
+      },
+      {
+        "name": "victorops_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "victorops_test",
+            "type": "victorops",
+            "settings": {
+              "url": "http://CHANNEL_ADDR/victorops_recv/victorops_test"
+            }
+          }
+        ]
+      },
+      {
         "name": "teams_recv",
         "grafana_managed_receiver_configs": [
           {
@@ -405,6 +613,93 @@ const alertmanagerConfig = `
             "secureSettings": {
               "password": "mysecretpassword"
             }
+          }
+        ]
+      },
+      {
+        "name": "sensugo_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "sensugo_test",
+            "type": "sensugo",
+            "settings": {
+              "url": "http://CHANNEL_ADDR/sensugo_recv/sensugo_test",
+              "namespace": "sensugo"
+            },
+            "secureSettings": {
+              "apikey": "mysecretkey"
+            }
+          }
+        ]
+      },
+      {
+        "name": "pushover_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "pushover_test",
+            "type": "pushover",
+            "settings": {},
+            "secureSettings": {
+              "userKey": "mysecretkey",
+              "apiToken": "mysecrettoken"
+            }
+          }
+        ]
+      },
+      {
+        "name": "line_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "line_test",
+            "type": "line",
+            "settings": {},
+            "secureSettings": {
+              "token": "mysecrettoken"
+            }
+          }
+        ]
+      },
+      {
+        "name": "threema_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "threema_test",
+            "type": "threema",
+            "settings": {
+              "gateway_id": "*1234567",
+              "recipient_id": "abcdefgh"
+            },
+            "secureSettings": {
+              "api_secret": "myapisecret"
+            }
+          }
+        ]
+      },
+      {
+        "name": "opsgenie_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "opsgenie_test",
+            "type": "opsgenie",
+            "settings": {
+              "apiUrl": "http://CHANNEL_ADDR/opsgenie_recv/opsgenie_test"
+            },
+            "secureSettings": {
+              "apiKey": "mysecretkey"
+            }
+          }
+        ]
+      },
+      {
+        "name": "alertmanager_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "name": "alertmanager_test",
+            "type": "prometheus-alertmanager",
+            "settings": {
+              "url": "http://CHANNEL_ADDR/alertmanager_recv/alertmanager_test"
+            },
+            "secureSettings": {}
           }
         ]
       },
@@ -550,6 +845,106 @@ var expAlertmanagerConfigFromAPI = `
           ]
         },
         {
+          "receiver": "discord_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"DiscordAlert\""
+          ]
+        },
+        {
+          "receiver": "sensugo_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"SensuGoAlert\""
+          ]
+        },
+        {
+          "receiver": "pushover_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"PushoverAlert\""
+          ]
+        },
+        {
+          "receiver": "googlechat_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"GoogleChatAlert\""
+          ]
+        },
+        {
+          "receiver": "kafka_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"KafkaAlert\""
+          ]
+        },
+        {
+          "receiver": "line_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"LineAlert\""
+          ]
+        },
+        {
+          "receiver": "threema_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"ThreemaAlert\""
+          ]
+        },
+        {
+          "receiver": "opsgenie_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"OpsGenieAlert\""
+          ]
+        },
+        {
+          "receiver": "alertmanager_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"AlertmanagerAlert\""
+          ]
+        },
+        {
+          "receiver": "victorops_recv",
+          "group_wait": "0s",
+          "group_by": [
+            "alertname"
+          ],
+          "matchers": [
+            "alertname=\"VictorOpsAlert\""
+          ]
+        },
+        {
           "receiver": "teams_recv",
           "group_wait": "0s",
           "group_by": [
@@ -615,6 +1010,67 @@ var expAlertmanagerConfigFromAPI = `
         ]
       },
       {
+        "name": "discord_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "discord_test",
+            "type": "discord",
+            "disableResolveMessage": false,
+            "settings": {
+              "url": "http://CHANNEL_ADDR/discord_recv/discord_test"
+            },
+            "secureFields": {}
+          }
+        ]
+      },
+      {
+        "name": "googlechat_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "googlechat_test",
+            "type": "googlechat",
+            "disableResolveMessage": false,
+            "settings": {
+              "url": "http://CHANNEL_ADDR/googlechat_recv/googlechat_test"
+            },
+            "secureFields": {}
+          }
+        ]
+      },
+      {
+        "name": "kafka_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "kafka_test",
+            "type": "kafka",
+            "disableResolveMessage": false,
+            "settings": {
+              "kafkaRestProxy": "http://CHANNEL_ADDR",
+              "kafkaTopic": "my_kafka_topic"
+            },
+            "secureFields": {}
+          }
+        ]
+      },
+      {
+        "name": "victorops_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "victorops_test",
+            "type": "victorops",
+            "disableResolveMessage": false,
+            "settings": {
+              "url": "http://CHANNEL_ADDR/victorops_recv/victorops_test"
+            },
+            "secureFields": {}
+          }
+        ]
+      },
+      {
         "name": "teams_recv",
         "grafana_managed_receiver_configs": [
           {
@@ -646,6 +1102,105 @@ var expAlertmanagerConfigFromAPI = `
             "secureFields": {
               "password": true
             }
+          }
+        ]
+      },
+      {
+        "name": "sensugo_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "sensugo_test",
+            "type": "sensugo",
+            "disableResolveMessage": false,
+            "settings": {
+              "url": "http://CHANNEL_ADDR/sensugo_recv/sensugo_test",
+              "namespace": "sensugo"
+            },
+            "secureFields": {
+              "apikey": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "pushover_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "pushover_test",
+            "type": "pushover",
+            "disableResolveMessage": false,
+            "settings": {},
+            "secureFields": {
+              "userKey": true,
+              "apiToken": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "line_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "line_test",
+            "type": "line",
+            "disableResolveMessage": false,
+            "settings": {},
+            "secureFields": {
+              "token": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "threema_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "threema_test",
+            "type": "threema",
+            "disableResolveMessage": false,
+            "settings": {
+              "gateway_id": "*1234567",
+              "recipient_id": "abcdefgh"
+            },
+            "secureFields": {
+              "api_secret": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "opsgenie_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "opsgenie_test",
+            "type": "opsgenie",
+            "disableResolveMessage": false,
+            "settings": {
+              "apiUrl": "http://CHANNEL_ADDR/opsgenie_recv/opsgenie_test"
+            },
+            "secureFields": {
+              "apiKey": true
+            }
+          }
+        ]
+      },
+      {
+        "name": "alertmanager_recv",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "",
+            "name": "alertmanager_test",
+            "type": "prometheus-alertmanager",
+            "disableResolveMessage": false,
+            "settings": {
+              "url": "http://CHANNEL_ADDR/alertmanager_recv/alertmanager_test"
+            },
+            "secureFields": {}
           }
         ]
       },
@@ -897,5 +1452,158 @@ var expNotifications = map[string][]string{
 		  "state": "alerting",
 		  "message": "\n**Firing**\nLabels:\n - alertname = WebhookAlert\n - __alert_rule_uid__ = UID_WebhookAlert\nAnnotations:\nSource: \n\n\n\n\n"
 		}`,
+	},
+	"discord_recv/discord_test": {
+		`{
+		  "content": "\n**Firing**\nLabels:\n - alertname = DiscordAlert\n - __alert_rule_uid__ = UID_DiscordAlert\nAnnotations:\nSource: \n\n\n\n\n",
+		  "embeds": [
+			{
+			  "color": 14037554,
+			  "footer": {
+				"icon_url": "https://grafana.com/assets/img/fav32.png",
+				"text": "Grafana v"
+			  },
+			  "title": "[FIRING:1] DiscordAlert (UID_DiscordAlert)",
+			  "type": "rich",
+			  "url": "http://localhost:3000/alerting/list"
+			}
+		  ],
+		  "username": "Grafana"
+		}`,
+	},
+	"sensugo/events": {
+		`{
+		  "check": {
+			"handlers": null,
+			"interval": 86400,
+			"issued": %s,
+			"metadata": {
+			  "labels": {
+				"ruleURL": "http://localhost:3000/alerting/list"
+			  },
+			  "name": "default"
+			},
+			"output": "\n**Firing**\nLabels:\n - alertname = SensuGoAlert\n - __alert_rule_uid__ = UID_SensuGoAlert\nAnnotations:\nSource: \n\n\n\n\n",
+			"status": 2
+		  },
+		  "entity": {
+			"metadata": {
+			  "name": "default",
+			  "namespace": "sensugo"
+			}
+		  },
+		  "ruleUrl": "http://localhost:3000/alerting/list"
+		}`,
+	},
+	"pushover_recv/pushover_test": {
+		"--abcd\r\nContent-Disposition: form-data; name=\"user\"\r\n\r\nmysecretkey\r\n--abcd\r\nContent-Disposition: form-data; name=\"token\"\r\n\r\nmysecrettoken\r\n--abcd\r\nContent-Disposition: form-data; name=\"priority\"\r\n\r\n0\r\n--abcd\r\nContent-Disposition: form-data; name=\"sound\"\r\n\r\n\r\n--abcd\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\n[FIRING:1] PushoverAlert (UID_PushoverAlert)\r\n--abcd\r\nContent-Disposition: form-data; name=\"url\"\r\n\r\nhttp://localhost:3000/alerting/list\r\n--abcd\r\nContent-Disposition: form-data; name=\"url_title\"\r\n\r\nShow alert rule\r\n--abcd\r\nContent-Disposition: form-data; name=\"message\"\r\n\r\n\n**Firing**\nLabels:\n - alertname = PushoverAlert\n - __alert_rule_uid__ = UID_PushoverAlert\nAnnotations:\nSource: \n\n\n\n\n\r\n--abcd\r\nContent-Disposition: form-data; name=\"html\"\r\n\r\n1\r\n--abcd--\r\n",
+	},
+	"telegram_recv/bot6sh027hs034h": {
+		"--abcd\r\nContent-Disposition: form-data; name=\"chat_id\"\r\n\r\ntelegram_chat_id\r\n--abcd\r\nContent-Disposition: form-data; name=\"parse_mode\"\r\n\r\nhtml\r\n--abcd\r\nContent-Disposition: form-data; name=\"text\"\r\n\r\n\n**Firing**\nLabels:\n - alertname = TelegramAlert\n - __alert_rule_uid__ = UID_TelegramAlert\nAnnotations:\nSource: \n\n\n\n\n\r\n--abcd--\r\n",
+	},
+	"googlechat_recv/googlechat_test": {
+		`{
+		  "previewText": "[FIRING:1] GoogleChatAlert (UID_GoogleChatAlert)",
+		  "fallbackText": "[FIRING:1] GoogleChatAlert (UID_GoogleChatAlert)",
+		  "cards": [
+			{
+			  "header": {
+				"title": "[FIRING:1] GoogleChatAlert (UID_GoogleChatAlert)"
+			  },
+			  "sections": [
+				{
+				  "widgets": [
+					{
+					  "textParagraph": {
+						"text": "\n**Firing**\nLabels:\n - alertname = GoogleChatAlert\n - __alert_rule_uid__ = UID_GoogleChatAlert\nAnnotations:\nSource: \n\n\n\n\n"
+					  }
+					},
+					{
+					  "buttons": [
+						{
+						  "textButton": {
+							"text": "OPEN IN GRAFANA",
+							"onClick": {
+							  "openLink": {
+								"url": "http://localhost:3000/alerting/list"
+							  }
+							}
+						  }
+						}
+					  ]
+					},
+					{
+					  "textParagraph": {
+						"text": "%s"
+					  }
+					}
+				  ]
+				}
+			  ]
+			}
+		  ]
+		}`,
+	},
+	"topics/my_kafka_topic": {
+		`{
+		  "records": [
+			{
+			  "value": {
+				"alert_state": "alerting",
+				"client": "Grafana",
+				"client_url": "http://localhost:3000/alerting/list",
+				"description": "[FIRING:1] KafkaAlert (UID_KafkaAlert)",
+				"details": "\n**Firing**\nLabels:\n - alertname = KafkaAlert\n - __alert_rule_uid__ = UID_KafkaAlert\nAnnotations:\nSource: \n\n\n\n\n",
+				"incident_key": "35c0bdb1715f9162a20d7b2a01cb2e3a4c5b1dc663571701e3f67212b696332f"
+			  }
+			}
+		  ]
+		}`,
+	},
+	"line_recv/line_test": {
+		`message=%5BFIRING%3A1%5D+LineAlert+%28UID_LineAlert%29%0Ahttp%3A%2Flocalhost%3A3000%2Falerting%2Flist%0A%0A%0A%2A%2AFiring%2A%2A%0ALabels%3A%0A+-+alertname+%3D+LineAlert%0A+-+__alert_rule_uid__+%3D+UID_LineAlert%0AAnnotations%3A%0ASource%3A+%0A%0A%0A%0A%0A`,
+	},
+	"threema_recv/threema_test": {
+		`from=%2A1234567&secret=myapisecret&text=%E2%9A%A0%EF%B8%8F+%5BFIRING%3A1%5D+ThreemaAlert+%28UID_ThreemaAlert%29%0A%0A%2AMessage%3A%2A%0A%0A%2A%2AFiring%2A%2A%0ALabels%3A%0A+-+alertname+%3D+ThreemaAlert%0A+-+__alert_rule_uid__+%3D+UID_ThreemaAlert%0AAnnotations%3A%0ASource%3A+%0A%0A%0A%0A%0A%0A%2AURL%3A%2A+http%3A%2Flocalhost%3A3000%2Falerting%2Flist%0A&to=abcdefgh`,
+	},
+	"victorops_recv/victorops_test": {
+		`{
+		  "alert_url": "http://localhost:3000/alerting/list",
+		  "entity_display_name": "[FIRING:1] VictorOpsAlert (UID_VictorOpsAlert)",
+		  "entity_id": "633ae988fa7074bcb51f3d1c5fef2ba1c5c4ccb45b3ecbf681f7d507b078b1ae",
+		  "message_type": "CRITICAL",
+		  "monitoring_tool": "Grafana v",
+		  "state_message": "\n**Firing**\nLabels:\n - alertname = VictorOpsAlert\n - __alert_rule_uid__ = UID_VictorOpsAlert\nAnnotations:\nSource: \n\n\n\n\n",
+		  "timestamp": %s
+		}`,
+	},
+	"opsgenie_recv/opsgenie_test": {
+		`{
+		  "alias": "47e92f0f6ef9fe99f3954e0d6155f8d09c4b9a038d8c3105e82c0cee4c62956e",
+		  "description": "[FIRING:1] OpsGenieAlert (UID_OpsGenieAlert)\nhttp://localhost:3000/alerting/list\n\n\n**Firing**\nLabels:\n - alertname = OpsGenieAlert\n - __alert_rule_uid__ = UID_OpsGenieAlert\nAnnotations:\nSource: \n\n\n\n\n",
+		  "details": {
+			"url": "http://localhost:3000/alerting/list"
+		  },
+		  "message": "[FIRING:1] OpsGenieAlert (UID_OpsGenieAlert)",
+		  "source": "Grafana",
+		  "tags": []
+		}`,
+	},
+	// Prometheus Alertmanager.
+	"v1/alerts": {
+		`[
+		  {
+			"labels": {
+			  "__alert_rule_uid__": "UID_AlertmanagerAlert",
+			  "alertname": "AlertmanagerAlert"
+			},
+			"annotations": {},
+			"startsAt": "%s",
+			"endsAt": "0001-01-01T00:00:00Z",
+			"generatorURL": "",
+			"UpdatedAt": "%s",
+			"Timeout": false
+		  }
+		]`,
 	},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds integration tests for all remaining channels that were skipped before (except email, that needs different handling).