### PR TITLE
Tempo: Fix the test data source implementation

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -91,13 +91,19 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TraceToLo
   }
 
   async testDatasource(): Promise<any> {
-    const response = await super.query({ targets: [{ query: '', refId: 'A' }] } as any).toPromise();
+    // to test Tempo we send a dummy traceID and verify Tempo answers with 'trace not found'
+    const response = await super.query({ targets: [{ query: '0' }] } as any).toPromise();
 
-    if (!response.error?.message?.startsWith('failed to get trace')) {
-      return { status: 'error', message: 'Data source is not working' };
+    const errorMessage = response.error?.message;
+    if (
+      errorMessage &&
+      errorMessage.startsWith('failed to get trace') &&
+      errorMessage.endsWith('trace not found in Tempo')
+    ) {
+      return { status: 'success', message: 'Data source is working' };
     }
 
-    return { status: 'success', message: 'Data source is working' };
+    return { status: 'error', message: 'Data source is not working' + (errorMessage ? `: ${errorMessage}` : '') };
   }
 
   getQueryDisplayText(query: TempoQuery) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the test data source button for Tempo. The existing implementation does not verify whether the 404 it received from Tempo is caused by a trace not found error (= expected) or path not found (= misconfiguration issue).

Additionally, the query sent to Tempo was incorrect as the query itself was empty `''`. When an empty traceID hits Tempo, it will always respond with path not found, even when configured correctly.

I believe we can further improve the error messages. For instance the first error below is shown as "Metric request error" but the actual error message is "connection refused".

Result:

- if the host is wrong, for instance I've put the wrong port here:

![Screen Shot 2021-05-27 at 18 25 24](https://user-images.githubusercontent.com/7748404/119696916-f5c5b200-be4f-11eb-97ec-ef6f9dcdd7bb.png)

- if you configure the wrong path (i.e. you are hitting Tempo, but not on the query endpoint):

![Screen Shot 2021-05-27 at 18 25 30](https://user-images.githubusercontent.com/7748404/119696956-037b3780-be50-11eb-84f0-832ada7fef72.png)

- message on success

![Screen Shot 2021-05-27 at 18 25 35](https://user-images.githubusercontent.com/7748404/119696977-09711880-be50-11eb-94c5-5aebaa795a00.png)

**Which issue(s) this PR fixes**:
Fixes #32677
Fixes https://github.com/grafana/tempo/issues/624

**Special notes for your reviewer**:
N/A
