### PR TITLE
FieldOverrides: Added support to change display name in an override field and have it be matched by a later rule

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -328,6 +328,33 @@ describe('applyFieldOverrides', () => {
     expect(data.fields[1].config).not.toBe(f0.fields[1].config);
     expect(data.fields[1].config.custom).not.toBe(f0.fields[1].config.custom);
   });
+
+  it('Can modify displayName and have it affect later overrides', () => {
+    const config: FieldConfigSource = {
+      defaults: {},
+      overrides: [
+        {
+          matcher: { id: FieldMatcherID.byName, options: 'value' },
+          properties: [{ id: 'displayName', value: 'Kittens' }],
+        },
+        {
+          matcher: { id: FieldMatcherID.byName, options: 'Kittens' },
+          properties: [{ id: 'displayName', value: 'Kittens improved' }],
+        },
+      ],
+    };
+
+    const data = applyFieldOverrides({
+      data: [f0], // the frame
+      fieldConfig: config,
+      replaceVariables: (str: string) => str,
+      fieldConfigRegistry: customFieldRegistry,
+      theme: createTheme(),
+    })[0];
+
+    expect(data.fields[1].config.displayName).toBe('Kittens improved');
+    expect(getFieldDisplayName(data.fields[1], data)).toBe('Kittens improved');
+  });
 });
 
 describe('setFieldConfigDefaults', () => {

--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -314,7 +314,7 @@ describe('applyFieldOverrides', () => {
     data.fields[1].getLinks!({ valueRowIndex: 0 });
 
     expect(data.fields[1].config.decimals).toEqual(1);
-    expect(replaceVariablesCalls[0].__value.value.text).toEqual('100.0');
+    expect(replaceVariablesCalls[3].__value.value.text).toEqual('100.0');
   });
 
   it('creates a deep clone of field config', () => {

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -116,7 +116,6 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
     };
 
     for (const field of newFrame.fields) {
-      const fieldScopedVars = { ...scopedVars };
       const config = field.config;
 
       field.state!.scopedVars = {
@@ -192,7 +191,13 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
       }
 
       // Attach data links supplier
-      field.getLinks = getLinksSupplier(newFrame, field, fieldScopedVars, context.replaceVariables, options.timeZone);
+      field.getLinks = getLinksSupplier(
+        newFrame,
+        field,
+        field.state!.scopedVars,
+        context.replaceVariables,
+        options.timeZone
+      );
     }
 
     return newFrame;
@@ -269,12 +274,12 @@ export function setFieldConfigDefaults(config: FieldConfig, defaults: FieldConfi
   validateFieldConfig(config);
 }
 
-const processFieldConfigValue = (
+function processFieldConfigValue(
   destination: Record<string, any>, // it's mutable
   source: Record<string, any>,
   fieldConfigProperty: FieldConfigPropertyItem,
   context: FieldOverrideEnv
-) => {
+) {
   const currentConfig = get(destination, fieldConfigProperty.path);
   if (currentConfig === null || currentConfig === undefined) {
     const item = context.fieldConfigRegistry.getIfExists(fieldConfigProperty.id);
@@ -289,7 +294,7 @@ const processFieldConfigValue = (
       }
     }
   }
-};
+}
 
 /**
  * This checks that all options on FieldConfig make sense.  It mutates any value that needs

--- a/packages/grafana-data/src/field/overrides/processors.ts
+++ b/packages/grafana-data/src/field/overrides/processors.ts
@@ -24,6 +24,16 @@ export const numberOverrideProcessor = (
   return parseFloat(value);
 };
 
+export const displayNameOverrideProcessor = (
+  value: any,
+  context: FieldOverrideContext,
+  settings?: StringFieldConfigSettings
+) => {
+  // clear the cached display name
+  delete context.field?.state?.displayName;
+  return stringOverrideProcessor(value, context, settings);
+};
+
 export interface SliderFieldConfigSettings {
   min: number;
   max: number;

--- a/packages/grafana-data/src/utils/tests/mockStandardProperties.ts
+++ b/packages/grafana-data/src/utils/tests/mockStandardProperties.ts
@@ -1,4 +1,4 @@
-import { identityOverrideProcessor } from '../../field';
+import { displayNameOverrideProcessor, identityOverrideProcessor } from '../../field';
 import { ThresholdsMode } from '../../types';
 
 export const mockStandardProperties = () => {
@@ -9,7 +9,7 @@ export const mockStandardProperties = () => {
     description: "Field's display name",
     editor: () => null,
     override: () => null,
-    process: identityOverrideProcessor,
+    process: displayNameOverrideProcessor,
     settings: {
       placeholder: 'none',
       expandTemplateVars: true,

--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -22,6 +22,7 @@ import {
   FieldColor,
   FieldColorConfigSettings,
   StatsPickerConfigSettings,
+  displayNameOverrideProcessor,
 } from '@grafana/data';
 
 import { Switch } from '../components/Switch/Switch';
@@ -55,7 +56,7 @@ export const getStandardFieldConfigs = () => {
     description: 'Change the field or series name',
     editor: standardEditorsRegistry.get('text').editor as any,
     override: standardEditorsRegistry.get('text').editor as any,
-    process: stringOverrideProcessor,
+    process: displayNameOverrideProcessor,
     settings: {
       placeholder: 'none',
       expandTemplateVars: true,

--- a/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
+++ b/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
@@ -31,7 +31,7 @@ export function seriesVisibilityConfigFactory(
 
       return {
         ...fieldConfig,
-        overrides: [override, ...fieldConfig.overrides],
+        overrides: [...fieldConfig.overrides, override],
       };
     }
 
@@ -40,7 +40,7 @@ export function seriesVisibilityConfigFactory(
 
     return {
       ...fieldConfig,
-      overrides: [override, ...fieldConfig.overrides],
+      overrides: [...fieldConfig.overrides, override],
     };
   }
 
@@ -61,7 +61,7 @@ export function seriesVisibilityConfigFactory(
 
     return {
       ...fieldConfig,
-      overrides: [override, ...overridesCopy],
+      overrides: [...overridesCopy, override],
     };
   }
 
@@ -76,7 +76,7 @@ export function seriesVisibilityConfigFactory(
 
   return {
     ...fieldConfig,
-    overrides: [override, ...overridesCopy],
+    overrides: [...overridesCopy, override],
   };
 }
 


### PR DESCRIPTION
Fixes #31364

So this is tricky stuff. But the basic premise is not that complicated. 

* [x] Always add the hide in rule last 
* [x] To support updating display name in override and have it impact later a custom override processor that clears displayName from state was added. 

But the above did not help, as in field override we mix a lot of calls with new and old field and frame so field equality checks where not working in getFieldDisplayName as the frame that was passed had the old copy of the field, and the field being passed was the new field being processed for overrides. So to make equality checks consistent I had to move the field copy out of the field override inner loop and first copy the frame & fields and then process the overrides. This way a call to `getFieldDisplayName(field, frame)`, will always find that field in the frame (using reference identity check). 


