### PR TITLE
PanelEdit: Always have bottom border to make sections easier to see when expanded

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -54,7 +54,6 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
     const boxStyles = cx(
       {
         [styles.box]: true,
-        [styles.boxExpanded]: isExpanded,
         [styles.boxNestedExpanded]: isNested && isExpanded,
       },
       className,
@@ -93,13 +92,7 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     box: css`
-      border-bottom: 1px solid ${theme.colors.border.weak};
-      &:last-child {
-        border-bottom: none;
-      }
-    `,
-    boxExpanded: css`
-      border-bottom: 0;
+      border-top: 1px solid ${theme.colors.border.weak};
     `,
     boxNestedExpanded: css`
       margin-bottom: ${theme.spacing(2)};

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
@@ -7,14 +7,16 @@ import {
   VariableSuggestionsScope,
   DynamicConfigValue,
   ConfigOverrideRule,
+  GrafanaTheme2,
 } from '@grafana/data';
-import { Container, fieldMatchersUI, ValuePicker } from '@grafana/ui';
+import { fieldMatchersUI, useStyles2, ValuePicker } from '@grafana/ui';
 import { OptionPaneRenderProps } from './types';
 import { OptionsPaneItemDescriptor } from './OptionsPaneItemDescriptor';
 import { OptionsPaneCategoryDescriptor } from './OptionsPaneCategoryDescriptor';
 import { DynamicConfigValueEditor } from './DynamicConfigValueEditor';
 import { getDataLinksVariableSuggestions } from 'app/features/panel/panellinks/link_srv';
 import { OverrideCategoryTitle } from './OverrideCategoryTitle';
+import { css } from '@emotion/css';
 
 export function getFieldOverrideCategories(props: OptionPaneRenderProps): OptionsPaneCategoryDescriptor[] {
   const categories: OptionsPaneCategoryDescriptor[] = [];
@@ -208,7 +210,7 @@ export function getFieldOverrideCategories(props: OptionPaneRenderProps): Option
       id: 'add button',
       customRender: function renderAddButton() {
         return (
-          <Container padding="md" key="Add override">
+          <AddOverrideButtonContainer key="Add override">
             <ValuePicker
               icon="plus"
               label="Add field override"
@@ -222,21 +224,11 @@ export function getFieldOverrideCategories(props: OptionPaneRenderProps): Option
                 .map<SelectableValue<string>>((i) => ({ label: i.name, value: i.id, description: i.description }))}
               onChange={(value) => onOverrideAdd(value)}
             />
-          </Container>
+          </AddOverrideButtonContainer>
         );
       },
     })
   );
-
-  //   <FeatureInfoBox
-  //   title="Overrides"
-  //   url={getDocsLink(DocsId.FieldConfigOverrides)}
-  //   className={css`
-  //     margin: ${theme.spacing.md};
-  //   `}
-  // >
-  //   Field override rules give you fine-grained control over how your data is displayed.
-  // </FeatureInfoBox>
 
   return categories;
 }
@@ -256,4 +248,16 @@ function getOverrideProperties(registry: FieldConfigOptionsRegistry) {
         description: item.description,
       };
     });
+}
+
+function AddOverrideButtonContainer({ children }: { children: React.ReactNode }) {
+  const styles = useStyles2(getBorderTopStyles);
+  return <div className={styles}>{children}</div>;
+}
+
+function getBorderTopStyles(theme: GrafanaTheme2) {
+  return css({
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    padding: `${theme.spacing(2)}`,
+  });
 }


### PR DESCRIPTION
Small UX improvement to make Panel edit section categories easier to see when expanded.

Before:
![Screenshot from 2021-06-11 15-33-54](https://user-images.githubusercontent.com/10999/121694556-80eaad00-caca-11eb-9362-fbda9700da2b.png)


After:
![Screenshot from 2021-06-11 15-32-25](https://user-images.githubusercontent.com/10999/121694559-82b47080-caca-11eb-8bb4-eed0e5af543c.png)
