### PR TITLE
GoogleCloudMonitoring: Fix query object for panels prior to v7

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -16,7 +16,6 @@ import { DataSourceWithBackend, toDataQueryResponse } from '@grafana/runtime';
 import { CloudMonitoringVariableSupport } from './variables';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { from, Observable, of, throwError } from 'rxjs';
-import { MetricQuery } from '../cloudwatch/types';
 
 export default class CloudMonitoringDatasource extends DataSourceWithBackend<
   CloudMonitoringQuery,
@@ -104,10 +103,10 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
       .toPromise();
   }
 
-  applyTemplateVariables(query: CloudMonitoringQuery, scopedVars: ScopedVars): Record<string, any> {
-    const { refId, queryType, sloQuery } = query;
-    // Query won't have the key metricQuery in v6.x, just the plain object
-    const metricQuery = query.metricQuery ? query.metricQuery : (query as MetricQuery);
+  applyTemplateVariables(
+    { metricQuery, refId, queryType, sloQuery }: CloudMonitoringQuery,
+    scopedVars: ScopedVars
+  ): Record<string, any> {
     return {
       datasourceId: this.id,
       refId,
@@ -344,7 +343,9 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
   }
 
   interpolateVariablesInQueries(queries: CloudMonitoringQuery[], scopedVars: ScopedVars): CloudMonitoringQuery[] {
-    return queries.map((query) => this.applyTemplateVariables(query, scopedVars) as CloudMonitoringQuery);
+    return queries.map(
+      (query) => this.applyTemplateVariables(this.migrateQuery(query), scopedVars) as CloudMonitoringQuery
+    );
   }
 
   interpolateFilters(filters: string[], scopedVars: ScopedVars) {

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -16,6 +16,7 @@ import { DataSourceWithBackend, toDataQueryResponse } from '@grafana/runtime';
 import { CloudMonitoringVariableSupport } from './variables';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { from, Observable, of, throwError } from 'rxjs';
+import { MetricQuery } from '../cloudwatch/types';
 
 export default class CloudMonitoringDatasource extends DataSourceWithBackend<
   CloudMonitoringQuery,
@@ -103,10 +104,10 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
       .toPromise();
   }
 
-  applyTemplateVariables(
-    { metricQuery, refId, queryType, sloQuery }: CloudMonitoringQuery,
-    scopedVars: ScopedVars
-  ): Record<string, any> {
+  applyTemplateVariables(query: CloudMonitoringQuery, scopedVars: ScopedVars): Record<string, any> {
+    const { refId, queryType, sloQuery } = query;
+    // Query won't have the key metricQuery in v6.x, just the plain object
+    const metricQuery = query.metricQuery ? query.metricQuery : (query as MetricQuery);
     return {
       datasourceId: this.id,
       refId,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

After some refactoring, panels from <7.x wouldn't work in v7 or v8. The information is still there but not under the query `metricQuery`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #29643

**Special notes for your reviewer**:

