### PR TITLE
Fix: allow variables in nested objects

### DIFF
--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -1,4 +1,11 @@
-import { ensureStringValues, findTemplateVarChanges, getCurrentText, getVariableRefresh, isAllVariable } from './utils';
+import {
+  containsVariable,
+  ensureStringValues,
+  findTemplateVarChanges,
+  getCurrentText,
+  getVariableRefresh,
+  isAllVariable,
+} from './utils';
 import { VariableRefresh } from './types';
 import { UrlQueryMap } from '@grafana/data';
 
@@ -172,5 +179,18 @@ describe('ensureStringValues', () => {
     ${true}            | ${'true'}
   `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
     expect(ensureStringValues(value)).toEqual(expected);
+  });
+});
+
+describe('containsVariable', () => {
+  it.each`
+    value                               | expected
+    ${''}                               | ${false}
+    ${'$var'}                           | ${true}
+    ${{ thing1: '${var}' }}             | ${true}
+    ${{ thing1: ['1', '${var}'] }}      | ${true}
+    ${{ thing1: { thing2: '${var}' } }} | ${true}
+  `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
+    expect(containsVariable(value, 'var')).toEqual(expected);
   });
 });

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -51,7 +51,7 @@ export const getSearchFilterScopedVar = (args: {
 
 export function containsVariable(...args: any[]) {
   const variableName = args[args.length - 1];
-  args[0] = isString(args[0]) ? args[0] : Object['values'](args[0]).join(' ');
+  args[0] = isString(args[0]) ? args[0] : JSON.stringify(args[0]);
   const variableString = args.slice(0, -1).join(' ');
   const matches = variableString.match(variableRegex);
   const isMatchingVariable =

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -1,4 +1,4 @@
-import { isString, isArray, isEqual } from 'lodash';
+import { isArray, isEqual } from 'lodash';
 import { ScopedVars, UrlQueryMap, VariableType } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
@@ -6,6 +6,7 @@ import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from './state/types';
 import { QueryVariableModel, VariableModel, VariableRefresh } from './types';
 import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { variableAdapters } from './adapters';
+import { safeStringifyValue } from 'app/core/utils/explore';
 
 /*
  * This regex matches 3 types of variable reference with an optional format specifier
@@ -51,7 +52,7 @@ export const getSearchFilterScopedVar = (args: {
 
 export function containsVariable(...args: any[]) {
   const variableName = args[args.length - 1];
-  args[0] = isString(args[0]) ? args[0] : JSON.stringify(args[0]);
+  args[0] = typeof args[0] === 'string' ? args[0] : safeStringifyValue(args[0]);
   const variableString = args.slice(0, -1).join(' ');
   const matches = variableString.match(variableRegex);
   const isMatchingVariable =


### PR DESCRIPTION
As a plugin author, I may want to structure my variable query with nested objects:
```
{
    thing1: "foo",
    thing2: {
        thing3: "${variable}"
    }
}
```
Right now, this is does not work because any non-string argument to `containsVariable` is converted to a string using `Object['values'](...).join('  ' )` which results in `"foo [object Object]"`

This PR replaces `Object['values'](...).join('  ' )`  with `JSON.stringify(...)` so the all contents of the type are preserved for the regex. 

