### PR TITLE
Docs: Update CloudWatch `authType` to be `arn`

### DIFF
--- a/docs/sources/datasources/cloudwatch.md
+++ b/docs/sources/datasources/cloudwatch.md
@@ -442,7 +442,7 @@ datasources:
   - name: CloudWatch
     type: cloudwatch
     jsonData:
-      authType: default
+      authType: arn
       assumeRoleArn: arn:aws:iam::123456789012:root
       defaultRegion: eu-west-2
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

When using the CloudWatch Datasource provisioning parameter `datasources.jsonData.assumeRoleArn` and setting the value of `datasources.jsonData.authType` to `default`, as previously proposed in the docs, the datasource tries to use the default SDK credentials instead of assuming the specified role.

When checking the datasource configuration in the UI, it looks like this, with no "Auth Provider" chosen:

![1](https://i.imgur.com/Ubnxgmj.png)

When the value of `authType` is be set to `arn`, the configuration works as expected.
