### PR TITLE
grafana/ui: Refactor Checkbox to fix alignment issues

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
@@ -18,54 +18,62 @@ export const Controlled = () => {
   const [checked, setChecked] = useState(false);
   const onChange = useCallback((e) => setChecked(e.currentTarget.checked), [setChecked]);
   return (
-    <Checkbox
-      value={checked}
-      onChange={onChange}
-      label="Skip TLS cert validation"
-      description="Set to true if you want to skip TLS cert validation"
-    />
+    <div>
+      <Checkbox
+        value={checked}
+        onChange={onChange}
+        label="Skip TLS cert validation"
+        description="Set to true if you want to skip TLS cert validation"
+      />
+    </div>
   );
 };
 
 export const uncontrolled = () => {
   return (
-    <Checkbox
-      defaultChecked={true}
-      label="Skip TLS cert validation"
-      description="Set to true if you want to skip TLS cert validation"
-    />
-  );
-};
-
-export const StackedList = () => {
-  return (
-    <VerticalGroup>
+    <div>
       <Checkbox
         defaultChecked={true}
         label="Skip TLS cert validation"
         description="Set to true if you want to skip TLS cert validation"
       />
-      <Checkbox
-        defaultChecked={true}
-        label="Another checkbox"
-        description="Another long description that does not make any sense"
-      />
-      <Checkbox
-        defaultChecked={true}
-        label="Another checkbox times 2"
-        description="Another long description that does not make any sense or does it?"
-      />
-    </VerticalGroup>
+    </div>
+  );
+};
+
+export const StackedList = () => {
+  return (
+    <div>
+      <VerticalGroup>
+        <Checkbox
+          defaultChecked={true}
+          label="Skip TLS cert validation"
+          description="Set to true if you want to skip TLS cert validation"
+        />
+        <Checkbox
+          defaultChecked={true}
+          label="Another checkbox"
+          description="Another long description that does not make any sense"
+        />
+        <Checkbox
+          defaultChecked={true}
+          label="Another checkbox times 2"
+          description="Another long description that does not make any sense or does it?"
+        />
+      </VerticalGroup>
+    </div>
   );
 };
 
 export const InAField = () => {
   return (
-    <Field
-      label="Hidden"
-      description="Annotation queries can be toggled on or of at the top of the dashboard. With this option checked this toggle will be hidden."
-    >
-      <Checkbox name="hide" id="hide" defaultChecked={true} />
-    </Field>
+    <div>
+      <Field
+        label="Hidden"
+        description="Annotation queries can be toggled on or of at the top of the dashboard. With this option checked this toggle will be hidden."
+      >
+        <Checkbox name="hide" id="hide" defaultChecked={true} />
+      </Field>
+    </div>
   );
 };

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -44,12 +44,14 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
 
 export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
   const labelStyles = getLabelStyles(theme);
-  const checkboxSize = '16px';
+  const checkboxSize = 2;
+  const labelPadding = 1;
+
   return {
     label: cx(
       labelStyles.label,
       css`
-        padding-left: ${theme.spacing(1)};
+        padding-left: ${theme.spacing(labelPadding)};
         white-space: nowrap;
         cursor: pointer;
       `
@@ -58,20 +60,19 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
       labelStyles.description,
       css`
         line-height: ${theme.typography.bodySmall.lineHeight};
-        padding-left: ${theme.spacing(1)};
+        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
       `
     ),
     wrapper: css`
       position: relative;
-      padding-left: ${checkboxSize};
       vertical-align: middle;
-      min-height: ${theme.spacing(3)};
+      font-size: 0;
     `,
     input: css`
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
+      width: 100% !important; // global styles unset this
       height: 100%;
       opacity: 0;
 
@@ -125,15 +126,11 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
     `,
     checkmark: css`
       display: inline-block;
-      width: ${checkboxSize};
-      height: ${checkboxSize};
+      width: ${theme.spacing(checkboxSize)};
+      height: ${theme.spacing(checkboxSize)};
       border-radius: ${theme.shape.borderRadius()};
-      margin-right: ${theme.spacing(1)};
       background: ${theme.components.input.background};
       border: 1px solid ${theme.components.input.borderColor};
-      position: absolute;
-      top: 2px;
-      left: 0;
 
       &:hover {
         cursor: pointer;

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -48,21 +48,6 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
   const labelPadding = 1;
 
   return {
-    label: cx(
-      labelStyles.label,
-      css`
-        padding-left: ${theme.spacing(labelPadding)};
-        white-space: nowrap;
-        cursor: pointer;
-      `
-    ),
-    description: cx(
-      labelStyles.description,
-      css`
-        line-height: ${theme.typography.bodySmall.lineHeight};
-        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
-      `
-    ),
     wrapper: css`
       position: relative;
       vertical-align: middle;
@@ -137,6 +122,21 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
         border-color: ${theme.components.input.borderHover};
       }
     `,
+    label: cx(
+      labelStyles.label,
+      css`
+        padding-left: ${theme.spacing(labelPadding)};
+        white-space: nowrap;
+        cursor: pointer;
+      `
+    ),
+    description: cx(
+      labelStyles.description,
+      css`
+        line-height: ${theme.typography.bodySmall.lineHeight};
+        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
+      `
+    ),
   };
 });
 

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -130,11 +130,13 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
     label: cx(
       labelStyles.label,
       css`
+        position: relative;
+        z-index: 2;
         padding-left: ${theme.spacing(labelPadding)};
         white-space: nowrap;
         cursor: pointer;
         position: relative;
-        top: -2px;
+        top: -3px;
       `
     ),
     description: cx(

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -55,6 +55,7 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
     `,
     input: css`
       position: absolute;
+      z-index: 1;
       top: 0;
       left: 0;
       width: 100% !important; // global styles unset this
@@ -87,6 +88,7 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
         &:after {
           content: '';
           position: absolute;
+          z-index: 2;
           left: 5px;
           top: 1px;
           width: 6px;
@@ -110,13 +112,14 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
       }
     `,
     checkmark: css`
+      position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
+      z-index: 2;
       display: inline-block;
       width: ${theme.spacing(checkboxSize)};
       height: ${theme.spacing(checkboxSize)};
       border-radius: ${theme.shape.borderRadius()};
       background: ${theme.components.input.background};
       border: 1px solid ${theme.components.input.borderColor};
-      pointer-events: none;
 
       &:hover {
         cursor: pointer;

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -28,7 +28,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         <input
           type="checkbox"
           className={styles.input}
-          checked={value ?? false}
+          checked={value}
           disabled={disabled}
           onChange={handleOnChange}
           {...inputProps}
@@ -102,6 +102,7 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
       &:disabled + span {
         background-color: ${theme.colors.action.disabledBackground};
         cursor: not-allowed;
+
         &:hover {
           background-color: ${theme.colors.action.disabledBackground};
         }
@@ -132,6 +133,8 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
         padding-left: ${theme.spacing(labelPadding)};
         white-space: nowrap;
         cursor: pointer;
+        position: relative;
+        top: -2px;
       `
     ),
     description: cx(
@@ -139,6 +142,7 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
       css`
         line-height: ${theme.typography.bodySmall.lineHeight};
         padding-left: ${theme.spacing(checkboxSize + labelPadding)};
+        margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
       `
     ),
   };

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -28,7 +28,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         <input
           type="checkbox"
           className={styles.input}
-          checked={value}
+          checked={value ?? false}
           disabled={disabled}
           onChange={handleOnChange}
           {...inputProps}
@@ -116,6 +116,7 @@ export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
       border-radius: ${theme.shape.borderRadius()};
       background: ${theme.components.input.background};
       border: 1px solid ${theme.components.input.borderColor};
+      pointer-events: none;
 
       &:hover {
         cursor: pointer;

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo } from 'react';
+import React, { FC, memo, useState } from 'react';
 import { useAsync } from 'react-use';
 import { connect, MapStateToProps } from 'react-redux';
 import { NavModel, locationUtil } from '@grafana/data';
@@ -9,6 +9,7 @@ import Page from 'app/core/components/Page/Page';
 import { loadFolderPage } from '../loaders';
 import ManageDashboards from './ManageDashboards';
 import { GrafanaRouteComponentProps } from '../../../core/navigation/types';
+import { Checkbox } from '@grafana/ui';
 
 export interface DashboardListPageRouteParams {
   uid?: string;
@@ -39,9 +40,15 @@ export const DashboardListPage: FC<Props> = memo(({ navModel, match, location })
     });
   }, [match.params.uid]);
 
+  const [testState, setTestState] = useState(false);
+
   return (
     <Page navModel={value?.pageNavModel ?? navModel}>
       <Page.Contents isLoading={loading}>
+        <Checkbox
+          value={testState}
+          onChange={(ev: React.ChangeEvent<HTMLInputElement>) => setTestState(ev.target.checked)}
+        />
         <ManageDashboards folder={value?.folder} />
       </Page.Contents>
     </Page>

--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useState } from 'react';
+import React, { FC, memo } from 'react';
 import { useAsync } from 'react-use';
 import { connect, MapStateToProps } from 'react-redux';
 import { NavModel, locationUtil } from '@grafana/data';
@@ -9,7 +9,6 @@ import Page from 'app/core/components/Page/Page';
 import { loadFolderPage } from '../loaders';
 import ManageDashboards from './ManageDashboards';
 import { GrafanaRouteComponentProps } from '../../../core/navigation/types';
-import { Checkbox } from '@grafana/ui';
 
 export interface DashboardListPageRouteParams {
   uid?: string;
@@ -40,15 +39,9 @@ export const DashboardListPage: FC<Props> = memo(({ navModel, match, location })
     });
   }, [match.params.uid]);
 
-  const [testState, setTestState] = useState(false);
-
   return (
     <Page navModel={value?.pageNavModel ?? navModel}>
       <Page.Contents isLoading={loading}>
-        <Checkbox
-          value={testState}
-          onChange={(ev: React.ChangeEvent<HTMLInputElement>) => setTestState(ev.target.checked)}
-        />
         <ManageDashboards folder={value?.folder} />
       </Page.Contents>
     </Page>

--- a/public/app/features/search/components/SearchCheckbox.tsx
+++ b/public/app/features/search/components/SearchCheckbox.tsx
@@ -1,18 +1,19 @@
 import React, { FC, memo } from 'react';
-import { css } from '@emotion/css';
+import { cx, css } from '@emotion/css';
 import { Checkbox, stylesFactory } from '@grafana/ui';
 
 interface Props {
   checked?: boolean;
-  onClick: any;
+  onClick?: React.MouseEventHandler<HTMLInputElement>;
+  className?: string;
   editable?: boolean;
 }
 
-export const SearchCheckbox: FC<Props> = memo(({ onClick, checked = false, editable = false }) => {
+export const SearchCheckbox: FC<Props> = memo(({ onClick, className, checked = false, editable = false }) => {
   const styles = getStyles();
 
   return editable ? (
-    <div onClick={onClick} className={styles.wrapper}>
+    <div onClick={onClick} className={cx(className)}>
       <Checkbox value={checked} />
     </div>
   ) : null;

--- a/public/app/features/search/components/SearchCheckbox.tsx
+++ b/public/app/features/search/components/SearchCheckbox.tsx
@@ -1,6 +1,5 @@
 import React, { FC, memo } from 'react';
-import { cx, css } from '@emotion/css';
-import { Checkbox, stylesFactory } from '@grafana/ui';
+import { Checkbox } from '@grafana/ui';
 
 interface Props {
   checked?: boolean;
@@ -10,26 +9,11 @@ interface Props {
 }
 
 export const SearchCheckbox: FC<Props> = memo(({ onClick, className, checked = false, editable = false }) => {
-  const styles = getStyles();
-
   return editable ? (
-    <div onClick={onClick} className={cx(className)}>
+    <div onClick={onClick} className={className}>
       <Checkbox value={checked} />
     </div>
   ) : null;
 });
-
-const getStyles = stylesFactory(() => ({
-  wrapper: css`
-    height: 21px;
-    & > label {
-      height: 100%;
-
-      & > input {
-        position: relative;
-      }
-    }
-  `,
-}));
 
 SearchCheckbox.displayName = 'SearchCheckbox';

--- a/public/app/features/search/components/SearchItem.test.tsx
+++ b/public/app/features/search/components/SearchItem.test.tsx
@@ -39,7 +39,7 @@ describe('SearchItem', () => {
     expect(screen.getAllByText('Test 1')).toHaveLength(1);
   });
 
-  it('should mark item as checked', () => {
+  it('should toggle items when checked', () => {
     const mockedOnToggleChecked = jest.fn();
     setup({ editable: true, onToggleChecked: mockedOnToggleChecked });
     const checkbox = screen.getByRole('checkbox');
@@ -47,6 +47,10 @@ describe('SearchItem', () => {
     fireEvent.click(checkbox);
     expect(mockedOnToggleChecked).toHaveBeenCalledTimes(1);
     expect(mockedOnToggleChecked).toHaveBeenCalledWith(data);
+  });
+
+  it('should mark items as checked', () => {
+    setup({ editable: true, item: { ...data, checked: true } });
     expect(screen.getByRole('checkbox')).toBeChecked();
   });
 

--- a/public/app/features/search/components/SearchItem.tsx
+++ b/public/app/features/search/components/SearchItem.tsx
@@ -34,9 +34,10 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
     [onTagSelected]
   );
 
-  const toggleItem = useCallback(
+  const handleCheckboxClick = useCallback(
     (ev: React.MouseEvent) => {
       ev.stopPropagation();
+      ev.preventDefault();
 
       if (onToggleChecked) {
         onToggleChecked(item);
@@ -55,7 +56,7 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
       className={styles.container}
     >
       <Card.Figure align={'center'} className={styles.checkbox}>
-        <SearchCheckbox editable={editable} checked={item.checked} onClick={toggleItem} />
+        <SearchCheckbox editable={editable} checked={item.checked} onClick={handleCheckboxClick} />
       </Card.Figure>
       <Card.Meta separator={''}>
         <span className={styles.metaContainer}>

--- a/public/app/features/search/components/SearchItem.tsx
+++ b/public/app/features/search/components/SearchItem.tsx
@@ -35,8 +35,9 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
   );
 
   const toggleItem = useCallback(
-    (event: React.MouseEvent) => {
-      event.preventDefault();
+    (ev: React.MouseEvent) => {
+      ev.stopPropagation();
+
       if (onToggleChecked) {
         onToggleChecked(item);
       }

--- a/public/app/features/search/components/SectionHeader.tsx
+++ b/public/app/features/search/components/SectionHeader.tsx
@@ -46,7 +46,12 @@ export const SectionHeader: FC<SectionHeaderProps> = ({
       onClick={onSectionExpand}
       aria-label={section.expanded ? `Collapse folder ${section.id}` : `Expand folder ${section.id}`}
     >
-      <SearchCheckbox editable={editable} checked={section.checked} onClick={onSectionChecked} />
+      <SearchCheckbox
+        className={styles.checkbox}
+        editable={editable}
+        checked={section.checked}
+        onClick={onSectionChecked}
+      />
 
       <div className={styles.icon}>
         <Icon name={getSectionIcon(section)} />
@@ -90,6 +95,9 @@ const getSectionHeaderStyles = stylesFactory((theme: GrafanaTheme, selected = fa
       'pointer',
       { selected }
     ),
+    checkbox: css`
+      padding: 0 ${sm} 0 0;
+    `,
     icon: css`
       padding: 0 ${sm} 0 ${editable ? 0 : sm};
     `,

--- a/public/app/features/search/components/SectionHeader.tsx
+++ b/public/app/features/search/components/SectionHeader.tsx
@@ -30,9 +30,9 @@ export const SectionHeader: FC<SectionHeaderProps> = ({
   };
 
   const onSectionChecked = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
+    (ev: React.MouseEvent) => {
+      ev.stopPropagation();
+
       if (onToggleChecked) {
         onToggleChecked(section);
       }

--- a/public/app/features/search/components/SectionHeader.tsx
+++ b/public/app/features/search/components/SectionHeader.tsx
@@ -29,9 +29,11 @@ export const SectionHeader: FC<SectionHeaderProps> = ({
     onSectionClick(section);
   };
 
-  const onSectionChecked = useCallback(
+  const handleCheckboxClick = useCallback(
     (ev: React.MouseEvent) => {
+      console.log('section header handleCheckboxClick');
       ev.stopPropagation();
+      ev.preventDefault();
 
       if (onToggleChecked) {
         onToggleChecked(section);
@@ -50,7 +52,7 @@ export const SectionHeader: FC<SectionHeaderProps> = ({
         className={styles.checkbox}
         editable={editable}
         checked={section.checked}
-        onClick={onSectionChecked}
+        onClick={handleCheckboxClick}
       />
 
       <div className={styles.icon}>


### PR DESCRIPTION
**What this PR does / why we need it**:

It's tricky to use `<Checkbox />` in your UI outside of traditional forms-with-labels (what I'm sure it was designed for), mainly because the actual visual checkbox itself does not occupy space in the DOM as it is absolutely positioned within some padding.

You can see the impacts of this when consumers write janky CSS to go into the internals and change the properties to get it to work as they want

https://github.com/grafana/grafana/blob/58bbe17d8434a28eefa25b1af0675a748d4d108a/public/app/features/search/components/SearchCheckbox.tsx#L21-L32

This PR is a slight refactor of checkbox to make the actual Checkbox take up space in the DOM and remove the padding/margin/space around it.

Of course, this regresses Checkbox in the Manage Dashboards page, so I've made an attempt to try and fix it, but I'm now I'm getting funny behaviour with it just there that I don't understand too much 😅

**Which issue(s) this PR fixes**:

Fixes #36063   
Related to #35649 

**Special notes for your reviewer**:

Still a draft until i fix the Manage Dashboards behaviour :) 