### PR TITLE
Remove GO111MODULE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 .PHONY: all deps-go deps-js deps build-go build-server build-cli build-js build build-docker-dev build-docker-full lint-go golangci-lint test-go test-js test run run-frontend clean devenv devenv-down protobuf help
 
-GO = GO111MODULE=on go
+GO = go
 GO_FILES ?= ./pkg/...
 SH_FILES ?= $(shell find ./scripts -name *.sh)
 
@@ -51,7 +51,7 @@ scripts/go/bin/bra: scripts/go/go.mod
 	$(GO) build -o ./bin/bra github.com/unknwon/bra
 
 run: scripts/go/bin/bra ## Build and run web server on filesystem changes.
-	@GO111MODULE=on scripts/go/bin/bra run
+	@scripts/go/bin/bra run
 
 run-frontend: deps-js ## Fetch js dependencies and watch frontend for rebuild
 	yarn start

--- a/UPGRADING_DEPENDENCIES.md
+++ b/UPGRADING_DEPENDENCIES.md
@@ -20,27 +20,24 @@ Upgrading Go or Node.js requires making changes in many different files. See bel
 
 The Grafana project uses [Go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) to manage dependencies on external packages. This requires a working Go environment with version 1.11 or greater installed.
 
-> **Note:** Since most developers of Grafana still use the `GOPATH` we need to specify `GO111MODULE=on` to make `go mod` and `got get` work as intended. If you have setup Grafana outside of the `GOPATH` on your machine you can skip `GO111MODULE=on` when running the commands below.
-
 To add or update a new dependency, use the `go get` command:
 
 ```bash
-# The GO111MODULE variable can be omitted when the code isn't located in GOPATH.
-# Pick the latest tagged release.
-GO111MODULE=on go get example.com/some/module/pkg
+go get example.com/some/module/pkg
 
 # Pick a specific version.
-GO111MODULE=on go get example.com/some/module/pkg@vX.Y.Z
+go get example.com/some/module/pkg@vX.Y.Z
 ```
 
 Tidy up the `go.mod` and `go.sum` files:
 
 ```bash
-# The GO111MODULE variable can be omitted when the code isn't located in GOPATH.
-GO111MODULE=on go mod tidy
+go mod tidy
 ```
 
 You have to commit the changes to `go.mod` and `go.sum` before submitting the pull request.
+
+To understand what the actual dependencies of `grafana-server` are, one could run it with `-vv` flag. This might produce an output, different from `go.mod` contents and `-vv` option is the source of truth here. It lists the modules _compiled_ into the executable, while `go.mod` lists also test and weak transitive dependencies (modules, used in some package, which is not in use by itself). If you are interested in reporting a vulnerability in a dependency module - please consult `-vv` output, maybe the "dependency" is not a dependency as such.
 
 ### Upgrading dependencies
 

--- a/build.go
+++ b/build.go
@@ -393,7 +393,6 @@ func runError(cmd string, args ...string) ([]byte, error) {
 func runPrint(cmd string, args ...string) {
 	log.Println(cmd, strings.Join(args, " "))
 	ecmd := exec.Command(cmd, args...)
-	ecmd.Env = append(os.Environ(), "GO111MODULE=on")
 	ecmd.Stdout = os.Stdout
 	ecmd.Stderr = os.Stderr
 	err := ecmd.Run()

--- a/devenv/docker/blocks/slow_proxy/Dockerfile
+++ b/devenv/docker/blocks/slow_proxy/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:latest as builder
 ADD main.go /
 WORKDIR /
-RUN GO111MODULE=off CGO_ENABLED=0 go build -o main .
+RUN go mod init proxy
+RUN CGO_ENABLED=0 go build -o main .
 
 FROM scratch
 WORKDIR /


### PR DESCRIPTION
This PR removes a long obsolete GO111MODULE environment variables, and prefers Go modules instead.
De facto this has been the behavior we have been experiencing since Go 1.16.
Time to make the code a bit shorter, I guess.