### PR TITLE
Explore: Fix import of queries between SQL data sources

### DIFF
--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -51,9 +51,8 @@ export function changeDatasource(
       })
     );
 
-    const queries = getState().explore[exploreId]!.queries;
-
     if (options?.importQueries) {
+      const queries = getState().explore[exploreId]!.queries;
       await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, instance));
     }
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -265,10 +265,7 @@ export const importQueries = (
     // Check if queries can be imported from previously selected datasource
     if (sourceDataSource.meta?.id === targetDataSource.meta?.id) {
       // Keep same queries if same type of datasource, but delete datasource query property to prevent miss-match of new and old data source instance
-      importedQueries = queries.map((query) => {
-        delete query.datasource;
-        return query;
-      });
+      importedQueries = queries.map(({ datasource, ...query }) => query);
     } else if (targetDataSource.importQueries) {
       // Datasource-specific importers
       importedQueries = await targetDataSource.importQueries(queries, sourceDataSource);
@@ -343,7 +340,7 @@ export const runQueries = (exploreId: ExploreId, options?: { replaceUrl?: boolea
           dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
         });
 
-      // If we don't have resuls saved in cache, run new queries
+      // If we don't have results saved in cache, run new queries
     } else {
       if (!hasNonEmptyQuery(queries)) {
         dispatch(clearQueriesAction({ exploreId }));

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -264,8 +264,11 @@ export const importQueries = (
     let importedQueries = queries;
     // Check if queries can be imported from previously selected datasource
     if (sourceDataSource.meta?.id === targetDataSource.meta?.id) {
-      // Keep same queries if same type of datasource
-      importedQueries = [...queries];
+      // Keep same queries if same type of datasource, but delete datasource query property to prevent miss-match of new and old data source instance
+      importedQueries = queries.map((query) => {
+        delete query.datasource;
+        return query;
+      });
     } else if (targetDataSource.importQueries) {
       // Datasource-specific importers
       importedQueries = await targetDataSource.importQueries(queries, sourceDataSource);

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -264,7 +264,7 @@ export const importQueries = (
     let importedQueries = queries;
     // Check if queries can be imported from previously selected datasource
     if (sourceDataSource.meta?.id === targetDataSource.meta?.id) {
-      // Keep same queries if same type of datasource, but delete datasource query property to prevent miss-match of new and old data source instance
+      // Keep same queries if same type of datasource, but delete datasource query property to prevent mismatch of new and old data source instance
       importedQueries = queries.map(({ datasource, ...query }) => query);
     } else if (targetDataSource.importQueries) {
       // Datasource-specific importers


### PR DESCRIPTION
**What this PR does / why we need it**:
Some data sources (e.g. graphite & sql data sources) have `datasource` property (which is optional and non-essential) in their queries. When switching between same type of data sources (e.g. postgres->postgres), we imported full query that included old/previous data source instance in the query object and therefore created miss-match between old and new instance. This PR fixes it.
**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/36104

**Special notes for your reviewer**:
1. Run `make devenv sources=postgres`
2. Create postgres1 and postgres2 data sources (Host: `localhost:5432`, User: `grafana`, Password: `password`, TLS/SSL Mode: `disable`)
3. Open Explore and choose `postgres1` data source. Run query and the switch to `postgres2`.

On master, the urls should be (non-matching postgres instances):
`http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22postgres1%22,%7B%22datasource%22:%22postgres2%22,%22format...`


On this branch (matching postgres2 instances):
`http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22postgres2%22,%7B%22datasource%22:%22postgres2%22,%22format...`
