### PR TITLE
Annotations: Adds tags endpoint

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -302,5 +302,5 @@ func GetAnnotationTags(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to find annotation tags", err)
 	}
 
-	return response.JSON(200, util.DynMap{"result": items})
+	return response.JSON(200, items)
 }

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -288,3 +288,19 @@ func canSave(c *models.ReqContext, repo annotations.Repository, annotationID int
 
 	return nil
 }
+
+func GetAnnotationTags(c *models.ReqContext) response.Response {
+	query := &annotations.TagsQuery{
+		OrgID: c.OrgId,
+		Tag:   c.Query("tag"),
+		Limit: c.QueryInt64("limit"),
+	}
+
+	repo := annotations.GetRepository()
+	items, err := repo.FindTags(query)
+	if err != nil {
+		return response.Error(500, "Failed to find annotation tags", err)
+	}
+
+	return response.JSON(200, util.DynMap{"result": items})
+}

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -297,10 +297,10 @@ func GetAnnotationTags(c *models.ReqContext) response.Response {
 	}
 
 	repo := annotations.GetRepository()
-	items, err := repo.FindTags(query)
+	result, err := repo.FindTags(query)
 	if err != nil {
 		return response.Error(500, "Failed to find annotation tags", err)
 	}
 
-	return response.JSON(200, items)
+	return response.JSON(200, util.DynMap{"result": result})
 }

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -259,6 +259,10 @@ func (repo *fakeAnnotationsRepo) Find(query *annotations.ItemQuery) ([]*annotati
 	annotations := []*annotations.ItemDTO{{Id: 1}}
 	return annotations, nil
 }
+func (repo *fakeAnnotationsRepo) FindTags(query *annotations.TagsQuery) ([]*annotations.TagsDTO, error) {
+	tags := []*annotations.TagsDTO{}
+	return tags, nil
+}
 
 var fakeAnnoRepo *fakeAnnotationsRepo
 

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -259,9 +259,11 @@ func (repo *fakeAnnotationsRepo) Find(query *annotations.ItemQuery) ([]*annotati
 	annotations := []*annotations.ItemDTO{{Id: 1}}
 	return annotations, nil
 }
-func (repo *fakeAnnotationsRepo) FindTags(query *annotations.TagsQuery) ([]*annotations.TagsDTO, error) {
-	tags := []*annotations.TagsDTO{}
-	return tags, nil
+func (repo *fakeAnnotationsRepo) FindTags(query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	result := annotations.FindTagsResult{
+		Tags: []*annotations.TagsDTO{},
+	}
+	return result, nil
 }
 
 var fakeAnnoRepo *fakeAnnotationsRepo

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -410,6 +410,7 @@ func (hs *HTTPServer) registerRoutes() {
 			annotationsRoute.Put("/:annotationId", bind(dtos.UpdateAnnotationsCmd{}), routing.Wrap(UpdateAnnotation))
 			annotationsRoute.Patch("/:annotationId", bind(dtos.PatchAnnotationsCmd{}), routing.Wrap(PatchAnnotation))
 			annotationsRoute.Post("/graphite", reqEditorRole, bind(dtos.PostGraphiteAnnotationsCmd{}), routing.Wrap(PostGraphiteAnnotation))
+			annotationsRoute.Get("/tags", routing.Wrap(GetAnnotationTags))
 		})
 
 		apiRoute.Post("/frontend-metrics", bind(metrics.PostFrontendMetricsCommand{}), routing.Wrap(hs.PostFrontendMetrics))

--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -17,7 +17,7 @@ type Repository interface {
 	Update(item *Item) error
 	Find(query *ItemQuery) ([]*ItemDTO, error)
 	Delete(params *DeleteParams) error
-	FindTags(query *TagsQuery) ([]*TagsDTO, error)
+	FindTags(query *TagsQuery) (FindTagsResult, error)
 }
 
 // AnnotationCleaner is responsible for cleaning up old annotations
@@ -57,6 +57,10 @@ type Tags struct {
 type TagsDTO struct {
 	Tag   string `json:"tag"`
 	Count int64  `json:"count"`
+}
+
+type FindTagsResult struct {
+	Tags []*TagsDTO `json:"tags"`
 }
 
 type DeleteParams struct {

--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -48,10 +48,15 @@ type TagsQuery struct {
 	Limit int64 `json:"limit"`
 }
 
+type Tags struct {
+	Key   string
+	Value string
+	Count int64
+}
+
 type TagsDTO struct {
-	ID    int64  `json:"id"`
-	Key   string `json:"Key"`
-	Value string `json:"Value"`
+	Tag   string `json:"tag"`
+	Count int64  `json:"count"`
 }
 
 type DeleteParams struct {

--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -17,6 +17,7 @@ type Repository interface {
 	Update(item *Item) error
 	Find(query *ItemQuery) ([]*ItemDTO, error)
 	Delete(params *DeleteParams) error
+	FindTags(query *TagsQuery) ([]*TagsDTO, error)
 }
 
 // AnnotationCleaner is responsible for cleaning up old annotations
@@ -38,6 +39,19 @@ type ItemQuery struct {
 	MatchAny     bool     `json:"matchAny"`
 
 	Limit int64 `json:"limit"`
+}
+
+type TagsQuery struct {
+	OrgID int64  `json:"orgId"`
+	Tag   string `json:"tag"`
+
+	Limit int64 `json:"limit"`
+}
+
+type TagsDTO struct {
+	ID    int64  `json:"id"`
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
 }
 
 type DeleteParams struct {

--- a/pkg/services/sqlstore/annotation.go
+++ b/pkg/services/sqlstore/annotation.go
@@ -292,7 +292,7 @@ func (r *SQLAnnotationRepo) FindTags(query *annotations.TagsQuery) ([]*annotatio
 	sql.WriteString(`where annotation.org_id = ?`)
 	params = append(params, query.OrgID)
 
-	sql.WriteString(`and (` + tagKey + dialect.LikeStr() + ` ? or ` + tagValue + dialect.LikeStr() + ` ?)`)
+	sql.WriteString(` and (` + tagKey + ` ` + dialect.LikeStr() + ` ? or ` + tagValue + ` ` + dialect.LikeStr() + ` ?)`)
 	params = append(params, `%`+query.Tag+`%`, `%`+query.Tag+`%`)
 
 	sql.WriteString(` ORDER BY ` + tagKey + `,` + tagValue + ` ` + dialect.Limit(query.Limit))

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -251,5 +251,41 @@ func TestAnnotations(t *testing.T) {
 			require.NoError(t, err)
 			assert.Empty(t, items)
 		})
+
+		t.Run("Should find tags by key", func(t *testing.T) {
+			items, err := repo.FindTags(&annotations.TagsQuery{
+				OrgID: 1,
+				Tag:   "server",
+			})
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+		})
+
+		t.Run("Should find tags by value", func(t *testing.T) {
+			items, err := repo.FindTags(&annotations.TagsQuery{
+				OrgID: 1,
+				Tag:   "server-1",
+			})
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+		})
+
+		t.Run("Should not find tags in other org", func(t *testing.T) {
+			items, err := repo.FindTags(&annotations.TagsQuery{
+				OrgID: 0,
+				Tag:   "server-1",
+			})
+			require.NoError(t, err)
+			require.Len(t, items, 0)
+		})
+
+		t.Run("Should not find tags that do not exist", func(t *testing.T) {
+			items, err := repo.FindTags(&annotations.TagsQuery{
+				OrgID: 0,
+				Tag:   "donald duck",
+			})
+			require.NoError(t, err)
+			require.Len(t, items, 0)
+		})
 	})
 }

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -253,45 +253,45 @@ func TestAnnotations(t *testing.T) {
 		})
 
 		t.Run("Should find tags by key", func(t *testing.T) {
-			items, err := repo.FindTags(&annotations.TagsQuery{
+			result, err := repo.FindTags(&annotations.TagsQuery{
 				OrgID: 1,
 				Tag:   "server",
 			})
 			require.NoError(t, err)
-			require.Len(t, items, 1)
-			require.Equal(t, "server:server-1", items[0].Tag)
-			require.Equal(t, int64(1), items[0].Count)
+			require.Len(t, result.Tags, 1)
+			require.Equal(t, "server:server-1", result.Tags[0].Tag)
+			require.Equal(t, int64(1), result.Tags[0].Count)
 		})
 
 		t.Run("Should find tags by value", func(t *testing.T) {
-			items, err := repo.FindTags(&annotations.TagsQuery{
+			result, err := repo.FindTags(&annotations.TagsQuery{
 				OrgID: 1,
 				Tag:   "outage",
 			})
 			require.NoError(t, err)
-			require.Len(t, items, 2)
-			require.Equal(t, "outage", items[0].Tag)
-			require.Equal(t, "type:outage", items[1].Tag)
-			require.Equal(t, int64(1), items[0].Count)
-			require.Equal(t, int64(1), items[1].Count)
+			require.Len(t, result.Tags, 2)
+			require.Equal(t, "outage", result.Tags[0].Tag)
+			require.Equal(t, "type:outage", result.Tags[1].Tag)
+			require.Equal(t, int64(1), result.Tags[0].Count)
+			require.Equal(t, int64(1), result.Tags[1].Count)
 		})
 
 		t.Run("Should not find tags in other org", func(t *testing.T) {
-			items, err := repo.FindTags(&annotations.TagsQuery{
+			result, err := repo.FindTags(&annotations.TagsQuery{
 				OrgID: 0,
 				Tag:   "server-1",
 			})
 			require.NoError(t, err)
-			require.Len(t, items, 0)
+			require.Len(t, result.Tags, 0)
 		})
 
 		t.Run("Should not find tags that do not exist", func(t *testing.T) {
-			items, err := repo.FindTags(&annotations.TagsQuery{
+			result, err := repo.FindTags(&annotations.TagsQuery{
 				OrgID: 0,
-				Tag:   "donald duck",
+				Tag:   "unknown:tag",
 			})
 			require.NoError(t, err)
-			require.Len(t, items, 0)
+			require.Len(t, result.Tags, 0)
 		})
 	})
 }

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -259,15 +259,21 @@ func TestAnnotations(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Len(t, items, 1)
+			require.Equal(t, "server:server-1", items[0].Tag)
+			require.Equal(t, int64(1), items[0].Count)
 		})
 
 		t.Run("Should find tags by value", func(t *testing.T) {
 			items, err := repo.FindTags(&annotations.TagsQuery{
 				OrgID: 1,
-				Tag:   "server-1",
+				Tag:   "outage",
 			})
 			require.NoError(t, err)
-			require.Len(t, items, 1)
+			require.Len(t, items, 2)
+			require.Equal(t, "outage", items[0].Tag)
+			require.Equal(t, "type:outage", items[1].Tag)
+			require.Equal(t, int64(1), items[0].Count)
+			require.Equal(t, int64(1), items[1].Count)
 		})
 
 		t.Run("Should not find tags in other org", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We're currently upgrading the annotations query editor for the built-in Grafana data source. We want to add a way for the user the select existing tags and therefore we need to expose a new search api for annotation tags. This PR adds the GET `/api/annotations/tags` endpoint.

**Annotation Query Editor for built-in Grafana data source**
![image](https://user-images.githubusercontent.com/562238/123901085-a13fb600-d96a-11eb-9d39-22bab9bb0582.png)

**Annotation Editor**
![image](https://user-images.githubusercontent.com/562238/123901143-bc122a80-d96a-11eb-8919-4a2ed2a9bd5e.png)

**Which issue(s) this PR fixes**:
Relates #36107

**Special notes for your reviewer**:

