### PR TITLE
InfluxDB: Deprecate direct browser access in data source

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -32,7 +32,7 @@ Name        | Description
 `Name`      | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.
 `Default`   | Default data source means that it will be pre-selected for new panels.
 `URL`       | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.
-`Access`    | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser.
+`Access`    | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser (**WARNING**: Browser access is deprecated and will be removed in a future release).
 `Whitelisted Cookies`| Cookies that will be forwarded to the data source. All other cookies will be deleted.
 `Database`  | The ID of the bucket you want to query from, copied from the [Buckets page](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/) of the InfluxDB UI.
 `User`      | The username you use to sign into InfluxDB.

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -32,7 +32,8 @@ Name        | Description
 `Name`      | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.
 `Default`   | Default data source means that it will be pre-selected for new panels.
 `URL`       | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.
-`Access`    | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser (**WARNING**: Browser access is deprecated and will be removed in a future release).
+`Access`    | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser.
+**Note**: Browser access is deprecated and will be removed in a future release.
 `Whitelisted Cookies`| Cookies that will be forwarded to the data source. All other cookies will be deleted.
 `Database`  | The ID of the bucket you want to query from, copied from the [Buckets page](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/) of the InfluxDB UI.
 `User`      | The username you use to sign into InfluxDB.

--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -9,7 +9,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { DataSourceHttpSettings, InfoBox, InlineField, InlineFormLabel, LegacyForms } from '@grafana/ui';
+import { Alert, DataSourceHttpSettings, InfoBox, InlineField, InlineFormLabel, LegacyForms } from '@grafana/ui';
 const { Select, Input, SecretFormField } = LegacyForms;
 import { InfluxOptions, InfluxSecureJsonData, InfluxVersion } from '../types';
 
@@ -277,6 +277,12 @@ export class ConfigEditor extends PureComponent<Props, State> {
               </a>
             </p>
           </InfoBox>
+        )}
+
+        {options.access === 'direct' && (
+          <Alert title="Deprecation Notice" severity="warning">
+            Browser access mode in the InfluxDB datasource is deprecated and will be removed in a future release.
+          </Alert>
         )}
 
         <DataSourceHttpSettings


### PR DESCRIPTION
In the InfluxDB datasource it is possible to choose browser-access, meaning queries go directly from the browser to the influxdb server. We are going to remove this possibility in a future release, so for now we will mark it as deprecated and show a deprecation-warning.