### PR TITLE
NodeGraph: Make web worker inline fixing error when assets are loaded with different origin

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -160,7 +160,12 @@ module.exports = {
       },
       {
         test: /\.worker\.js$/,
-        use: { loader: 'worker-loader' },
+        use: {
+          loader: 'worker-loader',
+          options: {
+            inline: 'fallback',
+          },
+        },
       },
     ],
   },


### PR DESCRIPTION
Web workers require to be loaded from the same origin and don't respect CORS in that regard. In Grafana cloud we load assets from different origin, this changes how web worker is loaded so it is loaded from a blob url which should circumvent that.

see:
https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker
https://stackoverflow.com/questions/25458104/can-should-html5-web-workers-use-cors-for-cross-origin