### PR TITLE
Visualizations: Fix Stat/BarGauge/Gauge/PieChart all values mode showing same name if same value

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -259,6 +259,32 @@ describe('FieldDisplay', () => {
       expect(result[1].display.text).toEqual('20');
     });
 
+    it('With cached display processor', () => {
+      const options = createDisplayOptions({
+        reduceOptions: {
+          values: true,
+          calcs: [],
+        },
+        data: [
+          toDataFrame({
+            fields: [
+              { name: 'Name', values: ['A', 'B'] },
+              { name: 'Value', values: [10, 10] },
+            ],
+          }),
+        ],
+      });
+
+      const cache = { numeric: 10, text: 'Value' };
+      options.data![0].fields[1].display = (v: any) => {
+        return cache;
+      };
+
+      const result = getFieldDisplayValues(options);
+      expect(result[0].display.title).toEqual('A');
+      expect(result[1].display.title).toEqual('B');
+    });
+
     it('Single string field multiple value fields', () => {
       const options = createDisplayOptions({
         reduceOptions: {


### PR DESCRIPTION
Fixes #35360 

We introduced a caching display processor to improve performance but that means when we generate field display values for the stat panels we cannot mutate the result from the display processor when showing row values. 