### PR TITLE
devenv: updated influxdb1 version

### DIFF
--- a/devenv/docker/blocks/influxdb1/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb1/docker-compose.yaml
@@ -1,5 +1,5 @@
   influxdb1:
-    image: influxdb:1.8.4-alpine
+    image: influxdb:1.8.6
     container_name: influxdb1
     ports:
       - '2004:2004'


### PR DESCRIPTION
updated influxdb1 (the old influxdb) to the newest version.
i also switched from `-alpine` to the default version, because this version also supports ARM platforms (like the macbook-m1). the `-alpine` version does not.