### PR TITLE
Hackathon: Sonification

### DIFF
--- a/packages/grafana-ui/src/types/icon.ts
+++ b/packages/grafana-ui/src/types/icon.ts
@@ -88,6 +88,7 @@ export const getAvailableIcons = () =>
     'gf-portrait',
     'grafana',
     'graph-bar',
+    'headphones',
     'heart',
     'heart-break',
     'history',

--- a/public/app/core/components/SonifierControls/SonifierControls.tsx
+++ b/public/app/core/components/SonifierControls/SonifierControls.tsx
@@ -1,0 +1,101 @@
+// Libraries
+import React, { PureComponent, FormEvent } from 'react';
+import { css } from '@emotion/css';
+
+import { ButtonGroup, ClickOutsideWrapper, Label, Select, Slider, ToolbarButton, withTheme2 } from '@grafana/ui';
+
+// Types
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import getSonifier from 'app/core/services/Sonifier';
+
+export interface State {
+  isOpen: boolean;
+  volume: number;
+  instrument: string;
+  instruments: string[];
+}
+
+const GAIN_FACTOR = 0.03;
+
+export class UnthemedSonifierControls extends PureComponent<{ theme: GrafanaTheme2 }, State> {
+  state: State = {
+    isOpen: false,
+    volume: 0,
+    instrument: '',
+    instruments: [],
+  };
+
+  onChangeVolume = (value: number) => {
+    const sonifier = getSonifier();
+    sonifier.setVolume(value * GAIN_FACTOR);
+  };
+
+  onOpen = (event: FormEvent<HTMLButtonElement>) => {
+    const { isOpen } = this.state;
+    event.stopPropagation();
+    event.preventDefault();
+    const sonifier = getSonifier();
+    const volume = sonifier.getVolume() / GAIN_FACTOR;
+    const instrument = sonifier.getInstrument();
+    const instruments = sonifier.getInstruments();
+    this.setState({ isOpen: !isOpen, volume, instrument, instruments });
+  };
+
+  onClose = () => {
+    this.setState({ isOpen: false });
+  };
+
+  onSelectInstrument = (value: SelectableValue<string>) => {
+    const sonifier = getSonifier();
+    sonifier.setInstrument(value.value as OscillatorType);
+  };
+
+  render() {
+    const { theme } = this.props;
+
+    const { isOpen, volume, instrument, instruments } = this.state;
+    const styles = getStyles(theme);
+    const instrumentOptions = instruments.map((i) => ({ label: i, value: i }));
+
+    return (
+      <ButtonGroup className={styles.container}>
+        <ToolbarButton aria-label="Sonifier Controls Open Button" onClick={this.onOpen} icon="bell" isOpen={isOpen} />
+        {isOpen && (
+          <div className={styles.menuWrapper}>
+            <ClickOutsideWrapper includeButtonPress={false} onClick={this.onClose}>
+              <Label>Volume</Label>
+              <Slider min={0} max={10} value={volume} onAfterChange={this.onChangeVolume} />
+              <Label>Sound</Label>
+              <Select value={instrument} options={instrumentOptions} onChange={this.onSelectInstrument} width={16} />
+            </ClickOutsideWrapper>
+          </div>
+        )}
+      </ButtonGroup>
+    );
+  }
+}
+
+/** @public */
+export const SonifierControls = withTheme2(UnthemedSonifierControls);
+export default SonifierControls;
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css`
+      position: relative;
+      display: flex;
+      vertical-align: middle;
+    `,
+    menuWrapper: css`
+      position: absolute;
+      z-index: ${theme.zIndex.dropdown};
+      top: ${theme.spacing(4)};
+      right: 0;
+      width: 240px;
+      background: ${theme.colors.background.primary};
+      border: 1px solid ${theme.colors.border.weak};
+      border-radius: ${theme.shape.borderRadius(1)};
+      padding: ${theme.spacing(2)};
+    `,
+  };
+};

--- a/public/app/core/services/Sonifier.ts
+++ b/public/app/core/services/Sonifier.ts
@@ -1,0 +1,299 @@
+export type Note = 'A' | 'Bb' | 'B' | 'C' | 'Db' | 'D' | 'Eb' | 'E' | 'F' | 'Gb' | 'G' | 'Ab';
+
+const A4_FREQUENCY = 440;
+
+const SemitoneMapping: { [note: string]: number } = {
+  A: 0,
+  Bb: 1,
+  B: 2,
+  C: 3,
+  Dd: 4,
+  D: 5,
+  Eb: 6,
+  E: 7,
+  F: 8,
+  Gb: 9,
+  G: 10,
+  Ab: 11,
+};
+
+type Scale = number[];
+type ScaleType = 'major' | 'minor' | 'chromatic';
+type ProcessFn = (() => void) | undefined;
+type SampleFrame<T> = {
+  data: T;
+  index: number;
+};
+type PlaySeriesOptions = {
+  min?: number;
+  max?: number;
+  onPointProcess?: (pointIndex: number) => void;
+};
+
+const Scales: { [name in 'major' | 'minor' | 'chromatic']: Scale } = {
+  chromatic: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  major: [2, 2, 1, 2, 2, 2, 1, 2],
+  minor: [2, 1, 2, 2, 1, 3, 1, 2],
+};
+
+export type Tuple = [ts: number, val: number];
+type SamplingMethod = 'random' | 'systematic';
+
+type SonifierOptions = {
+  baseFrequency?: number;
+  scales?: number;
+  maxSamples?: number;
+  samplingMethod?: SamplingMethod;
+  instrument?: OscillatorType;
+  scale?: ScaleType;
+  volume?: number;
+  fixedDeltaTime: boolean;
+};
+
+export class Sonifier {
+  isPlaying: boolean;
+  baseFrequency: number;
+  scales: number;
+  maxSamples: number;
+  samplingMethod: SamplingMethod;
+  instrument: OscillatorType;
+  scale: ScaleType;
+
+  private _audioContext: AudioContext;
+  private _volume: number;
+  private _paused: boolean;
+  private _fixedDt: boolean;
+  private _playQueue: Array<{ data: Tuple; duration: number; onProcess: ProcessFn }>;
+
+  constructor(options?: SonifierOptions) {
+    this.isPlaying = false;
+    this.baseFrequency = options?.baseFrequency || A4_FREQUENCY;
+    this.scales = options?.scales || 3;
+    this.maxSamples = options?.maxSamples || 50;
+    this.samplingMethod = options?.samplingMethod || 'systematic';
+    this.instrument = options?.instrument || 'square';
+    this.scale = options?.scale || 'chromatic';
+
+    this._volume = options?.volume || 0.03;
+    this._fixedDt = options?.fixedDeltaTime || false;
+    this._playQueue = [];
+    this._paused = false;
+    this._audioContext = new AudioContext();
+  }
+
+  private _advancePlayQueue(): void {
+    if (this._playQueue.length === 0) {
+      return;
+    }
+    const {
+      data: [t, f],
+      duration = 200,
+      onProcess,
+    } = this._playQueue.shift() as { data: Tuple; duration: number; onProcess: ProcessFn };
+
+    const oscilator = this._audioContext.createOscillator();
+    oscilator.type = this.instrument;
+    oscilator.onended = () => {
+      onProcess && onProcess();
+      if (this._playQueue.length > 0 && !this._paused) {
+        this._advancePlayQueue();
+      } else {
+        this.isPlaying = false;
+      }
+    };
+    const gainNode = this._audioContext.createGain();
+    gainNode.gain.value = this._volume;
+    oscilator.connect(gainNode);
+    gainNode.connect(this._audioContext.destination);
+    oscilator.frequency.value = f;
+
+    oscilator.start(t);
+    oscilator.stop(t + duration * 0.001);
+    this.isPlaying = true;
+  }
+
+  private _enqueueNote({ f, ts, duration }: { f: number; ts: number; duration: number }, onProcess?: () => void): void {
+    this._playQueue.push({ data: [ts, f], duration, onProcess });
+    if (!this.isPlaying) {
+      this._advancePlayQueue();
+    }
+  }
+
+  private _harmonizeFrequencies(
+    data: Array<SampleFrame<Tuple>>,
+    options?: PlaySeriesOptions
+  ): Array<SampleFrame<Tuple>> {
+    let harmonizedData: Array<SampleFrame<Tuple>> = [];
+
+    const sortedByValue = [...data].sort((a, b) => a.data[1] - b.data[1]);
+
+    let min = options?.min || sortedByValue[0].data[1];
+    let max = options?.max || sortedByValue[sortedByValue.length - 1].data[1];
+
+    let minT = data[0].data[0];
+    let maxT = data[data.length - 1].data[0];
+
+    let maxHarmonicIndex = this.scales * Scales[this.scale].length;
+
+    let dt = 1 / data.length;
+
+    for (let i = 0; i < sortedByValue.length; i++) {
+      const mappedIndex = Math.floor(((sortedByValue[i].data[1] - min) / (max - min)) * maxHarmonicIndex);
+
+      const f = this.baseFrequency * Math.pow(2, mappedIndex / 12);
+      if (!this._fixedDt) {
+        dt = (sortedByValue[i].data[0] - minT) / (maxT - minT);
+      }
+
+      harmonizedData.push({
+        index: sortedByValue[i].index,
+        data: [dt, f],
+      });
+    }
+
+    return [...harmonizedData].sort((a, b) => a.data[0] - b.data[0]);
+  }
+
+  private _sample(data: Tuple[]): Array<SampleFrame<Tuple>> {
+    const sample = [];
+
+    let step = data.length >= this.maxSamples ? Math.floor(data.length / this.maxSamples) : 1;
+    if (step === 1) {
+      return data.map((x, index) => ({
+        data: x,
+        index,
+      }));
+    }
+
+    let i = step;
+
+    while (i < data.length) {
+      let index;
+      switch (this.samplingMethod) {
+        case 'random': {
+          index = i - Math.floor(Math.random() * step);
+          break;
+        }
+        case 'systematic': {
+          index = i - step;
+          break;
+        }
+        default: {
+          index = i;
+          break;
+        }
+      }
+
+      sample.push({
+        data: data[index][1] !== null ? data[index] : ([data[index][0], 0] as Tuple),
+        index,
+      });
+
+      i += step;
+    }
+
+    return sample;
+  }
+
+  getInstruments(): OscillatorType[] {
+    return ['sine', 'square', 'triangle', 'sawtooth'];
+  }
+
+  getInstrument(): OscillatorType {
+    return this.instrument;
+  }
+
+  setInstrument(instrument: OscillatorType) {
+    this.instrument = instrument;
+  }
+
+  pause() {
+    this._paused = true;
+  }
+
+  stop() {
+    this.pause();
+    this._playQueue = [];
+  }
+
+  play() {
+    this._paused = false;
+    this._advancePlayQueue();
+  }
+
+  setVolume(volume: number) {
+    this._volume = volume;
+  }
+
+  getVolume(): number {
+    return this._volume;
+  }
+
+  playNote(note: string, duration: number): Promise<void> {
+    return new Promise((resolve) => {
+      const semitones = SemitoneMapping[note as string];
+      const f = this.baseFrequency * Math.pow(2, semitones / 12);
+      let start = this._audioContext.currentTime + 0.02;
+      this._enqueueNote({ f, ts: start, duration }, resolve);
+    });
+  }
+
+  playSeries(data: Tuple[], options?: PlaySeriesOptions): Promise<void> {
+    return new Promise((resolve) => {
+      if (data.length === 0) {
+        return;
+      }
+
+      const sampledData = this._sample(data);
+      const harmonizedData = this._harmonizeFrequencies(sampledData, options);
+
+      let start = this._audioContext.currentTime + 0.02;
+
+      const duration = harmonizedData.length * 0.4;
+
+      for (let i = 0; i < harmonizedData.length; ++i) {
+        const [dt, f] = harmonizedData[i].data;
+
+        if (i === harmonizedData.length - 1) {
+          this._enqueueNote(
+            {
+              f,
+              ts: start + dt * duration,
+              duration: 200,
+            },
+            () => {
+              options?.onPointProcess?.(harmonizedData[i].index);
+              resolve();
+            }
+          );
+        } else {
+          this._enqueueNote(
+            {
+              f,
+              ts: start + dt * duration,
+              duration: 200,
+            },
+            () => {
+              options?.onPointProcess?.(harmonizedData[i].index);
+            }
+          );
+        }
+      }
+    });
+  }
+
+  speak(text: string): Promise<SpeechSynthesisEvent> {
+    return new Promise((resolve, reject) => {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.onend = resolve;
+      utterance.onerror = (event: SpeechSynthesisErrorEvent) => reject(event.error);
+
+      speechSynthesis.speak(utterance);
+    });
+  }
+}
+
+// Singleton
+export const sonifier = new Sonifier();
+export const getSonifier = (): Sonifier => sonifier;
+export default getSonifier;

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -24,6 +24,7 @@ import { toggleTheme } from './toggleTheme';
 import { withFocusedPanel } from './withFocusedPanelId';
 import { HelpModal } from '../components/help/HelpModal';
 import { sonifyPanel } from 'app/features/dashboard/utils/panel';
+import getSonifier from './Sonifier';
 
 export class KeybindingSrv {
   modalOpen = false;
@@ -55,6 +56,13 @@ export class KeybindingSrv {
   private globalEsc() {
     const anyDoc = document as any;
     const activeElement = anyDoc.activeElement;
+
+    // Cancel sound
+    const sonifier = getSonifier();
+    if (sonifier.isPlaying) {
+      sonifier.stop();
+      return;
+    }
 
     // typehead needs to handle it
     const typeaheads = document.querySelectorAll('.slate-typeahead--open');

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -23,6 +23,7 @@ import { getTimeSrv } from '../../features/dashboard/services/TimeSrv';
 import { toggleTheme } from './toggleTheme';
 import { withFocusedPanel } from './withFocusedPanelId';
 import { HelpModal } from '../components/help/HelpModal';
+import { sonifyPanel } from 'app/features/dashboard/utils/panel';
 
 export class KeybindingSrv {
   modalOpen = false;
@@ -282,6 +283,12 @@ export class KeybindingSrv {
           },
         })
       );
+    });
+
+    // sonify panel
+    this.bindWithPanelId('p a', (panelId) => {
+      const panelInfo = dashboard.getPanelInfoById(panelId)!;
+      sonifyPanel(dashboard, panelInfo.panel);
     });
 
     // toggle panel legend

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -18,6 +18,7 @@ import { SaveDashboardModalProxy } from 'app/features/dashboard/components/SaveD
 import { locationService } from '@grafana/runtime';
 import { toggleKioskMode } from 'app/core/navigation/kiosk';
 import { getDashboardSrv } from '../../services/DashboardSrv';
+import SonifierControls from 'app/core/components/SonifierControls/SonifierControls';
 
 const mapDispatchToProps = {
   updateTimeZoneForSession,
@@ -232,6 +233,8 @@ class DashNav extends PureComponent<Props> {
     }
 
     this.addCustomContent(customRightActions, buttons);
+
+    buttons.push(<SonifierControls />);
 
     buttons.push(this.renderTimeControls());
     buttons.push(tvButton);

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -4,6 +4,7 @@ import { PanelMenuItem } from '@grafana/data';
 import {
   addLibraryPanel,
   copyPanel,
+  sonifyPanel,
   duplicatePanel,
   removePanel,
   sharePanel,
@@ -72,6 +73,11 @@ export function getPanelMenu(
   const onCopyPanel = (event: React.MouseEvent<any>) => {
     event.preventDefault();
     copyPanel(panel);
+  };
+
+  const onSonifyPanel = (event: React.MouseEvent<any>) => {
+    event.preventDefault();
+    sonifyPanel(dashboard, panel);
   };
 
   const onRemovePanel = (event: React.MouseEvent<any>) => {
@@ -165,6 +171,12 @@ export function getPanelMenu(
     subMenu.push({
       text: 'Copy',
       onClick: onCopyPanel,
+    });
+
+    subMenu.push({
+      text: 'Sonify',
+      onClick: onSonifyPanel,
+      shortcut: 'p a',
     });
 
     if (isPanelModelLibraryPanel(panel)) {

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -119,6 +119,13 @@ export function getPanelMenu(
     shortcut: 'p s',
   });
 
+  menu.push({
+    text: 'Audible',
+    iconClassName: 'headphones',
+    onClick: onSonifyPanel,
+    shortcut: 'p a',
+  });
+
   if (contextSrv.hasAccessToExplore() && !(panel.plugin && panel.plugin.meta.skipDataQuery)) {
     menu.push({
       text: 'Explore',
@@ -171,12 +178,6 @@ export function getPanelMenu(
     subMenu.push({
       text: 'Copy',
       onClick: onCopyPanel,
-    });
-
-    subMenu.push({
-      text: 'Sonify',
-      onClick: onSonifyPanel,
-      shortcut: 'p a',
     });
 
     if (isPanelModelLibraryPanel(panel)) {

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -21,6 +21,7 @@ import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { ShowConfirmModalEvent, ShowModalReactEvent } from '../../../types/events';
 import { AddLibraryPanelModal } from 'app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal';
 import { UnlinkModal } from 'app/features/library-panels/components/UnlinkModal/UnlinkModal';
+import Sonifier, { Tuple, sleep } from 'app/core/services/Sonifier';
 
 export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: boolean) => {
   // confirm deletion
@@ -65,12 +66,14 @@ export const copyPanel = (panel: PanelModel) => {
 export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
   const panelData = panel.getQueryRunner().getLastResult();
   if (panelData && panelData.state === LoadingState.Done) {
+    const name = panelData.series[0].name || 'First series';
     const timestamps = (panelData.series[0].fields.find((f) => f.type === FieldType.time)?.values || []) as number[];
     const values = (panelData.series[0].fields.find((f) => f.type === FieldType.number)?.values.toArray() ||
       []) as number[];
-    const series = timestamps.map((ts, i) => [ts, values[i]]);
-    console.log(series);
-    // Call sonifier
+    const series: Tuple[] = timestamps.map((ts, i) => [ts, values[i]]);
+    const sonifier = new Sonifier();
+    sonifier.speak('Series 1');
+    sonifier.playSeries(series);
   }
 };
 

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -4,7 +4,7 @@ import store from 'app/core/store';
 // Models
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import { TimeRange, AppEvents, rangeUtil, dateMath } from '@grafana/data';
+import { TimeRange, AppEvents, rangeUtil, dateMath, LoadingState, FieldType } from '@grafana/data';
 
 // Utils
 import { isString as _isString } from 'lodash';
@@ -60,6 +60,18 @@ export const copyPanel = (panel: PanelModel) => {
 
   store.set(LS_PANEL_COPY_KEY, JSON.stringify(saveModel));
   appEvents.emit(AppEvents.alertSuccess, ['Panel copied. Click **Add panel** icon to paste.']);
+};
+
+export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
+  const panelData = panel.getQueryRunner().getLastResult();
+  if (panelData && panelData.state === LoadingState.Done) {
+    const timestamps = (panelData.series[0].fields.find((f) => f.type === FieldType.time)?.values || []) as number[];
+    const values = (panelData.series[0].fields.find((f) => f.type === FieldType.number)?.values.toArray() ||
+      []) as number[];
+    const series = timestamps.map((ts, i) => [ts, values[i]]);
+    console.log(series);
+    // Call sonifier
+  }
 };
 
 export const sharePanel = (dashboard: DashboardModel, panel: PanelModel) => {

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -4,7 +4,17 @@ import store from 'app/core/store';
 // Models
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import { TimeRange, AppEvents, rangeUtil, dateMath, LoadingState, FieldType } from '@grafana/data';
+import {
+  TimeRange,
+  AppEvents,
+  rangeUtil,
+  dateMath,
+  LoadingState,
+  FieldType,
+  FieldCache,
+  ReducerID,
+  reduceField,
+} from '@grafana/data';
 
 // Utils
 import { isString as _isString } from 'lodash';
@@ -67,16 +77,31 @@ export const sonifyPanel = async (dashboard: DashboardModel, panel: PanelModel) 
   const panelData = panel.getQueryRunner().getLastResult();
   if (panelData && panelData.state === LoadingState.Done) {
     let count = 1;
+    const maxSonified = 5;
+    const statPrecision = 3;
     for (const frame of panelData.series) {
       const name = frame.name || `Series ${count}`;
-      const timestamps = (frame.fields.find((f) => f.type === FieldType.time)?.values || []) as number[];
-      const values = (frame.fields.find((f) => f.type === FieldType.number)?.values.toArray() || []) as number[];
-      const series: any[] = timestamps.map((ts, i) => [ts, values[i]]);
-      const sonifier = getSonifier();
-      await sonifier.speak(name);
-      await sonifier.playSeries(series);
-      count++;
-      if (count > 5) {
+      const fieldCache = new FieldCache(frame);
+      const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
+      const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
+      if (timeField && valueField) {
+        const series: any[] = [];
+        for (let j = 0; j < frame.length; j++) {
+          series.push([timeField?.values.get(j), valueField?.values.get(j)]);
+        }
+        const reducers = [ReducerID.min, ReducerID.max, ReducerID.mean];
+        const calcs = reduceField({ field: valueField, reducers });
+        const maxValue = (calcs[ReducerID.max] as number).toPrecision(statPrecision);
+        const minValue = (calcs[ReducerID.min] as number).toPrecision(statPrecision);
+        const meanValue = (calcs[ReducerID.mean] as number).toPrecision(statPrecision);
+        const stats = `${name}. Minimum ${minValue}, maximum ${maxValue}, average ${meanValue}`;
+        const sonifier = getSonifier();
+        await sonifier.speak(stats);
+        await sonifier.playSeries(series);
+        console.log(stats);
+        count++;
+      }
+      if (count > maxSonified) {
         break;
       }
     }

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -63,7 +63,7 @@ export const copyPanel = (panel: PanelModel) => {
   appEvents.emit(AppEvents.alertSuccess, ['Panel copied. Click **Add panel** icon to paste.']);
 };
 
-export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
+export const sonifyPanel = async (dashboard: DashboardModel, panel: PanelModel) => {
   const panelData = panel.getQueryRunner().getLastResult();
   if (panelData && panelData.state === LoadingState.Done) {
     let count = 1;
@@ -73,8 +73,8 @@ export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
       const values = (frame.fields.find((f) => f.type === FieldType.number)?.values.toArray() || []) as number[];
       const series: any[] = timestamps.map((ts, i) => [ts, values[i]]);
       const sonifier = getSonifier();
-      sonifier.speak(name);
-      sonifier.playSeries(series);
+      await sonifier.speak(name);
+      await sonifier.playSeries(series);
       count++;
       if (count > 5) {
         break;

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -21,7 +21,7 @@ import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { ShowConfirmModalEvent, ShowModalReactEvent } from '../../../types/events';
 import { AddLibraryPanelModal } from 'app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal';
 import { UnlinkModal } from 'app/features/library-panels/components/UnlinkModal/UnlinkModal';
-import Sonifier, { Tuple } from 'app/core/services/Sonifier';
+import Sonifier from 'app/core/services/Sonifier';
 
 export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: boolean) => {
   // confirm deletion
@@ -70,7 +70,7 @@ export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
     const timestamps = (panelData.series[0].fields.find((f) => f.type === FieldType.time)?.values || []) as number[];
     const values = (panelData.series[0].fields.find((f) => f.type === FieldType.number)?.values.toArray() ||
       []) as number[];
-    const series: Tuple[] = timestamps.map((ts, i) => [ts, values[i]]);
+    const series: any[] = timestamps.map((ts, i) => [ts, values[i]]);
     const sonifier = new Sonifier();
     sonifier.speak(name);
     sonifier.playSeries(series);

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -4,7 +4,7 @@ import store from 'app/core/store';
 // Models
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import { TimeRange, AppEvents, rangeUtil, dateMath, LoadingState, FieldType } from '@grafana/data';
+import { TimeRange, AppEvents, rangeUtil, dateMath, LoadingState, FieldType, DataFrame } from '@grafana/data';
 
 // Utils
 import { isString as _isString } from 'lodash';
@@ -66,14 +66,20 @@ export const copyPanel = (panel: PanelModel) => {
 export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
   const panelData = panel.getQueryRunner().getLastResult();
   if (panelData && panelData.state === LoadingState.Done) {
-    const name = panelData.series[0].name || 'First series';
-    const timestamps = (panelData.series[0].fields.find((f) => f.type === FieldType.time)?.values || []) as number[];
-    const values = (panelData.series[0].fields.find((f) => f.type === FieldType.number)?.values.toArray() ||
-      []) as number[];
-    const series: any[] = timestamps.map((ts, i) => [ts, values[i]]);
-    const sonifier = new Sonifier();
-    sonifier.speak(name);
-    sonifier.playSeries(series);
+    let count = 1;
+    for (const frame of panelData.series) {
+      const name = frame.name || `Series ${count}`;
+      const timestamps = (frame.fields.find((f) => f.type === FieldType.time)?.values || []) as number[];
+      const values = (frame.fields.find((f) => f.type === FieldType.number)?.values.toArray() || []) as number[];
+      const series: any[] = timestamps.map((ts, i) => [ts, values[i]]);
+      const sonifier = new Sonifier();
+      sonifier.speak(name);
+      sonifier.playSeries(series);
+      count++;
+      if (count > 5) {
+        break;
+      }
+    }
   }
 };
 

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -4,7 +4,7 @@ import store from 'app/core/store';
 // Models
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import { TimeRange, AppEvents, rangeUtil, dateMath, LoadingState, FieldType, DataFrame } from '@grafana/data';
+import { TimeRange, AppEvents, rangeUtil, dateMath, LoadingState, FieldType } from '@grafana/data';
 
 // Utils
 import { isString as _isString } from 'lodash';
@@ -21,7 +21,7 @@ import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { ShowConfirmModalEvent, ShowModalReactEvent } from '../../../types/events';
 import { AddLibraryPanelModal } from 'app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal';
 import { UnlinkModal } from 'app/features/library-panels/components/UnlinkModal/UnlinkModal';
-import Sonifier from 'app/core/services/Sonifier';
+import getSonifier from 'app/core/services/Sonifier';
 
 export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: boolean) => {
   // confirm deletion
@@ -72,7 +72,7 @@ export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
       const timestamps = (frame.fields.find((f) => f.type === FieldType.time)?.values || []) as number[];
       const values = (frame.fields.find((f) => f.type === FieldType.number)?.values.toArray() || []) as number[];
       const series: any[] = timestamps.map((ts, i) => [ts, values[i]]);
-      const sonifier = new Sonifier();
+      const sonifier = getSonifier();
       sonifier.speak(name);
       sonifier.playSeries(series);
       count++;

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -21,7 +21,7 @@ import { ShareModal } from 'app/features/dashboard/components/ShareModal';
 import { ShowConfirmModalEvent, ShowModalReactEvent } from '../../../types/events';
 import { AddLibraryPanelModal } from 'app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal';
 import { UnlinkModal } from 'app/features/library-panels/components/UnlinkModal/UnlinkModal';
-import Sonifier, { Tuple, sleep } from 'app/core/services/Sonifier';
+import Sonifier, { Tuple } from 'app/core/services/Sonifier';
 
 export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: boolean) => {
   // confirm deletion
@@ -72,7 +72,7 @@ export const sonifyPanel = (dashboard: DashboardModel, panel: PanelModel) => {
       []) as number[];
     const series: Tuple[] = timestamps.map((ts, i) => [ts, values[i]]);
     const sonifier = new Sonifier();
-    sonifier.speak('Series 1');
+    sonifier.speak(name);
     sonifier.playSeries(series);
   }
 };

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -21,6 +21,7 @@ import { LiveTailControls } from './useLiveTailControls';
 import { cancelQueries, clearQueries, runQueries } from './state/query';
 import ReturnToDashboardButton from './ReturnToDashboardButton';
 import { isSplit } from './state/selectors';
+import SonifierControls from 'app/core/components/SonifierControls/SonifierControls';
 
 interface OwnProps {
   exploreId: ExploreId;
@@ -131,6 +132,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
             ) : null}
             <ToolbarButtonRow>
               <ReturnToDashboardButton exploreId={exploreId} />
+              <SonifierControls />
 
               {exploreId === 'left' && !splitted ? (
                 <ToolbarButton

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -284,8 +284,8 @@ class LiveLogs extends PureComponent<Props, State> {
             &nbsp; Exit live mode
           </Button>
           <Button variant="secondary" onClick={this.onClickSonify} className={styles.button}>
-            <Icon name="bell" />
-            &nbsp; {sonify ? 'Stop level sound' : 'Sonify log level'}
+            <Icon name="headphones" />
+            &nbsp; {sonify ? 'Stop audible level' : 'Audible log level'}
           </Button>
           {sonify && (
             <Select
@@ -297,8 +297,8 @@ class LiveLogs extends PureComponent<Props, State> {
             />
           )}
           <Button variant="secondary" onClick={this.onClickSonifyValue} className={styles.button}>
-            <Icon name="bell" />
-            &nbsp; {sonifyValue ? 'Stop value sound' : 'Sonify value'}
+            <Icon name="headphones" />
+            &nbsp; {sonifyValue ? 'Stop value sound' : 'Audible values'}
           </Button>
           {sonifyValue && (
             <>

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -6,7 +6,7 @@ import { LogMessageAnsi, getLogRowStyles, Icon, Button, Themeable2, withTheme2, 
 import { LogRowModel, TimeZone, dateTimeFormat, GrafanaTheme2, LogLevel, SelectableValue } from '@grafana/data';
 
 import { ElapsedTime } from './ElapsedTime';
-import Sonifier, { Tuple } from 'app/core/services/Sonifier';
+import getSonifier, { Sonifier } from 'app/core/services/Sonifier';
 
 const LevelMapper = {
   [LogLevel.unknown]: 'A',
@@ -109,7 +109,7 @@ class LiveLogs extends PureComponent<Props, State> {
       sonifyValueMax: '',
       sonifyLevelMin: LogLevel.error,
     };
-    this.sonifier = new Sonifier();
+    this.sonifier = getSonifier();
   }
 
   static getDerivedStateFromProps(nextProps: Props, state: State) {
@@ -133,7 +133,7 @@ class LiveLogs extends PureComponent<Props, State> {
         this.rowsCheckedForSonification = {};
         this.rowsSonified = {};
       }
-      const series: Tuple[] = [];
+      const series: any[] = [];
       for (const row of logRowsToRender) {
         if (!this.rowsCheckedForSonification[row.uid]) {
           if (sonify && LevelMapper[row.logLevel] >= LevelMapper[sonifyLevelMin as LogLevel]) {

--- a/public/app/features/explore/LiveLogs.tsx
+++ b/public/app/features/explore/LiveLogs.tsx
@@ -290,7 +290,7 @@ class LiveLogs extends PureComponent<Props, State> {
           {sonifyValue && (
             <>
               <Input
-                width={48}
+                width={36}
                 placeholder="Example: duration=(\d+)ms"
                 onChange={this.onChangeValueExpression}
                 value={sonifyValueExpression}

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -7,6 +7,7 @@ import React, { useMemo } from 'react';
 import { AnnotationsPlugin } from './plugins/AnnotationsPlugin';
 import { ContextMenuPlugin } from './plugins/ContextMenuPlugin';
 import { ExemplarsPlugin } from './plugins/ExemplarsPlugin';
+import { AudiblePlugin } from './plugins/AudiblePlugin';
 import { TimeSeriesOptions } from './types';
 import { prepareGraphableFields } from './utils';
 import { AnnotationEditorPlugin } from './plugins/AnnotationEditorPlugin';
@@ -67,6 +68,7 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
               />
             )}
             {/* Renders annotation markers*/}
+            <AudiblePlugin config={config} frames={data.series} />
             {data.annotations && (
               <AnnotationsPlugin annotations={data.annotations} config={config} timeZone={timeZone} />
             )}

--- a/public/app/plugins/panel/timeseries/plugins/AudibleMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AudibleMarker.tsx
@@ -1,0 +1,52 @@
+import { css } from '@emotion/css';
+import { DataFrame, DataFrameFieldIndex, GrafanaTheme } from '@grafana/data';
+import { UPlotConfigBuilder, useStyles } from '@grafana/ui';
+import React from 'react';
+
+interface MarkerProps {
+  dataFrame: DataFrame;
+  dataFrameFieldIndex: DataFrameFieldIndex;
+  config: UPlotConfigBuilder;
+}
+
+export const AudibleMarker: React.FC<MarkerProps> = ({ dataFrame, dataFrameFieldIndex, config }) => {
+  const styles = useStyles(getStyles);
+
+  const getSymbol = () => {
+    const symbols = [
+      <rect key="diamond" x="3.38672" width="4.78985" height="4.78985" transform="rotate(45 3.38672 0)" />,
+      <path
+        key="x"
+        d="M1.94444 3.49988L0 5.44432L1.55552 6.99984L3.49996 5.05539L5.4444 6.99983L6.99992 5.44431L5.05548 3.49988L6.99983 1.55552L5.44431 0L3.49996 1.94436L1.5556 0L8.42584e-05 1.55552L1.94444 3.49988Z"
+      />,
+      <path key="triangle" d="M4 0L7.4641 6H0.535898L4 0Z" />,
+      <rect key="rectangle" width="5" height="5" />,
+      <path key="pentagon" d="M3 0.5L5.85317 2.57295L4.76336 5.92705H1.23664L0.146831 2.57295L3 0.5Z" />,
+      <path
+        key="plus"
+        d="m2.35672,4.2425l0,2.357l1.88558,0l0,-2.357l2.3572,0l0,-1.88558l-2.3572,0l0,-2.35692l-1.88558,0l0,2.35692l-2.35672,0l0,1.88558l2.35672,0z"
+      />,
+    ];
+    return symbols[dataFrameFieldIndex.frameIndex % symbols.length];
+  };
+
+  const seriesColor = config
+    .getSeries()
+    .find((s) => s.props.dataFrameFieldIndex?.frameIndex === dataFrameFieldIndex.frameIndex)?.props.lineColor;
+
+  return (
+    <svg viewBox="0 0 7 7" width="7" height="7" style={{ fill: seriesColor }} className={styles.marble}>
+      {getSymbol()}
+    </svg>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme) => {
+  return {
+    marble: css`
+      display: block;
+      opacity: 0.5;
+      transition: transform 0.15s ease-out;
+    `,
+  };
+};

--- a/public/app/plugins/panel/timeseries/plugins/AudiblePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AudiblePlugin.tsx
@@ -1,0 +1,74 @@
+import {
+  DataFrame,
+  DataFrameFieldIndex,
+  TIME_SERIES_TIME_FIELD_NAME,
+  TIME_SERIES_VALUE_FIELD_NAME,
+} from '@grafana/data';
+import { EventsCanvas, FIXED_UNIT, UPlotConfigBuilder, usePlotContext } from '@grafana/ui';
+import React, { useCallback, useEffect, useState } from 'react';
+import { AudibleMarker } from './AudibleMarker';
+import appEvents from 'app/core/app_events';
+import { AudiblePanelEvent } from 'app/types/events';
+
+interface PluginProps {
+  config: UPlotConfigBuilder;
+  frames: DataFrame[];
+}
+
+export const AudiblePlugin: React.FC<PluginProps> = ({ frames, config }) => {
+  const plotCtx = usePlotContext();
+  const [audibleFieldIndex, setAudibleFieldIndex] = useState<DataFrameFieldIndex>({ frameIndex: 0, fieldIndex: 0 });
+
+  useEffect(() => {
+    const sub = appEvents.subscribe(AudiblePanelEvent, (event) => {
+      setAudibleFieldIndex({ fieldIndex: event.payload.pointIndex, frameIndex: event.payload.seriesIndex });
+    });
+    return () => sub.unsubscribe();
+  }, []);
+
+  const mapExemplarToXYCoords = useCallback(
+    (dataFrame: DataFrame, dataFrameFieldIndex: DataFrameFieldIndex) => {
+      if (
+        dataFrameFieldIndex.fieldIndex !== audibleFieldIndex.fieldIndex ||
+        dataFrameFieldIndex.frameIndex !== audibleFieldIndex.frameIndex
+      ) {
+        return undefined;
+      }
+      const plotInstance = plotCtx.plot;
+      const time = dataFrame.fields.find((f) => f.name === TIME_SERIES_TIME_FIELD_NAME);
+      const value = dataFrame.fields.find((f) => f.name === TIME_SERIES_VALUE_FIELD_NAME);
+
+      if (!time || !value || !plotInstance) {
+        return undefined;
+      }
+
+      // Filter x, y scales out
+      const yScale =
+        Object.keys(plotInstance.scales).find((scale) => !['x', 'y'].some((key) => key === scale)) ?? FIXED_UNIT;
+
+      let y = value.values.get(dataFrameFieldIndex.fieldIndex);
+      return {
+        x: plotInstance.valToPos(time.values.get(dataFrameFieldIndex.fieldIndex), 'x'),
+        y: plotInstance.valToPos(y, yScale),
+      };
+    },
+    [plotCtx, audibleFieldIndex]
+  );
+
+  const renderMarker = useCallback(
+    (dataFrame: DataFrame, dataFrameFieldIndex: DataFrameFieldIndex) => {
+      return <AudibleMarker dataFrame={dataFrame} dataFrameFieldIndex={dataFrameFieldIndex} config={config} />;
+    },
+    [config, audibleFieldIndex]
+  );
+
+  return (
+    <EventsCanvas
+      config={config}
+      id="audible"
+      events={frames}
+      renderEventMarker={renderMarker}
+      mapEventToXYCoords={mapExemplarToXYCoords}
+    />
+  );
+};

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -84,6 +84,12 @@ export interface DashScrollPayload {
   pos?: number;
 }
 
+export interface AudiblePanelPayload {
+  panelId: number;
+  seriesIndex: number;
+  pointIndex: number;
+}
+
 export interface PanelChangeViewPayload {}
 
 /**
@@ -162,6 +168,10 @@ export class ShiftTimeEvent extends BusEventWithPayload<ShiftTimeEventPayload> {
 
 export class RemovePanelEvent extends BusEventWithPayload<number> {
   static type = 'remove-panel';
+}
+
+export class AudiblePanelEvent extends BusEventWithPayload<AudiblePanelPayload> {
+  static type = 'audible-panel';
 }
 
 /**


### PR DESCRIPTION
## Next steps

- [ ] make sonifier more robust
- [ ] decide if we want to include the log live features
- [ ] shorten the panel sonification (can seem quite long when sonifying a couple of series)
- [ ] fix tests

### Sonification in timeseries panel 

1. Add a timeseries panel with at least on series in it
2. Open panel menu -> More -> Sonify.   (or hit `p a` keys)

![Screenshot 2021-07-05 at 12 35 57](https://user-images.githubusercontent.com/859729/124458698-93849900-dd8d-11eb-940f-7caa9ff335a0.png)


### Loki live view sound of log level 

0. Loki datasource in Explore view
1. Add a query that produces logs at a good rate
2. Click "Sonify log level" 

![Screenshot 2021-07-05 at 12 37 50](https://user-images.githubusercontent.com/859729/124458910-dcd4e880-dd8d-11eb-9354-490624d26146.png)

### Loki live view sonify structured log

0. Loki datasource in Explore view
1. Add a query that produces logs at a good rate
2. Click "Sonify value"
3. Add a regular expression with a match group to extract a values, e.g., `time_ms=(\d+)`

![Screenshot 2021-07-05 at 12 39 57](https://user-images.githubusercontent.com/859729/124459165-29202880-dd8e-11eb-81d8-8070deaf42b0.png)

### Sound control in Dashboard and Explore toolbar

- Change volume
- Select different oscillator

![Screenshot 2021-07-05 at 12 34 42](https://user-images.githubusercontent.com/859729/124458543-646e2780-dd8d-11eb-9fc8-659ff9a91ef2.png)
