### PR TITLE
GraphNG: uPlot 1.6.11

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -72,7 +72,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.10"
+    "uplot": "1.6.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22041,10 +22041,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.10:
-  version "1.6.10"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.10.tgz#6dd1adf3180203777f5c369ef6f6aab312661943"
-  integrity sha512-9MIscZoF+gA6Y6EAFTZl3zBU4MDaSbJ9Qy4nQ3LaXifGuluAhq4UuQOADKC6qZJjC9QoepeZ2eh7LpJn2xbLSQ==
+uplot@1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.11.tgz#2ade33071e4eb30c6504ad7c68eb4c05d9dd47eb"
+  integrity sha512-DTA/wLLFSccSghZKM02hLgHoe8zDoCGFEkbbszXwkNRFgkkRKYc0gPNaJG76JFrwDlZNc7+u9noUHxt9fLu+lg==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
https://github.com/leeoniya/uPlot/releases/tag/1.6.11

Fixes https://github.com/grafana/grafana/issues/34904

this update touches the path clipping strategy, so look out for regressions specifically related to fillBelowTo, stacking, and proper area fills in general. in my testing everything looked okay.

let's hope this is the last one before 8.0 :crossed_fingers: 