### PR TITLE
Explore: change border radius for refresh picker component

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
+++ b/packages/grafana-ui/src/components/RefreshPicker/_RefreshPicker.scss
@@ -2,3 +2,7 @@
   position: relative;
   margin-left: 10px;
 }
+
+.refresh-picker .toolbar-button {
+  border-radius: 0px 2px 2px 0px;
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes the styling error for the refresh picker in explore. The styling previously caused this to happen:
![Screenshot 2021-06-14 at 15 43 06@2x](https://user-images.githubusercontent.com/16028771/122226952-bd494f00-ceb6-11eb-86c9-e51f4b410103.png)
but with this fix it now looks like this:
<img width="149" alt="Screenshot 2021-06-16 at 15 22 20" src="https://user-images.githubusercontent.com/16028771/122227044-d3570f80-ceb6-11eb-8707-a1a7ee862cd4.png">
(Sorry for the difference in image sizes, hopefully you can see the change)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35793

**Special notes for your reviewer**:
The problem was related to the border radius for ToolbarButton components that were children of the RefreshPicker component. To fix this i used the descendant combinator to target the ToolbarButton child but now the styling is hard coded instead of using `border-radius: ${theme.shape.borderRadius()};`
Is this fine or is this a "bad" hack? Please share your thoughts!
