### PR TITLE
Alerting: fix postgres migration on conflict

### DIFF
--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -103,7 +103,7 @@ func (mg *Migrator) Start() error {
 			Timestamp:   time.Now(),
 		}
 
-		err := mg.inTransaction(func(sess *xorm.Session) error {
+		err := mg.InTransaction(func(sess *xorm.Session) error {
 			err := mg.exec(m, sess)
 			if err != nil {
 				mg.Logger.Error("Exec failed", "error", err, "sql", sql)
@@ -183,7 +183,7 @@ func (mg *Migrator) ClearMigrationEntry(id string) error {
 
 type dbTransactionFunc func(sess *xorm.Session) error
 
-func (mg *Migrator) inTransaction(callback dbTransactionFunc) error {
+func (mg *Migrator) InTransaction(callback dbTransactionFunc) error {
 	sess := mg.x.NewSession()
 	defer sess.Close()
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Dashboard alert migration would fail with PostgreSQL if there were alerts with conflicting titles (there was no constrain in the `alert` table but there is in the new `alert_rule` table.
We used to handled this case:
https://github.com/grafana/grafana/blob/97a59a485522cf6894842b2688ed2b26e7b18974/pkg/services/sqlstore/migrations/ualert/ualert.go#L221-L230

but this didn't work in PostgreSQL because in case of error the transaction was aborted.
I have resolved this by running the insert statement in a nested transaction.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35529

**Special notes for your reviewer**:
You can import and save [this](https://gist.github.com/papagian/5a33dbd2791553450b636bffcc5ecd8c) dashboard for testing this fix (against all dialects) when `ngalert` is disabled and then enable `ngalert`.
The migration should run successfully and there should be two rules like (the second will have a random suffix: the rule UID):

![Screenshot 2021-06-11 at 1 04 21 PM](https://user-images.githubusercontent.com/1632407/121671655-8094e680-cab7-11eb-8c24-d0ca01a9f23b.png)
