### PR TITLE
Toolkit: Resolve external fonts when Grafana is served from a sub path

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -160,7 +160,8 @@ export const getFileLoaders = () => {
       test: /\.(woff|woff2|eot|ttf|otf)(\?v=\d+\.\d+\.\d+)?$/,
       loader: 'file-loader',
       options: {
-        publicPath: `/public/plugins/${getPluginId()}/fonts`,
+        // Keep publicPath relative for host.com/grafana/ deployments
+        publicPath: `public/plugins/${getPluginId()}/fonts`,
         outputPath: 'fonts',
         name: '[name].[ext]',
       },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Updates toolkit webpack file-loader config so it serves fonts with a relative public path. Fixes 404s occurring if grafana is behind a reverse proxy with a subpath and a plugin has a custom font in its bundle.


<img width="1679" alt="Screenshot 2021-06-08 at 10 06 48" src="https://user-images.githubusercontent.com/73201/121147605-4d492200-c841-11eb-8482-dd6b3124e02a.png">

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #33004

**Special notes for your reviewer**:

To test this locally Grafana needs to be served behind a reverse proxy with a subpath and have a plugin that includes a custom font in its bundle. Below are some instructions to help out with that:

1. Download [docker-nginx-proxy.zip](https://github.com/grafana/grafana/files/6614585/docker-nginx-proxy.zip) extract and `docker-compose up -d` (note this expects port 80 to be available)
2. Add the following to `custom.ini`:
```[server]
domain = grafana.local
# The full public facing url
root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana

# Serve Grafana from subpath specified in `root_url` setting. By default it is set to `false` for compatibility reasons.
serve_from_sub_path = true
```

3.  Update hosts file `127.0.0.1 grafana.local`
4. Navigate to http://grafana.local/grafana

Feel free to use this plugin to test it out with: [heywesty-font-panel.zip](https://github.com/grafana/grafana/files/6614736/heywesty-font-panel.zip) and [these instructions](https://github.com/grafana/grafana/tree/main/packages/grafana-toolkit#develop-grafana-toolkit) for linking toolkit for building the plugin using this branch



