### PR TITLE
Histogram: enable ui-only zoom (with bucket snapping)

### DIFF
--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -86,11 +86,11 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
 
       if (wantedMax === fullRangeMax) {
         wantedMax += bucketSize;
-      } else if (wantedMax < fullRangeMax) {
+      } else {
         wantedMax = incrRoundUp(wantedMax, bucketSize);
       }
 
-      if (wantedMin !== fullRangeMin) {
+      if (wantedMin > fullRangeMin) {
         wantedMin = incrRoundDn(wantedMin, bucketSize);
       }
 

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -27,6 +27,14 @@ import {
 import { PanelOptions } from './models.gen';
 import { ScaleDistribution } from '@grafana/ui/src/components/uPlot/models.gen';
 
+function incrRoundDn(num: number, incr: number) {
+  return Math.floor(num / incr) * incr;
+}
+
+function incrRoundUp(num: number, incr: number) {
+  return Math.ceil(num / incr) * incr;
+}
+
 export interface HistogramProps extends Themeable2 {
   options: PanelOptions; // used for diff
   alignedFrame: DataFrame; // This could take HistogramFields
@@ -70,7 +78,24 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
     distribution: ScaleDistribution.Linear,
     orientation: ScaleOrientation.Horizontal,
     direction: ScaleDirection.Right,
-    range: (u) => [u.data[0][0], u.data[0][u.data[0].length - 1] + bucketSize],
+    range: (u, wantedMin, wantedMax) => {
+      let fullRangeMin = u.data[0][0];
+      let fullRangeMax = u.data[0][u.data[0].length - 1];
+
+      // snap to bucket divisors...
+
+      if (wantedMax === fullRangeMax) {
+        wantedMax += bucketSize;
+      } else if (wantedMax < fullRangeMax) {
+        wantedMax = incrRoundUp(wantedMax, bucketSize);
+      }
+
+      if (wantedMin !== fullRangeMin) {
+        wantedMin = incrRoundDn(wantedMin, bucketSize);
+      }
+
+      return [wantedMin, wantedMax];
+    },
   });
 
   builder.addScale({
@@ -112,6 +137,14 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
     //ticks: false,
     //gap: 15,
     theme,
+  });
+
+  builder.setCursor({
+    drag: {
+      x: true,
+      y: false,
+      setScale: true,
+    },
   });
 
   let pathBuilder = uPlot.paths.bars!({ align: 1, size: [1, Infinity] });


### PR DESCRIPTION
this also does a tiny bit of refactoring to UPlotconfigBuilder.setCursor(), so make sure normal zoom still works in non-histogram panels.