### PR TITLE
Live: Rely on app url for origin check

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -84,6 +84,7 @@ type testState struct {
 func newTestLive(t *testing.T) *live.GrafanaLive {
 	gLive := live.NewGrafanaLive()
 	gLive.RouteRegister = routing.NewRouteRegister()
+	gLive.Cfg = &setting.Cfg{AppURL: "http://localhost:3000/"}
 	err := gLive.Init()
 	require.NoError(t, err)
 	return gLive

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -304,7 +304,6 @@ func checkOrigin(r *http.Request, appURL *url.URL) bool {
 		logger.Warn("Request Origin is not authorized", "origin", origin, "appUrl", appURL.String())
 		return false
 	}
-	logger.Debug("Authorized request with Origin", "origin", origin)
 	return true
 }
 

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -230,15 +232,26 @@ func (g *GrafanaLive) Init() error {
 		return err
 	}
 
+	appURL, err := url.Parse(g.Cfg.AppURL)
+	if err != nil {
+		return fmt.Errorf("error parsing AppURL %s: %w", g.Cfg.AppURL, err)
+	}
+
 	// Use a pure websocket transport.
 	wsHandler := centrifuge.NewWebsocketHandler(node, centrifuge.WebsocketConfig{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			return checkOrigin(r, appURL)
+		},
 	})
 
 	pushWSHandler := pushws.NewHandler(g.ManagedStreamRunner, pushws.Config{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			return checkOrigin(r, appURL)
+		},
 	})
 
 	g.websocketHandler = func(ctx *models.ReqContext) {
@@ -275,6 +288,24 @@ func (g *GrafanaLive) Init() error {
 	}, middleware.ReqOrgAdmin)
 
 	return nil
+}
+
+func checkOrigin(r *http.Request, appURL *url.URL) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	originURL, err := url.Parse(origin)
+	if err != nil {
+		logger.Warn("Failed to parse request origin", "error", err, "origin", origin)
+		return false
+	}
+	if !strings.EqualFold(originURL.Scheme, appURL.Scheme) || !strings.EqualFold(originURL.Host, appURL.Host) {
+		logger.Warn("Request Origin is not authorized", "origin", origin, "appUrl", appURL.String())
+		return false
+	}
+	logger.Debug("Authorized request with Origin", "origin", origin)
+	return true
 }
 
 func runConcurrentlyIfNeeded(ctx context.Context, semaphore chan struct{}, fn func()) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

At this moment we follow same origin strategy for WS connections, in current implementation this requires request Host to be properly set. Unfortunately this means that HTTP Host header should be properly passed on load balancer level (keeping port part, for example using `$http_host` Nginx variable). Here we change the check function to look at AppURL (`root_url` in configuration) for origin check - thus all requests from browsers using public URL should be authorized by Live.

**Which issue(s) this PR fixes**:

Fixes #34537