### PR TITLE
Dashboard: Fix issue with title or folder change has no effect after exiting settings view

### DIFF
--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -24,6 +24,8 @@ export interface OwnProps {
   isFullscreen: boolean;
   kioskMode: KioskMode;
   hideTimePicker: boolean;
+  folderTitle?: string;
+  title: string;
   onAddPanel: () => void;
 }
 
@@ -245,14 +247,14 @@ class DashNav extends PureComponent<Props> {
   }
 
   render() {
-    const { dashboard, isFullscreen } = this.props;
+    const { isFullscreen, title, folderTitle } = this.props;
     const onGoBack = isFullscreen ? this.onClose : undefined;
 
     return (
       <PageToolbar
         pageIcon={isFullscreen ? undefined : 'apps'}
-        title={dashboard.title}
-        parent={dashboard.meta.folderTitle}
+        title={title}
+        parent={folderTitle}
         onClickTitle={this.onDashboardNameClick}
         onClickParent={this.onFolderNameClick}
         onGoBack={onGoBack}

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -310,6 +310,8 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
           <div aria-label={selectors.pages.Dashboard.DashNav.nav}>
             <DashNav
               dashboard={dashboard}
+              title={dashboard.title}
+              folderTitle={dashboard.meta.folderTitle}
               isFullscreen={!!viewPanel}
               onAddPanel={this.onAddPanel}
               kioskMode={kioskMode}

--- a/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
+++ b/public/app/features/dashboard/containers/__snapshots__/DashboardPage.test.tsx.snap
@@ -116,6 +116,7 @@ exports[`DashboardPage Dashboard init completed  Should render dashboard grid 1`
       isFullscreen={false}
       kioskMode="off"
       onAddPanel={[Function]}
+      title="My dashboard"
     />
   </div>
   <div
@@ -495,6 +496,7 @@ exports[`DashboardPage When dashboard has editview url state should render setti
       isFullscreen={false}
       kioskMode="off"
       onAddPanel={[Function]}
+      title="My dashboard"
     />
   </div>
   <div


### PR DESCRIPTION
Fixes problem where updating title or folder had no effect when going back to dashboard
