### PR TITLE
LibraryPanels: Fix for unnecessary unsaved changes modal appearing

### DIFF
--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
@@ -240,7 +240,7 @@ export function hasChanges(current: DashboardModel, original: any) {
 }
 
 export function hasLibraryPanelChanged(current: PanelModelWithLibraryPanel, original: any): boolean {
-  if (!current || !original?.panels?.length) {
+  if (!current || !original?.panels) {
     return false;
   }
 
@@ -251,6 +251,11 @@ export function hasLibraryPanelChanged(current: PanelModelWithLibraryPanel, orig
   const originalPanel: PanelModel | undefined = original.panels.find(
     (p: PanelModel) => isPanelModelLibraryPanel(p) && p.libraryPanel.uid === current.libraryPanel.uid
   );
+
+  if (!originalPanel) {
+    return true;
+  }
+
   const currentClean = { ...current.getSaveModel(), id: 1 };
   const originalClean = { ...new PanelModel(originalPanel).getSaveModel(), id: 1 };
   return !isEqual(currentClean, originalClean);

--- a/public/app/features/library-panels/guard.ts
+++ b/public/app/features/library-panels/guard.ts
@@ -1,6 +1,10 @@
 import { PanelModel } from '../dashboard/state';
 import { PanelModelWithLibraryPanel } from './types';
 
-export function isPanelModelLibraryPanel(panel: PanelModel): panel is PanelModelWithLibraryPanel {
+export function isPanelModelLibraryPanel(panel?: PanelModel): panel is PanelModelWithLibraryPanel {
+  if (!panel) {
+    return false;
+  }
+
   return Boolean(panel.libraryPanel?.uid);
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This work builds on the great work in #34989 and makes sure that we compare changes between current library panel and the original. This is a bit of a hack until we have a better API for upgrading queries from data source plugins. 

**Which issue(s) this PR fixes**:
Fixes #34891

**Special notes for your reviewer**:

