### PR TITLE
Alerting: check if alert manager datasoruce is being configured with vanilla or cortex am

### DIFF
--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { DataSourceHttpSettings } from '@grafana/ui';
+import { Alert, DataSourceHttpSettings } from '@grafana/ui';
 import React from 'react';
 
 export type Props = DataSourcePluginOptionsEditorProps;
@@ -7,6 +7,9 @@ export type Props = DataSourcePluginOptionsEditorProps;
 export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
   return (
     <>
+      <Alert severity="info" title="Only Cortex alertmanager is supported">
+        Note that only Cortex implementation of alert manager is supported at this time.
+      </Alert>
       <DataSourceHttpSettings
         defaultUrl={''}
         dataSourceConfig={options}

--- a/public/app/plugins/datasource/alertmanager/DataSource.ts
+++ b/public/app/plugins/datasource/alertmanager/DataSource.ts
@@ -44,12 +44,19 @@ export class AlertManagerDatasource extends DataSourceApi<AlertManagerQuery> {
 
     try {
       alertmanagerResponse = await this._request('/api/v2/status');
+      if (alertmanagerResponse && alertmanagerResponse?.status === 200) {
+        return {
+          status: 'error',
+          message:
+            'Only Cortex alert manager implementation is supported. A URL to cortex instance should be provided.',
+        };
+      }
     } catch (e) {}
     try {
       cortexAlertmanagerResponse = await this._request('/alertmanager/api/v2/status');
     } catch (e) {}
 
-    return alertmanagerResponse?.status === 200 || cortexAlertmanagerResponse?.status === 200
+    return cortexAlertmanagerResponse?.status === 200
       ? {
           status: 'success',
           message: 'Health check passed.',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently we only support cortex alertmanager. Vanilla alertmanager does not have API endpoint to edit config. We could technically support it for just managing silences or viewing config read-only, but needs some more effort & testing. Will create a separate issue for it.

This PR adds a warning to datasource config screen about what is supporeted, and will fail datasource test if vanilla alertmangaer is detected.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

