### PR TITLE
Usage Stats: Make the UsageStatsService extension point more flexible (#34778)

### DIFF
--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -240,18 +240,21 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 }
 
 func (uss *UsageStatsService) registerExternalMetrics(metrics map[string]interface{}) {
-	for name, fn := range uss.externalMetrics {
-		result, err := fn()
+	for _, fn := range uss.externalMetrics {
+		fnMetrics, err := fn()
 		if err != nil {
-			metricsLogger.Error("Failed to fetch external metric", "name", name, "error", err)
+			metricsLogger.Error("Failed to fetch external metrics", "error", err)
 			continue
 		}
-		metrics[name] = result
+
+		for name, value := range fnMetrics {
+			metrics[name] = value
+		}
 	}
 }
 
-func (uss *UsageStatsService) RegisterMetric(name string, fn MetricFunc) {
-	uss.externalMetrics[name] = fn
+func (uss *UsageStatsService) RegisterMetricsFunc(fn MetricsFunc) {
+	uss.externalMetrics = append(uss.externalMetrics, fn)
 }
 
 func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -39,14 +39,19 @@ func (ac *OSSAccessControlService) IsDisabled() bool {
 }
 
 func (ac *OSSAccessControlService) registerUsageMetrics() {
-	ac.UsageStats.RegisterMetric("stats.oss.accesscontrol.enabled.count", ac.getUsageMetrics)
+	ac.UsageStats.RegisterMetricsFunc(func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"stats.oss.accesscontrol.enabled.count": ac.getUsageMetrics(),
+		}, nil
+	})
 }
 
-func (ac *OSSAccessControlService) getUsageMetrics() (interface{}, error) {
+func (ac *OSSAccessControlService) getUsageMetrics() interface{} {
 	if ac.IsDisabled() {
-		return 0, nil
+		return 0
 	}
-	return 1, nil
+
+	return 1
 }
 
 // Evaluate evaluates access to the given resource


### PR DESCRIPTION
* Usage Stats: Rename service to use a more idiomatic name

* Usage Stats: Update MetricsFunc definition and implementations

* Revert "Usage Stats: Rename service to use a more idiomatic name"

This reverts commit 910ecce3e8881ad51f7eddd82b8459de3711fdf8.

* Usage Stats: Update MetricsFunc definition and implementations

(cherry picked from commit f6019216706b29c744e77c3902eaca9dc4ec541a)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

https://github.com/grafana/grafana/pull/34778