### PR TITLE
Storybook: Add missing select options for controls

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.story.tsx
+++ b/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.story.tsx
@@ -33,8 +33,13 @@ export default {
     closeOnConfirm: true,
   },
   argTypes: {
-    confirmVariant: { control: { type: 'select' } },
-    size: { control: { type: 'select' } },
+    confirmVariant: {
+      control: {
+        type: 'select',
+      },
+      options: ['primary', 'secondary', 'destructive', 'link'],
+    },
+    size: { control: { type: 'select' }, options: ['xs', 'sm', 'md', 'lg'] },
   },
 } as Meta;
 
@@ -43,6 +48,7 @@ interface StoryProps extends Partial<Props> {
 }
 
 export const Basic: Story<StoryProps> = (args) => {
+  console.log('var', args.confirmVariant);
   return (
     <ConfirmButton
       closeOnConfirm={args.closeOnConfirm}

--- a/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.story.tsx
+++ b/packages/grafana-ui/src/components/ConfirmButton/ConfirmButton.story.tsx
@@ -48,7 +48,6 @@ interface StoryProps extends Partial<Props> {
 }
 
 export const Basic: Story<StoryProps> = (args) => {
-  console.log('var', args.confirmVariant);
   return (
     <ConfirmButton
       closeOnConfirm={args.closeOnConfirm}

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.story.tsx
@@ -20,9 +20,10 @@ export default {
   argTypes: {
     disabledOptions: {
       name: 'Disabled item',
-      control: { type: 'select', options: ['', 'graphite', 'prometheus', 'elastic'] },
+      control: { type: 'select' },
+      options: ['', 'graphite', 'prometheus', 'elastic'],
     },
-    size: { control: { type: 'select' } },
+    size: { control: { type: 'select' }, options: ['xs', 'sm', 'md', 'lg'] },
   },
 };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

ConfirmButton.story and RadioButtonGroup.story were missing options for select controls, causing them to crash. Also according to the [Storybook's docs](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-controloptions), the options are not part of the `control` prop in the `argTypes` anymore.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/34417

