### PR TITLE
Elasticsearch: Restore previous field naming strategy when using variables

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -35,6 +35,7 @@ import {
 import { bucketAggregationConfig } from './components/QueryEditor/BucketAggregationsEditor/utils';
 import {
   BucketAggregation,
+  BucketAggregationWithField,
   isBucketAggregationWithField,
 } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 import { generate, Observable, of, throwError } from 'rxjs';
@@ -390,7 +391,23 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       this.templateSrv.replace(JSON.stringify(expandedQueries), scopedVars)
     );
 
-    return finalQueries;
+    // FIXME: with 8.0 we introduced an undocumented breaking change on how we name frames fields.
+    // Although the introduced behavior is correct, it wasn't documented.
+    // The following lines will restore the previous behaviour for 8.0, to be removed with a proper
+    // changelog in 8.1 by returning `finalQueries` without any further modification
+    return finalQueries.map((q, queryIndex) => ({
+      ...q,
+      bucketAggs: q.bucketAggs?.map((bucketAgg, aggIndex) => {
+        if (isBucketAggregationWithField(bucketAgg)) {
+          return {
+            ...bucketAgg,
+            field: (queries[queryIndex].bucketAggs?.[aggIndex] as BucketAggregationWithField).field,
+          };
+        }
+
+        return bucketAgg;
+      }),
+    }));
   }
 
   testDatasource() {


### PR DESCRIPTION


**What this PR does / why we need it**:
https://github.com/grafana/grafana/pull/32762 Introduced a new way of interpolating variables in ES queries by simply replacing text in the stringified JSON query model.
It unintentionally slightly changed the behavior when naming fields that are dependant on a variable since the response parser now gets a fully interpolated query, which means when using variables in fields, that same field is now named with the variable value instead of the variable name (which is the correct behavior).

Although this should be considered the correct behaviour, it wasn't mentioned in the release notes and it should be considered a breaking change. 

This PR restores the previous naming strategy

**Which issue(s) this PR fixes**:
Fixes #34606


**Notes**
I will also revert this commit targeting 8.1 so we can introduce a proper breaking change entry to the changelog


