### PR TITLE
Dashboard Settings: Fix TimeZone dropdown doesn't change the timezone

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -61,51 +61,6 @@ describe('General Settings', () => {
       );
     });
   });
-  jest.mock('@grafana/runtime', () => ({
-    ...((jest.requireActual('@grafana/runtime') as unknown) as object),
-    getBackendSrv: () => ({
-      search: jest.fn(() => [
-        { title: 'A', id: 'A' },
-        { title: 'B', id: 'B' },
-      ]),
-    }),
-  }));
-
-  jest.mock('app/core/services/context_srv', () => ({
-    contextSrv: {
-      user: { orgId: 1 },
-    },
-  }));
-  jest.mock('@grafana/runtime', () => ({
-    ...((jest.requireActual('@grafana/runtime') as unknown) as object),
-    getBackendSrv: () => ({
-      search: jest.fn(() => [
-        { title: 'A', id: 'A' },
-        { title: 'B', id: 'B' },
-      ]),
-    }),
-  }));
-
-  jest.mock('app/core/services/context_srv', () => ({
-    contextSrv: {
-      user: { orgId: 1 },
-    },
-  }));
-  jest.mock('@grafana/runtime', () => ({
-    ...((jest.requireActual('@grafana/runtime') as unknown) as object),
-    getBackendSrv: () => ({
-      search: jest.fn(() => [
-        { title: 'A', id: 'A' },
-        { title: 'B', id: 'B' },
-      ]),
-    }),
-  }));
-
-  jest.mock('app/core/services/context_srv', () => ({
-    contextSrv: {
-      user: { orgId: 1 },
-    },
-  }));
 
   describe('when timezone is changed', () => {
     it('should call update function', async () => {

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { byRole, byText } from 'testing-library-selector';
+import { Props, GeneralSettingsUnconnected as GeneralSettings } from './GeneralSettings';
+import { DashboardModel } from '../../state';
+
+jest.mock('@grafana/runtime', () => ({
+  ...((jest.requireActual('@grafana/runtime') as unknown) as object),
+  getBackendSrv: () => ({
+    search: jest.fn(() => [
+      { title: 'A', id: 'A' },
+      { title: 'B', id: 'B' },
+    ]),
+  }),
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    user: { orgId: 1 },
+  },
+}));
+
+const setupTestContext = (options: Partial<Props>) => {
+  const defaults: Props = {
+    dashboard: ({
+      title: 'test dashboard title',
+      description: 'test dashboard description',
+      timepicker: {
+        refresh_intervals: ['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d', '2d'],
+        time_options: ['5m', '15m', '1h', '6h', '12h', '24h', '2d', '7d', '30d'],
+      },
+      meta: {
+        folderTitle: 'test',
+      },
+      timezone: 'utc',
+    } as unknown) as DashboardModel,
+    updateTimeZone: jest.fn(),
+  };
+
+  const props = { ...defaults, ...options };
+  const { rerender } = render(<GeneralSettings {...props} />);
+
+  return { rerender, props };
+};
+
+const clickSelectOption = async (selectElement: HTMLElement, optionText: string): Promise<void> => {
+  userEvent.click(byRole('textbox').get(selectElement));
+  userEvent.click(byText(optionText).get(selectElement));
+};
+
+describe('General Settings', () => {
+  describe('when component is mounted with timezone', () => {
+    it('should render correctly', () => {
+      setupTestContext({});
+      screen.getByDisplayValue('test dashboard title');
+      screen.getByDisplayValue('test dashboard description');
+      expect(screen.getByLabelText('Time zone picker select container')).toHaveTextContent(
+        'Coordinated Universal Time'
+      );
+    });
+  });
+  jest.mock('@grafana/runtime', () => ({
+    ...((jest.requireActual('@grafana/runtime') as unknown) as object),
+    getBackendSrv: () => ({
+      search: jest.fn(() => [
+        { title: 'A', id: 'A' },
+        { title: 'B', id: 'B' },
+      ]),
+    }),
+  }));
+
+  jest.mock('app/core/services/context_srv', () => ({
+    contextSrv: {
+      user: { orgId: 1 },
+    },
+  }));
+  jest.mock('@grafana/runtime', () => ({
+    ...((jest.requireActual('@grafana/runtime') as unknown) as object),
+    getBackendSrv: () => ({
+      search: jest.fn(() => [
+        { title: 'A', id: 'A' },
+        { title: 'B', id: 'B' },
+      ]),
+    }),
+  }));
+
+  jest.mock('app/core/services/context_srv', () => ({
+    contextSrv: {
+      user: { orgId: 1 },
+    },
+  }));
+  jest.mock('@grafana/runtime', () => ({
+    ...((jest.requireActual('@grafana/runtime') as unknown) as object),
+    getBackendSrv: () => ({
+      search: jest.fn(() => [
+        { title: 'A', id: 'A' },
+        { title: 'B', id: 'B' },
+      ]),
+    }),
+  }));
+
+  jest.mock('app/core/services/context_srv', () => ({
+    contextSrv: {
+      user: { orgId: 1 },
+    },
+  }));
+
+  describe('when timezone is changed', () => {
+    it('should call update function', async () => {
+      const { props } = setupTestContext({});
+      userEvent.click(screen.getByLabelText('Time zone picker select container'));
+      await clickSelectOption(screen.getByLabelText('Time zone picker select container'), 'Browser Time');
+      expect(props.updateTimeZone).toHaveBeenCalledWith('browser');
+      expect(props.dashboard.timezone).toBe('browser');
+    });
+  });
+});

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -23,7 +23,7 @@ const GRAPH_TOOLTIP_OPTIONS = [
   { value: 2, label: 'Shared Tooltip' },
 ];
 
-export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }:Props): JSX.Element {
+export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }: Props): JSX.Element {
   const [renderCounter, setRenderCounter] = useState(0);
 
   const onFolderChange = (folder: { id: number; title: string }) => {
@@ -133,7 +133,7 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }:Props):
       </div>
     </div>
   );
-};
+}
 
 const mapDispatchToProps = {
   updateTimeZone: (timeZone: TimeZone) => {

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -8,8 +8,7 @@ import { DashboardModel } from '../../state/DashboardModel';
 import { DeleteDashboardButton } from '../DeleteDashboard/DeleteDashboardButton';
 import { TimePickerSettings } from './TimePickerSettings';
 
-import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
-import { getTimeSrv } from '../../services/TimeSrv';
+import { updateTimeZoneDashboard } from 'app/features/dashboard/state/actions';
 
 interface OwnProps {
   dashboard: DashboardModel;
@@ -136,10 +135,7 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }: Props)
 }
 
 const mapDispatchToProps = {
-  updateTimeZone: (timeZone: TimeZone) => {
-    updateTimeZoneForSession(timeZone);
-    getTimeSrv().refreshDashboard();
-  },
+  updateTimeZone: updateTimeZoneDashboard,
 };
 
 const connector = connect(null, mapDispatchToProps);

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { connect, ConnectedProps } from 'react-redux';
 import { TimeZone } from '@grafana/data';
 import { TagsInput, Input, Field, CollapsableSection, RadioButtonGroup } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
@@ -7,9 +8,14 @@ import { DashboardModel } from '../../state/DashboardModel';
 import { DeleteDashboardButton } from '../DeleteDashboard/DeleteDashboardButton';
 import { TimePickerSettings } from './TimePickerSettings';
 
-interface Props {
+import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
+import { getTimeSrv } from '../../services/TimeSrv';
+
+interface OwnProps {
   dashboard: DashboardModel;
 }
+
+export type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const GRAPH_TOOLTIP_OPTIONS = [
   { value: 0, label: 'Default' },
@@ -17,7 +23,7 @@ const GRAPH_TOOLTIP_OPTIONS = [
   { value: 2, label: 'Shared Tooltip' },
 ];
 
-export const GeneralSettings: React.FC<Props> = ({ dashboard }) => {
+export const GeneralSettingsUnconnected: React.FC<Props> = ({ dashboard, updateTimeZone }) => {
   const [renderCounter, setRenderCounter] = useState(0);
 
   const onFolderChange = (folder: { id: number; title: string }) => {
@@ -51,6 +57,7 @@ export const GeneralSettings: React.FC<Props> = ({ dashboard }) => {
   const onTimeZoneChange = (timeZone: TimeZone) => {
     dashboard.timezone = timeZone;
     setRenderCounter(renderCounter + 1);
+    updateTimeZone(timeZone);
   };
 
   const onTagsChange = (tags: string[]) => {
@@ -127,3 +134,14 @@ export const GeneralSettings: React.FC<Props> = ({ dashboard }) => {
     </div>
   );
 };
+
+const mapDispatchToProps = {
+  updateTimeZone: (timeZone: TimeZone) => {
+    updateTimeZoneForSession(timeZone);
+    getTimeSrv().refreshDashboard();
+  },
+};
+
+const connector = connect(null, mapDispatchToProps);
+
+export const GeneralSettings = connector(GeneralSettingsUnconnected);

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -23,7 +23,7 @@ const GRAPH_TOOLTIP_OPTIONS = [
   { value: 2, label: 'Shared Tooltip' },
 ];
 
-export const GeneralSettingsUnconnected: React.FC<Props> = ({ dashboard, updateTimeZone }) => {
+export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }:Props): JSX.Element {
   const [renderCounter, setRenderCounter] = useState(0);
 
   const onFolderChange = (folder: { id: number; title: string }) => {

--- a/public/app/features/dashboard/state/actions.ts
+++ b/public/app/features/dashboard/state/actions.ts
@@ -11,12 +11,14 @@ import {
 } from './reducers';
 import { notifyApp } from 'app/core/actions';
 import { loadPanelPlugin } from 'app/features/plugins/state/actions';
+import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 // Types
 import { DashboardAcl, DashboardAclUpdateDTO, NewDashboardAclItem, PermissionLevel, ThunkResult } from 'app/types';
 import { PanelModel } from './PanelModel';
 import { cancelVariables } from '../../variables/state/actions';
 import { getPanelPluginNotFound } from '../dashgrid/PanelPluginError';
 import { getTimeSrv } from '../services/TimeSrv';
+import { TimeZone } from '@grafana/data';
 
 export function getDashboardPermissions(id: number): ThunkResult<void> {
   return async (dispatch) => {
@@ -180,4 +182,9 @@ export const cleanUpDashboardAndVariables = (): ThunkResult<void> => (dispatch, 
 
   dispatch(cleanUpDashboard());
   dispatch(cancelVariables());
+};
+
+export const updateTimeZoneDashboard = (timeZone: TimeZone): ThunkResult<void> => (dispatch) => {
+  dispatch(updateTimeZoneForSession(timeZone));
+  getTimeSrv().refreshDashboard();
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The time zone change is not reflected in the panel or in the time picker

**Approach**

* Now `dashboard.timezone` is being updated using a redux action, I followed the same approach we do on the `DashNavTimeControls` component, as well I added unit test.

![timezone](https://user-images.githubusercontent.com/239999/121946906-b5be6480-cd55-11eb-9db4-338b8695eea1.gif)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35504

**Special notes for your reviewer**:

I noticed that on the current version of the timezone is updated in the dashboard settings or in the time picker it's not required to save changes, therefore if the user refresh the page the timezone is not being updated, is it expected behavior? 