### PR TITLE
Variables: Hide default data source if missing from regex

### DIFF
--- a/public/app/features/variables/datasource/reducer.test.ts
+++ b/public/app/features/variables/datasource/reducer.test.ts
@@ -100,7 +100,7 @@ describe('dataSourceVariableReducer', () => {
   });
 
   describe('when createDataSourceOptions is dispatched without default in the regex and item is default data source', () => {
-    it('then the state should include an extra default option', () => {
+    it('then the state not should include an extra default option', () => {
       const plugins = getMockPlugins(3);
       const sources: DataSourceInstanceSettings[] = plugins.map((p) => getDataSourceInstanceSetting(p.name, p));
       sources[1].isDefault = true;
@@ -110,6 +110,31 @@ describe('dataSourceVariableReducer', () => {
         includeAll: false,
       });
       const payload = toVariablePayload({ id: '0', type: 'datasource' }, { sources, regex: /pretty/ });
+
+      reducerTester<VariablesState>()
+        .givenReducer(dataSourceVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(createDataSourceOptions(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          ['0']: ({
+            ...initialState['0'],
+            options: [{ text: 'pretty cool plugin-1', value: 'pretty cool plugin-1', selected: false }],
+          } as unknown) as DataSourceVariableModel,
+        });
+    });
+  });
+
+  describe('when createDataSourceOptions is dispatched without the regex and item is default data source', () => {
+    it('then the state should include an extra default option', () => {
+      const plugins = getMockPlugins(3);
+      const sources: DataSourceInstanceSettings[] = plugins.map((p) => getDataSourceInstanceSetting(p.name, p));
+      sources[1].isDefault = true;
+
+      const { initialState } = getVariableTestContext<DataSourceVariableModel>(adapter, {
+        query: sources[1].meta.id,
+        includeAll: false,
+      });
+      const payload = toVariablePayload({ id: '0', type: 'datasource' }, { sources, regex: undefined });
 
       reducerTester<VariablesState>()
         .givenReducer(dataSourceVariableReducer, cloneDeep(initialState))

--- a/public/app/features/variables/datasource/reducer.ts
+++ b/public/app/features/variables/datasource/reducer.ts
@@ -49,7 +49,7 @@ export const dataSourceVariableSlice = createSlice({
           options.push({ text: source.name, value: source.name, selected: false });
         }
 
-        if (source.isDefault) {
+        if (isDefault(source, regex)) {
           options.push({ text: 'default', value: 'default', selected: false });
         }
       }
@@ -72,7 +72,19 @@ function isValid(source: DataSourceInstanceSettings, regex?: RegExp) {
     return true;
   }
 
-  return regex && regex.exec(source.name);
+  return regex.exec(source.name);
+}
+
+function isDefault(source: DataSourceInstanceSettings, regex?: RegExp) {
+  if (!source.isDefault) {
+    return false;
+  }
+
+  if (!regex) {
+    return true;
+  }
+
+  return regex.exec('default');
 }
 
 export const dataSourceVariableReducer = dataSourceVariableSlice.reducer;


### PR DESCRIPTION
**What this PR does / why we need it**:
I missed this case when helping out with https://github.com/grafana/grafana/pull/32625. 

- We should always add `default` when there is no regex and the data source type chosen contains the default data source.
- We should always add `default` when there is a regex that matches `default` and the data source type chosen contains the default data source.
- We should never add `default` if the data source type chosen doesn't contain the default data source.

**Which issue(s) this PR fixes**:
Fixes #35476

**Special notes for your reviewer**:

