### PR TITLE
Middleware: Don't require HTTPS for HSTS headers to be emitted

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -259,7 +259,6 @@ cookie_samesite = lax
 allow_embedding = false
 
 # Set to true if you want to enable http strict transport security (HSTS) response header.
-# This is only sent when HTTPS is enabled in this configuration.
 # HSTS tells browsers that the site should only be accessed using HTTPS.
 strict_transport_security = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -259,7 +259,6 @@
 ;allow_embedding = false
 
 # Set to true if you want to enable http strict transport security (HSTS) response header.
-# This is only sent when HTTPS is enabled in this configuration.
 # HSTS tells browsers that the site should only be accessed using HTTPS.
 ;strict_transport_security = false
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -546,7 +546,7 @@ mitigate the risk of [Clickjacking](https://owasp.org/www-community/attacks/Clic
 
 ### strict_transport_security
 
-Set to `true` if you want to enable HTTP `Strict-Transport-Security` (HSTS) response header. This is only sent when HTTPS is enabled in this configuration. HSTS tells browsers that the site should only be accessed using HTTPS.
+Set to `true` if you want to enable HTTP `Strict-Transport-Security` (HSTS) response header. Only use this when HTTPS is enabled in your configuration, or when there is another upstream system that ensures your application does HTTPS (like a frontend load balancer). HSTS tells browsers that the site should only be accessed using HTTPS.
 
 ### strict_transport_security_max_age_seconds
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -47,7 +47,7 @@ func AddDefaultResponseHeaders(cfg *setting.Cfg) web.Handler {
 
 // addSecurityHeaders adds HTTP(S) response headers that enable various security protections in the client's browser.
 func addSecurityHeaders(w web.ResponseWriter, cfg *setting.Cfg) {
-	if (cfg.Protocol == setting.HTTPSScheme || cfg.Protocol == setting.HTTP2Scheme) && cfg.StrictTransportSecurity {
+	if cfg.StrictTransportSecurity {
 		strictHeaderValues := []string{fmt.Sprintf("max-age=%v", cfg.StrictTransportSecurityMaxAge)}
 		if cfg.StrictTransportSecurityPreload {
 			strictHeaderValues = append(strictHeaderValues, "preload")

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -68,7 +68,6 @@ func TestMiddleWareSecurityHeaders(t *testing.T) {
 		sc.fakeReq("GET", "/api/").exec()
 		assert.Equal(t, "max-age=64000; preload; includeSubDomains", sc.resp.Header().Get("Strict-Transport-Security"))
 	}, func(cfg *setting.Cfg) {
-		cfg.Protocol = setting.HTTPSScheme
 		cfg.StrictTransportSecurity = true
 		cfg.StrictTransportSecurityMaxAge = 64000
 	})


### PR DESCRIPTION
Grafana itself may not be serving content over HTTPS, but it may be
behind a transparent proxy which does.

Fixes #26770.  Based on #26868.
