### PR TITLE
Alerting: Use labels/tags in the missing channels for additional info

### DIFF
--- a/pkg/services/ngalert/notifier/channels/victorops_test.go
+++ b/pkg/services/ngalert/notifier/channels/victorops_test.go
@@ -53,6 +53,27 @@ func TestVictoropsNotifier(t *testing.T) {
 			expInitError: nil,
 			expMsgError:  nil,
 		}, {
+			name:     "One alert with severity in labels",
+			settings: `{"url": "http://localhost"}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1", "severity": "info"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+					},
+				},
+			},
+			expMsg: `{
+			  "alert_url": "http://localhost/alerting/list",
+			  "entity_display_name": "[FIRING:1]  (val1 info)",
+			  "entity_id": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
+			  "message_type": "INFO",
+			  "monitoring_tool": "Grafana v",
+			  "state_message": "**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\n - severity = info\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1%2Cseverity%3Dinfo\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n"
+			}`,
+			expInitError: nil,
+			expMsgError:  nil,
+		}, {
 			name:     "Multiple alerts",
 			settings: `{"url": "http://localhost"}`,
 			alerts: []*types.Alert{

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1389,7 +1389,9 @@ var expNotifications = map[string][]string{
 			  "firing": "\nLabels:\n - alertname = PagerdutyAlert\nAnnotations:\nSilence: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matchers=alertname%%3DPagerdutyAlert\n",
 			  "num_firing": "1",
 			  "num_resolved": "0",
-			  "resolved": ""
+			  "resolved": "",
+			  "alertname": "PagerdutyAlert",
+			  "state": "alerting"
 			}
 		  },
 		  "client": "Grafana",


### PR DESCRIPTION
**What this PR does / why we need it**:

In 7x, `opsgenie, victorops, pagerduty, webhook, alertmanager` channels uses the `AlertRuleTags`. `AlertRuleTags` is now migrated to be labels. `opsgenie` is already using these labels like tags before, `webhook, alertmanager` changes the way of payload so not needed to use there. In this PR I am updating `victorops, pagerduty` to use labels/tags as before to set some fields.