### PR TITLE
Alerting: Change `__value__` label to `__value_string__` annotation and add `ValueString` variable in notifications

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -166,7 +166,7 @@ func executeCondition(ctx AlertExecCtx, c *models.Condition, now time.Time, data
 		return ExecutionResults{Error: err}
 	}
 
-	// eval captures for the '__value__' label.
+	// eval captures for the '__value_string__' annotation and the Value property of the API response.
 	captures := make([]NumberValueCapture, 0, len(execResp.Responses))
 
 	captureVal := func(refID string, labels data.Labels, value *float64) {

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -29,6 +29,7 @@ type ExtendedAlert struct {
 	SilenceURL   string      `json:"silenceURL"`
 	DashboardURL string      `json:"dashboardURL"`
 	PanelURL     string      `json:"panelURL"`
+	ValueString  string      `json:"valueString"`
 }
 
 type ExtendedAlerts []ExtendedAlert
@@ -48,9 +49,6 @@ type ExtendedData struct {
 func removePrivateItems(kv template.KV) template.KV {
 	for key := range kv {
 		if strings.HasPrefix(key, "__") && strings.HasSuffix(key, "__") {
-			if key == "__value__" {
-				continue
-			}
 			kv = kv.Remove([]string{key})
 		}
 	}
@@ -88,6 +86,10 @@ func extendAlert(alert template.Alert, externalURL string, logger log.Logger) *E
 			u.RawQuery = "viewPanel=" + panelId
 			extended.PanelURL = u.String()
 		}
+	}
+
+	if alert.Annotations != nil {
+		extended.ValueString = alert.Annotations[`__value_string__`]
 	}
 
 	matchers := make([]string, 0)

--- a/pkg/services/ngalert/notifier/channels/template_data.go
+++ b/pkg/services/ngalert/notifier/channels/template_data.go
@@ -48,6 +48,9 @@ type ExtendedData struct {
 func removePrivateItems(kv template.KV) template.KV {
 	for key := range kv {
 		if strings.HasPrefix(key, "__") && strings.HasSuffix(key, "__") {
+			if key == "__value__" {
+				continue
+			}
 			kv = kv.Remove([]string{key})
 		}
 	}

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1455,9 +1455,10 @@ var expNotifications = map[string][]string{
 			  },
 			  "annotations": {},
 			  "startsAt": "%s",
+        "valueString": "[ var='A' labels={} value=1 ]",
 			  "endsAt": "0001-01-01T00:00:00Z",
 			  "generatorURL": "http://localhost:3000/alerting/UID_WebhookAlert/edit",
-			  "fingerprint": "7611eef9e67f6e50",
+			  "fingerprint": "929467973978d053",
 			  "silenceURL": "http://localhost:3000/alerting/silence/new?alertmanager=grafana&matchers=alertname%%3DWebhookAlert",
 			  "dashboardURL": "",
 			  "panelURL": ""
@@ -1621,10 +1622,11 @@ var expNotifications = map[string][]string{
 		  {
 			"labels": {
 			  "__alert_rule_uid__": "UID_AlertmanagerAlert",
-              "__value__": "[ var='A' labels={} value=1 ]",
 			  "alertname": "AlertmanagerAlert"
 			},
-			"annotations": {},
+			"annotations": {
+        "__value_string__": "[ var='A' labels={} value=1 ]"
+      },
 			"startsAt": "%s",
 			"endsAt": "0001-01-01T00:00:00Z",
 			"generatorURL": "http://localhost:3000/alerting/UID_AlertmanagerAlert/edit",


### PR DESCRIPTION
**What this PR does / why we need it**:
Does not remove the `__value__` tag before sending it to templating. This way people can get the EvalData from classic condition, or the Eval string from other SSE expressions that looks like:

`__value__ = [ var='B' labels={__name__=up, instance=fake-prometheus-data:9091, job=fake-data-gen} value=1 ], [ var='C' labels={__name__=up, instance=fake-prometheus-data:9091, job=fake-data-gen} value=1 ]`


**Which issue(s) this PR fixes**:

discovered in #36020, but issue is not about that specifically

**Special notes for your reviewer**:

