### PR TITLE
VizLegendTable: fixes column spacing to span to the right side

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -65,9 +65,6 @@ export const VizLegendTable = <T extends unknown>({
 
   return (
     <table className={cx(styles.table, className)}>
-      <colgroup>
-        <col style={{ width: '100%' }} />
-      </colgroup>
       <thead>
         <tr>
           {columns.map((columnHeader) => {
@@ -99,6 +96,9 @@ const getStyles = (theme: GrafanaTheme) => ({
   table: css`
     width: 100%;
     margin-left: ${theme.spacing.sm};
+    th:first-child {
+      width: 100%;
+    }
   `,
   header: css`
     color: ${theme.colors.textBlue};
@@ -106,6 +106,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     border-bottom: 1px solid ${theme.colors.border1};
     padding: ${theme.spacing.xxs} ${theme.spacing.sm};
     text-align: right;
+    white-space: nowrap;
   `,
   headerSortable: css`
     cursor: pointer;

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -65,6 +65,9 @@ export const VizLegendTable = <T extends unknown>({
 
   return (
     <table className={cx(styles.table, className)}>
+      <colgroup>
+        <col style={{ width: '100%' }} />
+      </colgroup>
       <thead>
         <tr>
           {columns.map((columnHeader) => {

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -115,7 +115,7 @@ const getStyles = (theme: GrafanaTheme) => {
       align-items: center;
     `,
     value: css`
-      text-align: left;
+      text-align: right;
     `,
     yAxisLabel: css`
       color: ${theme.palette.gray2};

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTableItem.tsx
@@ -115,7 +115,7 @@ const getStyles = (theme: GrafanaTheme) => {
       align-items: center;
     `,
     value: css`
-      text-align: right;
+      text-align: left;
     `,
     yAxisLabel: css`
       color: ${theme.palette.gray2};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes new timeseries legend table column spacing to span towards the right side.
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35012

