### PR TITLE
grafana/ui: Do not wrap words inside RadioButton

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTheme2, stylesFactory } from '../../../themes';
 import { GrafanaTheme2 } from '@grafana/data';
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import { getPropertiesForButtonSize } from '../commonStyles';
 import { getFocusStyles, getMouseFocusStyles } from '../../../themes/mixins';
 
@@ -36,14 +36,14 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
     <>
       <input
         type="radio"
-        className={cx(styles.radio)}
+        className={styles.radio}
         onChange={onChange}
         disabled={disabled}
         id={id}
         checked={active}
         name={name}
       />
-      <label className={cx(styles.radioLabel)} htmlFor={id} title={description}>
+      <label className={styles.radioLabel} htmlFor={id} title={description}>
         {children}
       </label>
     </>
@@ -83,7 +83,6 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme2, size: RadioBut
       }
 
       &:disabled + label {
-        cursor: default;
         color: ${theme.colors.text.disabled};
         cursor: not-allowed;
       }
@@ -104,6 +103,7 @@ const getRadioButtonStyles = stylesFactory((theme: GrafanaTheme2, size: RadioBut
       flex: ${fullWidth ? `1 0 0` : 'none'};
       text-align: center;
       user-select: none;
+      white-space: nowrap;
 
       &:hover {
         color: ${textColorHover};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Keep words in radio button on one line. 

**Special notes for your reviewer**:
Before:
![Screenshot 2021-06-14 at 16 42 13](https://user-images.githubusercontent.com/8878045/121901885-7aa93a80-cd2f-11eb-9a73-f8499b76e13d.png)

After:
![Screenshot 2021-06-14 at 16 42 34](https://user-images.githubusercontent.com/8878045/121901934-872d9300-cd2f-11eb-9618-25308d93c481.png)

