### PR TITLE
Plugin: add signature status to plugin_build_info

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -516,7 +516,7 @@ func init() {
 		Name:      "plugin_build_info",
 		Help:      "A metric with a constant '1' value labeled by pluginId, pluginType and version from which Grafana plugin was built",
 		Namespace: ExporterName,
-	}, []string{"plugin_id", "plugin_type", "version"})
+	}, []string{"plugin_id", "plugin_type", "version", "signature_status"})
 
 	StatsTotalDashboardVersions = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "stat_totals_dashboard_versions",
@@ -597,8 +597,8 @@ func SetEnvironmentInformation(labels map[string]string) error {
 	return nil
 }
 
-func SetPluginBuildInformation(pluginID, pluginType, version string) {
-	grafanaPluginBuildInfoDesc.WithLabelValues(pluginID, pluginType, version).Set(1)
+func SetPluginBuildInformation(pluginID, pluginType, version, signatureStatus string) {
+	grafanaPluginBuildInfoDesc.WithLabelValues(pluginID, pluginType, version, signatureStatus).Set(1)
 }
 
 func initMetricVars() {

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -178,7 +178,7 @@ func (pm *PluginManager) initExternalPlugins() error {
 		if p.IsCorePlugin {
 			p.Signature = plugins.PluginSignatureInternal
 		} else {
-			metrics.SetPluginBuildInformation(p.Id, p.Type, p.Info.Version)
+			metrics.SetPluginBuildInformation(p.Id, p.Type, p.Info.Version, string(p.Signature))
 		}
 	}
 


### PR DESCRIPTION
This could help us identify customers using unsigned plugins.

Signed-off-by: bergquist <carl.bergquist@gmail.com>
