### PR TITLE
influxdb: docs: add new screenshot

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -75,7 +75,7 @@ To help you choose the best language for your needs, here’s a comparison of [F
 
 Enter edit mode by clicking the panel title and clicking **Edit**. The editor allows you to select metrics and tags.
 
-![InfluxQL query editor](/static/img/docs/influxdb/influxql-query-editor-7-5.png)
+![InfluxQL query editor](/static/img/docs/influxdb/influxql-query-editor-8-0.png)
 
 ### Filter data (WHERE)
 


### PR DESCRIPTION
The influxdb influxql query editor had very minor visual changes in grafana 8. i updated the screenshot.

the screenshot is already live at https://grafana.com/static/img/docs/influxdb/influxql-query-editor-8-0.png