### PR TITLE
Alerting: recalculate EndsAt

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -83,13 +83,13 @@ func (st *Manager) setNextState(alertRule *ngModels.AlertRule, result eval.Resul
 	st.Log.Debug("setting alert state", "uid", alertRule.UID)
 	switch result.State {
 	case eval.Normal:
-		currentState = currentState.resultNormal(result)
+		currentState.resultNormal(result)
 	case eval.Alerting:
-		currentState = currentState.resultAlerting(alertRule, result)
+		currentState.resultAlerting(alertRule, result)
 	case eval.Error:
-		currentState = currentState.resultError(alertRule, result)
+		currentState.resultError(alertRule, result)
 	case eval.NoData:
-		currentState = currentState.resultNoData(alertRule, result)
+		currentState.resultNoData(alertRule, result)
 	case eval.Pending: // we do not emit results with this state
 	}
 

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -30,76 +30,54 @@ type Evaluation struct {
 	EvaluationString string
 }
 
-func (a *State) resultNormal(result eval.Result) *State {
+func (a *State) resultNormal(result eval.Result) {
 	if a.State != eval.Normal {
 		a.EndsAt = result.EvaluatedAt
 		a.StartsAt = result.EvaluatedAt
 	}
 	a.Error = result.Error // should be nil since state is not error
 	a.State = eval.Normal
-	return a
 }
 
-func (a *State) resultAlerting(alertRule *ngModels.AlertRule, result eval.Result) *State {
+func (a *State) resultAlerting(alertRule *ngModels.AlertRule, result eval.Result) {
 	switch a.State {
 	case eval.Alerting:
-		if !(alertRule.For > 0) {
-			// If there is not For set, we will set EndsAt to be twice the evaluation interval
-			// to avoid flapping with every evaluation
-			a.EndsAt = result.EvaluatedAt.Add(time.Duration(alertRule.IntervalSeconds*2) * time.Second)
-			return a
-		}
-		a.EndsAt = result.EvaluatedAt.Add(alertRule.For)
+		a.setEndsAt(alertRule, result)
 	case eval.Pending:
 		if result.EvaluatedAt.Sub(a.StartsAt) > alertRule.For {
 			a.State = eval.Alerting
 			a.StartsAt = result.EvaluatedAt
-			a.EndsAt = result.EvaluatedAt.Add(alertRule.For)
+			a.setEndsAt(alertRule, result)
 		}
 	default:
 		a.StartsAt = result.EvaluatedAt
+		a.setEndsAt(alertRule, result)
 		if !(alertRule.For > 0) {
-			a.EndsAt = result.EvaluatedAt.Add(time.Duration(alertRule.IntervalSeconds*2) * time.Second)
+			// If For is 0, immediately set Alerting
 			a.State = eval.Alerting
 		} else {
-			a.EndsAt = result.EvaluatedAt.Add(alertRule.For)
-			if result.EvaluatedAt.Sub(a.StartsAt) > alertRule.For {
-				a.State = eval.Alerting
-			} else {
-				a.State = eval.Pending
-			}
+			a.State = eval.Pending
 		}
 	}
-	return a
 }
 
-func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) *State {
+func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 	a.Error = result.Error
 	if a.StartsAt.IsZero() {
 		a.StartsAt = result.EvaluatedAt
 	}
-	if !(alertRule.For > 0) {
-		a.EndsAt = result.EvaluatedAt.Add(time.Duration(alertRule.IntervalSeconds*2) * time.Second)
-	} else {
-		a.EndsAt = result.EvaluatedAt.Add(alertRule.For)
-	}
+	a.setEndsAt(alertRule, result)
 
-	switch alertRule.ExecErrState {
-	case ngModels.AlertingErrState:
+	if alertRule.ExecErrState == ngModels.AlertingErrState {
 		a.State = eval.Alerting
 	}
-	return a
 }
 
-func (a *State) resultNoData(alertRule *ngModels.AlertRule, result eval.Result) *State {
+func (a *State) resultNoData(alertRule *ngModels.AlertRule, result eval.Result) {
 	if a.StartsAt.IsZero() {
 		a.StartsAt = result.EvaluatedAt
 	}
-	if !(alertRule.For > 0) {
-		a.EndsAt = result.EvaluatedAt.Add(time.Duration(alertRule.IntervalSeconds*2) * time.Second)
-	} else {
-		a.EndsAt = result.EvaluatedAt.Add(alertRule.For)
-	}
+	a.setEndsAt(alertRule, result)
 
 	switch alertRule.NoDataState {
 	case ngModels.Alerting:
@@ -109,7 +87,6 @@ func (a *State) resultNoData(alertRule *ngModels.AlertRule, result eval.Result) 
 	case ngModels.OK:
 		a.State = eval.Normal
 	}
-	return a
 }
 
 func (a *State) NeedsSending(resendDelay time.Duration) bool {
@@ -146,4 +123,14 @@ func (a *State) TrimResults(alertRule *ngModels.AlertRule) {
 	newResults := make([]Evaluation, numBuckets)
 	copy(newResults, a.Results[len(a.Results)-int(numBuckets):])
 	a.Results = newResults
+}
+
+func (a *State) setEndsAt(alertRule *ngModels.AlertRule, result eval.Result) {
+	if int64(alertRule.For.Seconds()) > alertRule.IntervalSeconds {
+		// For is set and longer than IntervalSeconds
+		a.EndsAt = result.EvaluatedAt.Add(alertRule.For)
+	} else {
+		// For is not set or is less than or equal to IntervalSeconds
+		a.EndsAt = result.EvaluatedAt.Add(time.Duration(alertRule.IntervalSeconds*2) * time.Second)
+	}
 }

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -86,7 +86,7 @@ func TestSetEndsAt(t *testing.T) {
 		testResult eval.Result
 	}{
 		{
-			name:      "For: unset Interval: 10s",
+			name:      "For: unset Interval: 10s EndsAt should be evaluation time + 2X IntervalSeconds",
 			expected:  evaluationTime.Add(20 * time.Second),
 			testState: &State{},
 			testRule: &ngmodels.AlertRule{
@@ -97,19 +97,7 @@ func TestSetEndsAt(t *testing.T) {
 			},
 		},
 		{
-			name:      "For: 0s Interval: 10s",
-			expected:  evaluationTime.Add(20 * time.Second),
-			testState: &State{},
-			testRule: &ngmodels.AlertRule{
-				For:             0 * time.Second,
-				IntervalSeconds: 10,
-			},
-			testResult: eval.Result{
-				EvaluatedAt: evaluationTime,
-			},
-		},
-		{
-			name:      "For: 1s Interval: 10s",
+			name:      "For: 0s Interval: 10s EndsAt should be evaluation time + 2X IntervalSeconds",
 			expected:  evaluationTime.Add(20 * time.Second),
 			testState: &State{},
 			testRule: &ngmodels.AlertRule{
@@ -121,7 +109,19 @@ func TestSetEndsAt(t *testing.T) {
 			},
 		},
 		{
-			name:      "For: 10s Interval: 10s",
+			name:      "For: 1s Interval: 10s EndsAt should be evaluation time + 2X IntervalSeconds",
+			expected:  evaluationTime.Add(20 * time.Second),
+			testState: &State{},
+			testRule: &ngmodels.AlertRule{
+				For:             0 * time.Second,
+				IntervalSeconds: 10,
+			},
+			testResult: eval.Result{
+				EvaluatedAt: evaluationTime,
+			},
+		},
+		{
+			name:      "For: 10s Interval: 10s EndsAt should be evaluation time + 2X IntervalSeconds",
 			expected:  evaluationTime.Add(20 * time.Second),
 			testState: &State{},
 			testRule: &ngmodels.AlertRule{
@@ -133,7 +133,7 @@ func TestSetEndsAt(t *testing.T) {
 			},
 		},
 		{
-			name:      "For: 11s Interval: 10s",
+			name:      "For: 11s Interval: 10s EndsAt should be evaluation time + For duration",
 			expected:  evaluationTime.Add(11 * time.Second),
 			testState: &State{},
 			testRule: &ngmodels.AlertRule{
@@ -145,7 +145,7 @@ func TestSetEndsAt(t *testing.T) {
 			},
 		},
 		{
-			name:      "For: 20s Interval: 10s",
+			name:      "For: 20s Interval: 10s EndsAt should be evaluation time + For duration",
 			expected:  evaluationTime.Add(20 * time.Second),
 			testState: &State{},
 			testRule: &ngmodels.AlertRule{

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -109,6 +109,18 @@ func TestSetEndsAt(t *testing.T) {
 			},
 		},
 		{
+			name:      "For: 1s Interval: 10s",
+			expected:  evaluationTime.Add(20 * time.Second),
+			testState: &State{},
+			testRule: &ngmodels.AlertRule{
+				For:             0 * time.Second,
+				IntervalSeconds: 10,
+			},
+			testResult: eval.Result{
+				EvaluatedAt: evaluationTime,
+			},
+		},
+		{
 			name:      "For: 10s Interval: 10s",
 			expected:  evaluationTime.Add(20 * time.Second),
 			testState: &State{},

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 
 	"github.com/stretchr/testify/assert"
@@ -70,6 +72,84 @@ func TestNeedsSending(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.testState.NeedsSending(tc.resendDelay))
+		})
+	}
+}
+
+func TestSetEndsAt(t *testing.T) {
+	evaluationTime, _ := time.Parse("2006-01-02", "2021-03-25")
+	testCases := []struct {
+		name       string
+		expected   time.Time
+		testState  *State
+		testRule   *ngmodels.AlertRule
+		testResult eval.Result
+	}{
+		{
+			name:      "For: unset Interval: 10s",
+			expected:  evaluationTime.Add(20 * time.Second),
+			testState: &State{},
+			testRule: &ngmodels.AlertRule{
+				IntervalSeconds: 10,
+			},
+			testResult: eval.Result{
+				EvaluatedAt: evaluationTime,
+			},
+		},
+		{
+			name:      "For: 0s Interval: 10s",
+			expected:  evaluationTime.Add(20 * time.Second),
+			testState: &State{},
+			testRule: &ngmodels.AlertRule{
+				For:             0 * time.Second,
+				IntervalSeconds: 10,
+			},
+			testResult: eval.Result{
+				EvaluatedAt: evaluationTime,
+			},
+		},
+		{
+			name:      "For: 10s Interval: 10s",
+			expected:  evaluationTime.Add(20 * time.Second),
+			testState: &State{},
+			testRule: &ngmodels.AlertRule{
+				For:             10 * time.Second,
+				IntervalSeconds: 10,
+			},
+			testResult: eval.Result{
+				EvaluatedAt: evaluationTime,
+			},
+		},
+		{
+			name:      "For: 11s Interval: 10s",
+			expected:  evaluationTime.Add(11 * time.Second),
+			testState: &State{},
+			testRule: &ngmodels.AlertRule{
+				For:             11 * time.Second,
+				IntervalSeconds: 10,
+			},
+			testResult: eval.Result{
+				EvaluatedAt: evaluationTime,
+			},
+		},
+		{
+			name:      "For: 20s Interval: 10s",
+			expected:  evaluationTime.Add(20 * time.Second),
+			testState: &State{},
+			testRule: &ngmodels.AlertRule{
+				For:             20 * time.Second,
+				IntervalSeconds: 10,
+			},
+			testResult: eval.Result{
+				EvaluatedAt: evaluationTime,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.testState.setEndsAt(tc.testRule, tc.testResult)
+			assert.Equal(t, tc.expected, tc.testState.EndsAt)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the calculation of EndsAt to account for conditions that have a For duration that is shorter than IntervalSeconds. 

Added unit tests for new method to set EndsAt correctly

**Which issue(s) this PR fixes**:
Fixes #35539

**Special notes for your reviewer**:
Verified the issues and tested the fix with a Discord notifier running for approximately one hour. The flapping reported was not noticed in that time period. 