### PR TITLE
Alerting: Load default configuration from status endpoint, if Cortex Alertmanager returns empty user configuration

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -7,6 +7,7 @@ import {
   Silence,
   SilenceCreatePayload,
   Matcher,
+  AlertmanagerStatus,
 } from 'app/plugins/datasource/alertmanager/types';
 import { getDatasourceAPIId, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
@@ -123,6 +124,18 @@ export async function fetchAlertGroups(alertmanagerSourceName: string): Promise<
   const result = await getBackendSrv()
     .fetch<AlertmanagerGroup[]>({
       url: `/api/alertmanager/${getDatasourceAPIId(alertmanagerSourceName)}/api/v2/alerts/groups`,
+      showErrorAlert: false,
+      showSuccessAlert: false,
+    })
+    .toPromise();
+
+  return result.data;
+}
+
+export async function fetchStatus(alertManagerSourceName: string): Promise<AlertmanagerStatus> {
+  const result = await getBackendSrv()
+    .fetch<AlertmanagerStatus>({
+      url: `/api/alertmanager/${getDatasourceAPIId(alertManagerSourceName)}/api/v2/status`,
       showErrorAlert: false,
       showSuccessAlert: false,
     })

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -3,7 +3,11 @@ import { PromAlertingRuleState, PromRuleType } from 'app/types/unified-alerting-
 import { AlertingRule, Alert, RecordingRule, RuleGroup, RuleNamespace } from 'app/types/unified-alerting';
 import DatasourceSrv from 'app/features/plugins/datasource_srv';
 import { DataSourceSrv, GetDataSourceListFilters } from '@grafana/runtime';
-import { AlertManagerCortexConfig, GrafanaManagedReceiverConfig } from 'app/plugins/datasource/alertmanager/types';
+import {
+  AlertManagerCortexConfig,
+  AlertmanagerStatus,
+  GrafanaManagedReceiverConfig,
+} from 'app/plugins/datasource/alertmanager/types';
 
 let nextDataSourceId = 1;
 
@@ -171,6 +175,37 @@ export const someGrafanaAlertManagerConfig: AlertManagerCortexConfig = {
       {
         name: 'critical',
         grafana_managed_receiver_configs: [mockGrafanaReceiver('slack'), mockGrafanaReceiver('pagerduty')],
+      },
+    ],
+  },
+};
+
+export const someCloudAlertManagerStatus: AlertmanagerStatus = {
+  cluster: {
+    peers: [],
+    status: 'ok',
+  },
+  uptime: '10 hours',
+  versionInfo: {
+    branch: '',
+    version: '',
+    goVersion: '',
+    buildDate: '',
+    buildUser: '',
+    revision: '',
+  },
+  config: {
+    route: {
+      receiver: 'default-email',
+    },
+    receivers: [
+      {
+        name: 'default-email',
+        email_configs: [
+          {
+            to: 'example@example.com',
+          },
+        ],
       },
     ],
   },

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -5,13 +5,6 @@ export type AlertManagerCortexConfig = {
   alertmanager_config: AlertmanagerConfig;
 };
 
-// NOTE - This type is incomplete! But currently, we don't need more.
-export type AlertmanagerStatusPayload = {
-  config: {
-    original: string;
-  };
-};
-
 export type TLSConfig = {
   ca_file: string;
   cert_file: string;
@@ -217,3 +210,20 @@ export type AlertmanagerGroup = {
   alerts: AlertmanagerAlert[];
   id: string;
 };
+
+export interface AlertmanagerStatus {
+  cluster: {
+    peers: unknown;
+    status: string;
+  };
+  config: AlertmanagerConfig;
+  uptime: string;
+  versionInfo: {
+    branch: string;
+    buildDate: string;
+    buildUser: string;
+    goVersion: string;
+    revision: string;
+    version: string;
+  };
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

For cortex alertmanager, if user config endpoint returns empty config, will load default config from alertmanager status endpoint.

**Which issue(s) this PR fixes**: 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35729

**Special notes for your reviewer**:

