### PR TITLE
InfluxDB: InfluxQL: apply on enter not on blur

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Seg.tsx
@@ -137,22 +137,23 @@ const Sel = ({ loadOptions, filterByLoadOptions, allowCustomValue, onChange, onC
 type InpProps = {
   initialValue: string;
   onChange: (newVal: string) => void;
+  onClose: () => void;
 };
 
-const Inp = ({ initialValue, onChange }: InpProps): JSX.Element => {
+const Inp = ({ initialValue, onChange, onClose }: InpProps): JSX.Element => {
   const [currentValue, setCurrentValue] = useShadowedState(initialValue);
-
-  const onBlur = () => {
-    // we send empty-string as undefined
-    onChange(currentValue);
-  };
 
   return (
     <Input
       autoFocus
       type="text"
       spellCheck={false}
-      onBlur={onBlur}
+      onBlur={onClose}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          onChange(currentValue);
+        }
+      }}
       onChange={(e) => {
         setCurrentValue(e.currentTarget.value);
       }}
@@ -208,6 +209,9 @@ export const Seg = ({
       return (
         <Inp
           initialValue={value}
+          onClose={() => {
+            setOpen(false);
+          }}
           onChange={(v) => {
             setOpen(false);
             onChange({ value: v, label: v });


### PR DESCRIPTION
In the InfluxDB InfluxQL editor, some places submit on `escape` and some submit on `enter`. i want to make this more consistent, and be submit on `enter` wherever possible. in the WHERE section it works like that, if you open a select-box there, and you enter a custom value, you have to press `enter` to choose it.
this pull-requests adjusts another place to work like that.
you can test it like this:
- in the `select` part, add another item, choose `math`
- try to modify the value "inside" math (the `/ 100` thing). if you press `esc` or leave the input field, the modified value is discarded. if you press `enter`, the modified value is stored.