### PR TITLE
Graph: Workaround for DashboardQueryRunner race condition

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, isArray } from 'lodash';
+import { isArray } from 'lodash';
 import { PanelCtrl } from 'app/features/panel/panel_ctrl';
 import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { ContextSrv } from 'app/core/services/context_srv';
@@ -173,13 +173,11 @@ class MetricsPanelCtrl extends PanelCtrl {
 
   updateTimeRange(datasource?: DataSourceApi) {
     this.datasource = datasource || this.datasource;
-    this.range = cloneDeep(this.timeSrv.timeRange());
+    this.range = this.timeSrv.timeRange();
 
     const newTimeData = applyPanelTimeOverrides(this.panel, this.range);
     this.timeInfo = newTimeData.timeInfo;
     this.range = newTimeData.timeRange;
-
-    return this.datasource;
   }
 
   issueQueries(datasource: DataSourceApi) {

--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -1,4 +1,4 @@
-import { isArray } from 'lodash';
+import { cloneDeep, isArray } from 'lodash';
 import { PanelCtrl } from 'app/features/panel/panel_ctrl';
 import { applyPanelTimeOverrides } from 'app/features/dashboard/utils/panel';
 import { ContextSrv } from 'app/core/services/context_srv';
@@ -20,11 +20,12 @@ import { PanelQueryRunner } from '../query/state/PanelQueryRunner';
 
 class MetricsPanelCtrl extends PanelCtrl {
   declare datasource: DataSourceApi;
+  declare range: TimeRange;
+
   contextSrv: ContextSrv;
   datasourceSrv: any;
   timeSrv: any;
   templateSrv: any;
-  declare range: TimeRange;
   interval: any;
   intervalMs: any;
   resolution: any;
@@ -98,7 +99,6 @@ class MetricsPanelCtrl extends PanelCtrl {
     // load datasource service
     return this.datasourceSrv
       .get(this.panel.datasource, this.panel.scopedVars)
-      .then(this.updateTimeRange.bind(this))
       .then(this.issueQueries.bind(this))
       .catch((err: any) => {
         this.processDataError(err);
@@ -173,7 +173,7 @@ class MetricsPanelCtrl extends PanelCtrl {
 
   updateTimeRange(datasource?: DataSourceApi) {
     this.datasource = datasource || this.datasource;
-    this.range = this.timeSrv.timeRange();
+    this.range = cloneDeep(this.timeSrv.timeRange());
 
     const newTimeData = applyPanelTimeOverrides(this.panel, this.range);
     this.timeInfo = newTimeData.timeInfo;
@@ -183,6 +183,8 @@ class MetricsPanelCtrl extends PanelCtrl {
   }
 
   issueQueries(datasource: DataSourceApi) {
+    this.updateTimeRange(datasource);
+
     this.datasource = datasource;
 
     const panel = this.panel as PanelModel;

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -184,10 +184,6 @@ export class GraphCtrl extends MetricsPanelCtrl {
     actions.push({ text: 'Toggle legend', click: 'ctrl.toggleLegend()', shortcut: 'p l' });
   }
 
-  issueQueries(datasource: any) {
-    return super.issueQueries(datasource);
-  }
-
   zoomOut(evt: any) {
     appEvents.publish(new ZoomOutEvent(2));
   }


### PR DESCRIPTION
Fixes #36247

This is a temporary work around for a race condition with DashboardQueryRunner.

Current process that causes this bug


* Add one old graph panel on an empty dashboard (default time:  range 6h)
* Change time range via time picker (5m)
* RefreshEvent emitted
* DashboardQueryRunner issues query
* MetricsPanelCtrl starts query process, fetches DataSourceAPI instance
* MetricsPanelCtrl calls updateTimeRange and this sets this.range (5m)
* DashboardQueryRunner complete the dashboard annotation query and emits a new result
* mergePanelAndDashData merges new annotation result (empty) with previous query result and emits result, this causes a panelDataObserver.next call in MetricsPanelCtrl which gets the new data result, updates time range (this.range to 6h) from result of the old query and renders graph with old data again. [line](https://github.com/grafana/grafana/blob/main/public/app/features/panel/metrics_panel_ctrl.ts#L159)
* MetricsPanelCtrl calls issueQueries which now uses a this.range (6h) that is for the old query result (so not the new time range)

This PR does not fix the underlying problem that if the annotation query is fast it will complete before any new panel queries have been issued. So we will have two data emits for every refresh, one before any panel queries have been issued and with new annotations/alert states and old data and time range.

If we could unsubscribe to the annotation / dashboard query runner after it is completed maybe that could fix the problem? (so that it does not fire for the previous query/observable).
