### PR TITLE
FieldColors: Unique colors by value mode POC

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -48,6 +48,7 @@ export const fieldColorModeRegistry = new Registry<FieldColorMode>(() => {
         return theme.visualization.palette;
       },
     }),
+    getUniqueColorsByValue(),
     new FieldColorSchemeMode({
       id: 'continuous-GrYlRd',
       name: 'Green-Yellow-Red',
@@ -232,5 +233,28 @@ export function getFieldSeriesColor(field: Field, theme: GrafanaTheme2): ColorSc
 function getFixedColor(field: Field, theme: GrafanaTheme2) {
   return () => {
     return theme.visualization.getColorByName(field.config.color?.fixedColor ?? FALLBACK_COLOR);
+  };
+}
+
+function getUniqueColorsByValue(): FieldColorMode {
+  return {
+    id: 'unique-colors-by-value',
+    name: 'Unique colors by value',
+    description: 'Assigns each value a unique color',
+
+    getCalculator: (_field, theme) => {
+      let assigned: Map<any, number> = new Map<number, number>();
+      let next = 0;
+      let colors = theme.visualization.palette.map(theme.visualization.getColorByName);
+
+      return (value, percent, threshold) => {
+        if (!assigned.has(value)) {
+          assigned.set(value, next);
+          next = (next + 1) % colors.length;
+        }
+
+        return colors[assigned.get(value) || 0];
+      };
+    },
   };
 }


### PR DESCRIPTION
#35947

Super quick simple POC for #35947 to start a discussion for how this could work 

Problems that need changes to display processor or scale calculator behaviors or interfaces 

* [ ] Does not work for strings as color scale functions do no get strings (or get -Infinity) for string values 
* [ ] How to make it work across fields? (When to reset the memory of values)?  
* [ ] How to make it work across panels? (when to reset the memory of values)?

Also relates to #221:  
A similar mode for Unique colors by series name (that work across panels) is also interesting and has many of the same challenges of when to reset. 
