### PR TITLE
Plugins: Fix permissions + add nav link for server admins

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -129,14 +129,10 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		return nil, err
 	}
 
-	hasPluginManagerApp := false
 	pluginsToPreload := []string{}
 	for _, app := range enabledPlugins.Apps {
 		if app.Preload {
 			pluginsToPreload = append(pluginsToPreload, app.Module)
-		}
-		if app.Id == "grafana-plugin-admin-app" {
-			hasPluginManagerApp = true
 		}
 	}
 
@@ -248,8 +244,8 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"http2Enabled":                     hs.Cfg.Protocol == setting.HTTP2Scheme,
 		"sentry":                           hs.Cfg.Sentry,
 		"pluginCatalogURL":                 hs.Cfg.PluginCatalogURL,
-		"pluginAdminEnabled":               c.IsGrafanaAdmin && hs.Cfg.PluginAdminEnabled && hasPluginManagerApp,
-		"pluginAdminExternalManageEnabled": hs.Cfg.PluginAdminExternalManageEnabled,
+		"pluginAdminEnabled":               (c.IsGrafanaAdmin || hs.Cfg.PluginAdminExternalManageEnabled) && hs.Cfg.PluginAdminEnabled,
+		"pluginAdminExternalManageEnabled": hs.Cfg.PluginAdminEnabled && hs.Cfg.PluginAdminExternalManageEnabled,
 		"expressionsEnabled":               hs.Cfg.ExpressionsEnabled,
 		"awsAllowedAuthProviders":          hs.Cfg.AWSAllowedAuthProviders,
 		"awsAssumeRoleEnabled":             hs.Cfg.AWSAssumeRoleEnabled,

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -363,6 +363,11 @@ func (hs *HTTPServer) buildAdminNavLinks(c *models.ReqContext) []*dtos.NavLink {
 		adminNavLinks = append(adminNavLinks, &dtos.NavLink{
 			Text: "Stats", Id: "server-stats", Url: hs.Cfg.AppSubURL + "/admin/stats", Icon: "graph-bar",
 		})
+		if hs.Cfg.PluginAdminEnabled {
+			adminNavLinks = append(adminNavLinks, &dtos.NavLink{
+				Text: "Plugin catalog", Id: "plugin-catalog", Url: hs.Cfg.AppSubURL + "/a/grafana-plugin-admin-app", Icon: "plug",
+			})
+		}
 	}
 
 	if hs.Cfg.LDAPEnabled && hasAccess(ac.ReqGrafanaAdmin, ac.ActionLDAPStatusRead) {


### PR DESCRIPTION
Will enable the plugin catalog when:
- User is a Grafana Admin/Server Admin, which is only relevant for non-Cloud OR when the external manage config is enabled, which is only relevant for Cloud (who also don't have the concept of server admin)
- Plugin catalog feature config is enabled

Also added link to plugin catalog in` Server Admin` section
![Screenshot 2021-05-28 at 16 38 28](https://user-images.githubusercontent.com/1173299/120000545-3863c780-bfd3-11eb-91e6-ab85031ac60b.png)

I also removed some code as the catalog app will always be auto enabled so the previously used `hasPluginManagerApp` will always have been `true`
