### PR TITLE
Governance: Add Erik Sundell to the Grafana team

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -78,6 +78,7 @@ The current team members are:
 - Diana Sarlinska ([Grafana Labs](https://grafana.com/))
 - Dominik Prokop ([Grafana Labs](https://grafana.com/))
 - Emil Tullstedt ([Grafana Labs](https://grafana.com/))
+- Erik Sundell ([Grafana Labs](https://grafana.com/))
 - Fredrik Enestad ([Soundtrack Your Brand](https://www.soundtrackyourbrand.com/))
 - Hugo Häggmark ([Grafana Labs](https://grafana.com/))
 - Ivana Huckova ([Grafana Labs](https://grafana.com/))


### PR DESCRIPTION
Erik Sundell has been proposed as a new team member and the vote achieved the super majority required.

@sunker can you approve the PR to confirm that you accept, please. Welcome to the team!