### PR TITLE
Elasticsearch: Add frozen indices search support

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -80,13 +80,13 @@ number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 se
 | `s`        | second      |
 | `ms`       | millisecond |
 
-### X-Pack Enabled
+### X-Pack enabled
 
 Enables `X-Pack` specific features and options, providing the query editor with additional aggregations such as `Rate` and `Top Metrics`.
 
-#### Include Frozen Indices
+#### Include frozen indices
 
-When `X-Pack Enabled` is active and the configured Elasticsearch version is `>=6.6.0`, you can configure Grafana to not ignore [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
+When `X-Pack enabled` is active and the configured Elasticsearch version is `>=6.6.0`, you can configure Grafana to not ignore [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
 ### Logs
 
 There are two parameters, `Message field name` and `Level field name`, that can optionally be configured from the data source settings page that determine

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -80,6 +80,13 @@ number followed by a valid time identifier, e.g. `1m` (1 minute) or `30s` (30 se
 | `s`        | second      |
 | `ms`       | millisecond |
 
+### X-Pack Enabled
+
+Enables `X-Pack` specific features and options, providing the query editor with additional aggregations such as `Rate` and `Top Metrics`.
+
+#### Include Frozen Indices
+
+When `X-Pack Enabled` is active and the configured Elasticsearch version is `>=6.6.0`, you can configure Grafana to not ignore [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
 ### Logs
 
 There are two parameters, `Message field name` and `Level field name`, that can optionally be configured from the data source settings page that determine

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -86,7 +86,7 @@ Enables `X-Pack` specific features and options, providing the query editor with 
 
 #### Include frozen indices
 
-When `X-Pack enabled` is active and the configured Elasticsearch version is `>=6.6.0`, you can configure Grafana to not ignore [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
+When `X-Pack enabled` is active and the configured Elasticsearch version is higher than `6.6.0`, you can configure Grafana to not ignore [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
 ### Logs
 
 There are two parameters, `Message field name` and `Level field name`, that can optionally be configured from the data source settings page that determine

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -67,7 +67,8 @@ func (rp *responseParser) getTimeSeries() (plugins.DataResponse, error) {
 		}
 
 		queryRes := plugins.DataQueryResult{
-			Meta: debugInfo,
+			Meta:       debugInfo,
+			Dataframes: plugins.NewDecodedDataFrames(data.Frames{}),
 		}
 		props := make(map[string]string)
 		err := rp.processBuckets(res.Aggregations, target, &queryRes, props, 0)

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -146,7 +146,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         <div className="gf-form-inline">
           <Switch
             label="X-Pack Enabled"
-            labelClass="width-13"
+            labelClass="width-10"
             checked={value.jsonData.xpack || false}
             onChange={jsonDataSwitchChangeHandler('xpack', value, onChange)}
           />
@@ -156,6 +156,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
           <div className="gf-form-inline">
             <Switch
               label="Include Frozen Indices"
+              labelClass="width-10"
               checked={value.jsonData.includeFrozen ?? false}
               onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}
             />

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -145,7 +145,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         </div>
         <div className="gf-form-inline">
           <Switch
-            label="X-Pack Enabled"
+            label="X-Pack enabled"
             labelClass="width-10"
             checked={value.jsonData.xpack || false}
             onChange={jsonDataSwitchChangeHandler('xpack', value, onChange)}
@@ -155,7 +155,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
         {gte(value.jsonData.esVersion, '6.6.0') && value.jsonData.xpack && (
           <div className="gf-form-inline">
             <Switch
-              label="Include Frozen Indices"
+              label="Include frozen indices"
               labelClass="width-10"
               checked={value.jsonData.includeFrozen ?? false}
               onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -151,11 +151,22 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
             onChange={jsonDataSwitchChangeHandler('xpack', value, onChange)}
           />
         </div>
+
+        {gte(value.jsonData.esVersion, '6.6.0') && value.jsonData.xpack && (
+          <div className="gf-form-inline">
+            <Switch
+              label="Include Frozen Indices"
+              checked={value.jsonData.includeFrozen ?? false}
+              onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}
+            />
+          </div>
+        )}
       </div>
     </>
   );
 };
 
+// TODO: Use change handlers from @grafana/data
 const changeHandler = (
   key: keyof DataSourceSettings<ElasticsearchOptions>,
   value: Props['value'],
@@ -167,6 +178,7 @@ const changeHandler = (
   });
 };
 
+// TODO: Use change handlers from @grafana/data
 const jsonDataChangeHandler = (key: keyof ElasticsearchOptions, value: Props['value'], onChange: Props['onChange']) => (
   event: React.SyntheticEvent<HTMLInputElement | HTMLSelectElement>
 ) => {

--- a/public/app/plugins/datasource/elasticsearch/configuration/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/configuration/utils.ts
@@ -19,6 +19,7 @@ export const coerceOptions = (
         options.jsonData.maxConcurrentShardRequests || defaultMaxConcurrentShardRequests(esVersion),
       logMessageField: options.jsonData.logMessageField || '',
       logLevelField: options.jsonData.logLevelField || '',
+      includeFrozen: options.jsonData.includeFrozen ?? false,
     },
   };
 };

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -896,6 +896,42 @@ describe('ElasticDatasource', function (this: any) {
   });
 });
 
+describe('getMultiSearchUrl', () => {
+  describe('When esVersion >= 6.6.0', () => {
+    it('Should add correct params to URL if "includeFrozen" is enabled', () => {
+      const { ds } = getTestContext({ jsonData: { esVersion: '6.6.0', includeFrozen: true, xpack: true } });
+
+      expect(ds.getMultiSearchUrl()).toMatch(/ignore_throttled=false/);
+    });
+
+    it('Should NOT add ignore_throttled if "includeFrozen" is disabled', () => {
+      const { ds } = getTestContext({ jsonData: { esVersion: '6.6.0', includeFrozen: false, xpack: true } });
+
+      expect(ds.getMultiSearchUrl()).not.toMatch(/ignore_throttled=false/);
+    });
+
+    it('Should NOT add ignore_throttled if "xpack" is disabled', () => {
+      const { ds } = getTestContext({ jsonData: { esVersion: '6.6.0', includeFrozen: true, xpack: false } });
+
+      expect(ds.getMultiSearchUrl()).not.toMatch(/ignore_throttled=false/);
+    });
+  });
+
+  describe('When esVersion < 6.6.0', () => {
+    it('Should NOT add ignore_throttled params regardless of includeFrozen', () => {
+      const { ds: dsWithIncludeFrozen } = getTestContext({
+        jsonData: { esVersion: '5.6.0', includeFrozen: false, xpack: true },
+      });
+      const { ds: dsWithoutIncludeFrozen } = getTestContext({
+        jsonData: { esVersion: '5.6.0', includeFrozen: true, xpack: true },
+      });
+
+      expect(dsWithIncludeFrozen.getMultiSearchUrl()).not.toMatch(/ignore_throttled=false/);
+      expect(dsWithoutIncludeFrozen.getMultiSearchUrl()).not.toMatch(/ignore_throttled=false/);
+    });
+  });
+});
+
 describe('enhanceDataFrame', () => {
   it('adds links to dataframe', () => {
     const df = new MutableDataFrame({

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -766,14 +766,14 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     const searchParams = new URLSearchParams();
 
     if (gte(this.esVersion, '7.0.0') && this.maxConcurrentShardRequests) {
-      searchParams.append('max_concurrent_shard_requests', '' + this.maxConcurrentShardRequests);
+      searchParams.append('max_concurrent_shard_requests', `${this.maxConcurrentShardRequests}`);
     }
 
     if (gte(this.esVersion, '6.6.0') && this.xpack && this.includeFrozen) {
       searchParams.append('ignore_throttled', 'false');
     }
 
-    return (`_msearch?` + searchParams.toString()).replace(/\?+$/, '');
+    return ('_msearch?' + searchParams.toString()).replace(/\?$/, '');
   }
 
   metricFindQuery(query: string, options?: any): Promise<MetricFindValue[]> {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -73,6 +73,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   logLevelField?: string;
   dataLinks: DataLinkConfig[];
   languageProvider: LanguageProvider;
+  includeFrozen: boolean;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>,
@@ -99,6 +100,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
     this.logMessageField = settingsData.logMessageField || '';
     this.logLevelField = settingsData.logLevelField || '';
     this.dataLinks = settingsData.dataLinks || [];
+    this.includeFrozen = settingsData.includeFrozen ?? false;
 
     if (this.logMessageField === '') {
       this.logMessageField = undefined;
@@ -761,11 +763,17 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
   }
 
   getMultiSearchUrl() {
+    const searchParams = new URLSearchParams();
+
     if (gte(this.esVersion, '7.0.0') && this.maxConcurrentShardRequests) {
-      return `_msearch?max_concurrent_shard_requests=${this.maxConcurrentShardRequests}`;
+      searchParams.append('max_concurrent_shard_requests', '' + this.maxConcurrentShardRequests);
     }
 
-    return '_msearch';
+    if (gte(this.esVersion, '6.6.0') && this.xpack && this.includeFrozen) {
+      searchParams.append('ignore_throttled', 'false');
+    }
+
+    return (`_msearch?` + searchParams.toString()).replace(/\?+$/, '');
   }
 
   metricFindQuery(query: string, options?: any): Promise<MetricFindValue[]> {

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -20,6 +20,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  includeFrozen?: boolean;
 }
 
 interface MetricConfiguration<T extends MetricAggregationType> {


### PR DESCRIPTION
Re-picking https://github.com/grafana/grafana/pull/27472

What this PR does / why we need it:
This PR adds a configuration option for elasticsearch 6.6.0+ to allow search requests to be executed against frozen indices.

The option is off by default to not change previous behavior.

See:
https://www.elastic.co/guide/en/elasticsearch/reference/current/frozen-indices.html
https://www.elastic.co/guide/en/elasticsearch/reference/current/searching_a_frozen_index.html

Which issue(s) this PR fixes:

Fixes #18277

**HOW TO TEST**

Using `elastic77` docker block, freeze an index and configure your data source to use the same index.

When the index is frozen and the `Include Frozen Indices` is not active you should get no data (also in alerting), when is active then everything should be normal.

Querying frozen indices is only available in X-Pack with ES >= 6.6.0, so be sure the x-pack flag is set to true in datasource settings.
![Screenshot 2021-06-22 at 10 22 10](https://user-images.githubusercontent.com/1170767/122899409-b782bc00-d343-11eb-8861-f380dc7952dc.png)


to freeze an index: `curl -X POST "localhost:13200/metrics-2021.06.22/_freeze?pretty` (replace `metrics-2021.06.22` with your index name)

/cc. @estermv @simianhacker 