### PR TITLE
Templating: Add default ref id for data source variable queries

### DIFF
--- a/public/app/features/variables/query/queryRunners.test.ts
+++ b/public/app/features/variables/query/queryRunners.test.ts
@@ -290,12 +290,11 @@ describe('QueryRunners', () => {
     describe('and calling getTarget', () => {
       it('then it should return correct target', () => {
         const { runner, datasource, variable } = getDatasourceTestContext();
-
         const target = runner.getTarget({ datasource, variable });
         expect(target).toEqual({ refId: 'A', query: 'A query' });
       });
       describe('and ref id is missing', () => {
-        it('then it should return correct target', () => {
+        it('then it should return correct target with dummy ref id', () => {
           const { runner, datasource, variable } = getDatasourceTestContext();
           delete variable.query.refId;
           const target = runner.getTarget({ datasource, variable });

--- a/public/app/features/variables/query/queryRunners.test.ts
+++ b/public/app/features/variables/query/queryRunners.test.ts
@@ -1,4 +1,4 @@
-import { QueryRunners } from './queryRunners';
+import { QueryRunners, variableDummyRefId } from './queryRunners';
 import { getDefaultTimeRange, VariableSupportType } from '@grafana/data';
 import { VariableRefresh } from '../types';
 import { of } from 'rxjs';
@@ -290,8 +290,17 @@ describe('QueryRunners', () => {
     describe('and calling getTarget', () => {
       it('then it should return correct target', () => {
         const { runner, datasource, variable } = getDatasourceTestContext();
+
         const target = runner.getTarget({ datasource, variable });
         expect(target).toEqual({ refId: 'A', query: 'A query' });
+      });
+      describe('and ref id is missing', () => {
+        it('then it should return correct target', () => {
+          const { runner, datasource, variable } = getDatasourceTestContext();
+          delete variable.query.refId;
+          const target = runner.getTarget({ datasource, variable });
+          expect(target).toEqual({ refId: variableDummyRefId, query: 'A query' });
+        });
       });
     });
 

--- a/public/app/features/variables/query/queryRunners.ts
+++ b/public/app/features/variables/query/queryRunners.ts
@@ -149,6 +149,8 @@ class CustomQueryRunner implements QueryRunner {
   }
 }
 
+export const variableDummyRefId = 'variable-query';
+
 class DatasourceQueryRunner implements QueryRunner {
   type = VariableSupportType.Datasource;
 
@@ -158,6 +160,9 @@ class DatasourceQueryRunner implements QueryRunner {
 
   getTarget({ datasource, variable }: GetTargetArgs) {
     if (hasDatasourceVariableSupport(datasource)) {
+      if (!variable.query.refId) {
+        variable.query.refId = variableDummyRefId;
+      }
       return variable.query;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add ref id in case it was missing for data source variable queries. See full issue description [here](https://github.com/grafana/grafana/issues/35920)

**Which issue(s) this PR fixes**:

Fixes #35920

