### PR TITLE
StreamingDataFrame: Populating name in StreamingDataFrame

### DIFF
--- a/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
@@ -48,7 +48,7 @@ export class StreamingDataFrame implements DataFrame {
       maxDelta: Infinity,
       ...opts,
     };
-
+    this.name = frame.schema?.name;
     this.push(frame);
   }
 


### PR DESCRIPTION
This PR populates the `name` field in a StreamingDataFrame instance, from the schema, if it exists.
