### PR TITLE
TimePicker: will display the correct dates when selecting range in calendar with tz.

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -4,6 +4,7 @@ export const Components = {
     fromField: 'TimePicker from field',
     toField: 'TimePicker to field',
     applyTimeRange: 'TimePicker submit button',
+    calendar: 'TimePicker calendar',
   },
   DataSource: {
     TestData: {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
@@ -8,6 +8,7 @@ import { Button } from '../../Button';
 import { Icon } from '../../Icon/Icon';
 import { Portal } from '../../Portal/Portal';
 import { ClickOutsideWrapper } from '../../ClickOutsideWrapper/ClickOutsideWrapper';
+import { selectors } from '@grafana/e2e-selectors';
 
 export const getStyles = stylesFactory((theme: GrafanaTheme2, isReversed = false) => {
   return {
@@ -208,7 +209,11 @@ export const TimePickerCalendar = memo<Props>((props) => {
   if (isFullscreen) {
     return (
       <ClickOutsideWrapper onClick={props.onClose}>
-        <div className={styles.container} onClick={stopPropagation}>
+        <div
+          className={styles.container}
+          onClick={stopPropagation}
+          aria-label={selectors.components.TimePicker.calendar}
+        >
           <Body {...props} />
         </div>
       </ClickOutsideWrapper>
@@ -218,7 +223,7 @@ export const TimePickerCalendar = memo<Props>((props) => {
   return (
     <Portal>
       <div className={styles.modal} onClick={stopPropagation}>
-        <div className={styles.content}>
+        <div className={styles.content} aria-label={selectors.components.TimePicker.calendar}>
           <Header {...props} />
           <Body {...props} />
           <Footer {...props} />

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.test.tsx
@@ -1,16 +1,99 @@
 import React from 'react';
-import { render, RenderResult } from '@testing-library/react';
-import { getDefaultTimeRange, TimeRange, TimeZone } from '@grafana/data';
+import { fireEvent, render, RenderResult } from '@testing-library/react';
+import { dateTimeParse, TimeRange } from '@grafana/data';
 import { TimeRangeForm } from './TimeRangeForm';
+import { selectors } from '@grafana/e2e-selectors';
 
-function setup(initial: TimeRange = getDefaultTimeRange(), timeZone?: TimeZone): RenderResult {
-  return render(<TimeRangeForm isFullscreen={true} value={initial} onApply={() => {}} timeZone={timeZone} />);
+type TimeRangeFormRenderResult = RenderResult & {
+  getCalendarDayByLabelText(label: string): HTMLButtonElement;
+};
+
+const defaultTimeRange: TimeRange = {
+  from: dateTimeParse('2021-06-17 00:00:00', { timeZone: 'utc' }),
+  to: dateTimeParse('2021-06-19 23:59:00', { timeZone: 'utc' }),
+  raw: {
+    from: '2021-06-17 00:00:00',
+    to: '2021-06-19 23:59:00',
+  },
+};
+
+function setup(initial: TimeRange = defaultTimeRange, timeZone = 'utc'): TimeRangeFormRenderResult {
+  const result = render(<TimeRangeForm isFullscreen={true} value={initial} onApply={() => {}} timeZone={timeZone} />);
+
+  return {
+    ...result,
+    getCalendarDayByLabelText: (label: string) => {
+      const item = result.getByLabelText(label);
+      return item?.parentElement as HTMLButtonElement;
+    },
+  };
 }
 
 describe('TimeRangeForm', () => {
-  it('renders buttons correcty', () => {
-    const container = setup();
+  it('should render form correcty', () => {
+    const { getByLabelText } = setup();
+    const { TimePicker } = selectors.components;
 
-    expect(container.queryByLabelText(/timepicker open button/i)).toBeInTheDocument();
+    expect(getByLabelText(TimePicker.applyTimeRange)).toBeInTheDocument();
+    expect(getByLabelText(TimePicker.fromField)).toBeInTheDocument();
+    expect(getByLabelText(TimePicker.toField)).toBeInTheDocument();
+  });
+
+  it('should display calendar when clicking the from input field', () => {
+    const { getByLabelText } = setup();
+    const { TimePicker } = selectors.components;
+
+    fireEvent.focus(getByLabelText(TimePicker.fromField));
+    expect(getByLabelText(TimePicker.calendar)).toBeInTheDocument();
+  });
+
+  it('should have passed time range entered in form', () => {
+    const { getByLabelText } = setup();
+    const { TimePicker } = selectors.components;
+
+    const fromValue = defaultTimeRange.raw.from as string;
+    const toValue = defaultTimeRange.raw.to as string;
+
+    expect(getByLabelText(TimePicker.fromField)).toHaveValue(fromValue);
+    expect(getByLabelText(TimePicker.toField)).toHaveValue(toValue);
+  });
+
+  it('should display calendar when clicking the to input field', () => {
+    const { getByLabelText } = setup();
+    const { TimePicker } = selectors.components;
+
+    fireEvent.focus(getByLabelText(TimePicker.toField));
+    expect(getByLabelText(TimePicker.calendar)).toBeInTheDocument();
+  });
+
+  it('should not display calendar without clicking any input field', () => {
+    const { queryByLabelText } = setup();
+    const { TimePicker } = selectors.components;
+
+    expect(queryByLabelText(TimePicker.calendar)).toBeNull();
+  });
+
+  it('should have passed time range selected in calendar', () => {
+    const { getByLabelText, getCalendarDayByLabelText } = setup();
+    const { TimePicker } = selectors.components;
+
+    fireEvent.focus(getByLabelText(TimePicker.toField));
+    const from = getCalendarDayByLabelText('June 17, 2021');
+    const to = getCalendarDayByLabelText('June 19, 2021');
+
+    expect(from).toHaveClass('react-calendar__tile--rangeStart');
+    expect(to).toHaveClass('react-calendar__tile--rangeEnd');
+  });
+
+  it('should select correct time range in calendar when having a custom time zone', () => {
+    const { getByLabelText, getCalendarDayByLabelText } = setup(defaultTimeRange, 'Asia/Tokyo');
+    const { TimePicker } = selectors.components;
+
+    fireEvent.focus(getByLabelText(TimePicker.toField));
+    const from = getCalendarDayByLabelText('June 17, 2021');
+    const to = getCalendarDayByLabelText('June 19, 2021');
+
+    expect(from).toHaveClass('react-calendar__tile--rangeStart');
+    expect(to).toHaveClass('react-calendar__tile--rangeEnd');
   });
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import { getDefaultTimeRange, TimeRange, TimeZone } from '@grafana/data';
+import { TimeRangeForm } from './TimeRangeForm';
+
+function setup(initial: TimeRange = getDefaultTimeRange(), timeZone?: TimeZone): RenderResult {
+  return render(<TimeRangeForm isFullscreen={true} value={initial} onApply={() => {}} timeZone={timeZone} />);
+}
+
+describe('TimeRangeForm', () => {
+  it('renders buttons correcty', () => {
+    const container = setup();
+
+    expect(container.queryByLabelText(/timepicker open button/i)).toBeInTheDocument();
+  });
+});

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.tsx
@@ -117,8 +117,8 @@ export const TimeRangeForm: React.FC<Props> = (props) => {
       <TimePickerCalendar
         isFullscreen={isFullscreen}
         isOpen={isOpen}
-        from={dateTimeParse(from.value, { timeZone })}
-        to={dateTimeParse(to.value, { timeZone })}
+        from={dateTimeParse(from.value)}
+        to={dateTimeParse(to.value)}
         onApply={onApply}
         onClose={() => setOpen(false)}
         onChange={onChange}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7106,6 +7106,11 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
+caniuse-db@1.0.30000772:
+  version "1.0.30000772"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000772.tgz#51aae891768286eade4a3d8319ea76d6a01b512b"
+  integrity sha1-UarokXaChureSj2DGep21qAbUSs=
+
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
   version "1.0.30001205"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz"
@@ -21908,10 +21913,10 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-underscore@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
-  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
+underscore@1.12.1, underscore@1.7.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 unfetch@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7106,11 +7106,6 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-db@1.0.30000772:
-  version "1.0.30000772"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000772.tgz#51aae891768286eade4a3d8319ea76d6a01b512b"
-  integrity sha1-UarokXaChureSj2DGep21qAbUSs=
-
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
   version "1.0.30001205"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz"
@@ -21913,10 +21908,10 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-underscore@1.12.1, underscore@1.7.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+underscore@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems like we, prior, to this change did convert the time two times. So if you had a custom time zone with a high offset the wrong day got selected in the calendar.

Added tests to verify the behavior of this component to prevent this from happening again.

**Which issue(s) this PR fixes**:
Fixes #35290
