### PR TITLE
Docs: Fix template example for unified alerting

### DIFF
--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -76,7 +76,7 @@ Here is an example of a template to render a single alert:
     Silence alert: {{ .SilenceURL }}
   {{ end }}
   {{ if gt (len .DashboardURL ) 0 }}
-    Go to dashboard: {{ .Dashboard URL }}
+    Go to dashboard: {{ .DashboardURL }}
   {{ end }}
 {{ end }}
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes wrong usage of template variable. Copy paste of the example template will error out while saving otherwise.

**Which issue(s) this PR fixes**:

Partially https://github.com/grafana/grafana/issues/35604