### PR TITLE
AzureMonitor: Require default subscription for workspaces() template variable query 

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -33,7 +33,7 @@ describe('AzureLogAnalyticsDatasource', () => {
 
   beforeEach(() => {
     ctx.instanceSettings = {
-      jsonData: { logAnalyticsSubscriptionId: 'xxx' },
+      jsonData: { logAnalyticsSubscriptionId: 'xxx', azureLogAnalyticsSameAs: false },
       url: 'http://azureloganalyticsapi',
     };
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/credentials.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/credentials.ts
@@ -74,7 +74,7 @@ function getLogAnalyticsSecret(options: AzureDataSourceSettings): undefined | st
   }
 }
 
-function isLogAnalyticsSameAs(options: AzureDataSourceSettings | AzureDataSourceInstanceSettings): boolean {
+export function isLogAnalyticsSameAs(options: AzureDataSourceSettings | AzureDataSourceInstanceSettings): boolean {
   return typeof options.jsonData.azureLogAnalyticsSameAs !== 'boolean' || options.jsonData.azureLogAnalyticsSameAs;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue with Azure Monitor where the `workspaces()` template variable query would fail with a cryptic error if a default subscription ID is not specified in the data source config.

Users should either use the `subscription(abc-123-def-456)` form to explicitly provide a subscription ID, or specify a default subscription ID in the data source config.