### PR TITLE
Access-Control: Document changes to the provisioner

### DIFF
--- a/docs/sources/enterprise/access-control/provisioning.md
+++ b/docs/sources/enterprise/access-control/provisioning.md
@@ -94,7 +94,7 @@ deleteRoles:
 
 To assign roles to built-in roles, add said built-in roles to the `builtInRoles` section of your roles. To remove a specific assignment, remove it from the list.
 
-> Assignments are updated if the version of the role is greater or equal to the one stored internally. You don't need to increment the version number of the role to update its assignments.
+> **Note:** Assignments are updated if the version of the role is greater or equal to the one stored internally. You don’t need to increment the version number of the role to update its assignments.
 
 For example, the following role is assigned to an organization editor or an organization administrator:
 

--- a/docs/sources/enterprise/access-control/provisioning.md
+++ b/docs/sources/enterprise/access-control/provisioning.md
@@ -74,7 +74,7 @@ The `orgId` is lost when the role is set to global.
 
 ### Delete roles 
 
-To delete a role, you can add a list of roles under the `deleteRoles` section in the configuration file. 
+To delete a role, add a list of roles under the `deleteRoles` section in the configuration file. 
 
 > Deletion of roles listed under the `deleteRoles` section happens **before** saving roles listed under the `roles` section.
 

--- a/docs/sources/enterprise/access-control/provisioning.md
+++ b/docs/sources/enterprise/access-control/provisioning.md
@@ -94,7 +94,7 @@ deleteRoles:
 
 To assign roles to built-in roles, add said built-in roles to the `builtInRoles` section of your roles. To remove a specific assignment, remove it from the list.
 
-> Assignments are updated if the version of the role is greater or equal to the one stored in database. You don't need to increment the version number of the role to update its assignments.
+> Assignments are updated if the version of the role is greater or equal to the one stored internally. You don't need to increment the version number of the role to update its assignments.
 
 For example, the following role is assigned to an organization editor or an organization administrator:
 

--- a/docs/sources/enterprise/access-control/provisioning.md
+++ b/docs/sources/enterprise/access-control/provisioning.md
@@ -27,7 +27,7 @@ To create or update custom roles, you can add a list of `roles` in the configura
 
 Every role has a [version]({{< relref "./roles.md#custom-roles" >}}) number. For each role you update, you must remember to increment it, otherwise changes won't be accounted for.
 
-When you update a role, the existing role inside grafana is altered to be exactly what is specified in the YAML file, including permissions.
+When you update a role, the existing role inside Grafana is altered to be exactly what is specified in the YAML file, including permissions.
 
 Here is an example YAML file to create a local role with a set of permissions:
 
@@ -74,7 +74,9 @@ The `orgId` is lost when the role is set to global.
 
 ### Delete roles 
 
-To delete a role, you can add a list of roles under the `deleteRoles` section in the configuration file. Such a deletion is performed after a role is inserted or updated.
+To delete a role, you can add a list of roles under the `deleteRoles` section in the configuration file. 
+
+> Deletion of roles listed under the `deleteRoles` section happens **before** saving roles listed under the `roles` section.
 
 Here is an example YAML file to delete a role:
 ```yaml
@@ -91,6 +93,8 @@ deleteRoles:
 ### Assign your custom role to specific built-in roles
 
 To assign roles to built-in roles, add said built-in roles to the `builtInRoles` section of your roles. To remove a specific assignment, remove it from the list.
+
+> Assignments are updated if the version of the role is greater or equal to the one stored in database. You don't need to increment the version number of the role to update its assignments.
 
 For example, the following role is assigned to an organization editor or an organization administrator:
 

--- a/docs/sources/enterprise/access-control/provisioning.md
+++ b/docs/sources/enterprise/access-control/provisioning.md
@@ -76,7 +76,7 @@ The `orgId` is lost when the role is set to global.
 
 To delete a role, add a list of roles under the `deleteRoles` section in the configuration file. 
 
-> Deletion of roles listed under the `deleteRoles` section happens **before** saving roles listed under the `roles` section.
+> **Note:** Any role in the `deleteRoles` section is deleted before any role in the `roles` section is saved.
 
 Here is an example YAML file to delete a role:
 ```yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
We slightly update the behavior of the access-control provisioner after the 8.0 release.
1. Deletion happens before insertion.
2. Assignments are updated when version remains unchanged.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/1565

**Special notes for your reviewer**:

