### PR TITLE
Chore: fix docs publish branch for v8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish_docs
 on:
   push:
     branches:
-    - main
+    - v8.0.x
     paths:
     - 'docs/sources/**'
     - 'packages/grafana-*/**'

--- a/docs/sources/whatsnew/whats-new-in-v8-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-0.md
@@ -10,8 +10,6 @@ list = false
 
 # What’s new in Grafana v8.0
 
-> **Note:** This topic will be updated frequently between now and the final release.
-
 This topic includes the release notes for Grafana v8.0. For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 
 ## Grafana OSS features


### PR DESCRIPTION
Sets correct branch in github publish workflow