### PR TITLE
AzureMonitor: Avoid instantiating appInsights for AppInsights for gov cloud

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -28,11 +28,13 @@ import AzureResourceGraphDatasource from './azure_resource_graph/azure_resource_
 
 export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDataSourceJsonData> {
   azureMonitorDatasource: AzureMonitorDatasource;
-  appInsightsDatasource: AppInsightsDatasource;
   azureLogAnalyticsDatasource: AzureLogAnalyticsDatasource;
-  insightsAnalyticsDatasource: InsightsAnalyticsDatasource;
   resourcePickerData: ResourcePickerData;
   azureResourceGraphDatasource: AzureResourceGraphDatasource;
+  /** @deprecated */
+  appInsightsDatasource?: AppInsightsDatasource;
+  /** @deprecated */
+  insightsAnalyticsDatasource: InsightsAnalyticsDatasource;
 
   pseudoDatasource: Record<AzureQueryType, DataSourceWithBackend>;
   optionsKey: Record<AzureQueryType, string>;
@@ -43,18 +45,24 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
   ) {
     super(instanceSettings);
     this.azureMonitorDatasource = new AzureMonitorDatasource(instanceSettings);
-    this.appInsightsDatasource = new AppInsightsDatasource(instanceSettings);
     this.azureLogAnalyticsDatasource = new AzureLogAnalyticsDatasource(instanceSettings);
-    this.insightsAnalyticsDatasource = new InsightsAnalyticsDatasource(instanceSettings);
     this.azureResourceGraphDatasource = new AzureResourceGraphDatasource(instanceSettings);
     this.resourcePickerData = new ResourcePickerData(instanceSettings);
 
     const pseudoDatasource: any = {};
-    pseudoDatasource[AzureQueryType.ApplicationInsights] = this.appInsightsDatasource;
     pseudoDatasource[AzureQueryType.AzureMonitor] = this.azureMonitorDatasource;
-    pseudoDatasource[AzureQueryType.InsightsAnalytics] = this.insightsAnalyticsDatasource;
     pseudoDatasource[AzureQueryType.LogAnalytics] = this.azureLogAnalyticsDatasource;
     pseudoDatasource[AzureQueryType.AzureResourceGraph] = this.azureResourceGraphDatasource;
+
+    if (
+      instanceSettings.jsonData.cloudName === 'azuremonitor' ||
+      instanceSettings.jsonData.cloudName === 'chinaazuremonitor'
+    ) {
+      this.appInsightsDatasource = new AppInsightsDatasource(instanceSettings);
+      this.insightsAnalyticsDatasource = new InsightsAnalyticsDatasource(instanceSettings);
+      pseudoDatasource[AzureQueryType.ApplicationInsights] = this.appInsightsDatasource;
+      pseudoDatasource[AzureQueryType.InsightsAnalytics] = this.insightsAnalyticsDatasource;
+    }
     this.pseudoDatasource = pseudoDatasource;
 
     const optionsKey: any = {};
@@ -129,7 +137,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
       return Promise.resolve([]);
     }
 
-    const aiResult = this.appInsightsDatasource.metricFindQueryInternal(query);
+    const aiResult = this.appInsightsDatasource?.metricFindQueryInternal(query);
     if (aiResult) {
       return aiResult;
     }
@@ -153,7 +161,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
     promises.push(this.azureMonitorDatasource.testDatasource());
     promises.push(this.azureLogAnalyticsDatasource.testDatasource());
 
-    if (this.appInsightsDatasource.isConfigured()) {
+    if (this.appInsightsDatasource?.isConfigured()) {
       promises.push(this.appInsightsDatasource.testDatasource());
     }
 
@@ -241,15 +249,15 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
 
   /* Application Insights API method */
   getAppInsightsMetricNames() {
-    return this.appInsightsDatasource.getMetricNames();
+    return this.appInsightsDatasource?.getMetricNames();
   }
 
   getAppInsightsMetricMetadata(metricName: string) {
-    return this.appInsightsDatasource.getMetricMetadata(metricName);
+    return this.appInsightsDatasource?.getMetricMetadata(metricName);
   }
 
   getAppInsightsColumns(refId: string | number) {
-    return this.appInsightsDatasource.logAnalyticsColumns[refId];
+    return this.appInsightsDatasource?.logAnalyticsColumns[refId];
   }
 
   /*Azure Log Analytics */

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -25,6 +25,7 @@ import InsightsAnalyticsDatasource from './insights_analytics/insights_analytics
 import { migrateMetricsDimensionFilters } from './query_ctrl';
 import { map } from 'rxjs/operators';
 import AzureResourceGraphDatasource from './azure_resource_graph/azure_resource_graph_datasource';
+import { getAzureCloud } from './credentials';
 
 export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDataSourceJsonData> {
   azureMonitorDatasource: AzureMonitorDatasource;
@@ -54,10 +55,8 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
     pseudoDatasource[AzureQueryType.LogAnalytics] = this.azureLogAnalyticsDatasource;
     pseudoDatasource[AzureQueryType.AzureResourceGraph] = this.azureResourceGraphDatasource;
 
-    if (
-      instanceSettings.jsonData.cloudName === 'azuremonitor' ||
-      instanceSettings.jsonData.cloudName === 'chinaazuremonitor'
-    ) {
+    const cloud = getAzureCloud(instanceSettings);
+    if (cloud === 'azuremonitor' || cloud === 'chinaazuremonitor') {
       // AppInsights and InsightAnalytics are only supported for Public and Azure China clouds
       this.appInsightsDatasource = new AppInsightsDatasource(instanceSettings);
       this.insightsAnalyticsDatasource = new InsightsAnalyticsDatasource(instanceSettings);

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -34,7 +34,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
   /** @deprecated */
   appInsightsDatasource?: AppInsightsDatasource;
   /** @deprecated */
-  insightsAnalyticsDatasource: InsightsAnalyticsDatasource;
+  insightsAnalyticsDatasource?: InsightsAnalyticsDatasource;
 
   pseudoDatasource: Record<AzureQueryType, DataSourceWithBackend>;
   optionsKey: Record<AzureQueryType, string>;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -58,6 +58,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
       instanceSettings.jsonData.cloudName === 'azuremonitor' ||
       instanceSettings.jsonData.cloudName === 'chinaazuremonitor'
     ) {
+      // AppInsights and InsightAnalytics are only supported for Public and Azure China clouds
       this.appInsightsDatasource = new AppInsightsDatasource(instanceSettings);
       this.insightsAnalyticsDatasource = new InsightsAnalyticsDatasource(instanceSettings);
       pseudoDatasource[AzureQueryType.ApplicationInsights] = this.appInsightsDatasource;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

`AppInsights` and `InsightAnalytics` are not supported in the `gov` cloud (they are actually deprecated). Trying to validate or use them in the different panels causes the error described in #35708.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35708

**Special notes for your reviewer**:

I was able to reproduce the issue when trying to create a new datasource and simply selecting "Azure Goverment" and trying to save it (no need to actually access the cloud).