### PR TITLE
StateTimeline: Default line width to 0

### DIFF
--- a/public/app/plugins/panel/state-timeline/types.ts
+++ b/public/app/plugins/panel/state-timeline/types.ts
@@ -41,7 +41,7 @@ export const defaultPanelOptions: Partial<TimelineOptions> = {
  * @alpha
  */
 export const defaultTimelineFieldConfig: TimelineFieldConfig = {
-  lineWidth: 1,
+  lineWidth: 0,
   fillOpacity: 70,
 };
 


### PR DESCRIPTION
Without the gap option the line stroke is just in the way, so setting default line width to 0
