### PR TITLE
OAuth: Add setting to skip org assignment for external users

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -344,9 +344,6 @@ auto_assign_org_id = 1
 # Default role new users will be automatically assigned (if auto_assign_org above is set to true)
 auto_assign_org_role = Viewer
 
-# Skip forced assignment of OrgID 1 or 'auto_assign_org_id'  for social logins
-skip_org_role_update_sync = false
-
 # Require email validation before sign up completes
 verify_email_enabled = false
 
@@ -405,6 +402,9 @@ oauth_auto_login = false
 
 # OAuth state max age cookie duration in seconds. Defaults to 600 seconds.
 oauth_state_cookie_max_age = 600
+
+# Skip forced assignment of OrgID 1 or 'auto_assign_org_id' for social logins
+oauth_skip_org_role_update_sync = false
 
 # limit of api_key seconds to live before expiration
 api_key_max_seconds_to_live = -1

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -344,6 +344,9 @@ auto_assign_org_id = 1
 # Default role new users will be automatically assigned (if auto_assign_org above is set to true)
 auto_assign_org_role = Viewer
 
+# Skip forced assignment of OrgID 1 or 'auto_assign_org_id'  for social logins
+skip_org_role_update_sync = false
+
 # Require email validation before sign up completes
 verify_email_enabled = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -397,6 +397,9 @@
 # OAuth state max age cookie duration in seconds. Defaults to 600 seconds.
 ;oauth_state_cookie_max_age = 600
 
+# Skip forced assignment of OrgID 1 or 'auto_assign_org_id' for social logins
+;oauth_skip_org_role_update_sync = false
+
 # limit of api_key seconds to live before expiration
 ;api_key_max_seconds_to_live = -1
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -677,12 +677,6 @@ options are `Admin` and `Editor`. e.g.:
 
 `auto_assign_org_role = Viewer`
 
-### skip_org_role_update_sync
-
-Skip forced assignment of OrgID `1` or `auto_assign_org_id` for external logins. Default is `false`.
-Use this setting to distribute users with external login to multiple organizations.
-Otherwise, the users' organization would get reset on every new login, for example, via AzureAD.
-
 ### verify_email_enabled
 
 Require email validation before sign up completes. Default is `false`.
@@ -771,6 +765,12 @@ This setting is ignored if multiple OAuth providers are configured. Default is `
 
 How many seconds the OAuth state cookie lives before being deleted. Default is `600` (seconds)
 Administrators can increase this if they experience OAuth login state mismatch errors.
+
+### oauth_skip_org_role_update_sync
+
+Skip forced assignment of OrgID `1` or `auto_assign_org_id` for external logins. Default is `false`.
+Use this setting to distribute users with external login to multiple organizations.
+Otherwise, the users' organization would get reset on every new login, for example, via AzureAD.
 
 ### api_key_max_seconds_to_live
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -677,6 +677,12 @@ options are `Admin` and `Editor`. e.g.:
 
 `auto_assign_org_role = Viewer`
 
+### skip_org_role_update_sync
+
+Skip forced assignment of OrgID `1` or `auto_assign_org_id` for external logins. Default is `false`.
+Use this setting to distribute users with external login to multiple organizations.
+Otherwise, the users' organization would get reset on every new login, for example, via AzureAD.
+
 ### verify_email_enabled
 
 Require email validation before sign up completes. Default is `false`.

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -278,7 +278,7 @@ func buildExternalUserInfo(token *oauth2.Token, userInfo *social.BasicUserInfo, 
 		Groups:     userInfo.Groups,
 	}
 
-	if userInfo.Role != "" {
+	if userInfo.Role != "" && !setting.SkipOrgRoleUpdateSync {
 		rt := models.RoleType(userInfo.Role)
 		if rt.IsValid() {
 			// The user will be assigned a role in either the auto-assigned organization or in the default one

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -132,7 +132,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) response.Response {
 			return nil
 		}
 
-		hashedState := hashStatecode(state, provider.ClientSecret)
+		hashedState := hs.hashStatecode(state, provider.ClientSecret)
 		cookies.WriteCookie(ctx.Resp, OauthStateCookieName, hashedState, hs.Cfg.OAuthCookieMaxAge, hs.CookieOptionsFromCfg)
 		if provider.HostedDomain != "" {
 			opts = append(opts, oauth2.SetAuthURLParam("hd", provider.HostedDomain))
@@ -155,7 +155,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) response.Response {
 		return nil
 	}
 
-	queryState := hashStatecode(ctx.Query("state"), provider.ClientSecret)
+	queryState := hs.hashStatecode(ctx.Query("state"), provider.ClientSecret)
 	oauthLogger.Info("state check", "queryState", queryState, "cookieState", cookieState)
 	if cookieState != queryState {
 		hs.handleOAuthLoginError(ctx, loginInfo, LoginError{
@@ -234,7 +234,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) response.Response {
 		return nil
 	}
 
-	loginInfo.ExternalUser = *buildExternalUserInfo(token, userInfo, name)
+	loginInfo.ExternalUser = *hs.buildExternalUserInfo(token, userInfo, name)
 	loginInfo.User, err = hs.SyncUser(ctx, &loginInfo.ExternalUser, connect)
 	if err != nil {
 		hs.handleOAuthLoginErrorWithRedirect(ctx, loginInfo, err)
@@ -265,7 +265,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) response.Response {
 }
 
 // buildExternalUserInfo returns a ExternalUserInfo struct from OAuth user profile
-func buildExternalUserInfo(token *oauth2.Token, userInfo *social.BasicUserInfo, name string) *models.ExternalUserInfo {
+func (hs *HTTPServer) buildExternalUserInfo(token *oauth2.Token, userInfo *social.BasicUserInfo, name string) *models.ExternalUserInfo {
 	oauthLogger.Debug("Building external user info from OAuth user info")
 
 	extUser := &models.ExternalUserInfo{
@@ -279,13 +279,13 @@ func buildExternalUserInfo(token *oauth2.Token, userInfo *social.BasicUserInfo, 
 		Groups:     userInfo.Groups,
 	}
 
-	if userInfo.Role != "" && !setting.OAuthSkipOrgRoleUpdateSync {
+	if userInfo.Role != "" && !hs.Cfg.OAuthSkipOrgRoleUpdateSync {
 		rt := models.RoleType(userInfo.Role)
 		if rt.IsValid() {
 			// The user will be assigned a role in either the auto-assigned organization or in the default one
 			var orgID int64
-			if setting.AutoAssignOrg && setting.AutoAssignOrgId > 0 {
-				orgID = int64(setting.AutoAssignOrgId)
+			if hs.Cfg.AutoAssignOrg && hs.Cfg.AutoAssignOrgId > 0 {
+				orgID = int64(hs.Cfg.AutoAssignOrgId)
 				plog.Debug("The user has a role assignment and organization membership is auto-assigned",
 					"role", userInfo.Role, "orgId", orgID)
 			} else {
@@ -328,8 +328,8 @@ func (hs *HTTPServer) SyncUser(
 	return cmd.Result, nil
 }
 
-func hashStatecode(code, seed string) string {
-	hashBytes := sha256.Sum256([]byte(code + setting.SecretKey + seed))
+func (hs *HTTPServer) hashStatecode(code, seed string) string {
+	hashBytes := sha256.Sum256([]byte(code + hs.Cfg.SecretKey + seed))
 	return hex.EncodeToString(hashBytes[:])
 }
 

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"golang.org/x/oauth2"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -20,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
-	"golang.org/x/oauth2"
 )
 
 var (
@@ -278,7 +279,7 @@ func buildExternalUserInfo(token *oauth2.Token, userInfo *social.BasicUserInfo, 
 		Groups:     userInfo.Groups,
 	}
 
-	if userInfo.Role != "" && !setting.SkipOrgRoleUpdateSync {
+	if userInfo.Role != "" && !setting.OAuthSkipOrgRoleUpdateSync {
 		rt := models.RoleType(userInfo.Role)
 		if rt.IsValid() {
 			// The user will be assigned a role in either the auto-assigned organization or in the default one

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -101,23 +101,23 @@ var (
 	MinRefreshInterval      string
 
 	// User settings
-	AllowUserSignUp         bool
-	AllowUserOrgCreate      bool
-	AutoAssignOrg           bool
-	AutoAssignOrgId         int
-	SkipOrgRoleUpdateSync   bool
-	AutoAssignOrgRole       string
-	VerifyEmailEnabled      bool
-	LoginHint               string
-	PasswordHint            string
-	DisableLoginForm        bool
-	DisableSignoutMenu      bool
-	SignoutRedirectUrl      string
-	ExternalUserMngLinkUrl  string
-	ExternalUserMngLinkName string
-	ExternalUserMngInfo     string
-	OAuthAutoLogin          bool
-	ViewersCanEdit          bool
+	AllowUserSignUp            bool
+	AllowUserOrgCreate         bool
+	AutoAssignOrg              bool
+	AutoAssignOrgId            int
+	OAuthSkipOrgRoleUpdateSync bool
+	AutoAssignOrgRole          string
+	VerifyEmailEnabled         bool
+	LoginHint                  string
+	PasswordHint               string
+	DisableLoginForm           bool
+	DisableSignoutMenu         bool
+	SignoutRedirectUrl         string
+	ExternalUserMngLinkUrl     string
+	ExternalUserMngLinkName    string
+	ExternalUserMngInfo        string
+	OAuthAutoLogin             bool
+	ViewersCanEdit             bool
 
 	// HTTP auth
 	SigV4AuthEnabled bool
@@ -395,10 +395,10 @@ type Cfg struct {
 	DefaultTheme string
 	HomePage     string
 
-	AutoAssignOrg         bool
-	AutoAssignOrgId       int
-	AutoAssignOrgRole     string
-	SkipOrgRoleUpdateSync bool
+	AutoAssignOrg              bool
+	AutoAssignOrgId            int
+	AutoAssignOrgRole          string
+	OAuthSkipOrgRoleUpdateSync bool
 
 	// ExpressionsEnabled specifies whether expressions are enabled.
 	ExpressionsEnabled bool
@@ -1254,6 +1254,8 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)
 	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
 	SignoutRedirectUrl = valueAsString(auth, "signout_redirect_url", "")
+	cfg.OAuthSkipOrgRoleUpdateSync = auth.Key("oauth_skip_org_role_update_sync").MustBool(false)
+	OAuthSkipOrgRoleUpdateSync = cfg.OAuthSkipOrgRoleUpdateSync
 
 	// SigV4
 	SigV4AuthEnabled = auth.Key("sigv4_auth_enabled").MustBool(false)
@@ -1328,8 +1330,6 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	AutoAssignOrg = cfg.AutoAssignOrg
 	cfg.AutoAssignOrgId = users.Key("auto_assign_org_id").MustInt(1)
 	AutoAssignOrgId = cfg.AutoAssignOrgId
-	cfg.SkipOrgRoleUpdateSync = users.Key("skip_org_role_update_sync").MustBool(false)
-	SkipOrgRoleUpdateSync = cfg.SkipOrgRoleUpdateSync
 	cfg.AutoAssignOrgRole = users.Key("auto_assign_org_role").In("Editor", []string{"Editor", "Admin", "Viewer"})
 	AutoAssignOrgRole = cfg.AutoAssignOrgRole
 	VerifyEmailEnabled = users.Key("verify_email_enabled").MustBool(false)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -101,23 +101,22 @@ var (
 	MinRefreshInterval      string
 
 	// User settings
-	AllowUserSignUp            bool
-	AllowUserOrgCreate         bool
-	AutoAssignOrg              bool
-	AutoAssignOrgId            int
-	OAuthSkipOrgRoleUpdateSync bool
-	AutoAssignOrgRole          string
-	VerifyEmailEnabled         bool
-	LoginHint                  string
-	PasswordHint               string
-	DisableLoginForm           bool
-	DisableSignoutMenu         bool
-	SignoutRedirectUrl         string
-	ExternalUserMngLinkUrl     string
-	ExternalUserMngLinkName    string
-	ExternalUserMngInfo        string
-	OAuthAutoLogin             bool
-	ViewersCanEdit             bool
+	AllowUserSignUp         bool
+	AllowUserOrgCreate      bool
+	AutoAssignOrg           bool
+	AutoAssignOrgId         int
+	AutoAssignOrgRole       string
+	VerifyEmailEnabled      bool
+	LoginHint               string
+	PasswordHint            string
+	DisableLoginForm        bool
+	DisableSignoutMenu      bool
+	SignoutRedirectUrl      string
+	ExternalUserMngLinkUrl  string
+	ExternalUserMngLinkName string
+	ExternalUserMngInfo     string
+	OAuthAutoLogin          bool
+	ViewersCanEdit          bool
 
 	// HTTP auth
 	SigV4AuthEnabled bool
@@ -1255,7 +1254,6 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
 	SignoutRedirectUrl = valueAsString(auth, "signout_redirect_url", "")
 	cfg.OAuthSkipOrgRoleUpdateSync = auth.Key("oauth_skip_org_role_update_sync").MustBool(false)
-	OAuthSkipOrgRoleUpdateSync = cfg.OAuthSkipOrgRoleUpdateSync
 
 	// SigV4
 	SigV4AuthEnabled = auth.Key("sigv4_auth_enabled").MustBool(false)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -105,6 +105,7 @@ var (
 	AllowUserOrgCreate      bool
 	AutoAssignOrg           bool
 	AutoAssignOrgId         int
+	SkipOrgRoleUpdateSync   bool
 	AutoAssignOrgRole       string
 	VerifyEmailEnabled      bool
 	LoginHint               string
@@ -394,9 +395,10 @@ type Cfg struct {
 	DefaultTheme string
 	HomePage     string
 
-	AutoAssignOrg     bool
-	AutoAssignOrgId   int
-	AutoAssignOrgRole string
+	AutoAssignOrg         bool
+	AutoAssignOrgId       int
+	AutoAssignOrgRole     string
+	SkipOrgRoleUpdateSync bool
 
 	// ExpressionsEnabled specifies whether expressions are enabled.
 	ExpressionsEnabled bool
@@ -1326,6 +1328,8 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	AutoAssignOrg = cfg.AutoAssignOrg
 	cfg.AutoAssignOrgId = users.Key("auto_assign_org_id").MustInt(1)
 	AutoAssignOrgId = cfg.AutoAssignOrgId
+	cfg.SkipOrgRoleUpdateSync = users.Key("skip_org_role_update_sync").MustBool(false)
+	SkipOrgRoleUpdateSync = cfg.SkipOrgRoleUpdateSync
 	cfg.AutoAssignOrgRole = users.Key("auto_assign_org_role").In("Editor", []string{"Editor", "Admin", "Viewer"})
 	AutoAssignOrgRole = cfg.AutoAssignOrgRole
 	VerifyEmailEnabled = users.Key("verify_email_enabled").MustBool(false)


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce `skip_social_org_role_assign` setting to skip any kind of org assignment during the login of external users.
As a consequence manual organization assignments won't be overridden during the upsert of an external user.

**Which issue(s) this PR fixes**:

Fixes #22605

**Special notes for your reviewer**:

