### PR TITLE
Datasource: Fix storing timeout option as numeric

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -167,13 +167,14 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
               <div className="gf-form">
                 <FormField
                   label="Timeout"
+                  type="number"
                   labelWidth={13}
                   inputWidth={20}
                   tooltip="HTTP request timeout in seconds"
                   value={dataSourceConfig.jsonData.timeout}
                   onChange={(event) => {
                     onSettingsChange({
-                      jsonData: { ...dataSourceConfig.jsonData, timeout: event.currentTarget.value },
+                      jsonData: { ...dataSourceConfig.jsonData, timeout: parseInt(event.currentTarget.value, 10) },
                     });
                   }}
                 />

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -17,10 +18,18 @@ func (ds *DataSource) getTimeout() time.Duration {
 	timeout := 0
 	if ds.JsonData != nil {
 		timeout = ds.JsonData.Get("timeout").MustInt()
+		if timeout == 0 {
+			if timeoutStr := ds.JsonData.Get("timeout").MustString(); timeoutStr != "" {
+				if t, err := strconv.Atoi(timeoutStr); err == nil {
+					timeout = t
+				}
+			}
+		}
 	}
 	if timeout == 0 {
 		timeout = setting.DataProxyTimeout
 	}
+	fmt.Printf("data source timeout, named %q, timeout %d", ds.Name, timeout)
 	return time.Duration(timeout) * time.Second
 }
 

--- a/pkg/models/datasource_cache.go
+++ b/pkg/models/datasource_cache.go
@@ -18,7 +18,7 @@ func (ds *DataSource) getTimeout() time.Duration {
 	timeout := 0
 	if ds.JsonData != nil {
 		timeout = ds.JsonData.Get("timeout").MustInt()
-		if timeout == 0 {
+		if timeout <= 0 {
 			if timeoutStr := ds.JsonData.Get("timeout").MustString(); timeoutStr != "" {
 				if t, err := strconv.Atoi(timeoutStr); err == nil {
 					timeout = t
@@ -26,10 +26,9 @@ func (ds *DataSource) getTimeout() time.Duration {
 			}
 		}
 	}
-	if timeout == 0 {
+	if timeout <= 0 {
 		timeout = setting.DataProxyTimeout
 	}
-	fmt.Printf("data source timeout, named %q, timeout %d", ds.Name, timeout)
 	return time.Duration(timeout) * time.Second
 }
 

--- a/pkg/models/datasource_cache_test.go
+++ b/pkg/models/datasource_cache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -308,6 +309,26 @@ func TestDataSource_GetHttpTransport(t *testing.T) {
 		require.NotNil(t, configuredOpts.SigV4)
 		require.Equal(t, "es", configuredOpts.SigV4.Service)
 	})
+}
+
+func TestDataSource_getTimeout(t *testing.T) {
+	setting.DataProxyTimeout = 30
+	testCases := []struct {
+		jsonData        *simplejson.Json
+		expectedTimeout time.Duration
+	}{
+		{jsonData: simplejson.New(), expectedTimeout: time.Duration(30 * time.Second)},
+		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": nil}), expectedTimeout: time.Duration(30 * time.Second)},
+		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": 1}), expectedTimeout: time.Duration(time.Second)},
+		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": "2"}), expectedTimeout: time.Duration(2 * time.Second)},
+	}
+
+	for _, tc := range testCases {
+		ds := &DataSource{
+			JsonData: tc.jsonData,
+		}
+		assert.Equal(t, tc.expectedTimeout, ds.getTimeout())
+	}
 }
 
 func TestDataSource_DecryptedValue(t *testing.T) {

--- a/pkg/models/datasource_cache_test.go
+++ b/pkg/models/datasource_cache_test.go
@@ -317,10 +317,11 @@ func TestDataSource_getTimeout(t *testing.T) {
 		jsonData        *simplejson.Json
 		expectedTimeout time.Duration
 	}{
-		{jsonData: simplejson.New(), expectedTimeout: time.Duration(30 * time.Second)},
-		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": nil}), expectedTimeout: time.Duration(30 * time.Second)},
-		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": 1}), expectedTimeout: time.Duration(time.Second)},
-		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": "2"}), expectedTimeout: time.Duration(2 * time.Second)},
+		{jsonData: simplejson.New(), expectedTimeout: 30 * time.Second},
+		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": nil}), expectedTimeout: 30 * time.Second},
+		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": 0}), expectedTimeout: 30 * time.Second},
+		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": 1}), expectedTimeout: time.Second},
+		{jsonData: simplejson.NewFromAny(map[string]interface{}{"timeout": "2"}), expectedTimeout: 2 * time.Second},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
#31871 introduced support for configuring timeout in seconds
for HTTP data sources. That had a bug where backend expected
a numeric timeout value where it was actually stored as a
string. This should resolve this by requiring input to be
numbers, storing input as numeric and falling back to string
value if there's no numeric value.

**Which issue(s) this PR fixes**:
Ref #31871

**Special notes for your reviewer**:

