### PR TITLE
Explore: props automatically inferred from mapStateToProps and mapDispatchToProps

### DIFF
--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -23,11 +23,6 @@ const dummyProps: Props = {
   exploreId: ExploreId.left,
   loading: false,
   modifyQueries: jest.fn(),
-  scanning: false,
-  scanRange: {
-    from: '0',
-    to: '0',
-  },
   scanStart: jest.fn(),
   scanStopAction: scanStopAction,
   setQueries: jest.fn(),
@@ -41,7 +36,6 @@ const dummyProps: Props = {
     to: 0,
   },
   timeZone: 'UTC',
-  onHiddenSeriesChanged: jest.fn(),
   queryResponse: {
     state: LoadingState.NotStarted,
     series: [],
@@ -74,7 +68,6 @@ const dummyProps: Props = {
       },
     },
   },
-  originPanelId: 1,
   addQueryRow: jest.fn(),
   theme: getTheme(),
   showMetrics: true,

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { DataSourceApi, LoadingState, toUtc, DataQueryError, DataQueryRequest, CoreApp } from '@grafana/data';
 import { ExploreId } from 'app/types/explore';
 import { shallow } from 'enzyme';
-import { Explore, ExploreProps } from './Explore';
+import { Explore, Props } from './Explore';
 import { scanStopAction } from './state/query';
 import { SecondaryActions } from './SecondaryActions';
 import { getTheme } from '@grafana/ui';
 
-const dummyProps: ExploreProps = {
+const dummyProps: Props = {
   changeSize: jest.fn(),
   datasourceInstance: {
     meta: {

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -8,6 +8,7 @@ import { SecondaryActions } from './SecondaryActions';
 import { getTheme } from '@grafana/ui';
 
 const dummyProps: Props = {
+  logsResult: undefined,
   changeSize: jest.fn(),
   datasourceInstance: {
     meta: {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -61,10 +61,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
 
 export interface ExploreProps {
   exploreId: ExploreId;
-  scanning?: boolean;
-  scanRange?: RawTimeRange;
-  onHiddenSeriesChanged?: (hiddenSeries: string[]) => void;
-  originPanelId: number;
   theme: GrafanaTheme;
 }
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { hot } from 'react-hot-loader';
 import { css, cx } from '@emotion/css';
 import { compose } from 'redux';
-import { connect } from 'react-redux';
+import { connect, ConnectedProps } from 'react-redux';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import memoizeOne from 'memoize-one';
 import { selectors } from '@grafana/e2e-selectors';
@@ -71,20 +71,14 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
 });
 
 export interface ExploreProps {
-  changeSize: typeof changeSize;
   datasourceInstance: DataSourceApi | null;
   datasourceMissing: boolean;
   exploreId: ExploreId;
-  modifyQueries: typeof modifyQueries;
   scanning?: boolean;
   scanRange?: RawTimeRange;
-  scanStart: typeof scanStart;
-  scanStopAction: typeof scanStopAction;
-  setQueries: typeof setQueries;
   queryKeys: string[];
   isLive: boolean;
   syncedTimes: boolean;
-  updateTimeRange: typeof updateTimeRange;
   graphResult: DataFrame[] | null;
   logsResult?: LogsModel;
   absoluteRange: AbsoluteTimeRange;
@@ -92,7 +86,6 @@ export interface ExploreProps {
   onHiddenSeriesChanged?: (hiddenSeries: string[]) => void;
   queryResponse: PanelData;
   originPanelId: number;
-  addQueryRow: typeof addQueryRow;
   theme: GrafanaTheme;
   loading: boolean;
   showMetrics: boolean;
@@ -100,7 +93,6 @@ export interface ExploreProps {
   showLogs: boolean;
   showTrace: boolean;
   showNodeGraph: boolean;
-  splitOpen: typeof splitOpen;
 }
 
 enum ExploreDrawer {
@@ -111,6 +103,8 @@ enum ExploreDrawer {
 interface ExploreState {
   openDrawer?: ExploreDrawer;
 }
+
+export type Props = ExploreProps & ConnectedProps<typeof connector>;
 
 /**
  * Explore provides an area for quick query iteration for a given datasource.
@@ -136,8 +130,8 @@ interface ExploreState {
  * The result viewers determine some of the query options sent to the datasource, e.g.,
  * `format`, to indicate eventual transformations by the datasources' result transformers.
  */
-export class Explore extends React.PureComponent<ExploreProps, ExploreState> {
-  constructor(props: ExploreProps) {
+export class Explore extends React.PureComponent<Props, ExploreState> {
+  constructor(props: Props) {
     super(props);
     this.state = {
       openDrawer: undefined,
@@ -433,7 +427,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partia
   };
 }
 
-const mapDispatchToProps: Partial<ExploreProps> = {
+const mapDispatchToProps = {
   changeSize,
   modifyQueries,
   scanStart,
@@ -444,8 +438,6 @@ const mapDispatchToProps: Partial<ExploreProps> = {
   splitOpen,
 };
 
-export default compose(
-  hot(module),
-  connect(mapStateToProps, mapDispatchToProps),
-  withTheme
-)(Explore) as React.ComponentType<{ exploreId: ExploreId }>;
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+export default compose(hot(module), connector, withTheme)(Explore) as React.ComponentType<{ exploreId: ExploreId }>;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -71,28 +71,12 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
 });
 
 export interface ExploreProps {
-  datasourceInstance: DataSourceApi | null;
-  datasourceMissing: boolean;
   exploreId: ExploreId;
   scanning?: boolean;
   scanRange?: RawTimeRange;
-  queryKeys: string[];
-  isLive: boolean;
-  syncedTimes: boolean;
-  graphResult: DataFrame[] | null;
-  logsResult?: LogsModel;
-  absoluteRange: AbsoluteTimeRange;
-  timeZone: TimeZone;
   onHiddenSeriesChanged?: (hiddenSeries: string[]) => void;
-  queryResponse: PanelData;
   originPanelId: number;
   theme: GrafanaTheme;
-  loading: boolean;
-  showMetrics: boolean;
-  showTable: boolean;
-  showLogs: boolean;
-  showTrace: boolean;
-  showNodeGraph: boolean;
 }
 
 enum ExploreDrawer {
@@ -385,7 +369,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   }
 }
 
-function mapStateToProps(state: StoreState, { exploreId }: ExploreProps): Partial<ExploreProps> {
+function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
   const explore = state.explore;
   const { syncedTimes } = explore;
   const item: ExploreItemState = explore[exploreId]!;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -14,18 +14,7 @@ import {
   Collapse,
   TooltipDisplayMode,
 } from '@grafana/ui';
-import {
-  AbsoluteTimeRange,
-  DataQuery,
-  DataSourceApi,
-  GrafanaTheme,
-  LoadingState,
-  PanelData,
-  RawTimeRange,
-  TimeZone,
-  LogsModel,
-  DataFrame,
-} from '@grafana/data';
+import { AbsoluteTimeRange, DataQuery, GrafanaTheme, LoadingState, RawTimeRange, DataFrame } from '@grafana/data';
 
 import LogsContainer from './LogsContainer';
 import QueryRows from './QueryRows';

--- a/public/app/features/explore/ExploreGraphNGPanel.tsx
+++ b/public/app/features/explore/ExploreGraphNGPanel.tsx
@@ -32,13 +32,13 @@ import { ContextMenuPlugin } from 'app/plugins/panel/timeseries/plugins/ContextM
 import { ExemplarsPlugin } from 'app/plugins/panel/timeseries/plugins/ExemplarsPlugin';
 import { css, cx } from '@emotion/css';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { splitOpen } from './state/main';
 import { getFieldLinksForExplore } from './utils/links';
 import { usePrevious } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import appEvents from 'app/core/app_events';
 import { seriesVisibilityConfigFactory } from '../dashboard/dashgrid/SeriesVisibilityConfigFactory';
 import { identity } from 'lodash';
+import { SplitOpen } from 'app/types/explore';
 
 const MAX_NUMBER_OF_TIME_SERIES = 20;
 
@@ -51,7 +51,7 @@ interface Props {
   onUpdateTimeRange: (absoluteRange: AbsoluteTimeRange) => void;
   onHiddenSeriesChanged?: (hiddenSeries: string[]) => void;
   tooltipDisplayMode: TooltipDisplayMode;
-  splitOpenFn?: typeof splitOpen;
+  splitOpenFn?: SplitOpen;
 }
 
 export function ExploreGraphNGPanel({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds refactoring so that props are now automatically inferred from matchStateToProps and mapDispatchToProps. The props have been split into explicit props `ExploreProps` and implicit props that are mapped to the component from the store.
See: https://github.com/grafana/grafana/blob/main/contribute/style-guides/redux.md#typing-of-connected-props

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35099

**Special notes for your reviewer**:

