### PR TITLE
Grafana-UI: Remove references to old monaco libraries

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -191,8 +191,6 @@ const getBaseWebpackConfig: WebpackConfigurationGetter = async (options) => {
       '@grafana/ui',
       '@grafana/runtime',
       '@grafana/data',
-      'monaco-editor',
-      'react-monaco-editor',
       // @ts-ignore
       (context, request, callback) => {
         const prefix = 'grafana/';

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -32,9 +32,6 @@ const buildCjsPackage = ({ env }) => {
       '@grafana/data',
       '@grafana/e2e-selectors',
       'moment',
-      'monaco-editor', // Monaco should not be used directly
-      'monaco-editor/esm/vs/editor/editor.api', // Monaco should not be used directly
-      'react-monaco-editor',
       'jquery', // required to use jquery.plot, which is assigned externally
     ],
     plugins: [

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -24,7 +24,7 @@ function shouldExclude(filename) {
     return false;
   }
 
-  const packagesToProcessbyBabel = ['debug', 'lru-cache', 'yallist', 'react-hook-form', 'rc-trigger', 'monaco-editor'];
+  const packagesToProcessbyBabel = ['debug', 'lru-cache', 'yallist', 'react-hook-form', 'rc-trigger'];
   for (const package of packagesToProcessbyBabel) {
     if (filename.indexOf(`node_modules/${package}`) > 0) {
       return false;
@@ -145,7 +145,6 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        // include: MONACO_DIR, // https://github.com/react-monaco-editor/react-monaco-editor
         use: ['style-loader', 'css-loader'],
       },
       // for pre-caching SVGs as part of the JS bundles


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans up some of the references to old monaco libraries we were using

We should no longer define `monaco-editor` and `react-monaco-editor` as externals because we don't bundle them with Grafana any more. `monaco-editor` is not a runtime dependency (its imported only for types), and we just don't use `react-monaco-editor` anymore.

I've tested the monaco editor in Azure Monitor, MongoDB plugin, and the panel inspect json view and they still worked.