### PR TITLE
Drone: Retrieve the machine-user from a Vault secret

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3493,4 +3493,12 @@ get:
   path: infra/data/ci/github/grafanabot
   name: pat
 
+---
+kind: secret
+name: drone_token
+
+get:
+  path: infra/data/ci/drone
+  name: machine-user-token
+
 ...

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -1,4 +1,4 @@
-load('scripts/vault.star', 'from_secret', 'github_token', 'pull_secret')
+load('scripts/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token')
 
 grabpl_version = '2.0.0'
 build_image = 'grafana/build-container:1.4.1'
@@ -193,7 +193,7 @@ def enterprise_downstream_step(edition):
         'image': 'grafana/drone-downstream',
         'settings': {
             'server': 'https://drone.grafana.net',
-            'token': from_secret('drone_token'),
+            'token': from_secret(drone_token),
             'repositories': [
                 'grafana/grafana-enterprise@main',
             ],

--- a/scripts/vault.star
+++ b/scripts/vault.star
@@ -1,5 +1,6 @@
 pull_secret = 'dockerconfigjson'
 github_token = 'github_token'
+drone_token = 'drone_token'
 
 def from_secret(secret):
     return {
@@ -19,5 +20,6 @@ def vault_secret(name, path, key):
 def secrets():
     return [
         vault_secret(pull_secret, 'secret/data/common/gcr', '.dockerconfigjson'),
-        vault_secret(github_token, 'infra/data/ci/github/grafanabot', 'pat')
+        vault_secret(github_token, 'infra/data/ci/github/grafanabot', 'pat'),
+        vault_secret(drone_token, 'infra/data/ci/drone', 'machine-user-token'),
     ]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: The `trigger-enterprise-downstream` Drone step consumes a secret `drone_token` which is currently not valid. This PR updates the Drone configuration to consume that secret from [Vault](https://docs.drone.io/secret/external/vault/), instead of from a [repository secret](https://docs.drone.io/secret/repository/).

**Which issue(s) this PR fixes**: N/A

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

