### PR TITLE
NodeGraph: Fix sorting markers in grid view

### DIFF
--- a/public/app/plugins/datasource/testdata/testData/serviceMapResponse.ts
+++ b/public/app/plugins/datasource/testdata/testData/serviceMapResponse.ts
@@ -172,7 +172,7 @@ export const nodes = {
     {
       name: NodeGraphDataFrameFieldNames.arc + 'faults',
       type: FieldType.number,
-      config: { color: { mode: FieldColorModeId.Fixed, fixedColor: 'red' }, displayName: 'faults' },
+      config: { color: { mode: FieldColorModeId.Fixed, fixedColor: 'red' }, displayName: 'Faults' },
       values: [
         0,
         0,

--- a/public/app/plugins/panel/nodeGraph/Legend.tsx
+++ b/public/app/plugins/panel/nodeGraph/Legend.tsx
@@ -55,7 +55,7 @@ export const Legend = function Legend(props: Props) {
           <>
             <VizLegendListItem item={item} className={styles.item} onLabelClick={sortable ? onClick : undefined} />
             {sortable &&
-              (sort?.field === item.data!.field ? <Icon name={sort!.ascending ? 'angle-up' : 'angle-down'} /> : '')}
+              (sort?.field === item.data!.field ? <Icon name={sort!.ascending ? 'arrow-up' : 'arrow-down'} /> : '')}
           </>
         );
       }}

--- a/public/app/plugins/panel/nodeGraph/Legend.tsx
+++ b/public/app/plugins/panel/nodeGraph/Legend.tsx
@@ -38,7 +38,7 @@ export const Legend = function Legend(props: Props) {
     (item) => {
       onSort({
         field: item.data!.field,
-        ascending: item.data!.field === sort?.field ? !sort?.ascending : true,
+        ascending: item.data!.field === sort?.field ? !sort?.ascending : false,
       });
     },
     [sort, onSort]

--- a/public/app/plugins/panel/nodeGraph/layout.ts
+++ b/public/app/plugins/panel/nodeGraph/layout.ts
@@ -179,8 +179,8 @@ function gridLayout(
       const val1 = sort!.field.values.get(node1.dataFrameRowIndex);
       const val2 = sort!.field.values.get(node2.dataFrameRowIndex);
 
-      // Lets pretend we don't care about type for a while
-      return sort!.ascending ? val2 - val1 : val1 - val2;
+      // Lets pretend we don't care about type of the stats for a while (they can be strings)
+      return sort!.ascending ? val1 - val2 : val2 - val1;
     });
   }
 


### PR DESCRIPTION
- The sorting did ascending sort when it should do descending.
- Default sort when clicked is descending as that seems more meaningful.
- Fix a case in test data field label.
