### PR TITLE
CLI: Add option to skip tests and linting for `grafana-toolkit plugin:build`

### DIFF
--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -105,6 +105,9 @@ This command creates a production-ready build of your plugin.
 Available options:
 
 - `--coverage` - Reports code coverage after the test step of the build.
+- `--skipTest` - Skip running tests as part of build. Useful if you're running the build as part of a larger pipeline.
+- `--skipLint` - Skip linting as part of build. Useful if you're running the build as part of a larger pipeline.
+- `--coverage` - Reports code coverage after the test step of the build.
 - `--preserveConsole` - Preserves console statements in the code.
 
 ### Sign your plugin

--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -104,7 +104,6 @@ This command creates a production-ready build of your plugin.
 
 Available options:
 
-- `--coverage` - Reports code coverage after the test step of the build.
 - `--skipTest` - Skip running tests as part of build. Useful if you're running the build as part of a larger pipeline.
 - `--skipLint` - Skip linting as part of build. Useful if you're running the build as part of a larger pipeline.
 - `--coverage` - Reports code coverage after the test step of the build.

--- a/packages/grafana-toolkit/src/cli/index.ts
+++ b/packages/grafana-toolkit/src/cli/index.ts
@@ -148,6 +148,8 @@ export const run = (includeInternalScripts = false) => {
     .command('plugin:build')
     .option('--maxJestWorkers <num>|<string>', 'Limit number of Jest workers spawned')
     .option('--coverage', 'Run code coverage', false)
+    .option('--skipTest', 'Skip running tests (for pipelines that run it separate)', false)
+    .option('--skipLint', 'Skip running lint (for pipelines that run it separate)', false)
     .option('--preserveConsole', 'Preserves console calls', false)
     .description('Prepares plugin dist package')
     .action(async (cmd) => {
@@ -156,6 +158,8 @@ export const run = (includeInternalScripts = false) => {
         silent: true,
         maxJestWorkers: cmd.maxJestWorkers,
         preserveConsole: cmd.preserveConsole,
+        skipLint: cmd.skipLint,
+        skipTest: cmd.skipTest,
       });
     });
 

--- a/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.build.ts
@@ -18,6 +18,8 @@ interface PluginBuildOptions {
   coverage: boolean;
   maxJestWorkers?: string;
   preserveConsole?: boolean;
+  skipTest?: boolean;
+  skipLint?: boolean;
 }
 
 interface Fixable {
@@ -132,11 +134,17 @@ export const pluginBuildRunner: TaskRunner<PluginBuildOptions> = async ({
   coverage,
   maxJestWorkers,
   preserveConsole,
+  skipTest,
+  skipLint,
 }) => {
   await versions();
   await prepare();
-  await lintPlugin({ fix: false });
-  await testPlugin({ updateSnapshot: false, coverage, maxWorkers: maxJestWorkers, watch: false });
+  if (!skipLint) {
+    await lintPlugin({ fix: false });
+  }
+  if (!skipTest) {
+    await testPlugin({ updateSnapshot: false, coverage, maxWorkers: maxJestWorkers, watch: false });
+  }
   await bundlePlugin({ watch: false, production: true, preserveConsole });
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Our plugin has a separate step of CI that tests and lints, so we'd like
to be able to control whether the build step will run it too.
defaults to continuing with lint and tests, so fully compatible.

update README for grafana-toolkit

**Which issue(s) this PR fixes**:

None are opened for this issue.

