### PR TITLE
Access control: Update docs with new settings permission

### DIFF
--- a/docs/sources/enterprise/access-control/fine-grained-access-control-references.md
+++ b/docs/sources/enterprise/access-control/fine-grained-access-control-references.md
@@ -12,21 +12,21 @@ The reference information that follows complements conceptual information about 
 
 Fixed roles | Permissions | Descriptions
 --- | --- | ---
-fixed:permissions:admin:read | roles:read<br>roles:list<br>roles.builtin:list | Allows to list and get available roles and built-in role assignments.
-fixed:permissions:admin:edit | All permissions from `fixed:permissions:admin:read` and <br>roles:write<br>roles:delete<br>roles.builtin:add<br>roles.builtin:remove | Allows every read action and in addition allows to create, change and delete custom roles and create or remove built-in role assignments.
-fixed:reporting:admin:read | reports:read<br>reports:send<br>reports.settings:read | Allows to read reports and report settings.
-fixed:reporting:admin:edit | All permissions from `fixed:reporting:admin:read` and <br>reports.admin:write<br>reports:delete<br>reports.settings:write | Allows every read action for reports and in addition allows to administer reports. 
-fixed:users:admin:read | users.authtoken:list<br>users.quotas:list<br>users:read<br>users.teams:read | Allows to list and get users and related information.
-fixed:users:admin:edit | All permissions from `fixed:users:admin:read` and <br>users.password:update<br>users:write<br>users:create<br>users:delete<br>users:enable<br>users:disable<br>users.permissions:update<br>users:logout<br>users.authtoken:update<br>users.quotas:update | Allows every read action for users and in addition allows to administer users. 
-fixed:users:org:read | org.users:read | Allows to get user organizations.
-fixed:users:org:edit | All permissions from `fixed:users:org:read` and <br>org.users:add<br>org.users:remove<br>org.users.role:update | Allows every read action for user organizations and in addition allows to administer user organizations.
-fixed:ldap:admin:read | ldap.user:read<br>ldap.status:read | Allows to read LDAP information and status.
-fixed:ldap:admin:edit | All permissions from `fixed:ldap:admin:read` and <br>ldap.user:sync | Allows every read action for LDAP and in addition allows to administer LDAP.
-fixed:settings:admin:edit | settings:write | Allows to update all settings
+`fixed:permissions:admin:read` | `roles:read`<br>`roles:list`<br>`roles.builtin:list` | Allows to list and get available roles and built-in role assignments.
+`fixed:permissions:admin:edit` | All permissions from `fixed:permissions:admin:read` and <br>`roles:write`<br>`roles:delete`<br>`roles.builtin:add`<br>`roles.builtin:remove` | Allows every read action and in addition allows to create, change and delete custom roles and create or remove built-in role assignments.
+`fixed:reporting:admin:read` | `reports:read`<br>`reports:send`<br>`reports.settings:read` | Allows to read reports and report settings.
+`fixed:reporting:admin:edit` | All permissions from `fixed:reporting:admin:read` and <br>`reports.admin:write`<br>`reports:delete`<br>`reports.settings:write` | Allows every read action for reports and in addition allows to administer reports. 
+`fixed:users:admin:read` | `users.authtoken:list`<br>`users.quotas:list`<br>`users:read`<br>`users.teams:read` | Allows to list and get users and related information.
+`fixed:users:admin:edit` | All permissions from `fixed:users:admin:read` and <br>`users.password:update`<br>`users:write`<br>`users:create`<br>`users:delete`<br>`users:enable`<br>`users:disable`<br>`users.permissions:update`<br>`users:logout`<br>`users.authtoken:update`<br>`users.quotas:update` | Allows every read action for users and in addition allows to administer users. 
+`fixed:users:org:read` | `org.users:read` | Allows to get user organizations.
+`fixed:users:org:edit` | All permissions from `fixed:users:org:read` and <br>`org.users:add`<br>`org.users:remove`<br>`org.users.role:update` | Allows every read action for user organizations and in addition allows to administer user organizations.
+`fixed:ldap:admin:read` | `ldap.user:read`<br>`ldap.status:read` | Allows to read LDAP information and status.
+`fixed:ldap:admin:edit` | All permissions from `fixed:ldap:admin:read` and <br>`ldap.user:sync` | Allows every read action for LDAP and in addition allows to administer LDAP.
+`fixed:settings:admin:edit` | `settings:write` | Update all settings
 
 ## Default built-in role assignments
 
 Built-in roles | Associated roles | Descriptions
 --- | --- | ---
-Grafana Admin | fixed:permissions:admin:edit<br>fixed:permissions:admin:read<br>fixed:reporting:admin:edit<br>fixed:reporting:admin:read<br>fixed:users:admin:edit<br>fixed:users:admin:read<br>fixed:users:org:edit<br>fixed:users:org:read<br>fixed:ldap:admin:edit<br>fixed:ldap:admin:read<br>fixed:settings:admin:edit | Allows access to resources which [Grafana Server Admin]({{< relref "../../permissions/_index.md#grafana-server-admin-role" >}}) has permissions by default.
-Admin | fixed:users:org:edit<br>fixed:users:org:read<br>fixed:reporting:admin:edit<br>fixed:reporting:admin:read | Allows access to resource which [Admin]({{< relref "../../permissions/organization_roles.md" >}}) has permissions by default.
+Grafana Admin | `fixed:permissions:admin:edit`<br>`fixed:permissions:admin:read`<br>`fixed:reporting:admin:edit`<br>`fixed:reporting:admin:read`<br>`fixed:users:admin:edit`<br>`fixed:users:admin:read`<br>`fixed:users:org:edit`<br>`fixed:users:org:read`<br>`fixed:ldap:admin:edit`<br>`fixed:ldap:admin:read`<br>`fixed:settings:admin:edit` | Allows access to resources which [Grafana Server Admin]({{< relref "../../permissions/_index.md#grafana-server-admin-role" >}}) has permissions by default.
+Admin | `fixed:users:org:edit`<br>`fixed:users:org:read`<br>`fixed:reporting:admin:edit`<br>`fixed:reporting:admin:read` | Allows access to resource which [Admin]({{< relref "../../permissions/organization_roles.md" >}}) has permissions by default.

--- a/docs/sources/enterprise/access-control/fine-grained-access-control-references.md
+++ b/docs/sources/enterprise/access-control/fine-grained-access-control-references.md
@@ -22,10 +22,11 @@ fixed:users:org:read | org.users:read | Allows to get user organizations.
 fixed:users:org:edit | All permissions from `fixed:users:org:read` and <br>org.users:add<br>org.users:remove<br>org.users.role:update | Allows every read action for user organizations and in addition allows to administer user organizations.
 fixed:ldap:admin:read | ldap.user:read<br>ldap.status:read | Allows to read LDAP information and status.
 fixed:ldap:admin:edit | All permissions from `fixed:ldap:admin:read` and <br>ldap.user:sync | Allows every read action for LDAP and in addition allows to administer LDAP.
+fixed:settings:admin:edit | settings:write | Allows to update all settings
 
 ## Default built-in role assignments
 
 Built-in roles | Associated roles | Descriptions
 --- | --- | ---
-Grafana Admin | fixed:permissions:admin:edit<br>fixed:permissions:admin:read<br>fixed:reporting:admin:edit<br>fixed:reporting:admin:read<br>fixed:users:admin:edit<br>fixed:users:admin:read<br>fixed:users:org:edit<br>fixed:users:org:read<br>fixed:ldap:admin:edit<br>fixed:ldap:admin:read | Allows access to resources which [Grafana Server Admin]({{< relref "../../permissions/_index.md#grafana-server-admin-role" >}}) has permissions by default.
+Grafana Admin | fixed:permissions:admin:edit<br>fixed:permissions:admin:read<br>fixed:reporting:admin:edit<br>fixed:reporting:admin:read<br>fixed:users:admin:edit<br>fixed:users:admin:read<br>fixed:users:org:edit<br>fixed:users:org:read<br>fixed:ldap:admin:edit<br>fixed:ldap:admin:read<br>fixed:settings:admin:edit | Allows access to resources which [Grafana Server Admin]({{< relref "../../permissions/_index.md#grafana-server-admin-role" >}}) has permissions by default.
 Admin | fixed:users:org:edit<br>fixed:users:org:read<br>fixed:reporting:admin:edit<br>fixed:reporting:admin:read | Allows access to resource which [Admin]({{< relref "../../permissions/organization_roles.md" >}}) has permissions by default.

--- a/docs/sources/enterprise/access-control/permissions.md
+++ b/docs/sources/enterprise/access-control/permissions.md
@@ -62,6 +62,7 @@ ldap.user:read | n/a | Get a user via LDAP.
 ldap.user:sync | n/a | Sync a user via LDAP.
 ldap.status:read | n/a | Verify the LDAP servers’ availability.
 status:accesscontrol | service:access-control | Get access-control enabled status.
+settings:write | settings:\*\*, settings:auth.saml:*, or on the property level settings:auth.saml:enabled | Update settings
 
 ## Scope definitions
 
@@ -75,3 +76,4 @@ reports:* | Restrict an action to a set of reports. For example, `reports:*` mat
 service:accesscontrol | Restrict an action to target only the fine-grained access control service. For example, you can use this in conjunction with the `provisioning:reload` or the `status:accesscontrol` actions.
 global:users:* | Restrict an action to a set of global users.
 users:* | Restrict an action to a set of users from an organization.
+settings:** | Restrict an action to a set of settings. For example, `settings:**`matches all settings, `settings:auth.saml:*` matches all saml settings and `settings:auth.saml:enabled`matches the enable property on the saml settings

--- a/docs/sources/enterprise/access-control/permissions.md
+++ b/docs/sources/enterprise/access-control/permissions.md
@@ -62,7 +62,7 @@ ldap.user:read | n/a | Get a user via LDAP.
 ldap.user:sync | n/a | Sync a user via LDAP.
 ldap.status:read | n/a | Verify the LDAP servers’ availability.
 status:accesscontrol | service:access-control | Get access-control enabled status.
-settings:write | settings:\*\*, settings:auth.saml:*, or on the property level settings:auth.saml:enabled | Update settings
+settings:write | settings:\*\*<br>settings:auth.saml:*<br>settings:auth.saml:enabled (property level) | Update settings
 
 ## Scope definitions
 

--- a/docs/sources/enterprise/access-control/permissions.md
+++ b/docs/sources/enterprise/access-control/permissions.md
@@ -25,44 +25,44 @@ The following list contains fine-grained access control actions.
 
 Actions | Applicable scopes | Descriptions
 --- | --- | ---
-roles:list | roles:* | List available roles without permissions.
-roles:read | roles:* | Read a specific role with it's permissions.
-roles:write | permissions:delegate | Create or update a custom role.
-roles:delete | permissions:delegate | Delete a custom role.
-roles.builtin:list | roles:* | List built-in role assignments.
-roles.builtin:add | permissions:delegate | Create a built-in role assignment.
-roles.builtin:remove | permissions:delegate | Delete a built-in role assignment.
-reports.admin:create | reports:* | Create reports.
-reports.admin:write | reports:* | Update reports.
-reports:delete | reports:* | Delete reports.
-reports:read | reports:* | List all available reports or get a specific report.
-reports:send | reports:* | Send a report email.
-reports.settings:write | n/a | Update report settings.
-reports.settings:read | n/a | Read report settings.
-provisioning:reload | service:access-control | Reload provisioning files.
-users:read | global:users:* | Read or search user profiles.
-users:write | global:users:* | Update a user’s profile.
-users.teams:read | global:users:* | Read a user’s teams.
-users.authtoken:list | global:users:* | List authentication tokens that are assigned to a user.
-users.authtoken:update | global:users:* | Update authentication tokens that are assigned to a user.
-users.password:update | global:users:* | Update a user’s password.
-users:delete | global:users:* | Delete a user.
-users:create | n/a | Create a user.
-users:enable | global:users:* | Enable a user.
-users:disable | global:users:* | Disable a user.
-users.permissions:update | global:users:* | Update a user’s organization-level permissions.
-users:logout | global:users:* | Log out a user.
-users.quotas:list | global:users:* | List a user’s quotas.
-users.quotas:update | global:users:* | Update a user’s quotas.
-org.users.read | users:* | Get user profiles within an organization.
-org.users.add | users:* | Add a user to an organization.
-org.users.remove | users:* | Remove a user from an organization.
-org.users.role:update | users:* | Update the organization role (`Viewer`, `Editor`, `Admin`) for an organization.
-ldap.user:read | n/a | Get a user via LDAP.
-ldap.user:sync | n/a | Sync a user via LDAP.
-ldap.status:read | n/a | Verify the LDAP servers’ availability.
-status:accesscontrol | service:access-control | Get access-control enabled status.
-settings:write | settings:\*\*<br>settings:auth.saml:*<br>settings:auth.saml:enabled (property level) | Update settings
+`roles:list` | `roles:*` | List available roles without permissions.
+`roles:read` | `roles:*` | Read a specific role with it's permissions.
+`roles:write` | `permissions:delegate` | Create or update a custom role.
+`roles:delete` | `permissions:delegate` | Delete a custom role.
+`roles.builtin:list` | `roles:*` | List built-in role assignments.
+`roles.builtin:add` | `permissions:delegate` | Create a built-in role assignment.
+`roles.builtin:remove` | `permissions:delegate` | Delete a built-in role assignment.
+`reports.admin:create` | `reports:*` | Create reports.
+`reports.admin:write` | `reports:*` | Update reports.
+`reports:delete` | `reports:*` | Delete reports.
+`reports:read` | `reports:*` | List all available reports or get a specific report.
+`reports:send` | `reports:*` | Send a report email.
+`reports.settings:write` | n/a | Update report settings.
+`reports.settings:read` | n/a | Read report settings.
+`provisioning:reload` | `service:accesscontrol` | Reload provisioning files.
+`users:read` | `global:users:*` | Read or search user profiles.
+`users:write` | `global:users:*` | Update a user’s profile.
+`users.teams:read` | `global:users:*` | Read a user’s teams.
+`users.authtoken:list` | `global:users:*` | List authentication tokens that are assigned to a user.
+`users.authtoken:update` | `global:users:*` | Update authentication tokens that are assigned to a user.
+`users.password:update` | `global:users:*` | Update a user’s password.
+`users:delete` | `global:users:*` | Delete a user.
+`users:create` | n/a | Create a user.
+`users:enable` | `global:users:*` | Enable a user.
+`users:disable` | `global:users:*` | Disable a user.
+`users.permissions:update` | `global:users:*` | Update a user’s organization-level permissions.
+`users:logout` | `global:users:*` | Log out a user.
+`users.quotas:list` | `global:users:*` | List a user’s quotas.
+`users.quotas:update` | `global:users:*` | Update a user’s quotas.
+`org.users.read` | `users:*` | Get user profiles within an organization.
+`org.users.add` | `users:*` | Add a user to an organization.
+`org.users.remove` | `users:*` | Remove a user from an organization.
+`org.users.role:update` | `users:*` | Update the organization role (`Viewer`, `Editor`, `Admin`) for an organization.
+`ldap.user:read` | n/a | Get a user via LDAP.
+`ldap.user:sync` | n/a | Sync a user via LDAP.
+`ldap.status:read` | n/a | Verify the LDAP servers’ availability.
+`status:accesscontrol` | `service:accesscontrol` | Get access-control enabled status.
+`settings:write` | `settings:**`<br>`settings:auth.saml:*`<br>`settings:auth.saml:enabled` (property level) | Update settings
 
 ## Scope definitions
 
@@ -70,10 +70,10 @@ The following list contains fine-grained access control scopes.
 
 Scopes | Descriptions
 --- | ---
-roles:* | Restrict an action to a set of roles. For example, `roles:*` matches any role, `roles:randomuid` matches only the role with UID `randomuid` and `roles:custom:reports:{editor,viewer}` matches both `custom:reports:editor` and `custom:reports:viewer` roles.
-permissions:delegate | The scope is only applicable for roles associated with the Access Control itself and indicates that you can delegate your permissions only, or a subset of it, by creating a new role or making an assignment.
-reports:* | Restrict an action to a set of reports. For example, `reports:*` matches any report and `reports:1` matches the report with id `1`.
-service:accesscontrol | Restrict an action to target only the fine-grained access control service. For example, you can use this in conjunction with the `provisioning:reload` or the `status:accesscontrol` actions.
-global:users:* | Restrict an action to a set of global users.
-users:* | Restrict an action to a set of users from an organization.
-settings:** | Restrict an action to a subset of settings. For example, `settings:**` matches all settings, `settings:auth.saml:*` matches all SAML settings, and `settings:auth.saml:enabled` matches the enable property on the SAML settings.
+`roles:*` | Restrict an action to a set of roles. For example, `roles:*` matches any role, `roles:randomuid` matches only the role with UID `randomuid` and `roles:custom:reports:{editor,viewer}` matches both `custom:reports:editor` and `custom:reports:viewer` roles.
+`permissions:delegate` | The scope is only applicable for roles associated with the Access Control itself and indicates that you can delegate your permissions only, or a subset of it, by creating a new role or making an assignment.
+`reports:*` | Restrict an action to a set of reports. For example, `reports:*` matches any report and `reports:1` matches the report with id `1`.
+`service:accesscontrol` | Restrict an action to target only the fine-grained access control service. For example, you can use this in conjunction with the `provisioning:reload` or the `status:accesscontrol` actions.
+`global:users:*` | Restrict an action to a set of global users.
+`users:*` | Restrict an action to a set of users from an organization.
+`settings:**` | Restrict an action to a subset of settings. For example, `settings:**` matches all settings, `settings:auth.saml:*` matches all SAML settings, and `settings:auth.saml:enabled` matches the enable property on the SAML settings.

--- a/docs/sources/enterprise/access-control/permissions.md
+++ b/docs/sources/enterprise/access-control/permissions.md
@@ -76,4 +76,4 @@ reports:* | Restrict an action to a set of reports. For example, `reports:*` mat
 service:accesscontrol | Restrict an action to target only the fine-grained access control service. For example, you can use this in conjunction with the `provisioning:reload` or the `status:accesscontrol` actions.
 global:users:* | Restrict an action to a set of global users.
 users:* | Restrict an action to a set of users from an organization.
-settings:** | Restrict an action to a set of settings. For example, `settings:**`matches all settings, `settings:auth.saml:*` matches all saml settings and `settings:auth.saml:enabled`matches the enable property on the saml settings
+settings:** | Restrict an action to a subset of settings. For example, `settings:**` matches all settings, `settings:auth.saml:*` matches all SAML settings, and `settings:auth.saml:enabled` matches the enable property on the SAML settings.


### PR DESCRIPTION

**What this PR does / why we need it**:
Update the access control documentation with new permissions for settings