### PR TITLE
AzureMonitor: Fix KQL template variable queries without default workspace

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -285,7 +285,7 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
     const querystring = querystringBuilder.generate().uriString;
     const url = isGUIDish(workspace)
       ? `${this.baseUrl}/v1/workspaces/${workspace}/query?${querystring}`
-      : `${this.baseUrl}/v1/${workspace}/query?${querystring}`;
+      : `${this.baseUrl}/v1${workspace}/query?${querystring}`;
 
     const queries = [
       {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes KQL template variable queries not working when a default workspace wasn't defined in the data source config

**Which issue(s) this PR fixes**:

Fixes #35590 