### PR TITLE
Logs panel: Make it possible to copy first and last line

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 import { LogRows, CustomScrollbar, useTheme2 } from '@grafana/ui';
 import { PanelProps, Field } from '@grafana/data';
 import { Options } from './types';

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { LogRows, CustomScrollbar } from '@grafana/ui';
+import { css } from 'emotion';
+import { LogRows, CustomScrollbar, useTheme2 } from '@grafana/ui';
 import { PanelProps, Field } from '@grafana/data';
 import { Options } from './types';
 import { dataFrameToLogsModel, dedupLogRows } from 'app/core/logs_model';
@@ -11,7 +12,9 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   data,
   timeZone,
   options: { showLabels, showTime, wrapLogMessage, sortOrder, dedupStrategy, enableLogDetails },
+  title,
 }) => {
+  const theme = useTheme2();
   if (!data) {
     return (
       <div className="panel-empty">
@@ -19,6 +22,12 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
       </div>
     );
   }
+
+  const spacing = css`
+    margin-bottom: ${theme.spacing(1.5)};
+    //We can remove this hot-fix when we fix panel menu with no title overflowing top of all panels
+    margin-top: ${theme.spacing(!title ? 2.5 : 0)};
+  `;
 
   const newResults = data ? dataFrameToLogsModel(data.series, data.request?.intervalMs) : null;
   const logRows = newResults?.rows || [];
@@ -30,19 +39,21 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
 
   return (
     <CustomScrollbar autoHide>
-      <LogRows
-        logRows={logRows}
-        deduplicatedRows={deduplicatedRows}
-        dedupStrategy={dedupStrategy}
-        highlighterExpressions={[]}
-        showLabels={showLabels}
-        showTime={showTime}
-        wrapLogMessage={wrapLogMessage}
-        timeZone={timeZone}
-        getFieldLinks={getFieldLinks}
-        logsSortOrder={sortOrder}
-        enableLogDetails={enableLogDetails}
-      />
+      <div className={spacing}>
+        <LogRows
+          logRows={logRows}
+          deduplicatedRows={deduplicatedRows}
+          dedupStrategy={dedupStrategy}
+          highlighterExpressions={[]}
+          showLabels={showLabels}
+          showTime={showTime}
+          wrapLogMessage={wrapLogMessage}
+          timeZone={timeZone}
+          getFieldLinks={getFieldLinks}
+          logsSortOrder={sortOrder}
+          enableLogDetails={enableLogDetails}
+        />
+      </div>
     </CustomScrollbar>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
We are adding a padding to bottom so the last log line can be copied and also padding to the top so the first log line can be copied if no Panel title is set.

Before top: 
![image](https://user-images.githubusercontent.com/30407135/121336139-85249800-c91b-11eb-8bad-8fab35dee35b.png)

After top: 
![image](https://user-images.githubusercontent.com/30407135/121336598-f8c6a500-c91b-11eb-8d7c-157069c27c20.png)

Before bottom: 
<img width="1440" alt="Screenshot 2021-06-09 at 12 16 20" src="https://user-images.githubusercontent.com/30407135/121337167-8904ea00-c91c-11eb-847d-c98425ff975d.png">

After bottom:
![image](https://user-images.githubusercontent.com/30407135/121337025-5f4bc300-c91c-11eb-9909-aead8f00a9dc.png)


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/24862#event-4863580672


