### PR TITLE
Dashboard: Allow more than 26 queries per panel.

### DIFF
--- a/public/app/core/utils/query.test.ts
+++ b/public/app/core/utils/query.test.ts
@@ -1,15 +1,15 @@
 import { DataQuery } from '@grafana/data';
 import { getNextRefIdChar } from './query';
 
-function _dataQueryHelper(ids: string[]): DataQuery[] {
+function dataQueryHelper(ids: string[]): DataQuery[] {
   return ids.map((letter) => {
     return { refId: letter };
   });
 }
 
-const singleDataQuery: DataQuery[] = _dataQueryHelper('ABCDE'.split(''));
-const outOfOrderDataQuery: DataQuery[] = _dataQueryHelper('ABD'.split(''));
-const singleExtendedDataQuery: DataQuery[] = _dataQueryHelper('ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''));
+const singleDataQuery: DataQuery[] = dataQueryHelper('ABCDE'.split(''));
+const outOfOrderDataQuery: DataQuery[] = dataQueryHelper('ABD'.split(''));
+const singleExtendedDataQuery: DataQuery[] = dataQueryHelper('ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''));
 
 describe('Get next refId char', () => {
   it('should return next char', () => {

--- a/public/app/core/utils/query.test.ts
+++ b/public/app/core/utils/query.test.ts
@@ -1,30 +1,30 @@
 import { DataQuery } from '@grafana/data';
 import { getNextRefIdChar } from './query';
 
-const dataQueries: DataQuery[] = [
-  {
-    refId: 'A',
-  },
-  {
-    refId: 'B',
-  },
-  {
-    refId: 'C',
-  },
-  {
-    refId: 'D',
-  },
-  {
-    refId: 'E',
-  },
-];
+function _dataQueryHelper(ids: string[]): DataQuery[] {
+  return ids.map((letter) => {
+    return { refId: letter };
+  });
+}
+
+const singleDataQuery: DataQuery[] = _dataQueryHelper('ABCDE'.split(''));
+const outOfOrderDataQuery: DataQuery[] = _dataQueryHelper('ABD'.split(''));
+const singleExtendedDataQuery: DataQuery[] = _dataQueryHelper('ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''));
 
 describe('Get next refId char', () => {
   it('should return next char', () => {
-    expect(getNextRefIdChar(dataQueries)).toEqual('F');
+    expect(getNextRefIdChar(singleDataQuery)).toEqual('F');
   });
 
   it('should get first char', () => {
     expect(getNextRefIdChar([])).toEqual('A');
+  });
+
+  it('should get the first avaliable character if a query has been deleted out of order', () => {
+    expect(getNextRefIdChar(outOfOrderDataQuery)).toEqual('C');
+  });
+
+  it('should append a new char and start from AA when Z is reached', () => {
+    expect(getNextRefIdChar(singleExtendedDataQuery)).toEqual('AA');
   });
 });

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -1,16 +1,12 @@
-import { every, find } from 'lodash';
 import { DataQuery } from '@grafana/data';
 
 export const getNextRefIdChar = (queries: DataQuery[]): string => {
-  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-  return (
-    find(letters, (refId) => {
-      return every(queries, (other) => {
-        return other.refId !== refId;
-      });
-    }) ?? 'NA'
-  );
+  for (let num = 0; ; num++) {
+    const refId = _getRefId(num);
+    if (!queries.some((query) => query.refId === refId)) {
+      return refId;
+    }
+  }
 };
 
 export function addQuery(queries: DataQuery[], query?: Partial<DataQuery>): DataQuery[] {
@@ -34,4 +30,14 @@ export function isDataQuery(url: string): boolean {
 
 export function isLocalUrl(url: string) {
   return !url.match(/^http/);
+}
+
+function _getRefId(num: number): string {
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+  if (num < letters.length) {
+    return letters[num];
+  } else {
+    return _getRefId(Math.floor(num / letters.length) - 1) + letters[num % letters.length];
+  }
 }

--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -2,7 +2,7 @@ import { DataQuery } from '@grafana/data';
 
 export const getNextRefIdChar = (queries: DataQuery[]): string => {
   for (let num = 0; ; num++) {
-    const refId = _getRefId(num);
+    const refId = getRefId(num);
     if (!queries.some((query) => query.refId === refId)) {
       return refId;
     }
@@ -32,12 +32,12 @@ export function isLocalUrl(url: string) {
   return !url.match(/^http/);
 }
 
-function _getRefId(num: number): string {
+function getRefId(num: number): string {
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
   if (num < letters.length) {
     return letters[num];
   } else {
-    return _getRefId(Math.floor(num / letters.length) - 1) + letters[num % letters.length];
+    return getRefId(Math.floor(num / letters.length) - 1) + letters[num % letters.length];
   }
 }


### PR DESCRIPTION
Fixes #4978

**What this PR does / why we need it**:
This PR allows users to create more than 26 queries per panel, which was previously the upper limit.

We often encounter situations where we need many complex or simple queries for a particular panel type (e.g. Diagram Plugins).

**Which issue(s) this PR fixes**:
Open issue:
Fixes #4978

Duplicate issues:
https://github.com/grafana/grafana/issues/7783
https://github.com/grafana/grafana/issues/11129
https://github.com/grafana/grafana/issues/13934
https://github.com/grafana/grafana/issues/19056
https://github.com/grafana/grafana/issues/19200
https://github.com/grafana/grafana/issues/20184
https://github.com/grafana/grafana/issues/20868
https://github.com/grafana/grafana/issues/21802
https://github.com/grafana/grafana/issues/28104
https://github.com/grafana/grafana/issues/27957

