### PR TITLE
Alerting: Don't reset value when changing evaluator method on classic condition

### DIFF
--- a/public/app/features/expressions/components/Condition.tsx
+++ b/public/app/features/expressions/components/Condition.tsx
@@ -44,7 +44,7 @@ export const Condition: FC<Props> = ({ condition, index, onChange, onRemoveCondi
   const onEvalFunctionChange = (evalFunction: SelectableValue<EvalFunction>) => {
     onChange({
       ...condition,
-      evaluator: { params: [], type: evalFunction.value! },
+      evaluator: { params: condition.evaluator.params, type: evalFunction.value! },
     });
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where the threshold value was cleared when changing evaluator method.
**Which issue(s) this PR fixes**:

Fixes #35305

**Special notes for your reviewer**:

