### PR TITLE
Live: grafana_live namespace for centrifuge prom metrics

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -144,6 +144,7 @@ func (g *GrafanaLive) Init() error {
 	// cfg.LogLevel = centrifuge.LogLevelDebug
 	cfg.LogHandler = handleLog
 	cfg.LogLevel = centrifuge.LogLevelError
+	cfg.MetricsNamespace = "grafana_live"
 
 	// Node is the core object in Centrifuge library responsible for many useful
 	// things. For example Node allows to publish messages to channels from server


### PR DESCRIPTION
**What this PR does / why we need it**:

By default all Prometheus metrics inside Centrifuge library use `centrifuge` namespace, with this change Centrifufuge specific metrics will have `grafana_live` namespace.