### PR TITLE
Alerting/testing promql extraction

### DIFF
--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -74,7 +74,7 @@ func (srv TestingApiSrv) RouteTestRuleConfig(c *models.ReqContext, body apimodel
 		http.MethodGet,
 		queryURL,
 		nil,
-		jsonExtractor(nil),
+		instantQueryResultsExtractor,
 		nil,
 	)
 }

--- a/pkg/services/ngalert/api/promql_compat.go
+++ b/pkg/services/ngalert/api/promql_compat.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/cortexproject/cortex/pkg/util"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+type instantQueryResponse struct {
+	Status    string    `json:"status"`
+	Data      queryData `json:"data,omitempty"`
+	ErrorType string    `json:"errorType,omitempty"`
+	Error     string    `json:"error,omitempty"`
+}
+
+type queryData struct {
+	ResultType parser.ValueType `json:"resultType"`
+	Result     json.RawMessage  `json:"result"`
+	vector     vector           `json:"-"`
+	scalar     scalar           `json:"-"`
+}
+
+type scalar promql.Scalar
+
+func (s *scalar) UnmarshalJSON(b []byte) error {
+	var xs []interface{}
+	if err := json.Unmarshal(b, &xs); err != nil {
+		return err
+	}
+	// scalars are encoded like `[ts/1000, "value"]`
+	if len(xs) != 2 {
+		return fmt.Errorf("unexpected number of scalar encoded values: %d", len(xs))
+	}
+	ts, ok := xs[0].(float64)
+	if !ok {
+		return fmt.Errorf("first value in scalar uncoercible to timestamp: %v", xs[0])
+	}
+	s.T = int64(ts) * 1000
+	v, ok := xs[1].(string)
+	if !ok {
+		return fmt.Errorf("second value in scalar not string encoded: %v", xs[1])
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return err
+	}
+	s.V = f
+	return nil
+}
+
+func (d *queryData) UnmarshalJSON(b []byte) error {
+	type plain queryData
+	if err := json.Unmarshal(b, (*plain)(d)); err != nil {
+		return err
+	}
+
+	switch d.ResultType {
+	case parser.ValueTypeScalar:
+		return json.Unmarshal(d.Result, &d.scalar)
+	case parser.ValueTypeVector:
+		return json.Unmarshal(d.Result, &d.vector)
+	default:
+		return fmt.Errorf("unexpected response type: %s", d.ResultType)
+	}
+	return nil
+}
+
+type sample struct {
+	Metric labels.Labels `json:"metric"`
+	Value  scalar        `json:"value"`
+}
+type vector []sample
+
+func instantQueryResults(resp instantQueryResponse) (eval.Results, error) {
+	if resp.Error != "" || resp.Status != "success" {
+		return nil, errors.New(resp.Error)
+	}
+
+	switch resp.Data.ResultType {
+	case parser.ValueTypeScalar:
+		return eval.Results{{
+			Instance:         map[string]string{},
+			State:            eval.Alerting,
+			EvaluatedAt:      util.TimeFromMillis(resp.Data.scalar.T),
+			EvaluationString: fmt.Sprint(resp.Data.scalar.V),
+		}}
+	case parser.ValueTypeVector:
+		results := make(eval.Results, 0, len(resp.Data.vector))
+		for _, s := range resp.Data.vector {
+			results = append(results, eval.Result{
+				Instance:         s.Metric.Map(),
+				State:            eval.Alerting,
+				EvaluatedAt:      util.TimeFromMillis(s.Value.T),
+				EvaluationString: fmt.Sprint(s.Value.V),
+			})
+		}
+	default:
+		return nil, fmt.Errorf("unexpected response type: %s", d.ResultType)
+	}
+}

--- a/pkg/services/ngalert/api/promql_compat_test.go
+++ b/pkg/services/ngalert/api/promql_compat_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_instantQueryExtractor(t *testing.T) {
+func Test_instantQueryMarshaling(t *testing.T) {
 	for _, tc := range []struct {
 		desc      string
 		in        string

--- a/pkg/services/ngalert/api/promql_compat_test.go
+++ b/pkg/services/ngalert/api/promql_compat_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_instantQueryExtractor(t *testing.T) {
+	for _, tc := range []struct {
+		desc      string
+		in        string
+		exp       parser.ValueType
+		expScalar *scalar
+		expVector *vector
+		isError   bool // successfully unpack an upstream error
+	}{
+		{
+			desc: "scalar",
+			in: `{
+  "status": "success",
+  "data": {
+    "resultType": "scalar",
+    "result": [
+      12,
+      "2"
+    ]
+  }
+}`,
+			exp: parser.ValueTypeScalar,
+			expScalar: &scalar{
+				T: 12000,
+				V: 2,
+			},
+		},
+		{
+			desc: "vector",
+			in: `{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {
+          "__name__": "apiserver_request:burnrate1d"
+        },
+        "value": [
+          12.04,
+          "10.5"
+        ]
+      }
+    ]
+  }
+}`,
+			exp: parser.ValueTypeVector,
+			expVector: &vector{
+				sample{
+					Value: scalar{
+						T: 12000, // loses some precision during marshaling
+						V: 10.5,
+					},
+					Metric: []labels.Label{{
+						Name:  "__name__",
+						Value: "apiserver_request:burnrate1d",
+					}},
+				},
+			},
+		},
+		{
+			desc: "successfully parse error",
+			in: `{
+  "status": "failure",
+  "errorType": "someErr",
+  "error": "error doing something"
+}`,
+			isError: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			var out instantQueryResponse
+			err := json.Unmarshal([]byte(tc.in), &out)
+			require.NoError(t, err)
+
+			if tc.isError {
+				require.Equal(t, out.Status, "failure")
+				require.Greater(t, len(out.ErrorType), 0)
+				require.Greater(t, len(out.Error), 0)
+				return
+			}
+
+			require.Equal(t, tc.exp, out.Data.ResultType)
+			b, err := json.MarshalIndent(out, "", "  ")
+			require.Nil(t, err)
+			require.Equal(t, tc.in, string(b))
+
+			if tc.expScalar != nil {
+				require.Equal(t, *tc.expScalar, out.Data.scalar)
+			}
+			if tc.expVector != nil {
+				require.Equal(t, *tc.expVector, out.Data.vector)
+			}
+		})
+	}
+}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -228,11 +228,7 @@ func conditionEval(c *models.ReqContext, cmd ngmodels.EvalAlertConditionCommand,
 		return response.Error(http.StatusBadRequest, "Failed to evaluate conditions", err)
 	}
 
-	return streamEvalResultsAsDataFrame(evalResults)
-}
-
-func streamEvalResultsAsDataFrame(xs eval.Results) response.StreamingResponse {
-	frame := xs.AsDataFrame()
+	frame := evalResults.AsDataFrame()
 	return response.JSONStreaming(http.StatusOK, util.DynMap{
 		"instances": []*data.Frame{&frame},
 	})

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -228,8 +228,11 @@ func conditionEval(c *models.ReqContext, cmd ngmodels.EvalAlertConditionCommand,
 		return response.Error(http.StatusBadRequest, "Failed to evaluate conditions", err)
 	}
 
-	frame := evalResults.AsDataFrame()
+	return streamEvalResultsAsDataFrame(evalResults)
+}
 
+func streamEvalResultsAsDataFrame(xs eval.Results) response.StreamingResponse {
+	frame := xs.AsDataFrame()
 	return response.JSONStreaming(http.StatusOK, util.DynMap{
 		"instances": []*data.Frame{&frame},
 	})


### PR DESCRIPTION
This introduces some custom unmarshaling for instant queries (I can't believe we didn't have this elsewhere, feel free to point me in the right direction), which the testing route then uses to map query responses into the data types expected. This achieves parity for both grafana managed & lotex based queries using grafana's internal dataframes.

Vector extraction:
```
$ curl -s admin:admin@localhost:3000/api/v1/rule/test/35 -XPOST -H 'Content-Type: application/json' -d '{ "expr": "sum by (namespace) (agent_prometheus_active_instances) >  0" }' | jq '.'
{
  "instances": [
    {
      "schema": {
        "name": "evaluation results",
        "fields": [
          {
            "name": "namespace",
            "type": "string",
            "typeInfo": {
              "frame": "string"
            }
          },
          {
            "name": "State",
            "type": "string",
            "typeInfo": {
              "frame": "string"
            }
          }
        ]
      },
      "data": {
        "values": [
          [
            "gem-perf",
            "default"
          ],
          [
            "Alerting",
            "Alerting"
          ]
        ]
      }
    }
  ]
}
```

Scalar extraction:
```
$ curl -s admin:admin@localhost:3000/api/v1/rule/test/35 -XPOST -H 'Content-Type: application/json' -d '{ "expr": "1+1"}' | jq '.'
{
  "instances": [
    {
      "schema": {
        "name": "evaluation results",
        "fields": [
          {
            "name": "State",
            "type": "string",
            "typeInfo": {
              "frame": "string"
            }
          }
        ]
      },
      "data": {
        "values": [
          [
            "Alerting"
          ]
        ]
      }
    }
  ]
}
```