### PR TITLE
Elasticsearch: Allow case sensitive custom options in date_histogram interval

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.test.tsx
@@ -1,0 +1,92 @@
+import { getDefaultTimeRange } from '@grafana/data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ElasticDatasource } from 'app/plugins/datasource/elasticsearch/datasource';
+import { ElasticsearchQuery } from 'app/plugins/datasource/elasticsearch/types';
+import React, { ComponentProps, ReactNode } from 'react';
+import { ElasticsearchProvider } from '../../ElasticsearchQueryContext';
+import { DateHistogram } from '../aggregations';
+import { DateHistogramSettingsEditor } from './DateHistogramSettingsEditor';
+
+const renderWithESProvider = (
+  ui: ReactNode,
+  {
+    providerProps: {
+      datasource = {} as ElasticDatasource,
+      query = { refId: 'A' },
+      onChange = () => void 0,
+      onRunQuery = () => void 0,
+      range = getDefaultTimeRange(),
+    } = {},
+    ...renderOptions
+  }: { providerProps?: Partial<Omit<ComponentProps<typeof ElasticsearchProvider>, 'children'>> } & Parameters<
+    typeof render
+  >[1]
+) => {
+  return render(
+    <ElasticsearchProvider
+      query={query}
+      onChange={onChange}
+      datasource={datasource}
+      onRunQuery={onRunQuery}
+      range={range}
+    >
+      {ui}
+    </ElasticsearchProvider>,
+    renderOptions
+  );
+};
+
+describe('DateHistogram Settings Editor', () => {
+  describe('Custom options for interval', () => {
+    it('Allows users to create and select case sensitive custom options', () => {
+      const bucketAgg: DateHistogram = {
+        id: '1',
+        type: 'date_histogram',
+        settings: {
+          interval: 'auto',
+        },
+      };
+
+      const query: ElasticsearchQuery = {
+        refId: 'A',
+        bucketAggs: [bucketAgg],
+        metrics: [{ id: '2', type: 'count' }],
+        query: '',
+      };
+
+      const onChange = jest.fn();
+
+      renderWithESProvider(<DateHistogramSettingsEditor bucketAgg={bucketAgg} />, {
+        providerProps: { query, onChange },
+      });
+
+      const intervalInput = screen.getByLabelText('Interval') as HTMLInputElement;
+
+      expect(intervalInput).toBeInTheDocument();
+      expect(screen.getByText('auto')).toBeInTheDocument();
+
+      // we open the menu
+      userEvent.click(intervalInput);
+
+      // default options don't have 1M but 1m
+      expect(screen.queryByText('1M')).not.toBeInTheDocument();
+      expect(screen.getByText('1m')).toBeInTheDocument();
+
+      // we type in the input 1M, which should prompt an option creation
+      userEvent.type(intervalInput, '1M');
+      const creatableOption = screen.getByLabelText('Select option');
+      expect(creatableOption).toHaveTextContent('Create: 1M');
+
+      // we click on the creatable option to trigger its creation
+      userEvent.click(creatableOption);
+
+      expect(onChange).toHaveBeenCalled();
+
+      // we open the menu again
+      userEvent.click(intervalInput);
+      // the created option should be available
+      expect(screen.getByText('1M')).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -1,0 +1,114 @@
+import React, { ComponentProps, useState } from 'react';
+import { InlineField, Input, Select } from '@grafana/ui';
+import { DateHistogram } from '../aggregations';
+import { bucketAggregationConfig } from '../utils';
+import { useDispatch } from '../../../../hooks/useStatelessReducer';
+import { SelectableValue } from '@grafana/data';
+import { changeBucketAggregationSetting } from '../state/actions';
+import { inlineFieldProps } from '.';
+
+type IntervalOption = SelectableValue<string>;
+
+const defaultIntervalOptions: IntervalOption[] = [
+  { label: 'auto', value: 'auto' },
+  { label: '10s', value: '10s' },
+  { label: '1m', value: '1m' },
+  { label: '5m', value: '5m' },
+  { label: '10m', value: '10m' },
+  { label: '20m', value: '20m' },
+  { label: '1h', value: '1h' },
+  { label: '1d', value: '1d' },
+];
+
+const hasValue = (searchValue: IntervalOption['value']) => ({ value }: IntervalOption) => value === searchValue;
+
+const isValidNewOption: ComponentProps<typeof Select>['isValidNewOption'] = (
+  inputValue,
+  _,
+  options: IntervalOption[]
+) => {
+  // TODO: would be extremely nice here to allow only template variables and values that are
+  // valid date histogram's Interval options
+  const valueExists = options.some(hasValue(inputValue));
+  // we also don't want users to create "empty" values
+  return !valueExists && inputValue.trim().length > 0;
+};
+
+const optionStartsWithValue: ComponentProps<typeof Select>['filterOption'] = (option: IntervalOption, value) =>
+  option.value?.startsWith(value) || false;
+
+interface Props {
+  bucketAgg: DateHistogram;
+}
+
+const getInitialState = (initialValue?: string): IntervalOption[] => {
+  return defaultIntervalOptions.concat(
+    defaultIntervalOptions.some(hasValue(initialValue))
+      ? []
+      : {
+          value: initialValue,
+          label: initialValue,
+        }
+  );
+};
+
+export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
+  const dispatch = useDispatch();
+
+  const [intervalOptions, setIntervalOptions] = useState<IntervalOption[]>(
+    getInitialState(bucketAgg.settings?.interval)
+  );
+
+  const addIntervalOption = (value: string) => setIntervalOptions([...intervalOptions, { value, label: value }]);
+
+  const handleIntervalChange = (v: string) => dispatch(changeBucketAggregationSetting(bucketAgg, 'interval', v));
+
+  return (
+    <>
+      <InlineField label="Interval" {...inlineFieldProps}>
+        <Select<string>
+          inputId="asd"
+          onChange={(e) => handleIntervalChange(e.value!)}
+          options={intervalOptions}
+          value={bucketAgg.settings?.interval || bucketAggregationConfig[bucketAgg.type].defaultSettings?.interval}
+          allowCustomValue
+          isValidNewOption={isValidNewOption}
+          filterOption={optionStartsWithValue}
+          onCreateOption={(value) => {
+            addIntervalOption(value);
+            handleIntervalChange(value);
+          }}
+        />
+      </InlineField>
+
+      <InlineField label="Min Doc Count" {...inlineFieldProps}>
+        <Input
+          onBlur={(e) => dispatch(changeBucketAggregationSetting(bucketAgg, 'min_doc_count', e.target.value!))}
+          defaultValue={
+            bucketAgg.settings?.min_doc_count || bucketAggregationConfig[bucketAgg.type].defaultSettings?.min_doc_count
+          }
+        />
+      </InlineField>
+
+      <InlineField label="Trim Edges" {...inlineFieldProps} tooltip="Trim the edges on the timeseries datapoints">
+        <Input
+          onBlur={(e) => dispatch(changeBucketAggregationSetting(bucketAgg, 'trimEdges', e.target.value!))}
+          defaultValue={
+            bucketAgg.settings?.trimEdges || bucketAggregationConfig[bucketAgg.type].defaultSettings?.trimEdges
+          }
+        />
+      </InlineField>
+
+      <InlineField
+        label="Offset"
+        {...inlineFieldProps}
+        tooltip="Change the start value of each bucket by the specified positive (+) or negative offset (-) duration, such as 1h for an hour, or 1d for a day"
+      >
+        <Input
+          onBlur={(e) => dispatch(changeBucketAggregationSetting(bucketAgg, 'offset', e.target.value!))}
+          defaultValue={bucketAgg.settings?.offset || bucketAggregationConfig[bucketAgg.type].defaultSettings?.offset}
+        />
+      </InlineField>
+    </>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from '../../../../hooks/useStatelessReducer';
 import { SelectableValue } from '@grafana/data';
 import { changeBucketAggregationSetting } from '../state/actions';
 import { inlineFieldProps } from '.';
+import { uniqueId } from 'lodash';
 
 type IntervalOption = SelectableValue<string>;
 
@@ -67,7 +68,7 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
     <>
       <InlineField label="Interval" {...inlineFieldProps}>
         <Select<string>
-          inputId="asd"
+          inputId={uniqueId('es-date_histogram-interval')}
           onChange={(e) => handleIntervalChange(e.value!)}
           options={intervalOptions}
           value={bucketAgg.settings?.interval || bucketAggregationConfig[bucketAgg.type].defaultSettings?.interval}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -14,6 +14,22 @@ import {
 import { FiltersSettingsEditor } from './FiltersSettingsEditor';
 import { useDescription } from './useDescription';
 import { useQuery } from '../../ElasticsearchQueryContext';
+import { SelectableValue } from '@grafana/data';
+
+const isValidNewOption: ComponentProps<typeof Select>['isValidNewOption'] = (
+  inputValue,
+  _,
+  options: Array<SelectableValue<string>>
+) => {
+  // TODO: would be extremely nice here to allow only template variables and values that are
+  // valid date histogram's Interval options
+  const valueExists = options.some(({ value }) => value === inputValue);
+  // we also don't want users to create "empty" values
+  return !valueExists && inputValue.trim().length > 0;
+};
+
+const optionStartsWithValue: ComponentProps<typeof Select>['filterOption'] = (option: SelectableValue<string>, value) =>
+  option.value?.startsWith(value) || false;
 
 const inlineFieldProps: Partial<ComponentProps<typeof InlineField>> = {
   labelWidth: 16,
@@ -98,6 +114,8 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
               options={intervalOptions}
               value={bucketAgg.settings?.interval || bucketAggregationConfig[bucketAgg.type].defaultSettings?.interval}
               allowCustomValue
+              isValidNewOption={isValidNewOption}
+              filterOption={optionStartsWithValue}
             />
           </InlineField>
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/index.tsx
@@ -4,34 +4,13 @@ import { useDispatch } from '../../../../hooks/useStatelessReducer';
 import { SettingsEditorContainer } from '../../SettingsEditorContainer';
 import { changeBucketAggregationSetting } from '../state/actions';
 import { BucketAggregation } from '../aggregations';
-import {
-  bucketAggregationConfig,
-  createOrderByOptionsFromMetrics,
-  intervalOptions,
-  orderOptions,
-  sizeOptions,
-} from '../utils';
+import { bucketAggregationConfig, createOrderByOptionsFromMetrics, orderOptions, sizeOptions } from '../utils';
 import { FiltersSettingsEditor } from './FiltersSettingsEditor';
 import { useDescription } from './useDescription';
 import { useQuery } from '../../ElasticsearchQueryContext';
-import { SelectableValue } from '@grafana/data';
+import { DateHistogramSettingsEditor } from './DateHistogramSettingsEditor';
 
-const isValidNewOption: ComponentProps<typeof Select>['isValidNewOption'] = (
-  inputValue,
-  _,
-  options: Array<SelectableValue<string>>
-) => {
-  // TODO: would be extremely nice here to allow only template variables and values that are
-  // valid date histogram's Interval options
-  const valueExists = options.some(({ value }) => value === inputValue);
-  // we also don't want users to create "empty" values
-  return !valueExists && inputValue.trim().length > 0;
-};
-
-const optionStartsWithValue: ComponentProps<typeof Select>['filterOption'] = (option: SelectableValue<string>, value) =>
-  option.value?.startsWith(value) || false;
-
-const inlineFieldProps: Partial<ComponentProps<typeof InlineField>> = {
+export const inlineFieldProps: Partial<ComponentProps<typeof InlineField>> = {
   labelWidth: 16,
 };
 
@@ -41,6 +20,7 @@ interface Props {
 
 export const SettingsEditor = ({ bucketAgg }: Props) => {
   const dispatch = useDispatch();
+
   const { metrics } = useQuery();
   const settingsDescription = useDescription(bucketAgg);
   const orderBy = createOrderByOptionsFromMetrics(metrics);
@@ -106,52 +86,7 @@ export const SettingsEditor = ({ bucketAgg }: Props) => {
         </InlineField>
       )}
 
-      {bucketAgg.type === 'date_histogram' && (
-        <>
-          <InlineField label="Interval" {...inlineFieldProps}>
-            <Select
-              onChange={(e) => dispatch(changeBucketAggregationSetting(bucketAgg, 'interval', e.value!))}
-              options={intervalOptions}
-              value={bucketAgg.settings?.interval || bucketAggregationConfig[bucketAgg.type].defaultSettings?.interval}
-              allowCustomValue
-              isValidNewOption={isValidNewOption}
-              filterOption={optionStartsWithValue}
-            />
-          </InlineField>
-
-          <InlineField label="Min Doc Count" {...inlineFieldProps}>
-            <Input
-              onBlur={(e) => dispatch(changeBucketAggregationSetting(bucketAgg, 'min_doc_count', e.target.value!))}
-              defaultValue={
-                bucketAgg.settings?.min_doc_count ||
-                bucketAggregationConfig[bucketAgg.type].defaultSettings?.min_doc_count
-              }
-            />
-          </InlineField>
-
-          <InlineField label="Trim Edges" {...inlineFieldProps} tooltip="Trim the edges on the timeseries datapoints">
-            <Input
-              onBlur={(e) => dispatch(changeBucketAggregationSetting(bucketAgg, 'trimEdges', e.target.value!))}
-              defaultValue={
-                bucketAgg.settings?.trimEdges || bucketAggregationConfig[bucketAgg.type].defaultSettings?.trimEdges
-              }
-            />
-          </InlineField>
-
-          <InlineField
-            label="Offset"
-            {...inlineFieldProps}
-            tooltip="Change the start value of each bucket by the specified positive (+) or negative offset (-) duration, such as 1h for an hour, or 1d for a day"
-          >
-            <Input
-              onBlur={(e) => dispatch(changeBucketAggregationSetting(bucketAgg, 'offset', e.target.value!))}
-              defaultValue={
-                bucketAgg.settings?.offset || bucketAggregationConfig[bucketAgg.type].defaultSettings?.offset
-              }
-            />
-          </InlineField>
-        </>
-      )}
+      {bucketAgg.type === 'date_histogram' && <DateHistogramSettingsEditor bucketAgg={bucketAgg} />}
 
       {bucketAgg.type === 'histogram' && (
         <>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -76,17 +76,6 @@ export const orderByOptions = [
   { label: 'Doc Count', value: '_count' },
 ];
 
-export const intervalOptions = [
-  { label: 'auto', value: 'auto' },
-  { label: '10s', value: '10s' },
-  { label: '1m', value: '1m' },
-  { label: '5m', value: '5m' },
-  { label: '10m', value: '10m' },
-  { label: '20m', value: '20m' },
-  { label: '1h', value: '1h' },
-  { label: '1d', value: '1d' },
-];
-
 /**
  * This returns the valid options for each of the enabled extended stat
  */


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes handling of creatable options & handles case-sensitive input for `date_histogram`'s `interval` so users can now create, for example, `1m` and `1M` as separate options.

Also, we weren't properly handling custom options creations, so upon creating a new option, when closing and reopening the settings editor, the `interval` select showed a blank state.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35912

**Notes**

#36194 fixes the handling of custom options also for `size` in `terms` aggregation, but also refactors the handling to be generic. that PR targets this branch, so the tests for `DateHistogramSettingsEditor` will need to be rewritten in case we decide the changes in #36194 are good.
