### PR TITLE
Loki: Send correct time range in template variable queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -289,7 +289,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
 
   getTimeRangeParams() {
     const timeRange = this.timeSrv.timeRange();
-    return { from: timeRange.from.valueOf() * NS_IN_MS, to: timeRange.to.valueOf() * NS_IN_MS };
+    return { start: timeRange.from.valueOf() * NS_IN_MS, end: timeRange.to.valueOf() * NS_IN_MS };
   }
 
   async importQueries(queries: DataQuery[], originDataSource: DataSourceApi): Promise<LokiQuery[]> {

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -442,7 +442,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   fetchSeriesLabels = async (match: string): Promise<Record<string, string[]>> => {
     const url = '/loki/api/v1/series';
-    const { from: start, to: end } = this.datasource.getTimeRangeParams();
+    const { start, end } = this.datasource.getTimeRangeParams();
 
     const cacheKey = this.generateCacheKey(url, start, end, match);
     let value = this.seriesCache.get(cacheKey);
@@ -464,7 +464,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   fetchSeries = async (match: string): Promise<Array<Record<string, string>>> => {
     const url = '/loki/api/v1/series';
-    const { from: start, to: end } = this.datasource.getTimeRangeParams();
+    const { start, end } = this.datasource.getTimeRangeParams();
     const params = { match, start, end };
     return await this.request(url, params);
   };
@@ -489,7 +489,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
   async fetchLabelValues(key: string): Promise<string[]> {
     const url = `/loki/api/v1/label/${key}/values`;
     const rangeParams = this.datasource.getTimeRangeParams();
-    const { from: start, to: end } = rangeParams;
+    const { start, end } = rangeParams;
 
     const cacheKey = this.generateCacheKey(url, start, end, key);
     const params = { start, end };


### PR DESCRIPTION
**What this PR does / why we need it**:

For template variable queries we've been using incorrect `from` and `to` parameters. These should have been everywhere (in all loki queries) `start` & `end` https://grafana.com/docs/loki/latest/api/#get-lokiapiv1labels. This PR fixes it. 

