### PR TITLE
Loki: When parser added, filter label as parsed labels

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -590,6 +590,96 @@ describe('LokiDatasource', () => {
       expect(res).toEqual([]);
     });
   });
+
+  describe('modifyQuery', () => {
+    describe('when called with ADD_FILTER', () => {
+      describe('and query has no parser', () => {
+        it('then the correct label should be added for logs query', () => {
+          const query: LokiQuery = { refId: 'A', expr: '{bar="baz"}' };
+          const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER' };
+          const ds = createLokiDSForTests();
+          const result = ds.modifyQuery(query, action);
+
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('{bar="baz",job="grafana"}');
+        });
+
+        it('then the correct label should be added for metrics query', () => {
+          const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"}[5m])' };
+          const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER' };
+          const ds = createLokiDSForTests();
+          const result = ds.modifyQuery(query, action);
+
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('rate({bar="baz",job="grafana"}[5m])');
+        });
+        describe('and query has parser', () => {
+          it('then the correct label should be added for logs query', () => {
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt' };
+            const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER' };
+            const ds = createLokiDSForTests();
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('{bar="baz"} | logfmt | job="grafana"');
+          });
+          it('then the correct label should be added for metrics query', () => {
+            const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
+            const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER' };
+            const ds = createLokiDSForTests();
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('rate({bar="baz",job="grafana"} | logfmt [5m])');
+          });
+        });
+      });
+    });
+
+    describe('when called with ADD_FILTER_OUT', () => {
+      describe('and query has no parser', () => {
+        it('then the correct label should be added for logs query', () => {
+          const query: LokiQuery = { refId: 'A', expr: '{bar="baz"}' };
+          const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER_OUT' };
+          const ds = createLokiDSForTests();
+          const result = ds.modifyQuery(query, action);
+
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('{bar="baz",job!="grafana"}');
+        });
+
+        it('then the correct label should be added for metrics query', () => {
+          const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"}[5m])' };
+          const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER_OUT' };
+          const ds = createLokiDSForTests();
+          const result = ds.modifyQuery(query, action);
+
+          expect(result.refId).toEqual('A');
+          expect(result.expr).toEqual('rate({bar="baz",job!="grafana"}[5m])');
+        });
+        describe('and query has parser', () => {
+          it('then the correct label should be added for logs query', () => {
+            const query: LokiQuery = { refId: 'A', expr: '{bar="baz"} | logfmt' };
+            const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER_OUT' };
+            const ds = createLokiDSForTests();
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('{bar="baz"} | logfmt | job!="grafana"');
+          });
+          it('then the correct label should be added for metrics query', () => {
+            const query: LokiQuery = { refId: 'A', expr: 'rate({bar="baz"} | logfmt [5m])' };
+            const action = { key: 'job', value: 'grafana', type: 'ADD_FILTER_OUT' };
+            const ds = createLokiDSForTests();
+            const result = ds.modifyQuery(query, action);
+
+            expect(result.refId).toEqual('A');
+            expect(result.expr).toEqual('rate({bar="baz",job!="grafana"} | logfmt [5m])');
+          });
+        });
+      });
+    });
+  });
 });
 
 function createLokiDSForTests(

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -1,4 +1,5 @@
 import { escapeRegExp } from 'lodash';
+import { PIPE_PARSERS } from './syntax';
 
 export function formatQuery(selector: string | undefined): string {
   return `${selector || ''}`.trim();
@@ -49,4 +50,14 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
   }
 
   return results;
+}
+
+export function queryHasPipeParser(expr: string): boolean {
+  const parsers = PIPE_PARSERS.map((parser) => `${parser.label}`).join('|');
+  const regexp = new RegExp(`\\\|\\\s?(${parsers})`);
+  return regexp.test(expr);
+}
+
+export function addParsedLabelToQuery(expr: string, key: string, value: string | number, operator: string) {
+  return expr + ` | ${key}${operator}"${value.toString()}"`;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using Explore/Dashboard to view Loki Logs, after using parser expression (`| json`, `| logfmt`, ...) we get labels which are actual labels and labels which are parsed. At this moment, there is no way for us to know which labels are actual and which are parsed. This is a problem when it comes to filtering for/out labels trough logs detail view. When user filters labels which are parsed, the query is modified to use a stream selector (actual labels), which does not work since it's a parsed label and not a loki label. 

This might be in the future fixed by Loki and there will be a way for us to check which labels are which. There is an issue grafana/loki#3057 and also design doc https://docs.google.com/document/d/1DP_piybk4WBs_NWwWuMS4FRQSUK0eeAUY3pT0td7ueQ for this.

However, as this is a big problem, we (read @cyriltovena ) came up with great workaround. If parser is used, we can filter any label (normal or extracted) trough this syntax `{app="foo"} | json | key="any label"`. If parser is not used, then we know all labels are normal and we can use label filtering. The filtering is added at the end of query

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/30856

**Special notes for your reviewer**:
To test, use Loki datasource and try to use 2 types of query:
1. Query without parser e.g.: `{job="grafana"}
- Run query
- Open details view
- Try filtering for label - the new query should be `{job="grafana", newLabel="newValue"}`
- Try filtering out label - the new query should be `{job="grafana", newLabel!="newValue"}`

2. Query without parser e.g.: `{job="grafana"} | logfmt`
- Run query
- Open details view
- Try filtering for label - the new query should be `{job="grafana"} | logfmt | newLabel="newValue`
- Try filtering out label - the new query should be `{job="grafana"} | logfmt | newLabel!="newValue`