### PR TITLE
add dashboard kiosk mode for embeding panel

### DIFF
--- a/public/app/core/navigation/kiosk.ts
+++ b/public/app/core/navigation/kiosk.ts
@@ -26,6 +26,8 @@ export function getKioskMode(queryParam?: UrlQueryValue): KioskMode {
   switch (queryParam) {
     case 'tv':
       return KioskMode.TV;
+    case 'dashboard':
+      return KioskMode.Dashboard;
     //  legacy support
     case '1':
     case true:

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -182,20 +182,20 @@ class DashNav extends PureComponent<Props> {
 
   renderRightActionsButton() {
     const { dashboard, onAddPanel, isFullscreen, kioskMode } = this.props;
-    const { canEdit, showSettings } = dashboard.meta;
+    const { canInteraction, canEdit, showSettings } = dashboard.meta;
     const { snapshot } = dashboard;
     const snapshotUrl = snapshot && snapshot.originalUrl;
     const buttons: ReactNode[] = [];
-    const tvButton = (
-      <ToolbarButton tooltip="Cycle view mode" icon="monitor" onClick={this.onToggleTVMode} key="tv-button" />
+    const cycleViewButton = (
+      <ToolbarButton tooltip="Cycle view mode" icon="monitor" onClick={this.onToggleTVMode} key="circle-button" />
     );
 
     if (this.isPlaylistRunning()) {
       return [this.renderPlaylistControls(), this.renderTimeControls()];
     }
 
-    if (kioskMode === KioskMode.TV) {
-      return [this.renderTimeControls(), tvButton];
+    if (kioskMode === KioskMode.TV || !canInteraction) {
+      return [this.renderTimeControls(), cycleViewButton];
     }
 
     if (canEdit && !isFullscreen) {
@@ -238,7 +238,7 @@ class DashNav extends PureComponent<Props> {
     this.addCustomContent(customRightActions, buttons);
 
     buttons.push(this.renderTimeControls());
-    buttons.push(tvButton);
+    buttons.push(cycleViewButton);
     return buttons;
   }
 
@@ -247,16 +247,19 @@ class DashNav extends PureComponent<Props> {
   }
 
   render() {
-    const { isFullscreen, title, folderTitle } = this.props;
+    const { isFullscreen, title, folderTitle, dashboard } = this.props;
+    const canInteraction = dashboard.meta.canInteraction;
     const onGoBack = isFullscreen ? this.onClose : undefined;
-
+    const parent = canInteraction ? folderTitle : undefined;
+    const onClickTitle = canInteraction ? this.onDashboardNameClick : undefined;
+    const onClickParent = canInteraction ? this.onFolderNameClick : undefined;
     return (
       <PageToolbar
         pageIcon={isFullscreen ? undefined : 'apps'}
         title={title}
-        parent={folderTitle}
-        onClickTitle={this.onDashboardNameClick}
-        onClickParent={this.onFolderNameClick}
+        parent={parent}
+        onClickTitle={onClickTitle}
+        onClickParent={onClickParent}
         onGoBack={onGoBack}
         leftItems={this.renderLeftActionsButton()}
       >

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -58,8 +58,15 @@ export const PanelHeader: FC<Props> = ({ panel, error, isViewing, isEditing, dat
                   />
                 ) : null}
                 <span className="panel-title-text">{title}</span>
-                <Icon name="angle-down" className="panel-menu-toggle" />
-                <PanelHeaderMenuWrapper panel={panel} dashboard={dashboard} show={panelMenuOpen} onClose={closeMenu} />
+                {dashboard.meta.canInteraction && <Icon name="angle-down" className="panel-menu-toggle" />}
+                {dashboard.meta.canInteraction && (
+                  <PanelHeaderMenuWrapper
+                    panel={panel}
+                    dashboard={dashboard}
+                    show={panelMenuOpen}
+                    onClose={closeMenu}
+                  />
+                )}
                 {data.request && data.request.timeInfo && (
                   <span className="panel-time-info">
                     <Icon name="clock-nine" size="sm" /> {data.request.timeInfo}

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -16,7 +16,15 @@ import {
   dashboardInitSlow,
 } from './reducers';
 // Types
-import { DashboardDTO, DashboardInitPhase, DashboardRoutes, StoreState, ThunkDispatch, ThunkResult } from 'app/types';
+import {
+  DashboardDTO,
+  DashboardInitPhase,
+  DashboardRoutes,
+  KioskMode,
+  StoreState,
+  ThunkDispatch,
+  ThunkResult,
+} from 'app/types';
 import { DashboardModel } from './DashboardModel';
 import { DataQuery, locationUtil } from '@grafana/data';
 import { initVariablesTransaction } from '../../variables/state/actions';
@@ -158,6 +166,9 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
     if (storeState.dashboard.modifiedQueries) {
       const { panelId, queries } = storeState.dashboard.modifiedQueries;
       dashboard.meta.fromExplore = !!(panelId && queries);
+    }
+    if (queryParams.kiosk !== KioskMode.Dashboard) {
+      dashboard.meta.canInteraction = true;
     }
 
     // template values service needs to initialize completely before the rest of the dashboard can load

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -16,6 +16,7 @@ export interface DashboardMeta {
   canShare?: boolean;
   canStar?: boolean;
   canAdmin?: boolean;
+  canInteraction?: boolean;
   url?: string;
   folderId?: number;
   fromExplore?: boolean;
@@ -65,6 +66,7 @@ export interface DashboardInitError {
 export enum KioskMode {
   Off = 'off',
   TV = 'tv',
+  Dashboard = 'dashboard',
   Full = 'full',
 }
 


### PR DESCRIPTION
**Why we need it**:
Currently, grafana show some disturbed information to end-users in kiosk tv mode, i.e.
**1. FoldMenu:** ![图片](https://user-images.githubusercontent.com/6059935/120658056-afa7c880-c4b7-11eb-8642-40da3cfe496f.png)
**2. Panel Header Dropdown:** ![图片](https://user-images.githubusercontent.com/6059935/120644204-a7e12780-c4a9-11eb-8b39-8f54fde41afd.png)



And kiosk full mode miss time picker for user adjust time range.
**3. TimePicker** ![图片](https://user-images.githubusercontent.com/6059935/120658399-fe556280-c4b7-11eb-832b-3017b0d3eb0b.png)

**What this PR does**:
This PR add a new kiosk mode for embeding dashboard.

![图片](https://user-images.githubusercontent.com/6059935/120657895-8424de00-c4b7-11eb-85d1-9903b4796c96.png)
 
**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/7450
https://github.com/grafana/grafana/issues/25894
https://github.com/grafana/grafana/issues/26105

