### PR TITLE
BarChart: hide cursor crosshair

### DIFF
--- a/public/app/plugins/panel/barchart/__snapshots__/utils.test.ts.snap
+++ b/public/app/plugins/panel/barchart/__snapshots__/utils.test.ts.snap
@@ -65,6 +65,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [
@@ -185,6 +187,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [
@@ -305,6 +309,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [
@@ -425,6 +431,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [
@@ -545,6 +553,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [
@@ -665,6 +675,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [
@@ -785,6 +797,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [
@@ -905,6 +919,8 @@ Object {
       "stroke": [Function],
       "width": [Function],
     },
+    "x": false,
+    "y": false,
   },
   "hooks": Object {
     "draw": Array [

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -353,6 +353,10 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
   };
 
   return {
+    cursor: {
+      x: false,
+      y: false,
+    },
     // scale & axis opts
     xValues,
     xSplits,

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -75,6 +75,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptions> = ({
 
   const config = getConfig(opts, theme);
 
+  builder.setCursor(config.cursor);
+
   builder.addHook('init', config.init);
   builder.addHook('drawClear', config.drawClear);
   builder.addHook('draw', config.draw);


### PR DESCRIPTION
we don't need it in bar charts, and it also doesn't work correctly in hz layout mode.