### PR TITLE
Loki: Add support for "label_values(log stream selector, label)" in templating

### DIFF
--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -148,10 +148,11 @@ Check out the [Templating]({{< relref "../variables/_index.md" >}}) documentatio
 Variable of the type _Query_ allows you to query Loki for a list labels or label values. The Loki data source plugin
 provides the following functions you can use in the `Query` input field.
 
-| Name                  | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `label_names()`       | Returns a list of label names.                                  |
-| `label_values(label)` | Returns a list of label values for the `label` in every metric. |
+| Name                                       | Description                                                                          |
+| -------------------------------------------| -------------------------------------------------------------------------------------|
+| `label_names()`                            | Returns a list of label names.                                                       |
+| `label_values(label)`                      | Returns a list of label values for the `label`.                                      |
+| `label_values(log stream selector, label)` | Returns a list of label values for the `label` in the specified `log stream selector`.|
 
 ## Annotations
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -313,30 +313,53 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     const labelNamesRegex = /^label_names\(\)\s*$/;
     const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
 
-    const params = this.getTimeRangeParams();
     const labelNames = query.match(labelNamesRegex);
     if (labelNames) {
-      return await this.labelNamesQuery(params);
+      return await this.labelNamesQuery();
     }
 
     const labelValues = query.match(labelValuesRegex);
     if (labelValues) {
-      return await this.labelValuesQuery(labelValues[2], params);
+      // If we have query expr, use /series endpoint
+      if (labelValues[1]) {
+        return await this.labelValuesSeriesQuery(labelValues[1], labelValues[2]);
+      }
+      return await this.labelValuesQuery(labelValues[2]);
     }
 
     return Promise.resolve([]);
   }
 
-  async labelNamesQuery(params?: Record<string, string | number>) {
+  async labelNamesQuery() {
     const url = `${LOKI_ENDPOINT}/label`;
+    const params = this.getTimeRangeParams();
     const result = await this.metadataRequest(url, params);
     return result.map((value: string) => ({ text: value }));
   }
 
-  async labelValuesQuery(label: string, params?: Record<string, string | number>) {
+  async labelValuesQuery(label: string) {
+    const params = this.getTimeRangeParams();
     const url = `${LOKI_ENDPOINT}/label/${label}/values`;
     const result = await this.metadataRequest(url, params);
     return result.map((value: string) => ({ text: value }));
+  }
+
+  async labelValuesSeriesQuery(expr: string, label: string) {
+    const timeParams = this.getTimeRangeParams();
+    const params = {
+      ...timeParams,
+      match: expr,
+    };
+    const url = `${LOKI_ENDPOINT}/series`;
+    const streams = new Set();
+    const result = await this.metadataRequest(url, params);
+    result.forEach((stream: { [key: string]: string }) => {
+      if (stream[label]) {
+        streams.add({ text: stream[label] });
+      }
+    });
+
+    return Array.from(streams);
   }
 
   interpolateQueryExpr(value: any, variable: any) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for `label_values(log stream selector, label)` pattern in templating. We are using [/series endpoint](https://grafana.com/docs/loki/latest/api/#series) for this and it will allow users to do following templating queries:

- `label_values({app="foo", namespace="prod"},instance)`
- `label_values({compose_service=~$service, compose_project=~$project}, container_name)`  - nested variables

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/25205

**Special notes for your reviewer**:
How to test this:
1. Go to Dashbboard -> Create variables
2. Choose Loki and try following queries (depending on your instance):
`label_values(job)`
`label_values({job="grafana"}, instance)`
