### PR TITLE
GraphNG: Remove fieldName and hideInLegend properties from UPlotSeriesBuilder

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -7,7 +7,6 @@ import {
   FieldSparkline,
   FieldType,
   getFieldColorModeForField,
-  getFieldDisplayName,
 } from '@grafana/data';
 import {
   AxisPlacement,
@@ -158,7 +157,6 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
       builder.addSeries({
         scaleKey,
         theme,
-        fieldName: getFieldDisplayName(field, data),
         drawStyle: customConfig.drawStyle!,
         lineColor: customConfig.lineColor ?? seriesColor,
         lineWidth: customConfig.lineWidth,

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -185,11 +185,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
       show: !customConfig.hideFrom?.viz,
       gradientMode: customConfig.gradientMode,
       thresholds: config.thresholds,
-
       // The following properties are not used in the uPlot config, but are utilized as transport for legend config
       dataFrameFieldIndex: field.state?.origin,
-      fieldName: getFieldDisplayName(field, frame),
-      hideInLegend: customConfig.hideFrom?.legend,
     });
 
     // Render thresholds in graph

--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
@@ -29,18 +29,17 @@ export const PlotLegend: React.FC<PlotLegendProps> = ({
       const fieldIndex = seriesConfig.dataFrameFieldIndex;
       const axisPlacement = config.getAxisPlacement(s.props.scaleKey);
 
-      if (seriesConfig.hideInLegend || !fieldIndex) {
+      if (!fieldIndex) {
         return undefined;
       }
 
       const field = data[fieldIndex.frameIndex]?.fields[fieldIndex.fieldIndex];
 
-      if (!field) {
+      if (!field || field.config.custom.hideFrom?.legend) {
         return undefined;
       }
 
-      const label = getFieldDisplayName(field, data[fieldIndex.frameIndex]!);
-
+      const label = getFieldDisplayName(field, data[fieldIndex.frameIndex]!, data);
       return {
         disabled: !seriesConfig.show ?? false,
         fieldIndex,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -405,7 +405,6 @@ describe('UPlotConfigBuilder', () => {
     builder.addSeries({
       drawStyle: DrawStyle.Line,
       scaleKey: 'scale-x',
-      fieldName: 'A-series',
       lineColor: '#0000ff',
       theme: darkTheme,
     });
@@ -418,7 +417,6 @@ describe('UPlotConfigBuilder', () => {
     builder.addSeries({
       drawStyle: DrawStyle.Line,
       scaleKey: 'scale-x',
-      fieldName: 'A-series',
       lineColor: '#FFAABB',
       fillOpacity: 50,
       theme: darkTheme,
@@ -432,7 +430,6 @@ describe('UPlotConfigBuilder', () => {
     builder.addSeries({
       drawStyle: DrawStyle.Line,
       scaleKey: 'scale-x',
-      fieldName: 'A-series',
       lineColor: '#FFAABB',
       fillOpacity: 50,
       fillColor: '#FF0000',
@@ -447,7 +444,6 @@ describe('UPlotConfigBuilder', () => {
     builder.addSeries({
       drawStyle: DrawStyle.Line,
       scaleKey: 'scale-x',
-      fieldName: 'A-series',
       lineColor: '#FFAABB',
       fillOpacity: 50,
       gradientMode: GraphGradientMode.Opacity,
@@ -462,7 +458,6 @@ describe('UPlotConfigBuilder', () => {
     builder.addSeries({
       drawStyle: DrawStyle.Line,
       scaleKey: 'scale-x',
-      fieldName: 'A-series',
       fillOpacity: 50,
       gradientMode: GraphGradientMode.Opacity,
       showPoints: PointVisibility.Auto,
@@ -524,7 +519,6 @@ describe('UPlotConfigBuilder', () => {
       builder.addSeries({
         drawStyle: DrawStyle.Line,
         scaleKey: 'scale-x',
-        fieldName: 'A-series',
         fillOpacity: 50,
         gradientMode: GraphGradientMode.Opacity,
         showPoints: PointVisibility.Auto,
@@ -536,7 +530,6 @@ describe('UPlotConfigBuilder', () => {
       builder.addSeries({
         drawStyle: DrawStyle.Line,
         scaleKey: 'scale-x',
-        fieldName: 'B-series',
         fillOpacity: 50,
         gradientMode: GraphGradientMode.Opacity,
         showPoints: PointVisibility.Auto,
@@ -550,7 +543,6 @@ describe('UPlotConfigBuilder', () => {
       builder.addSeries({
         drawStyle: DrawStyle.Line,
         scaleKey: 'scale-x',
-        fieldName: 'C-series',
         fillOpacity: 50,
         gradientMode: GraphGradientMode.Opacity,
         showPoints: PointVisibility.Auto,

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -23,13 +23,11 @@ export interface SeriesProps extends LineConfig, BarConfig, FillConfig, PointsCo
   thresholds?: ThresholdsConfig;
   /** Used when gradientMode is set to Scheme  */
   colorMode?: FieldColorMode;
-  fieldName: string;
   drawStyle?: DrawStyle;
   pathBuilder?: Series.PathBuilder;
   pointsBuilder?: Series.Points.Show;
   show?: boolean;
   dataFrameFieldIndex?: DataFrameFieldIndex;
-  hideInLegend?: boolean;
   theme: GrafanaTheme2;
 }
 

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -3,7 +3,6 @@ import {
   FieldType,
   formattedValueToString,
   getFieldColorModeForField,
-  getFieldDisplayName,
   getFieldSeriesColor,
   MutableDataFrame,
   VizOrientation,
@@ -136,8 +135,6 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptions> = ({
         fieldIndex: i,
         frameIndex: 0,
       },
-      fieldName: getFieldDisplayName(field, frame),
-      hideInLegend: customConfig.hideFrom?.legend,
     });
 
     // The builder will manage unique scaleKeys and combine where appropriate

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -4,7 +4,6 @@ import {
   DataFrame,
   formattedValueToString,
   getFieldColorModeForField,
-  getFieldDisplayName,
   getFieldSeriesColor,
   GrafanaTheme2,
 } from '@grafana/data';
@@ -152,8 +151,6 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
         fieldIndex: i,
         frameIndex: 0,
       },
-      fieldName: getFieldDisplayName(field, frame),
-      hideInLegend: customConfig.hideFrom?.legend,
     });
   }
 

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -178,11 +178,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
       theme,
       show: !customConfig.hideFrom?.viz,
       thresholds: config.thresholds,
-
       // The following properties are not used in the uPlot config, but are utilized as transport for legend config
       dataFrameFieldIndex: field.state?.origin,
-      fieldName: getFieldDisplayName(field, frame),
-      hideInLegend: customConfig.hideFrom?.legend,
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/34449

This one was a nasty bastard. To test the correctness of the fix you can use the dashboard attached below.

The problem was caused by the field name for a given field being calculated twice. The first time it was calculated during series config creation for uPlot (for example here: https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/TimeSeries/utils.ts#L191),  the second time display name was calculated directly in the PlotLegend(https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx#L42). The difference between these two is the getDisplayName arguments that are passed- in the first pass the aligned data frame is used for name calculation (series refId is added as a label), in the second one the original data frame is used.

Since for the numeric fields, a reference to the original field is added to the aligned data frame(https://github.com/grafana/grafana/blob/44358958333860f9b2eac914029f894b278692f1/public/app/plugins/panel/timeseries/utils.ts#L33) the field state is cached and the second pass uses the display name calculated for the aligned frame (https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/field/fieldState.ts#L42).

In this PR I'm removing the fieldName from UPlotSeriesConfig as we don't use it anywhere. Additionally I'm removing the hideFromLegend property, as we can get it directly from the field config when necessary, rather than passing to uplot config builder.

Next step I'm gonna investigate (separate PR if needed) is the `fillBelowTo` config as it also uses the getDisplayName calculation based on aligned frame(https://github.com/grafana/grafana/blob/8ba8291c513a384c5e8b71127f4b0d492e785047/packages/grafana-ui/src/components/TimeSeries/utils.ts#L157) which may cause similar issues.


Dashboard:
```
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "gnetId": null,
  "graphTooltip": 0,
  "id": 197,
  "links": [],
  "panels": [
    {
      "datasource": "Google Sheets",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "graph": false,
              "legend": false,
              "tooltip": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single"
        }
      },
      "targets": [
        {
          "cacheDurationSeconds": 0,
          "refId": "A",
          "spreadsheet": "1A1CmxbwIOSFU53Q8BZuKh6HzR8IFJbBxeWmuSXFkvyI"
        },
        {
          "cacheDurationSeconds": 0,
          "hide": false,
          "refId": "B",
          "spreadsheet": "1iJmWxwto_-fyKmZsNpWFNT62VjmhEyA26xboDAf87Yg"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "refresh": false,
  "schemaVersion": 30,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2021-05-17T04:59:30.000Z",
    "to": "2021-05-17T05:00:30.000Z"
  },
  "timepicker": {},
  "timezone": "utc",
  "title": "spanNulls-thresh-bug",
  "uid": "6wYTFnqMz",
  "version": 3
}
```