### PR TITLE
FieldDisplay: add cache to reuse field value calculations

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -213,20 +213,17 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
 
 function cachingDisplayProcessor(disp: DisplayProcessor, maxCacheSize = 2500): DisplayProcessor {
   const cache = new Map<any, DisplayValue>();
-  console.log('NEW CACHE');
 
   return (value: any) => {
     let v = cache.get(value);
     if (!v) {
-      v = disp(value);
-      cache.set(value, v);
-
       // Don't grow too big
-      if (cache.size > maxCacheSize) {
+      if (cache.size === maxCacheSize) {
         cache.clear();
       }
-    } else {
-      console.log('USING VALUE FROM CACHE', v);
+
+      v = disp(value);
+      cache.set(value, v);
     }
     return v;
   };

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -187,6 +187,8 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
         timeZone: options.timeZone,
       });
 
+      // ?? maybe here?
+
       // Attach data links supplier
       newField.getLinks = getLinksSupplier(
         newFrame,

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -226,26 +226,6 @@ export function unsetSameFutureValues(values: any[]): any[] | undefined {
   return clone;
 }
 
-export function cachingDisplayProcessor(disp: DisplayProcessor): DisplayProcessor {
-  const cache = new Map<any, DisplayValue>();
-
-  const p = (value: any) => {
-    let v = cache.get(value);
-    if (!v) {
-      v = disp(value);
-      cache.set(value, v);
-
-      // Don't grow too big
-      if (cache.size > 2500) {
-        cache.clear();
-      }
-    }
-    return v;
-  };
-  p.__isCached = true;
-  return p;
-}
-
 // This will return a set of frames with only graphable values included
 export function prepareTimelineFields(
   series: DataFrame[] | undefined,
@@ -272,12 +252,6 @@ export function prepareTimelineFields(
         case FieldType.string:
           // magic value for join() to leave nulls alone
           (field.config.custom = field.config.custom ?? {}).spanNulls = -1;
-
-          if (!(field.display as any).__isCached) {
-            field.display = cachingDisplayProcessor(field.display!);
-          } else {
-            console.log('REUSEING', field.display);
-          }
 
           if (mergeValues) {
             let merged = unsetSameFutureValues(field.values.toArray());

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -14,8 +14,6 @@ import {
   getValueFormat,
   ThresholdsMode,
   GrafanaTheme2,
-  DisplayValue,
-  DisplayProcessor,
 } from '@grafana/data';
 import {
   UPlotConfigBuilder,


### PR DESCRIPTION
(leon):

this gets us a lot closer to https://github.com/grafana/grafana/issues/34947. we pay a tiny bit in non-streaming cases for huge wins in streaming, because `field.display()` is slow and complex to optimize quickly without undue risk.

this makes https://github.com/grafana/grafana/pull/34951 less necessary for perf, though i think that's still a good improvement and simplification.

before:

![image](https://user-images.githubusercontent.com/43234/120406761-425a3300-c311-11eb-80cd-fa1daea87768.png)

after:

![image](https://user-images.githubusercontent.com/43234/120406625-ea233100-c310-11eb-85ce-ad9730878054.png)