### PR TITLE
PanelEdit: Display the VisualizationPicker that was not displayed if a panel has an unknown panel plugin

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setPanelEditorUIState, toggleVizPicker } from './state/reducers';
 import { selectors } from '@grafana/e2e-selectors';
 import { PanelModel } from '../../state';
+import { getPanelPluginWithFallback } from '../../state/selectors';
 
 type Props = {
   panel: PanelModel;
@@ -15,7 +16,7 @@ type Props = {
 export const VisualizationButton: FC<Props> = ({ panel }) => {
   const styles = useStyles(getStyles);
   const dispatch = useDispatch();
-  const plugin = useSelector((state: StoreState) => state.plugins.panels[panel.type]);
+  const plugin = useSelector((state: StoreState) => getPanelPluginWithFallback(state, panel.type));
   const isPanelOptionsVisible = useSelector((state: StoreState) => state.panelEditor.ui.isPanelOptionsVisible);
   const isVizPickerOpen = useSelector((state: StoreState) => state.panelEditor.isVizPickerOpen);
 

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const VisualizationButton: FC<Props> = ({ panel }) => {
   const styles = useStyles(getStyles);
   const dispatch = useDispatch();
-  const plugin = useSelector((state: StoreState) => getPanelPluginWithFallback(state, panel.type));
+  const plugin = useSelector(getPanelPluginWithFallback(panel.type));
   const isPanelOptionsVisible = useSelector((state: StoreState) => state.panelEditor.ui.isPanelOptionsVisible);
   const isVizPickerOpen = useSelector((state: StoreState) => state.panelEditor.isVizPickerOpen);
 

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx
@@ -1,45 +1,30 @@
 import React, { FC } from 'react';
 import { css } from '@emotion/css';
-import { GrafanaTheme, PanelPlugin } from '@grafana/data';
+import { GrafanaTheme } from '@grafana/data';
 import { ToolbarButton, ButtonGroup, useStyles } from '@grafana/ui';
 import { StoreState } from 'app/types';
-import { connect, MapStateToProps, MapDispatchToProps } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { setPanelEditorUIState, toggleVizPicker } from './state/reducers';
 import { selectors } from '@grafana/e2e-selectors';
 import { PanelModel } from '../../state';
 
-interface OwnProps {
+type Props = {
   panel: PanelModel;
-}
+};
 
-interface ConnectedProps {
-  plugin?: PanelPlugin;
-  isVizPickerOpen: boolean;
-  isPanelOptionsVisible: boolean;
-}
-
-interface DispatchProps {
-  toggleVizPicker: typeof toggleVizPicker;
-  setPanelEditorUIState: typeof setPanelEditorUIState;
-}
-
-type Props = OwnProps & ConnectedProps & DispatchProps;
-
-export const VisualizationButtonUnconnected: FC<Props> = ({
-  plugin,
-  toggleVizPicker,
-  isPanelOptionsVisible,
-  isVizPickerOpen,
-  setPanelEditorUIState,
-}) => {
+export const VisualizationButton: FC<Props> = ({ panel }) => {
   const styles = useStyles(getStyles);
+  const dispatch = useDispatch();
+  const plugin = useSelector((state: StoreState) => state.plugins.panels[panel.type]);
+  const isPanelOptionsVisible = useSelector((state: StoreState) => state.panelEditor.ui.isPanelOptionsVisible);
+  const isVizPickerOpen = useSelector((state: StoreState) => state.panelEditor.isVizPickerOpen);
 
   const onToggleOpen = () => {
-    toggleVizPicker(!isVizPickerOpen);
+    dispatch(toggleVizPicker(!isVizPickerOpen));
   };
 
   const onToggleOptionsPane = () => {
-    setPanelEditorUIState({ isPanelOptionsVisible: !isPanelOptionsVisible });
+    dispatch(setPanelEditorUIState({ isPanelOptionsVisible: !isPanelOptionsVisible }));
   };
 
   if (!plugin) {
@@ -71,7 +56,7 @@ export const VisualizationButtonUnconnected: FC<Props> = ({
   );
 };
 
-VisualizationButtonUnconnected.displayName = 'VisualizationTabUnconnected';
+VisualizationButton.displayName = 'VisualizationTab';
 
 const getStyles = (theme: GrafanaTheme) => {
   return {
@@ -84,20 +69,3 @@ const getStyles = (theme: GrafanaTheme) => {
     `,
   };
 };
-
-const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = (state, props) => {
-  return {
-    plugin: state.plugins.panels[props.panel.type],
-    isPanelOptionsVisible: state.panelEditor.ui.isPanelOptionsVisible,
-    isVizPickerOpen: state.panelEditor.isVizPickerOpen,
-  };
-};
-
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> = {
-  toggleVizPicker,
-  setPanelEditorUIState,
-};
-
-export const VisualizationButton = connect(mapStateToProps, mapDispatchToProps, undefined, { forwardRef: true })(
-  VisualizationButtonUnconnected
-);

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/css';
 import { GrafanaTheme, PanelPluginMeta, SelectableValue } from '@grafana/data';
 import { Button, CustomScrollbar, Icon, Input, RadioButtonGroup, useStyles } from '@grafana/ui';
 import { changePanelPlugin } from '../../state/actions';
-import { StoreState } from 'app/types';
 import { PanelModel } from '../../state/PanelModel';
 import { useDispatch, useSelector } from 'react-redux';
 import { filterPluginList, getAllPanelPluginMeta, VizTypePicker } from '../VizTypePicker/VizTypePicker';
@@ -18,7 +17,7 @@ interface Props {
 }
 
 export const VisualizationSelectPane: FC<Props> = ({ panel }) => {
-  const plugin = useSelector((state: StoreState) => getPanelPluginWithFallback(state, panel.type));
+  const plugin = useSelector(getPanelPluginWithFallback(panel.type));
   const [searchQuery, setSearchQuery] = useState('');
   const [listMode, setListMode] = useState(ListMode.Visualizations);
   const dispatch = useDispatch();

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
@@ -11,13 +11,14 @@ import { Field } from '@grafana/ui/src/components/Forms/Field';
 import { PanelLibraryOptionsGroup } from 'app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup';
 import { toggleVizPicker } from './state/reducers';
 import { selectors } from '@grafana/e2e-selectors';
+import { getPanelPluginWithFallback } from '../../state/selectors';
 
 interface Props {
   panel: PanelModel;
 }
 
 export const VisualizationSelectPane: FC<Props> = ({ panel }) => {
-  const plugin = useSelector((state: StoreState) => state.plugins.panels[panel.type]);
+  const plugin = useSelector((state: StoreState) => getPanelPluginWithFallback(state, panel.type));
   const [searchQuery, setSearchQuery] = useState('');
   const [listMode, setListMode] = useState(ListMode.Visualizations);
   const dispatch = useDispatch();

--- a/public/app/features/dashboard/dashgrid/PanelPluginError.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelPluginError.tsx
@@ -74,7 +74,7 @@ export function getPanelPluginNotFound(id: string, silent?: boolean): PanelPlugi
       links: [],
       logos: {
         large: '',
-        small: '',
+        small: 'public/img/grafana_icon.svg',
       },
       screenshots: [],
       updated: '',

--- a/public/app/features/dashboard/state/selectors.ts
+++ b/public/app/features/dashboard/state/selectors.ts
@@ -1,4 +1,6 @@
-import { DashboardState, PanelState } from 'app/types';
+import { DashboardState, PanelState, StoreState } from 'app/types';
+import { PanelPlugin } from '@grafana/data';
+import { getPanelPluginNotFound } from '../dashgrid/PanelPluginError';
 
 export function getPanelStateById(state: DashboardState, panelId: number): PanelState {
   if (!panelId) {
@@ -6,4 +8,10 @@ export function getPanelStateById(state: DashboardState, panelId: number): Panel
   }
 
   return state.panels[panelId] ?? ({} as PanelState);
+}
+
+export function getPanelPluginWithFallback(state: StoreState, panelType: string): PanelPlugin {
+  const plugin = state.plugins.panels[panelType];
+
+  return plugin || getPanelPluginNotFound(`Panel plugin not found (${panelType})`, true);
 }

--- a/public/app/features/dashboard/state/selectors.ts
+++ b/public/app/features/dashboard/state/selectors.ts
@@ -10,8 +10,7 @@ export function getPanelStateById(state: DashboardState, panelId: number): Panel
   return state.panels[panelId] ?? ({} as PanelState);
 }
 
-export function getPanelPluginWithFallback(state: StoreState, panelType: string): PanelPlugin {
+export const getPanelPluginWithFallback = (panelType: string) => (state: StoreState): PanelPlugin => {
   const plugin = state.plugins.panels[panelType];
-
   return plugin || getPanelPluginNotFound(`Panel plugin not found (${panelType})`, true);
-}
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
If you have a panel with a plugin that is no longer available the VisualisationPicker won't render a button which makes it rather tricky to change the panel visualisation. This PR addresses this by returning an "unknown" plugin to the visualisation picker so the picker appears.


https://user-images.githubusercontent.com/73201/122248269-4321c600-cec8-11eb-9c98-9597cd800721.mp4

https://user-images.githubusercontent.com/73201/122248301-474de380-cec8-11eb-99bc-cc649c7f0410.mp4



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35733

**Special notes for your reviewer**:
This PR also refactors the `<VisualisationButton />` component to use redux hooks over `map<State|Dispatch>ToConnect`.
