### PR TITLE
[v8.0.x] Graph: Workaround for DashboardQueryRunner race condition (#36254)

### DIFF
--- a/public/app/features/panel/metrics_panel_ctrl.ts
+++ b/public/app/features/panel/metrics_panel_ctrl.ts
@@ -19,12 +19,13 @@ import { PanelModel } from 'app/features/dashboard/state';
 import { PanelQueryRunner } from '../query/state/PanelQueryRunner';
 
 class MetricsPanelCtrl extends PanelCtrl {
-  datasource: DataSourceApi;
+  declare datasource: DataSourceApi;
+  declare range: TimeRange;
+
   contextSrv: ContextSrv;
   datasourceSrv: any;
   timeSrv: any;
   templateSrv: any;
-  range: TimeRange;
   interval: any;
   intervalMs: any;
   resolution: any;
@@ -98,7 +99,6 @@ class MetricsPanelCtrl extends PanelCtrl {
     // load datasource service
     return this.datasourceSrv
       .get(this.panel.datasource, this.panel.scopedVars)
-      .then(this.updateTimeRange.bind(this))
       .then(this.issueQueries.bind(this))
       .catch((err: any) => {
         this.processDataError(err);
@@ -178,11 +178,11 @@ class MetricsPanelCtrl extends PanelCtrl {
     const newTimeData = applyPanelTimeOverrides(this.panel, this.range);
     this.timeInfo = newTimeData.timeInfo;
     this.range = newTimeData.timeRange;
-
-    return this.datasource;
   }
 
   issueQueries(datasource: DataSourceApi) {
+    this.updateTimeRange(datasource);
+
     this.datasource = datasource;
 
     const panel = this.panel as PanelModel;

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -184,10 +184,6 @@ export class GraphCtrl extends MetricsPanelCtrl {
     actions.push({ text: 'Toggle legend', click: 'ctrl.toggleLegend()', shortcut: 'p l' });
   }
 
-  issueQueries(datasource: any) {
-    return super.issueQueries(datasource);
-  }
-
   zoomOut(evt: any) {
     appEvents.publish(new ZoomOutEvent(2));
   }


### PR DESCRIPTION
* Graph: Workaround for DashboardQueryRunner race condition

* Removed deepClone

(cherry picked from commit 6f38883583c4c43af149f68db482b39a3240ec95)

Backports https://github.com/grafana/grafana/pull/36254
