### PR TITLE
UsageStats: Extend usage stats for count permissions in folders and dashborads

### DIFF
--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -74,6 +74,10 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.alert_rules.count"] = statsQuery.Result.AlertRules
 	metrics["stats.library_panels.count"] = statsQuery.Result.LibraryPanels
 	metrics["stats.library_variables.count"] = statsQuery.Result.LibraryVariables
+	metrics["stats.dashboards_viewers_can_edit.count"] = statsQuery.Result.DashboardsViewersCanEdit
+	metrics["stats.dashboards_viewers_can_admin.count"] = statsQuery.Result.DashboardsViewersCanAdmin
+	metrics["stats.folders_viewers_can_edit.count"] = statsQuery.Result.FoldersViewersCanEdit
+	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
 	validLicCount := 0
 	if uss.License.HasValidLicense() {
 		validLicCount = 1

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -43,26 +43,30 @@ func TestMetrics(t *testing.T) {
 		var getSystemStatsQuery *models.GetSystemStatsQuery
 		uss.Bus.AddHandler(func(query *models.GetSystemStatsQuery) error {
 			query.Result = &models.SystemStats{
-				Dashboards:            1,
-				Datasources:           2,
-				Users:                 3,
-				ActiveUsers:           4,
-				Orgs:                  5,
-				Playlists:             6,
-				Alerts:                7,
-				Stars:                 8,
-				Folders:               9,
-				DashboardPermissions:  10,
-				FolderPermissions:     11,
-				ProvisionedDashboards: 12,
-				Snapshots:             13,
-				Teams:                 14,
-				AuthTokens:            15,
-				DashboardVersions:     16,
-				Annotations:           17,
-				AlertRules:            18,
-				LibraryPanels:         19,
-				LibraryVariables:      20,
+				Dashboards:                1,
+				Datasources:               2,
+				Users:                     3,
+				ActiveUsers:               4,
+				Orgs:                      5,
+				Playlists:                 6,
+				Alerts:                    7,
+				Stars:                     8,
+				Folders:                   9,
+				DashboardPermissions:      10,
+				FolderPermissions:         11,
+				ProvisionedDashboards:     12,
+				Snapshots:                 13,
+				Teams:                     14,
+				AuthTokens:                15,
+				DashboardVersions:         16,
+				Annotations:               17,
+				AlertRules:                18,
+				LibraryPanels:             19,
+				LibraryVariables:          20,
+				DashboardsViewersCanAdmin: 3,
+				DashboardsViewersCanEdit:  2,
+				FoldersViewersCanAdmin:    1,
+				FoldersViewersCanEdit:     5,
 			}
 			getSystemStatsQuery = query
 			return nil
@@ -308,6 +312,10 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, getSystemStatsQuery.Result.ProvisionedDashboards, metrics.Get("stats.provisioned_dashboards.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Snapshots, metrics.Get("stats.snapshots.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Teams, metrics.Get("stats.teams.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DashboardsViewersCanEdit, metrics.Get("stats.dashboards_viewers_can_edit.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DashboardsViewersCanAdmin, metrics.Get("stats.dashboards_viewers_can_admin.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.FoldersViewersCanEdit, metrics.Get("stats.folders_viewers_can_edit.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.FoldersViewersCanAdmin, metrics.Get("stats.folders_viewers_can_admin.count").MustInt64())
 			assert.Equal(t, 15, metrics.Get("stats.total_auth_token.count").MustInt())
 			assert.Equal(t, 5, metrics.Get("stats.avg_auth_token_per_user.count").MustInt())
 			assert.Equal(t, 16, metrics.Get("stats.dashboard_versions.count").MustInt())

--- a/pkg/models/stats.go
+++ b/pkg/models/stats.go
@@ -1,26 +1,30 @@
 package models
 
 type SystemStats struct {
-	Dashboards            int64
-	Datasources           int64
-	Users                 int64
-	ActiveUsers           int64
-	Orgs                  int64
-	Playlists             int64
-	Alerts                int64
-	Stars                 int64
-	Snapshots             int64
-	Teams                 int64
-	DashboardPermissions  int64
-	FolderPermissions     int64
-	Folders               int64
-	ProvisionedDashboards int64
-	AuthTokens            int64
-	DashboardVersions     int64
-	Annotations           int64
-	AlertRules            int64
-	LibraryPanels         int64
-	LibraryVariables      int64
+	Dashboards                int64
+	Datasources               int64
+	Users                     int64
+	ActiveUsers               int64
+	Orgs                      int64
+	Playlists                 int64
+	Alerts                    int64
+	Stars                     int64
+	Snapshots                 int64
+	Teams                     int64
+	DashboardPermissions      int64
+	FolderPermissions         int64
+	Folders                   int64
+	ProvisionedDashboards     int64
+	AuthTokens                int64
+	DashboardVersions         int64
+	Annotations               int64
+	AlertRules                int64
+	LibraryPanels             int64
+	LibraryVariables          int64
+	DashboardsViewersCanEdit  int64
+	DashboardsViewersCanAdmin int64
+	FoldersViewersCanEdit     int64
+	FoldersViewersCanAdmin    int64
 
 	Admins         int
 	Editors        int

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -73,6 +73,11 @@ func GetSystemStats(query *models.GetSystemStatsQuery) error {
 		WHERE d.is_folder = ?
 	) AS folder_permissions,`, dialect.BooleanStr(true))
 
+	sb.Write(viewersPermissionsCounterSQL("dashboards_viewers_can_edit", false, models.PERMISSION_EDIT))
+	sb.Write(viewersPermissionsCounterSQL("dashboards_viewers_can_admin", false, models.PERMISSION_ADMIN))
+	sb.Write(viewersPermissionsCounterSQL("folders_viewers_can_edit", true, models.PERMISSION_EDIT))
+	sb.Write(viewersPermissionsCounterSQL("folders_viewers_can_admin", true, models.PERMISSION_ADMIN))
+
 	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_provisioning") + `) AS provisioned_dashboards,`)
 	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_snapshot") + `) AS snapshots,`)
 	sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("dashboard_version") + `) AS dashboard_versions,`)
@@ -110,6 +115,18 @@ func roleCounterSQL() string {
 			strconv.FormatInt(userStatsCache.active.Viewers, 10) + ` AS active_viewers`
 
 	return sqlQuery
+}
+
+func viewersPermissionsCounterSQL(statName string, isFolder bool, permission models.PermissionType) string {
+	return `(
+		SELECT COUNT(*)
+		FROM ` + dialect.Quote("dashboard_acl") + ` AS acl
+			INNER JOIN ` + dialect.Quote("dashboard") + ` AS d
+			ON d.id = acl.dashboard_id
+		WHERE acl.role = "` + string(models.ROLE_VIEWER) + `"
+			AND d.is_folder = ` + dialect.BooleanStr(isFolder) + `
+			AND acl.permission = ` + strconv.FormatInt(int64(permission), 10) + `
+	) AS ` + statName + `, `
 }
 
 func GetAdminStats(query *models.GetAdminStatsQuery) error {

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -123,7 +123,7 @@ func viewersPermissionsCounterSQL(statName string, isFolder bool, permission mod
 		FROM ` + dialect.Quote("dashboard_acl") + ` AS acl
 			INNER JOIN ` + dialect.Quote("dashboard") + ` AS d
 			ON d.id = acl.dashboard_id
-		WHERE acl.role = "` + string(models.ROLE_VIEWER) + `"
+		WHERE acl.role = '` + string(models.ROLE_VIEWER) + `'
 			AND d.is_folder = ` + dialect.BooleanStr(isFolder) + `
 			AND acl.permission = ` + strconv.FormatInt(int64(permission), 10) + `
 	) AS ` + statName + `, `


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

We want to extend the usage stats adding the number of permissions set in folders and dashboards for viewers. There are more information in the issue description.

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana-enterprise/issues/924

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

I tried to follow the same pattern name of the rest of the stats like `stats.{stat_name}.count`.