### PR TITLE
Web compat: polyfill MediaQueryList.addEventListener() for Safari < 14

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -4,6 +4,7 @@ import 'regenerator-runtime/runtime';
 
 import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import 'abortcontroller-polyfill/dist/polyfill-patch-fetch'; // fetch polyfill needed for PhantomJs rendering
+import './polyfills/old-mediaquerylist'; // Safari < 14 does not have mql.addEventListener()
 import 'file-saver';
 import 'jquery';
 

--- a/public/app/polyfills/old-mediaquerylist.ts
+++ b/public/app/polyfills/old-mediaquerylist.ts
@@ -1,0 +1,20 @@
+// Safari < 14 does not have mql.addEventListener(), but uses the old spec mql.addListener()
+
+let oMatchMedia = window.matchMedia;
+
+type MqlListener = (this: MediaQueryList, ev: MediaQueryListEvent) => any;
+
+window.matchMedia = (mediaQueryString) => {
+  let mql = oMatchMedia(mediaQueryString);
+
+  if (!mql.addEventListener) {
+    mql.addEventListener = (type: string, listener: MqlListener) => {
+      mql.addListener(listener);
+    };
+    mql.removeEventListener = (type: string, listener: MqlListener) => {
+      mql.removeListener(listener);
+    };
+  }
+
+  return mql;
+};


### PR DESCRIPTION
this should fix the Safari < 14 issue portion of https://github.com/grafana/grafana/issues/35594

(tested this in BrowserStack)