### PR TITLE
Governance: Add Will Browne to the Grafana team

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -102,6 +102,7 @@ The current team members are:
 - Tobias Skarhed ([Grafana Labs](https://grafana.com/))
 - Torkel Ödegaard ([Grafana Labs](https://grafana.com/))
 - Utkarsh Bhatnagar ([Tinder](https://www.tinder.com/))
+- Will Browne ([Grafana Labs](https://grafana.com/))
 
 ### Maintainers
 


### PR DESCRIPTION
Will Browne has been proposed as a new team member and the vote achieved the super majority required.

@wbrowne can you approve the PR to confirm that you accept, please. Welcome to the team!