### PR TITLE
OAuth: Fix fallback to auto_assign_org_role setting for Azure AD OAuth when no role claims exists

### DIFF
--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -98,11 +98,7 @@ func extractEmail(claims azureClaims) string {
 
 func extractRole(claims azureClaims) models.RoleType {
 	if len(claims.Roles) == 0 {
-		if setting.AutoAssignOrgRole == "" {
-			return models.ROLE_VIEWER
-		} else {
-			return models.RoleType(setting.AutoAssignOrgRole)
-		}
+		return models.RoleType(setting.AutoAssignOrgRole)
 	}
 
 	roleOrder := []models.RoleType{

--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
 
 	"golang.org/x/oauth2"
@@ -97,7 +98,11 @@ func extractEmail(claims azureClaims) string {
 
 func extractRole(claims azureClaims) models.RoleType {
 	if len(claims.Roles) == 0 {
-		return models.ROLE_VIEWER
+		if setting.AutoAssignOrgRole == "" {
+			return models.ROLE_VIEWER
+		} else {
+			return models.RoleType(setting.AutoAssignOrgRole)
+		}
 	}
 
 	roleOrder := []models.RoleType{

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/setting"
 	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -21,12 +22,13 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		fields  fields
-		claims  *azureClaims
-		args    args
-		want    *BasicUserInfo
-		wantErr bool
+		name                     string
+		fields                   fields
+		claims                   *azureClaims
+		args                     args
+		settingAutoAssignOrgRole string
+		want                     *BasicUserInfo
+		wantErr                  bool
 	}{
 		{
 			name: "Email in email claim",
@@ -141,7 +143,26 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Groups:  []string{},
 			},
 		},
-
+		{
+			name: "role from env variable",
+			claims: &azureClaims{
+				Email:             "me@example.com",
+				PreferredUsername: "",
+				Roles:             []string{},
+				Name:              "My Name",
+				ID:                "1234",
+			},
+			settingAutoAssignOrgRole: "Editor",
+			want: &BasicUserInfo{
+				Id:      "1234",
+				Name:    "My Name",
+				Email:   "me@example.com",
+				Login:   "me@example.com",
+				Company: "",
+				Role:    "Editor",
+				Groups:  []string{},
+			},
+		},
 		{
 			name: "Editor role",
 			claims: &azureClaims{
@@ -257,6 +278,8 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			if tt.claims != nil {
 				token = token.WithExtra(map[string]interface{}{"id_token": raw})
 			}
+
+			setting.AutoAssignOrgRole = tt.settingAutoAssignOrgRole
 
 			got, err := s.UserInfo(tt.args.client, token)
 			if (err != nil) != tt.wantErr {

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -39,6 +39,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Name:              "My Name",
 				ID:                "1234",
 			},
+			settingAutoAssignOrgRole: "Viewer",
 			want: &BasicUserInfo{
 				Id:      "1234",
 				Name:    "My Name",
@@ -76,6 +77,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Name:              "My Name",
 				ID:                "1234",
 			},
+			settingAutoAssignOrgRole: "Viewer",
 			want: &BasicUserInfo{
 				Id:      "1234",
 				Name:    "My Name",
@@ -230,6 +232,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Name:              "My Name",
 				ID:                "1234",
 			},
+			settingAutoAssignOrgRole: "Viewer",
 			want: &BasicUserInfo{
 				Id:      "1234",
 				Name:    "My Name",


### PR DESCRIPTION
**What this PR does / why we need it**:
Rather than fallback to Viewer role when no role claims exists, fixes so it fallback to auto_assign_org_role setting.

**Which issue(s) this PR fixes**:
Fixes #30555 

**Special notes for your reviewer**:

