### PR TITLE
AzureMonitor: cleanup initialization of configuration editor

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ConfigEditor.tsx
@@ -123,11 +123,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
   };
 
   render() {
-    // TODO: Clean up
     const { options } = this.props;
-    options.jsonData.cloudName = options.jsonData.cloudName || 'azuremonitor';
-    // This is bad, causes so many messy typing issues everwhere..
-    options.secureJsonData = (options.secureJsonData || {}) as AzureDataSourceSecureJsonData;
 
     return (
       <>


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes leftovers in ConfigEditor which are now obsolete after all credentials logic was moved into the dedicated `credentials.ts` file.

**Which issue(s) this PR fixes**:

Related to #33721

**Special notes for your reviewer**:

The cloud is being set by `credentials.ts` based on selected authentication type and the proper cloud for which Grafana is configured.