### PR TITLE
Postgres/MySQL/MSSQL: Fix so that numeric/non-string values are returned from query variables

### DIFF
--- a/public/app/plugins/datasource/mssql/response_parser.ts
+++ b/public/app/plugins/datasource/mssql/response_parser.ts
@@ -1,5 +1,4 @@
-import { map } from 'lodash';
-import { AnnotationEvent, DataFrame, FieldType, MetricFindValue } from '@grafana/data';
+import { AnnotationEvent, DataFrame, MetricFindValue } from '@grafana/data';
 import { BackendDataSourceResponse, toDataQueryResponse, FetchResponse } from '@grafana/runtime';
 
 export default class ResponseParser {
@@ -21,69 +20,19 @@ export default class ResponseParser {
         values.push({ text: '' + textField.values.get(i), value: '' + valueField.values.get(i) });
       }
     } else {
-      const textFields = frame.fields.filter((f) => f.type === FieldType.string);
-      if (textFields) {
-        values.push(
-          ...textFields
-            .flatMap((f) => f.values.toArray())
-            .map((v) => ({
-              text: '' + v,
-            }))
-        );
-      }
+      values.push(
+        ...frame.fields
+          .flatMap((f) => f.values.toArray())
+          .map((v) => ({
+            text: v,
+          }))
+      );
     }
 
     return Array.from(new Set(values.map((v) => v.text))).map((text) => ({
       text,
       value: values.find((v) => v.text === text)?.value,
     }));
-  }
-
-  transformToKeyValueList(rows: any, textColIndex: number, valueColIndex: number): MetricFindValue[] {
-    const res = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      if (!this.containsKey(res, rows[i][textColIndex])) {
-        res.push({ text: rows[i][textColIndex], value: rows[i][valueColIndex] });
-      }
-    }
-
-    return res;
-  }
-
-  transformToSimpleList(rows: any): MetricFindValue[] {
-    const res = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      for (let j = 0; j < rows[i].length; j++) {
-        res.push(rows[i][j]);
-      }
-    }
-
-    const unique = Array.from(new Set(res));
-
-    return map(unique, (value) => {
-      return { text: value };
-    });
-  }
-
-  findColIndex(columns: any[], colName: string) {
-    for (let i = 0; i < columns.length; i++) {
-      if (columns[i].text === colName) {
-        return i;
-      }
-    }
-
-    return -1;
-  }
-
-  containsKey(res: any[], key: any) {
-    for (let i = 0; i < res.length; i++) {
-      if (res[i].text === key) {
-        return true;
-      }
-    }
-    return false;
   }
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {

--- a/public/app/plugins/datasource/mssql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mssql/specs/datasource.test.ts
@@ -84,7 +84,7 @@ describe('MSSQLDatasource', () => {
     });
   });
 
-  describe('When performing metricFindQuery', () => {
+  describe('When performing metricFindQuery that returns multiple string fields', () => {
     let results: MetricFindValue[];
     const query = 'select * from atable';
     const response = {
@@ -153,6 +153,50 @@ describe('MSSQLDatasource', () => {
       expect(results[0].value).toBe('value1');
       expect(results[2].text).toBe('aTitle3');
       expect(results[2].value).toBe('value3');
+    });
+  });
+
+  describe('When performing metricFindQuery without key, value columns', () => {
+    let results: any;
+    const query = 'select id, values from atable';
+    const response = {
+      results: {
+        tempvar: {
+          refId: 'tempvar',
+          frames: [
+            dataFrameToJSON(
+              new MutableDataFrame({
+                fields: [
+                  { name: 'id', values: [1, 2, 3] },
+                  { name: 'values', values: ['test1', 'test2', 'test3'] },
+                ],
+                meta: {
+                  executedQueryString: 'select id, values from atable',
+                },
+              })
+            ),
+          ],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      fetchMock.mockImplementation(() => of(createFetchResponse(response)));
+
+      return ctx.ds.metricFindQuery(query).then((data: any) => {
+        results = data;
+      });
+    });
+
+    it('should return list of all field values as text', () => {
+      expect(results).toEqual([
+        { text: 1 },
+        { text: 2 },
+        { text: 3 },
+        { text: 'test1' },
+        { text: 'test2' },
+        { text: 'test3' },
+      ]);
     });
   });
 

--- a/public/app/plugins/datasource/mysql/response_parser.ts
+++ b/public/app/plugins/datasource/mysql/response_parser.ts
@@ -1,5 +1,4 @@
-import { map } from 'lodash';
-import { AnnotationEvent, DataFrame, FieldType, MetricFindValue } from '@grafana/data';
+import { AnnotationEvent, DataFrame, MetricFindValue } from '@grafana/data';
 import { BackendDataSourceResponse, FetchResponse, toDataQueryResponse } from '@grafana/runtime';
 
 export default class ResponseParser {
@@ -21,69 +20,19 @@ export default class ResponseParser {
         values.push({ text: '' + textField.values.get(i), value: '' + valueField.values.get(i) });
       }
     } else {
-      const textFields = frame.fields.filter((f) => f.type === FieldType.string);
-      if (textFields) {
-        values.push(
-          ...textFields
-            .flatMap((f) => f.values.toArray())
-            .map((v) => ({
-              text: '' + v,
-            }))
-        );
-      }
+      values.push(
+        ...frame.fields
+          .flatMap((f) => f.values.toArray())
+          .map((v) => ({
+            text: v,
+          }))
+      );
     }
 
     return Array.from(new Set(values.map((v) => v.text))).map((text) => ({
       text,
       value: values.find((v) => v.text === text)?.value,
     }));
-  }
-
-  transformToKeyValueList(rows: any, textColIndex: number, valueColIndex: number): MetricFindValue[] {
-    const res = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      if (!this.containsKey(res, rows[i][textColIndex])) {
-        res.push({ text: rows[i][textColIndex], value: rows[i][valueColIndex] });
-      }
-    }
-
-    return res;
-  }
-
-  transformToSimpleList(rows: any): MetricFindValue[] {
-    const res = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      for (let j = 0; j < rows[i].length; j++) {
-        res.push(rows[i][j]);
-      }
-    }
-
-    const unique = Array.from(new Set(res));
-
-    return map(unique, (value) => {
-      return { text: value };
-    });
-  }
-
-  findColIndex(columns: any[], colName: string) {
-    for (let i = 0; i < columns.length; i++) {
-      if (columns[i].text === colName) {
-        return i;
-      }
-    }
-
-    return -1;
-  }
-
-  containsKey(res: any[], key: any) {
-    for (let i = 0; i < res.length; i++) {
-      if (res[i].text === key) {
-        return true;
-      }
-    }
-    return false;
   }
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -121,7 +121,7 @@ describe('MySQLDatasource', () => {
     });
   });
 
-  describe('When performing metricFindQuery', () => {
+  describe('When performing metricFindQuery that returns multiple string fields', () => {
     const query = 'select * from atable';
     const response = {
       results: {
@@ -144,7 +144,7 @@ describe('MySQLDatasource', () => {
       },
     };
 
-    it('should return list of all column values', async () => {
+    it('should return list of all string field values', async () => {
       const { ds } = setupTextContext(response);
       const results = await ds.metricFindQuery(query, {});
 
@@ -254,6 +254,44 @@ describe('MySQLDatasource', () => {
       expect(results[0].value).toBe('value1');
       expect(results[2].text).toBe('aTitle3');
       expect(results[2].value).toBe('value3');
+    });
+  });
+
+  describe('When performing metricFindQuery without key, value columns', () => {
+    const query = 'select id, values from atable';
+    const response = {
+      results: {
+        tempvar: {
+          refId: 'tempvar',
+          frames: [
+            dataFrameToJSON(
+              new MutableDataFrame({
+                fields: [
+                  { name: 'id', values: [1, 2, 3] },
+                  { name: 'values', values: ['test1', 'test2', 'test3'] },
+                ],
+                meta: {
+                  executedQueryString: 'select id, values from atable',
+                },
+              })
+            ),
+          ],
+        },
+      },
+    };
+
+    it('should return list of all field values as text', async () => {
+      const { ds } = setupTextContext(response);
+      const results = await ds.metricFindQuery(query, {});
+
+      expect(results).toEqual([
+        { text: 1 },
+        { text: 2 },
+        { text: 3 },
+        { text: 'test1' },
+        { text: 'test2' },
+        { text: 'test3' },
+      ]);
     });
   });
 

--- a/public/app/plugins/datasource/postgres/response_parser.ts
+++ b/public/app/plugins/datasource/postgres/response_parser.ts
@@ -1,6 +1,5 @@
-import { AnnotationEvent, DataFrame, FieldType, MetricFindValue } from '@grafana/data';
+import { AnnotationEvent, DataFrame, MetricFindValue } from '@grafana/data';
 import { BackendDataSourceResponse, FetchResponse, toDataQueryResponse } from '@grafana/runtime';
-import { map } from 'lodash';
 
 export default class ResponseParser {
   transformMetricFindResponse(raw: FetchResponse<BackendDataSourceResponse>): MetricFindValue[] {
@@ -21,72 +20,19 @@ export default class ResponseParser {
         values.push({ text: '' + textField.values.get(i), value: '' + valueField.values.get(i) });
       }
     } else {
-      const textFields = frame.fields.filter((f) => f.type === FieldType.string);
-      if (textFields) {
-        values.push(
-          ...textFields
-            .flatMap((f) => f.values.toArray())
-            .map((v) => ({
-              text: '' + v,
-            }))
-        );
-      }
+      values.push(
+        ...frame.fields
+          .flatMap((f) => f.values.toArray())
+          .map((v) => ({
+            text: v,
+          }))
+      );
     }
 
     return Array.from(new Set(values.map((v) => v.text))).map((text) => ({
       text,
       value: values.find((v) => v.text === text)?.value,
     }));
-  }
-
-  transformToKeyValueList(rows: any, textColIndex: number, valueColIndex: number) {
-    const res = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      if (!this.containsKey(res, rows[i][textColIndex])) {
-        res.push({
-          text: rows[i][textColIndex],
-          value: rows[i][valueColIndex],
-        });
-      }
-    }
-
-    return res;
-  }
-
-  transformToSimpleList(rows: any[][]) {
-    const res = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      for (let j = 0; j < rows[i].length; j++) {
-        res.push(rows[i][j]);
-      }
-    }
-
-    const unique = Array.from(new Set(res));
-
-    return map(unique, (value) => {
-      return { text: value };
-    });
-  }
-
-  findColIndex(columns: any[], colName: string) {
-    for (let i = 0; i < columns.length; i++) {
-      if (columns[i].text === colName) {
-        return i;
-      }
-    }
-
-    return -1;
-  }
-
-  containsKey(res: any, key: any) {
-    for (let i = 0; i < res.length; i++) {
-      if (res[i].text === key) {
-        return true;
-      }
-    }
-    return false;
   }
 
   async transformAnnotationResponse(options: any, data: BackendDataSourceResponse): Promise<AnnotationEvent[]> {

--- a/public/app/plugins/datasource/postgres/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/specs/datasource.test.ts
@@ -338,8 +338,8 @@ describe('PostgreSQLDatasource', () => {
     });
   });
 
-  describe('When performing metricFindQuery', () => {
-    it('should return list of all column values', async () => {
+  describe('When performing metricFindQuery that returns multiple string fields', () => {
+    it('should return list of all string field values', async () => {
       const query = 'select * from atable';
       const response = {
         results: {
@@ -483,6 +483,43 @@ describe('PostgreSQLDatasource', () => {
         { text: 'aTitle', value: 'value1' },
         { text: 'aTitle2', value: 'value2' },
         { text: 'aTitle3', value: 'value3' },
+      ]);
+    });
+  });
+
+  describe('When performing metricFindQuery without key, value columns', () => {
+    it('should return list of all field values as text', async () => {
+      const query = 'select id, values from atable';
+      const response = {
+        results: {
+          tempvar: {
+            refId: 'tempvar',
+            frames: [
+              dataFrameToJSON(
+                new MutableDataFrame({
+                  fields: [
+                    { name: 'id', values: [1, 2, 3] },
+                    { name: 'values', values: ['test1', 'test2', 'test3'] },
+                  ],
+                  meta: {
+                    executedQueryString: 'select id, values from atable',
+                  },
+                })
+              ),
+            ],
+          },
+        },
+      };
+      const { ds } = setupTestContext(response);
+      const results = await ds.metricFindQuery(query, {});
+
+      expect(results).toEqual([
+        { text: 1 },
+        { text: 2 },
+        { text: 3 },
+        { text: 'test1' },
+        { text: 'test2' },
+        { text: 'test3' },
       ]);
     });
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a problem with query variables where SQL query returning for example only numeric values didn't populate the query variables with values.

**Which issue(s) this PR fixes**:
Fixes #35391 

**Special notes for your reviewer**:

