### PR TITLE
TimeSeries: Fix fill below for dataframes with name

### DIFF
--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -36,20 +36,16 @@ export function getFrameDisplayName(frame: DataFrame, index?: number) {
   return `Series (${index})`;
 }
 
-export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[], noCache = false): string {
-  if (!noCache) {
-    const existingTitle = field.state?.displayName;
+export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
+  const existingTitle = field.state?.displayName;
 
-    if (existingTitle) {
-      return existingTitle;
-    }
+  if (existingTitle) {
+    return existingTitle;
   }
 
   const displayName = calculateFieldDisplayName(field, frame, allFrames);
-  if (!noCache) {
-    field.state = field.state || {};
-    field.state.displayName = displayName;
-  }
+  field.state = field.state || {};
+  field.state.displayName = displayName;
 
   return displayName;
 }
@@ -57,7 +53,7 @@ export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?:
 /**
  * Get an appropriate display name. If the 'displayName' field config is set, use that
  */
-function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
+export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
   const hasConfigTitle = field.config?.displayName && field.config?.displayName.length;
 
   let displayName = hasConfigTitle ? field.config!.displayName! : field.name;

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -51,10 +51,9 @@ export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?:
 }
 
 /**
- * Get an appropriate display name. If the 'displayName' field config is set, use that. If possible use the cached getFieldDisplayName instead.
- * @internal
+ * Get an appropriate display name. If the 'displayName' field config is set, use that.
  */
-export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
+function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
   const hasConfigTitle = field.config?.displayName && field.config?.displayName.length;
 
   let displayName = hasConfigTitle ? field.config!.displayName! : field.name;

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -36,16 +36,20 @@ export function getFrameDisplayName(frame: DataFrame, index?: number) {
   return `Series (${index})`;
 }
 
-export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
-  const existingTitle = field.state?.displayName;
+export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[], noCache = false): string {
+  if (!noCache) {
+    const existingTitle = field.state?.displayName;
 
-  if (existingTitle) {
-    return existingTitle;
+    if (existingTitle) {
+      return existingTitle;
+    }
   }
 
   const displayName = calculateFieldDisplayName(field, frame, allFrames);
-  field.state = field.state || {};
-  field.state.displayName = displayName;
+  if (!noCache) {
+    field.state = field.state || {};
+    field.state.displayName = displayName;
+  }
 
   return displayName;
 }

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -51,7 +51,8 @@ export function getFieldDisplayName(field: Field, frame?: DataFrame, allFrames?:
 }
 
 /**
- * Get an appropriate display name. If the 'displayName' field config is set, use that
+ * Get an appropriate display name. If the 'displayName' field config is set, use that. If possible use the cached getFieldDisplayName instead.
+ * @internal
  */
 export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFrames?: DataFrame[]): string {
   const hasConfigTitle = field.config?.displayName && field.config?.displayName.length;

--- a/packages/grafana-data/src/field/index.ts
+++ b/packages/grafana-data/src/field/index.ts
@@ -14,5 +14,5 @@ export { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 export { sortThresholds, getActiveThreshold } from './thresholds';
 export { applyFieldOverrides, validateFieldConfig, applyRawFieldOverrides } from './fieldOverrides';
 export { getFieldDisplayValuesProxy } from './getFieldDisplayValuesProxy';
-export { getFieldDisplayName, getFrameDisplayName } from './fieldState';
+export { getFieldDisplayName, calculateFieldDisplayName, getFrameDisplayName } from './fieldState';
 export { getScaleCalculator, getFieldConfigWithMinMax } from './scale';

--- a/packages/grafana-data/src/field/index.ts
+++ b/packages/grafana-data/src/field/index.ts
@@ -14,5 +14,5 @@ export { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 export { sortThresholds, getActiveThreshold } from './thresholds';
 export { applyFieldOverrides, validateFieldConfig, applyRawFieldOverrides } from './fieldOverrides';
 export { getFieldDisplayValuesProxy } from './getFieldDisplayValuesProxy';
-export { getFieldDisplayName, calculateFieldDisplayName, getFrameDisplayName } from './fieldState';
+export { getFieldDisplayName, getFrameDisplayName } from './fieldState';
 export { getScaleCalculator, getFieldConfigWithMinMax } from './scale';

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -38,7 +38,7 @@ export interface GraphNGProps extends Themeable2 {
   fields?: XYFieldMatchers; // default will assume timeseries data
   onLegendClick?: (event: GraphNGLegendEvent) => void;
   children?: (builder: UPlotConfigBuilder, alignedFrame: DataFrame) => React.ReactNode;
-  prepConfig: (alignedFrame: DataFrame, getTimeRange: () => TimeRange) => UPlotConfigBuilder;
+  prepConfig: (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames?: DataFrame[]) => UPlotConfigBuilder;
   propsToDiff?: string[];
   preparePlotFrame?: (frames: DataFrame[], dimFields: XYFieldMatchers) => DataFrame;
   renderLegend: (config: UPlotConfigBuilder) => React.ReactElement | null;
@@ -105,7 +105,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
       pluginLog('GraphNG', false, 'data prepared', state.alignedData);
 
       if (withConfig) {
-        state.config = props.prepConfig(alignedFrame, this.getTimeRange);
+        state.config = props.prepConfig(alignedFrame, this.getTimeRange, this.props.frames);
         pluginLog('GraphNG', false, 'config prepared', state.config);
       }
     }
@@ -182,7 +182,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
           propsChanged;
 
         if (shouldReconfig) {
-          newState.config = this.props.prepConfig(newState.alignedFrame, this.getTimeRange);
+          newState.config = this.props.prepConfig(newState.alignedFrame, this.getTimeRange, this.props.frames);
           pluginLog('GraphNG', false, 'config recreated', newState.config);
         }
       }

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -38,7 +38,7 @@ export interface GraphNGProps extends Themeable2 {
   fields?: XYFieldMatchers; // default will assume timeseries data
   onLegendClick?: (event: GraphNGLegendEvent) => void;
   children?: (builder: UPlotConfigBuilder, alignedFrame: DataFrame) => React.ReactNode;
-  prepConfig: (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames: DataFrame[]) => UPlotConfigBuilder;
+  prepConfig: (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => UPlotConfigBuilder;
   propsToDiff?: string[];
   preparePlotFrame?: (frames: DataFrame[], dimFields: XYFieldMatchers) => DataFrame;
   renderLegend: (config: UPlotConfigBuilder) => React.ReactElement | null;
@@ -105,7 +105,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
       pluginLog('GraphNG', false, 'data prepared', state.alignedData);
 
       if (withConfig) {
-        state.config = props.prepConfig(alignedFrame, this.getTimeRange, this.props.frames);
+        state.config = props.prepConfig(alignedFrame, this.props.frames, this.getTimeRange);
         pluginLog('GraphNG', false, 'config prepared', state.config);
       }
     }
@@ -182,7 +182,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
           propsChanged;
 
         if (shouldReconfig) {
-          newState.config = this.props.prepConfig(newState.alignedFrame, this.getTimeRange, this.props.frames);
+          newState.config = this.props.prepConfig(newState.alignedFrame, this.props.frames, this.getTimeRange);
           pluginLog('GraphNG', false, 'config recreated', newState.config);
         }
       }

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -38,7 +38,7 @@ export interface GraphNGProps extends Themeable2 {
   fields?: XYFieldMatchers; // default will assume timeseries data
   onLegendClick?: (event: GraphNGLegendEvent) => void;
   children?: (builder: UPlotConfigBuilder, alignedFrame: DataFrame) => React.ReactNode;
-  prepConfig: (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames?: DataFrame[]) => UPlotConfigBuilder;
+  prepConfig: (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames: DataFrame[]) => UPlotConfigBuilder;
   propsToDiff?: string[];
   preparePlotFrame?: (frames: DataFrame[], dimFields: XYFieldMatchers) => DataFrame;
   renderLegend: (config: UPlotConfigBuilder) => React.ReactElement | null;

--- a/packages/grafana-ui/src/components/GraphNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.test.ts
@@ -198,6 +198,7 @@ describe('GraphNG utils', () => {
       getTimeRange: getDefaultTimeRange,
       eventBus: new EventBusSrv(),
       sync: DashboardCursorSync.Tooltip,
+      allFrames: [frame!],
     }).getConfig();
     expect(result).toMatchSnapshot();
   });

--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -16,7 +16,7 @@ export class UnthemedTimeSeries extends React.Component<TimeSeriesProps> {
   static contextType = PanelContextRoot;
   panelContext: PanelContext = {} as PanelContext;
 
-  prepConfig = (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames: DataFrame[]) => {
+  prepConfig = (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => {
     const { eventBus, sync } = this.context;
     const { theme, timeZone } = this.props;
     return preparePlotConfigBuilder({ frame: alignedFrame, theme, timeZone, getTimeRange, eventBus, sync, allFrames });

--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -16,7 +16,7 @@ export class UnthemedTimeSeries extends React.Component<TimeSeriesProps> {
   static contextType = PanelContextRoot;
   panelContext: PanelContext = {} as PanelContext;
 
-  prepConfig = (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames?: DataFrame[]) => {
+  prepConfig = (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames: DataFrame[]) => {
     const { eventBus, sync } = this.context;
     const { theme, timeZone } = this.props;
     return preparePlotConfigBuilder({ frame: alignedFrame, theme, timeZone, getTimeRange, eventBus, sync, allFrames });

--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -16,10 +16,10 @@ export class UnthemedTimeSeries extends React.Component<TimeSeriesProps> {
   static contextType = PanelContextRoot;
   panelContext: PanelContext = {} as PanelContext;
 
-  prepConfig = (alignedFrame: DataFrame, getTimeRange: () => TimeRange) => {
+  prepConfig = (alignedFrame: DataFrame, getTimeRange: () => TimeRange, allFrames?: DataFrame[]) => {
     const { eventBus, sync } = this.context;
     const { theme, timeZone } = this.props;
-    return preparePlotConfigBuilder({ frame: alignedFrame, theme, timeZone, getTimeRange, eventBus, sync });
+    return preparePlotConfigBuilder({ frame: alignedFrame, theme, timeZone, getTimeRange, eventBus, sync, allFrames });
   };
 
   renderLegend = (config: UPlotConfigBuilder) => {

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -9,7 +9,7 @@ import {
   FieldType,
   formattedValueToString,
   getFieldColorModeForField,
-  getFieldDisplayName,
+  calculateFieldDisplayName,
   getFieldSeriesColor,
 } from '@grafana/data';
 
@@ -156,7 +156,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
         indexByName = getNamesToFieldIndex(frame, allFrames);
       }
 
-      const t = indexByName.alignedNames.get(getFieldDisplayName(field, frame, undefined, true));
+      const t = indexByName.alignedNames.get(calculateFieldDisplayName(field, frame));
       const b = indexByName.originNames.get(customConfig.fillBelowTo);
       if (isNumber(b) && isNumber(t)) {
         builder.addBand({
@@ -271,16 +271,15 @@ export function getNamesToFieldIndex(
     const origin = frame.fields[i].state?.origin;
     if (allFrames && origin) {
       originNames.set(
-        getFieldDisplayName(
+        calculateFieldDisplayName(
           allFrames[origin.frameIndex].fields[origin.fieldIndex],
           allFrames[origin.frameIndex],
-          allFrames,
-          true
+          allFrames
         ),
         i
       );
     }
-    alignedNames.set(getFieldDisplayName(frame.fields[i], frame, undefined, true), i);
+    alignedNames.set(calculateFieldDisplayName(frame.fields[i], frame), i);
   }
   return { alignedNames, originNames };
 }

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -154,7 +154,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
       if (!indexByName) {
         indexByName = getNamesToFieldIndex(frame);
       }
-      const t = indexByName.get(getFieldDisplayName(field, frame));
+
+      const t = indexByName.get(getFieldDisplayName(field, frame, undefined, true));
       const b = indexByName.get(customConfig.fillBelowTo);
       if (isNumber(b) && isNumber(t)) {
         builder.addBand({
@@ -262,7 +263,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
 export function getNamesToFieldIndex(frame: DataFrame): Map<string, number> {
   const names = new Map<string, number>();
   for (let i = 0; i < frame.fields.length; i++) {
-    names.set(getFieldDisplayName(frame.fields[i], frame), i);
+    names.set(getFieldDisplayName(frame.fields[i], frame, undefined, true), i);
   }
   return names;
 }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -227,7 +227,7 @@ type UPlotConfigPrepOpts<T extends Record<string, any> = {}> = {
   timeZone: TimeZone;
   getTimeRange: () => TimeRange;
   eventBus: EventBus;
-  allFrames?: DataFrame[];
+  allFrames: DataFrame[];
 } & T;
 
 /** @alpha */

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -227,6 +227,7 @@ type UPlotConfigPrepOpts<T extends Record<string, any> = {}> = {
   timeZone: TimeZone;
   getTimeRange: () => TimeRange;
   eventBus: EventBus;
+  allFrames?: DataFrame[];
 } & T;
 
 /** @alpha */

--- a/public/app/plugins/panel/barchart/BarChart.tsx
+++ b/public/app/plugins/panel/barchart/BarChart.tsx
@@ -51,6 +51,7 @@ export const BarChart: React.FC<BarChartProps> = (props) => {
       legend,
       tooltip,
       text,
+      allFrames: props.frames,
     });
   };
 

--- a/public/app/plugins/panel/barchart/BarChart.tsx
+++ b/public/app/plugins/panel/barchart/BarChart.tsx
@@ -34,7 +34,7 @@ export const BarChart: React.FC<BarChartProps> = (props) => {
     return <PlotLegend data={props.frames} config={config} maxHeight="35%" maxWidth="60%" {...props.legend} />;
   };
 
-  const prepConfig = (alignedFrame: DataFrame, getTimeRange: () => TimeRange) => {
+  const prepConfig = (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => {
     const { timeZone, orientation, barWidth, showValue, groupWidth, stacking, legend, tooltip, text } = props;
 
     return preparePlotConfigBuilder({

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -105,6 +105,7 @@ describe('BarChart utils', () => {
         timeZone: DefaultTimeZone,
         getTimeRange: getDefaultTimeRange,
         eventBus: new EventBusSrv(),
+        allFrames: [frame],
       }).getConfig();
       expect(result).toMatchSnapshot();
     });
@@ -119,6 +120,7 @@ describe('BarChart utils', () => {
           timeZone: DefaultTimeZone,
           getTimeRange: getDefaultTimeRange,
           eventBus: new EventBusSrv(),
+          allFrames: [frame],
         }).getConfig()
       ).toMatchSnapshot();
     });
@@ -133,6 +135,7 @@ describe('BarChart utils', () => {
           timeZone: DefaultTimeZone,
           getTimeRange: getDefaultTimeRange,
           eventBus: new EventBusSrv(),
+          allFrames: [frame],
         }).getConfig()
       ).toMatchSnapshot();
     });

--- a/public/app/plugins/panel/state-timeline/TimelineChart.tsx
+++ b/public/app/plugins/panel/state-timeline/TimelineChart.tsx
@@ -43,6 +43,7 @@ export class TimelineChart extends React.Component<TimelineProps> {
       frame: alignedFrame,
       getTimeRange,
       eventBus,
+      allFrames: this.props.frames,
       ...this.props,
 
       // When there is only one row, use the full space

--- a/public/app/plugins/panel/state-timeline/TimelineChart.tsx
+++ b/public/app/plugins/panel/state-timeline/TimelineChart.tsx
@@ -35,7 +35,7 @@ export class TimelineChart extends React.Component<TimelineProps> {
   static contextType = PanelContextRoot;
   panelContext: PanelContext = {} as PanelContext;
 
-  prepConfig = (alignedFrame: DataFrame, getTimeRange: () => TimeRange) => {
+  prepConfig = (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => {
     this.panelContext = this.context as PanelContext;
     const { eventBus } = this.panelContext;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The fill below to config does not work when there are named fields in the aligned dataframe.
This PR makes the config prep use the non cached way to calculate the field names for the aligned frames, because running the cached version over the aligned frames messes up the cache. It then adds a reference to the original name of the field from the original dataframes so that we can find what field to fill to from the config.

**Which issue(s) this PR fixes**:
Fixes #34916

