### PR TITLE
tsdb: accept millisecond-min-interval

### DIFF
--- a/pkg/tsdb/interval/interval.go
+++ b/pkg/tsdb/interval/interval.go
@@ -67,6 +67,11 @@ func (ic *intervalCalculator) Calculate(timerange plugins.DataTimeRange, minInte
 }
 
 func GetIntervalFrom(dsInfo *models.DataSource, queryModel *simplejson.Json, defaultInterval time.Duration) (time.Duration, error) {
+	intervalMs := queryModel.Get("intervalMs").MustInt64(-1)
+	if intervalMs != -1 {
+		return time.Millisecond * time.Duration(intervalMs), nil
+	}
+
 	interval := queryModel.Get("interval").MustString("")
 
 	if interval == "" && dsInfo != nil && dsInfo.JsonData != nil {

--- a/pkg/tsdb/interval/interval.go
+++ b/pkg/tsdb/interval/interval.go
@@ -67,9 +67,9 @@ func (ic *intervalCalculator) Calculate(timerange plugins.DataTimeRange, minInte
 }
 
 func GetIntervalFrom(dsInfo *models.DataSource, queryModel *simplejson.Json, defaultInterval time.Duration) (time.Duration, error) {
-	intervalMs := queryModel.Get("intervalMs").MustInt64(-1)
-	if intervalMs != -1 {
-		return time.Millisecond * time.Duration(intervalMs), nil
+	intervalMS := queryModel.Get("intervalMs").MustInt64(-1)
+	if intervalMS != -1 {
+		return time.Millisecond * time.Duration(intervalMS), nil
 	}
 
 	interval := queryModel.Get("interval").MustString("")

--- a/pkg/tsdb/interval/interval_test.go
+++ b/pkg/tsdb/interval/interval_test.go
@@ -80,6 +80,7 @@ func TestGetIntervalFrom(t *testing.T) {
 		{"45s", nil, `{"interval": "45s"}`, time.Second * 15, time.Second * 45},
 		{"45", nil, `{"interval": "45"}`, time.Second * 15, time.Second * 45},
 		{"2m", nil, `{"interval": "2m"}`, time.Second * 15, time.Minute * 2},
+		{"20000ms", nil, `{"intervalMs": 20000}`, time.Second * 15, time.Second * 20},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
when in a dashboard-panel, i have a prometheus/influxdb-influxql/postgres query, and add an Expression (operation: Math, Expression: `$A` ... so it just returns the query-result), the min-interval query-option does not get applied.

it seems the code they use to get the interval-value is picking data from a JSON structure, and it picks the string-field named "interval". for the datasources i mentioned the value is an int64-field named "intervalMs".

so i created this diff that first tries the "intervalMs". it works, but i'm not sure if this is the right approach. i don't even know which data source uses the string "interval" field. 
also, this code is used in other datasources too, like `azuremonitor`, `elastic`, `sqleng`, where i did not test it, so i don't know if this breaks anything.

fixes https://github.com/grafana/grafana/pull/34597