### PR TITLE
Log Details: Add key for the DataLinkButton

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -167,15 +167,12 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
         <td className={style.logDetailsLabel}>{parsedKey}</td>
         <td className={cx(styles.wordBreakAll, wrapLogMessage && styles.wrapLine)}>
           {parsedValue}
-          {links &&
-            links.map((link) => {
-              return (
-                <>
-                  &nbsp;
-                  <DataLinkButton link={link} />
-                </>
-              );
-            })}
+          {links?.map((link) => (
+            <span key={link.title}>
+              &nbsp;
+              <DataLinkButton link={link} />
+            </span>
+          ))}
           {showFieldsStats && (
             <LogLabelStats
               stats={fieldStats!}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes thrown error due to missing key
![image](https://user-images.githubusercontent.com/30407135/120033717-4417b400-bffc-11eb-9d2b-fb140b4bdbca.png)
 