### PR TITLE
AddPanelWidget: Add padding to prevent top being cut off

### DIFF
--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.tsx
@@ -136,38 +136,40 @@ export const AddPanelWidgetUnconnected: React.FC<Props> = ({ panel, dashboard })
   const copiedPanelPlugins = useMemo(() => getCopiedPanelPlugins(), []);
 
   return (
-    <div className={cx('panel-container', styles.wrapper)}>
-      <AddPanelWidgetHandle onCancel={onCancelAddPanel} onBack={addPanelView ? onBack : undefined} styles={styles}>
-        {addPanelView ? 'Add panel from panel library' : 'Add panel'}
-      </AddPanelWidgetHandle>
-      {addPanelView ? (
-        <LibraryPanelsSearch onClick={onAddLibraryPanel} variant={LibraryPanelsSearchVariant.Tight} showPanelFilter />
-      ) : (
-        <div className={styles.actionsWrapper}>
-          <div className={styles.actionsRow}>
-            <div onClick={() => onCreateNewPanel()} aria-label={selectors.pages.AddDashboard.addNewPanel}>
-              <Icon name="file-blank" size="xl" />
-              Add an empty panel
-            </div>
-            <div onClick={onCreateNewRow}>
-              <Icon name="wrap-text" size="xl" />
-              Add a new row
-            </div>
-          </div>
-          <div className={styles.actionsRow}>
-            <div onClick={() => setAddPanelView(true)}>
-              <Icon name="book-open" size="xl" />
-              Add a panel from the panel library
-            </div>
-            {copiedPanelPlugins.length === 1 && (
-              <div onClick={() => onPasteCopiedPanel(copiedPanelPlugins[0])}>
-                <Icon name="clipboard-alt" size="xl" />
-                Paste panel from clipboard
+    <div className={styles.wrapper}>
+      <div className={cx('panel-container', styles.callToAction)}>
+        <AddPanelWidgetHandle onCancel={onCancelAddPanel} onBack={addPanelView ? onBack : undefined} styles={styles}>
+          {addPanelView ? 'Add panel from panel library' : 'Add panel'}
+        </AddPanelWidgetHandle>
+        {addPanelView ? (
+          <LibraryPanelsSearch onClick={onAddLibraryPanel} variant={LibraryPanelsSearchVariant.Tight} showPanelFilter />
+        ) : (
+          <div className={styles.actionsWrapper}>
+            <div className={styles.actionsRow}>
+              <div onClick={() => onCreateNewPanel()} aria-label={selectors.pages.AddDashboard.addNewPanel}>
+                <Icon name="file-blank" size="xl" />
+                Add an empty panel
               </div>
-            )}
+              <div onClick={onCreateNewRow}>
+                <Icon name="wrap-text" size="xl" />
+                Add a new row
+              </div>
+            </div>
+            <div className={styles.actionsRow}>
+              <div onClick={() => setAddPanelView(true)}>
+                <Icon name="book-open" size="xl" />
+                Add a panel from the panel library
+              </div>
+              {copiedPanelPlugins.length === 1 && (
+                <div onClick={() => onPasteCopiedPanel(copiedPanelPlugins[0])}>
+                  <Icon name="clipboard-alt" size="xl" />
+                  Paste panel from clipboard
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };
@@ -213,7 +215,12 @@ const getStyles = (theme: GrafanaTheme) => {
   `;
 
   return {
+    // wrapper is used to make sure box-shadow animation isn't cut off in dashboard page
     wrapper: css`
+      height: 100%;
+      padding-top: ${theme.spacing.sm};
+    `,
+    callToAction: css`
       overflow: hidden;
       outline: 2px dotted transparent;
       outline-offset: 2px;

--- a/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.tsx
+++ b/public/app/features/dashboard/components/AddPanelWidget/AddPanelWidget.tsx
@@ -218,7 +218,7 @@ const getStyles = (theme: GrafanaTheme) => {
     // wrapper is used to make sure box-shadow animation isn't cut off in dashboard page
     wrapper: css`
       height: 100%;
-      padding-top: ${theme.spacing.sm};
+      padding-top: ${theme.spacing.xs};
     `,
     callToAction: css`
       overflow: hidden;

--- a/public/app/features/dashboard/components/AddPanelWidget/__snapshots__/AddPanelWidget.test.tsx.snap
+++ b/public/app/features/dashboard/components/AddPanelWidget/__snapshots__/AddPanelWidget.test.tsx.snap
@@ -2,60 +2,65 @@
 
 exports[`Render should render component 1`] = `
 <div
-  className="panel-container css-e4b3m6"
+  className="css-1q8dxo2"
 >
-  <AddPanelWidgetHandle
-    onCancel={[Function]}
-    styles={
-      Object {
-        "actionsRow": "css-l02n0m",
-        "actionsWrapper": "css-gxxmom",
-        "backButton": "css-1cdxa9p",
-        "headerRow": "css-3sdqvi",
-        "noMargin": "css-u023fv",
-        "wrapper": "css-e4b3m6",
-      }
-    }
-  >
-    Add panel
-  </AddPanelWidgetHandle>
   <div
-    className="css-gxxmom"
+    className="panel-container css-e4b3m6"
   >
+    <AddPanelWidgetHandle
+      onCancel={[Function]}
+      styles={
+        Object {
+          "actionsRow": "css-l02n0m",
+          "actionsWrapper": "css-gxxmom",
+          "backButton": "css-1cdxa9p",
+          "callToAction": "css-e4b3m6",
+          "headerRow": "css-3sdqvi",
+          "noMargin": "css-u023fv",
+          "wrapper": "css-1q8dxo2",
+        }
+      }
+    >
+      Add panel
+    </AddPanelWidgetHandle>
     <div
-      className="css-l02n0m"
+      className="css-gxxmom"
     >
       <div
-        aria-label="Add new panel"
-        onClick={[Function]}
+        className="css-l02n0m"
       >
-        <Icon
-          name="file-blank"
-          size="xl"
-        />
-        Add an empty panel
+        <div
+          aria-label="Add new panel"
+          onClick={[Function]}
+        >
+          <Icon
+            name="file-blank"
+            size="xl"
+          />
+          Add an empty panel
+        </div>
+        <div
+          onClick={[Function]}
+        >
+          <Icon
+            name="wrap-text"
+            size="xl"
+          />
+          Add a new row
+        </div>
       </div>
       <div
-        onClick={[Function]}
+        className="css-l02n0m"
       >
-        <Icon
-          name="wrap-text"
-          size="xl"
-        />
-        Add a new row
-      </div>
-    </div>
-    <div
-      className="css-l02n0m"
-    >
-      <div
-        onClick={[Function]}
-      >
-        <Icon
-          name="book-open"
-          size="xl"
-        />
-        Add a panel from the panel library
+        <div
+          onClick={[Function]}
+        >
+          <Icon
+            name="book-open"
+            size="xl"
+          />
+          Add a panel from the panel library
+        </div>
       </div>
     </div>
   </div>

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -375,7 +375,7 @@ const mapDispatchToProps = {
  * Styles
  */
 export const getStyles = stylesFactory((theme: GrafanaTheme2, kioskMode) => {
-  const contentPadding = kioskMode !== KioskMode.Full ? theme.spacing(0, 2, 2) : theme.spacing(2);
+  const contentPadding = kioskMode !== KioskMode.Full ? theme.spacing(0.5, 2, 2) : theme.spacing(2);
   return {
     dashboardContainer: css`
       position: absolute;

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -375,7 +375,7 @@ const mapDispatchToProps = {
  * Styles
  */
 export const getStyles = stylesFactory((theme: GrafanaTheme2, kioskMode) => {
-  const contentPadding = kioskMode !== KioskMode.Full ? theme.spacing(0.5, 2, 2) : theme.spacing(2);
+  const contentPadding = kioskMode !== KioskMode.Full ? theme.spacing(0, 2, 2) : theme.spacing(2);
   return {
     dashboardContainer: css`
       position: absolute;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This adds a wrapping element with padding-top to the AddPanelWidget wrapper (due to padding removed here: https://github.com/grafana/grafana/pull/34602) so the add new panel chrome isn't cut off.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/73201/119810120-09235c80-bee6-11eb-892a-68e62e121989.png) | ![after](https://user-images.githubusercontent.com/73201/119810286-2f48fc80-bee6-11eb-82ac-cdb1321995e6.png) |



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related issue #33187

**Special notes for your reviewer**:

