### PR TITLE
Frontend: Display dashboard datasource panel when source panel is in a collapsed row

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -437,17 +437,14 @@ export class DashboardModel {
       return this.panelInEdit;
     }
 
-    const panel = this.panels.find((p) => p.id === id);
-
-    if (panel) {
-      return panel;
-    }
-
-    const rows = this.panels.filter((p) => p.type === 'row');
-    for (const row of rows) {
-      const rowPanel: any = row.panels?.find((p: any) => p.id === id);
-      if (rowPanel) {
-        return new PanelModel(rowPanel);
+    for (const panel of this.panels) {
+      if (panel.id === id) {
+        return panel;
+      } else if (panel.type === 'row') {
+        const rowPanel: any = panel.panels?.find((p: any) => p.id === id);
+        if (rowPanel) {
+          return new PanelModel(rowPanel);
+        }
       }
     }
 
@@ -877,6 +874,7 @@ export class DashboardModel {
 
   toggleRow(row: PanelModel) {
     const rowIndex = indexOf(this.panels, row);
+    let sharedPanelsToRefresh = new Set<PanelModel>();
 
     if (row.collapsed) {
       row.collapsed = false;
@@ -908,7 +906,7 @@ export class DashboardModel {
           );
 
           for (const sharedPanel of sharedDashboardPanels) {
-            sharedPanel.refresh();
+            sharedPanelsToRefresh.add(sharedPanel);
           }
         }
 
@@ -924,6 +922,8 @@ export class DashboardModel {
         if (hasRepeat) {
           this.processRowRepeats(row);
         }
+
+        sharedPanelsToRefresh.forEach((p) => p.refresh());
       }
 
       // sort panels

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -3,7 +3,7 @@ import { LegacyForms, VerticalGroup } from '@grafana/ui';
 import { DataQuery, PanelData, SelectableValue } from '@grafana/data';
 import { css } from '@emotion/css';
 
-import { DashboardQuery, ResultInfo, SHARED_DASHBODARD_QUERY } from './types';
+import { DashboardQuery, ResultInfo, SHARED_DASHBOARD_QUERY } from './types';
 import config from 'app/core/config';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { PanelModel } from 'app/features/dashboard/state';
@@ -141,7 +141,7 @@ export class DashboardQueryEditor extends PureComponent<Props, State> {
         continue;
       }
 
-      if (panel.targets && panel.datasource !== SHARED_DASHBODARD_QUERY) {
+      if (panel.targets && panel.datasource !== SHARED_DASHBOARD_QUERY) {
         const item = {
           value: panel.id,
           label: panel.title ? panel.title : 'Panel ' + panel.id,

--- a/public/app/plugins/datasource/dashboard/index.ts
+++ b/public/app/plugins/datasource/dashboard/index.ts
@@ -1,3 +1,3 @@
 export { isSharedDashboardQuery, runSharedRequest } from './runSharedRequest';
 export { DashboardQueryEditor } from './DashboardQueryEditor';
-export { SHARED_DASHBODARD_QUERY } from './types';
+export { SHARED_DASHBOARD_QUERY } from './types';

--- a/public/app/plugins/datasource/dashboard/runSharedRequest.ts
+++ b/public/app/plugins/datasource/dashboard/runSharedRequest.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { QueryRunnerOptions } from 'app/features/query/state/PanelQueryRunner';
-import { DashboardQuery, SHARED_DASHBODARD_QUERY } from './types';
+import { DashboardQuery, SHARED_DASHBOARD_QUERY } from './types';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import {
   DataQuery,
@@ -16,11 +16,11 @@ export function isSharedDashboardQuery(datasource: string | DataSourceApi | null
     // default datasource
     return false;
   }
-  if (datasource === SHARED_DASHBODARD_QUERY) {
+  if (datasource === SHARED_DASHBOARD_QUERY) {
     return true;
   }
   const ds = datasource as DataSourceApi;
-  return ds.meta && ds.meta.name === SHARED_DASHBODARD_QUERY;
+  return ds.meta && ds.meta.name === SHARED_DASHBOARD_QUERY;
 }
 
 export function runSharedRequest(options: QueryRunnerOptions): Observable<PanelData> {

--- a/public/app/plugins/datasource/dashboard/types.ts
+++ b/public/app/plugins/datasource/dashboard/types.ts
@@ -1,6 +1,6 @@
 import { DataFrame, DataQuery, DataQueryError } from '@grafana/data';
 
-export const SHARED_DASHBODARD_QUERY = '-- Dashboard --';
+export const SHARED_DASHBOARD_QUERY = '-- Dashboard --';
 
 export interface DashboardQuery extends DataQuery {
   panelId?: number;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where a panel using the dashboard datasource would throw an error if the source panel was in a collapsed row.

**Which issue(s) this PR fixes**:
Closes #32709

**Notes**:
I'm sure there's a more sophisticated way to solve this problem, but I imagine it would involve a larger refactor.