### PR TITLE
State timeline: defer quadtree construction until first mousemove

### DIFF
--- a/public/app/plugins/panel/state-timeline/timeline.ts
+++ b/public/app/plugins/panel/state-timeline/timeline.ts
@@ -5,7 +5,6 @@ import { distribute, SPACE_BETWEEN } from 'app/plugins/panel/barchart/distribute
 import { TimelineFieldConfig, TimelineMode, TimelineValueAlignment } from './types';
 import { GrafanaTheme2, TimeRange } from '@grafana/data';
 import { BarValueVisibility } from '@grafana/ui';
-import tinycolor from 'tinycolor2';
 
 const { round, min, ceil } = Math;
 
@@ -515,5 +514,5 @@ export function getConfig(opts: TimelineCoreOptions) {
 
 function getFillColor(fieldConfig: TimelineFieldConfig, color: string) {
   const opacityPercent = (fieldConfig.fillOpacity ?? 100) / 100;
-  return tinycolor(color).setAlpha(opacityPercent).toString();
+  return color + Math.round(opacityPercent * 255).toString(16);
 }

--- a/public/app/plugins/panel/state-timeline/timeline.ts
+++ b/public/app/plugins/panel/state-timeline/timeline.ts
@@ -518,7 +518,9 @@ function getFillColor(fieldConfig: TimelineFieldConfig, color: string) {
   if (color.length === 7 && color[0] === '#') {
     color = color + Math.round(opacityPercent * 255).toString(16);
   } else if (color.startsWith('rgb(')) {
-    color = color.replace(')', `, ${opacityPercent * 100})`);
+    // rgb() does not require the "a" suffix to accept alpha values in modern browsers:
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb()#accepts_alpha_value
+    color = color.replace(')', `, ${opacityPercent})`);
   }
 
   return color;

--- a/public/app/plugins/panel/state-timeline/timeline.ts
+++ b/public/app/plugins/panel/state-timeline/timeline.ts
@@ -5,6 +5,7 @@ import { distribute, SPACE_BETWEEN } from 'app/plugins/panel/barchart/distribute
 import { TimelineFieldConfig, TimelineMode, TimelineValueAlignment } from './types';
 import { GrafanaTheme2, TimeRange } from '@grafana/data';
 import { BarValueVisibility } from '@grafana/ui';
+import tinycolor from 'tinycolor2';
 
 const { round, min, ceil } = Math;
 
@@ -522,14 +523,5 @@ export function getConfig(opts: TimelineCoreOptions) {
 
 function getFillColor(fieldConfig: TimelineFieldConfig, color: string) {
   const opacityPercent = (fieldConfig.fillOpacity ?? 100) / 100;
-
-  if (color.length === 7 && color[0] === '#') {
-    color = color + Math.round(opacityPercent * 255).toString(16);
-  } else if (color.startsWith('rgb(')) {
-    // rgb() does not require the "a" suffix to accept alpha values in modern browsers:
-    // https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb()#accepts_alpha_value
-    color = color.replace(')', `, ${opacityPercent})`);
-  }
-
-  return color;
+  return tinycolor(color).setAlpha(opacityPercent).toString();
 }

--- a/public/app/plugins/panel/state-timeline/timeline.ts
+++ b/public/app/plugins/panel/state-timeline/timeline.ts
@@ -142,7 +142,7 @@ export function getConfig(opts: TimelineCoreOptions) {
     const fieldConfig = getFieldConfig(seriesIdx);
     const fillColor = getFillColor(fieldConfig, valueColor);
 
-    const boxRect = (boxRectsBySeries[seriesIdx][valueIdx] = {
+    boxRectsBySeries[seriesIdx][valueIdx] = {
       x: round(left - xOff),
       y: round(top - yOff),
       w: boxWidth,
@@ -151,9 +151,7 @@ export function getConfig(opts: TimelineCoreOptions) {
       didx: valueIdx,
       // for computing label contrast
       fillColor,
-    });
-
-    qt.add(boxRect);
+    };
 
     if (discrete) {
       let fillStyle = fillColor;
@@ -428,6 +426,16 @@ export function getConfig(opts: TimelineCoreOptions) {
   const setCursor = (u: uPlot) => {
     let cx = round(u.cursor!.left! * pxRatio);
     let cy = round(u.cursor!.top! * pxRatio);
+
+    // if quadtree is empty, fill it
+    if (!qt.o.length && qt.q == null) {
+      for (const seriesRects of boxRectsBySeries) {
+        for (const rect of seriesRects) {
+          rect && qt.add(rect);
+        }
+      }
+    }
+
     doHover(cx, cy);
   };
 

--- a/public/app/plugins/panel/state-timeline/timeline.ts
+++ b/public/app/plugins/panel/state-timeline/timeline.ts
@@ -514,5 +514,12 @@ export function getConfig(opts: TimelineCoreOptions) {
 
 function getFillColor(fieldConfig: TimelineFieldConfig, color: string) {
   const opacityPercent = (fieldConfig.fillOpacity ?? 100) / 100;
-  return color + Math.round(opacityPercent * 255).toString(16);
+
+  if (color.length === 7 && color[0] === '#') {
+    color = color + Math.round(opacityPercent * 255).toString(16);
+  } else if (color.startsWith('rgb(')) {
+    color = color.replace(')', `, ${opacityPercent * 100})`);
+  }
+
+  return color;
 }


### PR DESCRIPTION
part 2 of #34947

this builds on the tinycolor bypass PR (#34948).

interestingly, this increases the cumulative costs of the addAlpha() function, most likely because we're throttling less and getting higher fps. though an ~8x increase is rather surprising.

updated profile:

![image](https://user-images.githubusercontent.com/43234/120056091-b4740480-bfff-11eb-983a-1f26acd1b7fb.png)