### PR TITLE
Alerting: Fix alert permissions migration

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/permissions.go
+++ b/pkg/services/sqlstore/migrations/ualert/permissions.go
@@ -109,6 +109,8 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*models.Dashb
 			return models.ErrDashboardAclInfoMissing
 		}
 
+		// unset Id so that the new record will get a different one
+		item.Id = 0
 		item.OrgID = orgID
 		item.DashboardID = dashboardID
 		item.Created = time.Now()
@@ -136,6 +138,7 @@ func (m *migration) getACL(orgID, dashboardID int64) ([]*models.DashboardAcl, er
 	rawSQL := `
 			-- get distinct permissions for the dashboard and its parent folder
 			SELECT DISTINCT
+				da.id,
 				da.user_id,
 				da.team_id,
 				da.permission,

--- a/pkg/services/sqlstore/migrations/ualert/permissions.go
+++ b/pkg/services/sqlstore/migrations/ualert/permissions.go
@@ -11,6 +11,35 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 )
 
+type roleType string
+
+const (
+	ROLE_VIEWER roleType = "Viewer"
+	ROLE_EDITOR roleType = "Editor"
+	ROLE_ADMIN  roleType = "Admin"
+)
+
+func (r roleType) IsValid() bool {
+	return r == ROLE_VIEWER || r == ROLE_ADMIN || r == ROLE_EDITOR
+}
+
+type permissionType int
+
+type dashboardAcl struct {
+	// nolint:stylecheck
+	Id          int64
+	OrgID       int64 `xorm:"org_id"`
+	DashboardID int64 `xorm:"dashboard_id"`
+
+	UserID     int64     `xorm:"user_id"`
+	TeamID     int64     `xorm:"team_id"`
+	Role       *roleType // pointer to be nullable
+	Permission permissionType
+
+	Created time.Time
+	Updated time.Time
+}
+
 // getOrCreateGeneralFolder returns the general folder under the specific organisation
 // If the general folder does not exist it creates it.
 func (m *migration) getOrCreateGeneralFolder(orgID int64) (*dashboard, error) {
@@ -100,7 +129,7 @@ func (m *migration) generateNewDashboardUid(orgId int64) (string, error) {
 
 // based on SQLStore.UpdateDashboardACL()
 // it should be called from inside a transaction
-func (m *migration) setACL(orgID int64, dashboardID int64, items []*models.DashboardAcl) error {
+func (m *migration) setACL(orgID int64, dashboardID int64, items []*dashboardAcl) error {
 	if dashboardID <= 0 {
 		return fmt.Errorf("folder id must be greater than zero for a folder permission")
 	}
@@ -129,12 +158,12 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*models.Dashb
 }
 
 // based on SQLStore.GetDashboardAclInfoList()
-func (m *migration) getACL(orgID, dashboardID int64) ([]*models.DashboardAcl, error) {
+func (m *migration) getACL(orgID, dashboardID int64) ([]*dashboardAcl, error) {
 	var err error
 
 	falseStr := m.mg.Dialect.BooleanStr(false)
 
-	result := make([]*models.DashboardAcl, 0)
+	result := make([]*dashboardAcl, 0)
 	rawSQL := `
 			-- get distinct permissions for the dashboard and its parent folder
 			SELECT DISTINCT


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Migrating alert permissions used to fail in MySQL >= 5.7 and PostgreSQL because order by column is not in select list.
I have also noticed that I used the [imported model](https://github.com/grafana/grafana/blob/4cdcb3103a085d19e5d022f93c4df7c0b92eb6bf/pkg/models/dashboard_acl.go#L35) for getting/setting permissions and I changed it also to use another struct so that any future modifications in model (models.DashboardAcl) won't affect the migration.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
For reproducing the issue one has to try to migrate an alert under a dashboard with permissions (using MySQL >= 5.7 or PostgreSQL)