### PR TITLE
Expressions: updating copy from experimental to beta.

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryEditor.tsx
@@ -118,7 +118,7 @@ export class QueryEditor extends PureComponent<Props, State> {
           Query
         </Button>
         {config.expressionsEnabled && (
-          <Tooltip content="Experimental feature: queries could stop working in next version" placement="right">
+          <Tooltip content="Beta feature: queries could stop working in next version" placement="right">
             <Button
               type="button"
               icon="plus"

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -344,7 +344,7 @@ export class QueryGroup extends PureComponent<Props, State> {
           </Button>
         )}
         {config.expressionsEnabled && this.isExpressionsSupported(dsSettings) && (
-          <Tooltip content="Experimental feature: queries could stop working in next version" placement="right">
+          <Tooltip content="Beta feature: queries could stop working in next version" placement="right">
             <Button
               icon="plus"
               onClick={this.onAddExpressionClick}


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the copy of the expression button to align with the alerting functionality.

Before:
<img width="631" alt="Skärmavbild 2021-06-03 kl  09 48 16" src="https://user-images.githubusercontent.com/172951/120607876-e0084c00-c450-11eb-91cd-5a4744e5c939.png">

After:
<img width="596" alt="Skärmavbild 2021-06-03 kl  09 48 31" src="https://user-images.githubusercontent.com/172951/120607882-e1397900-c450-11eb-94e0-717a46d2e752.png">

