### PR TITLE
VisualisationPicker: Allow scrolling in Safari

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
@@ -162,7 +162,7 @@ const getStyles = (theme: GrafanaTheme) => {
     openWrapper: css`
       display: flex;
       flex-direction: column;
-      flex: 1 1 0;
+      flex: 1 1 100%;
       height: 100%;
       background: ${theme.colors.bg1};
       border: 1px solid ${theme.colors.border1};


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR addresses the issue of not being able to scroll the Viz Picker in Safari. Flex-basis takes priority over height declarations in Safari. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis) it's like this for all browsers if a value other than auto is set.

https://user-images.githubusercontent.com/73201/119634633-3521dd80-be13-11eb-9752-019e98d4ecb1.mp4 

https://user-images.githubusercontent.com/73201/119634656-3bb05500-be13-11eb-901a-711e61aa23a7.mp4

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #34550

**Special notes for your reviewer**:

