### PR TITLE
Alerting: Fix alert migration RefID generation

### DIFF
--- a/pkg/expr/translate/translate.go
+++ b/pkg/expr/translate/translate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // DashboardAlertConditions turns dashboard alerting conditions into server side expression queries and a
@@ -279,10 +280,6 @@ const alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // getNewRefID finds first capital letter in the alphabet not in use
 // to use for a new RefID. It errors if it runs out of letters.
-//
-// TODO: Research if there is a limit. If so enforce is by
-// number of queries not letters. If no limit generate more types
-// of refIDs.
 func getNewRefID(refIDs map[string][]int) (string, error) {
 	for _, r := range alpha {
 		sR := string(r)
@@ -291,7 +288,15 @@ func getNewRefID(refIDs map[string][]int) (string, error) {
 		}
 		return sR, nil
 	}
-	return "", fmt.Errorf("ran out of letters when creating expression")
+	for i := 0; i < 20; i++ {
+		sR := util.GenerateShortUID()
+		if _, ok := refIDs[sR]; ok {
+			continue
+		}
+		return sR, nil
+
+	}
+	return "", fmt.Errorf("failed to generate unique RefID")
 }
 
 // getRelativeDuration turns the alerting durations for dashboard conditions

--- a/pkg/expr/translate/translate.go
+++ b/pkg/expr/translate/translate.go
@@ -294,7 +294,6 @@ func getNewRefID(refIDs map[string][]int) (string, error) {
 			continue
 		}
 		return sR, nil
-
 	}
 	return "", fmt.Errorf("failed to generate unique RefID")
 }

--- a/pkg/services/sqlstore/migrations/ualert/cond_trans.go
+++ b/pkg/services/sqlstore/migrations/ualert/cond_trans.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func transConditions(set dashAlertSettings, orgID int64, dsUIDMap dsUIDLookup) (*condition, error) {
@@ -223,7 +225,15 @@ func getNewRefID(refIDs map[string][]int) (string, error) {
 		}
 		return sR, nil
 	}
-	return "", fmt.Errorf("ran out of letters when creating expression")
+	for i := 0; i < 20; i++ {
+		sR := util.GenerateShortUID()
+		if _, ok := refIDs[sR]; ok {
+			continue
+		}
+		return sR, nil
+
+	}
+	return "", fmt.Errorf("failed to generate unique RefID")
 }
 
 // getRelativeDuration turns the alerting durations for dashboard conditions

--- a/pkg/services/sqlstore/migrations/ualert/cond_trans.go
+++ b/pkg/services/sqlstore/migrations/ualert/cond_trans.go
@@ -213,10 +213,6 @@ const alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // getNewRefID finds first capital letter in the alphabet not in use
 // to use for a new RefID. It errors if it runs out of letters.
-//
-// TODO: Research if there is a limit. If so enforce is by
-// number of queries not letters. If no limit generate more types
-// of refIDs.
 func getNewRefID(refIDs map[string][]int) (string, error) {
 	for _, r := range alpha {
 		sR := string(r)

--- a/pkg/services/sqlstore/migrations/ualert/cond_trans.go
+++ b/pkg/services/sqlstore/migrations/ualert/cond_trans.go
@@ -227,7 +227,6 @@ func getNewRefID(refIDs map[string][]int) (string, error) {
 			continue
 		}
 		return sR, nil
-
 	}
 	return "", fmt.Errorf("failed to generate unique RefID")
 }


### PR DESCRIPTION
if the alert has more than 26 conditions

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The migration would fail with `ran out of letters when creating expression` if there was an alert with more the 26 conditions. This fix will try to generate a random RefID instead of failing and it aborts if it fails on the 20th attempt.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
For reproducing the error you can import and save [this](https://gist.github.com/papagian/a9e856de357dcd2ff1816dfd55cf78cd) dashboard.
The migration should run successfully and there should be a rule `alert rule with many conditions` which will look like:
![Screenshot 2021-06-14 at 5 36 35 PM](https://user-images.githubusercontent.com/1632407/121913487-1c358980-cd3a-11eb-81ea-1665f81424bc.png)
