### PR TITLE
Docs: Fix Prometheus data source provisioning example about httpMethod

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -211,9 +211,9 @@ datasources:
     type: prometheus
     # Access mode - proxy (server in the UI) or direct (browser in the UI).
     access: proxy
-    httpMethod: POST
     url: http://localhost:9090
     jsonData:
+      httpMethod: POST
       exemplarTraceIdDestinations:
         # Field with internal link pointing to data source in Grafana.
         # datasourceUid value can be anything, but it should be unique across all defined data source uids.


### PR DESCRIPTION
As `httpMethod` is a [jsonData config field](https://github.com/grafana/grafana/blame/main/docs/sources/administration/provisioning.md#L155), we should fix the provisioning example in `docs/sources/datasources/prometheus.md`

related: #31651