### PR TITLE
Datasource: Add support for max_idle_connections_per_host in dataproxy settings

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -69,7 +69,7 @@ socket = /tmp/grafana.sock
 # CDN Url
 cdn_url =
 
-# Sets the maximum time in minutes before timing out read of an incoming request and closing idle connections. 
+# Sets the maximum time in minutes before timing out read of an incoming request and closing idle connections.
 # `0` means there is no timeout for reading the request.
 read_timeout = 0
 
@@ -157,6 +157,9 @@ expect_continue_timeout_seconds = 1
 
 # The maximum number of idle connections that Grafana will keep alive.
 max_idle_connections = 100
+
+# The maximum number of idle connections per host that Grafana will keep alive.
+max_idle_connections_per_host = 2
 
 # How many seconds the data proxy keeps an idle connection open before timing out.
 idle_conn_timeout_seconds = 90
@@ -520,11 +523,11 @@ active_sync_enabled = true
 
 #################################### AWS ###########################
 [aws]
-# Enter a comma-separated list of allowed AWS authentication providers. 
+# Enter a comma-separated list of allowed AWS authentication providers.
 # Options are: default (AWS SDK Default), keys (Access && secret key), credentials (Credentials field), ec2_iam_role (EC2 IAM Role)
 allowed_auth_providers = default,keys,credentials
 
-# Allow AWS users to assume a role using temporary security credentials. 
+# Allow AWS users to assume a role using temporary security credentials.
 # If true, assume role will be enabled for all AWS authentication providers that are specified in aws_auth_providers
 assume_role_enabled = true
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -164,6 +164,9 @@
 # The maximum number of idle connections that Grafana will keep alive.
 ;max_idle_connections = 100
 
+# The maximum number of idle connections per host that Grafana will keep alive.
+;max_idle_connections_per_host = 2
+
 # How many seconds the data proxy keeps an idle connection open before timing out.
 ;idle_conn_timeout_seconds = 90
 
@@ -510,11 +513,11 @@
 
 #################################### AWS ###########################
 [aws]
-# Enter a comma-separated list of allowed AWS authentication providers. 
+# Enter a comma-separated list of allowed AWS authentication providers.
 # Options are: default (AWS SDK Default), keys (Access && secret key), credentials (Credentials field), ec2_iam_role (EC2 IAM Role)
 ; allowed_auth_providers = default,keys,credentials
 
-# Allow AWS users to assume a role using temporary security credentials. 
+# Allow AWS users to assume a role using temporary security credentials.
 # If true, assume role will be enabled for all AWS authentication providers that are specified in aws_auth_providers
 ; assume_role_enabled = true
 

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -167,6 +167,7 @@ func (ds *DataSource) GetHttpTransport() (*dataSourceTransport, error) {
 		TLSHandshakeTimeout:   time.Duration(setting.DataProxyTLSHandshakeTimeout) * time.Second,
 		ExpectContinueTimeout: time.Duration(setting.DataProxyExpectContinueTimeout) * time.Second,
 		MaxIdleConns:          setting.DataProxyMaxIdleConns,
+		MaxConnsPerHost:       setting.DataProxyMaxIdleConnsPerHost,
 		IdleConnTimeout:       time.Duration(setting.DataProxyIdleConnTimeout) * time.Second,
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -83,6 +83,7 @@ var (
 	DataProxyTLSHandshakeTimeout   int
 	DataProxyExpectContinueTimeout int
 	DataProxyMaxIdleConns          int
+	DataProxyMaxIdleConnsPerHost   int
 	DataProxyKeepAlive             int
 	DataProxyIdleConnTimeout       int
 	StaticRootPath                 string
@@ -809,6 +810,7 @@ func (cfg *Cfg) Load(args *CommandLineArgs) error {
 	DataProxyTLSHandshakeTimeout = dataproxy.Key("tls_handshake_timeout_seconds").MustInt(10)
 	DataProxyExpectContinueTimeout = dataproxy.Key("expect_continue_timeout_seconds").MustInt(1)
 	DataProxyMaxIdleConns = dataproxy.Key("max_idle_connections").MustInt(100)
+	DataProxyMaxIdleConnsPerHost = dataproxy.Key("max_idle_connections_per_host").MustInt(2)
 	DataProxyIdleConnTimeout = dataproxy.Key("idle_conn_timeout_seconds").MustInt(90)
 	cfg.SendUserHeader = dataproxy.Key("send_user_header").MustBool(false)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `max_idle_connections_per_host` to defaults.ini so it can be configurable and injected to the HTTP Client

**Which issue(s) this PR fixes**:

Fixes #35358

