### PR TITLE
Postgres/MySQL/MSSQL: Do not  show field name prefix for fields with labels 

### DIFF
--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -137,6 +137,17 @@ describe('Check field state calculations (displayName and id)', () => {
     expect(title).toEqual('Server A');
   });
 
+  it('should only use label for time series value field names', () => {
+    const title = checkScenario({
+      frames: [
+        toDataFrame({
+          fields: [{ name: 'value', labels: { server: 'Server A' } }],
+        }),
+      ],
+    });
+    expect(title).toEqual('Server A');
+  });
+
   it('should use label value only if all series have same name', () => {
     const title = checkScenario({
       frames: [

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -81,11 +81,11 @@ describe('Check field state calculations (displayName and id)', () => {
       frames: [
         toDataFrame({
           name: 'Series A',
-          fields: [{ name: 'Field 1' }],
+          fields: [{ name: 'Field 1' }, { name: 'Field 2' }],
         }),
         toDataFrame({
           name: 'Series B',
-          fields: [{ name: 'Field 1' }],
+          fields: [{ name: 'Field 1' }, { name: 'Field 2' }],
         }),
       ],
     });

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -81,11 +81,11 @@ describe('Check field state calculations (displayName and id)', () => {
       frames: [
         toDataFrame({
           name: 'Series A',
-          fields: [{ name: 'Field 1' }, { name: 'Field 2' }],
+          fields: [{ name: 'Field 1' }],
         }),
         toDataFrame({
           name: 'Series B',
-          fields: [{ name: 'Field 1' }, { name: 'Field 2' }],
+          fields: [{ name: 'Field 1' }],
         }),
       ],
     });

--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -214,6 +214,6 @@ describe('Check field state calculations (displayName and id)', () => {
       ],
       fieldIndex: 1,
     });
-    expect(title).toEqual('line {host="ec2-13-53-116-156.eu-north-1.compute.amazonaws.com", region="eu-north1"}');
+    expect(title).toEqual('{host="ec2-13-53-116-156.eu-north-1.compute.amazonaws.com", region="eu-north1"}');
   });
 });

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -96,7 +96,8 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     frameNameAdded = true;
   }
 
-  if (field.name && field.name.toLowerCase() !== TIME_SERIES_VALUE_FIELD_NAME_LOWER_CASE) {
+  // check if we should add field name before labels
+  if (otherFieldNamesExists(field, frame)) {
     parts.push(field.name);
   }
 
@@ -169,6 +170,34 @@ function getUniqueFieldName(field: Field, frame?: DataFrame) {
   }
 
   return field.name;
+}
+
+/**
+ * Scans data for other fields with labels but with different field names, if found returns true.
+ * */
+function otherFieldNamesExists(field: Field, frame?: DataFrame): boolean {
+  // Also matches undefined
+  if (field.name == null || !frame) {
+    return false;
+  }
+
+  for (let i = 0; i < frame.fields.length; i++) {
+    const otherField = frame.fields[i];
+    if (otherField === field) {
+      continue;
+    }
+
+    // ignore time field
+    if (otherField.type === FieldType.time) {
+      return false;
+    }
+
+    if (field.name !== otherField.name) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -97,7 +97,7 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
   }
 
   // check if we should add field name before labels
-  if (otherFieldNamesExists(field, frame)) {
+  if (field.name !== TIME_SERIES_VALUE_FIELD_NAME && (!field.labels || Object.keys(field.labels).length === 0)) {
     parts.push(field.name);
   }
 
@@ -170,34 +170,6 @@ function getUniqueFieldName(field: Field, frame?: DataFrame) {
   }
 
   return field.name;
-}
-
-/**
- * Scans data for other fields with labels but with different field names, if found returns true.
- * */
-function otherFieldNamesExists(field: Field, frame?: DataFrame): boolean {
-  // Also matches undefined
-  if (field.name == null || !frame) {
-    return false;
-  }
-
-  for (let i = 0; i < frame.fields.length; i++) {
-    const otherField = frame.fields[i];
-    if (otherField === field) {
-      continue;
-    }
-
-    // ignore time field
-    if (otherField.type === FieldType.time) {
-      return false;
-    }
-
-    if (field.name !== otherField.name) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 /**

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -50,6 +50,8 @@ export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?:
   return displayName;
 }
 
+const TIME_SERIES_VALUE_FIELD_NAME_LOWER_CASE = TIME_SERIES_VALUE_FIELD_NAME.toLowerCase();
+
 /**
  * Get an appropriate display name. If the 'displayName' field config is set, use that
  */
@@ -94,7 +96,7 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
     frameNameAdded = true;
   }
 
-  if (field.name && field.name !== TIME_SERIES_VALUE_FIELD_NAME) {
+  if (field.name && field.name.toLowerCase() !== TIME_SERIES_VALUE_FIELD_NAME_LOWER_CASE) {
     parts.push(field.name);
   }
 
@@ -126,7 +128,7 @@ function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: 
   } else if (field.name) {
     displayName = field.name;
   } else {
-    displayName = TIME_SERIES_VALUE_FIELD_NAME;
+    displayName = TIME_SERIES_VALUE_FIELD_NAME_LOWER_CASE;
   }
 
   // Ensure unique field name


### PR DESCRIPTION
Fixes #35390 (partially)

The new postgres/sql data source backend return series name in a field label, this is big change compared to v7.5 as it then makes use of Grafana's automatic field naming for field and field labels.

But postgres queries (old and new) does not follow the standard time series field naming convention of naming value field as `Value` (capital V), field names named `Value` are handled
a bit differently in the field naming logic. I changed this to have same behavior now for `value` but I am afraid this will not solve all use scenarios. I can see that other field
value names migth also cause issues with this change.

Not sure what the solution is, it's not trivial to know if field name should be used in field name or just labels.



