### PR TITLE
StreamingDataFrame: skip empty labels

### DIFF
--- a/packages/grafana-data/src/dataframe/StreamingDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/StreamingDataFrame.test.ts
@@ -1,4 +1,5 @@
 import { reduceField, ReducerID } from '..';
+import { getFieldDisplayName } from '../field';
 import { DataFrame, FieldType } from '../types/dataFrame';
 import { DataFrameJSON } from './DataFrameJSON';
 import { StreamingDataFrame } from './StreamingDataFrame';
@@ -352,6 +353,27 @@ describe('Streaming JSON', () => {
         },
       ]
     `);
+
+    // Push value with empty labels
+    stream.push({
+      data: {
+        values: [[''], [500], [50], [7]],
+      },
+    });
+
+    expect(stream.fields.map((f) => getFieldDisplayName(f, stream, [stream]))).toMatchInlineSnapshot(`
+      Array [
+        "time",
+        "speed A",
+        "light A",
+        "speed B",
+        "light B",
+        "speed C",
+        "light C",
+        "speed 4",
+        "light 4",
+      ]
+    `); // speed+light 4  ¯\_(ツ)_/¯ better than undefined labels
   });
 
   /*

--- a/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
@@ -186,7 +186,6 @@ export class StreamingDataFrame implements DataFrame {
 
     // parse labels
     const parsedLabels: Labels = {};
-
     if (label.length) {
       label.split(',').forEach((kv) => {
         const [key, val] = kv.trim().split('=');

--- a/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
@@ -187,10 +187,12 @@ export class StreamingDataFrame implements DataFrame {
     // parse labels
     const parsedLabels: Labels = {};
 
-    label.split(',').forEach((kv) => {
-      const [key, val] = kv.trim().split('=');
-      parsedLabels[key] = val;
-    });
+    if (label.length) {
+      label.split(',').forEach((kv) => {
+        const [key, val] = kv.trim().split('=');
+        parsedLabels[key] = val;
+      });
+    }
 
     if (labelCount === 0) {
       // mutate existing fields and add labels


### PR DESCRIPTION
Currently if a result has values with labels and without, we display some bad lables:

![image](https://user-images.githubusercontent.com/705951/123003548-312ca100-d368-11eb-91df-c316d6ac4ed2.png)

With this PR applied it is a bit more sensible:
![image](https://user-images.githubusercontent.com/705951/123003633-53262380-d368-11eb-85be-af175840ba42.png)

