### PR TITLE
Loki: Fix highlight of logs when using filter expressions with backticks

### DIFF
--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -52,4 +52,12 @@ describe('getHighlighterExpressionsFromQuery', () => {
   it('does not escape filter term if regex filter operator is used', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |~ "x[yz].w" |~ "z.+"')).toEqual(['x[yz].w', 'z.+']);
   });
+
+  it('removes extra backslash escaping if regex filter operator and quotes are used', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |~ "\\\\w+"')).toEqual(['\\w+']);
+  });
+
+  it('does not remove backslash escaping if regex filter operator and backticks are used', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |~ `\\w+`')).toEqual(['\\w+']);
+  });
 });

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -5,16 +5,40 @@ describe('getHighlighterExpressionsFromQuery', () => {
     expect(getHighlighterExpressionsFromQuery('')).toEqual([]);
   });
 
-  it('returns an expression for query with filter', () => {
+  it('returns an expression for query with filter using quotes', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x"')).toEqual(['x']);
+  });
+
+  it('returns an expression for query with filter using backticks', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= `x`')).toEqual(['x']);
   });
 
   it('returns expressions for query with filter chain', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" |~ "y"')).toEqual(['x', 'y']);
   });
 
-  it('returns drops expressions for query with negative filter chain', () => {
+  it('returns expressions for query with filter chain using both backticks and quotes', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" |~ `y`')).toEqual(['x', 'y']);
+  });
+
+  it('returns expression for query with log parser', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" | logfmt')).toEqual(['x']);
+  });
+
+  it('returns expressions for query with filter chain folowed by log parser', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" |~ "y" | logfmt')).toEqual(['x', 'y']);
+  });
+
+  it('returns drops expressions for query with negative filter chain using quotes', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" != "y"')).toEqual(['x']);
+  });
+
+  it('returns expressions for query with filter chain using backticks', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= `x` |~ `y`')).toEqual(['x', 'y']);
+  });
+
+  it('returns expressions for query with filter chain using quotes and backticks', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x" |~ `y`')).toEqual(['x', 'y']);
   });
 
   it('returns null if filter term is not wrapped in double quotes', () => {

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -38,11 +38,15 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
     }
 
     // Unwrap the filter term by removing quotes
-    const quotedTerm = filterTerm.match(/^"((?:[^\\"]|\\")*)"$/);
+    const quotedTerm = filterTerm.match(/"(.*?)"/);
+    const backslashTerm = filterTerm.match(/`(.*?)`/);
+    const term = quotedTerm || backslashTerm;
 
-    if (quotedTerm) {
-      const unwrappedFilterTerm = quotedTerm[1];
+    if (term) {
+      const unwrappedFilterTerm = term[1];
       const regexOperator = filterOperator === '|~';
+      console.log('unwrappedFil', unwrappedFilterTerm);
+      console.log('escapeRegExp', escapeRegExp(unwrappedFilterTerm));
       results.push(regexOperator ? unwrappedFilterTerm : escapeRegExp(unwrappedFilterTerm));
     } else {
       return [];

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -37,19 +37,25 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
       expression = expression.substr(filterEnd);
     }
 
-    // Unwrap the filter term by removing quotes
     const quotedTerm = filterTerm.match(/"(.*?)"/);
-    const backslashTerm = filterTerm.match(/`(.*?)`/);
-    const term = quotedTerm || backslashTerm;
+    const backtickedTerm = filterTerm.match(/`(.*?)`/);
+    const term = quotedTerm || backtickedTerm;
 
     if (term) {
       const unwrappedFilterTerm = term[1];
       const regexOperator = filterOperator === '|~';
-      console.log('unwrappedFil', unwrappedFilterTerm);
-      console.log('escapeRegExp', escapeRegExp(unwrappedFilterTerm));
-      results.push(regexOperator ? unwrappedFilterTerm : escapeRegExp(unwrappedFilterTerm));
+
+      // Only filter expressions with |~ operator are treated as regular expressions
+      if (regexOperator) {
+        // When using backticks, Loki doesn't require to escape special characters and we can just push regular expression to highlights array
+        // When using quotes, we have extra backslash escaping and we need to replace \\ with \
+        results.push(backtickedTerm ? unwrappedFilterTerm : unwrappedFilterTerm.replace(/\\\\/g, '\\'));
+      } else {
+        // We need to escape this string so it is not matched as regular expression
+        results.push(escapeRegExp(unwrappedFilterTerm));
+      }
     } else {
-      return [];
+      return results;
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In Loki, we were highlighting logs only if filter expression with **quotes** was used. However, in LogQL you can use both - [quotes and backticks](https://grafana.com/docs/loki/latest/logql/). 

This PR updates a way how we get the highlight regular expression as LogQL has changed quite a lot since this was implemented. I have also added tests for all of the usecases.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/31497

**Special notes for your reviewer**:

See below screenshots from the queries I have tested this with:
1. We are not using `|~` operator and therefore we want to match `1.` literally as string (Loki results matched the highlighting)
![image](https://user-images.githubusercontent.com/30407135/122921758-2facaa00-d363-11eb-9398-1e3b0fc04cc6.png)
 2. We are using `|~` operator and therefore we want to match `1.` as regex (Loki results matched the highlighting)
 ![image](https://user-images.githubusercontent.com/30407135/122921941-65ea2980-d363-11eb-9ccd-6458b1653a9a.png)
3. We are using `|~` operator and we want to match `1.` literally, but we have written regex for it with quotes that we need to double escape for Loki (Loki results matched the highlighting)
![image](https://user-images.githubusercontent.com/30407135/122922495-f88ac880-d363-11eb-8ec0-0d3cfe6319e3.png)
4. We are using `|~` operator and we want to match `1.` literally, but we have written regex for it with backticks that we don't need to double escape for Loki (Loki results matched the highlighting)
![image](https://user-images.githubusercontent.com/30407135/122922680-2ec84800-d364-11eb-9364-364173e0a267.png)
5. Parser doesn't break it 
![image](https://user-images.githubusercontent.com/30407135/122922773-443d7200-d364-11eb-8600-aae7b221caeb.png)

