### PR TITLE
Docs: Add data links provisioning example to ElasticSearch documentation

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -246,6 +246,10 @@ datasources:
       esVersion: "7.0.0"
       logMessageField: message
       logLevelField: fields.level
+      dataLinks:
+        - datasourceUid: my_jaeger_uid # Target UID needs to be known
+          field: traceID
+          url: "$${__value.raw}" # Careful about the double "$$" because of env var expansion
 ```
 
 ## Amazon Elasticsearch Service


### PR DESCRIPTION
**What this PR does / why we need it**:

Our ElasticSearch documentation currently doesn't show any indication of its support for provisioning data links. This PR adds an example in ElasticSearch's Data Sources docs.

**Which issue(s) this PR fixes**:

Fixes #33086

**Special notes for your reviewer**:
