### PR TITLE
Variables: Fix for changing readonly query property

### DIFF
--- a/packages/grafana-e2e-selectors/src/types/selectors.ts
+++ b/packages/grafana-e2e-selectors/src/types/selectors.ts
@@ -2,14 +2,23 @@ export type StringSelector = string;
 export type FunctionSelector = (id: string) => string;
 export type CssSelector = () => string;
 
+/**
+ * @alpha
+ */
 export interface Selectors {
   [key: string]: StringSelector | FunctionSelector | CssSelector | UrlSelector | Selectors;
 }
 
+/**
+ * @alpha
+ */
 export type E2ESelectors<S extends Selectors> = {
   [P in keyof S]: S[P];
 };
 
+/**
+ * @alpha
+ */
 export interface UrlSelector extends Selectors {
   url: string | FunctionSelector;
 }

--- a/packages/grafana-ui/src/types/completion.ts
+++ b/packages/grafana-ui/src/types/completion.ts
@@ -1,4 +1,4 @@
-import { Value, Editor as CoreEditor } from 'slate';
+import { Editor as CoreEditor, Value } from 'slate';
 import { SearchFunctionType } from '../utils';
 
 /**
@@ -135,6 +135,9 @@ export interface TypeaheadInput {
   editor?: CoreEditor;
 }
 
+/**
+ * @alpha
+ */
 export interface SuggestionsState {
   groupedItems: CompletionItemGroup[];
   typeaheadPrefix: string;

--- a/packages/grafana-ui/src/types/completion.ts
+++ b/packages/grafana-ui/src/types/completion.ts
@@ -1,4 +1,4 @@
-import { Editor as CoreEditor, Value } from 'slate';
+import { Value, Editor as CoreEditor } from 'slate';
 import { SearchFunctionType } from '../utils';
 
 /**
@@ -135,9 +135,6 @@ export interface TypeaheadInput {
   editor?: CoreEditor;
 }
 
-/**
- * @alpha
- */
 export interface SuggestionsState {
   groupedItems: CompletionItemGroup[];
   typeaheadPrefix: string;

--- a/public/app/features/variables/query/queryRunners.test.ts
+++ b/public/app/features/variables/query/queryRunners.test.ts
@@ -293,6 +293,7 @@ describe('QueryRunners', () => {
         const target = runner.getTarget({ datasource, variable });
         expect(target).toEqual({ refId: 'A', query: 'A query' });
       });
+
       describe('and ref id is missing', () => {
         it('then it should return correct target with dummy ref id', () => {
           const { runner, datasource, variable } = getDatasourceTestContext();

--- a/public/app/features/variables/query/queryRunners.ts
+++ b/public/app/features/variables/query/queryRunners.ts
@@ -160,10 +160,7 @@ class DatasourceQueryRunner implements QueryRunner {
 
   getTarget({ datasource, variable }: GetTargetArgs) {
     if (hasDatasourceVariableSupport(datasource)) {
-      if (!variable.query.refId) {
-        variable.query.refId = variableDummyRefId;
-      }
-      return variable.query;
+      return { ...variable.query, refId: variable.query.refId ?? variableDummyRefId };
     }
 
     throw new Error("Couldn't create a target with supplied arguments.");


### PR DESCRIPTION
**What this PR does / why we need it**:
I wasn't able to reproduce #35980 because the `getType()` function existed. Maybe this is because I'm building Grafana with latest @grafana-data package, not sure? Then I noticed that I missed that https://github.com/grafana/grafana/pull/35923 is trying to add a new prop to an immutable oject. So this PR fixes the later issue.

**Which issue(s) this PR fixes**:
Fixes #35980

**Special notes for your reviewer**:
@sunker can you check again that you're using the correct grafana-data package?
