### PR TITLE
Time series: fix soft scale limits when all values are 0

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -39,8 +39,8 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
       : {};
 
     // uPlot's default ranging config for both min & max is {pad: 0.1, hard: null, soft: 0, mode: 3}
-    let softMinMode: Range.SoftMode = softMin == null ? 3 : softMin === 0 ? 1 : 2;
-    let softMaxMode: Range.SoftMode = softMax == null ? 3 : softMax === 0 ? 1 : 2;
+    let softMinMode: Range.SoftMode = softMin == null ? 3 : 1;
+    let softMaxMode: Range.SoftMode = softMax == null ? 3 : 1;
 
     const rangeConfig: Range.Config = {
       min: {


### PR DESCRIPTION
this fixes an issue reported here: https://github.com/grafana/grafana/issues/30564#issuecomment-860060570

uPlot's `mode: 2` soft ranging is not a good fit for Grafana, where users are not exposed to the full config. besides the issue above, it can cause unexpected limit expansion to occur if you have e.g. all values of 1,000, soft limits of 999-1001, your actual scale range would be at least +/- the internal padding factor of 0.1, so 900-1,100.

`mode 1` will always evaluate the soft limits prior to adding padding to the scales.