### PR TITLE
Variables: Support raw values of boolean type

### DIFF
--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -169,6 +169,7 @@ describe('ensureStringValues', () => {
     ${[1, 2]}          | ${['1', '2']}
     ${'1'}             | ${'1'}
     ${['1', '2']}      | ${['1', '2']}
+    ${true}            | ${'true'}
   `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
     expect(ensureStringValues(value)).toEqual(expected);
   });

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -239,5 +239,9 @@ export function ensureStringValues(value: any | any[]): string | string[] {
     return value;
   }
 
+  if (typeof value === 'boolean') {
+    return value.toString();
+  }
+
   return '';
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`http://x.y/?var-booleanvar` should pass value of boolean `true` into a variable, now it was ignored - converted to `''`.

`$var` variable used to have `'true'` value that was then inserted into query.

Fixes #35024