### PR TITLE
Alerting: Add integration test case for email channel

### DIFF
--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -171,6 +171,11 @@ func (b *InProcBus) AddHandlerCtx(handler HandlerFunc) {
 	b.handlersWithCtx[queryTypeName] = handler
 }
 
+// GetHandlerCtx returns the handler function for the given struct name.
+func (b *InProcBus) GetHandlerCtx(name string) HandlerFunc {
+	return b.handlersWithCtx[name]
+}
+
 func (b *InProcBus) AddEventListener(handler HandlerFunc) {
 	handlerType := reflect.TypeOf(handler)
 	eventName := handlerType.In(0).Elem().Name()
@@ -209,6 +214,10 @@ func DispatchCtx(ctx context.Context, msg Msg) error {
 
 func Publish(msg Msg) error {
 	return globalBus.Publish(msg)
+}
+
+func GetHandlerCtx(name string) HandlerFunc {
+	return globalBus.(*InProcBus).GetHandlerCtx(name)
 }
 
 func ClearBusHandlers() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Email was the last channel remaining to be added in the integration tests