### PR TITLE
Governance: Add Zoltan Bedi to the Grafana team

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -104,6 +104,7 @@ The current team members are:
 - Torkel Ödegaard ([Grafana Labs](https://grafana.com/))
 - Utkarsh Bhatnagar ([Tinder](https://www.tinder.com/))
 - Will Browne ([Grafana Labs](https://grafana.com/))
+- Zoltán Bedi ([Grafana Labs](https://grafana.com/))
 
 ### Maintainers
 


### PR DESCRIPTION
Zoltan Bedi has been proposed as a new team member and the vote achieved the super majority required.

@zoltanbedi can you approve the PR to confirm that you accept, please. Welcome to the team!