### PR TITLE
Chore: adds buffer size to ReplaySubject

### DIFF
--- a/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
@@ -39,7 +39,7 @@ class DashboardQueryRunnerImpl implements DashboardQueryRunner {
     this.cancel = this.cancel.bind(this);
     this.destroy = this.destroy.bind(this);
     this.executeRun = this.executeRun.bind(this);
-    this.results = new ReplaySubject<DashboardQueryRunnerWorkerResult>();
+    this.results = new ReplaySubject<DashboardQueryRunnerWorkerResult>(1);
     this.runs = new Subject<DashboardQueryRunnerOptions>();
     this.cancellationStream = new Subject<any>();
     this.runsSubscription = this.runs.subscribe((options) => this.executeRun(options));


### PR DESCRIPTION
**What this PR does / why we need it**:
While testing #36254 I realized that I forgot to initialize the buffer size for the ReplaySubject in DashboardQueryRunner. This means that we can have extensive memory usage for dashboards that have auto refresh enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

