### PR TITLE
Plugins: Fix loading symbolically linked plugins

### DIFF
--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -526,6 +526,7 @@ func (s *PluginScanner) walker(currentPath string, f os.FileInfo, err error) err
 	// We scan all the subfolders for plugin.json (with some exceptions) so that we also load embedded plugins, for
 	// example https://github.com/raintank/worldping-app/tree/master/dist/grafana-worldmap-panel worldmap panel plugin
 	// is embedded in worldping app.
+	fmt.Println(currentPath, f.Name())
 	if err != nil {
 		return fmt.Errorf("filepath.Walk reported an error for %q: %w", currentPath, err)
 	}

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -526,7 +526,6 @@ func (s *PluginScanner) walker(currentPath string, f os.FileInfo, err error) err
 	// We scan all the subfolders for plugin.json (with some exceptions) so that we also load embedded plugins, for
 	// example https://github.com/raintank/worldping-app/tree/master/dist/grafana-worldmap-panel worldmap panel plugin
 	// is embedded in worldping app.
-	fmt.Println(currentPath, f.Name())
 	if err != nil {
 		return fmt.Errorf("filepath.Walk reported an error for %q: %w", currentPath, err)
 	}

--- a/pkg/plugins/manager/manager_test.go
+++ b/pkg/plugins/manager/manager_test.go
@@ -414,7 +414,6 @@ func TestPluginManager_Init(t *testing.T) {
 		require.Empty(t, pm.scanningErrors)
 		const pluginID = "test"
 		assert.NotNil(t, pm.plugins[pluginID])
-		assert.NotNil(t, pm.plugins[(pluginID)])
 	})
 }
 

--- a/pkg/plugins/manager/manager_test.go
+++ b/pkg/plugins/manager/manager_test.go
@@ -397,6 +397,25 @@ func TestPluginManager_Init(t *testing.T) {
 		assert.False(t, pm.plugins[pluginID].IsCorePlugin)
 		assert.NotNil(t, pm.plugins[("test")])
 	})
+
+	t.Run("With back-end plugin that is symlinked to plugins dir", func(t *testing.T) {
+		origAppURL := setting.AppUrl
+		t.Cleanup(func() {
+			setting.AppUrl = origAppURL
+		})
+		setting.AppUrl = defaultAppURL
+
+		pm := createManager(t, func(pm *PluginManager) {
+			pm.Cfg.PluginsPath = "testdata/symbolic-plugin-dirs"
+		})
+		err := pm.Init()
+		require.NoError(t, err)
+		// This plugin should be properly registered, even though it is symlinked to prlugins dir
+		require.Empty(t, pm.scanningErrors)
+		const pluginID = "test"
+		assert.NotNil(t, pm.plugins[pluginID])
+		assert.NotNil(t, pm.plugins[(pluginID)])
+	})
 }
 
 func TestPluginManager_IsBackendOnlyPlugin(t *testing.T) {

--- a/pkg/plugins/manager/testdata/symbolic-plugin-dirs/plugin
+++ b/pkg/plugins/manager/testdata/symbolic-plugin-dirs/plugin
@@ -1,0 +1,1 @@
+../symbolic-file-links/plugin

--- a/pkg/util/filepath.go
+++ b/pkg/util/filepath.go
@@ -68,7 +68,6 @@ func walk(path string, info os.FileInfo, resolvedPath string, symlinkPathsFollow
 		}
 
 		path2, err := filepath.EvalSymlinks(resolvedPath)
-		fmt.Println("path2", path2)
 		if err != nil {
 			return err
 		}
@@ -81,7 +80,6 @@ func walk(path string, info os.FileInfo, resolvedPath string, symlinkPathsFollow
 			symlinkPathsFollowed[path2] = true
 		}
 		info2, err := os.Lstat(path2)
-		fmt.Println("info2", err)
 		if err != nil {
 			return err
 		}

--- a/pkg/util/filepath.go
+++ b/pkg/util/filepath.go
@@ -57,7 +57,6 @@ func walk(path string, info os.FileInfo, resolvedPath string, symlinkPathsFollow
 	}
 
 	if resolvedPath != "" && info.Mode()&os.ModeSymlink == os.ModeSymlink {
-
 		// We only want to lstat on directories. If this entry is a symbolic link to a file, no need to recurse.
 		statInfo, err := os.Stat(resolvedPath)
 		if err != nil {
@@ -85,7 +84,6 @@ func walk(path string, info os.FileInfo, resolvedPath string, symlinkPathsFollow
 		}
 		return walk(path, info2, path2, symlinkPathsFollowed, walkFn)
 	} else if info.IsDir() {
-
 		list, err := ioutil.ReadDir(path)
 		if err != nil {
 			return walkFn(resolvedPath, info, err)


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Hey!

It seems [this change](https://github.com/grafana/grafana/commit/83f26e9ce274d20e25b90fee0fc0907fc9623d27#diff-c3e51d4a9bdb7b3197a7d4dd09c9ac236c1add5a4be3c8bd64fd3bd52e2dad9cR59) broke loading plugins that are symbolically linked to plugins dir.
It intends to check if symbolic link links to a directory, but `.IsDir()` is always false for `os.Lstat`,  `os.Stat` should be used instead. This PR reproduces and fixes the issue

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

