### PR TITLE
Inspect: fixes toggleDownloadForExcel function

### DIFF
--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -131,11 +131,11 @@ export class InspectDataTab extends PureComponent<Props, State> {
     });
   };
 
-  toggleDownloadForExcel() {
+  toggleDownloadForExcel = () => {
     this.setState((prevState) => ({
       downloadForExcel: !prevState.downloadForExcel,
     }));
-  }
+  };
 
   getProcessedData(): DataFrame[] {
     const { options, panel } = this.props;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fixes #34686 

Fixes the `Download for Excel` toggle option in the `Inspect` --> `Data` tab.

Also fixes the same when using Explore --> Inspector --> Data --> Download for Excel

The button no longer throws an error, and the feature appears to work. Here is a snapshot of the same export with and without the Excel option:

![image](https://user-images.githubusercontent.com/37156449/119580031-6048f600-bd5b-11eb-9437-ed99da39c999.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #34686 

**Special notes for your reviewer**:

