### PR TITLE
VariableSettings: fix tool-tip hyperlink color

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/_Tooltip.scss
+++ b/packages/grafana-ui/src/components/Tooltip/_Tooltip.scss
@@ -18,6 +18,10 @@ $popper-margin-from-ref: 5px;
   em {
     color: lighten($textColor, 20%);
   }
+  a {
+    color: $white;
+    text-decoration: underline;
+  }
 }
 
 .popper {

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -190,10 +190,6 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
                   Optional, if you want to extract part of a series name or metric node segment. Named capture groups
                   can be used to separate the display text and value (
                   <a
-                    className={css`
-                      color: #fff;
-                      text-decoration: underline;
-                    `}
                     href="https://grafana.com/docs/grafana/latest/variables/filter-variables-with-regex#filter-and-modify-using-named-text-and-value-capture-groups"
                     target="__blank"
                   >

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -190,6 +190,10 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
                   Optional, if you want to extract part of a series name or metric node segment. Named capture groups
                   can be used to separate the display text and value (
                   <a
+                    className={css`
+                      color: #fff;
+                      text-decoration: underline;
+                    `}
                     href="https://grafana.com/docs/grafana/latest/variables/filter-variables-with-regex#filter-and-modify-using-named-text-and-value-capture-groups"
                     target="__blank"
                   >


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Right now, it is difficult to recognize the tool-tip in the variable's setting `regex` field due to the missing color or indication of the hyperlink.

**Which issue(s) this PR fixes**: This PR fixed this by adding `color` to the hyperlink.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #36122

**Special notes for your reviewer**:

