### PR TITLE
Live: option to disable connecting to Live on frontend

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -122,6 +122,7 @@ export interface GrafanaConfig {
   viewersCanEdit: boolean;
   editorsCanAdmin: boolean;
   disableSanitizeHtml: boolean;
+  liveDisabled: boolean;
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;
   pluginsToPreload: string[];

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -122,7 +122,7 @@ export interface GrafanaConfig {
   viewersCanEdit: boolean;
   editorsCanAdmin: boolean;
   disableSanitizeHtml: boolean;
-  liveDisabled: boolean;
+  liveEnabled: boolean;
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;
   pluginsToPreload: string[];

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -54,6 +54,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   viewersCanEdit = false;
   editorsCanAdmin = false;
   disableSanitizeHtml = false;
+  liveDisabled = false;
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;
   pluginsToPreload: string[] = [];

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -54,7 +54,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   viewersCanEdit = false;
   editorsCanAdmin = false;
   disableSanitizeHtml = false;
-  liveDisabled = false;
+  liveEnabled = true;
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;
   pluginsToPreload: string[] = [];

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -207,6 +207,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"alertingErrorOrTimeout":     setting.AlertingErrorOrTimeout,
 		"alertingNoDataOrNullValues": setting.AlertingNoDataOrNullValues,
 		"alertingMinInterval":        setting.AlertingMinInterval,
+		"liveDisabled":               hs.Cfg.LiveMaxConnections == 0,
 		"autoAssignOrg":              setting.AutoAssignOrg,
 		"verifyEmailEnabled":         setting.VerifyEmailEnabled,
 		"sigV4AuthEnabled":           setting.SigV4AuthEnabled,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -207,7 +207,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"alertingErrorOrTimeout":     setting.AlertingErrorOrTimeout,
 		"alertingNoDataOrNullValues": setting.AlertingNoDataOrNullValues,
 		"alertingMinInterval":        setting.AlertingMinInterval,
-		"liveDisabled":               hs.Cfg.LiveMaxConnections == 0,
+		"liveEnabled":                hs.Cfg.LiveMaxConnections != 0,
 		"autoAssignOrg":              setting.AutoAssignOrg,
 		"verifyEmailEnabled":         setting.VerifyEmailEnabled,
 		"sigV4AuthEnabled":           setting.SigV4AuthEnabled,

--- a/public/app/features/live/LiveConnectionWarning.tsx
+++ b/public/app/features/live/LiveConnectionWarning.tsx
@@ -45,7 +45,7 @@ export class LiveConnectionWarning extends PureComponent<Props, State> {
   render() {
     const { show } = this.state;
     if (show) {
-      if (!contextSrv.isSignedIn || (window as any).grafanaBootData.settings.liveDisabled === true) {
+      if (!contextSrv.isSignedIn || !config.liveEnabled) {
         return null; // do not show the warning for anonymous users (and /login page etc)
       }
 

--- a/public/app/features/live/LiveConnectionWarning.tsx
+++ b/public/app/features/live/LiveConnectionWarning.tsx
@@ -45,8 +45,8 @@ export class LiveConnectionWarning extends PureComponent<Props, State> {
   render() {
     const { show } = this.state;
     if (show) {
-      if (!contextSrv.isSignedIn) {
-        return null; // do not show the warning for anonomous users (and /login page etc)
+      if (!contextSrv.isSignedIn || (window as any).grafanaBootData.settings.liveDisabled === true) {
+        return null; // do not show the warning for anonymous users (and /login page etc)
       }
 
       return (

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -51,7 +51,7 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
   readonly connectionState: BehaviorSubject<boolean>;
   readonly connectionBlocker: Promise<void>;
   readonly scopes: Record<LiveChannelScope, GrafanaLiveScope>;
-  private orgId: number;
+  private readonly orgId: number;
 
   constructor() {
     const baseURL = window.location.origin.replace('http', 'ws');
@@ -64,7 +64,9 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
       sessionId,
       orgId: this.orgId,
     });
-    this.centrifuge.connect(); // do connection
+    if ((window as any).grafanaBootData.settings.liveDisabled !== true) {
+      this.centrifuge.connect(); // do connection
+    }
     this.connectionState = new BehaviorSubject<boolean>(this.centrifuge.isConnected());
     this.connectionBlocker = new Promise<void>((resolve) => {
       if (this.centrifuge.isConnected()) {

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -64,7 +64,7 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
       sessionId,
       orgId: this.orgId,
     });
-    if ((window as any).grafanaBootData.settings.liveDisabled !== true) {
+    if (config.liveEnabled) {
       this.centrifuge.connect(); // do connection
     }
     this.connectionState = new BehaviorSubject<boolean>(this.centrifuge.isConnected());


### PR DESCRIPTION
**What this PR does / why we need it**:

I suppose we should provide a way to disable Live in v8 since users that come across WS connection problems will see a connection warning, also connection will be try to re-establish in background.

Not sure I did it right - thus a draft 