### PR TITLE
Docs change to account for a change in access

### DIFF
--- a/docs/sources/sharing/_index.md
+++ b/docs/sources/sharing/_index.md
@@ -15,6 +15,6 @@ Refer to [Share a dashboard]({{< relref "share-dashboard.md" >}}) and [Share a p
 
 You must have an authorized viewer permission to see an image rendered by a direct link.
 
-The same permission is also required to view embedded links unless you have anonymous access permission enabled for your Grafana instance. You can enable [anonymous access]({{< relref "../auth/overview.md" >}}) by yourself in Grafana OSS. To enable anonymous access on a Grafana Cloud instance, contact your Customer Support.
+The same permission is also required to view embedded links unless you have anonymous access permission enabled for your Grafana instance. You can enable [anonymous access]({{< relref "../auth/overview.md" >}}) by yourself in Grafana OSS.
 
 When you share a panel or dashboard as a snapshot, a snapshot (of the panel or the dashboard at that moment in time) is publicly available on the web. Anyone with a link to it can access it. Since snapshots do not need any authorization to view, Grafana strips information related to the account it came from, as well as any sensitive data from the snapshot.


### PR DESCRIPTION
A small change in language removing a note about Anonymous access in Grafana Cloud, which isn't supported. 

Ref: https://github.com/grafana/grafana/issues/35678