### PR TITLE
Live: add allowed_origins option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -901,6 +901,10 @@ plugin_catalog_url = https://grafana.com/grafana/plugins/
 # tuning. 0 disables Live, -1 means unlimited connections.
 max_connections = 100
 
+# allowed_origins is a comma-separated list of origins that can establish connection with Grafana Live.
+# If not set then origin will be matched over root_url. Supports globbing: see https://github.com/gobwas/glob.
+allowed_origins =
+
 # engine defines an HA (high availability) engine to use for Grafana Live. By default no engine used - in
 # this case Live features work only on a single Grafana server.
 # Available options: "redis".

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -887,6 +887,10 @@
 # tuning. 0 disables Live, -1 means unlimited connections.
 ;max_connections = 100
 
+# allowed_origins is a comma-separated list of origins that can establish connection with Grafana Live.
+# If not set then origin will be matched over root_url. Supports globbing: see https://github.com/gobwas/glob.
+;allowed_origins =
+
 # engine defines an HA (high availability) engine to use for Grafana Live. By default no engine used - in
 # this case Live features work only on a single Grafana server. Available options: "redis".
 # Setting ha_engine is an EXPERIMENTAL feature.

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/setting"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,10 +57,11 @@ func Test_runConcurrentlyIfNeeded_DeadlineExceeded(t *testing.T) {
 
 func TestCheckOrigin(t *testing.T) {
 	testCases := []struct {
-		name    string
-		origin  string
-		appURL  string
-		success bool
+		name           string
+		origin         string
+		appURL         string
+		allowedOrigins []string
+		success        bool
 	}{
 		{
 			name:    "empty_origin",
@@ -96,6 +99,27 @@ func TestCheckOrigin(t *testing.T) {
 			appURL:  "https://example.com",
 			success: true,
 		},
+		{
+			name:           "authorized_allowed_origins",
+			origin:         "https://test.example.com",
+			appURL:         "http://localhost:3000/",
+			allowedOrigins: []string{"https://test.example.com"},
+			success:        true,
+		},
+		{
+			name:           "authorized_allowed_origins_pattern",
+			origin:         "https://test.example.com",
+			appURL:         "http://localhost:3000/",
+			allowedOrigins: []string{"https://*.example.com"},
+			success:        true,
+		},
+		{
+			name:           "authorized_allowed_origins_all",
+			origin:         "https://test.example.com",
+			appURL:         "http://localhost:3000/",
+			allowedOrigins: []string{"*"},
+			success:        true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -104,9 +128,15 @@ func TestCheckOrigin(t *testing.T) {
 			t.Parallel()
 			appURL, err := url.Parse(tc.appURL)
 			require.NoError(t, err)
+
+			originGlobs, err := setting.GetAllowedOriginGlobs(tc.allowedOrigins)
+			require.NoError(t, err)
+
+			checkOrigin := getCheckOriginFunc(appURL, tc.allowedOrigins, originGlobs)
+
 			r := httptest.NewRequest("GET", tc.appURL, nil)
 			r.Header.Set("Origin", tc.origin)
-			require.Equal(t, tc.success, checkOrigin(r, appURL),
+			require.Equal(t, tc.success, checkOrigin(r),
 				"origin %s, appURL: %s", tc.origin, tc.appURL,
 			)
 		})

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gobwas/glob"
+
 	"github.com/prometheus/common/model"
 	ini "gopkg.in/ini.v1"
 
@@ -391,6 +393,9 @@ type Cfg struct {
 	LiveHAEngine string
 	// LiveHAEngineAddress is a connection address for Live HA engine.
 	LiveHAEngineAddress string
+	// LiveAllowedOrigins is a set of origins accepted by Live. If not provided
+	// then Live uses AppURL as the only allowed origin.
+	LiveAllowedOrigins []string
 
 	// Grafana.com URL
 	GrafanaComURL string
@@ -1446,6 +1451,19 @@ func (cfg *Cfg) readDataSourcesSettings() {
 	cfg.DataSourceLimit = datasources.Key("datasource_limit").MustInt(5000)
 }
 
+func GetAllowedOriginGlobs(originPatterns []string) ([]glob.Glob, error) {
+	var originGlobs []glob.Glob
+	allowedOrigins := originPatterns
+	for _, originPattern := range allowedOrigins {
+		g, err := glob.Compile(originPattern)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing origin pattern: %v", err)
+		}
+		originGlobs = append(originGlobs, g)
+	}
+	return originGlobs, nil
+}
+
 func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 	section := iniFile.Section("live")
 	cfg.LiveMaxConnections = section.Key("max_connections").MustInt(100)
@@ -1459,5 +1477,20 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 		return fmt.Errorf("unsupported live HA engine type: %s", cfg.LiveHAEngine)
 	}
 	cfg.LiveHAEngineAddress = section.Key("ha_engine_address").MustString("127.0.0.1:6379")
+
+	var originPatterns []string
+	allowedOrigins := section.Key("allowed_origins").MustString("")
+	for _, originPattern := range strings.Split(allowedOrigins, ",") {
+		originPattern = strings.TrimSpace(originPattern)
+		if originPattern == "" {
+			continue
+		}
+		originPatterns = append(originPatterns, originPattern)
+	}
+	_, err := GetAllowedOriginGlobs(originPatterns)
+	if err != nil {
+		return err
+	}
+	cfg.LiveAllowedOrigins = originPatterns
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `[live] allowed_origins` option in order to configure allowed origins while connecting to WS endpoint.

Check origin first looks at App URL, then on custom origin patterns if any. Origin patterns support globbing to allow subdomains.

Examples of configuration:
```
[live]
allowed_origins = https://mysite.com
```
Or:
```
[live]
allowed_origins = https://*.mysite.com,https://*.myothersite.com
```
Or to allow all:
```
[live]
allowed_origins = *
```

**Which issue(s) this PR fixes**:

#36291