### PR TITLE
Alerting: Migrate tags as labels and not annotations

### DIFF
--- a/pkg/services/ngalert/notifier/channels/opsgenie_test.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie_test.go
@@ -51,7 +51,7 @@ func TestOpsgenieNotifier(t *testing.T) {
 				},
 				"message": "[FIRING:1]  (val1)",
 				"source": "Grafana",
-				"tags": ["ann1:annv1"]
+				"tags": ["alertname:alert1", "lbl1:val1"]
 			}`,
 		},
 		{
@@ -76,7 +76,7 @@ func TestOpsgenieNotifier(t *testing.T) {
 				},
 				"message": "[FIRING:1]  (val1)",
 				"source": "Grafana",
-				"tags": ["ann1:annv1"]
+				"tags": ["alertname:alert1", "lbl1:val1"]
 			}`,
 		},
 		{
@@ -97,7 +97,8 @@ func TestOpsgenieNotifier(t *testing.T) {
 				"alias": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n",
 				"details": {
-					"ann1": "annv1",
+					"alertname": "alert1",
+					"lbl1": "val1",
 					"url": "http://localhost/alerting/list"
 				},
 				"message": "[FIRING:1]  (val1)",
@@ -128,12 +129,12 @@ func TestOpsgenieNotifier(t *testing.T) {
 				"alias": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
 				"description": "[FIRING:2]  \nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n",
 				"details": {
-					"ann1": "annv1",
+					"alertname": "alert1",
 					"url": "http://localhost/alerting/list"
 				},
 				"message": "[FIRING:2]  ",
 				"source": "Grafana",
-				"tags": ["ann1:annv1"]
+				"tags": ["alertname:alert1"]
 			}`,
 			expInitError: nil,
 			expMsgError:  nil,

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -72,17 +72,18 @@ func (a *alertRule) makeVersion() *alertRuleVersion {
 	}
 }
 
-func addMigrationInfo(da *dashAlert) map[string]string {
-	annotations := da.ParsedSettings.AlertRuleTags
-	if annotations == nil {
-		annotations = make(map[string]string, 3)
+func addMigrationInfo(da *dashAlert) (map[string]string, map[string]string) {
+	lbls := da.ParsedSettings.AlertRuleTags
+	if lbls == nil {
+		lbls = make(map[string]string)
 	}
 
+	annotations := make(map[string]string, 3)
 	annotations["__dashboardUid__"] = da.DashboardUID
 	annotations["__panelId__"] = fmt.Sprintf("%v", da.PanelId)
 	annotations["__alertId__"] = fmt.Sprintf("%v", da.Id)
 
-	return annotations
+	return lbls, annotations
 }
 
 func getMigrationString(da dashAlert) string {
@@ -90,7 +91,9 @@ func getMigrationString(da dashAlert) string {
 }
 
 func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string) (*alertRule, error) {
-	annotations := addMigrationInfo(&da)
+	lbls, annotations := addMigrationInfo(&da)
+	lbls["alertname"] = da.Name
+	annotations["message"] = da.Message
 
 	ar := &alertRule{
 		OrgId:           da.OrgId,
@@ -105,10 +108,7 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 		For:             duration(da.For),
 		Updated:         time.Now().UTC(),
 		Annotations:     annotations,
-		Labels: map[string]string{
-			"alertname": da.Name,
-			"message":   da.Message,
-		},
+		Labels:          lbls,
 	}
 
 	var err error

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1609,7 +1609,7 @@ var expNotifications = map[string][]string{
 		  },
 		  "message": "[FIRING:1] OpsGenieAlert ",
 		  "source": "Grafana",
-		  "tags": []
+		  "tags": ["alertname:OpsGenieAlert"]
 		}`,
 	},
 	// Prometheus Alertmanager.


### PR DESCRIPTION
**What this PR does / why we need it**:

It also fixes a bug that I introduced in https://github.com/grafana/grafana/pull/34898/ where I converted `message` into a label while refactoring.