### PR TITLE
[v8.0.x] Prometheus: Update default HTTP method to POST for existing data sources

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -152,7 +152,7 @@ Since not all datasources have the same configuration settings we only have the 
 | timeInterval            | string  | Prometheus, Elasticsearch, InfluxDB, MySQL, PostgreSQL and MSSQL | Lowest interval/step value that should be used for this data source.                        |
 | httpMode                | string  | Influxdb                                                         | HTTP Method. 'GET', 'POST', defaults to GET                                                 |
 | maxSeries               | number  | Influxdb                                                         | Max number of series/tables that Grafana processes                                          |
-| httpMethod              | string  | Prometheus                                                       | HTTP Method. 'GET', 'POST', defaults to GET                                                 |
+| httpMethod              | string  | Prometheus                                                       | HTTP Method. 'GET', 'POST', defaults to POST                                                 |
 | customQueryParameters   | string  | Prometheus                                                       | Query parameters to add, as a URL-encoded string.                                                 |
 | esVersion               | string  | Elasticsearch                                                    | Elasticsearch version (E.g. `7.0.0`, `7.6.1`)                                            |
 | timeField               | string  | Elasticsearch                                                    | Which field that should be used as timestamp                                                |

--- a/docs/sources/whatsnew/whats-new-in-v8-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-0.md
@@ -32,7 +32,8 @@ New visualization that allows categorical data display. Following the new panel 
 
 ### Time series panel updates
 
-The Time series is out of beta!  We are removing the `Beta`tag and graduating the Time series panel to a stable state.
+The Time series is out of beta! We are removing the `Beta`tag and graduating the Time series panel to a stable state.
+
 - **Time series** is now the default visualization option, replacing the **Graph (old)**.
 - The Time series panel now supports stacking. For more information, refer to [Graph stacked time series]({{< relref "../panels/visualizations/time-series/graph-time-series-stacking.md" >}}).
 - You can now add alerts in the Time series panel, just like the old Graph panel.
@@ -88,7 +89,7 @@ Grafana 8.0 includes many performance enhancements.
 
 #### Initial startup and load performance
 
-We reduced the Grafana initial download size massively, approximately 40%. This means that on slower or mobile connections, the initial login page or home dashboard will load much faster. 
+We reduced the Grafana initial download size massively, approximately 40%. This means that on slower or mobile connections, the initial login page or home dashboard will load much faster.
 
 All panels that have migrated from Flot to uPlot will also render two to three times faster because the library is much more efficient. Right now, this includes the Time series, Stat, Timeline, Histogram, and Barchart panel visualizations.
 
@@ -179,7 +180,7 @@ You can now configure generic OAuth with empty scopes. This allows OAuth Identit
 
 ##### Added OAuth support for strict parsing of role_attribute_path
 
-You can now configure generic OAuth with strict parsing of the `role_attribute_path`. By default, if  th `role_attribute_path` property does not return a role, then the user is assigned the `Viewer` role. You can disable the role assignment by setting `role_attribute_strict = true`. It denies user access if no role or an invalid role is returned.
+You can now configure generic OAuth with strict parsing of the `role_attribute_path`. By default, if the `role_attribute_path` property does not return a role, then the user is assigned the `Viewer` role. You can disable the role assignment by setting `role_attribute_strict = true`. It denies user access if no role or an invalid role is returned.
 
 ## Enterprise features
 
@@ -211,3 +212,7 @@ Documentation was updated to reflect these changes.
 ### Elasticsearch: Use application/x-ndjson content type for multi-search requests
 
 For multi-search requests, we now use the correct application/x-ndjson content type instead of the incorrect application/json. Although this should be transparent to most of the users, if you are running Elasticsearch behind a proxy, then be sure that your proxy correctly handles requests with this content type.
+
+### Prometheus: Update default HTTP method to POST for existing data sources
+
+The default HTTP method for Prometheus data source is now POST, previously it was GET. The POST APIs are there since January 2018 (Prometheus 2.1.0) and they have fewer limitations than the GET APIs. Users with Prometheus instance with version < 2.1.0 that use the default HTTP method should update their HTTP method to GET.

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.test.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.test.tsx
@@ -88,7 +88,7 @@ describe('PromSettings', () => {
   describe('PromSettings component', () => {
     const defaultProps = createDefaultConfigOptions();
 
-    it('should show POST httpMethod if no httpMethod and no url', () => {
+    it('should show POST httpMethod if no httpMethod', () => {
       const options = defaultProps;
       options.url = '';
       options.jsonData.httpMethod = '';
@@ -99,18 +99,6 @@ describe('PromSettings', () => {
         </div>
       );
       expect(screen.getByText('POST')).toBeInTheDocument();
-    });
-    it('should show GET httpMethod if no httpMethod and url', () => {
-      const options = defaultProps;
-      options.url = 'test_url';
-      options.jsonData.httpMethod = '';
-
-      render(
-        <div>
-          <PromSettings onOptionsChange={() => {}} options={options} />
-        </div>
-      );
-      expect(screen.getByText('GET')).toBeInTheDocument();
     });
     it('should show POST httpMethod if POST httpMethod is configured', () => {
       const options = defaultProps;

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -20,15 +20,10 @@ type Props = Pick<DataSourcePluginOptionsEditorProps<PromOptions>, 'options' | '
 export const PromSettings = (props: Props) => {
   const { options, onOptionsChange } = props;
 
-  /**
-   * We want to change the default httpMethod to 'POST' for all of the new Prometheus data sources instances (no url) added in 7.5+.
-   * We are explicitly adding httpMethod, as previously it could be undefined and defaulted to 'GET'.
-   * Undefined httpMethod is still going to be considered 'GET' for backward compatibility reasons, but if users open data
-   * source settings it is going to be set to 'GET' explicitly and it will be selected in httpMethod dropdown as 'GET'.
-   * */
+  // We are explicitly adding httpMethod so it is correctly displayed in dropdown. This way, it is more predictable for users.
 
   if (!options.jsonData.httpMethod) {
-    options.url ? (options.jsonData.httpMethod = 'GET') : (options.jsonData.httpMethod = 'POST');
+    options.jsonData.httpMethod = 'POST';
   }
 
   return (

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -78,7 +78,7 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions> 
     this.withCredentials = instanceSettings.withCredentials;
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
     this.queryTimeout = instanceSettings.jsonData.queryTimeout;
-    this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
+    this.httpMethod = instanceSettings.jsonData.httpMethod || 'POST';
     this.directUrl = instanceSettings.jsonData.directUrl;
     this.exemplarTraceIdDestinations = instanceSettings.jsonData.exemplarTraceIdDestinations;
     this.ruleMappings = {};


### PR DESCRIPTION
Backport for https://github.com/grafana/grafana/pull/34599 as automatic backport failed on merge conflicts in What's new.
