### PR TITLE
Datasource: add button to navigate to explore from settings

### DIFF
--- a/public/app/features/datasources/settings/ButtonRow.test.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.test.tsx
@@ -8,6 +8,7 @@ const setup = (propOverrides?: object) => {
     onSubmit: jest.fn(),
     onDelete: jest.fn(),
     onTest: jest.fn(),
+    exploreUrl: '/explore',
   };
 
   Object.assign(props, propOverrides);

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -5,17 +5,21 @@ import config from 'app/core/config';
 import { Button, LinkButton } from '@grafana/ui';
 
 export interface Props {
+  exploreUrl: string;
   isReadOnly: boolean;
   onDelete: () => void;
   onSubmit: (event: any) => void;
   onTest: (event: any) => void;
 }
 
-const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest }) => {
+const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreUrl }) => {
   return (
     <div className="gf-form-button-row">
-      <LinkButton variant="secondary" fill="outline" href={`${config.appSubUrl}/datasources`}>
+      <LinkButton variant="secondary" fill="solid" href={`${config.appSubUrl}/datasources`}>
         Back
+      </LinkButton>
+      <LinkButton variant="secondary" fill="solid" href={exploreUrl}>
+        Explore
       </LinkButton>
       <Button
         type="button"

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -20,7 +20,7 @@ import { getNavModel } from 'app/core/selectors/navModel';
 
 // Types
 import { StoreState } from 'app/types/';
-import { DataSourceSettings } from '@grafana/data';
+import { DataSourceSettings, urlUtil } from '@grafana/data';
 import { Alert, Button, LinkButton } from '@grafana/ui';
 import { getDataSourceLoadingNav, buildNavModel, getDataSourceNav } from '../state/navModel';
 import { PluginStateInfo } from 'app/features/plugins/PluginStateInfo';
@@ -149,6 +149,13 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
     return this.props.dataSource.id > 0;
   }
 
+  onNavigateToExplore() {
+    const { dataSource } = this.props;
+    const exploreState = JSON.stringify({ datasource: dataSource.name, context: 'explore' });
+    const url = urlUtil.renderUrl('/explore', { left: exploreState });
+    return url;
+  }
+
   renderLoadError(loadError: any) {
     let showDelete = false;
     let msg = loadError.toString();
@@ -269,6 +276,7 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
           isReadOnly={this.isReadOnly()}
           onDelete={this.onDelete}
           onTest={(event) => this.onTest(event)}
+          exploreUrl={this.onNavigateToExplore()}
         />
       </form>
     );

--- a/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
+++ b/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
@@ -5,11 +5,18 @@ exports[`Render should render component 1`] = `
   className="gf-form-button-row"
 >
   <LinkButton
-    fill="outline"
+    fill="solid"
     href="/datasources"
     variant="secondary"
   >
     Back
+  </LinkButton>
+  <LinkButton
+    fill="solid"
+    href="/explore"
+    variant="secondary"
+  >
+    Explore
   </LinkButton>
   <Button
     aria-label="Data source settings page Delete button"
@@ -35,11 +42,18 @@ exports[`Render should render with buttons enabled 1`] = `
   className="gf-form-button-row"
 >
   <LinkButton
-    fill="outline"
+    fill="solid"
     href="/datasources"
     variant="secondary"
   >
     Back
+  </LinkButton>
+  <LinkButton
+    fill="solid"
+    href="/explore"
+    variant="secondary"
+  >
+    Explore
   </LinkButton>
   <Button
     aria-label="Data source settings page Delete button"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: This PR adds the option to navigate to the `explore` route from the `data-source` settings page.

**Which issue(s) this PR fixes**: #13737

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #13737

**Special notes for your reviewer**:

