### PR TITLE
Stat: don't use layout with sparkline if y field is not number or boolean

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties } from 'react';
 import tinycolor from 'tinycolor2';
 
 // Utils
-import { formattedValueToString, DisplayValue, FieldConfig } from '@grafana/data';
+import { formattedValueToString, DisplayValue, FieldConfig, FieldType } from '@grafana/data';
 import { calculateFontSize } from '../../utils/measureText';
 
 // Types
@@ -413,9 +413,10 @@ export class StackedWithNoChartLayout extends BigValueLayout {
 export function buildLayout(props: Props): BigValueLayout {
   const { width, height, sparkline } = props;
   const useWideLayout = width / height > 2.5;
+  const graphableSparkline = sparkline?.y.type === FieldType.number || sparkline?.y.type === FieldType.boolean;
 
   if (useWideLayout) {
-    if (height > 50 && !!sparkline) {
+    if (height > 50 && graphableSparkline) {
       return new WideWithChartLayout(props);
     } else {
       return new WideNoChartLayout(props);
@@ -423,7 +424,7 @@ export function buildLayout(props: Props): BigValueLayout {
   }
 
   // stacked layouts
-  if (height > 100 && !!sparkline) {
+  if (height > 100 && graphableSparkline) {
     return new StackedWithChartLayout(props);
   } else {
     return new StackedWithNoChartLayout(props);


### PR DESCRIPTION
without this, Stat panel chooses a layout with sparkline (and tries to render a graph) even when there are no graph-able y fields.

related: https://github.com/grafana/grafana/issues/34835

feels like this should be handled even earlier by not creating the sparkline object at all, but that appears to be more involved.