### PR TITLE
AzureMonitor: Disable inputs if the data source is read-only

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AnalyticsConfig.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AnalyticsConfig.test.tsx
@@ -102,4 +102,15 @@ describe('Render', () => {
     }));
     expect(screen.queryByText('is no longer supported', { exact: false })).toBeInTheDocument();
   });
+
+  it('should disable inputs', () => {
+    setup((props) => ({
+      ...props,
+      options: {
+        ...props.options,
+        readOnly: true,
+      },
+    }));
+    expect(screen.queryByText('Load Workspaces')?.closest('button')).toBeDisabled();
+  });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AnalyticsConfig.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AnalyticsConfig.tsx
@@ -130,6 +130,7 @@ export const AnalyticsConfig: FunctionComponent<Props> = (props: Props) => {
                 value={workspaces.find((opt) => opt.value === defaultWorkspace)}
                 options={workspaces}
                 onChange={onDefaultWorkspaceChange}
+                isDisabled={props.options.readOnly}
               />
             </div>
           </div>
@@ -142,7 +143,7 @@ export const AnalyticsConfig: FunctionComponent<Props> = (props: Props) => {
                 size="sm"
                 type="button"
                 onClick={onLoadWorkspaces}
-                disabled={!hasRequiredFields}
+                disabled={!hasRequiredFields || props.options.readOnly}
               >
                 Load Workspaces
               </Button>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AzureCredentialsForm.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AzureCredentialsForm.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import AzureCredentialsForm, { Props } from './AzureCredentialsForm';
 import { LegacyForms, Button } from '@grafana/ui';
-const { Input } = LegacyForms;
+const { Input, Select } = LegacyForms;
 
 const setup = (propsFunc?: (props: Props) => Props) => {
   let props: Props = {
@@ -85,6 +85,15 @@ describe('Render', () => {
         disabled: true,
       }));
       expect(wrapper.find(Button).exists()).toBe(false);
+    });
+
+    it('should disable cloud selector', () => {
+      const wrapper = setup((props) => ({
+        ...props,
+        disabled: true,
+      }));
+      const selects = wrapper.find(Select);
+      selects.forEach((s) => expect(s.prop('isDisabled')).toBe(true));
     });
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AzureCredentialsForm.tsx
@@ -160,6 +160,7 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
               value={authTypeOptions.find((opt) => opt.value === credentials.authType)}
               options={authTypeOptions}
               onChange={onAuthTypeChange}
+              isDisabled={disabled}
             />
           </div>
         </div>
@@ -177,6 +178,7 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
                   value={azureCloudOptions.find((opt) => opt.value === credentials.azureCloud)}
                   options={azureCloudOptions}
                   onChange={onAzureCloudChange}
+                  isDisabled={disabled}
                 />
               </div>
             </div>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import InsightsConfig, { Props } from './InsightsConfig';
+import { Button, LegacyForms } from '@grafana/ui';
+const { Input } = LegacyForms;
 
 const setup = (propOverrides?: object) => {
   const props: Props = {
@@ -80,5 +82,26 @@ describe('Render', () => {
       },
     });
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should disable buttons and inputs', () => {
+    const wrapper = setup({
+      options: {
+        secureJsonFields: {
+          appInsightsApiKey: true,
+        },
+        jsonData: {
+          appInsightsAppId: 'cddcc020-2c94-460a-a3d0-df3147ffa792',
+        },
+        secureJsonData: {
+          appInsightsApiKey: 'e7f3f661-a933-4b3f-8176-51c4f982ec48',
+        },
+        readOnly: true,
+      },
+    });
+    const buttons = wrapper.find(Button);
+    const inputs = wrapper.find(Input);
+    buttons.forEach((b) => expect(b.prop('disabled')).toBe(true));
+    inputs.forEach((i) => expect(i.prop('disabled')).toBe(true));
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/InsightsConfig.tsx
@@ -35,7 +35,12 @@ export class InsightsConfig extends PureComponent<Props> {
               </div>
               <div className="gf-form">
                 <div className="max-width-30 gf-form-inline">
-                  <Button variant="secondary" type="button" onClick={this.onAppInsightsResetApiKey}>
+                  <Button
+                    variant="secondary"
+                    type="button"
+                    onClick={this.onAppInsightsResetApiKey}
+                    disabled={this.props.options.readOnly}
+                  >
                     reset
                   </Button>
                 </div>
@@ -51,6 +56,7 @@ export class InsightsConfig extends PureComponent<Props> {
                     placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
                     value={options.secureJsonData!.appInsightsApiKey || ''}
                     onChange={onUpdateSecureJsonDataOption('appInsightsApiKey')}
+                    disabled={this.props.options.readOnly}
                   />
                 </div>
               </div>
@@ -64,6 +70,7 @@ export class InsightsConfig extends PureComponent<Props> {
                   className="width-30"
                   value={options.jsonData.appInsightsAppId || ''}
                   onChange={onUpdateJsonDataOption('appInsightsAppId')}
+                  disabled={this.props.options.readOnly}
                 />
               </div>
             </div>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MonitorConfig.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MonitorConfig.tsx
@@ -35,6 +35,7 @@ export const MonitorConfig: FunctionComponent<Props> = (props: Props) => {
         azureCloudOptions={azureClouds}
         onCredentialsChange={onCredentialsChange}
         getSubscriptions={getSubscriptions}
+        disabled={props.options.readOnly}
       />
     </>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/__snapshots__/InsightsConfig.test.tsx.snap
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/__snapshots__/InsightsConfig.test.tsx.snap
@@ -169,6 +169,7 @@ exports[`Render should render component 1`] = `
         >
           <Input
             className="width-30"
+            disabled={false}
             placeholder="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
             value=""
           />
@@ -191,6 +192,7 @@ exports[`Render should render component 1`] = `
         >
           <Input
             className="width-30"
+            disabled={false}
             value=""
           />
         </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

If the data source is marked as read-only, nothing is preventing users from modifying some of the configuration fields. This PR prevents from that.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #34616 

**Special notes for your reviewer**:

cc/ @kostrse 
