### PR TITLE
AzureMonitor: Resource Picker alignment/spacing tweaks

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/NestedRows.tsx
@@ -187,29 +187,29 @@ const NestedEntry: React.FC<NestedEntryProps> = ({
       {/* When groups are selectable, I *think* we will want to show a 2-wide space instead
             of the collapse button for leaf rows that have no children to get them to align */}
 
-      <span className={styles.entryContentItem}>
-        {hasChildren ? (
-          <IconButton
-            className={styles.collapseButton}
-            name={isOpen ? 'angle-down' : 'angle-right'}
-            aria-label={isOpen ? 'Collapse' : 'Expand'}
-            onClick={handleToggleCollapse}
-            id={entry.id}
-          />
-        ) : (
-          <Space layout="inline" h={2} />
-        )}
-      </span>
-
-      {isSelectable && (
-        <span className={styles.entryContentItem}>
-          <Checkbox id={checkboxId} onChange={handleSelectedChanged} disabled={isDisabled} value={isSelected} />
-        </span>
+      {hasChildren ? (
+        <IconButton
+          className={styles.collapseButton}
+          name={isOpen ? 'angle-down' : 'angle-right'}
+          aria-label={isOpen ? 'Collapse' : 'Expand'}
+          onClick={handleToggleCollapse}
+          id={entry.id}
+        />
+      ) : (
+        <Space layout="inline" h={2} />
       )}
 
-      <span className={styles.entryContentItem}>
-        <EntryIcon entry={entry} isOpen={isOpen} />
-      </span>
+      <Space layout="inline" h={2} />
+
+      {isSelectable && (
+        <>
+          <Checkbox id={checkboxId} onChange={handleSelectedChanged} disabled={isDisabled} value={isSelected} />
+          <Space layout="inline" h={2} />
+        </>
+      )}
+
+      <EntryIcon entry={entry} isOpen={isOpen} />
+      <Space layout="inline" h={1} />
 
       <label htmlFor={checkboxId} className={cx(styles.entryContentItem, styles.truncated)}>
         {entry.name}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/styles.ts
@@ -51,6 +51,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
   nestedEntry: css({
     display: 'flex',
+    alignItems: 'center',
   }),
 
   entryContentItem: css({


### PR DESCRIPTION

**What this PR does / why we need it**:

Minor tweaks to the alignment and spacing of the buttons and icons in the resource picker rows. Kind of depends on https://github.com/grafana/grafana/pull/35124

![image](https://user-images.githubusercontent.com/46142/120519625-bc022780-c3ca-11eb-9dd3-9080f13bca9c.png)
