### PR TITLE
Dashboard: Fix Table view when editing causes the panel data to not update

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -250,7 +250,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
               }
 
               if (tableViewEnabled) {
-                return <PanelEditorTableView width={width} height={height} panel={panel} />;
+                return <PanelEditorTableView width={width} height={height} panel={panel} dashboard={dashboard} />;
               }
 
               return (

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -1,11 +1,10 @@
 import { PanelChrome } from '@grafana/ui';
 import { PanelRenderer } from 'app/features/panel/PanelRenderer';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { PanelModel, DashboardModel } from '../../state';
 import { usePanelLatestData } from './usePanelLatestData';
 import { PanelOptions } from 'app/plugins/panel/table/models.gen';
 import { RefreshEvent } from 'app/types/events';
-import { Subscription } from 'rxjs';
 import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { getTimeSrv, TimeSrv } from '../../services/TimeSrv';
 interface Props {

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -1,22 +1,42 @@
 import { PanelChrome } from '@grafana/ui';
 import { PanelRenderer } from 'app/features/panel/PanelRenderer';
-import React, { useState } from 'react';
-import { PanelModel } from '../../state';
+import React, { useCallback, useEffect, useState } from 'react';
+import { PanelModel, DashboardModel } from '../../state';
 import { usePanelLatestData } from './usePanelLatestData';
 import { PanelOptions } from 'app/plugins/panel/table/models.gen';
-
+import { RefreshEvent } from 'app/types/events';
+import { Subscription } from 'rxjs';
+import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
+import { getTimeSrv, TimeSrv } from '../../services/TimeSrv';
 interface Props {
   width: number;
   height: number;
   panel: PanelModel;
+  dashboard: DashboardModel;
 }
 
-export function PanelEditorTableView({ width, height, panel }: Props) {
-  const { data } = usePanelLatestData(panel, { withTransforms: true, withFieldConfig: false }, true);
+export function PanelEditorTableView({ width, height, panel, dashboard }: Props) {
+  const { data } = usePanelLatestData(panel, { withTransforms: true, withFieldConfig: false }, false);
   const [options, setOptions] = useState<PanelOptions>({
     frameIndex: 0,
     showHeader: true,
   });
+
+  const timeSrv: TimeSrv = getTimeSrv();
+  const timeData = applyPanelTimeOverrides(panel, timeSrv.timeRange());
+
+  const onRefresh = useCallback(() => {
+    panel.runAllPanelQueries(dashboard.id, dashboard.getTimezone(), timeData, width);
+  }, [dashboard, panel, timeData, width]);
+
+  // Subscribe to panel events
+  useEffect(() => {
+    const subs = new Subscription();
+    subs.add(panel.events.subscribe(RefreshEvent, onRefresh));
+    return () => {
+      subs.unsubscribe();
+    };
+  }, [onRefresh, panel]);
 
   if (!data) {
     return null;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -22,21 +22,18 @@ export function PanelEditorTableView({ width, height, panel, dashboard }: Props)
     showHeader: true,
   });
 
-  const timeSrv: TimeSrv = getTimeSrv();
-  const timeData = applyPanelTimeOverrides(panel, timeSrv.timeRange());
-
-  const onRefresh = useCallback(() => {
-    panel.runAllPanelQueries(dashboard.id, dashboard.getTimezone(), timeData, width);
-  }, [dashboard, panel, timeData, width]);
-
-  // Subscribe to panel events
+  // Subscribe to panel event
   useEffect(() => {
-    const subs = new Subscription();
-    subs.add(panel.events.subscribe(RefreshEvent, onRefresh));
+    const timeSrv: TimeSrv = getTimeSrv();
+    const timeData = applyPanelTimeOverrides(panel, timeSrv.timeRange());
+
+    const sub = panel.events.subscribe(RefreshEvent, () => {
+      panel.runAllPanelQueries(dashboard.id, dashboard.getTimezone(), timeData, width);
+    });
     return () => {
-      subs.unsubscribe();
+      sub.unsubscribe();
     };
-  }, [onRefresh, panel]);
+  }, [panel, dashboard, width]);
 
   if (!data) {
     return null;

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -240,21 +240,7 @@ export class PanelChrome extends Component<Props, State> {
       if (this.state.refreshWhenInView) {
         this.setState({ refreshWhenInView: false });
       }
-
-      panel.getQueryRunner().run({
-        datasource: panel.datasource,
-        queries: panel.targets,
-        panelId: panel.editSourceId || panel.id,
-        dashboardId: this.props.dashboard.id,
-        timezone: this.props.dashboard.getTimezone(),
-        timeRange: timeData.timeRange,
-        timeInfo: timeData.timeInfo,
-        maxDataPoints: panel.maxDataPoints || width,
-        minInterval: panel.interval,
-        scopedVars: panel.scopedVars,
-        cacheTimeout: panel.cacheTimeout,
-        transformations: panel.transformations,
-      });
+      panel.runAllPanelQueries(this.props.dashboard.id, this.props.dashboard.getTimezone(), timeData, width);
     } else {
       // The panel should render on refresh as well if it doesn't have a query, like clock panel
       this.setState((prevState) => ({

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -7,6 +7,8 @@ import {
   PanelProps,
   standardEditorsRegistry,
   standardFieldConfigEditorRegistry,
+  dateTime,
+  TimeRange,
 } from '@grafana/data';
 import { ComponentClass } from 'react';
 import { PanelQueryRunner } from '../../query/state/PanelQueryRunner';
@@ -17,6 +19,7 @@ import { variableAdapters } from '../../variables/adapters';
 import { createQueryVariableAdapter } from '../../variables/query/adapter';
 import { mockStandardFieldConfigOptions } from '../../../../test/helpers/fieldConfig';
 import { queryBuilder } from 'app/features/variables/shared/testing/builders';
+import { TimeOverrideResult } from '../utils/panel';
 
 standardFieldConfigEditorRegistry.setInit(() => mockStandardFieldConfigOptions());
 standardEditorsRegistry.setInit(() => mockStandardFieldConfigOptions());
@@ -455,6 +458,32 @@ describe('PanelModel', () => {
         const title = model.getDisplayTitle();
 
         expect(title).toEqual('Multi value variable A + B A + B %7BA%2CB%7D');
+      });
+    });
+
+    describe('runAllPanelQueries', () => {
+      it('when called then it should call all pending queries', () => {
+        model.getQueryRunner = jest.fn().mockReturnValue({
+          run: jest.fn(),
+        });
+        const dashboardId = 123;
+        const dashboardTimezone = 'browser';
+        const width = 860;
+        const timeData = {
+          timeInfo: '',
+          timeRange: {
+            from: dateTime([2019, 1, 11, 12, 0]),
+            to: dateTime([2019, 1, 11, 18, 0]),
+            raw: {
+              from: 'now-6h',
+              to: 'now',
+            },
+          } as TimeRange,
+        } as TimeOverrideResult;
+
+        model.runAllPanelQueries(dashboardId, dashboardTimezone, timeData, width);
+
+        expect(model.getQueryRunner).toBeCalled();
       });
     });
   });

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -38,7 +38,6 @@ import {
 } from './getPanelOptionsWithDefaults';
 import { QueryGroupOptions } from 'app/types';
 import { PanelModelLibraryPanel } from '../../library-panels/types';
-
 export interface GridPos {
   x: number;
   y: number;
@@ -46,6 +45,8 @@ export interface GridPos {
   h: number;
   static?: boolean;
 }
+
+import { TimeOverrideResult } from '../utils/panel';
 
 const notPersistedProperties: { [str: string]: boolean } = {
   events: true,
@@ -290,6 +291,23 @@ export class PanelModel implements DataConfigSource {
     this.gridPos.y = newPos.y;
     this.gridPos.w = newPos.w;
     this.gridPos.h = newPos.h;
+  }
+
+  runAllPanelQueries(dashboardId: number, dashboardTimezone: string, timeData: TimeOverrideResult, width: number) {
+    this.getQueryRunner().run({
+      datasource: this.datasource,
+      queries: this.targets,
+      panelId: this.editSourceId || this.id,
+      dashboardId: dashboardId,
+      timezone: dashboardTimezone,
+      timeRange: timeData.timeRange,
+      timeInfo: timeData.timeInfo,
+      maxDataPoints: this.maxDataPoints || width,
+      minInterval: this.interval,
+      scopedVars: this.scopedVars,
+      cacheTimeout: this.cacheTimeout,
+      transformations: this.transformations,
+    });
   }
 
   refresh() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Setting visualization to "Table view" when editing causes the panel data to not update. This is because the `PanelEditorTableView` was not subscribing to the `RefreshEvents`



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #34820

**Special notes for your reviewer**:

The approach I took was extracting from the `PanelChrome` component the logic of running all the panel queries and adding the subscription of the  `RefreshEvent` in the `PanelEditorTableView`

![TableViewWithUpdates](https://user-images.githubusercontent.com/239999/120219243-3308b600-c23b-11eb-885b-2ad2f134f24a.gif)

