### PR TITLE
Chore: Fix jaeger devenv block

### DIFF
--- a/devenv/docker/blocks/jaeger/docker-compose.yaml
+++ b/devenv/docker/blocks/jaeger/docker-compose.yaml
@@ -1,8 +1,10 @@
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
-      - "6831:6831"
+      - "6831:6831/udp"
       - "16686:16686"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   # Additional loki to generate some traces
   # datasource URL: http://localhost:3100/
   loki:

--- a/devenv/docker/blocks/jaeger/docker-compose.yaml
+++ b/devenv/docker/blocks/jaeger/docker-compose.yaml
@@ -3,8 +3,6 @@
     ports:
       - "6831:6831/udp"
       - "16686:16686"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
   # Additional loki to generate some traces
   # datasource URL: http://localhost:3100/
   loki:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix so that local Grafana instance can send traces to Jaeger using localhost address:
```ini
[tracing.jaeger]
address = localhost:6831
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- Only tested on Ubuntu 20.04
- Added the `extra_hosts` to make it work on Mac (I believe)