### PR TITLE
Loki: Parse log levels when ANSI coloring is enabled

### DIFF
--- a/public/app/core/logs_model.test.ts
+++ b/public/app/core/logs_model.test.ts
@@ -871,6 +871,36 @@ describe('logSeriesToLogsModel', () => {
       },
     ]);
   });
+
+  it('should correctly get the log level if the message has ANSI color', () => {
+    const logSeries: DataFrame[] = [
+      toDataFrame({
+        fields: [
+          {
+            name: 'ts',
+            type: FieldType.time,
+            values: ['1970-01-01T00:00:01Z'],
+          },
+          {
+            name: 'line',
+            type: FieldType.string,
+            values: ['Line with ANSI \u001B[31mwarn\u001B[0m et dolor'],
+          },
+          {
+            name: 'id',
+            type: FieldType.string,
+            values: ['0'],
+          },
+        ],
+        refId: 'A',
+        meta: {},
+      }),
+    ];
+
+    const logsModel = dataFrameToLogsModel(logSeries, 0);
+    expect(logsModel.rows).toHaveLength(1);
+    expect(logsModel.rows[0].logLevel).toEqual(LogLevel.warn);
+  });
 });
 
 describe('getSeriesProperties()', () => {

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -359,6 +359,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
       const hasUnescapedContent = !!message.match(/\\n|\\t|\\r/);
 
       const searchWords = series.meta && series.meta.searchWords ? series.meta.searchWords : [];
+      const entry = hasAnsi ? ansicolor.strip(message) : message;
 
       let logLevel = LogLevel.unknown;
       if (logLevelField && logLevelField.values.get(j)) {
@@ -366,7 +367,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
       } else if (seriesLogLevel) {
         logLevel = seriesLogLevel;
       } else {
-        logLevel = getLogLevel(message);
+        logLevel = getLogLevel(entry);
       }
       rows.push({
         entryFieldIndex: stringField.index,
@@ -382,7 +383,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
         hasAnsi,
         hasUnescapedContent,
         searchWords,
-        entry: hasAnsi ? ansicolor.strip(message) : message,
+        entry,
         raw: message,
         labels: stringField.labels || {},
         uid: idField ? idField.values.get(j) : j.toString(),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes a bug where the log levels are not parsed if ANSI colouring is enabled. The log level is now determined from the stripped message instead of the whole message.

The log messages now look like this where we can have in this case a yellow color indicating a warning message even though the string determining the log level has a red ANSI colour.
<img width="1440" alt="Screenshot 2021-06-11 at 17 26 45" src="https://user-images.githubusercontent.com/16028771/121847832-79edb580-cce9-11eb-8a86-1ecc513c0735.png">


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #33757

**Special notes for your reviewer**:

To reproduce this bug navigate to `pkg/tsdb/testdatasource/scenarios.go`.
Remove the code on line 578-582 and replace the code on line 584 with
```Go
message := fmt.Sprintln("Line with ANSI \u001B[31mdebug\u001B[0m et dolor")
```
Then head to the explore tab in grafana and query some logs with `gdev-testdata` as datasource.