### PR TITLE
GraphNG: uPlot 1.6.13

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -72,7 +72,7 @@
     "react-transition-group": "4.4.1",
     "slate": "0.47.8",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.12"
+    "uplot": "1.6.13"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "16.0.0",

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -64,7 +64,7 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
     const rangeFn = (u: uPlot, dataMin: number, dataMax: number, scaleKey: string) => {
       const scale = u.scales[scaleKey];
 
-      let minMax = [dataMin, dataMax];
+      let minMax: uPlot.Range.MinMax = [dataMin, dataMax];
 
       if (scale.distr === 1 || scale.distr === 2) {
         // @ts-ignore here we may use hardMin / hardMax to make sure any extra padding is computed from a more accurate delta

--- a/public/test/jest-setup.ts
+++ b/public/test/jest-setup.ts
@@ -6,6 +6,21 @@ import 'mutationobserver-shim';
 const global = window as any;
 global.$ = global.jQuery = $;
 
+// https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty(global, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
 import '../vendor/flot/jquery.flot';
 import '../vendor/flot/jquery.flot.time';
 import angular from 'angular';

--- a/yarn.lock
+++ b/yarn.lock
@@ -22152,10 +22152,10 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-uplot@1.6.12:
-  version "1.6.12"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.12.tgz#a2741f224c3d3b4f4f25a53797c1687ddfef2989"
-  integrity sha512-afBjwy/9SM0E7w29Gen+wQ+UAe6ipiA2zE/s1dMCidMXQYvYkCpEgxLRkVA179/8eRJz+og2r7ZFS1HIzT75fQ==
+uplot@1.6.13:
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.13.tgz#21608f484792a837e7ff4610428881c1e2f2387f"
+  integrity sha512-O5NHrZwetCUMUrYMN2/OG6v0poPXtlb68XBCERHqvvePFJvFPIuJI/SxdyZOygKzh0pAjMTX0xz3S0msAsPX0w==
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/35301

^^ the old graph panel actually handled this, so it's a parity/regression/accessbility fix

two additional features relevant for us:

- the addition of `cursor.idxs` that allows us to support multi-hover in the tooltip for misaligned datapoints without having to repeat the left/right scanning logic. this will let us better iterate on resolving https://github.com/grafana/grafana/pull/34552 and related issues. it also opens up a path to a multi-hover tooltip in the State timeline panel as well as future uPlot-based panels.
- addition of `series.points.filter()` for custom per-point show/hide logic, which is necessary to do cheap assertions of rendered ranges without gaps and address https://github.com/grafana/grafana/issues/35426

release notes: https://github.com/leeoniya/uPlot/releases/tag/1.6.13

aside: what's interesting (to me) is that Flot does not support this natively. try browser-zooming https://www.flotcharts.org/flot/examples/series-types/index.html and everything but the svg axes becomes blurry. i think the only reason it ever worked was because the old graph panel fully re-initializes the Flot instance on all resize callbacks fired by grafana.