### PR TITLE
PanelEdit: Allow standard field config properties extensions without altering order of standard options 

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -165,7 +165,8 @@ export const Components = {
     backArrow: 'Go Back button',
   },
   OptionsGroup: {
-    toggle: (title?: string) => (title ? `Options group ${title}` : 'Options group'),
+    group: (title?: string) => (title ? `Options group ${title}` : 'Options group'),
+    toggle: (title?: string) => (title ? `Options group ${title} toggle` : 'Options group toggle'),
   },
   PluginVisualization: {
     item: (title: string) => `Plugin visualization item ${title}`,

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -5,7 +5,7 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(builder: PanelOp
   builder.addRadio({
     path: 'tooltip.mode',
     name: 'Tooltip mode',
-    category: ['Legend'],
+    category: ['Tooltip'],
     description: '',
     defaultValue: 'single',
     settings: {

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -71,7 +71,11 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
     });
 
     return (
-      <div className={boxStyles} data-testid="options-category">
+      <div
+        className={boxStyles}
+        data-testid="options-category"
+        aria-label={selectors.components.OptionsGroup.group(id)}
+      >
         <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
           <div className={cx(styles.toggle, 'editor-options-group-toggle')}>
             <Icon name={isExpanded ? 'angle-down' : 'angle-right'} />

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import {
   FieldConfigSource,
   LoadingState,
@@ -210,5 +210,28 @@ describe('OptionsPaneOptions', () => {
     expect(
       screen.queryByLabelText(selectors.components.ValuePicker.button('Add field override'))
     ).not.toBeInTheDocument();
+  });
+
+  it('should allow standard properties extension', async () => {
+    const scenario = new OptionsPaneOptionsTestScenario();
+
+    scenario.plugin = getPanelPlugin({
+      id: 'TestPanel',
+    }).useFieldConfig({
+      useCustomConfig: (b) => {
+        b.addBooleanSwitch({
+          name: 'CustomThresholdOption',
+          path: 'CustomThresholdOption',
+          category: ['Thresholds'],
+        });
+      },
+    });
+
+    scenario.render();
+
+    const thresholdsSection = screen.getByLabelText(selectors.components.OptionsGroup.group('Thresholds'));
+    expect(
+      within(thresholdsSection).getByLabelText(OptionsPaneSelector.fieldLabel('Thresholds CustomThresholdOption'))
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
With "Show thresholds as..." option introduced in the Time series Panel, the Thresholds and Standard options categories got switched (thanks @oddlittlebird for catching this):

![image](https://user-images.githubusercontent.com/2376619/119524589-132a4b80-bd7e-11eb-9d51-f05b8447b494.png)

This PR mitigates this unwanted behaviour making sure that the custom options added to standard categories do no change the order of common options.

Also - this PR fixes Tooltip config being rendered under Legend category.
