### PR TITLE
AzureMonitor: Fix Azure Resource Graph queries in Azure China

### DIFF
--- a/pkg/tsdb/azuremonitor/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-resource-graph-datasource.go
@@ -226,7 +226,7 @@ func (e *AzureResourceGraphDatasource) getPluginRoute(plugin *plugins.DataSource
 		return nil, "", err
 	}
 
-	routeName, err := getResourceGraphApiRoute(cloud)
+	routeName, err := getManagementApiRoute(cloud)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/tsdb/azuremonitor/routes.go
+++ b/pkg/tsdb/azuremonitor/routes.go
@@ -43,19 +43,3 @@ func getAppInsightsApiRoute(azureCloud string) (string, error) {
 		return "", err
 	}
 }
-
-func getResourceGraphApiRoute(azureCloud string) (string, error) {
-	switch azureCloud {
-	case azureMonitorPublic:
-		return "azureresourcegraph", nil
-	case azureMonitorChina:
-		return "chinaazureresourcegraph", nil
-	case azureMonitorUSGovernment:
-		return "govazureresourcegraph", nil
-	case azureMonitorGermany:
-		return "germanyazureresourcegraph", nil
-	default:
-		err := fmt.Errorf("the cloud '%s' not supported", azureCloud)
-		return "", err
-	}
-}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/api/routes.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/api/routes.ts
@@ -21,6 +21,8 @@ export function getLogAnalyticsManagementApiRoute(azureCloud: string): string {
       return 'chinaworkspacesloganalytics';
     case 'govazuremonitor':
       return 'govworkspacesloganalytics';
+    case 'germanyazuremonitor':
+      return 'germanyworkspacesloganalytics';
     default:
       throw new Error('The cloud not supported.');
   }
@@ -45,22 +47,6 @@ export function getAppInsightsApiRoute(azureCloud: string): string {
       return 'appinsights';
     case 'chinaazuremonitor':
       return 'chinaappinsights';
-    default:
-      throw new Error('The cloud not supported.');
-  }
-}
-
-export function getLogAnalyticsResourcePickerApiRoute(azureCloud: string) {
-  switch (azureCloud) {
-    case 'azuremonitor':
-      return 'loganalytics-resourcepickerdata';
-
-    case 'govazuremonitor': // Azure US Government
-      return 'loganalytics-resourcepickerdata-gov';
-
-    case 'chinaazuremonitor': // Azure China
-      return 'loganalytics-resourcepickerdata-china';
-
     default:
       throw new Error('The cloud not supported.');
   }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/plugin.json
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/plugin.json
@@ -31,7 +31,7 @@
   "routes": [
     {
       "path": "azuremonitor",
-      "method": "GET",
+      "method": "*",
       "url": "https://management.azure.com",
       "authType": "azure",
       "tokenAuth": {
@@ -48,7 +48,7 @@
     },
     {
       "path": "govazuremonitor",
-      "method": "GET",
+      "method": "*",
       "url": "https://management.usgovcloudapi.net",
       "authType": "azure",
       "tokenAuth": {
@@ -65,7 +65,7 @@
     },
     {
       "path": "germanyazuremonitor",
-      "method": "GET",
+      "method": "*",
       "url": "https://management.microsoftazure.de",
       "authType": "azure",
       "tokenAuth": {
@@ -82,7 +82,7 @@
     },
     {
       "path": "chinaazuremonitor",
-      "method": "GET",
+      "method": "*",
       "url": "https://management.chinacloudapi.cn",
       "authType": "azure",
       "tokenAuth": {
@@ -90,74 +90,6 @@
         "params": {
           "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
           "azure_cloud": "AzureChinaCloud",
-          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
-          "client_id": "{{.JsonData.clientId | orEmpty}}",
-          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
-        }
-      },
-      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
-    },
-    {
-      "path": "azureresourcegraph",
-      "method": "POST",
-      "url": "https://management.azure.com",
-      "authType": "azure",
-      "tokenAuth": {
-        "scopes": ["https://management.azure.com/.default"],
-        "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
-          "azure_cloud": "AzureCloud",
-          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
-          "client_id": "{{.JsonData.clientId | orEmpty}}",
-          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
-        }
-      },
-      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
-    },
-    {
-      "path": "chinaazureresourcegraph",
-      "method": "POST",
-      "url": "https://management.azure.com",
-      "authType": "azure",
-      "tokenAuth": {
-        "scopes": ["https://management.chinacloudapi.cn/.default"],
-        "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
-          "azure_cloud": "AzureChinaCloud",
-          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
-          "client_id": "{{.JsonData.clientId | orEmpty}}",
-          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
-        }
-      },
-      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
-    },
-    {
-      "path": "govazureresourcegraph",
-      "method": "POST",
-      "url": "https://management.usgovcloudapi.net",
-      "authType": "azure",
-      "tokenAuth": {
-        "scopes": ["https://management.usgovcloudapi.net/.default"],
-        "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
-          "azure_cloud": "AzureUSGovernment",
-          "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
-          "client_id": "{{.JsonData.clientId | orEmpty}}",
-          "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
-        }
-      },
-      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
-    },
-    {
-      "path": "germanyazureresourcegraph",
-      "method": "POST",
-      "url": "https://management.microsoftazure.de",
-      "authType": "azure",
-      "tokenAuth": {
-        "scopes": ["https://management.microsoftazure.de/.default"],
-        "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
-          "azure_cloud": "AzureGermanCloud",
           "tenant_id": "{{.JsonData.tenantId | orEmpty}}",
           "client_id": "{{.JsonData.clientId | orEmpty}}",
           "client_secret": "{{.SecureJsonData.clientSecret | orEmpty}}"
@@ -184,59 +116,8 @@
       ]
     },
     {
-      "path": "loganalytics-resourcepickerdata",
-      "method": "POST",
-      "url": "https://management.azure.com",
-      "authType": "azure",
-      "tokenAuth": {
-        "scopes": ["https://management.azure.com/.default"],
-        "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
-          "azure_cloud": "AzureCloud",
-          "tenant_id": "{{.JsonData.logAnalyticsTenantId | orEmpty}}",
-          "client_id": "{{.JsonData.logAnalyticsClientId | orEmpty}}",
-          "client_secret": "{{.SecureJsonData.logAnalyticsClientSecret | orEmpty}}"
-        }
-      },
-      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
-    },
-    {
-      "path": "loganalytics-resourcepickerdata-china",
-      "method": "POST",
-      "url": "https://management.chinacloudapi.cn",
-      "authType": "azure",
-      "tokenAuth": {
-        "scopes": ["https://management.chinacloudapi.cn/.default"],
-        "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
-          "azure_cloud": "AzureChinaCloud",
-          "tenant_id": "{{.JsonData.logAnalyticsTenantId | orEmpty}}",
-          "client_id": "{{.JsonData.logAnalyticsClientId | orEmpty}}",
-          "client_secret": "{{.SecureJsonData.logAnalyticsClientSecret | orEmpty}}"
-        }
-      },
-      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
-    },
-    {
-      "path": "loganalytics-resourcepickerdata-gov",
-      "method": "POST",
-      "url": "https://management.usgovcloudapi.net",
-      "authType": "azure",
-      "tokenAuth": {
-        "scopes": ["https://management.usgovcloudapi.net/.default"],
-        "params": {
-          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
-          "azure_cloud": "AzureUSGovernment",
-          "tenant_id": "{{.JsonData.logAnalyticsTenantId | orEmpty}}",
-          "client_id": "{{.JsonData.logAnalyticsClientId | orEmpty}}",
-          "client_secret": "{{.SecureJsonData.logAnalyticsClientSecret | orEmpty}}"
-        }
-      },
-      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
-    },
-    {
       "path": "workspacesloganalytics",
-      "method": "GET",
+      "method": "*",
       "url": "https://management.azure.com",
       "authType": "azure",
       "tokenAuth": {
@@ -253,7 +134,7 @@
     },
     {
       "path": "chinaworkspacesloganalytics",
-      "method": "GET",
+      "method": "*",
       "url": "https://management.chinacloudapi.cn",
       "authType": "azure",
       "tokenAuth": {
@@ -270,11 +151,28 @@
     },
     {
       "path": "govworkspacesloganalytics",
-      "method": "GET",
+      "method": "*",
       "url": "https://management.usgovcloudapi.net",
       "authType": "azure",
       "tokenAuth": {
         "scopes": ["https://management.usgovcloudapi.net/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureUSGovernment",
+          "tenant_id": "{{.JsonData.logAnalyticsTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.logAnalyticsClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.logAnalyticsClientSecret | orEmpty}}"
+        }
+      },
+      "headers": [{ "name": "x-ms-app", "content": "Grafana" }]
+    },
+    {
+      "path": "germanyworkspacesloganalytics",
+      "method": "*",
+      "url": "https://management.microsoftazure.de",
+      "authType": "azure",
+      "tokenAuth": {
+        "scopes": ["https://management.microsoftazure.de/.default"],
         "params": {
           "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
           "azure_cloud": "AzureUSGovernment",

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -17,7 +17,7 @@ import {
   RawAzureResourceItem,
 } from '../types';
 
-const RESOURCE_GRAPH_URL = '/providers/Microsoft.ResourceGraph/resources?api-version=2020-04-01-preview';
+const RESOURCE_GRAPH_URL = '/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01';
 
 export default class ResourcePickerData {
   private proxyUrl: string;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -1,5 +1,5 @@
 import { FetchResponse, getBackendSrv } from '@grafana/runtime';
-import { getLogAnalyticsResourcePickerApiRoute } from '../api/routes';
+import { getLogAnalyticsManagementApiRoute } from '../api/routes';
 import {
   locationDisplayNames,
   logsSupportedLocationsKusto,
@@ -148,7 +148,7 @@ export default class ResourcePickerData {
     try {
       return await getBackendSrv()
         .fetch<AzureGraphResponse<T>>({
-          url: this.proxyUrl + '/' + getLogAnalyticsResourcePickerApiRoute(this.cloud) + RESOURCE_GRAPH_URL,
+          url: this.proxyUrl + '/' + getLogAnalyticsManagementApiRoute(this.cloud) + RESOURCE_GRAPH_URL,
           method: 'POST',
           data: {
             query: query,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes Azure Resource Graph queries and Resource Picker in Azure China:
1. Routes are optimized and duplicated routes were removed to workaround #35231
2. API version of Resource Picker queries was updated because old API version not supported in Azure China.

**Special notes for your reviewer**:

I found that routes actually can support * method match, so I removed all duplicated routes to Azure Management API.
Was tested in Azure Public Cloud and Azure China.

Fixes #31662
