### PR TITLE
Panels: avoid crash while switching between panels types

### DIFF
--- a/public/app/features/dashboard/state/getPanelOptionsWithDefaults.ts
+++ b/public/app/features/dashboard/state/getPanelOptionsWithDefaults.ts
@@ -198,7 +198,9 @@ export function restoreCustomOverrideRules(current: FieldConfigSource, old: Fiel
       if (isCustomFieldProp(prop)) {
         const currentOverride = result.overrides.find((o) => isEqual(o.matcher, override.matcher));
         if (currentOverride) {
-          currentOverride.properties.push(prop);
+          if (currentOverride !== override) {
+            currentOverride.properties.push(prop);
+          }
         } else {
           result.overrides.push(override);
         }


### PR DESCRIPTION
From: https://github.com/grafana/grafana/issues/34624#issuecomment-853145085

If the old and new props share the same object, we do not need to push to them

-----

Browser crashes when toggling between graph & time series panels.  

Example: to reproduce https://g80-beta.grafana.net/d/O9oYtDeMz/crash?orgId=1&editPanel=2 ( change viz to old graph and then back to time-series ) browser crashes. 

* Create a time-series with 10 series ( random walk )
* Add a couple of overrides ( in my case, added y-axis placement, y-axis label )
* Save the dashboard
* Change viz type to graph(old)
* Change viz type to time-series and wait for few seconds then the browser will crash
* Also noticed the y axis override didn't work as expected.

confirmed the issue in beta2, beta3 

( @kminehart  confirmed similar issue for bar chart )

https://user-images.githubusercontent.com/153843/120511419-514cee00-c3c2-11eb-9e7e-d923950ab29b.mov
