### PR TITLE
CloudWatch: Remove client cache

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -157,9 +157,6 @@ func NewInstanceSettings() datasource.InstanceFactoryFunc {
 
 // cloudWatchExecutor executes CloudWatch requests.
 type cloudWatchExecutor struct {
-	ec2Client  ec2iface.EC2API
-	rgtaClient resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
-
 	logsService *LogsService
 	im          instancemgmt.InstanceManager
 	cfg         *setting.Cfg
@@ -209,32 +206,22 @@ func (e *cloudWatchExecutor) getCWLogsClient(region string, pluginCtx backend.Pl
 }
 
 func (e *cloudWatchExecutor) getEC2Client(region string, pluginCtx backend.PluginContext) (ec2iface.EC2API, error) {
-	if e.ec2Client != nil {
-		return e.ec2Client, nil
-	}
-
 	sess, err := e.newSession(region, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
-	e.ec2Client = newEC2Client(sess)
 
-	return e.ec2Client, nil
+	return newEC2Client(sess), nil
 }
 
 func (e *cloudWatchExecutor) getRGTAClient(region string, pluginCtx backend.PluginContext) (resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI,
 	error) {
-	if e.rgtaClient != nil {
-		return e.rgtaClient, nil
-	}
-
 	sess, err := e.newSession(region, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
-	e.rgtaClient = newRGTAClient(sess)
 
-	return e.rgtaClient, nil
+	return newRGTAClient(sess), nil
 }
 
 func (e *cloudWatchExecutor) alertQuery(ctx context.Context, logsClient cloudwatchlogsiface.CloudWatchLogsAPI,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

After #31149, the [`cloudWatchExecutor` struct](https://github.com/grafana/grafana/pull/31149/files#diff-ed359d338e3137d184fd19ea8b50a55fbc4070aa8ca09c75abb227c7f24b1f9bL78) no longer holds a reference to the `Datasource` it's associated with. This means that a single executor is shared for different data sources.

The problem is that the `ec2Client` and `rgtaClient` were not removed from the struct, so they will be initialized the first time it receives a request and reused afterwards, which will be wrong if there are multiple CW data sources. This is causing the issue at https://github.com/grafana/grafana/issues/36197#issuecomment-870464498.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #36197

**Special notes for your reviewer**:

The sessions are cached anyway so I don't think it's necessary to cache the clients too but let me know if I am missing something. Also this is the same approached used in other clients like `getCWClient`.

