### PR TITLE
Stat: don't show sparkline if y field is not number

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -204,7 +204,7 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
           }
 
           let sparkline: FieldSparkline | undefined = undefined;
-          if (options.sparkline) {
+          if (options.sparkline && dataFrame.fields[i].type === FieldType.number) {
             sparkline = {
               y: dataFrame.fields[i],
               x: timeField,

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -204,7 +204,7 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
           }
 
           let sparkline: FieldSparkline | undefined = undefined;
-          if (options.sparkline && dataFrame.fields[i].type === FieldType.number) {
+          if (options.sparkline) {
             sparkline = {
               y: dataFrame.fields[i],
               x: timeField,

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -151,8 +151,7 @@ export abstract class BigValueLayout {
   renderChart(): JSX.Element | null {
     const { sparkline, colorMode } = this.props;
 
-    const fieldType = sparkline?.y?.type;
-    if (fieldType !== FieldType.number) {
+    if (!sparkline || sparkline.y?.type !== FieldType.number) {
       return null;
     }
 

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -3,7 +3,7 @@ import React, { CSSProperties } from 'react';
 import tinycolor from 'tinycolor2';
 
 // Utils
-import { formattedValueToString, DisplayValue, FieldConfig } from '@grafana/data';
+import { formattedValueToString, DisplayValue, FieldConfig, FieldType } from '@grafana/data';
 import { calculateFontSize } from '../../utils/measureText';
 
 // Types
@@ -151,7 +151,8 @@ export abstract class BigValueLayout {
   renderChart(): JSX.Element | null {
     const { sparkline, colorMode } = this.props;
 
-    if (!sparkline || !sparkline.y) {
+    const fieldType = sparkline?.y?.type;
+    if (fieldType !== FieldType.number) {
       return null;
     }
 


### PR DESCRIPTION
Alternative to: #34856

could support boolean, but need the bool > number logic applied here also