### PR TITLE
NodeGraph: Make grid view responsive

### DIFF
--- a/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
@@ -23,6 +23,15 @@ jest.mock('./layout.worker.js', () => {
   };
 });
 
+jest.mock('react-use/lib/useMeasure', () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return [() => {}, { width: 500, height: 200 }];
+    },
+  };
+});
+
 describe('NodeGraph', () => {
   it('doesnt fail without any data', async () => {
     render(<NodeGraph dataFrames={[]} getLinks={() => []} />);
@@ -57,7 +66,6 @@ describe('NodeGraph', () => {
     await screen.findByLabelText('Node: service:1');
 
     panView({ x: 10, y: 10 });
-    screen.debug(getSvg());
     // Though we try to pan down 10px we are rendering in straight line 3 nodes so there are bounds preventing
     // as panning vertically
     await waitFor(() => expect(getTranslate()).toEqual({ x: 10, y: 0 }));
@@ -209,9 +217,9 @@ describe('NodeGraph', () => {
     const button = await screen.findByTitle(/Grid layout/);
     userEvent.click(button);
 
-    await expectNodePositionCloseTo('service:0', { x: -180, y: -60 });
-    await expectNodePositionCloseTo('service:1', { x: -60, y: -60 });
-    await expectNodePositionCloseTo('service:2', { x: 60, y: -60 });
+    await expectNodePositionCloseTo('service:0', { x: -60, y: -60 });
+    await expectNodePositionCloseTo('service:1', { x: 60, y: -60 });
+    await expectNodePositionCloseTo('service:2', { x: -60, y: 80 });
   });
 });
 

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -135,6 +135,7 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit }: Props) {
     processed.edges,
     config,
     nodeCountLimit,
+    width,
     focusedNodeId
   );
 


### PR DESCRIPTION
Remove hardcoded number of nodes per row in grid view with computation based on width:
![Screenshot from 2021-06-01 15-06-26](https://user-images.githubusercontent.com/1014802/120328292-f98f8380-c2ea-11eb-9ca0-58381f70bf2b.png)
![Screenshot from 2021-06-01 15-06-20](https://user-images.githubusercontent.com/1014802/120328295-fac0b080-c2ea-11eb-922d-22cde22a2123.png)
