### PR TITLE
Alerting: Increase alertmanager_conf column if MySQL

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -261,4 +261,7 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("Add column default in alert_configuration", migrator.NewAddColumnMigration(alertConfiguration, &migrator.Column{
 		Name: "default", Type: migrator.DB_Bool, Nullable: false, Default: "0",
 	}))
+
+	mg.AddMigration("alert alert_configuration alertmanager_configuration column from TEXT to MEDIUMTEXT if mysql", migrator.NewRawSQLMigration("").
+		Mysql("ALTER TABLE alert_configuration MODIFY alertmanager_configuration MEDIUMTEXT;"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases the size of the `alertmanager_configuration` data base field type from TEXT to MEDIUMTEXT with MySQL.

**Which issue(s) this PR fixes**:

Fixes #35583

**Special notes for your reviewer**:
There are similar migrations for other alerting tables (in the same file).

