### PR TITLE
Logs Panel: Improve performance for panels with a lot of logs

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -168,7 +168,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
               {lazyRendering && (
                 <td colSpan={5}>
                   <Button variant="secondary" size="md" style={{ marginTop: theme.spacing.sm }} onClick={this.showMore}>
-                    Show more rows.
+                    Show more rows
                   </Button>
                 </td>
               )}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -32,6 +32,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
     <CustomScrollbar autoHide>
       <LogRows
         logRows={logRows}
+        lazyRendering={true}
         deduplicatedRows={deduplicatedRows}
         dedupStrategy={dedupStrategy}
         highlighterExpressions={[]}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is to discuss potential fixes to https://github.com/grafana/grafana/issues/34038#issuecomment-851968266

**Problem**

Rendering log panel with too many logs may cause performance issues, i.e.
- delay of showing the context menu (when the panel header/chevron is clicked)
- laggy dragging

I haven't found the root cause yet. It still needs more investigation. Both issues seem to be related, though. This PR is to discuss solutions and it also presents an idea how to mitigate the problem by reducing number of log rows.

**Delayed context menu opening**

It is somehow related to `react-draggable-transparent-selection` class being added/removed to the body element [here](https://github.com/react-grid-layout/react-draggable/blob/v4.0.3/lib/utils/domFns.js#L157) even when the panel header is not dragged, but just clicked. This means the class is added/removed when the context menu is opened:

<img width="1531" alt="Screenshot 2021-06-02 at 11 34 47" src="https://user-images.githubusercontent.com/745532/120458949-00280480-c398-11eb-9dc4-0260e8293476.png">

Note: in theory to prevent it we could also stop event propagation in PanelHeaderMenuTrigger but on capture phase because react-draggable uses capture phase for all events:

```diff
   const onMouseDown = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
       setClickCoordinates(eventToClickCoordinates(event));
     },
     [setClickCoordinates]
   );
 
   return (
-    <div {...divProps} className="panel-title-container" onClick={onMenuToggle} onMouseDown={onMouseDown}>
+    <div {...divProps} className="panel-title-container" onClick={onMenuToggle} onMouseDownCapture={onMouseDown}>
       {children({ panelMenuOpen, closeMenu: () => setPanelMenuOpen(false) })}
     </div>
   );

```

Adding the class to the root element should not be the problem per-se. Something else is probably triggering recalculation of all log rows (?). I thought it was related to `DraggableCore` and layout changes/calculation but removing suspects did not improve on the delay for the context menu. However, removing the code that adds/removes the class removes the problem for the delay of the context menu. 

*This problem is visible only when there's a lot of logs so fixing laggy dragging can potentially fix it as well.*

**Laggy dragging**

Laggy dragging could be caused by the fact that all rows are rendered (also not visible on the screen). Some elements are positioned relatively so I guess updating the layout may take a bit longer when the parent container moves (?). I'm not 100% sure yet what's the bottleneck.

It could be improved with virtualization but in case of logs the rows have dynamic height. The height changes when details are shown or details about fields are expanded. To make it work it requires some fiddling with react-window `VariableSizeList` component. It still could be an option but probably worth getting to the root cause first.

In case this issue proves to be a pain and there are no other easy fixes, this PR introduces lazy rendering. The user has to click on "show more rows" to render more logs. It improves performance of loading the context menu and dragging:

https://user-images.githubusercontent.com/745532/120461272-26e73a80-c39a-11eb-831d-01e2b39263e5.mov

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->


**Which issue(s) this PR fixes**: 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

N/A

**Special notes for your reviewer**:

It can be tested with test data and a panel with ~1000 logs. 
