### PR TITLE
State Timeline: Fix crash when hovering over panel

### DIFF
--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -42,7 +42,7 @@ export const StateTimelinePanel: React.FC<TimelinePanelProps> = ({
 
       return (
         <StateTimelineTooltip
-          data={data.series}
+          data={frames ?? []}
           alignedData={alignedData}
           seriesIdx={seriesIdx}
           datapointIdx={datapointIdx}
@@ -50,7 +50,7 @@ export const StateTimelinePanel: React.FC<TimelinePanelProps> = ({
         />
       );
     },
-    [timeZone, data]
+    [timeZone, frames]
   );
 
   if (!frames || warn) {

--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
@@ -37,7 +37,11 @@ export const StateTimelineTooltip: React.FC<StateTimelineTooltipProps> = ({
   const value = field.values.get(datapointIdx!);
   const display = fieldFmt(value);
   const fieldDisplayName = dataFrameFieldIndex
-    ? getFieldDisplayName(field, data[dataFrameFieldIndex.frameIndex], data)
+    ? getFieldDisplayName(
+        data[dataFrameFieldIndex.frameIndex].fields[dataFrameFieldIndex.fieldIndex],
+        data[dataFrameFieldIndex.frameIndex],
+        data
+      )
     : null;
 
   const nextStateIdx = findNextStateIndex(field, datapointIdx!);

--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
@@ -37,11 +37,7 @@ export const StateTimelineTooltip: React.FC<StateTimelineTooltipProps> = ({
   const value = field.values.get(datapointIdx!);
   const display = fieldFmt(value);
   const fieldDisplayName = dataFrameFieldIndex
-    ? getFieldDisplayName(
-        data[dataFrameFieldIndex.frameIndex].fields[dataFrameFieldIndex.fieldIndex],
-        data[dataFrameFieldIndex.frameIndex],
-        data
-      )
+    ? getFieldDisplayName(field, data[dataFrameFieldIndex.frameIndex], data)
     : null;
 
   const nextStateIdx = findNextStateIndex(field, datapointIdx!);

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -1,29 +1,29 @@
 import React from 'react';
 import { XYFieldMatchers } from '@grafana/ui/src/components/GraphNG/types';
 import {
+  ArrayVector,
   DataFrame,
+  FALLBACK_COLOR,
+  Field,
+  FieldColorModeId,
   FieldConfig,
+  FieldType,
   formattedValueToString,
   getFieldDisplayName,
-  outerJoinDataFrames,
-  Field,
-  FALLBACK_COLOR,
-  FieldType,
-  ArrayVector,
-  FieldColorModeId,
   getValueFormat,
-  ThresholdsMode,
   GrafanaTheme2,
+  outerJoinDataFrames,
+  ThresholdsMode,
 } from '@grafana/data';
 import {
-  UPlotConfigBuilder,
   FIXED_UNIT,
   SeriesVisibilityChangeMode,
+  UPlotConfigBuilder,
   UPlotConfigPrepFn,
-  VizLegendOptions,
   VizLegendItem,
+  VizLegendOptions,
 } from '@grafana/ui';
-import { TimelineCoreOptions, getConfig } from './timeline';
+import { getConfig, TimelineCoreOptions } from './timeline';
 import { AxisPlacement, ScaleDirection, ScaleOrientation } from '@grafana/ui/src/components/uPlot/config';
 import { TimelineFieldConfig, TimelineOptions } from './types';
 import { PlotTooltipInterpolator } from '@grafana/ui/src/components/uPlot/types';
@@ -401,12 +401,12 @@ export function findNextStateIndex(field: Field, datapointIdx: number) {
   let end;
   let rightPointer = datapointIdx + 1;
 
-  if (rightPointer === field.values.length) {
+  if (rightPointer >= field.values.length) {
     return null;
   }
 
   while (end === undefined) {
-    if (rightPointer === field.values.length) {
+    if (rightPointer >= field.values.length) {
       return null;
     }
     const rightValue = field.values.get(rightPointer);


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a new area in the code base for me so I don't fully understand why we were using a lookup to access a field that we already have, I'm certain there were good reasons and I'll change this fix accordingly. This fix replaces the lookup based approach to just passing the field to `getFieldDisplayName`.

Use this dashboard to repro the issue on main:
```json

{
  "__inputs": [],
  "__requires": [
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "8.1.0-pre"
    },
    {
      "type": "panel",
      "id": "state-timeline",
      "name": "State timeline",
      "version": ""
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "gnetId": null,
  "graphTooltip": 0,
  "id": null,
  "links": [],
  "panels": [
    {
      "datasource": null,
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "fillOpacity": 70,
            "lineWidth": 0
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "alignValue": "left",
        "legend": {
          "displayMode": "list",
          "placement": "bottom"
        },
        "mergeValues": true,
        "rowHeight": 0.9,
        "showValue": "auto",
        "tooltip": {
          "mode": "single"
        }
      },
      "targets": [
        {
          "csvWave": [
            {
              "labels": "",
              "name": "kalle",
              "timeStep": 182,
              "valuesCSV": "0,1,100"
            },
            {
              "timeStep": 60,
              "valuesCSV": "0,0,92,2,1,1"
            }
          ],
          "refId": "A",
          "scenarioId": "predictable_csv_wave"
        }
      ],
      "title": "Panel Title",
      "transformations": [
        {
          "id": "filterFieldsByName",
          "options": {
            "include": {
              "names": [
                "Time",
                "A-series"
              ]
            }
          }
        }
      ],
      "type": "state-timeline"
    }
  ],
  "schemaVersion": 30,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "State Timeline with Filter by Name Transform crashes #35601",
  "uid": "AUiqwDg7k",
  "version": 4
}

```

**Which issue(s) this PR fixes**:
Fixes #35601
Fixes #35752

**Special notes for your reviewer**:

