### PR TITLE
Histogram: reduce default bucket size, fix rendering

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -12,6 +12,7 @@ import { createTheme, GrafanaTheme2 } from '../../themes';
  * @internal
  */
 /* eslint-disable */
+// prettier-ignore
 export const histogramBucketSizes = [
   1e-9,  2e-9,  2.5e-9,  4e-9,  5e-9,
   1e-8,  2e-8,  2.5e-8,  4e-8,  5e-8,

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -8,19 +8,30 @@ import { AlignedData, join } from './joinDataFrames';
 import { getDisplayProcessor } from '../../field';
 import { createTheme, GrafanaTheme2 } from '../../themes';
 
-/* eslint-disable */
-// prettier-ignore
 /**
  * @internal
  */
+/* eslint-disable */
 export const histogramBucketSizes = [
-    .001, .002, .0025, .005,
-     .01,  .02,  .025,  .05,
-      .1,   .2,   .25,   .5,
-       1,    2,     4,    5,
-      10,   20,    25,   50,
-     100,  200,   250,  500,
-    1000, 2000,  2500, 5000,
+  1e-9,  2e-9,  2.5e-9,  4e-9,  5e-9,
+  1e-8,  2e-8,  2.5e-8,  4e-8,  5e-8,
+  1e-7,  2e-7,  2.5e-7,  4e-7,  5e-7,
+  1e-6,  2e-6,  2.5e-6,  4e-6,  5e-6,
+  1e-5,  2e-5,  2.5e-5,  4e-5,  5e-5,
+  1e-4,  2e-4,  2.5e-4,  4e-4,  5e-4,
+  1e-3,  2e-3,  2.5e-3,  4e-3,  5e-3,
+  1e-2,  2e-2,  2.5e-2,  4e-2,  5e-2,
+  1e-1,  2e-1,  2.5e-1,  4e-1,  5e-1,
+  1,     2,              4,     5,
+  1e+1,  2e+1,  2.5e+1,  4e+1,  5e+1,
+  1e+2,  2e+2,  2.5e+2,  4e+2,  5e+2,
+  1e+3,  2e+3,  2.5e+3,  4e+3,  5e+3,
+  1e+4,  2e+4,  2.5e+4,  4e+4,  5e+4,
+  1e+5,  2e+5,  2.5e+5,  4e+5,  5e+5,
+  1e+6,  2e+6,  2.5e+6,  4e+6,  5e+6,
+  1e+7,  2e+7,  2.5e+7,  4e+7,  5e+7,
+  1e+8,  2e+8,  2.5e+8,  4e+8,  5e+8,
+  1e+9,  2e+9,  2.5e+9,  4e+9,  5e+9,
 ];
 /* eslint-enable */
 
@@ -135,6 +146,8 @@ export function getHistogramFields(frame: DataFrame): HistogramFields | undefine
   return undefined;
 }
 
+const APPROX_BUCKETS = 20;
+
 /**
  * @alpha
  */
@@ -163,7 +176,7 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
 
     // choose bucket
     for (const size of histogramBucketSizes) {
-      if (range / 10 < size) {
+      if (range / APPROX_BUCKETS < size) {
         bucketSize = size;
         break;
       }

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -72,7 +72,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.11"
+    "uplot": "1.6.12"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/public/app/plugins/panel/histogram/HistogramPanel.tsx
+++ b/public/app/plugins/panel/histogram/HistogramPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { PanelProps, buildHistogram, getHistogramFields } from '@grafana/data';
 
-import { Histogram } from './Histogram';
+import { Histogram, getBucketSize } from './Histogram';
 import { PanelOptions } from './models.gen';
 import { useTheme2 } from '@grafana/ui';
 
@@ -38,6 +38,8 @@ export const HistogramPanel: React.FC<Props> = ({ data, options, width, height }
     );
   }
 
+  const bucketSize = getBucketSize(histogram);
+
   return (
     <Histogram
       options={options}
@@ -47,6 +49,7 @@ export const HistogramPanel: React.FC<Props> = ({ data, options, width, height }
       width={width}
       height={height}
       alignedFrame={histogram}
+      bucketSize={bucketSize}
     >
       {(config, alignedFrame) => {
         return null; // <TooltipPlugin data={alignedFrame} config={config} mode={options.tooltip.mode} timeZone={timeZone} />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -22043,10 +22043,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.11:
-  version "1.6.11"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.11.tgz#2ade33071e4eb30c6504ad7c68eb4c05d9dd47eb"
-  integrity sha512-DTA/wLLFSccSghZKM02hLgHoe8zDoCGFEkbbszXwkNRFgkkRKYc0gPNaJG76JFrwDlZNc7+u9noUHxt9fLu+lg==
+uplot@1.6.12:
+  version "1.6.12"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.12.tgz#a2741f224c3d3b4f4f25a53797c1687ddfef2989"
+  integrity sha512-afBjwy/9SM0E7w29Gen+wQ+UAe6ipiA2zE/s1dMCidMXQYvYkCpEgxLRkVA179/8eRJz+og2r7ZFS1HIzT75fQ==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
- this decreases the auto bucket width from ~10% of range -> ~5% of range.
- this fixes the case when the auto-bucket size changes that are data-dependent did not re-initialize the plot config, causeing ticks scale to be out of sync with the actual aggregated histogram data.
- it also adds a wider range of available bucket increments so the max auto bucket size is not capped at 5000 (and min at .001).
- it also updates uPlot to 1.6.12, which fixes the bars pathBuilder to use analyze the full x dataset to determine the avaiable space for the bar width. previoulsy it only used the first two datapoints, which is problematic if the data is not uniformly-spaced, and can cause too-wide bars (see below).
- the uPlot update also adjusts the auto-points density assertion logic to use the distance between first/last datapoints instead of full width of the plotting area. this fixes streaming cases with a mostly-empty chart and a lot of dense data at the beginning. before this it was rendering points which then disappeared after there was more data in view (but effective density was unchanged).

uPlot changelog: https://github.com/leeoniya/uPlot/releases/tag/1.6.12

![image](https://user-images.githubusercontent.com/43234/120870283-24cdd900-c55e-11eb-91d7-9ccc39006713.png)
