### PR TITLE
Alerting/Docs: Non-timeseries / numeric alerting

### DIFF
--- a/docs/sources/alerting/unified-alerting/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/create-grafana-managed-rule.md
@@ -58,7 +58,7 @@ So, as you can see from the above scenario Grafana will not send out notificatio
 You can use reduce and math expressions to create a rule that will create an alert per series returned by the query.
 
 1. Add one or more queries
-2. Add a `reduce` expression for each query to aggregate values in the selected time range into a single value. Not needed in case a query returns a single value per series. 
+2. Add a `reduce` expression for each query to aggregate values in the selected time range into a single value. With some data sources this is not needed for [rules using numeric data]({{< relref "./grafana-managed-numeric-rule.md" >}}).
 3. Add a `math` expressions with the condition for the rule. Not needed in case a query or a reduce expression already returns 0 if rule should not be firing, or > 0 if it should be firing. Some examples: `$B > 70` if it should fire in case value of B query/expression is more than 70. `$B < $C * 100` in case it should fire if value of B is less than value of C multiplied by 100. If queries being compared have multiple series in their results, series from different queries are matched if they have the same labels or one is a subset of the other.
 
 See or [expressions documentation]({{< relref "../../panels/expressions.md" >}}) for in depth explanation of `math` and `reduce` expressions.

--- a/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
@@ -48,3 +48,19 @@ SELECT Host, Disk, CASE WHEN PercentFree < 5.0 THEN PercentFree ELSE 0 END FROM 
     Disk
   Where __timeFilter(Time)
 ```
+
+This query would return the following Table response to Grafana:
+
+| Host | Disk | PercentFree
+| ---  | -----| --------
+| web1 | /etc | 3
+| web2 | /var | 4
+| web3 | /var | 0
+
+When this query is used as the **condition** in an alert rule, the non-zero will be alerting. So three alert instances will be produced:
+
+| Labels                | Status 
+| ----------------------| ------
+| {Host=web1,disk=/etc} | Alerting
+| {Host=web2,disk=/var} | Alerting
+| {Host=web3,disk=/var} | Normal 

--- a/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
@@ -1,6 +1,6 @@
 +++
-title = "Numeric data Grafana manged alert rules"
-description = "Number data based Grafana manged alert rules"
+title = "Numeric data Grafana managed alert rules"
+description = "Number data based Grafana managed alert rules"
 keywords = ["grafana", "alerting", "guide", "rules", "create"]
 weight = 400
 +++

--- a/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
@@ -7,8 +7,7 @@ weight = 400
 
 # Alerting on numeric data
 
-With certain data sources number data that is not time series can be directly alerted on, or passed into Server Side Expressions (SSE). This allows for more efficiency by doing more processing within the data source, and can also simplify alert rules.
-
+Among certain data sources numeric data that is not time series can be directly alerted on, or passed into Server Side Expressions (SSE). This allows for more processing and resulting efficiency within the data source, and it can also simplify alert rules.
 When alerting on numeric data instead of time series data, there is no need to reduce each labeled time series into a single number. Instead labeled numbers are returned to Grafana instead.
 
 ## Tabular Data
@@ -27,7 +26,7 @@ If there are string columns then those columns become labels. The name of column
 
 ## Example
 
-If you have a MySQL table called "DiskSpace" like the following:
+For a MySQL table called "DiskSpace":
 
 | Time        | Host | Disk | PercentFree
 | ----------- | ---  | -----| --------
@@ -36,7 +35,7 @@ If you have a MySQL table called "DiskSpace" like the following:
 | 2021-June-7 | web3 | /var | 8
 | ...         | ...  | ...  | ...
 
-You can query this data filtering on time, but without returning time series to Grafana:
+You can query the data filtering on time, but without returning time series to Grafana. For example:
 
 ```sql
 SELECT Host, Disk, CASE WHEN PercentFree < 5.0 THEN PercentFree ELSE 0 END FROM (
@@ -51,7 +50,7 @@ SELECT Host, Disk, CASE WHEN PercentFree < 5.0 THEN PercentFree ELSE 0 END FROM 
   Where __timeFilter(Time)
 ```
 
-This query would return the following Table response to Grafana:
+This query returns the following Table response to Grafana:
 
 | Host | Disk | PercentFree
 | ---  | -----| --------
@@ -59,7 +58,7 @@ This query would return the following Table response to Grafana:
 | web2 | /var | 4
 | web3 | /var | 0
 
-When this query is used as the **condition** in an alert rule, the non-zero will be alerting. So three alert instances will be produced:
+When this query is used as the **condition** in an alert rule, then the non-zero will be alerting. As a result, three alert instances are produced:
 
 | Labels                | Status
 | ----------------------| ------

--- a/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
@@ -25,3 +25,26 @@ If there are string columns then those columns become labels. The name of column
 
 ## Example
 
+If you have a MySQL table called "DiskSpace" like the following:
+
+| Time        | Host | Disk | PercentFree
+| ----------- | ---  | -----| --------
+| 2021-June-7 | web1 | /etc | 3
+| 2021-June-7 | web2 | /var | 4
+| 2021-June-7 | web3 | /var | 8
+| ...         | ...  | ...  | ...
+
+You can query this data filtering on time, but without returning time series to Grafana:
+
+```sql
+SELECT Host, Disk, CASE WHEN PercentFree < 5.0 THEN PercentFree ELSE 0 END FROM (
+  SELECT 
+      Host, 
+      Disk, 
+      Avg(PercentFree) 
+  FROM DiskSpace
+  Group By 
+    Host, 
+    Disk
+  Where __timeFilter(Time)
+```

--- a/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
@@ -1,0 +1,27 @@
++++
+title = "Numeric data Grafana manged alert rules"
+description = "Number data based Grafana manged alert rules"
+keywords = ["grafana", "alerting", "guide", "rules", "create"]
+weight = 400
++++
+
+# Alerting on numeric data
+
+With certain datasources non-timeseries data can be directly alerted on, or passed into Server Side Expressions (SSE). This allows for more efficiency by doing more processing within the data source, and can also simplify alert rules.
+
+When alerting on numeric data instead of timeseries data, there is no need to reduce each labeled time series into a single number. Instead labeled numbers are returned to Grafana instead.
+
+## Tabular Data
+
+This feature is supported with backend data sources that query tabular data:
+ - SQL Datasources such as MySQL, Postgres, MSSQL, and Oracle.
+ - The Azure Kusto based services: Azure Monitor (Logs), Azure Monitor (Azure Resource Graph), and Azure Data Explorer.
+
+A query with Grafana managed alerts or SSE is considered numeric with these datasources if:
+ - The "Format AS" option is a table.
+ - The table response returned to Grafana from the query includes only one numeric (e.g. int, double, float) column, and optionally additional string columns.
+
+If there are string columns then those columns become labels. The name of column becomes the label name, and the value for each row becomes the value of the corresponding label. If multiple rows are returned, then each row should be uniquely identified their labels.
+
+## Example
+

--- a/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-number-alerts.md
@@ -7,19 +7,21 @@ weight = 400
 
 # Alerting on numeric data
 
-With certain datasources non-timeseries data can be directly alerted on, or passed into Server Side Expressions (SSE). This allows for more efficiency by doing more processing within the data source, and can also simplify alert rules.
+With certain data sources number data that is not time series can be directly alerted on, or passed into Server Side Expressions (SSE). This allows for more efficiency by doing more processing within the data source, and can also simplify alert rules.
 
-When alerting on numeric data instead of timeseries data, there is no need to reduce each labeled time series into a single number. Instead labeled numbers are returned to Grafana instead.
+When alerting on numeric data instead of time series data, there is no need to reduce each labeled time series into a single number. Instead labeled numbers are returned to Grafana instead.
 
 ## Tabular Data
 
 This feature is supported with backend data sources that query tabular data:
- - SQL Datasources such as MySQL, Postgres, MSSQL, and Oracle.
- - The Azure Kusto based services: Azure Monitor (Logs), Azure Monitor (Azure Resource Graph), and Azure Data Explorer.
 
-A query with Grafana managed alerts or SSE is considered numeric with these datasources if:
- - The "Format AS" option is a table.
- - The table response returned to Grafana from the query includes only one numeric (e.g. int, double, float) column, and optionally additional string columns.
+- SQL data sources such as MySQL, Postgres, MSSQL, and Oracle.
+- The Azure Kusto based services: Azure Monitor (Logs), Azure Monitor (Azure Resource Graph), and Azure Data Explorer.
+
+A query with Grafana managed alerts or SSE is considered numeric with these data sources, if:
+
+- The "Format AS" option is set to "Table" in the data source query.
+- The table response returned to Grafana from the query includes only one numeric (e.g. int, double, float) column, and optionally additional string columns.
 
 If there are string columns then those columns become labels. The name of column becomes the label name, and the value for each row becomes the value of the corresponding label. If multiple rows are returned, then each row should be uniquely identified their labels.
 
@@ -59,8 +61,8 @@ This query would return the following Table response to Grafana:
 
 When this query is used as the **condition** in an alert rule, the non-zero will be alerting. So three alert instances will be produced:
 
-| Labels                | Status 
+| Labels                | Status
 | ----------------------| ------
 | {Host=web1,disk=/etc} | Alerting
 | {Host=web2,disk=/var} | Alerting
-| {Host=web3,disk=/var} | Normal 
+| {Host=web3,disk=/var} | Normal

--- a/docs/sources/alerting/unified-alerting/grafana-managed-numeric-rule.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-numeric-rule.md
@@ -1,6 +1,6 @@
 +++
-title = "Numeric data Grafana managed alert rules"
-description = "Number data based Grafana managed alert rules"
+title = "Grafana managed alert rules for numeric data"
+description = "Grafana managed alert rules for numeric data"
 keywords = ["grafana", "alerting", "guide", "rules", "create"]
 weight = 400
 +++
@@ -35,7 +35,7 @@ For a MySQL table called "DiskSpace":
 | 2021-June-7 | web3 | /var | 8
 | ...         | ...  | ...  | ...
 
-You can query the data filtering on time, but without returning time series to Grafana. For example:
+You can query the data filtering on time, but without returning time series to Grafana. For example, an alert that would trigger per Host,Disk when there is less than 5% free:
 
 ```sql
 SELECT Host, Disk, CASE WHEN PercentFree < 5.0 THEN PercentFree ELSE 0 END FROM (

--- a/docs/sources/alerting/unified-alerting/grafana-managed-numeric-rule.md
+++ b/docs/sources/alerting/unified-alerting/grafana-managed-numeric-rule.md
@@ -35,7 +35,7 @@ For a MySQL table called "DiskSpace":
 | 2021-June-7 | web3 | /var | 8
 | ...         | ...  | ...  | ...
 
-You can query the data filtering on time, but without returning time series to Grafana. For example, an alert that would trigger per Host,Disk when there is less than 5% free:
+You can query the data filtering on time, but without returning the time series to Grafana. For example, an alert that would trigger per Host, Disk when there is less than 5% free space:
 
 ```sql
 SELECT Host, Disk, CASE WHEN PercentFree < 5.0 THEN PercentFree ELSE 0 END FROM (


### PR DESCRIPTION
Explains cases in which data that is not time series can be alerted on:

TODO:
 - [x] What to title this? 
 - [x] Update "Not needed in case a query returns a single value per series." in Multi dimensional rule section of creating Grafana managed alerts to link to this instead
 - [ ] Link to from index? Isn't quite a task document...

