### PR TITLE
Fix Markdown syntax in enterprise/license/_index.md

### DIFF
--- a/docs/sources/enterprise/license/_index.md
+++ b/docs/sources/enterprise/license/_index.md
@@ -7,7 +7,7 @@ weight = 10
 
 # Grafana Enterprise license
 
-To run Grafana Enterprise, you need a valid license. Contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise) to obtain the license. For information on how to activate your license, refer to [Activate an Enterprise license]({{< relref "./activate-license.md" >}}).
+To run Grafana Enterprise, you need a valid license. [Contact a Grafana Labs representative](https://grafana.com/contact?about=grafana-enterprise) to obtain the license. For information on how to activate your license, refer to [Activate an Enterprise license]({{< relref "./activate-license.md" >}}).
 
 See also:
 


### PR DESCRIPTION
Add a missing `[` in `docs/sources/enterprise/license/_index.md`.