### PR TITLE
Elasticsearch: Name fields after template variables values instead of their name

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -35,7 +35,6 @@ import {
 import { bucketAggregationConfig } from './components/QueryEditor/BucketAggregationsEditor/utils';
 import {
   BucketAggregation,
-  BucketAggregationWithField,
   isBucketAggregationWithField,
 } from './components/QueryEditor/BucketAggregationsEditor/aggregations';
 import { generate, Observable, of, throwError } from 'rxjs';
@@ -391,23 +390,7 @@ export class ElasticDatasource extends DataSourceApi<ElasticsearchQuery, Elastic
       this.templateSrv.replace(JSON.stringify(expandedQueries), scopedVars)
     );
 
-    // FIXME: with 8.0 we introduced an undocumented breaking change on how we name frames fields.
-    // Although the introduced behavior is correct, it wasn't documented.
-    // The following lines will restore the previous behaviour for 8.0, to be removed with a proper
-    // changelog in 8.1 by returning `finalQueries` without any further modification
-    return finalQueries.map((q, queryIndex) => ({
-      ...q,
-      bucketAggs: q.bucketAggs?.map((bucketAgg, aggIndex) => {
-        if (isBucketAggregationWithField(bucketAgg)) {
-          return {
-            ...bucketAgg,
-            field: (queries[queryIndex].bucketAggs?.[aggIndex] as BucketAggregationWithField).field,
-          };
-        }
-
-        return bucketAgg;
-      }),
-    }));
+    return finalQueries;
   }
 
   testDatasource() {


### PR DESCRIPTION
This reverts commit 185bf8f9a23e37c7fd521ea8dc3de44aace5fc77. (#35624)

**What this PR does / why we need it**:

#32762 Introduced a new way of interpolating variables in ES queries by simply replacing text in the stringified JSON query model.
It unintentionally slightly changed the behavior when naming fields that are dependant on a variable since the response parser now gets a fully interpolated query, which means when using variables in fields, that same field is now named with the variable value instead of the variable name (which is the correct behavior).

#35624 restored the previous behavior for 8.0.x as this wasn't marked as a breaking change, this PR reverts #35624 for 8.1 in order to correctly introduce a breaking change

# Release notice breaking change

When parsing Elasticsearch query responses using template variables, each field gets named after the variable value instead of the name.
For example, executing a `terms` aggregation on a variable named `$groupBy` that has `@hostname` as a value, the resulting column in the table response will be `@hostname` instead of `$groupBy`