### PR TITLE
grafana/ui: Fix checkbox vertical alignment 

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import mdx from './Checkbox.mdx';
 import { Checkbox } from './Checkbox';
 import { VerticalGroup } from '../Layout/Layout';
+import { Field } from './Field';
 
 export default {
   title: 'Forms/Checkbox',
@@ -55,5 +56,16 @@ export const StackedList = () => {
         description="Another long description that does not make any sense or does it?"
       />
     </VerticalGroup>
+  );
+};
+
+export const InAField = () => {
+  return (
+    <Field
+      label="Hidden"
+      description="Annotation queries can be toggled on or of at the top of the dashboard. With this option checked this toggle will be hidden."
+    >
+      <Checkbox name="hide" id="hide" defaultChecked={true} />
+    </Field>
   );
 };

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -48,21 +48,6 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
   const labelPadding = 1;
 
   return {
-    label: cx(
-      labelStyles.label,
-      css`
-        padding-left: ${theme.spacing(labelPadding)};
-        white-space: nowrap;
-        cursor: pointer;
-      `
-    ),
-    description: cx(
-      labelStyles.description,
-      css`
-        line-height: ${theme.typography.bodySmall.lineHeight};
-        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
-      `
-    ),
     wrapper: css`
       position: relative;
       vertical-align: middle;
@@ -137,6 +122,21 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
         border-color: ${theme.components.input.borderHover};
       }
     `,
+    label: cx(
+      labelStyles.label,
+      css`
+        padding-left: ${theme.spacing(labelPadding)};
+        white-space: nowrap;
+        cursor: pointer;
+      `
+    ),
+    description: cx(
+      labelStyles.description,
+      css`
+        line-height: ${theme.typography.bodySmall.lineHeight};
+        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
+      `
+    ),
   };
 });
 

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -44,12 +44,14 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
 
 export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
   const labelStyles = getLabelStyles(theme);
-  const checkboxSize = '16px';
+  const checkboxSize = 2;
+  const labelPadding = 1;
+
   return {
     label: cx(
       labelStyles.label,
       css`
-        padding-left: ${theme.spacing(1)};
+        padding-left: ${theme.spacing(labelPadding)};
         white-space: nowrap;
         cursor: pointer;
       `
@@ -58,19 +60,19 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
       labelStyles.description,
       css`
         line-height: ${theme.typography.bodySmall.lineHeight};
-        padding-left: ${theme.spacing(1)};
+        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
       `
     ),
     wrapper: css`
       position: relative;
-      padding-left: ${checkboxSize};
       vertical-align: middle;
+      font-size: 0;
     `,
     input: css`
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
+      width: 100% !important; // global styles unset this
       height: 100%;
       opacity: 0;
 
@@ -124,15 +126,11 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
     `,
     checkmark: css`
       display: inline-block;
-      width: ${checkboxSize};
-      height: ${checkboxSize};
+      width: ${theme.spacing(checkboxSize)};
+      height: ${theme.spacing(checkboxSize)};
       border-radius: ${theme.shape.borderRadius()};
-      margin-right: ${theme.spacing(1)};
       background: ${theme.components.input.background};
       border: 1px solid ${theme.components.input.borderColor};
-      position: absolute;
-      top: 2px;
-      left: 0;
 
       &:hover {
         cursor: pointer;

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -44,20 +44,34 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
 
 export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
   const labelStyles = getLabelStyles(theme);
-  const checkboxSize = 2;
-  const labelPadding = 1;
-
+  const checkboxSize = '16px';
   return {
+    label: cx(
+      labelStyles.label,
+      css`
+        padding-left: ${theme.spacing(1)};
+        white-space: nowrap;
+        cursor: pointer;
+      `
+    ),
+    description: cx(
+      labelStyles.description,
+      css`
+        line-height: ${theme.typography.bodySmall.lineHeight};
+        padding-left: ${theme.spacing(1)};
+      `
+    ),
     wrapper: css`
       position: relative;
+      padding-left: ${checkboxSize};
       vertical-align: middle;
-      font-size: 0;
+      min-height: ${theme.spacing(3)};
     `,
     input: css`
       position: absolute;
       top: 0;
       left: 0;
-      width: 100% !important; // global styles unset this
+      width: 100%;
       height: 100%;
       opacity: 0;
 
@@ -111,32 +125,21 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
     `,
     checkmark: css`
       display: inline-block;
-      width: ${theme.spacing(checkboxSize)};
-      height: ${theme.spacing(checkboxSize)};
+      width: ${checkboxSize};
+      height: ${checkboxSize};
       border-radius: ${theme.shape.borderRadius()};
+      margin-right: ${theme.spacing(1)};
       background: ${theme.components.input.background};
       border: 1px solid ${theme.components.input.borderColor};
+      position: absolute;
+      top: 2px;
+      left: 0;
 
       &:hover {
         cursor: pointer;
         border-color: ${theme.components.input.borderHover};
       }
     `,
-    label: cx(
-      labelStyles.label,
-      css`
-        padding-left: ${theme.spacing(labelPadding)};
-        white-space: nowrap;
-        cursor: pointer;
-      `
-    ),
-    description: cx(
-      labelStyles.description,
-      css`
-        line-height: ${theme.typography.bodySmall.lineHeight};
-        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
-      `
-    ),
   };
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where checkboxes would be vertically lower than they should be. It also fixes a previous issue where the visual element was not totally within the box, making it tricky to align it.

I've changed the blue pseudo-checkbox so it's no longer absolutely positioned and is instead in the flow of the document. This removes the need for fixed height and weird margin/padding hacks.

![image](https://user-images.githubusercontent.com/46142/120517461-6167cc00-c3c8-11eb-8539-4be7794adf86.png)

![image](https://user-images.githubusercontent.com/46142/120517521-75abc900-c3c8-11eb-87f9-7ee52d0f9286.png)


**Which issue(s) this PR fixes**:

Fixes a slight regression introduced in https://github.com/grafana/grafana/pull/35022

**Special notes for your reviewer**:

You can see the main substance of my changes in the [first commit](https://github.com/grafana/grafana/pull/35124/commits/a5d95fd9f6a9ea77eb544f96608ff3adadf033f7)

Should this be backported? I think it should be because the original #35022 was backported...

"Longer term" I think the labels and the checkmark itself should be split into separate components, and composed together 😌 