### PR TITLE
TimeSeries: Ensure series overrides that contain color are migrated, and migrate the previous `fieldConfig` when changing the panel type

### DIFF
--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -101,6 +101,60 @@ Object {
 }
 `;
 
+exports[`Graph Migrations preserves colors in series overrides 1`] = `
+Object {
+  "fieldConfig": Object {
+    "defaults": Object {
+      "custom": Object {
+        "axisPlacement": "hidden",
+        "drawStyle": "line",
+        "fillOpacity": 60,
+        "gradientMode": "opacity",
+        "lineInterpolation": "stepAfter",
+        "lineWidth": 1,
+        "showPoints": "never",
+        "spanNulls": true,
+      },
+      "nullValueMode": "null",
+      "unit": "short",
+    },
+    "overrides": Array [
+      Object {
+        "matcher": Object {
+          "id": "byName",
+          "options": "A-series",
+        },
+        "properties": Array [
+          Object {
+            "id": "color",
+            "value": Object {
+              "fixedColor": "rgba(165, 72, 170, 0.77)",
+              "mode": "fixed",
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "options": Object {
+    "legend": Object {
+      "calcs": Array [
+        "mean",
+        "lastNotNull",
+        "max",
+        "min",
+        "sum",
+      ],
+      "displayMode": "table",
+      "placement": "bottom",
+    },
+    "tooltip": Object {
+      "mode": "single",
+    },
+  },
+}
+`;
+
 exports[`Graph Migrations simple bars 1`] = `
 Object {
   "fieldConfig": Object {

--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -101,7 +101,7 @@ Object {
 }
 `;
 
-exports[`Graph Migrations preserves colors in series overrides 1`] = `
+exports[`Graph Migrations preserves colors from series overrides 1`] = `
 Object {
   "fieldConfig": Object {
     "defaults": Object {

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -58,6 +58,15 @@ describe('Graph Migrations', () => {
     expect(panel).toMatchSnapshot();
   });
 
+  it('preserves colors in series overrides', () => {
+    const old: any = {
+      angular: customColor,
+    };
+    const panel = {} as PanelModel;
+    panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+    expect(panel).toMatchSnapshot();
+  });
+
   describe('legend', () => {
     test('without values', () => {
       const old: any = {
@@ -290,6 +299,89 @@ describe('Graph Migrations', () => {
     });
   });
 });
+
+const customColor = {
+  aliasColors: {},
+  dashLength: 10,
+  fill: 5,
+  fillGradient: 6,
+  legend: {
+    avg: true,
+    current: true,
+    max: true,
+    min: true,
+    show: true,
+    total: true,
+    values: true,
+    alignAsTable: true,
+  },
+  lines: true,
+  linewidth: 1,
+  nullPointMode: 'null',
+  options: {
+    alertThreshold: true,
+  },
+  pointradius: 2,
+  seriesOverrides: [
+    {
+      $$hashKey: 'object:12',
+      alias: 'A-series',
+      color: 'rgba(165, 72, 170, 0.77)',
+    },
+  ],
+  spaceLength: 10,
+  steppedLine: true,
+  thresholds: [],
+  timeRegions: [],
+  title: 'Panel Title',
+  tooltip: {
+    shared: true,
+    sort: 0,
+    value_type: 'individual',
+  },
+  type: 'graph',
+  xaxis: {
+    buckets: null,
+    mode: 'time',
+    name: null,
+    show: true,
+    values: [],
+  },
+  yaxes: [
+    {
+      $$hashKey: 'object:42',
+      format: 'short',
+      label: null,
+      logBase: 1,
+      max: null,
+      min: null,
+      show: false,
+    },
+    {
+      $$hashKey: 'object:43',
+      format: 'short',
+      label: null,
+      logBase: 1,
+      max: null,
+      min: null,
+      show: true,
+    },
+  ],
+  yaxis: {
+    align: false,
+    alignLevel: null,
+  },
+  timeFrom: null,
+  timeShift: null,
+  bars: false,
+  dashes: false,
+  hiddenSeries: false,
+  percentage: false,
+  points: false,
+  stack: false,
+  decimals: 1,
+  datasource: null,
+};
 
 const stairscase = {
   aliasColors: {},

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -58,7 +58,7 @@ describe('Graph Migrations', () => {
     expect(panel).toMatchSnapshot();
   });
 
-  it('preserves colors in series overrides', () => {
+  it('preserves colors from series overrides', () => {
     const old: any = {
       angular: customColor,
     };

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -1,7 +1,16 @@
-import { PanelModel } from '@grafana/data';
+import { PanelModel, FieldConfigSource } from '@grafana/data';
 import { graphPanelChangedHandler } from './migrations';
 
 describe('Graph Migrations', () => {
+  let prevFieldConfig: FieldConfigSource;
+
+  beforeEach(() => {
+    prevFieldConfig = {
+      defaults: {},
+      overrides: [],
+    };
+  });
+
   it('simple bars', () => {
     const old: any = {
       angular: {
@@ -9,7 +18,7 @@ describe('Graph Migrations', () => {
       },
     };
     const panel = {} as PanelModel;
-    panel.options = graphPanelChangedHandler(panel, 'graph', old);
+    panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
     expect(panel).toMatchSnapshot();
   });
 
@@ -18,7 +27,16 @@ describe('Graph Migrations', () => {
       angular: stairscase,
     };
     const panel = {} as PanelModel;
-    panel.options = graphPanelChangedHandler(panel, 'graph', old);
+
+    prevFieldConfig = {
+      defaults: {
+        custom: {},
+        unit: 'areaF2',
+        displayName: 'DISPLAY NAME',
+      },
+      overrides: [],
+    };
+    panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
     expect(panel).toMatchSnapshot();
   });
 
@@ -27,7 +45,7 @@ describe('Graph Migrations', () => {
       angular: twoYAxis,
     };
     const panel = {} as PanelModel;
-    panel.options = graphPanelChangedHandler(panel, 'graph', old);
+    panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
     expect(panel).toMatchSnapshot();
   });
 
@@ -36,7 +54,7 @@ describe('Graph Migrations', () => {
       angular: stepedColordLine,
     };
     const panel = {} as PanelModel;
-    panel.options = graphPanelChangedHandler(panel, 'graph', old);
+    panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
     expect(panel).toMatchSnapshot();
   });
 
@@ -56,7 +74,7 @@ describe('Graph Migrations', () => {
         },
       };
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel).toMatchSnapshot();
     });
     test('with single value', () => {
@@ -74,7 +92,7 @@ describe('Graph Migrations', () => {
         },
       };
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel).toMatchSnapshot();
     });
     test('with multiple values', () => {
@@ -82,7 +100,7 @@ describe('Graph Migrations', () => {
         angular: legend,
       };
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel).toMatchSnapshot();
     });
   });
@@ -93,7 +111,7 @@ describe('Graph Migrations', () => {
         angular: stacking,
       };
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel).toMatchSnapshot();
     });
     test('groups', () => {
@@ -101,7 +119,7 @@ describe('Graph Migrations', () => {
         angular: stackingGroups,
       };
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel).toMatchSnapshot();
     });
   });
@@ -131,7 +149,7 @@ describe('Graph Migrations', () => {
         },
       };
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel.fieldConfig.defaults.custom.thresholdsStyle.mode).toBe('area');
       expect(panel.fieldConfig.defaults.thresholds?.steps).toMatchInlineSnapshot(`
         Array [
@@ -176,7 +194,7 @@ describe('Graph Migrations', () => {
       };
 
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel.fieldConfig.defaults.custom.thresholdsStyle.mode).toBe('line+area');
       expect(panel.fieldConfig.defaults.thresholds?.steps).toMatchInlineSnapshot(`
         Array [
@@ -213,7 +231,7 @@ describe('Graph Migrations', () => {
       };
 
       const panel = {} as PanelModel;
-      panel.options = graphPanelChangedHandler(panel, 'graph', old);
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
       expect(panel.fieldConfig.defaults.custom.thresholdsStyle.mode).toBe('line+area');
       expect(panel.fieldConfig.defaults.thresholds?.steps).toMatchInlineSnapshot(`
         Array [
@@ -266,7 +284,7 @@ describe('Graph Migrations', () => {
         ],
       };
 
-      panel.options = graphPanelChangedHandler(panel, 'graph', {});
+      panel.options = graphPanelChangedHandler(panel, 'graph', {}, prevFieldConfig);
       expect(panel.fieldConfig.defaults.custom.hideFrom).toEqual({ viz: false, legend: false, tooltip: false });
       expect(panel.fieldConfig.overrides[0].properties[0].value).toEqual({ viz: true, legend: false, tooltip: false });
     });
@@ -274,14 +292,6 @@ describe('Graph Migrations', () => {
 });
 
 const stairscase = {
-  fieldConfig: {
-    defaults: {
-      custom: {},
-      unit: 'areaF2',
-      displayName: 'DISPLAY NAME',
-    },
-    overrides: [],
-  },
   aliasColors: {},
   dashLength: 10,
   fill: 5,

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -8,7 +8,7 @@ import {
   FieldMatcherID,
   fieldReducers,
   NullValueMode,
-  PanelModel,
+  PanelTypeChangedHandler,
   Threshold,
   ThresholdsMode,
 } from '@grafana/data';
@@ -32,14 +32,18 @@ import { defaultGraphConfig } from './config';
 /**
  * This is called when the panel changes from another panel
  */
-export const graphPanelChangedHandler = (
-  panel: PanelModel<Partial<TimeSeriesOptions>> | any,
-  prevPluginId: string,
-  prevOptions: any
+export const graphPanelChangedHandler: PanelTypeChangedHandler = (
+  panel,
+  prevPluginId,
+  prevOptions,
+  prevFieldConfig
 ) => {
   // Changing from angular/flot panel to react/uPlot
   if (prevPluginId === 'graph' && prevOptions.angular) {
-    const { fieldConfig, options } = flotToGraphOptions(prevOptions.angular);
+    const { fieldConfig, options } = flotToGraphOptions({
+      ...prevOptions.angular,
+      fieldConfig: prevFieldConfig,
+    });
     panel.fieldConfig = fieldConfig; // Mutates the incoming panel
     return options;
   }

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -228,6 +228,15 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
               value: { mode: StackingMode.Normal, group: v },
             });
             break;
+          case 'color':
+            rule.properties.push({
+              id: 'color',
+              value: {
+                fixedColor: v,
+                mode: FieldColorModeId.Fixed,
+              },
+            });
+            break;
           default:
             console.log('Ignore override migration:', seriesOverride.alias, p, v);
         }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

there's 2 parts to this PR:

- the first commit handles a bug where field overrides in the old graph panel weren't being migrated correctly
  - firstly, if we look at https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/state/PanelModel.ts#L418, i think the `onPanelTypeChanged` function actually gets called with 4 arguments. so i've switched to use what i think is the correct type for handler function for when the graph type changes, which will prevent errors like this in the future. at the very least, it's consistent now between `graphPanelChangedHandler` and `onPanelTypeChanged`. 
  - i've then merged in the `prevFieldConfig` into the options passed to `flotToGraphOptions`, which it seems to be expecting anyway.
  - aaaaaaand finally updated the unit tests, because they're including `fieldConfig` as part of the previous options, which in my limited testing doesn't seem to happen at all - i could be completely wrong, or this could have changed at some point and not happen anymore, idk.
- the second commit handles the specific bug mentioned in the issue below, which is that a series override that altered the color wasn't being migrated correctly.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/35625

**Special notes for your reviewer**:

