### PR TITLE
Caching: hide caching settings when its disabled in grafana.ini

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -83,6 +83,9 @@ export class GrafanaBootConfig implements GrafanaConfig {
   azure: AzureSettings = {
     managedIdentityEnabled: false,
   };
+  caching = {
+    enabled: false,
+  };
 
   constructor(options: GrafanaBootConfig) {
     const mode = options.bootData.user.lightTheme ? 'light' : 'dark';

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -255,6 +255,9 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 			"cloud":                  hs.Cfg.Azure.Cloud,
 			"managedIdentityEnabled": hs.Cfg.Azure.ManagedIdentityEnabled,
 		},
+		"caching": map[string]bool{
+			"enabled": hs.Cfg.SectionWithEnvOverrides("caching").Key("enabled").MustBool(true),
+		},
 	}
 
 	return jsonObj, nil

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -68,7 +68,7 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
       id: `datasource-cache-${dataSource.id}`,
       text: 'Cache',
       url: `datasources/edit/${dataSource.id}/cache`,
-      hideFromTabs: !pluginMeta.isBackend,
+      hideFromTabs: !pluginMeta.isBackend || !config.caching.enabled,
     });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This hides the caching tab in the data source settings when caching is disabled in grafana.ini