### PR TITLE
InfluxDB: InfluxQL query editor: fix retention policy handling

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/FromSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/FromSection.tsx
@@ -35,7 +35,7 @@ export const FromSection = ({
     // if `default` does not exist in the list of policies, we add it
     const allPoliciesWithDefault = allPolicies.some((p) => p === 'default')
       ? allPolicies
-      : [DEFAULT_POLICY, allPolicies];
+      : [DEFAULT_POLICY, ...allPolicies];
 
     return allPoliciesWithDefault.map(toSelectableValue);
   };


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/35966

there is a bug in the retention-policy handling code. the code wants to add a new item at the beginning of an array, and misses the spread-operator.

so, it should work like this:
a. if you have a retention-policy called `default` then the list of retention policies is untouched.
b. if you do not have a retention-policy called `default`, then we add the option `default` to the beginning of the list. so, for example you have policies `one` and `two`, the list should become `["default", "one", "two"]`. unfortunately, it became `["default", ["one", "two"]]`.

how to test:
- `make devenv sources=influxdb1` should create the datasource you need
- go to `explore`, choose the `gdev-influxdb1-influxql` datasource
- open the first dropdown next to `FROM` (the one that says `default`)
- you should see 5 options: "default", "autogen", "bar", "1m_avg", "5m_avg" (in the wrong version the options shown were "default" and "autogenbar1m_avg5m_avg")