### PR TITLE
Configuration: Fix changing org preferences in FireFox

### DIFF
--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -90,7 +90,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
 
   onSubmitForm = async () => {
     const { homeDashboardId, theme, timezone } = this.state;
-    this.service.update({ homeDashboardId, theme, timezone });
+    await this.service.update({ homeDashboardId, theme, timezone });
     window.location.reload();
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
What I could find was that we were reloading the window before the result was received from the backend which resulted in `NS_BINDING_ABORTED` error in FireFox. This PR adds an await before reloading the page.

**Which issue(s) this PR fixes**:
Fixes #35503

**Special notes for your reviewer**:

