### PR TITLE
Alerting: Do no hard fail on finding discontinued channels on migration

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/channel.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel.go
@@ -110,7 +110,8 @@ func (m *migration) makeReceiverAndRoute(ruleUid string, channelUids []interface
 
 	addChannel := func(c *notificationChannel) error {
 		if c.Type == "hipchat" || c.Type == "sensu" {
-			return fmt.Errorf("discontinued notification channel found: %s", c.Type)
+			m.mg.Logger.Error("alert migration error: discontinued notification channel found", "type", c.Type, "name", c.Name, "uid", c.Uid)
+			return nil
 		}
 
 		uid, ok := m.generateChannelUID()
@@ -179,7 +180,8 @@ func (m *migration) updateDefaultAndUnmigratedChannels(amConfig *PostableUserCon
 			continue
 		}
 		if c.Type == "hipchat" || c.Type == "sensu" {
-			return fmt.Errorf("discontinued notification channel found: %s", c.Type)
+			m.mg.Logger.Error("alert migration error: discontinued notification channel found", "type", c.Type, "name", c.Name, "uid", c.Uid)
+			continue
 		}
 
 		uid, ok := m.generateChannelUID()


### PR DESCRIPTION
**What this PR does / why we need it**:

We do not want to prevent starting up of Grafana if on migration we find the discontinued notification channels. 