### PR TITLE
Grafana-UI: Allow Card consumers to override disabled prop for actions

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.test.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Card } from './Card';
+import { Button } from '../Button';
+import { IconButton } from '../IconButton/IconButton';
 
 describe('Card', () => {
   it('should execute callback when clicked', () => {
@@ -8,5 +10,67 @@ describe('Card', () => {
     render(<Card heading="Test Heading" onClick={callback} />);
     fireEvent.click(screen.getByText('Test Heading'));
     expect(callback).toBeCalledTimes(1);
+  });
+
+  describe('Card Actions', () => {
+    it('Children should be disabled or enabled according to Card disabled prop', () => {
+      const { rerender } = render(
+        <Card heading="Test Heading">
+          <Card.Actions>
+            <Button>Click Me</Button>
+          </Card.Actions>
+          <Card.SecondaryActions>
+            <IconButton name="trash-alt" aria-label="Delete" />
+          </Card.SecondaryActions>
+        </Card>
+      );
+
+      expect(screen.getByRole('button', { name: 'Click Me' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled();
+
+      rerender(
+        <Card heading="Test Heading" disabled>
+          <Card.Actions>
+            <Button>Click Me</Button>
+          </Card.Actions>
+          <Card.SecondaryActions>
+            <IconButton name="trash-alt" aria-label="Delete" />
+          </Card.SecondaryActions>
+        </Card>
+      );
+
+      expect(screen.getByRole('button', { name: 'Click Me' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    });
+
+    it('Children should be independently enabled or disabled if explicitly set', () => {
+      const { rerender } = render(
+        <Card heading="Test Heading">
+          <Card.Actions>
+            <Button disabled>Click Me</Button>
+          </Card.Actions>
+          <Card.SecondaryActions>
+            <IconButton name="trash-alt" aria-label="Delete" disabled />
+          </Card.SecondaryActions>
+        </Card>
+      );
+
+      expect(screen.getByRole('button', { name: 'Click Me' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+
+      rerender(
+        <Card heading="Test Heading" disabled>
+          <Card.Actions>
+            <Button disabled={false}>Click Me</Button>
+          </Card.Actions>
+          <Card.SecondaryActions>
+            <IconButton name="trash-alt" aria-label="Delete" disabled={false} />
+          </Card.SecondaryActions>
+        </Card>
+      );
+
+      expect(screen.getByRole('button', { name: 'Click Me' })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -252,8 +252,8 @@ const BaseActions: FC<ActionsProps> = ({ children, styles, disabled, variant }) 
   return (
     <div className={css}>
       {Array.isArray(children)
-        ? React.Children.map(children, (child) => cloneElement(child, { disabled }))
-        : cloneElement(children, { disabled })}
+        ? React.Children.map(children, (child) => cloneElement(child, { disabled, ...child.props }))
+        : cloneElement(children, { disabled, ...children.props })}
     </div>
   );
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
following up on https://github.com/grafana/grafana/pull/29034#discussion_r525965265, I found myself in the situation of needing an "enabled" card with some disabled actions. This PR ensures that when any card action/secondary action children's `disabled` prop is explicitly set, it overrides the default card one so that they can have them set independently from the parent Card component.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

