### PR TITLE
BarChart: make sure tooltip closes when user presses E

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -56,6 +56,7 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
     }
 
     return () => {
+      setCoords(null);
       if (plotCtx && plotCtx.plot) {
         plotCtx.plot.over.removeEventListener('mouseleave', plotMouseLeave);
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes tooltip when tooltip plugin is unmounted.

**Which issue(s) this PR fixes**:
Fixes #34790
