### PR TITLE
PieChart: Fix legend dimension limits 

### DIFF
--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -29,7 +29,7 @@ export class UnthemedTimeSeries extends React.Component<TimeSeriesProps> {
       return null;
     }
 
-    return <PlotLegend data={frames} config={config} maxHeight="35%" maxWidth="60%" {...legend} />;
+    return <PlotLegend data={frames} config={config} {...legend} />;
   };
 
   render() {

--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -35,7 +35,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
     return <div style={containerStyle}>{children(width, height)}</div>;
   }
 
-  const { placement, maxHeight, maxWidth } = legend.props;
+  const { placement, maxHeight = '35%', maxWidth = '60%' } = legend.props;
 
   let size: VizSize | null = null;
 

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -97,7 +97,6 @@ export const VizLegendTable = <T extends unknown>({
 const getStyles = (theme: GrafanaTheme) => ({
   table: css`
     width: 100%;
-    margin-right: ${theme.spacing.sm};
     th:first-child {
       width: 100%;
     }

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -97,7 +97,7 @@ export const VizLegendTable = <T extends unknown>({
 const getStyles = (theme: GrafanaTheme) => ({
   table: css`
     width: 100%;
-    margin-left: ${theme.spacing.sm};
+    margin-right: ${theme.spacing.sm};
     th:first-child {
       width: 100%;
     }


### PR DESCRIPTION
Noticed that the legend in the pie chart did not have any size constraints. Moved those to defaults inside VizLayout 

Fixes #32676