### PR TITLE
SideMenu: remove `box-shadow` from `img` elements

### DIFF
--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -98,7 +98,6 @@ $mobile-menu-breakpoint: md;
     border-radius: 50%;
     width: 28px;
     height: 28px;
-    box-shadow: 0 0 14px 2px rgba(255, 255, 255, 0.05);
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- makes sidemenu links using images more consistent with the ones using icons
- fixes https://github.com/grafana/grafana/issues/35427

before:
![image](https://user-images.githubusercontent.com/20999846/121348575-6bd21a80-c920-11eb-8efd-88f41d4ba4fb.png)

after:
![image](https://user-images.githubusercontent.com/20999846/121348608-74c2ec00-c920-11eb-97e1-acb5ce2e1b8c.png)



**Special notes for your reviewer**:
- first PR, so if there's any other labels that should have been added or anything, let me know!
