### PR TITLE
Usage Stats: Make the UsageStatsService extension point more flexible

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -16,21 +16,21 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var metricsLogger log.Logger = log.New("metrics")
+var metricsLogger = log.New("metrics")
 
 func init() {
 	registry.RegisterService(&Service{
 		log:             log.New("infra.usagestats"),
-		externalMetrics: make(map[string]MetricFunc),
+		externalMetrics: make([]MetricsFunc, 0),
 	})
 }
 
 type UsageStats interface {
-	GetUsageReport(ctx context.Context) (UsageReport, error)
-	RegisterMetric(name string, fn MetricFunc)
+	GetUsageReport(context.Context) (UsageReport, error)
+	RegisterMetricFunc(MetricsFunc)
 }
 
-type MetricFunc func() (interface{}, error)
+type MetricsFunc func() (map[string]interface{}, error)
 
 type Service struct {
 	Cfg                *setting.Cfg               `inject:""`
@@ -43,7 +43,7 @@ type Service struct {
 	log log.Logger
 
 	oauthProviders           map[string]bool
-	externalMetrics          map[string]MetricFunc
+	externalMetrics          []MetricsFunc
 	concurrentUserStatsCache memoConcurrentUserStats
 }
 

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -6,20 +6,21 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 var metricsLogger = log.New("metrics")
 
 func init() {
-	registry.RegisterService(&Service{
+	registry.RegisterService(&UsageStatsService{
 		log:             log.New("infra.usagestats"),
 		externalMetrics: make([]MetricsFunc, 0),
 	})
@@ -32,7 +33,7 @@ type UsageStats interface {
 
 type MetricsFunc func() (map[string]interface{}, error)
 
-type Service struct {
+type UsageStatsService struct {
 	Cfg                *setting.Cfg               `inject:""`
 	Bus                bus.Bus                    `inject:""`
 	SQLStore           *sqlstore.SQLStore         `inject:""`
@@ -47,12 +48,12 @@ type Service struct {
 	concurrentUserStatsCache memoConcurrentUserStats
 }
 
-func (uss *Service) Init() error {
+func (uss *UsageStatsService) Init() error {
 	uss.oauthProviders = social.GetOAuthProviders(uss.Cfg)
 	return nil
 }
 
-func (uss *Service) Run(ctx context.Context) error {
+func (uss *UsageStatsService) Run(ctx context.Context) error {
 	uss.updateTotalStats()
 
 	sendReportTicker := time.NewTicker(time.Hour * 24)
@@ -82,7 +83,7 @@ type memoConcurrentUserStats struct {
 
 const concurrentUserStatsCacheLifetime = time.Hour
 
-func (uss *Service) GetConcurrentUsersStats(ctx context.Context) (*concurrentUsersStats, error) {
+func (uss *UsageStatsService) GetConcurrentUsersStats(ctx context.Context) (*concurrentUsersStats, error) {
 	memoizationPeriod := time.Now().Add(-concurrentUserStatsCacheLifetime)
 	if !uss.concurrentUserStatsCache.memoized.Before(memoizationPeriod) {
 		return uss.concurrentUserStatsCache.stats, nil

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -6,14 +6,13 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
-
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -28,7 +27,7 @@ func init() {
 
 type UsageStats interface {
 	GetUsageReport(context.Context) (UsageReport, error)
-	RegisterMetricFunc(MetricsFunc)
+	RegisterMetricsFunc(MetricsFunc)
 }
 
 type MetricsFunc func() (map[string]interface{}, error)

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -240,18 +240,21 @@ func (uss *Service) GetUsageReport(ctx context.Context) (UsageReport, error) {
 }
 
 func (uss *Service) registerExternalMetrics(metrics map[string]interface{}) {
-	for name, fn := range uss.externalMetrics {
-		result, err := fn()
+	for _, fn := range uss.externalMetrics {
+		fnMetrics, err := fn()
 		if err != nil {
-			metricsLogger.Error("Failed to fetch external metric", "name", name, "error", err)
+			metricsLogger.Error("Failed to fetch external metrics", "error", err)
 			continue
 		}
-		metrics[name] = result
+
+		for name, value := range fnMetrics {
+			metrics[name] = value
+		}
 	}
 }
 
-func (uss *Service) RegisterMetric(name string, fn MetricFunc) {
-	uss.externalMetrics[name] = fn
+func (uss *Service) RegisterMetricFunc(fn MetricsFunc) {
+	uss.externalMetrics = append(uss.externalMetrics, fn)
 }
 
 func (uss *Service) sendUsageStats(ctx context.Context) error {

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -26,7 +26,7 @@ type UsageReport struct {
 	Packaging       string                 `json:"packaging"`
 }
 
-func (uss *Service) GetUsageReport(ctx context.Context) (UsageReport, error) {
+func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, error) {
 	version := strings.ReplaceAll(uss.Cfg.BuildVersion, ".", "_")
 
 	metrics := map[string]interface{}{}
@@ -239,7 +239,7 @@ func (uss *Service) GetUsageReport(ctx context.Context) (UsageReport, error) {
 	return report, nil
 }
 
-func (uss *Service) registerExternalMetrics(metrics map[string]interface{}) {
+func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interface{}) {
 	for _, fn := range uss.externalMetrics {
 		fnMetrics, err := fn()
 		if err != nil {
@@ -253,11 +253,11 @@ func (uss *Service) registerExternalMetrics(metrics map[string]interface{}) {
 	}
 }
 
-func (uss *Service) RegisterMetricFunc(fn MetricsFunc) {
+func (uss *UsageStatsService) RegisterMetricFunc(fn MetricsFunc) {
 	uss.externalMetrics = append(uss.externalMetrics, fn)
 }
 
-func (uss *Service) sendUsageStats(ctx context.Context) error {
+func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
 	if !uss.Cfg.ReportingEnabled {
 		return nil
 	}
@@ -296,7 +296,7 @@ var sendUsageStats = func(data *bytes.Buffer) {
 	}()
 }
 
-func (uss *Service) updateTotalStats() {
+func (uss *UsageStatsService) updateTotalStats() {
 	if !uss.Cfg.MetricsEndpointEnabled || uss.Cfg.MetricsEndpointDisableTotalStats {
 		return
 	}
@@ -336,7 +336,7 @@ func (uss *Service) updateTotalStats() {
 	}
 }
 
-func (uss *Service) shouldBeReported(dsType string) bool {
+func (uss *UsageStatsService) shouldBeReported(dsType string) bool {
 	ds := uss.PluginManager.GetDataSource(dsType)
 	if ds == nil {
 		return false

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -253,7 +253,7 @@ func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interfa
 	}
 }
 
-func (uss *UsageStatsService) RegisterMetricFunc(fn MetricsFunc) {
+func (uss *UsageStatsService) RegisterMetricsFunc(fn MetricsFunc) {
 	uss.externalMetrics = append(uss.externalMetrics, fn)
 }
 

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -26,7 +26,7 @@ type UsageReport struct {
 	Packaging       string                 `json:"packaging"`
 }
 
-func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, error) {
+func (uss *Service) GetUsageReport(ctx context.Context) (UsageReport, error) {
 	version := strings.ReplaceAll(uss.Cfg.BuildVersion, ".", "_")
 
 	metrics := map[string]interface{}{}
@@ -239,7 +239,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	return report, nil
 }
 
-func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interface{}) {
+func (uss *Service) registerExternalMetrics(metrics map[string]interface{}) {
 	for name, fn := range uss.externalMetrics {
 		result, err := fn()
 		if err != nil {
@@ -250,11 +250,11 @@ func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interfa
 	}
 }
 
-func (uss *UsageStatsService) RegisterMetric(name string, fn MetricFunc) {
+func (uss *Service) RegisterMetric(name string, fn MetricFunc) {
 	uss.externalMetrics[name] = fn
 }
 
-func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
+func (uss *Service) sendUsageStats(ctx context.Context) error {
 	if !uss.Cfg.ReportingEnabled {
 		return nil
 	}
@@ -293,7 +293,7 @@ var sendUsageStats = func(data *bytes.Buffer) {
 	}()
 }
 
-func (uss *UsageStatsService) updateTotalStats() {
+func (uss *Service) updateTotalStats() {
 	if !uss.Cfg.MetricsEndpointEnabled || uss.Cfg.MetricsEndpointDisableTotalStats {
 		return
 	}
@@ -333,7 +333,7 @@ func (uss *UsageStatsService) updateTotalStats() {
 	}
 }
 
-func (uss *UsageStatsService) shouldBeReported(dsType string) bool {
+func (uss *Service) shouldBeReported(dsType string) bool {
 	ds := uss.PluginManager.GetDataSource(dsType)
 	if ds == nil {
 		return false

--- a/pkg/infra/usagestats/usage_stats_service_test.go
+++ b/pkg/infra/usagestats/usage_stats_service_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestService_GetConcurrentUsersStats(t *testing.T) {
+func TestUsageStatsService_GetConcurrentUsersStats(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
-	uss := &Service{
+	uss := &UsageStatsService{
 		Bus:      bus.New(),
 		SQLStore: sqlStore,
 		License:  &licensing.OSSLicensingService{},

--- a/pkg/infra/usagestats/usage_stats_service_test.go
+++ b/pkg/infra/usagestats/usage_stats_service_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUsageStatsService_GetConcurrentUsersStats(t *testing.T) {
+func TestService_GetConcurrentUsersStats(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
-	uss := &UsageStatsService{
+	uss := &Service{
 		Bus:      bus.New(),
 		SQLStore: sqlStore,
 		License:  &licensing.OSSLicensingService{},

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -27,9 +27,9 @@ import (
 // This is to ensure that the interface contract is held by the implementation
 func Test_InterfaceContractValidity(t *testing.T) {
 	newUsageStats := func() UsageStats {
-		return &Service{}
+		return &UsageStatsService{}
 	}
-	v, ok := newUsageStats().(*Service)
+	v, ok := newUsageStats().(*UsageStatsService)
 
 	assert.NotNil(t, v)
 	assert.True(t, ok)
@@ -548,7 +548,7 @@ func (pm *fakePluginManager) PanelCount() int {
 	return len(pm.panels)
 }
 
-func setupSomeDataSourcePlugins(t *testing.T, uss *Service) {
+func setupSomeDataSourcePlugins(t *testing.T, uss *UsageStatsService) {
 	t.Helper()
 
 	uss.PluginManager = &fakePluginManager{
@@ -591,10 +591,10 @@ type httpResp struct {
 	err            error
 }
 
-func createService(t *testing.T, cfg setting.Cfg) *Service {
+func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
 	t.Helper()
 
-	return &Service{
+	return &UsageStatsService{
 		Bus:                bus.New(),
 		Cfg:                &cfg,
 		SQLStore:           sqlstore.InitTestDB(t),

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -413,7 +413,7 @@ func TestMetrics(t *testing.T) {
 		metricName := "stats.test_metric.count"
 
 		t.Run("Adds a new metric to the external metrics", func(t *testing.T) {
-			uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+			uss.RegisterMetricsFunc(func() (map[string]interface{}, error) {
 				return map[string]interface{}{metricName: 1}, nil
 			})
 
@@ -467,7 +467,7 @@ func TestMetrics(t *testing.T) {
 		})
 
 		t.Run("Should include external metrics", func(t *testing.T) {
-			uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+			uss.RegisterMetricsFunc(func() (map[string]interface{}, error) {
 				return map[string]interface{}{metricName: 1}, nil
 			})
 
@@ -484,7 +484,7 @@ func TestMetrics(t *testing.T) {
 		metrics := map[string]interface{}{"stats.test_metric.count": 1, "stats.test_metric_second.count": 2}
 		extMetricName := "stats.test_external_metric.count"
 
-		uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+		uss.RegisterMetricsFunc(func() (map[string]interface{}, error) {
 			return map[string]interface{}{extMetricName: 1}, nil
 		})
 
@@ -493,13 +493,13 @@ func TestMetrics(t *testing.T) {
 		assert.Equal(t, 1, metrics[extMetricName])
 
 		t.Run("When loading a metric results to an error", func(t *testing.T) {
-			uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+			uss.RegisterMetricsFunc(func() (map[string]interface{}, error) {
 				return map[string]interface{}{extMetricName: 1}, nil
 			})
 			extErrorMetricName := "stats.test_external_metric_error.count"
 
 			t.Run("Should not add it to metrics", func(t *testing.T) {
-				uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+				uss.RegisterMetricsFunc(func() (map[string]interface{}, error) {
 					return map[string]interface{}{extErrorMetricName: 1}, errors.New("some error")
 				})
 

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -5,25 +5,23 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/licensing"
-	"github.com/stretchr/testify/require"
-
-	"net/http"
-	"net/http/httptest"
-
-	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This is to ensure that the interface contract is held by the implementation
@@ -415,30 +413,13 @@ func TestMetrics(t *testing.T) {
 		metricName := "stats.test_metric.count"
 
 		t.Run("Adds a new metric to the external metrics", func(t *testing.T) {
-			uss.RegisterMetric(metricName, func() (interface{}, error) {
-				return 1, nil
+			uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+				return map[string]interface{}{metricName: 1}, nil
 			})
 
-			metric, err := uss.externalMetrics[metricName]()
+			metrics, err := uss.externalMetrics[0]()
 			require.NoError(t, err)
-			assert.Equal(t, 1, metric)
-		})
-
-		t.Run("When metric already exists, the metric should be overridden", func(t *testing.T) {
-			uss.RegisterMetric(metricName, func() (interface{}, error) {
-				return 1, nil
-			})
-
-			metric, err := uss.externalMetrics[metricName]()
-			require.NoError(t, err)
-			assert.Equal(t, 1, metric)
-
-			uss.RegisterMetric(metricName, func() (interface{}, error) {
-				return 2, nil
-			})
-			newMetric, err := uss.externalMetrics[metricName]()
-			require.NoError(t, err)
-			assert.Equal(t, 2, newMetric)
+			assert.Equal(t, map[string]interface{}{metricName: 1}, metrics)
 		})
 	})
 
@@ -486,8 +467,8 @@ func TestMetrics(t *testing.T) {
 		})
 
 		t.Run("Should include external metrics", func(t *testing.T) {
-			uss.RegisterMetric(metricName, func() (interface{}, error) {
-				return 1, nil
+			uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+				return map[string]interface{}{metricName: 1}, nil
 			})
 
 			report, err := uss.GetUsageReport(context.Background())
@@ -503,8 +484,8 @@ func TestMetrics(t *testing.T) {
 		metrics := map[string]interface{}{"stats.test_metric.count": 1, "stats.test_metric_second.count": 2}
 		extMetricName := "stats.test_external_metric.count"
 
-		uss.RegisterMetric(extMetricName, func() (interface{}, error) {
-			return 1, nil
+		uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+			return map[string]interface{}{extMetricName: 1}, nil
 		})
 
 		uss.registerExternalMetrics(metrics)
@@ -512,14 +493,14 @@ func TestMetrics(t *testing.T) {
 		assert.Equal(t, 1, metrics[extMetricName])
 
 		t.Run("When loading a metric results to an error", func(t *testing.T) {
-			uss.RegisterMetric(extMetricName, func() (interface{}, error) {
-				return 1, nil
+			uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+				return map[string]interface{}{extMetricName: 1}, nil
 			})
 			extErrorMetricName := "stats.test_external_metric_error.count"
 
 			t.Run("Should not add it to metrics", func(t *testing.T) {
-				uss.RegisterMetric(extErrorMetricName, func() (interface{}, error) {
-					return 1, errors.New("some error")
+				uss.RegisterMetricFunc(func() (map[string]interface{}, error) {
+					return map[string]interface{}{extErrorMetricName: 1}, errors.New("some error")
 				})
 
 				uss.registerExternalMetrics(metrics)
@@ -619,7 +600,7 @@ func createService(t *testing.T, cfg setting.Cfg) *Service {
 		SQLStore:           sqlstore.InitTestDB(t),
 		License:            &licensing.OSSLicensingService{},
 		AlertingUsageStats: &alertingUsageMock{},
-		externalMetrics:    make(map[string]MetricFunc),
+		externalMetrics:    make([]MetricsFunc, 0),
 		PluginManager:      &fakePluginManager{},
 	}
 }

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -29,9 +29,9 @@ import (
 // This is to ensure that the interface contract is held by the implementation
 func Test_InterfaceContractValidity(t *testing.T) {
 	newUsageStats := func() UsageStats {
-		return &UsageStatsService{}
+		return &Service{}
 	}
-	v, ok := newUsageStats().(*UsageStatsService)
+	v, ok := newUsageStats().(*Service)
 
 	assert.NotNil(t, v)
 	assert.True(t, ok)
@@ -567,7 +567,7 @@ func (pm *fakePluginManager) PanelCount() int {
 	return len(pm.panels)
 }
 
-func setupSomeDataSourcePlugins(t *testing.T, uss *UsageStatsService) {
+func setupSomeDataSourcePlugins(t *testing.T, uss *Service) {
 	t.Helper()
 
 	uss.PluginManager = &fakePluginManager{
@@ -610,10 +610,10 @@ type httpResp struct {
 	err            error
 }
 
-func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
+func createService(t *testing.T, cfg setting.Cfg) *Service {
 	t.Helper()
 
-	return &UsageStatsService{
+	return &Service{
 		Bus:                bus.New(),
 		Cfg:                &cfg,
 		SQLStore:           sqlstore.InitTestDB(t),

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -39,14 +39,16 @@ func (ac *OSSAccessControlService) IsDisabled() bool {
 }
 
 func (ac *OSSAccessControlService) registerUsageMetrics() {
-	ac.UsageStats.RegisterMetric("stats.oss.accesscontrol.enabled.count", ac.getUsageMetrics)
+	ac.UsageStats.RegisterMetricFunc(ac.getUsageMetrics)
 }
 
-func (ac *OSSAccessControlService) getUsageMetrics() (interface{}, error) {
-	if ac.IsDisabled() {
-		return 0, nil
+func (ac *OSSAccessControlService) getUsageMetrics() (map[string]interface{}, error) {
+	var value int
+	if !ac.IsDisabled() {
+		value = 1
 	}
-	return 1, nil
+
+	return map[string]interface{}{"stats.oss.accesscontrol.enabled.count": value}, nil
 }
 
 // Evaluate evaluates access to the given resource

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -39,16 +39,19 @@ func (ac *OSSAccessControlService) IsDisabled() bool {
 }
 
 func (ac *OSSAccessControlService) registerUsageMetrics() {
-	ac.UsageStats.RegisterMetricFunc(ac.getUsageMetrics)
+	ac.UsageStats.RegisterMetricsFunc(func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"stats.oss.accesscontrol.enabled.count": ac.getUsageMetrics(),
+		}, nil
+	})
 }
 
-func (ac *OSSAccessControlService) getUsageMetrics() (map[string]interface{}, error) {
-	var value int
-	if !ac.IsDisabled() {
-		value = 1
+func (ac *OSSAccessControlService) getUsageMetrics() interface{} {
+	if ac.IsDisabled() {
+		return 0
 	}
 
-	return map[string]interface{}{"stats.oss.accesscontrol.enabled.count": value}, nil
+	return 1
 }
 
 // Evaluate evaluates access to the given resource

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func setupTestEnv(t testing.TB) *OSSAccessControlService {
@@ -23,7 +22,7 @@ func setupTestEnv(t testing.TB) *OSSAccessControlService {
 
 	ac := OSSAccessControlService{
 		Cfg:        cfg,
-		UsageStats: &usageStatsMock{metricFuncs: make(map[string]usagestats.MetricsFunc)},
+		UsageStats: &usageStatsMock{metricsFuncs: make([]usagestats.MetricsFunc, 0)},
 		Log:        log.New("accesscontrol-test"),
 	}
 
@@ -33,22 +32,25 @@ func setupTestEnv(t testing.TB) *OSSAccessControlService {
 }
 
 type usageStatsMock struct {
-	t           *testing.T
-	metricFuncs map[string]usagestats.MetricsFunc
+	t            *testing.T
+	metricsFuncs []usagestats.MetricsFunc
 }
 
-func (usm *usageStatsMock) RegisterMetricFunc(name string, fn usagestats.MetricsFunc) {
-	usm.metricFuncs[name] = fn
+func (usm *usageStatsMock) RegisterMetricsFunc(fn usagestats.MetricsFunc) {
+	usm.metricsFuncs = append(usm.metricsFuncs, fn)
 }
 
 func (usm *usageStatsMock) GetUsageReport(_ context.Context) (usagestats.UsageReport, error) {
-	metrics := make(map[string]interface{})
-	for name, fn := range usm.metricFuncs {
-		v, err := fn()
-		metrics[name] = v
+	all := make(map[string]interface{})
+	for _, fn := range usm.metricsFuncs {
+		fnMetrics, err := fn()
 		require.NoError(usm.t, err)
+
+		for name, value := range fnMetrics {
+			all[name] = value
+		}
 	}
-	return usagestats.UsageReport{Metrics: metrics}, nil
+	return usagestats.UsageReport{Metrics: all}, nil
 }
 
 type evaluatingPermissionsTestCase struct {
@@ -146,7 +148,7 @@ func TestUsageMetrics(t *testing.T) {
 
 			s := &OSSAccessControlService{
 				Cfg:        cfg,
-				UsageStats: &usageStatsMock{t: t, metricFuncs: make(map[string]usagestats.MetricsFunc)},
+				UsageStats: &usageStatsMock{t: t, metricsFuncs: make([]usagestats.MetricsFunc, 0)},
 				Log:        log.New("accesscontrol-test"),
 			}
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -23,7 +23,7 @@ func setupTestEnv(t testing.TB) *OSSAccessControlService {
 
 	ac := OSSAccessControlService{
 		Cfg:        cfg,
-		UsageStats: &usageStatsMock{metricFuncs: make(map[string]usagestats.MetricFunc)},
+		UsageStats: &usageStatsMock{metricFuncs: make(map[string]usagestats.MetricsFunc)},
 		Log:        log.New("accesscontrol-test"),
 	}
 
@@ -34,10 +34,10 @@ func setupTestEnv(t testing.TB) *OSSAccessControlService {
 
 type usageStatsMock struct {
 	t           *testing.T
-	metricFuncs map[string]usagestats.MetricFunc
+	metricFuncs map[string]usagestats.MetricsFunc
 }
 
-func (usm *usageStatsMock) RegisterMetric(name string, fn usagestats.MetricFunc) {
+func (usm *usageStatsMock) RegisterMetricFunc(name string, fn usagestats.MetricsFunc) {
 	usm.metricFuncs[name] = fn
 }
 
@@ -146,7 +146,7 @@ func TestUsageMetrics(t *testing.T) {
 
 			s := &OSSAccessControlService{
 				Cfg:        cfg,
-				UsageStats: &usageStatsMock{t: t, metricFuncs: make(map[string]usagestats.MetricFunc)},
+				UsageStats: &usageStatsMock{t: t, metricFuncs: make(map[string]usagestats.MetricsFunc)},
 				Log:        log.New("accesscontrol-test"),
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It changes the definition of a `MetricFunc` by `type MetricFunc func() (interface{}, error)` to `type MetricsFunc func() (map[string]interface{}, error)` in order to make the `UsageStatsService` extension point more flexible. Moreover, it adapts the current code according to this new type definition.

**Special notes for your reviewer**:

Related design doc: https://docs.google.com/document/d/1vewDqVBeeNusvPaz9dOvsbOK01IQSEcp32KRC9ekWw4/edit#