### PR TITLE
Elasticsearch: Convert Timeseries and Tables to Dataframes

### DIFF
--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -210,6 +210,8 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			sort.Strings(percentileKeys)
 			for _, percentileName := range percentileKeys {
 				tags := make(map[string]string, len(props))
+				timeVector := make([]time.Time, 0, len(esAggBuckets))
+				values := make([]*float64, 0, len(esAggBuckets))
 
 				for k, v := range props {
 					tags[k] = v
@@ -285,6 +287,8 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 				}
 
 				tags := make(map[string]string, len(props))
+				timeVector := make([]time.Time, 0, len(esAggBuckets))
+				values := make([]*float64, 0, len(esAggBuckets))
 
 				for k, v := range props {
 					tags[k] = v

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -234,12 +234,14 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			metrics := metric.Settings.Get("metrics").MustArray()
 
 			for _, metricField := range metrics {
+				tags := make(map[string]string, len(props))
+				timeVector := make([]time.Time, 0, len(esAggBuckets))
+				values := make([]*float64, 0, len(esAggBuckets))
+
 				for _, v := range buckets {
 					bucket := simplejson.NewFromAny(v)
 					stats := bucket.GetPath(metric.ID, "top")
 					key := castToFloat(bucket.Get("key"))
-
-					tags := make(map[string]string, len(props))
 
 					for k, v := range props {
 						tags[k] = v

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -193,7 +193,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			tags["metric"] = countType
 			frames = append(frames, data.NewFrame(metric.Field,
 				data.NewField("time", nil, timeVector),
-				data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: metric.Field})))
+				data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: rp.getMetricName(tags["metric"]) + " " + metric.Field})))
 		case percentilesType:
 			buckets := esAggBuckets
 			if len(buckets) == 0 {
@@ -225,7 +225,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 				}
 				frames = append(frames, data.NewFrame(metric.Field,
 					data.NewField("time", nil, timeVector),
-					data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: tags["metric"] + " " + metric.Field})))
+					data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: rp.getMetricName(tags["metric"]) + " " + metric.Field})))
 			}
 		case topMetricsType:
 			buckets := esAggBuckets
@@ -310,7 +310,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 				labels := tags
 				frames = append(frames, data.NewFrame(metric.Field,
 					data.NewField("time", nil, timeVector),
-					data.NewField("value", labels, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: metric.Field})))
+					data.NewField("value", labels, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: rp.getMetricName(tags["metric"]) + " " + metric.Field})))
 			}
 		default:
 			for k, v := range props {
@@ -338,7 +338,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			}
 			frames = append(frames, data.NewFrame(metric.Field,
 				data.NewField("time", nil, timeVector),
-				data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: metric.Field})))
+				data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: rp.getMetricName(tags["metric"]) + " " + metric.Field})))
 		}
 	}
 	if query.Dataframes != nil {
@@ -579,7 +579,7 @@ func (rp *responseParser) getFieldName(dataField data.Field, target *Query, metr
 	}
 
 	if target.Alias != "" {
-		seriesName := target.Alias
+		frameName := target.Alias
 
 		subMatches := aliasPatternRegex.FindAllStringSubmatch(target.Alias, -1)
 		for _, subMatch := range subMatches {
@@ -590,20 +590,20 @@ func (rp *responseParser) getFieldName(dataField data.Field, target *Query, metr
 			}
 
 			if strings.Index(group, "term ") == 0 {
-				seriesName = strings.Replace(seriesName, subMatch[0], dataField.Labels[group[5:]], 1)
+				frameName = strings.Replace(frameName, subMatch[0], dataField.Labels[group[5:]], 1)
 			}
 			if v, ok := dataField.Labels[group]; ok {
-				seriesName = strings.Replace(seriesName, subMatch[0], v, 1)
+				frameName = strings.Replace(frameName, subMatch[0], v, 1)
 			}
 			if group == "metric" {
-				seriesName = strings.Replace(seriesName, subMatch[0], metricName, 1)
+				frameName = strings.Replace(frameName, subMatch[0], metricName, 1)
 			}
 			if group == "field" {
-				seriesName = strings.Replace(seriesName, subMatch[0], field, 1)
+				frameName = strings.Replace(frameName, subMatch[0], field, 1)
 			}
 		}
 
-		return seriesName
+		return frameName
 	}
 	// todo, if field and pipelineAgg
 	if field != "" && isPipelineAgg(metricType) {

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -225,7 +225,7 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 				}
 				frames = append(frames, data.NewFrame(metric.Field,
 					data.NewField("time", nil, timeVector),
-					data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: tags["metric"] + metric.Field})))
+					data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: tags["metric"] + " " + metric.Field})))
 			}
 		case topMetricsType:
 			buckets := esAggBuckets

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -2,12 +2,14 @@ package elasticsearch
 
 import (
 	"errors"
+	"github.com/grafana/grafana/pkg/components/null"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
-	"github.com/grafana/grafana/pkg/components/null"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/plugins"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
@@ -73,12 +75,12 @@ func (rp *responseParser) getTimeSeries() (plugins.DataResponse, error) {
 			Columns: make([]plugins.DataTableColumn, 0),
 			Rows:    make([]plugins.DataRowValues, 0),
 		}
-		err := rp.processBuckets(res.Aggregations, target, &queryRes.Series, &table, props, 0)
+		err := rp.processBuckets(res.Aggregations, target, &queryRes, &table, props, 0)
 		if err != nil {
 			return plugins.DataResponse{}, err
 		}
-		rp.nameSeries(queryRes.Series, target)
-		rp.trimDatapoints(queryRes.Series, target)
+		rp.nameFields(queryRes, target)
+		rp.trimDatapoints(queryRes, target)
 
 		if len(table.Rows) > 0 {
 			queryRes.Tables = append(queryRes.Tables, table)
@@ -91,7 +93,7 @@ func (rp *responseParser) getTimeSeries() (plugins.DataResponse, error) {
 
 // nolint:staticcheck // plugins.* deprecated
 func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Query,
-	series *plugins.DataTimeSeriesSlice, table *plugins.DataTable, props map[string]string, depth int) error {
+	queryResult *plugins.DataQueryResult, table *plugins.DataTable, props map[string]string, depth int) error {
 	var err error
 	maxDepth := len(target.BucketAggs) - 1
 
@@ -110,7 +112,7 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 
 		if depth == maxDepth {
 			if aggDef.Type == dateHistType {
-				err = rp.processMetrics(esAgg, target, series, props)
+				err = rp.processMetrics(esAgg, target, queryResult, props)
 			} else {
 				err = rp.processAggregationDocs(esAgg, aggDef, target, table, props)
 			}
@@ -135,7 +137,7 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 				if key, err := bucket.Get("key_as_string").String(); err == nil {
 					newProps[aggDef.Field] = key
 				}
-				err = rp.processBuckets(bucket.MustMap(), target, series, table, newProps, depth+1)
+				err = rp.processBuckets(bucket.MustMap(), target, queryResult, table, newProps, depth+1)
 				if err != nil {
 					return err
 				}
@@ -158,7 +160,7 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 
 				newProps["filter"] = bucketKey
 
-				err = rp.processBuckets(bucket.MustMap(), target, series, table, newProps, depth+1)
+				err = rp.processBuckets(bucket.MustMap(), target, queryResult, table, newProps, depth+1)
 				if err != nil {
 					return err
 				}
@@ -169,34 +171,39 @@ func (rp *responseParser) processBuckets(aggs map[string]interface{}, target *Qu
 }
 
 // nolint:staticcheck // plugins.* deprecated
-func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, series *plugins.DataTimeSeriesSlice,
+func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, query *plugins.DataQueryResult,
 	props map[string]string) error {
+	frames := data.Frames{}
+	esAggBuckets := esAgg.Get("buckets").MustArray()
+
 	for _, metric := range target.Metrics {
 		if metric.Hide {
 			continue
 		}
 
+		tags := make(map[string]string, len(props))
+		timeVector := make([]time.Time, 0, len(esAggBuckets))
+		values := make([]*float64, 0, len(esAggBuckets))
+
 		switch metric.Type {
 		case countType:
-			newSeries := plugins.DataTimeSeries{
-				Tags: make(map[string]string),
-			}
-
-			for _, v := range esAgg.Get("buckets").MustArray() {
+			for _, v := range esAggBuckets {
 				bucket := simplejson.NewFromAny(v)
-				value := castToNullFloat(bucket.Get("doc_count"))
-				key := castToNullFloat(bucket.Get("key"))
-				newSeries.Points = append(newSeries.Points, plugins.DataTimePoint{value, key})
+				value := castToFloat(bucket.Get("doc_count"))
+				key := castToFloat(bucket.Get("key"))
+				timeVector = append(timeVector, time.Unix(int64(*key)/1000, 0).UTC())
+				values = append(values, value)
 			}
 
 			for k, v := range props {
-				newSeries.Tags[k] = v
+				tags[k] = v
 			}
-			newSeries.Tags["metric"] = countType
-			*series = append(*series, newSeries)
-
+			tags["metric"] = countType
+			frames = append(frames, data.NewFrame(metric.Field,
+				data.NewField("time", nil, timeVector),
+				data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: metric.Field})))
 		case percentilesType:
-			buckets := esAgg.Get("buckets").MustArray()
+			buckets := esAggBuckets
 			if len(buckets) == 0 {
 				break
 			}
@@ -210,28 +217,68 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 			}
 			sort.Strings(percentileKeys)
 			for _, percentileName := range percentileKeys {
-				newSeries := plugins.DataTimeSeries{
-					Tags: make(map[string]string),
-				}
+				tags := make(map[string]string, len(props))
+
 				for k, v := range props {
-					newSeries.Tags[k] = v
+					tags[k] = v
 				}
-				newSeries.Tags["metric"] = "p" + percentileName
-				newSeries.Tags["field"] = metric.Field
+				tags["metric"] = "p" + percentileName
+				tags["field"] = metric.Field
 				for _, v := range buckets {
 					bucket := simplejson.NewFromAny(v)
-					value := castToNullFloat(bucket.GetPath(metric.ID, "values", percentileName))
-					key := castToNullFloat(bucket.Get("key"))
-					newSeries.Points = append(newSeries.Points, plugins.DataTimePoint{value, key})
+					value := castToFloat(bucket.GetPath(metric.ID, "values", percentileName))
+					key := castToFloat(bucket.Get("key"))
+					timeVector = append(timeVector, time.Unix(int64(*key)/1000, 0).UTC())
+					values = append(values, value)
 				}
-				*series = append(*series, newSeries)
+				frames = append(frames, data.NewFrame(metric.Field,
+					data.NewField("time", nil, timeVector),
+					data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: tags["metric"] + metric.Field})))
 			}
 		case topMetricsType:
-			topMetricSeries := processTopMetrics(metric, esAgg, props)
-			*series = append(*series, topMetricSeries...)
+			buckets := esAggBuckets
+			metrics := metric.Settings.Get("metrics").MustArray()
+
+			for _, metricField := range metrics {
+				for _, v := range buckets {
+					bucket := simplejson.NewFromAny(v)
+					stats := bucket.GetPath(metric.ID, "top")
+					key := castToFloat(bucket.Get("key"))
+
+					tags := make(map[string]string, len(props))
+
+					for k, v := range props {
+						tags[k] = v
+					}
+					tags["metric"] = "top_metrics"
+					tags["field"] = metricField.(string)
+
+					timeVector = append(timeVector, time.Unix(int64(*key)/1000, 0).UTC())
+
+					for _, stat := range stats.MustArray() {
+						stat := stat.(map[string]interface{})
+
+						metrics, hasMetrics := stat["metrics"]
+						if hasMetrics {
+							metrics := metrics.(map[string]interface{})
+							metricValue, hasMetricValue := metrics[metricField.(string)]
+
+							if hasMetricValue && metricValue != nil {
+								v := metricValue.(float64)
+								values = append(values, &v)
+							}
+						}
+					}
+				}
+
+				frames = append(frames, data.NewFrame(metricField.(string),
+					data.NewField("time", nil, timeVector),
+					data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: rp.getMetricName(tags["metric"]) + " " + metricField.(string)}),
+				))
+			}
 
 		case extendedStatsType:
-			buckets := esAgg.Get("buckets").MustArray()
+			buckets := esAggBuckets
 
 			metaKeys := make([]string, 0)
 			meta := metric.Meta.MustMap()
@@ -245,60 +292,71 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 					continue
 				}
 
-				newSeries := plugins.DataTimeSeries{
-					Tags: make(map[string]string),
-				}
+				tags := make(map[string]string, len(props))
+
 				for k, v := range props {
-					newSeries.Tags[k] = v
+					tags[k] = v
 				}
-				newSeries.Tags["metric"] = statName
-				newSeries.Tags["field"] = metric.Field
+				tags["metric"] = statName
+				tags["field"] = metric.Field
 
 				for _, v := range buckets {
 					bucket := simplejson.NewFromAny(v)
-					key := castToNullFloat(bucket.Get("key"))
-					var value null.Float
+					key := castToFloat(bucket.Get("key"))
+					var value *float64
 					switch statName {
 					case "std_deviation_bounds_upper":
-						value = castToNullFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "upper"))
+						value = castToFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "upper"))
 					case "std_deviation_bounds_lower":
-						value = castToNullFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "lower"))
+						value = castToFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "lower"))
 					default:
-						value = castToNullFloat(bucket.GetPath(metric.ID, statName))
+						value = castToFloat(bucket.GetPath(metric.ID, statName))
 					}
-					newSeries.Points = append(newSeries.Points, plugins.DataTimePoint{value, key})
+					timeVector = append(timeVector, time.Unix(int64(*key)/1000, 0).UTC())
+					values = append(values, value)
 				}
-				*series = append(*series, newSeries)
+				labels := tags
+				frames = append(frames, data.NewFrame(metric.Field,
+					data.NewField("time", nil, timeVector),
+					data.NewField("value", labels, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: metric.Field})))
 			}
 		default:
-			newSeries := plugins.DataTimeSeries{
-				Tags: make(map[string]string),
-			}
 			for k, v := range props {
-				newSeries.Tags[k] = v
+				tags[k] = v
 			}
 
-			newSeries.Tags["metric"] = metric.Type
-			newSeries.Tags["field"] = metric.Field
-			newSeries.Tags["metricId"] = metric.ID
-			for _, v := range esAgg.Get("buckets").MustArray() {
+			tags["metric"] = metric.Type
+			tags["field"] = metric.Field
+			tags["metricId"] = metric.ID
+			for _, v := range esAggBuckets {
 				bucket := simplejson.NewFromAny(v)
-				key := castToNullFloat(bucket.Get("key"))
+				key := castToFloat(bucket.Get("key"))
 				valueObj, err := bucket.Get(metric.ID).Map()
 				if err != nil {
 					continue
 				}
-				var value null.Float
+				var value *float64
 				if _, ok := valueObj["normalized_value"]; ok {
-					value = castToNullFloat(bucket.GetPath(metric.ID, "normalized_value"))
+					value = castToFloat(bucket.GetPath(metric.ID, "normalized_value"))
 				} else {
-					value = castToNullFloat(bucket.GetPath(metric.ID, "value"))
+					value = castToFloat(bucket.GetPath(metric.ID, "value"))
 				}
-				newSeries.Points = append(newSeries.Points, plugins.DataTimePoint{value, key})
+				timeVector = append(timeVector, time.Unix(int64(*key)/1000, 0).UTC())
+				values = append(values, value)
 			}
-			*series = append(*series, newSeries)
+			frames = append(frames, data.NewFrame(metric.Field,
+				data.NewField("time", nil, timeVector),
+				data.NewField("value", tags, values).SetConfig(&data.FieldConfig{DisplayNameFromDS: metric.Field})))
 		}
 	}
+	if query.Dataframes != nil {
+		oldFrames, err := query.Dataframes.Decoded()
+		if err != nil {
+			return err
+		}
+		frames = append(oldFrames, frames...)
+	}
+	query.Dataframes = plugins.NewDecodedDataFrames(frames)
 	return nil
 }
 
@@ -318,7 +376,7 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 		table.Columns = append(table.Columns, plugins.DataTableColumn{Text: aggDef.Field})
 	}
 
-	addMetricValue := func(values *plugins.DataRowValues, metricName string, value null.Float) {
+	addMetricValue := func(values *plugins.DataRowValues, metricName string, value *float64) {
 		found := false
 		for _, c := range table.Columns {
 			if c.Text == metricName {
@@ -329,7 +387,6 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 		if !found {
 			table.Columns = append(table.Columns, plugins.DataTableColumn{Text: metricName})
 		}
-		*values = append(*values, value)
 	}
 
 	for _, v := range esAgg.Get("buckets").MustArray() {
@@ -343,13 +400,13 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 		if key, err := bucket.Get("key").String(); err == nil {
 			values = append(values, key)
 		} else {
-			values = append(values, castToNullFloat(bucket.Get("key")))
+			values = append(values, castToFloat(bucket.Get("key")))
 		}
 
 		for _, metric := range target.Metrics {
 			switch metric.Type {
 			case countType:
-				addMetricValue(&values, rp.getMetricName(metric.Type), castToNullFloat(bucket.Get("doc_count")))
+				addMetricValue(&values, rp.getMetricName(metric.Type), castToFloat(bucket.Get("doc_count")))
 			case extendedStatsType:
 				metaKeys := make([]string, 0)
 				meta := metric.Meta.MustMap()
@@ -363,14 +420,14 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 						continue
 					}
 
-					var value null.Float
+					var value *float64
 					switch statName {
 					case "std_deviation_bounds_upper":
-						value = castToNullFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "upper"))
+						value = castToFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "upper"))
 					case "std_deviation_bounds_lower":
-						value = castToNullFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "lower"))
+						value = castToFloat(bucket.GetPath(metric.ID, "std_deviation_bounds", "lower"))
 					default:
-						value = castToNullFloat(bucket.GetPath(metric.ID, statName))
+						value = castToFloat(bucket.GetPath(metric.ID, statName))
 					}
 
 					addMetricValue(&values, rp.getMetricName(metric.Type), value)
@@ -394,7 +451,7 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 					}
 				}
 
-				addMetricValue(&values, metricName, castToNullFloat(bucket.GetPath(metric.ID, "value")))
+				addMetricValue(&values, metricName, castToFloat(bucket.GetPath(metric.ID, "value")))
 			}
 		}
 
@@ -404,7 +461,9 @@ func (rp *responseParser) processAggregationDocs(esAgg *simplejson.Json, aggDef 
 	return nil
 }
 
-func (rp *responseParser) trimDatapoints(series plugins.DataTimeSeriesSlice, target *Query) {
+// TODO remove deprecations
+// nolint:staticcheck // plugins.DataQueryResult deprecated
+func (rp *responseParser) trimDatapoints(queryResult plugins.DataQueryResult, target *Query) {
 	var histogram *BucketAgg
 	for _, bucketAgg := range target.BucketAggs {
 		if bucketAgg.Type == dateHistType {
@@ -422,40 +481,58 @@ func (rp *responseParser) trimDatapoints(series plugins.DataTimeSeriesSlice, tar
 		return
 	}
 
-	for i := range series {
-		if len(series[i].Points) > trimEdges*2 {
-			series[i].Points = series[i].Points[trimEdges : len(series[i].Points)-trimEdges]
+	frames, err := queryResult.Dataframes.Decoded()
+	if err != nil {
+		return
+	}
+
+	for _, frame := range frames {
+		for _, field := range frame.Fields {
+			if field.Len() > trimEdges*2 {
+				for i := 0; i < field.Len(); i++ {
+					if i < trimEdges || i > field.Len()-trimEdges {
+						field.Delete(i)
+					}
+				}
+			}
 		}
 	}
 }
 
-func (rp *responseParser) nameSeries(seriesList plugins.DataTimeSeriesSlice, target *Query) {
+// nolint:staticcheck // plugins.DataQueryResult deprecated
+func (rp *responseParser) nameFields(queryResult plugins.DataQueryResult, target *Query) {
 	set := make(map[string]struct{})
-	for _, v := range seriesList {
-		if metricType, exists := v.Tags["metric"]; exists {
-			if _, ok := set[metricType]; !ok {
-				set[metricType] = struct{}{}
+	frames, err := queryResult.Dataframes.Decoded()
+	if err != nil {
+		return
+	}
+	for _, v := range frames {
+		for _, vv := range v.Fields {
+			if metricType, exists := vv.Labels["metric"]; exists {
+				if _, ok := set[metricType]; !ok {
+					set[metricType] = struct{}{}
+				}
 			}
 		}
 	}
 	metricTypeCount := len(set)
-	for i := range seriesList {
-		seriesList[i].Name = rp.getSeriesName(seriesList[i], target, metricTypeCount)
+	for i := range frames {
+		frames[i].Name = rp.getFieldName(*frames[i].Fields[1], target, metricTypeCount)
 	}
 }
 
 var aliasPatternRegex = regexp.MustCompile(`\{\{([\s\S]+?)\}\}`)
 
 // nolint:staticcheck // plugins.* deprecated
-func (rp *responseParser) getSeriesName(series plugins.DataTimeSeries, target *Query, metricTypeCount int) string {
-	metricType := series.Tags["metric"]
+func (rp *responseParser) getFieldName(dataField data.Field, target *Query, metricTypeCount int) string {
+	metricType := dataField.Labels["metric"]
 	metricName := rp.getMetricName(metricType)
-	delete(series.Tags, "metric")
+	delete(dataField.Labels, "metric")
 
 	field := ""
-	if v, ok := series.Tags["field"]; ok {
+	if v, ok := dataField.Labels["field"]; ok {
 		field = v
-		delete(series.Tags, "field")
+		delete(dataField.Labels, "field")
 	}
 
 	if target.Alias != "" {
@@ -470,9 +547,9 @@ func (rp *responseParser) getSeriesName(series plugins.DataTimeSeries, target *Q
 			}
 
 			if strings.Index(group, "term ") == 0 {
-				seriesName = strings.Replace(seriesName, subMatch[0], series.Tags[group[5:]], 1)
+				seriesName = strings.Replace(seriesName, subMatch[0], dataField.Labels[group[5:]], 1)
 			}
-			if v, ok := series.Tags[group]; ok {
+			if v, ok := dataField.Labels[group]; ok {
 				seriesName = strings.Replace(seriesName, subMatch[0], v, 1)
 			}
 			if group == "metric" {
@@ -489,7 +566,7 @@ func (rp *responseParser) getSeriesName(series plugins.DataTimeSeries, target *Q
 	if field != "" && isPipelineAgg(metricType) {
 		if isPipelineAggWithMultipleBucketPaths(metricType) {
 			metricID := ""
-			if v, ok := series.Tags["metricId"]; ok {
+			if v, ok := dataField.Labels["metricId"]; ok {
 				metricID = v
 			}
 
@@ -521,14 +598,14 @@ func (rp *responseParser) getSeriesName(series plugins.DataTimeSeries, target *Q
 		metricName += " " + field
 	}
 
-	delete(series.Tags, "metricId")
+	delete(dataField.Labels, "metricId")
 
-	if len(series.Tags) == 0 {
+	if len(dataField.Labels) == 0 {
 		return metricName
 	}
 
 	name := ""
-	for _, v := range series.Tags {
+	for _, v := range dataField.Labels {
 		name += v + " "
 	}
 
@@ -551,23 +628,23 @@ func (rp *responseParser) getMetricName(metric string) string {
 	return metric
 }
 
-func castToNullFloat(j *simplejson.Json) null.Float {
+func castToFloat(j *simplejson.Json) *float64 {
 	f, err := j.Float64()
 	if err == nil {
-		return null.FloatFrom(f)
+		return &f
 	}
 
 	if s, err := j.String(); err == nil {
 		if strings.ToLower(s) == "nan" {
-			return null.NewFloat(0, false)
+			return nil
 		}
 
 		if v, err := strconv.ParseFloat(s, 64); err == nil {
-			return null.FloatFromPtr(&v)
+			return &v
 		}
 	}
 
-	return null.NewFloat(0, false)
+	return nil
 }
 
 func findAgg(target *Query, aggID string) (*BucketAgg, error) {
@@ -611,33 +688,4 @@ func processTopMetricValues(stats *simplejson.Json, field string) null.Float {
 		}
 	}
 	return null.NewFloat(0, false)
-}
-
-func processTopMetrics(metric *MetricAgg, esAgg *simplejson.Json, props map[string]string) plugins.DataTimeSeriesSlice {
-	var series plugins.DataTimeSeriesSlice
-	metrics, hasMetrics := metric.Settings.MustMap()["metrics"].([]interface{})
-
-	if hasMetrics {
-		for _, metricField := range metrics {
-			newSeries := plugins.DataTimeSeries{
-				Tags: make(map[string]string),
-			}
-
-			for _, v := range esAgg.Get("buckets").MustArray() {
-				bucket := simplejson.NewFromAny(v)
-				stats := bucket.GetPath(metric.ID, "top")
-				value := processTopMetricValues(stats, metricField.(string))
-				key := castToNullFloat(bucket.Get("key"))
-				newSeries.Points = append(newSeries.Points, plugins.DataTimePoint{value, key})
-			}
-
-			for k, v := range props {
-				newSeries.Tags[k] = v
-			}
-			newSeries.Tags["metric"] = "top_metrics"
-			newSeries.Tags["field"] = metricField.(string)
-			series = append(series, newSeries)
-		}
-	}
-	return series
 }

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -240,13 +240,13 @@ func (rp *responseParser) processMetrics(esAgg *simplejson.Json, target *Query, 
 					tags[k] = v
 				}
 
+				tags["field"] = metricField.(string)
+				tags["metric"] = "top_metrics"
+
 				for _, v := range buckets {
 					bucket := simplejson.NewFromAny(v)
 					stats := bucket.GetPath(metric.ID, "top")
 					key := castToFloat(bucket.Get("key"))
-
-					tags["metric"] = "top_metrics"
-					tags["field"] = metricField.(string)
 
 					timeVector = append(timeVector, time.Unix(int64(*key)/1000, 0).UTC())
 

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -1025,24 +1025,37 @@ func TestResponseParser(t *testing.T) {
 
 		queryRes := result.Results["A"]
 		assert.NotNil(t, queryRes)
-		assert.Len(t, queryRes.Series, 2)
+		dataframes, err := queryRes.Dataframes.Decoded()
+		assert.NoError(t, err)
+		assert.Len(t, dataframes, 2)
 
-		seriesOne := queryRes.Series[0]
+		seriesOne := dataframes[0]
 		assert.Equal(t, seriesOne.Name, "Top Metrics @value")
-		assert.Len(t, seriesOne.Points, 2)
-		assert.Equal(t, seriesOne.Points[0][0].Float64, 1.)
-		assert.Equal(t, seriesOne.Points[0][1].Float64, 1609459200000.)
-		assert.Equal(t, seriesOne.Points[1][0].Float64, 1.)
-		assert.Equal(t, seriesOne.Points[1][1].Float64, 1609459210000.)
+		assert.Len(t, seriesOne.Fields, 2)
+		v, _ := seriesOne.FloatAt(0, 0)
+		assert.Equal(t, 1609459200000., v)
+		v, _ = seriesOne.FloatAt(1, 0)
+		assert.Equal(t, 1., v)
 
-		seriesTwo := queryRes.Series[1]
+		v, _ = seriesOne.FloatAt(0, 1)
+		assert.Equal(t, 1609459210000., v)
+		v, _ = seriesOne.FloatAt(1, 1)
+		assert.Equal(t, 1., v)
+
+		seriesTwo := dataframes[1]
 		assert.Equal(t, seriesTwo.Name, "Top Metrics @anotherValue")
-		assert.Len(t, seriesTwo.Points, 2)
+		l, _ := seriesTwo.MarshalJSON()
+		fmt.Println(string(l))
+		assert.Len(t, seriesTwo.Fields, 2)
+		v, _ = seriesTwo.FloatAt(0, 0)
+		assert.Equal(t, 1609459200000., v)
+		v, _ = seriesTwo.FloatAt(1, 0)
+		assert.Equal(t, 2., v)
 
-		assert.Equal(t, seriesTwo.Points[0][0].Float64, 2.)
-		assert.Equal(t, seriesTwo.Points[0][1].Float64, 1609459200000.)
-		assert.Equal(t, seriesTwo.Points[1][0].Float64, 2.)
-		assert.Equal(t, seriesTwo.Points[1][1].Float64, 1609459210000.)
+		v, _ = seriesTwo.FloatAt(0, 1)
+		assert.Equal(t, 1609459210000., v)
+		v, _ = seriesTwo.FloatAt(1, 1)
+		assert.Equal(t, 2., v)
 	})
 }
 

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -758,22 +758,6 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[1].Len(), 2)
 			require.Equal(t, frame.Fields[2].Name, "Count")
 			require.Equal(t, frame.Fields[2].Len(), 2)
-			//
-			//rows := queryRes.Tables[0].Rows
-			//So(rows, ShouldHaveLength, 2)
-			//cols := queryRes.Tables[0].Columns
-			//So(cols, ShouldHaveLength, 3)
-			//
-			//So(cols[0].Text, ShouldEqual, "host")
-			//So(cols[1].Text, ShouldEqual, "Average")
-			//So(cols[2].Text, ShouldEqual, "Count")
-			//
-			//So(rows[0][0].(string), ShouldEqual, "server-1")
-			//So(rows[0][1].(null.Float).Float64, ShouldEqual, 1000)
-			//So(rows[0][2].(null.Float).Float64, ShouldEqual, 369)
-			//So(rows[1][0].(string), ShouldEqual, "server-2")
-			//So(rows[1][1].(null.Float).Float64, ShouldEqual, 2000)
-			//So(rows[1][2].(null.Float).Float64, ShouldEqual, 200)
 		})
 
 		t.Run("Multiple metrics of same type", func(t *testing.T) {
@@ -985,58 +969,6 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Fields[4].Name, "params.var1 * params.var2 * 2")
 			require.Equal(t, frame.Fields[4].Len(), 2)
 		})
-		// t.Run("Raw documents query", func(t *testing.T) {
-		// 	targets := map[string]string{
-		// 		"A": `{
-		// 			"timeField": "@timestamp",
-		// 			"metrics": [{ "type": "raw_document", "id": "1" }]
-		// 		}`,
-		// 	}
-		// 	response := `{
-		//     "responses": [
-		//       {
-		//         "hits": {
-		//           "total": 100,
-		//           "hits": [
-		//             {
-		//               "_id": "1",
-		//               "_type": "type",
-		//               "_index": "index",
-		//               "_source": { "sourceProp": "asd" },
-		//               "fields": { "fieldProp": "field" }
-		//             },
-		//             {
-		//               "_source": { "sourceProp": "asd2" },
-		//               "fields": { "fieldProp": "field2" }
-		//             }
-		//           ]
-		//         }
-		//       }
-		//     ]
-		// 	}`
-		// 	rp, err := newResponseParserForTest(targets, response)
-		// 	So(err, ShouldBeNil)
-		// 	result, err := rp.getTimeSeries()
-		// 	So(err, ShouldBeNil)
-		// 	So(result.Results, ShouldHaveLength, 1)
-
-		// 	queryRes := result.Results["A"]
-		// 	So(queryRes, ShouldNotBeNil)
-		// 	So(queryRes.Tables, ShouldHaveLength, 1)
-
-		// 	rows := queryRes.Tables[0].Rows
-		// 	So(rows, ShouldHaveLength, 1)
-		// 	cols := queryRes.Tables[0].Columns
-		// 	So(cols, ShouldHaveLength, 3)
-
-		// 	So(cols[0].Text, ShouldEqual, "host")
-		// 	So(cols[1].Text, ShouldEqual, "Average test")
-		// 	So(cols[2].Text, ShouldEqual, "Average test2")
-
-		// 	So(rows[0][0].(string), ShouldEqual, "server-1")
-		// 	So(rows[0][1].(null.Float).Float64, ShouldEqual, 1000)
-		// 	So(rows[0][2].(null.Float).Float64, ShouldEqual, 3000)
-		// })
 	})
 
 	t.Run("With top_metrics", func(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -15,6 +15,30 @@ import (
 
 func TestResponseParser(t *testing.T) {
 	t.Run("Elasticsearch response parser test", func(t *testing.T) {
+		t.Run("Boot Up", func(t *testing.T) {
+			// This happens when ES is booting up.
+			// the response is somehow incomplete, Grafana shouldn't panic in this case.
+			targets := map[string]string{
+				"A": `{
+					"timeField": "@timestamp",
+					"metrics": [{ "type": "count", "id": "1" }],
+          			"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "2" }]
+				}`,
+			}
+			response := `{
+        		"responses": [
+					{
+						"aggregations": null
+					}
+				]
+			}`
+			rp, err := newResponseParserForTest(targets, response)
+			require.NoError(t, err)
+			result, err := rp.getTimeSeries()
+			require.NoError(t, err)
+			require.Len(t, result.Results, 1)
+		})
+
 		t.Run("Simple query and count", func(t *testing.T) {
 			targets := map[string]string{
 				"A": `{

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -1029,32 +1029,36 @@ func TestResponseParser(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, dataframes, 2)
 
-		seriesOne := dataframes[0]
-		assert.Equal(t, seriesOne.Name, "Top Metrics @value")
-		assert.Len(t, seriesOne.Fields, 2)
-		v, _ := seriesOne.FloatAt(0, 0)
+		frame := dataframes[0]
+		assert.Equal(t, frame.Name, "Top Metrics @value")
+		assert.Len(t, frame.Fields, 2)
+		require.Equal(t, frame.Fields[0].Len(), 2)
+		require.Equal(t, frame.Fields[1].Len(), 2)
+		v, _ := frame.FloatAt(0, 0)
 		assert.Equal(t, 1609459200000., v)
-		v, _ = seriesOne.FloatAt(1, 0)
+		v, _ = frame.FloatAt(1, 0)
 		assert.Equal(t, 1., v)
 
-		v, _ = seriesOne.FloatAt(0, 1)
+		v, _ = frame.FloatAt(0, 1)
 		assert.Equal(t, 1609459210000., v)
-		v, _ = seriesOne.FloatAt(1, 1)
+		v, _ = frame.FloatAt(1, 1)
 		assert.Equal(t, 1., v)
 
-		seriesTwo := dataframes[1]
-		assert.Equal(t, seriesTwo.Name, "Top Metrics @anotherValue")
-		l, _ := seriesTwo.MarshalJSON()
+		frame = dataframes[1]
+		assert.Equal(t, frame.Name, "Top Metrics @anotherValue")
+		l, _ := frame.MarshalJSON()
 		fmt.Println(string(l))
-		assert.Len(t, seriesTwo.Fields, 2)
-		v, _ = seriesTwo.FloatAt(0, 0)
+		assert.Len(t, frame.Fields, 2)
+		require.Equal(t, frame.Fields[0].Len(), 2)
+		require.Equal(t, frame.Fields[1].Len(), 2)
+		v, _ = frame.FloatAt(0, 0)
 		assert.Equal(t, 1609459200000., v)
-		v, _ = seriesTwo.FloatAt(1, 0)
+		v, _ = frame.FloatAt(1, 0)
 		assert.Equal(t, 2., v)
 
-		v, _ = seriesTwo.FloatAt(0, 1)
+		v, _ = frame.FloatAt(0, 1)
 		assert.Equal(t, 1609459210000., v)
-		v, _ = seriesTwo.FloatAt(1, 1)
+		v, _ = frame.FloatAt(1, 1)
 		assert.Equal(t, 2., v)
 	})
 }

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -15,30 +15,6 @@ import (
 
 func TestResponseParser(t *testing.T) {
 	t.Run("Elasticsearch response parser test", func(t *testing.T) {
-		t.Run("Boot Up", func(t *testing.T) {
-			// This happens when ES is booting up.
-			// the response is somehow incomplete, Grafana shouldn't panic in this case.
-			targets := map[string]string{
-				"A": `{
-					"timeField": "@timestamp",
-					"metrics": [{ "type": "count", "id": "1" }],
-          			"bucketAggs": [{ "type": "date_histogram", "field": "@timestamp", "id": "2" }]
-				}`,
-			}
-			response := `{
-        		"responses": [
-					{
-						"aggregations": null
-					}
-				]
-			}`
-			rp, err := newResponseParserForTest(targets, response)
-			require.NoError(t, err)
-			result, err := rp.getTimeSeries()
-			require.NoError(t, err)
-			require.Len(t, result.Results, 1)
-		})
-
 		t.Run("Simple query and count", func(t *testing.T) {
 			targets := map[string]string{
 				"A": `{

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -333,9 +333,9 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Name, "p90")
 			require.Len(t, frame.Fields, 2)
 			require.Equal(t, frame.Fields[0].Name, "time")
-			require.Equal(t, frame.Fields[0].Len(), 4)
+			require.Equal(t, frame.Fields[0].Len(), 2)
 			require.Equal(t, frame.Fields[1].Name, "value")
-			require.Equal(t, frame.Fields[1].Len(), 4)
+			require.Equal(t, frame.Fields[1].Len(), 2)
 		})
 
 		t.Run("With extended stats", func(t *testing.T) {
@@ -417,17 +417,17 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Name, "server1 Std Dev Lower")
 			require.Len(t, frame.Fields, 2)
 			require.Equal(t, frame.Fields[0].Name, "time")
-			require.Equal(t, frame.Fields[0].Len(), 2)
+			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
-			require.Equal(t, frame.Fields[1].Len(), 2)
+			require.Equal(t, frame.Fields[1].Len(), 1)
 
 			frame = dataframes[2]
 			require.Equal(t, frame.Name, "server1 Std Dev Upper")
 			require.Len(t, frame.Fields, 2)
 			require.Equal(t, frame.Fields[0].Name, "time")
-			require.Equal(t, frame.Fields[0].Len(), 3)
+			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
-			require.Equal(t, frame.Fields[1].Len(), 3)
+			require.Equal(t, frame.Fields[1].Len(), 1)
 
 			frame = dataframes[3]
 			require.Equal(t, frame.Name, "server2 Max")
@@ -441,17 +441,17 @@ func TestResponseParser(t *testing.T) {
 			require.Equal(t, frame.Name, "server2 Std Dev Lower")
 			require.Len(t, frame.Fields, 2)
 			require.Equal(t, frame.Fields[0].Name, "time")
-			require.Equal(t, frame.Fields[0].Len(), 2)
+			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
-			require.Equal(t, frame.Fields[1].Len(), 2)
+			require.Equal(t, frame.Fields[1].Len(), 1)
 
 			frame = dataframes[5]
 			require.Equal(t, frame.Name, "server2 Std Dev Upper")
 			require.Len(t, frame.Fields, 2)
 			require.Equal(t, frame.Fields[0].Name, "time")
-			require.Equal(t, frame.Fields[0].Len(), 3)
+			require.Equal(t, frame.Fields[0].Len(), 1)
 			require.Equal(t, frame.Fields[1].Name, "value")
-			require.Equal(t, frame.Fields[1].Len(), 3)
+			require.Equal(t, frame.Fields[1].Len(), 1)
 		})
 
 		t.Run("Single group by with alias pattern", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is responsible for removing deprecated packages and converting timeseries and table objects to dataframes for Elasticsearch.

