### PR TITLE
Alerting: Don't save Alertmanager config on migration when 0 channels

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -243,10 +243,27 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 		return err
 	}
 
+	if err := m.writeAlertmanagerConfig(&amConfig, allChannels); err != nil {
+		return err
+	}
+
+	if err := m.writeSilencesFile(); err != nil {
+		m.mg.Logger.Error("alert migration error: failed to write silence file", "err", err)
+	}
+
+	return nil
+}
+
+func (m *migration) writeAlertmanagerConfig(amConfig *PostableUserConfig, allChannels map[interface{}]*notificationChannel) error {
+	if len(allChannels) == 0 {
+		// No channels, hence don't require Alertmanager config.
+		return nil
+	}
+
 	if err := amConfig.EncryptSecureSettings(); err != nil {
 		return err
 	}
-	rawAmConfig, err := json.Marshal(&amConfig)
+	rawAmConfig, err := json.Marshal(amConfig)
 	if err != nil {
 		return err
 	}
@@ -260,10 +277,6 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	})
 	if err != nil {
 		return err
-	}
-
-	if err := m.writeSilencesFile(); err != nil {
-		m.mg.Logger.Error("alert migration error: failed to write silence file", "err", err)
 	}
 
 	return nil

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -257,6 +257,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 func (m *migration) writeAlertmanagerConfig(amConfig *PostableUserConfig, allChannels map[interface{}]*notificationChannel) error {
 	if len(allChannels) == 0 {
 		// No channels, hence don't require Alertmanager config.
+		m.mg.Logger.Info("alert migration: no notification channel found, skipping Alertmanager config")
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Hence, on migration, if there are 0 channels, Alertmanager will write it's default config instead we writing something empty on migration.