### PR TITLE
Table: Fix "No data" not being centered

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -198,7 +198,7 @@ export const Table: FC<Props> = memo((props: Props) => {
   return (
     <div {...getTableProps()} className={tableStyles.table} aria-label={ariaLabel}>
       <CustomScrollbar hideVerticalTrack={true}>
-        <div style={{ width: `${totalColumnsWidth}px` }}>
+        <div style={{ width: totalColumnsWidth ? `${totalColumnsWidth}px` : '100%' }}>
           {!noHeader && (
             <div>
               {headerGroups.map((headerGroup: HeaderGroup) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fixes the positioning part of  #35574

**Special notes for your reviewer**:
 Issue can be reproduced in gdev dashboard `Panel Tests - React Table`

1. Inspect the first panel
2. Choose data frame "series joined by time"

Is there any case where the desired width of this container would be 0?

The root cause of why there is No data in #35574 still need investigation.