### PR TITLE
Docs: Fix code sample for access control provisioning

### DIFF
--- a/docs/sources/enterprise/access-control/provisioning.md
+++ b/docs/sources/enterprise/access-control/provisioning.md
@@ -131,7 +131,7 @@ apiVersion: 1
 
 # list of default built-in role assignments that should be removed
 removeDefaultAssignments:
-  - builtInRole: "Grafana server administrator"
+  - builtInRole: "Grafana Admin"
     fixedRole: "fixed:permissions:admin"
 
 ```


### PR DESCRIPTION
`Grafana Admin` is an identifier when used there, so we cannot expand it to Grafana server administrator without breaking the sample.
