### PR TITLE
MSSQL: Fix issue with hidden queries still being executed

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -83,9 +83,7 @@ class DataSourceWithBackend<
     const { intervalMs, maxDataPoints, range, requestId } = request;
     let targets = request.targets;
 
-    if (this.filterQuery) {
-      targets = targets.filter((q) => this.filterQuery!(q));
-    }
+    targets = targets.filter((q) => this.filterQuery(q));
 
     const queries = targets.map((q) => {
       let datasourceId = this.id;
@@ -153,11 +151,13 @@ class DataSourceWithBackend<
   /**
    * Override to skip executing a query
    *
-   * @returns false if the query should be skipped
+   * @returns false if the query should be skipped, override to customize logic
    *
    * @virtual
    */
-  filterQuery?(query: TQuery): boolean;
+  filterQuery(query: TQuery): boolean {
+    return !query.hide;
+  }
 
   /**
    * Override to apply template variables.  The result is usually also `TQuery`, but sometimes this can

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -15,6 +15,10 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
     return `Expression: ${query.type}`;
   }
 
+  filterQuery() {
+    return true;
+  }
+
   newQuery(query?: Partial<ExpressionQuery>): ExpressionQuery {
     return {
       refId: '--', // Replaced with query

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -70,13 +70,6 @@ export class MysqlDatasource extends DataSourceWithBackend<MySQLQuery, MySQLOpti
     return expandedQueries;
   }
 
-  filterQuery(query: MySQLQuery): boolean {
-    if (query.hide) {
-      return false;
-    }
-    return true;
-  }
-
   applyTemplateVariables(target: MySQLQuery, scopedVars: ScopedVars): Record<string, any> {
     const queryModel = new MySQLQueryModel(target, this.templateSrv, scopedVars);
     return {

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -72,10 +72,6 @@ export class PostgresDatasource extends DataSourceWithBackend<PostgresQuery, Pos
     return expandedQueries;
   }
 
-  filterQuery(query: PostgresQuery): boolean {
-    return !query.hide;
-  }
-
   applyTemplateVariables(target: PostgresQuery, scopedVars: ScopedVars): Record<string, any> {
     const queryModel = new PostgresQueryModel(target, this.templateSrv, scopedVars);
     return {


### PR DESCRIPTION
Fixes #35779

This changes DataSourceWithBackend so there is a default implementation for filterQuery. This feels like the best solution as the most common thing will be for data sources
to just filter out hidden queries and for every data source to have to do this feels bad and something that will be missed as it's optional and not required.



