### PR TITLE
AzureMonitor: Add an error message if a request failed with deprecated creds

### DIFF
--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -164,7 +164,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	res, err := ctxhttp.Do(ctx, dsInfo.Services[azureLogAnalytics].HTTPClient, req)
 	if err != nil {
 		if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials."))
+			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials"))
 		}
 		return dataResponseErrorWithExecuted(err)
 	}
@@ -211,7 +211,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	}
 
 	if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials."})
+		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials"})
 	}
 
 	dataResponse.Frames = data.Frames{frame}

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -164,7 +164,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	res, err := ctxhttp.Do(ctx, dsInfo.Services[azureLogAnalytics].HTTPClient, req)
 	if err != nil {
 		if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are not being used. Go to the data source configuration to update it. Got error %v", err))
+			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials."))
 		}
 		return dataResponseErrorWithExecuted(err)
 	}
@@ -211,7 +211,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	}
 
 	if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log Analytics credentials are not being used. Go to the data source configuration to update it."})
+		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials."})
 	}
 
 	dataResponse.Frames = data.Frames{frame}

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -163,6 +163,9 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	azlog.Debug("AzureLogAnalytics", "Request ApiURL", req.URL.String())
 	res, err := ctxhttp.Do(ctx, dsInfo.Services[azureLogAnalytics].HTTPClient, req)
 	if err != nil {
+		if !dsInfo.Settings.AzureLogAnalyticsSameAs {
+			return dataResponseErrorWithExecuted(fmt.Errorf("Log analytics credentials are not being used. Go to the data source configuration to update it. Got error %v", err))
+		}
 		return dataResponseErrorWithExecuted(err)
 	}
 
@@ -206,6 +209,11 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 			}
 		}
 	}
+
+	if !dsInfo.Settings.AzureLogAnalyticsSameAs {
+		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log analytics credentials are not being used. Go to the data source configuration to update it."})
+	}
+
 	dataResponse.Frames = data.Frames{frame}
 	return dataResponse
 }

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -164,7 +164,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	res, err := ctxhttp.Do(ctx, dsInfo.Services[azureLogAnalytics].HTTPClient, req)
 	if err != nil {
 		if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials"))
+			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials")) //nolint:golint,stylecheck
 		}
 		return dataResponseErrorWithExecuted(err)
 	}

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -164,7 +164,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	res, err := ctxhttp.Do(ctx, dsInfo.Services[azureLogAnalytics].HTTPClient, req)
 	if err != nil {
 		if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-			return dataResponseErrorWithExecuted(fmt.Errorf("Log analytics credentials are not being used. Go to the data source configuration to update it. Got error %v", err))
+			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are not being used. Go to the data source configuration to update it. Got error %v", err))
 		}
 		return dataResponseErrorWithExecuted(err)
 	}
@@ -211,7 +211,7 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	}
 
 	if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log analytics credentials are not being used. Go to the data source configuration to update it."})
+		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log Analytics credentials are not being used. Go to the data source configuration to update it."})
 	}
 
 	dataResponse.Frames = data.Frames{frame}

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,5 +213,27 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 				t.Errorf("Unexpected HTTP headers: %v", cmp.Diff(req.Header, tt.expectedHeaders))
 			}
 		})
+	}
+}
+
+func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
+	ds := AzureLogAnalyticsDatasource{}
+	dsInfo := datasourceInfo{
+		Services: map[string]datasourceService{
+			azureLogAnalytics: {URL: "http://ds"},
+		},
+		Settings: azureMonitorSettings{AzureLogAnalyticsSameAs: false},
+	}
+	ctx := context.TODO()
+	query := &AzureLogAnalyticsQuery{
+		Params:    url.Values{},
+		TimeRange: backend.TimeRange{},
+	}
+	res := ds.executeQuery(ctx, query, dsInfo)
+	if res.Error == nil {
+		t.Fatal("expecting an error")
+	}
+	if !strings.Contains(res.Error.Error(), "Log analytics credentials are not being used") {
+		t.Error("expecting the error to inform of bad credentials")
 	}
 }

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -233,7 +233,7 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 	if res.Error == nil {
 		t.Fatal("expecting an error")
 	}
-	if !strings.Contains(res.Error.Error(), "Log Analytics credentials are not being used") {
+	if !strings.Contains(res.Error.Error(), "Log Analytics credentials are no longer supported") {
 		t.Error("expecting the error to inform of bad credentials")
 	}
 }

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -233,7 +233,7 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 	if res.Error == nil {
 		t.Fatal("expecting an error")
 	}
-	if !strings.Contains(res.Error.Error(), "Log analytics credentials are not being used") {
+	if !strings.Contains(res.Error.Error(), "Log Analytics credentials are not being used") {
 		t.Error("expecting the error to inform of bad credentials")
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

If a request fails because the user was using Log Analytics credentials (but is no longer supported), we alert the user explaining the situation:

![Screenshot from 2021-06-28 12-17-29](https://user-images.githubusercontent.com/4025665/123620756-da611480-d80a-11eb-92fd-8f8e7c6ffd82.png)

If the request success but different Log Analytics credentials are configured we still show a warning to the user:

![Screenshot from 2021-06-28 12-17-02](https://user-images.githubusercontent.com/4025665/123620779-de8d3200-d80a-11eb-961f-38f75a9a4db2.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

First part of #35858

**Special notes for your reviewer**:

Let me know if you have a better suggestion for the error message (unfortunately we cannot include a link that directly takes you to the config view).

~~The error message is a bit ugly because it includes the whole URL but that is a different issue.~~

cc/ @kostrse 


