### PR TITLE
Prometheus: Fix performance issue in editor when too many ids

### DIFF
--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -436,6 +436,10 @@ const tokenizer: Grammar = {
       },
     },
   ],
+  idList: {
+    pattern: /\d+(\|\d+)+/,
+    alias: 'number',
+  },
   number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
   operator: new RegExp(`/[-+*/=%^~]|&&?|\\|?\\||!=?|<(?:=>?|<|>)?|>[>=]?|\\b(?:${OPERATORS.join('|')})\\b`, 'i'),
   punctuation: /[{};()`,.]/,


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR I fixed the below issue by matching the whole id block as one instead of one by one. We talked with @aocenas about possible ways to fix this and there is another one which I think make sense as well. It is to turn off code highlighting after a number of tokens to reduce performance issue. ~I'll do that in another PR~. I think a more sophisticated fix by disabling the highlighting if there are too many tokens doesn't worth the effort if we are going to replace the whole query input very soon.

**Which issue(s) this PR fixes**:

Fixes #35438

**Special notes for your reviewer**:

