### PR TITLE
test: remove health check request for e2e flow

### DIFF
--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -1,6 +1,5 @@
 import { DeleteDataSourceConfig } from './deleteDataSource';
 import { e2e } from '../index';
-import { fromBaseUrl, getDataSourceId } from '../support/url';
 import { v4 as uuidv4 } from 'uuid';
 
 export interface AddDataSourceConfig {
@@ -35,7 +34,6 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
     basicAuth,
     basicAuthPassword,
     basicAuthUser,
-    checkHealth,
     expectedAlertMessage,
     form,
     name,
@@ -88,26 +86,17 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
 
   return e2e()
     .url()
-    .then((url: string) => {
-      const id = getDataSourceId(url);
-
+    .then(() => {
       e2e.getScenarioContext().then(({ addedDataSources }: any) => {
         e2e.setScenarioContext({
-          addedDataSources: [...addedDataSources, { id, name } as DeleteDataSourceConfig],
+          addedDataSources: [...addedDataSources, { name } as DeleteDataSourceConfig],
         });
       });
-
-      if (checkHealth) {
-        const healthUrl = fromBaseUrl(`/api/datasources/${id}/health`);
-        e2e().logToConsole(`Fetching ${healthUrl}`);
-        e2e().request(healthUrl).its('body').should('have.property', 'status').and('eq', 'OK');
-      }
 
       // @todo remove `wrap` when possible
       return e2e().wrap(
         {
           config: fullConfig,
-          id,
         },
         { log: false }
       );

--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -6,6 +6,9 @@ export interface AddDataSourceConfig {
   basicAuth: boolean;
   basicAuthPassword: string;
   basicAuthUser: string;
+  /**
+   * @deprecated check health request is no longer supported
+   */
   checkHealth: boolean;
   expectedAlertMessage: string | RegExp;
   form: () => void;

--- a/packages/grafana-e2e/src/support/url.ts
+++ b/packages/grafana-e2e/src/support/url.ts
@@ -12,12 +12,3 @@ export const getDashboardUid = (url: string): string => {
     return matches[1];
   }
 };
-
-export const getDataSourceId = (url: string): string => {
-  const matches = new URL(url).pathname.match(/\/edit\/([^/]+)/);
-  if (!matches) {
-    throw new Error(`Couldn't parse id from ${url}`);
-  } else {
-    return matches[1];
-  }
-};


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, our enterprise plugins e2e tests are failing with Grafana 8.

It looks like the check health (which sends a request to `/api/datasources/${id}/health`) in the `addDataSource` flow fails because previously, we would grab the datasource `id` from the url but after Grafana 8, this `id` is no longer exposed in the url (and uses the `uid` instead.

**Grafana 7 url:**

```
.../datasources/edit/{id}
```

![Screenshot 2021-06-10 at 11 33 32](https://user-images.githubusercontent.com/36230812/121510626-bc5c7d00-c9df-11eb-80f1-8a3a53a50190.png)

**Grafana 8 url:**

```
.../datasources/edit/{uid}
```

![Screenshot 2021-06-10 at 11 33 02](https://user-images.githubusercontent.com/36230812/121510615-b9fa2300-c9df-11eb-9d45-6b3151b5b8ec.png)

To simplify the flow, rather than trying to get the `id`, we are considering removing the check health completely because we are able to check the health check status with the alert text instead (which we are also currently testing for). Additionally, by removing this, we will no longer be making two requests to the api.

**Successful health check**
![Screenshot 2021-06-10 at 11 24 32](https://user-images.githubusercontent.com/36230812/121509648-c6ca4700-c9de-11eb-8ba2-ece37ea9368e.png)

**Failed health check**
![Screenshot 2021-06-10 at 11 26 00](https://user-images.githubusercontent.com/36230812/121509661-c9c53780-c9de-11eb-9f01-970e88a27087.png)

**Question:**

If we want to remove the check health in the flow, we no longer require the `checkHealth` prop in the config. Should we also remove this from the config within this PR or would we need to wait for a later release to deprecate this?

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/integrations-team/issues/173

**Special notes for your reviewer**:

TIA 🙏 