### PR TITLE
Azure monitor: ensure that time column has a name

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -248,6 +248,8 @@ func (e *AzureMonitorDatasource) parseResponse(amr AzureMonitorResponse, query *
 
 		frame := data.NewFrameOfFieldTypes("", len(series.Data), data.FieldTypeTime, data.FieldTypeNullableFloat64)
 		frame.RefID = query.RefID
+		timeField := frame.Fields[0]
+		timeField.Name = "Time"
 		dataField := frame.Fields[1]
 		dataField.Name = amr.Value[0].Name.LocalizedValue
 		dataField.Labels = labels

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource.go
@@ -249,7 +249,7 @@ func (e *AzureMonitorDatasource) parseResponse(amr AzureMonitorResponse, query *
 		frame := data.NewFrameOfFieldTypes("", len(series.Data), data.FieldTypeTime, data.FieldTypeNullableFloat64)
 		frame.RefID = query.RefID
 		timeField := frame.Fields[0]
-		timeField.Name = "Time"
+		timeField.Name = data.TimeSeriesTimeFieldName
 		dataField := frame.Fields[1]
 		dataField.Name = amr.Value[0].Name.LocalizedValue
 		dataField.Labels = labels

--- a/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-datasource_test.go
@@ -203,7 +203,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC), 5, time.Minute)),
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(2.0875), ptr.Float64(2.1525), ptr.Float64(2.155), ptr.Float64(3.6925), ptr.Float64(2.44),
@@ -223,7 +223,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 13, 29, 0, 0, time.UTC), 5, time.Minute)),
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(8.26), ptr.Float64(8.7), ptr.Float64(14.82), ptr.Float64(10.07), ptr.Float64(8.52),
@@ -243,7 +243,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 14, 26, 0, 0, time.UTC), 5, time.Minute)),
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(3.07), ptr.Float64(2.92), ptr.Float64(2.87), ptr.Float64(2.27), ptr.Float64(2.52),
@@ -263,7 +263,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 14, 43, 0, 0, time.UTC), 5, time.Minute)),
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(1.51), ptr.Float64(2.38), ptr.Float64(1.69), ptr.Float64(2.27), ptr.Float64(1.96),
@@ -283,7 +283,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 14, 44, 0, 0, time.UTC), 5, time.Minute)),
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(4), ptr.Float64(4), ptr.Float64(4), ptr.Float64(4), ptr.Float64(4),
@@ -303,19 +303,19 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "PageBlob"},
 						[]*float64{ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), nil}).SetConfig(&data.FieldConfig{Unit: "short"})),
 
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "BlockBlob"},
 						[]*float64{ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), nil}).SetConfig(&data.FieldConfig{Unit: "short"})),
 
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "Azure Data Lake Storage"},
 						[]*float64{ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), nil}).SetConfig(&data.FieldConfig{Unit: "short"})),
@@ -335,7 +335,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 13, 29, 0, 0, time.UTC), 5, time.Minute)),
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(8.26), ptr.Float64(8.7), ptr.Float64(14.82), ptr.Float64(10.07), ptr.Float64(8.52),
@@ -356,20 +356,20 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "PageBlob"},
 						[]*float64{ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), ptr.Float64(3), nil}).SetConfig(&data.FieldConfig{Unit: "short", DisplayName: "blobtype=PageBlob"})),
 
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "BlockBlob"}, []*float64{
 						ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), ptr.Float64(1), nil,
 					}).SetConfig(&data.FieldConfig{Unit: "short", DisplayName: "blobtype=BlockBlob"})),
 
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2019, 2, 9, 15, 21, 0, 0, time.UTC), 6, time.Hour)),
 					data.NewField("Blob Count", data.Labels{"blobtype": "Azure Data Lake Storage"}, []*float64{
 						ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), ptr.Float64(0), nil,
@@ -390,21 +390,21 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2020, 06, 30, 9, 58, 0, 0, time.UTC), 3, time.Hour)),
 					data.NewField("Blob Capacity", data.Labels{"blobtype": "PageBlob", "tier": "Standard"},
 						[]*float64{ptr.Float64(675530), ptr.Float64(675530), ptr.Float64(675530)}).SetConfig(
 						&data.FieldConfig{Unit: "decbytes", DisplayName: "danieltest {Blob Type=PageBlob, Tier=Standard}"})),
 
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2020, 06, 30, 9, 58, 0, 0, time.UTC), 3, time.Hour)),
 					data.NewField("Blob Capacity", data.Labels{"blobtype": "BlockBlob", "tier": "Hot"},
 						[]*float64{ptr.Float64(0), ptr.Float64(0), ptr.Float64(0)}).SetConfig(
 						&data.FieldConfig{Unit: "decbytes", DisplayName: "danieltest {Blob Type=BlockBlob, Tier=Hot}"})),
 
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						makeDates(time.Date(2020, 06, 30, 9, 58, 0, 0, time.UTC), 3, time.Hour)),
 					data.NewField("Blob Capacity", data.Labels{"blobtype": "Azure Data Lake Storage", "tier": "Cool"},
 						[]*float64{ptr.Float64(0), ptr.Float64(0), ptr.Float64(0)}).SetConfig(
@@ -425,7 +425,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			},
 			expectedFrames: data.Frames{
 				data.NewFrame("",
-					data.NewField("", nil,
+					data.NewField("Time", nil,
 						[]time.Time{time.Date(2019, 2, 8, 10, 13, 0, 0, time.UTC)}),
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(2.0875),


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now if you try to make a Metrics query with Azure Monitor and switch to the Table view you'll hit an error. This is because our Time fields seem to be missing a name property which are [required for parsing deep links](https://github.com/grafana/grafana/blob/8fe58fc2e3b62b06af87b0c4b2252b32d7008f3f/packages/grafana-data/src/field/fieldOverrides.ts#L354). 

**Which issue(s) this PR fixes**:

Fixes #35999

**Special notes for your reviewer**:
This seems to fix the problem, but doesn't feel like the most robust solution to me. I wonder if it is safe to assume the first field is always the time field here?
