### PR TITLE
GraphNG: more precise axis auto-sizing

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -23,6 +23,8 @@ export interface AxisProps {
   timeZone?: TimeZone;
 }
 
+const fontSize = 12;
+
 export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
   merge(props: AxisProps) {
     this.props.size = optMinMax('max', this.props.size, props.size);
@@ -51,7 +53,7 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       theme,
     } = this.props;
 
-    const font = `12px ${theme.typography.fontFamily}`;
+    const font = `${fontSize}px ${theme.typography.fontFamily}`;
 
     const gridColor = theme.isDark ? 'rgba(240, 250, 255, 0.09)' : 'rgba(0, 10, 23, 0.09)';
 
@@ -120,7 +122,7 @@ function calculateSpace(self: uPlot, axisIdx: number, scaleMin: number, scaleMax
     const maxTicks = plotDim / defaultSpacing;
     const increment = (scaleMax - scaleMin) / maxTicks;
     const sample = formatTime(self, [scaleMin], axisIdx, defaultSpacing, increment);
-    const width = measureText(sample[0], 12).width + 18;
+    const width = measureText(sample[0], fontSize).width + 18;
     return width;
   }
 
@@ -130,22 +132,17 @@ function calculateSpace(self: uPlot, axisIdx: number, scaleMin: number, scaleMax
 /** height of x axis or width of y axis in CSS pixels alloted for values, gap & ticks, but excluding axis label */
 function calculateAxisSize(self: uPlot, values: string[], axisIdx: number) {
   const axis = self.axes[axisIdx];
+
+  let axisSize = axis.ticks!.size!;
+
   if (axis.side === 2) {
-    return 33;
+    axisSize += axis!.gap! + fontSize;
+  } else if (values?.length) {
+    let longestValue = values.reduce((acc, value) => (value.length > acc.length ? value : acc), '');
+    axisSize += axis!.gap! + measureText(longestValue, fontSize).width;
   }
 
-  if (values === null || !values.length) {
-    return 0;
-  }
-
-  let maxLength = values[0];
-  for (let i = 0; i < values.length; i++) {
-    if (values[i].length > maxLength.length) {
-      maxLength = values[i];
-    }
-  }
-
-  return measureText(maxLength, 12).width + 18;
+  return Math.ceil(axisSize);
 }
 
 const timeUnitSize = {


### PR DESCRIPTION
this is a follow-up to the tick size reduction PR: https://github.com/grafana/grafana/pull/35632 and the result of a recent discussion in https://github.com/leeoniya/uPlot/issues/532 about the proper way to accurately compute axis size.

as the comment above the function states, the axis size must include the tick size and the axis gap. previously there were some magical fudge factors to bump things into place.

this PR drops the additional outer axis margin that was caused by the arbitrary constants. we can do one of two things prior to merging:

1. add them back explicitly to match what existed before
2. keep the exact size for the plot and move the responsibility of adding margins (or padding) to CSS. in the wrapper or VizLayout

option 2 makes more sense to me, but will wait for feedback. if we move the margins out of the canvas, then we'll have a few thousand pixels fewer to clearRect() per panel so that's a tiny win there :D

before:

![image](https://user-images.githubusercontent.com/43234/122301881-ef62ad00-cec6-11eb-9a3f-29215e7b47b3.png)

after:

![image](https://user-images.githubusercontent.com/43234/122301902-f8ec1500-cec6-11eb-842d-a2b5d4e0f85c.png)