### PR TITLE
Alerting: Fixed typo in the delete dashboard modal confirmation prompt

### DIFF
--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -46,7 +46,7 @@ const getModalBody = (panels: PanelModel[], title: string) => {
       <p>Do you want to delete this dashboard?</p>
       <p>
         This dashboard contains {totalAlerts} alert{totalAlerts > 1 ? 's' : ''}. Deleting this dashboard also deletes
-        deletes those alerts
+        those alerts.
       </p>
     </>
   ) : (


### PR DESCRIPTION
This PR fixes a minor typo in the confirmation prompt when deleting dashboards with alerts.

![Screen Shot 2021-06-29 at 9 55 37 AM](https://user-images.githubusercontent.com/95875/123800937-2ae67980-d8c0-11eb-8a17-3e6bd33ac4ef.png)

