### PR TITLE
Dashboard: Fixes blank / empty panels after duplicate and add library panel

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -162,11 +162,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
     }
 
     this.props.dashboard.sortPanelsByGridPos();
-
-    // onLayoutChange is called onMount this marks layout as initialized and we are ready to render panels
-    if (!this.state.isLayoutInitialized) {
-      this.setState({ isLayoutInitialized: true });
-    }
+    this.forceUpdate();
   };
 
   triggerForceUpdate = () => {


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/35276 introduced some bugs, duplicate panel and adding copy pasted panel stopped working.

We need the double grid render adding new elements as the isInView logic does not work when there is no element, so we need a secondary render.

