### PR TITLE
Alerting: check upstream response content type in lotex proxy

### DIFF
--- a/pkg/services/ngalert/api/promql_compat.go
+++ b/pkg/services/ngalert/api/promql_compat.go
@@ -116,7 +116,7 @@ func instantQueryResults(resp instantQueryResponse) (eval.Results, error) {
 func instantQueryResultsExtractor(r *response.NormalResponse) (interface{}, error) {
 	contentType := r.Header().Get("Content-Type")
 	if !strings.Contains(contentType, "json") {
-		return nil, fmt.Errorf("Unexpected content type from upstream. Expected JSON, got %v", contentType)
+		return nil, fmt.Errorf("unexpected content type from upstream. expected JSON, got %v", contentType)
 	}
 	var resp instantQueryResponse
 	err := json.Unmarshal(r.Body(), &resp)

--- a/pkg/services/ngalert/api/promql_compat.go
+++ b/pkg/services/ngalert/api/promql_compat.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -112,9 +113,13 @@ func instantQueryResults(resp instantQueryResponse) (eval.Results, error) {
 	}
 }
 
-func instantQueryResultsExtractor(b []byte) (interface{}, error) {
+func instantQueryResultsExtractor(r *response.NormalResponse) (interface{}, error) {
+	contentType := r.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "json") {
+		return nil, fmt.Errorf("Unexpected content type from upstream. Expected JSON, got %v", contentType)
+	}
 	var resp instantQueryResponse
-	err := json.Unmarshal(b, &resp)
+	err := json.Unmarshal(r.Body(), &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -136,7 +136,7 @@ func yamlExtractor(v interface{}) func(*response.NormalResponse) (interface{}, e
 	return func(resp *response.NormalResponse) (interface{}, error) {
 		contentType := resp.Header().Get("Content-Type")
 		if !strings.Contains(contentType, "yaml") {
-			return nil, fmt.Errorf("Unexpected content type from upstream. Expected YAML, got %v", contentType)
+			return nil, fmt.Errorf("unexpected content type from upstream. expected YAML, got %v", contentType)
 		}
 		decoder := yaml.NewDecoder(bytes.NewReader(resp.Body()))
 		decoder.KnownFields(true)
@@ -155,7 +155,7 @@ func jsonExtractor(v interface{}) func(*response.NormalResponse) (interface{}, e
 	return func(resp *response.NormalResponse) (interface{}, error) {
 		contentType := resp.Header().Get("Content-Type")
 		if !strings.Contains(contentType, "json") {
-			return nil, fmt.Errorf("Unexpected content type from upstream. Expected JSON, got %v", contentType)
+			return nil, fmt.Errorf("unexpected content type from upstream. expected JSON, got %v", contentType)
 		}
 		return v, json.Unmarshal(resp.Body(), v)
 	}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -88,7 +88,7 @@ func (p *AlertingProxy) withReq(
 	method string,
 	u *url.URL,
 	body io.Reader,
-	extractor func([]byte) (interface{}, error),
+	extractor func(*response.NormalResponse) (interface{}, error),
 	headers map[string]string,
 ) response.Response {
 	req, err := http.NewRequest(method, u.String(), body)
@@ -119,7 +119,7 @@ func (p *AlertingProxy) withReq(
 		return response.Error(status, errMessage, nil)
 	}
 
-	t, err := extractor(resp.Body())
+	t, err := extractor(resp)
 	if err != nil {
 		return response.Error(500, err.Error(), nil)
 	}
@@ -132,9 +132,13 @@ func (p *AlertingProxy) withReq(
 	return response.JSON(status, b)
 }
 
-func yamlExtractor(v interface{}) func([]byte) (interface{}, error) {
-	return func(b []byte) (interface{}, error) {
-		decoder := yaml.NewDecoder(bytes.NewReader(b))
+func yamlExtractor(v interface{}) func(*response.NormalResponse) (interface{}, error) {
+	return func(resp *response.NormalResponse) (interface{}, error) {
+		contentType := resp.Header().Get("Content-Type")
+		if !strings.Contains(contentType, "yaml") {
+			return nil, fmt.Errorf("Unexpected content type from upstream. Expected YAML, got %v", contentType)
+		}
+		decoder := yaml.NewDecoder(bytes.NewReader(resp.Body()))
 		decoder.KnownFields(true)
 
 		err := decoder.Decode(v)
@@ -143,18 +147,22 @@ func yamlExtractor(v interface{}) func([]byte) (interface{}, error) {
 	}
 }
 
-func jsonExtractor(v interface{}) func([]byte) (interface{}, error) {
+func jsonExtractor(v interface{}) func(*response.NormalResponse) (interface{}, error) {
 	if v == nil {
 		// json unmarshal expects a pointer
 		v = &map[string]interface{}{}
 	}
-	return func(b []byte) (interface{}, error) {
-		return v, json.Unmarshal(b, v)
+	return func(resp *response.NormalResponse) (interface{}, error) {
+		contentType := resp.Header().Get("Content-Type")
+		if !strings.Contains(contentType, "json") {
+			return nil, fmt.Errorf("Unexpected content type from upstream. Expected JSON, got %v", contentType)
+		}
+		return v, json.Unmarshal(resp.Body(), v)
 	}
 }
 
-func messageExtractor(b []byte) (interface{}, error) {
-	return map[string]string{"message": string(b)}, nil
+func messageExtractor(resp *response.NormalResponse) (interface{}, error) {
+	return map[string]string{"message": string(resp.Body())}, nil
 }
 
 func validateCondition(c ngmodels.Condition, user *models.SignedInUser, skipCache bool, datasourceCache datasources.CacheService) error {

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -79,7 +79,7 @@ async function rulerGetRequest<T>(url: string, empty: T): Promise<T> {
       return empty;
     } else if (
       e?.status === 500 &&
-      e?.data?.message?.includes('Unexpected content type from upstream. Expected YAML, got text/html')
+      e?.data?.message?.includes('unexpected content type from upstream. expected YAML, got text/html')
     ) {
       throw {
         ...e,

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -77,7 +77,10 @@ async function rulerGetRequest<T>(url: string, empty: T): Promise<T> {
   } catch (e) {
     if (e?.status === 404 || e?.data?.message?.includes('group does not exist')) {
       return empty;
-    } else if (e?.status === 500 && e?.data?.message?.includes('mapping values are not allowed in this context')) {
+    } else if (
+      e?.status === 500 &&
+      e?.data?.message?.includes('Unexpected content type from upstream. Expected YAML, got text/html')
+    ) {
       throw {
         ...e,
         data: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Frontend needs to detect if a Prometheus datasource is actually Cortex. It does this by trying to hit a ruler endpoint and checking  if it returns valid result. Cortex returns rules config, prometheus returns index page html.  However it did not always work, as for different versions of prometheus different errors seem to be generated when trying to parse index page as yaml.

This PR implements response content type checking in the lotex proxy. If unexpected content type is received, it will not try to parse but return a specific error message that frontend can rely upon.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

