### PR TITLE
Cloudwatch: Fix missing defaultRegion

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -102,7 +102,7 @@ func NewInstanceSettings() datasource.InstanceFactoryFunc {
 	return func(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		jsonData := struct {
 			Profile       string `json:"profile"`
-			Region        string `json:"defaulRegion"`
+			Region        string `json:"defaultRegion"`
 			AssumeRoleARN string `json:"assumeRoleArn"`
 			ExternalID    string `json:"externalId"`
 			Endpoint      string `json:"endpoint"`

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -1,0 +1,73 @@
+package cloudwatch
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInstanceSettings(t *testing.T) {
+	tests := []struct {
+		name       string
+		settings   backend.DataSourceInstanceSettings
+		expectedDS datasourceInfo
+		Err        require.ErrorAssertionFunc
+	}{
+		{
+			name: "creates a request",
+			settings: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"profile": "foo",
+					"defaultRegion": "us-east2",
+					"assumeRoleArn": "role",
+					"externalId": "id",
+					"endpoint": "bar",
+					"customMetricsNamespaces": "ns",
+					"authType": "keys"
+				}`),
+				DecryptedSecureJSONData: map[string]string{
+					"accessKey": "A123",
+					"secretKey": "secret",
+				},
+			},
+			expectedDS: datasourceInfo{
+				profile:       "foo",
+				region:        "us-east2",
+				assumeRoleARN: "role",
+				externalID:    "id",
+				endpoint:      "bar",
+				namespace:     "ns",
+				authType:      awsds.AuthTypeKeys,
+				accessKey:     "A123",
+				secretKey:     "secret",
+			},
+			Err: require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewInstanceSettings()
+			model, err := f(tt.settings)
+			tt.Err(t, err)
+			datasourceComparer := cmp.Comparer(func(d1 datasourceInfo, d2 datasourceInfo) bool {
+				return d1.profile == d2.profile &&
+					d1.region == d2.region &&
+					d1.authType == d2.authType &&
+					d1.assumeRoleARN == d2.assumeRoleARN &&
+					d1.externalID == d2.externalID &&
+					d1.namespace == d2.namespace &&
+					d1.endpoint == d2.endpoint &&
+					d1.accessKey == d2.accessKey &&
+					d1.secretKey == d2.secretKey &&
+					d1.datasourceID == d2.datasourceID
+			})
+			if !cmp.Equal(model.(datasourceInfo), tt.expectedDS, datasourceComparer) {
+				t.Errorf("Unexpected result. Expecting\n%v \nGot:\n%v", model, tt.expectedDS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fixes a typo in the data source definition of Cloudwatch. This caused that the default region was not automatically detected.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35369

**Special notes for your reviewer**:

Added some basic test for the function.
