### PR TITLE
grafana/ui: Make sure ConfirmButton cannot be clicked when closed

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.tsx
+++ b/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.tsx
@@ -155,12 +155,14 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       display: flex;
       overflow: hidden;
       position: absolute;
+      pointer-events: none;
     `,
     confirmButtonShow: css`
       z-index: 1;
       opacity: 1;
       transition: opacity 0.08s ease-out, transform 0.1s ease-out;
       transform: translateX(0);
+      pointer-events: all;
     `,
     confirmButtonHide: css`
       opacity: 0;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When in closed state, ConfirmButton's actions can still be clicked even though they're not visible on the screen. 
This PR disables all pointer events for the buttons in closed state. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/1500

**Special notes for your reviewer**:

