### PR TITLE
alerting: fixes per-receiver metric cardinality

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -448,7 +448,7 @@ func (am *Alertmanager) buildReceiverIntegrations(receiver *apimodels.PostableAp
 		if err != nil {
 			return nil, err
 		}
-		integrations = append(integrations, notify.NewIntegration(n, n, r.Name, i))
+		integrations = append(integrations, notify.NewIntegration(n, n, r.Type, i))
 	}
 
 	return integrations, nil


### PR DESCRIPTION
We were using the integration code improperly in a way which created metrics per receiver name instead of receiver type.
For reference, alertmanager creates them like this: https://github.com/prometheus/alertmanager/blob/master/cmd/alertmanager/main.go#L144-L167

They can be uniquely identifiable by `(name, index)`: https://github.com/prometheus/alertmanager/blob/master/notify/notify.go#L61-L68


see: `fake-email-contact`
![image](https://user-images.githubusercontent.com/8173478/120007194-a2667780-bfa7-11eb-9b48-89fcacad03b8.png)
