### PR TITLE
Dashboard: Adding Max time range and Oldest 'From' settings

### DIFF
--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -206,10 +206,14 @@ export function registerAngularDirectives() {
     'refreshIntervals',
     'timePickerHidden',
     'nowDelay',
+    'maxTimeRange',
+    'oldestFrom',
     'timezone',
     ['onTimeZoneChange', { watchDepth: 'reference', wrapApply: true }],
     ['onRefreshIntervalChange', { watchDepth: 'reference', wrapApply: true }],
     ['onNowDelayChange', { watchDepth: 'reference', wrapApply: true }],
+    ['onMaxTimeRangeChange', { watchDepth: 'reference', wrapApply: true }],
+    ['onOldestFromChange', { watchDepth: 'reference', wrapApply: true }],
     ['onHideTimePickerChange', { watchDepth: 'reference', wrapApply: true }],
   ]);
 }

--- a/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
+++ b/public/app/features/dashboard/components/DashboardSettings/SettingsCtrl.ts
@@ -262,6 +262,16 @@ export class SettingsCtrl {
     this.renderCount++;
   };
 
+   onMaxTimeRangeChange = (maxTimeRange: string) => {
+    this.dashboard.timepicker.maxTimeRange = maxTimeRange;
+    this.renderCount++;
+  };
+
+  onOldestFromChange = (oldestFrom: string) => {
+    this.dashboard.timepicker.oldestFrom = oldestFrom;
+    this.renderCount++;
+  };
+
   onHideTimePickerChange = (hide: boolean) => {
     this.dashboard.timepicker.hidden = hide;
     this.renderCount++;

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -123,6 +123,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
               />
             </Tooltip>
           </div>
+
           <div className="gf-form">
             <span className="gf-form-label width-7">Max time range</span>
             <Tooltip

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -9,20 +9,26 @@ interface Props {
   onTimeZoneChange: (timeZone: TimeZone) => void;
   onRefreshIntervalChange: (interval: string[]) => void;
   onNowDelayChange: (nowDelay: string) => void;
+  onMaxTimeRangeChange: (maxTimeRange: string) => void;
+  onOldestFromChange: (oldestFrom: string) => void;
   onHideTimePickerChange: (hide: boolean) => void;
   renderCount: number; // hack to make sure Angular changes are propagated properly, please remove when DashboardSettings are migrated to React
   refreshIntervals: string[];
   timePickerHidden: boolean;
   nowDelay: string;
+  maxTimeRange: string;
+  oldestFrom: string;
   timezone: TimeZone;
 }
 
 interface State {
   isNowDelayValid: boolean;
+  isMaxTimeRangeValid: boolean;
+  isOldestFromValid: boolean;
 }
 
 export class TimePickerSettings extends PureComponent<Props, State> {
-  state: State = { isNowDelayValid: true };
+  state: State = { isNowDelayValid: true, isMaxTimeRangeValid: true, isOldestFromValid: true };
 
   onNowDelayChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value;
@@ -38,6 +44,38 @@ export class TimePickerSettings extends PureComponent<Props, State> {
     }
 
     this.setState({ isNowDelayValid: false });
+  };
+
+  onMaxTimeRangeChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.value;
+
+    if (isEmpty(value)) {
+      this.setState({ isMaxTimeRangeValid: true });
+      return this.props.onMaxTimeRangeChange(value);
+    }
+
+    if (value.match(/^[1-9]\d*[yMwdhms]$/)) {
+      this.setState({ isMaxTimeRangeValid: true });
+      return this.props.onMaxTimeRangeChange(value);
+    }
+
+    this.setState({ isMaxTimeRangeValid: false });
+  };
+
+  onOldestFromChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.value;
+
+    if (isEmpty(value)) {
+      this.setState({ isOldestFromValid: true });
+      return this.props.onOldestFromChange(value);
+    }
+
+    if (value.match(/^[1-9]\d*[yMwdhms]$/)) {
+      this.setState({ isOldestFromValid: true });
+      return this.props.onOldestFromChange(value);
+    }
+
+    this.setState({ isOldestFromValid: false });
   };
 
   onHideTimePickerChange = () => {
@@ -82,6 +120,40 @@ export class TimePickerSettings extends PureComponent<Props, State> {
                 placeholder="0m"
                 onChange={this.onNowDelayChange}
                 defaultValue={this.props.nowDelay}
+              />
+            </Tooltip>
+          </div>
+          <div className="gf-form">
+            <span className="gf-form-label width-7">Max time range</span>
+            <Tooltip
+              placement="right"
+              content={
+                'Prevent users from choosing a time range larger than a specified time interval. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds).'
+              }
+            >
+              <Input
+                width={60}
+                invalid={!this.state.isMaxTimeRangeValid}
+                onChange={this.onMaxTimeRangeChange}
+                defaultValue={this.props.maxTimeRange}
+              />
+            </Tooltip>
+          </div>
+
+          <div className="gf-form">
+            <span className="gf-form-label width-7">Oldest 'From'</span>
+            <span className="gf-form-label width-3">now -</span>
+            <Tooltip
+              placement="right"
+              content={
+                'Limit how far back the start of the time range can go from now. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds).'
+              }
+            >
+              <Input
+                width={53.5}
+                invalid={!this.state.isOldestFromValid}
+                onChange={this.onOldestFromChange}
+                defaultValue={this.props.oldestFrom}
               />
             </Tooltip>
           </div>

--- a/public/app/features/dashboard/components/DashboardSettings/template.html
+++ b/public/app/features/dashboard/components/DashboardSettings/template.html
@@ -54,11 +54,15 @@
     onTimeZoneChange="ctrl.onTimeZoneChange"
     onRefreshIntervalChange="ctrl.onRefreshIntervalChange"
     onNowDelayChange="ctrl.onNowDelayChange"
+    onMaxTimeRangeChange="ctrl.onMaxTimeRangeChange"
+    onOldestFromChange="ctrl.onOldestFromChange"
     onHideTimePickerChange="ctrl.onHideTimePickerChange"
     renderCount="ctrl.renderCount"
     refreshIntervals="ctrl.dashboard.timepicker.refresh_intervals"
     timePickerHidden="ctrl.dashboard.timepicker.hidden"
     nowDelay="ctrl.dashboard.timepicker.nowDelay"
+    maxTimeRange="ctrl.dashboard.timepicker.maxTimeRange"
+    oldestFrom="ctrl.dashboard.timepicker.oldestFrom"
     timezone="ctrl.dashboard.timezone"
   >
   </time-picker-settings>

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import coreModule from 'app/core/core_module';
 // Types
 import {
+  AppEvents,
   dateMath,
   DefaultTimeRange,
   TimeRange,
@@ -65,11 +66,57 @@ export class TimeSrv {
     this.initTimeFromUrl();
     this.parseTime();
 
+    if (this.dashboard.timepicker.maxTimeRange || this.dashboard.timepicker.oldestFrom) {
+      this.checkTimeAtLoad();
+    }
+
     // remember time at load so we can go back to it
     this.timeAtLoad = _.cloneDeep(this.time);
 
     if (this.refresh) {
       this.setAutoRefresh(this.refresh);
+    }
+  }
+
+  checkTimeAtLoad() {
+    let maxTimeRangeInMillis = 0,
+      oldestFromInMillis = 0;
+    if (this.dashboard.timepicker.maxTimeRange) {
+      maxTimeRangeInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.maxTimeRange);
+    }
+    if (this.dashboard.timepicker.oldestFrom) {
+      oldestFromInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.oldestFrom);
+    }
+    let min = 0;
+    if (maxTimeRangeInMillis !== 0 && oldestFromInMillis !== 0) {
+      min = Math.min(maxTimeRangeInMillis, oldestFromInMillis);
+    } else if (maxTimeRangeInMillis !== 0) {
+      min = maxTimeRangeInMillis;
+    } else if (oldestFromInMillis !== 0) {
+      min = oldestFromInMillis;
+    }
+    let str;
+    if (min !== 0) {
+      str = rangeUtil.secondsToHms(min / 1000);
+    }
+    const timezone = this.dashboard ? this.dashboard.getTimezone() : undefined;
+    let from: any = this.time.from;
+    let to: any = this.time.to;
+    if (dateMath.isMathString(from)) {
+      from = dateMath.parse(from, false, timezone);
+    }
+    if (dateMath.isMathString(to)) {
+      to = dateMath.parse(to, false, timezone);
+    }
+
+    if (
+      min !== 0 &&
+      ((maxTimeRangeInMillis !== 0 && to.valueOf() - from.valueOf() > maxTimeRangeInMillis) ||
+        (oldestFromInMillis !== 0 && Date.now() - from.valueOf() > oldestFromInMillis))
+    ) {
+      this.time.from = 'now-' + str;
+      this.time.to = 'now';
+      this.setTime(this.time);
     }
   }
 
@@ -235,6 +282,48 @@ export class TimeSrv {
   }
 
   setTime(time: RawTimeRange, fromRouteUpdate?: boolean) {
+    let isSetTime = true;
+    let maxTimeRangeInMillis = 0,
+      oldestFromInMillis = 0;
+
+    if (this.dashboard.timepicker.maxTimeRange) {
+      maxTimeRangeInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.maxTimeRange);
+    }
+
+    if (this.dashboard.timepicker.oldestFrom) {
+      oldestFromInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.oldestFrom);
+    }
+
+    const timezone = this.dashboard ? this.dashboard.getTimezone() : undefined;
+    let from: any = time.from;
+    let to: any = time.to;
+
+    if (dateMath.isMathString(from)) {
+      from = dateMath.parse(from, false, timezone);
+    }
+
+    if (dateMath.isMathString(to)) {
+      to = dateMath.parse(to, false, timezone);
+    }
+
+    if (maxTimeRangeInMillis !== 0 && to.valueOf() - from.valueOf() > maxTimeRangeInMillis) {
+      appEvents.emit(AppEvents.alertWarning, [
+        'Timerange can not be more than ' + this.dashboard.timepicker.maxTimeRange,
+      ]);
+      isSetTime = false;
+    }
+
+    if (oldestFromInMillis !== 0 && Date.now() - from.valueOf() > oldestFromInMillis) {
+      appEvents.emit(AppEvents.alertWarning, [
+        'The start of the timerange can not be more than ' + this.dashboard.timepicker.oldestFrom + ' old from now',
+      ]);
+      isSetTime = false;
+    }
+
+    if (!isSetTime) {
+      return;
+    }
+
     _.extend(this.time, time);
 
     // disable refresh if zoom in or zoom out


### PR DESCRIPTION
**What this PR does / why we need it:**

The current Grafana UI allows users to set the time range to go arbitrarily far back using the time picker, calendar picker, and zoom-out feature. However, going too far back may cause significant performance degradation and potentially result in the data source crashing depending on how it was set up. In addition to this, TSDBs usually have a specific data retention time, and therefore it does not make sense to go any further back than the retained time.

I added two additional fields under “Time Options” in Admin’s Dashboard Setting to choose an appropriate time range and time limit.

     1. Max time range: prevent users from choosing a time range larger than a specified time interval
     2. Oldest 'From': limit how far back the start of the time range can go from now

The input for both of these options must be valid time spans or empty, otherwise, the option will default to the last valid input. By default, both inputs are empty. If either input is empty, there will be no restriction for their corresponding setting. You can see how it looks like in the image below.

![admin](https://user-images.githubusercontent.com/71486417/123795273-79683800-d901-11eb-818c-adc2f55cf72b.png)

From a user perspective, there will be no change in the time range controls UI. If the user picks or zooms out to a valid time range, then the dashboard should update exactly as before. If the user picks an invalid time range, then the dashboard should not update, the current time range settings should remain the same, and he or she will get an error message. If the user clicks the zoom-out control, it should only zoom out if the new time range would be valid, otherwise, he or she will get an error message. You can see how the error looks like in the dashboard in the image below.

![Screenshot (46)](https://user-images.githubusercontent.com/71486417/123797052-6ce4df00-d903-11eb-9b2e-82b92f1ffc71.png)

Note that if the dashboard's default time range is more than the configuration settings then it will set the time range of the dashboard to the minimum value of "Oldest From" and "Max time range" before now via a page load. 
For example: 
Suppose **Max time range**: 7h and **Oldest 'From'**: now - 5h and default time range is "last 12 hours". Then the default time range of the dashboard is more than the input values. So here, Grafana will set the time range as "last 5 hours" (Minimum of 7h and 5h is 5h).

 Also, if the user enters an invalid time range via URL time control, they will be taken to the valid time range by applying the above-mentioned technique.