### PR TITLE
Catalog: Highlight library tab when active

### DIFF
--- a/plugins-bundled/internal/plugin-admin-app/src/pages/Library.tsx
+++ b/plugins-bundled/internal/plugin-admin-app/src/pages/Library.tsx
@@ -14,7 +14,7 @@ export const Library = ({ meta, onNavChanged, basename }: AppRootProps) => {
   const styles = useStyles2(getStyles);
 
   useEffect(() => {
-    onNavChanged(getCatalogNavModel(CatalogTab.Browse, basename));
+    onNavChanged(getCatalogNavModel(CatalogTab.Library, basename));
   }, [onNavChanged, basename]);
 
   const filteredPlugins = items.filter((plugin) => !!installedPlugins.find((_) => _.id === plugin.slug));


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
There was a typo / copy paste which prevented Library tab in Catalog app from highlighting when active.

<img width="456" alt="Screenshot 2021-05-26 at 17 28 11" src="https://user-images.githubusercontent.com/73201/119687820-c7dc6f80-be47-11eb-8028-bbf25a19c4a6.png">


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

