### PR TITLE
A11y: Add focus styles to dashboard toolbar links

### DIFF
--- a/packages/grafana-data/src/utils/location.test.ts
+++ b/packages/grafana-data/src/utils/location.test.ts
@@ -80,4 +80,22 @@ describe('locationUtil', () => {
       expect(urlWithoutMaster).toBe('/subUrl/grafana/');
     });
   });
+
+  describe('updateSearchParams', () => {
+    beforeEach(() => {
+      locationUtil.initialize({
+        config: {} as any,
+        getVariablesUrlParams: (() => {}) as any,
+        getTimeRangeForUrl: (() => {}) as any,
+      });
+    });
+
+    test('absolute url', () => {
+      const newURL = locationUtil.updateSearchParams(
+        'http://www.domain.com:1234/test?a=1&b=2#hashtag',
+        '?a=newValue&newKey=hello'
+      );
+      expect(newURL).toBe('http://www.domain.com:1234/test?a=newValue&b=2&newKey=hello#hashtag');
+    });
+  });
 });

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -42,6 +42,14 @@ const assureBaseUrl = (url: string): string => {
   return url;
 };
 
+const updateSearchParams = (href: string, searchParams: string) => {
+  const curURL = new URL(href);
+  const urlSearchParams = new URLSearchParams(searchParams);
+  urlSearchParams.forEach((val, key) => curURL.searchParams.set(key, val));
+
+  return curURL.href;
+};
+
 interface LocationUtilDependencies {
   config: GrafanaConfig;
   getTimeRangeForUrl: () => RawTimeRange;
@@ -63,6 +71,7 @@ export const locationUtil = {
   },
   stripBaseFromUrl,
   assureBaseUrl,
+  updateSearchParams,
   getTimeRangeUrlParams: () => {
     if (!getTimeRangeUrlParams) {
       return null;

--- a/packages/grafana-ui/src/components/Link/Link.tsx
+++ b/packages/grafana-ui/src/components/Link/Link.tsx
@@ -1,14 +1,27 @@
 import { locationUtil, textUtil } from '@grafana/data';
 import React, { AnchorHTMLAttributes, forwardRef } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 
-export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {}
+export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  partial?: boolean;
+}
+
+function updatePath(loc: ReturnType<typeof useLocation>, newPath: string) {
+  const curParams = new URLSearchParams(loc.search);
+  const newParams = new URLSearchParams(newPath);
+  newParams.forEach((value, key) => {
+    curParams.set(key, value);
+  });
+  return loc.pathname + (curParams ? `?${curParams.toString()}` : '') + (location.hash ? `#${location.hash}` : '');
+}
 
 /**
  * @alpha
  */
-export const Link = forwardRef<HTMLAnchorElement, Props>(({ href, children, ...rest }, ref) => {
-  const validUrl = locationUtil.stripBaseFromUrl(textUtil.sanitizeUrl(href ?? ''));
+export const Link = forwardRef<HTMLAnchorElement, Props>(({ href, children, partial, ...rest }, ref) => {
+  const location = useLocation();
+  let newHref = href && (partial ? updatePath(location, href) : href);
+  const validUrl = locationUtil.stripBaseFromUrl(textUtil.sanitizeUrl(newHref ?? ''));
 
   return (
     <RouterLink ref={ref as React.Ref<HTMLAnchorElement>} to={validUrl} {...rest}>

--- a/packages/grafana-ui/src/components/Link/Link.tsx
+++ b/packages/grafana-ui/src/components/Link/Link.tsx
@@ -1,27 +1,14 @@
 import { locationUtil, textUtil } from '@grafana/data';
 import React, { AnchorHTMLAttributes, forwardRef } from 'react';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 
-export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  partial?: boolean;
-}
-
-function updatePath(loc: ReturnType<typeof useLocation>, newPath: string) {
-  const curParams = new URLSearchParams(loc.search);
-  const newParams = new URLSearchParams(newPath);
-  newParams.forEach((value, key) => {
-    curParams.set(key, value);
-  });
-  return loc.pathname + (curParams ? `?${curParams.toString()}` : '') + (location.hash ? `#${location.hash}` : '');
-}
+export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {}
 
 /**
  * @alpha
  */
-export const Link = forwardRef<HTMLAnchorElement, Props>(({ href, children, partial, ...rest }, ref) => {
-  const location = useLocation();
-  let newHref = href && (partial ? updatePath(location, href) : href);
-  const validUrl = locationUtil.stripBaseFromUrl(textUtil.sanitizeUrl(newHref ?? ''));
+export const Link = forwardRef<HTMLAnchorElement, Props>(({ href, children, ...rest }, ref) => {
+  const validUrl = locationUtil.stripBaseFromUrl(textUtil.sanitizeUrl(href ?? ''));
 
   return (
     <RouterLink ref={ref as React.Ref<HTMLAnchorElement>} to={validUrl} {...rest}>

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.story.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.story.tsx
@@ -27,8 +27,8 @@ export const Examples = () => {
           pageIcon="apps"
           title="A very long dashboard name"
           parent="A long folder name"
-          onClickTitle={() => action('Title clicked')}
-          onClickParent={() => action('Parent clicked')}
+          titleHref=""
+          parentHref=""
           leftItems={[
             <IconButton name="share-alt" size="lg" key="share" />,
             <IconButton name="favorite" iconType="mono" size="lg" key="favorite" />,

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -65,7 +65,7 @@ export const PageToolbar: FC<Props> = React.memo(
         )}
         {parent && parentHref && (
           <>
-            <Link className={cx(styles.titleText, styles.parentLink, styles.titleLink)} href={parentHref} partial>
+            <Link className={cx(styles.titleText, styles.parentLink, styles.titleLink)} href={parentHref}>
               {parent} <span className={styles.parentIcon}></span>
             </Link>
             {titleHref && (
@@ -76,7 +76,7 @@ export const PageToolbar: FC<Props> = React.memo(
           </>
         )}
         {titleHref && (
-          <Link className={cx(styles.titleText, styles.titleLink)} href={titleHref} partial>
+          <Link className={cx(styles.titleText, styles.titleLink)} href={titleHref}>
             {title}
           </Link>
         )}

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -7,14 +7,16 @@ import { Icon } from '../Icon/Icon';
 import { styleMixins } from '../../themes';
 import { IconButton } from '../IconButton/IconButton';
 import { selectors } from '@grafana/e2e-selectors';
+import { Link } from '..';
+import { getFocusStyles } from '../../themes/mixins';
 
 export interface Props {
   pageIcon?: IconName;
   title: string;
   parent?: string;
   onGoBack?: () => void;
-  onClickTitle?: () => void;
-  onClickParent?: () => void;
+  titleHref?: string;
+  parentHref?: string;
   leftItems?: ReactNode[];
   children?: ReactNode;
   className?: string;
@@ -23,18 +25,7 @@ export interface Props {
 
 /** @alpha */
 export const PageToolbar: FC<Props> = React.memo(
-  ({
-    title,
-    parent,
-    pageIcon,
-    onGoBack,
-    children,
-    onClickTitle,
-    onClickParent,
-    leftItems,
-    isFullscreen,
-    className,
-  }) => {
+  ({ title, parent, pageIcon, onGoBack, children, titleHref, parentHref, leftItems, isFullscreen, className }) => {
     const styles = useStyles2(getStyles);
 
     /**
@@ -56,7 +47,7 @@ export const PageToolbar: FC<Props> = React.memo(
       <div className={mainStyle}>
         {pageIcon && !onGoBack && (
           <div className={styles.pageIcon}>
-            <Icon name={pageIcon} size="lg" />
+            <Icon name={pageIcon} size="lg" aria-hidden />
           </div>
         )}
         {onGoBack && (
@@ -72,17 +63,24 @@ export const PageToolbar: FC<Props> = React.memo(
             />
           </div>
         )}
-        {parent && onClickParent && (
-          <button onClick={onClickParent} className={cx(styles.titleText, styles.parentLink)}>
-            {parent} <span className={styles.parentIcon}>/</span>
-          </button>
+        {parent && parentHref && (
+          <>
+            <Link className={cx(styles.titleText, styles.parentLink, styles.titleLink)} href={parentHref} partial>
+              {parent} <span className={styles.parentIcon}></span>
+            </Link>
+            {titleHref && (
+              <span className={cx(styles.titleText, styles.titleDivider, styles.parentLink)} aria-hidden>
+                /
+              </span>
+            )}
+          </>
         )}
-        {onClickTitle && (
-          <button onClick={onClickTitle} className={styles.titleText}>
+        {titleHref && (
+          <Link className={cx(styles.titleText, styles.titleLink)} href={titleHref} partial>
             {title}
-          </button>
+          </Link>
         )}
-        {!onClickTitle && <div className={styles.titleText}>{title}</div>}
+        {!titleHref && <div className={styles.titleText}>{title}</div>}
         {leftItems?.map((child, index) => (
           <div className={styles.leftActionItem} key={index}>
             {child}
@@ -109,21 +107,18 @@ PageToolbar.displayName = 'PageToolbar';
 const getStyles = (theme: GrafanaTheme2) => {
   const { spacing, typography } = theme;
 
-  const titleStyles = `
-      font-size: ${typography.size.lg};
-      padding: ${spacing(0.5, 1, 0.5, 1)};
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      max-width: 240px;
+  const focusStyle = getFocusStyles(theme);
+  const titleStyles = css`
+    font-size: ${typography.size.lg};
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 240px;
+    border-radius: 2px;
 
-      // clear default button styles
-      background: none;
-      border: none;
-
-      @media ${styleMixins.mediaUp(theme.v1.breakpoints.xl)} {
-        max-width: unset;
-      }
+    @media ${styleMixins.mediaUp(theme.v1.breakpoints.xl)} {
+      max-width: unset;
+    }
   `;
 
   return {
@@ -142,6 +137,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: none;
       @media ${styleMixins.mediaUp(theme.v1.breakpoints.md)} {
         display: flex;
+        padding-right: ${theme.spacing(1)};
         align-items: center;
       }
     `,
@@ -154,12 +150,17 @@ const getStyles = (theme: GrafanaTheme2) => {
     parentIcon: css`
       margin-left: ${theme.spacing(0.5)};
     `,
-    titleText: css`
-      ${titleStyles};
+    titleText: titleStyles,
+    titleLink: css`
+      &:focus-visible {
+        ${focusStyle}
+      }
+    `,
+    titleDivider: css`
+      padding: ${spacing(0, 0.5, 0, 0.5)};
     `,
     parentLink: css`
       display: none;
-      padding-right: 0;
       @media ${styleMixins.mediaUp(theme.v1.breakpoints.md)} {
         display: unset;
       }

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -57,10 +57,6 @@ class DashNav extends PureComponent<Props> {
     super(props);
   }
 
-  onFolderNameClick = () => {
-    locationService.partial({ search: 'open', folder: 'current' });
-  };
-
   onClose = () => {
     locationService.partial({ viewPanel: null });
   };
@@ -94,10 +90,6 @@ class DashNav extends PureComponent<Props> {
   onPlaylistStop = () => {
     playlistSrv.stop();
     this.forceUpdate();
-  };
-
-  onDashboardNameClick = () => {
-    locationService.partial({ search: 'open' });
   };
 
   addCustomContent(actions: DashNavButtonModel[], buttons: ReactNode[]) {
@@ -255,8 +247,8 @@ class DashNav extends PureComponent<Props> {
         pageIcon={isFullscreen ? undefined : 'apps'}
         title={title}
         parent={folderTitle}
-        onClickTitle={this.onDashboardNameClick}
-        onClickParent={this.onFolderNameClick}
+        titleHref="?search=open"
+        parentHref="?search=open&folder=current"
         onGoBack={onGoBack}
         leftItems={this.renderLeftActionsButton()}
       >

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -7,7 +7,7 @@ import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 import { DashNavButton } from './DashNavButton';
 import { DashNavTimeControls } from './DashNavTimeControls';
 import { ButtonGroup, ModalsController, ToolbarButton, PageToolbar } from '@grafana/ui';
-import { textUtil } from '@grafana/data';
+import { locationUtil, textUtil } from '@grafana/data';
 // State
 import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 // Types
@@ -242,13 +242,16 @@ class DashNav extends PureComponent<Props> {
     const { isFullscreen, title, folderTitle } = this.props;
     const onGoBack = isFullscreen ? this.onClose : undefined;
 
+    const titleHref = locationUtil.updateSearchParams(window.location.href, '?search=open');
+    const parentHref = locationUtil.updateSearchParams(window.location.href, '?search=open&folder=current');
+
     return (
       <PageToolbar
         pageIcon={isFullscreen ? undefined : 'apps'}
         title={title}
         parent={folderTitle}
-        titleHref="?search=open"
-        parentHref="?search=open&folder=current"
+        titleHref={titleHref}
+        parentHref={parentHref}
         onGoBack={onGoBack}
         leftItems={this.renderLeftActionsButton()}
       >


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds focus styles to dashboard parent and title links.
Uses anchor elements instead of buttons for better semantics.
Hides decorative separator ("/") from screen readers.

**Which issue(s) this PR fixes**:
Relates to #35613
