### PR TITLE
Postgres/MySQL/MSSQL: Fix annotation parsing for empty responses

### DIFF
--- a/public/app/plugins/datasource/mssql/response_parser.ts
+++ b/public/app/plugins/datasource/mssql/response_parser.ts
@@ -88,11 +88,6 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
-
-    if (!frames || !frames.length) {
-      return [];
-    }
-
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time');
 

--- a/public/app/plugins/datasource/mssql/response_parser.ts
+++ b/public/app/plugins/datasource/mssql/response_parser.ts
@@ -88,6 +88,9 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
+    if (!frames || !frames.length) {
+      return [];
+    }
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time');
 

--- a/public/app/plugins/datasource/mssql/response_parser.ts
+++ b/public/app/plugins/datasource/mssql/response_parser.ts
@@ -88,6 +88,11 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
+
+    if (!frames || !frames.length) {
+      return [];
+    }
+
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time');
 

--- a/public/app/plugins/datasource/mysql/response_parser.ts
+++ b/public/app/plugins/datasource/mysql/response_parser.ts
@@ -88,6 +88,11 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
+
+    if (!frames || !frames.length) {
+      return [];
+    }
+
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time' || f.name === 'time_sec');
 

--- a/public/app/plugins/datasource/mysql/response_parser.ts
+++ b/public/app/plugins/datasource/mysql/response_parser.ts
@@ -88,6 +88,9 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
+    if (!frames || !frames.length) {
+      return [];
+    }
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time' || f.name === 'time_sec');
 

--- a/public/app/plugins/datasource/mysql/response_parser.ts
+++ b/public/app/plugins/datasource/mysql/response_parser.ts
@@ -88,11 +88,6 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
-
-    if (!frames || !frames.length) {
-      return [];
-    }
-
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time' || f.name === 'time_sec');
 

--- a/public/app/plugins/datasource/postgres/response_parser.ts
+++ b/public/app/plugins/datasource/postgres/response_parser.ts
@@ -91,6 +91,11 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
+
+    if (!frames || !frames.length) {
+      return [];
+    }
+
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time');
 

--- a/public/app/plugins/datasource/postgres/response_parser.ts
+++ b/public/app/plugins/datasource/postgres/response_parser.ts
@@ -91,6 +91,9 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
+    if (!frames || !frames.length) {
+      return [];
+    }
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time');
 

--- a/public/app/plugins/datasource/postgres/response_parser.ts
+++ b/public/app/plugins/datasource/postgres/response_parser.ts
@@ -91,11 +91,6 @@ export default class ResponseParser {
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {
     const frames = toDataQueryResponse({ data: data }).data as DataFrame[];
-
-    if (!frames || !frames.length) {
-      return [];
-    }
-
     const frame = frames[0];
     const timeField = frame.fields.find((f) => f.name === 'time');
 


### PR DESCRIPTION
Environment:
Grafana version: 8.0.0

**What this PR does / why we need it**:
Fix sql annotations (sql, mysql, msssql) by adding add a safeguard to early return the empty annotations array when an sql responds without rows.

There's already a similar safeguard in the metric query: https://github.com/grafana/grafana/blob/00cc0619be31d2d033b2d9c5c2b363df31204222/public/app/plugins/datasource/mysql/response_parser.ts#L6-L11

The changes here adopt the same approach.

**Which issue(s) this PR fixes**:
Fixes #35380

![image](https://user-images.githubusercontent.com/431376/121177038-36b0c400-c85d-11eb-9ebe-ab4a0bdb9df7.png)

When annotation queries return an empty array, the parsing fails as the code tries to access a non-existent element.
```
utils.ts:34 handleAnnotationQueryRunnerError TypeError: Cannot read property 'fields' of undefined
    at h.transformAnnotationResponse (response_parser.ts:92)
    at t.project (datasource.ts:118)
    at t._next (map.js:35)
    at t.next (Subscriber.js:53)
    at t._next (throwIfEmpty.js:32)
    at t.next (Subscriber.js:53)
    at t._next (Subscriber.js:76)
    at t.next (Subscriber.js:53)
    at t._next (Subscriber.js:76)
    at t.next (Subscriber.js:53)
```

There's a related Issue for influxdb, but I haven't had a look at it: https://github.com/grafana/grafana/issues/33715
