### PR TITLE
Alerting: fix conflicting folder and dashboard permissions during migration

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/permissions.go
+++ b/pkg/services/sqlstore/migrations/ualert/permissions.go
@@ -163,7 +163,6 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*dashboardAcl
 					teamPermissionsMap[item.TeamID] = item
 				}
 			}
-
 		}
 	}
 

--- a/pkg/services/sqlstore/migrations/ualert/permissions.go
+++ b/pkg/services/sqlstore/migrations/ualert/permissions.go
@@ -134,10 +134,10 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*dashboardAcl
 		return fmt.Errorf("folder id must be greater than zero for a folder permission")
 	}
 
-	// userMap is a map keeping the highest permission per user
+	// userPermissionsMap is a map keeping the highest permission per user
 	// for handling conficting inherited (folder) and non-inherited (dashboard) user permissions
 	userPermissionsMap := make(map[int64]*dashboardAcl, len(items))
-	// teamMap is a map keeping the highest permission per team
+	// teamPermissionsMap is a map keeping the highest permission per team
 	// for handling conficting inherited (folder) and non-inherited (dashboard) team permissions
 	teamPermissionsMap := make(map[int64]*dashboardAcl, len(items))
 	for _, item := range items {
@@ -167,12 +167,20 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*dashboardAcl
 		}
 	}
 
+	type keyType struct {
+		UserID     int64 `xorm:"user_id"`
+		TeamID     int64 `xorm:"team_id"`
+		Role       roleType
+		Permission permissionType
+	}
+	// seen keeps track of inserted perrmissions to avoid duplicates (due to inheritance)
+	seen := make(map[keyType]struct{}, len(items))
 	for _, item := range items {
 		if item.UserID == 0 && item.TeamID == 0 && (item.Role == nil || !item.Role.IsValid()) {
 			return models.ErrDashboardAclInfoMissing
 		}
 
-		// ignore dupicate user permissions
+		// ignore duplicate user permissions
 		if item.UserID != 0 {
 			acl, ok := userPermissionsMap[item.UserID]
 			if ok {
@@ -182,7 +190,7 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*dashboardAcl
 			}
 		}
 
-		// ignore dupicate team permissions
+		// ignore duplicate team permissions
 		if item.TeamID != 0 {
 			acl, ok := teamPermissionsMap[item.TeamID]
 			if ok {
@@ -190,6 +198,14 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*dashboardAcl
 					continue
 				}
 			}
+		}
+
+		key := keyType{UserID: item.UserID, TeamID: item.TeamID, Role: "", Permission: item.Permission}
+		if item.Role != nil {
+			key.Role = *item.Role
+		}
+		if _, ok := seen[key]; ok {
+			continue
 		}
 
 		// unset Id so that the new record will get a different one
@@ -203,6 +219,7 @@ func (m *migration) setACL(orgID int64, dashboardID int64, items []*dashboardAcl
 		if _, err := m.sess.Insert(item); err != nil {
 			return err
 		}
+		seen[key] = struct{}{}
 	}
 
 	// Update dashboard HasAcl flag


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
During dashboard alert permissions migration: if alert’s dashboard has permissions, it will creates a folder to match permissions of the dashboard including the inherited permissions from the folder.  However, the `dashboard_acl` table has a unique constrain on [`dashboard_id`, `user_id` columns](https://github.com/grafana/grafana/blob/9e53b44f35af326009d9bb22d2d7750b12266b40/pkg/services/sqlstore/migrations/dashboard_acl.go#L30) and on [`dashboard_id`, `team_id`](https://github.com/grafana/grafana/blob/9e53b44f35af326009d9bb22d2d7750b12266b40/pkg/services/sqlstore/migrations/dashboard_acl.go#L31) which will result to constrain violations if the alert has conflicting folder and dashboard permissions for a specific user or team.
This fix handles these cases and:
- If the dashboard has a permission for a specific user and inherits from its folder a permission for the same user, then the highest permission is stored (given [the highest permission wins](https://grafana.com/docs/grafana/latest/permissions/restricting-access/#example-3)).
- If the dashboard has a permission for a specific team and inherits from its folder a permission for the same team, then the highest permission is stored.

In addition to the above, if the dashboard has a (role) permission and the folder has the same (role) permission (eg editor role can edit), it makes sure that the permission is stored once (no duplicates).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

