### PR TITLE
Legend: move margin outside of `VizLegendTable` to prevent scrollbars overlapping

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -2,6 +2,7 @@ import React, { FC, CSSProperties, ComponentType } from 'react';
 import { useMeasure } from 'react-use';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
 import { LegendPlacement } from '..';
+import { useTheme2 } from '../../themes';
 
 /**
  * @beta
@@ -30,6 +31,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
     height: `${height}px`,
   };
   const [legendRef, legendMeasure] = useMeasure();
+  const theme = useTheme2();
 
   if (!legend) {
     return <div style={containerStyle}>{children(width, height)}</div>;
@@ -44,6 +46,10 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
   };
 
   const legendStyle: CSSProperties = {};
+
+  const legendSpacing: CSSProperties = {
+    marginLeft: theme.spacing(),
+  };
 
   switch (placement) {
     case 'bottom':
@@ -78,7 +84,9 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
     <div style={containerStyle}>
       <div style={vizStyle}>{size && children(size.width, size.height)}</div>
       <div style={legendStyle} ref={legendRef}>
-        <CustomScrollbar hideHorizontalTrack>{legend}</CustomScrollbar>
+        <div style={legendSpacing}>
+          <CustomScrollbar hideHorizontalTrack>{legend}</CustomScrollbar>
+        </div>
       </div>
     </div>
   );

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -97,7 +97,6 @@ export const VizLegendTable = <T extends unknown>({
 const getStyles = (theme: GrafanaTheme) => ({
   table: css`
     width: 100%;
-    margin-left: ${theme.spacing.sm};
     th:first-child {
       width: 100%;
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

having margin on the table itself pushes it behind the scrollbar containers.

so we move the margin up a level to the `VizLayout` component. have to then create another wrapping element, as the visualisation size is calculated based on the width of the element with `legendRef`. if we just stick the margin on the same element the width is unaffected, so the sizing breaks.

instead, we move the margin **inside** that element such that it increases the total width of the element with `legendRef` and sizes the visualisation accordingly.

hope that makes sense!

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/32676

**Special notes for your reviewer**:

