### PR TITLE
DevEnv: Fix docker-driver plugin installation direction url

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -45,7 +45,7 @@ make devenv sources=postgres,openldap,grafana postgres_version=9.2 grafana_versi
 The grafana block is pre-configured with the dev-datasources and dashboards.
 
 #### Jaeger
-Jaeger block runs both Jaeger and Loki container. Loki container sends traces to Jaeger and also logs its own logs into itself so it is possible to setup derived field for traceID from Loki to Jaeger. You need to install a docker plugin for the self logging to work, without it the container won't start. See https://github.com/grafana/loki/tree/master/cmd/docker-driver#plugin-installation for installation instructions.
+Jaeger block runs both Jaeger and Loki container. Loki container sends traces to Jaeger and also logs its own logs into itself so it is possible to setup derived field for traceID from Loki to Jaeger. You need to install a docker plugin for the self logging to work, without it the container won't start. See https://grafana.com/docs/loki/latest/clients/docker-driver/#installing for installation instructions.
 
 #### Graphite
 


### PR DESCRIPTION
**What this PR does / why we need it**:
URL for installation instructions for the docker-driver plugin is outdated. This changes the URL.
