### PR TITLE
FieldDisplay: updated condition for No data text display

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -102,7 +102,7 @@ describe('FieldDisplay', () => {
   it('Should return field with default text when no mapping or data available', () => {
     const options = createEmptyDisplayOptions();
     const display = getFieldDisplayValues(options);
-    expect(display[0].display.text).toEqual('No data');
+    expect(display[0].display.text).toEqual('');
     expect(display[0].display.numeric).toEqual(0);
   });
 

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -106,6 +106,27 @@ describe('FieldDisplay', () => {
     expect(display[0].display.numeric).toEqual(0);
   });
 
+  it('Should return empty when no field mapped and no data', () => {
+    const mapEmptyToText = '';
+    const options = createEmptyDisplayOptions({
+      options: {
+        data: [
+          {
+            name: '',
+          },
+        ],
+        fieldConfig: {
+          defaults: {
+            mapEmptyToText,
+          },
+        },
+      },
+    });
+    const display = getFieldDisplayValues(options);
+    expect(display[0].display.text).toEqual('');
+    expect(display[0].display.numeric).toEqual(0);
+  });
+
   it('Should return field mapped value when there is no data', () => {
     const mapEmptyToText = '0';
     const options = createEmptyDisplayOptions({

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -1,4 +1,4 @@
-import { toString, isEmpty } from 'lodash';
+import { toString } from 'lodash';
 
 import { getDisplayProcessor } from './displayProcessor';
 import {
@@ -373,7 +373,7 @@ function createNoValuesFieldDisplay(options: GetFieldDisplayValuesOptions): Fiel
 }
 
 function getDisplayText(display: DisplayValue, fallback: string): string {
-  if (!display || isEmpty(display.text)) {
+  if (!display) {
     return fallback;
   }
   return display.text;

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.test.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.test.tsx
@@ -29,7 +29,7 @@ describe('BarGaugePanel', () => {
 
     it('should render with title "No data"', () => {
       const displayValue = wrapper.find(`div[aria-label="${valueSelector}"]`).text();
-      expect(displayValue).toBe('No data');
+      expect(displayValue).toBe('');
     });
   });
 


### PR DESCRIPTION
**What this PR does / why we need it:**
In this fix, If the response and the 'No value' field is empty, the panel will show empty.

**Which issue(s) this PR fixes:**
Fixes #33599

**Special notes for your reviewer**:
I have updated the 'fieldDisplay.test.js' based on the above changes
