### PR TITLE
Auth: JWT - Handle auto-configured JWKS uri with trusted issuer

### DIFF
--- a/docs/sources/auth/jwt.md
+++ b/docs/sources/auth/jwt.md
@@ -11,6 +11,7 @@ You can configure Grafana to accept a JWT token provided in the HTTP header. The
 - PEM-encoded key file
 - JSON Web Key Set (JWKS) in a local file 
 - JWKS provided by the configured JWKS endpoint
+- JWKS provided by the configured by trusted issuer well-known discovery
 
 ## Enable JWT
 
@@ -63,6 +64,12 @@ jwk_set_url = https://your-auth-provider.example.com/.well-known/jwks.json
 # Cache TTL for data loaded from http endpoint.
 cache_ttl = 60m
 ```
+
+### Verify token using a JSON Web Key Set loaded from https endpoint, without specify it
+
+Assuming you trusted an issuer (see Validate claims below) for security reasons, you can let `jwk_set_url` (and `jwk_set_file`, `key_file`) empty. In this case, the OIDC JSON config schema
+located at `[iss]/.well-know/openid-configuration` will be used and the JSON filed "jwks_uri" will be
+used to fill `jwk_set_url` automaticaly.
 
 ### Verify token using a JSON Web Key Set loaded from JSON file
 

--- a/docs/sources/auth/jwt.md
+++ b/docs/sources/auth/jwt.md
@@ -69,7 +69,7 @@ cache_ttl = 60m
 
 Assuming you trusted an issuer (see Validate claims below) for security reasons, you can let `jwk_set_url` (and `jwk_set_file`, `key_file`) empty. In this case, the OIDC JSON config schema
 located at `[iss]/.well-know/openid-configuration` will be used and the JSON filed "jwks_uri" will be
-used to fill `jwk_set_url` automaticaly.
+used to fill `jwk_set_url` automatically.
 
 ### Verify token using a JSON Web Key Set loaded from JSON file
 

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -175,6 +175,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 
 	loginInfo.ExternalUser = *buildExternalUserInfo(token, userInfo, name)
 	loginInfo.User, err = syncUser(ctx, &loginInfo.ExternalUser, connect)
+
 	if err != nil {
 		hs.handleOAuthLoginErrorWithRedirect(ctx, loginInfo, err)
 		return

--- a/pkg/services/auth/jwt/auth.go
+++ b/pkg/services/auth/jwt/auth.go
@@ -49,7 +49,7 @@ func (s *AuthService) Init() error {
 	}
 	if s.Cfg.JWTAuthKeyFile == "" && s.Cfg.JWTAuthJWKSetFile == "" && s.Cfg.JWTAuthJWKSetURL == "" {
 		if err := s.detectJWKSUri(); err != nil {
-			s.log.Debug("JWKS uri not detected due to", "err", err)
+			s.log.Error("JWKS uri not detected due to", "err", err)
 		}
 	}
 	if err := s.initKeySet(); err != nil {
@@ -63,8 +63,8 @@ func (s *AuthService) Init() error {
 // This can't work if you don't trust any issuers in JWTAuthExpectClaims
 func (s *AuthService) detectJWKSUri() error {
 	if s.expectRegistered.Issuer != "" {
-		oidcConfigURL := strings.TrimSuffix(s.expect["iss"].(string), "/") + OidcWellKnowConfigUri
-		var httpClient = &http.Client{Timeout: 10 * time.Second}
+		oidcConfigURL := strings.TrimSuffix(s.expectRegistered.Issuer, "/") + OidcWellKnowConfigUri
+		var httpClient = &http.Client{Timeout: 5 * time.Second}
 		r, err := httpClient.Get(oidcConfigURL)
 		if err != nil {
 			return err

--- a/pkg/services/auth/jwt/auth_test.go
+++ b/pkg/services/auth/jwt/auth_test.go
@@ -138,6 +138,14 @@ func TestVerifyUsingJWKSetURL(t *testing.T) {
 		_, err := sc.authJWTSvc.Verify(sc.ctx, token)
 		require.Error(t, err)
 	})
+
+	jwkHTTPScenario(t, "verifies a token signed with a key auto-configured with trusted issuer", func(t *testing.T, sc scenarioContext) {
+		//TODO
+	})
+
+	jwkHTTPScenario(t, "verifies a token signed with a key auto-configured with untrusted issuer", func(t *testing.T, sc scenarioContext) {
+		//TODO
+	})
 }
 
 func TestCachingJWKHTTPResponse(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

To follow OIDC and handle automaticaly non standard JWKS Uri, use the well-know config endpoint.
This permits to avoiding pass keys in grafana config, and why not be able to authorize multiple JWT issuers.
The only madatory conf in this case is the expected claim "iss" as trusted issuer. Anyway, it's always a good practice with JWT to provide it and verify it.

**Which issue(s) this PR fixes**:

Fixes #34494

**Special notes for your reviewer**:

I'm not comfortable with Go, feel free to propose changes in structure or correct directly
