### PR TITLE
Grafana-UI: allow custom validity checks for creatable selects

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -5,10 +5,10 @@ import { Icon, Select, AsyncSelect, MultiSelect, AsyncMultiSelect } from '@grafa
 import { getAvailableIcons, IconName } from '../../types';
 import { SelectCommonProps } from './types';
 import { Meta, Story } from '@storybook/react';
-import { kebabCase } from 'lodash';
 import { generateOptions } from './mockOptions';
 import mdx from './Select.mdx';
 import { auto } from '@popperjs/core';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Forms/Select',
@@ -94,6 +94,7 @@ export const Basic: Story<StoryProps> = (args) => {
         value={value}
         onChange={(v) => {
           setValue(v);
+          action('onChange')(v);
         }}
         prefix={getPrefix(args.icon)}
         {...args}
@@ -113,6 +114,7 @@ export const BasicSelectPlainValue: Story<StoryProps> = (args) => {
         value={value}
         onChange={(v) => {
           setValue(v.value);
+          action('onChange')(v);
         }}
         prefix={getPrefix(args.icon)}
         {...args}
@@ -145,6 +147,7 @@ export const SelectWithOptionDescriptions: Story = (args) => {
         value={value}
         onChange={(v) => {
           setValue(v.value);
+          action('onChange')(v);
         }}
         prefix={getPrefix(args.icon)}
         {...args}
@@ -187,6 +190,7 @@ export const MultiSelectWithOptionGroups: Story = (args) => {
         value={value}
         onChange={(v) => {
           setValue(v.map((v: any) => v.value));
+          action('onChange')(v);
         }}
         prefix={getPrefix(args.icon)}
         {...args}
@@ -205,6 +209,7 @@ export const MultiSelectBasic: Story = (args) => {
         value={value}
         onChange={(v) => {
           setValue(v);
+          action('onChange')(v);
         }}
         prefix={getPrefix(args.icon)}
         {...args}
@@ -228,6 +233,7 @@ export const MultiSelectAsync: Story = (args) => {
       value={value}
       onChange={(v) => {
         setValue(v);
+        action('onChange')(v);
       }}
       prefix={getPrefix(args.icon)}
       {...args}
@@ -248,6 +254,7 @@ export const BasicSelectAsync: Story = (args) => {
       value={value}
       onChange={(v) => {
         setValue(v);
+        action('onChange')(v);
       }}
       prefix={getPrefix(args.icon)}
       {...args}
@@ -266,6 +273,7 @@ export const AutoMenuPlacement: Story = (args) => {
           value={value}
           onChange={(v) => {
             setValue(v);
+            action('onChange')(v);
           }}
           prefix={getPrefix(args.icon)}
           {...args}
@@ -289,12 +297,14 @@ export const CustomValueCreation: Story = (args) => {
         value={value}
         onChange={(v) => {
           setValue(v);
+          action('onChange')(v);
         }}
         allowCustomValue={args.allowCustomValue}
         onCreateOption={(v) => {
-          const customValue: SelectableValue<string> = { value: kebabCase(v), label: v };
+          const customValue: SelectableValue<string> = { value: v, label: v };
           setCustomOptions([...customOptions, customValue]);
           setValue(customValue);
+          action('onCreateOption')(v);
         }}
         prefix={getPrefix(args.icon)}
         {...args}

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { ComponentProps, useCallback } from 'react';
 import { default as ReactSelect } from 'react-select';
 import Creatable from 'react-select/creatable';
 import { default as ReactAsyncSelect } from 'react-select/async';
@@ -134,6 +134,7 @@ export function SelectBase<T>({
   tabSelectsValue = true,
   value,
   width,
+  isValidNewOption,
 }: SelectBaseProps<T>) {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
@@ -149,7 +150,7 @@ export function SelectBase<T>({
 
   let ReactSelectComponent = ReactSelect;
 
-  const creatableProps: any = {};
+  const creatableProps: ComponentProps<typeof Creatable> = {};
   let asyncSelectProps: any = {};
   let selectedValue;
   if (isMulti && loadOptions) {
@@ -218,6 +219,7 @@ export function SelectBase<T>({
     ReactSelectComponent = Creatable as any;
     creatableProps.formatCreateLabel = formatCreateLabel ?? ((input: string) => `Create: ${input}`);
     creatableProps.onCreateOption = onCreateOption;
+    creatableProps.isValidNewOption = isValidNewOption;
   }
 
   // Instead of having AsyncSelect, as a separate component we render ReactAsyncSelect

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -19,7 +19,7 @@ export interface SelectCommonProps<T> {
   components?: any;
   defaultValue?: any;
   disabled?: boolean;
-  filterOption?: (option: SelectableValue, searchQuery: string) => boolean;
+  filterOption?: (option: SelectableValue<T>, searchQuery: string) => boolean;
   /** Function for formatting the text that is displayed when creating a new value*/
   formatCreateLabel?: (input: string) => string;
   getOptionLabel?: (item: SelectableValue<T>) => React.ReactNode;
@@ -64,6 +64,12 @@ export interface SelectCommonProps<T> {
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
   width?: number;
   isOptionDisabled?: () => boolean;
+  /** allowCustomValue must be enabled. Determines whether the "create new" option should be displayed based on the current input value, select value and options array. */
+  isValidNewOption?: (
+    inputValue: string,
+    value: SelectableValue<T> | null,
+    options: Readonly<Array<SelectableValue<T>>>
+  ) => boolean;
 }
 
 export interface SelectAsyncProps<T> {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The current implementation of the `Select` component doesn't allow users to create new options whose values match an already available option differently cased.

This creates issues when, for instance in Elasticsearch, `1m` has a different meaning than `1M` for the `interval` parameter of the `date_histogram`aggregation, and the default options for the select component only has `1m`, making it impossible for users to set `1M` as a value.

The original idea was to expose a single `caseSensitve` prop that, when paired with `allowCustomValue`, would make the creatable options case-sensitve. But this required overriding the `filterOption` prop exposed by the select component.

This PR exposes `react-select`'s `isValidNewOption` prop to component users in a similar way it is done with other props, so that the desired behavior is achievable with some custom code.

`isValidNewOption`, as documented in https://react-select.com/props#creatable-props, decides whether, for a given input, the component should or not prompt the user to create a new option.

This allows components users to define a custom behavior for that and other use cases, for example, the same select described above, might allow users to only create options that are valid `interval` values, while providing a sensible set of commonly used values.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

does NOT fix, but is related to https://github.com/grafana/grafana/issues/35912, the fix for that issue needs this change to be applied first.

**Special notes for your reviewer**:

The added test doesn't probably add much value here given the code needs to be implemented by end-users, but I thought adding it would still have been beneficial.

I'm also not sure if this is worth mentioning in the changelog or not.
