### PR TITLE
Packaging: Update PID file location from `/var/run` to `/run`

### DIFF
--- a/packaging/deb/default/grafana-server
+++ b/packaging/deb/default/grafana-server
@@ -21,4 +21,4 @@ PLUGINS_DIR=/var/lib/grafana/plugins
 PROVISIONING_CFG_DIR=/etc/grafana/provisioning
 
 # Only used on systemd systems
-PID_FILE_DIR=/var/run/grafana
+PID_FILE_DIR=/run/grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
/var/run is generally deprecated on most distros and only kept functional via symlink form /var/run => /run. Especially systemd enforces the new directory by throwing a warnings e.g. when PIDFile= or socket paths are set to /var/run, and rewrites them automatically to /run. Also RuntimeDirectory=grafana (used in the grafana-server systemd unit) will create /run/grafana, not /var/run/grafana.

This commit hence aligns the PID file path with the actual path of systemd units runtime directory.

**Which issue(s) this PR fixes**:
No apparent issue or bug is fixed, but it aligns the config with modern standards and makes it future prove.

**Special notes for your reviewer**:

