### PR TITLE
Chore: Replace util.DynMap with structs

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -302,5 +302,5 @@ func GetAnnotationTags(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to find annotation tags", err)
 	}
 
-	return response.JSON(200, util.DynMap{"result": result})
+	return response.JSON(200, annotations.GetAnnotationTagsResponse{Result: result})
 }

--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -41,6 +41,7 @@ type ItemQuery struct {
 	Limit int64 `json:"limit"`
 }
 
+// TagsQuery is the query for a tags search.
 type TagsQuery struct {
 	OrgID int64  `json:"orgId"`
 	Tag   string `json:"tag"`
@@ -48,21 +49,25 @@ type TagsQuery struct {
 	Limit int64 `json:"limit"`
 }
 
-type Tags struct {
+// Tag is the DB result of a tags search.
+type Tag struct {
 	Key   string
 	Value string
 	Count int64
 }
 
+// TagsDTO is the frontend DTO for Tag.
 type TagsDTO struct {
 	Tag   string `json:"tag"`
 	Count int64  `json:"count"`
 }
 
+// FindTagsResult is the result of a tags search.
 type FindTagsResult struct {
 	Tags []*TagsDTO `json:"tags"`
 }
 
+// GetAnnotationTagsResponse is a response struct for FindTagsResult.
 type GetAnnotationTagsResponse struct {
 	Result FindTagsResult `json:"result"`
 }

--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -63,6 +63,10 @@ type FindTagsResult struct {
 	Tags []*TagsDTO `json:"tags"`
 }
 
+type GetAnnotationTagsResponse struct {
+	Result FindTagsResult `json:"result"`
+}
+
 type DeleteParams struct {
 	OrgId       int64
 	Id          int64

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 func (l *LibraryElementService) registerAPIEndpoints() {
@@ -31,7 +30,7 @@ func (l *LibraryElementService) createHandler(c *models.ReqContext, cmd CreateLi
 		return toLibraryElementError(err, "Failed to create library element")
 	}
 
-	return response.JSON(200, util.DynMap{"result": element})
+	return response.JSON(200, LibraryElementResponse{Result: element})
 }
 
 // deleteHandler handles DELETE /api/library-elements/:uid.
@@ -51,7 +50,7 @@ func (l *LibraryElementService) getHandler(c *models.ReqContext) response.Respon
 		return toLibraryElementError(err, "Failed to get library element")
 	}
 
-	return response.JSON(200, util.DynMap{"result": element})
+	return response.JSON(200, LibraryElementResponse{Result: element})
 }
 
 // getAllHandler handles GET /api/library-elements/.
@@ -71,7 +70,7 @@ func (l *LibraryElementService) getAllHandler(c *models.ReqContext) response.Res
 		return toLibraryElementError(err, "Failed to get library elements")
 	}
 
-	return response.JSON(200, util.DynMap{"result": elementsResult})
+	return response.JSON(200, LibraryElementSearchResponse{Result: elementsResult})
 }
 
 // patchHandler handles PATCH /api/library-elements/:uid
@@ -81,7 +80,7 @@ func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibr
 		return toLibraryElementError(err, "Failed to update library element")
 	}
 
-	return response.JSON(200, util.DynMap{"result": element})
+	return response.JSON(200, LibraryElementResponse{Result: element})
 }
 
 // getConnectionsHandler handles GET /api/library-panels/:uid/connections/.
@@ -91,7 +90,7 @@ func (l *LibraryElementService) getConnectionsHandler(c *models.ReqContext) resp
 		return toLibraryElementError(err, "Failed to get connections")
 	}
 
-	return response.JSON(200, util.DynMap{"result": connections})
+	return response.JSON(200, LibraryElementConnectionsResponse{Result: connections})
 }
 
 // getByNameHandler handles GET /api/library-elements/name/:name/.
@@ -101,7 +100,7 @@ func (l *LibraryElementService) getByNameHandler(c *models.ReqContext) response.
 		return toLibraryElementError(err, "Failed to get library element")
 	}
 
-	return response.JSON(200, util.DynMap{"result": elements})
+	return response.JSON(200, LibraryElementArrayResponse{Result: elements})
 }
 
 func toLibraryElementError(err error, message string) response.Response {

--- a/pkg/services/libraryelements/models.go
+++ b/pkg/services/libraryelements/models.go
@@ -181,3 +181,19 @@ type searchLibraryElementsQuery struct {
 	excludeUID    string
 	folderFilter  string
 }
+
+type LibraryElementResponse struct {
+	Result LibraryElementDTO `json:"result"`
+}
+
+type LibraryElementSearchResponse struct {
+	Result LibraryElementSearchResult `json:"result"`
+}
+
+type LibraryElementArrayResponse struct {
+	Result []LibraryElementDTO `json:"result"`
+}
+
+type LibraryElementConnectionsResponse struct {
+	Result []LibraryElementConnectionDTO `json:"result"`
+}

--- a/pkg/services/libraryelements/models.go
+++ b/pkg/services/libraryelements/models.go
@@ -182,18 +182,22 @@ type searchLibraryElementsQuery struct {
 	folderFilter  string
 }
 
+// LibraryElementResponse is a response struct for LibraryElementDTO.
 type LibraryElementResponse struct {
 	Result LibraryElementDTO `json:"result"`
 }
 
+// LibraryElementSearchResponse is a response struct for LibraryElementSearchResult.
 type LibraryElementSearchResponse struct {
 	Result LibraryElementSearchResult `json:"result"`
 }
 
+// LibraryElementArrayResponse is a response struct for an array of LibraryElementDTO.
 type LibraryElementArrayResponse struct {
 	Result []LibraryElementDTO `json:"result"`
 }
 
+// LibraryElementConnectionsResponse is a response struct for an array of LibraryElementConnectionDTO.
 type LibraryElementConnectionsResponse struct {
 	Result []LibraryElementConnectionDTO `json:"result"`
 }

--- a/pkg/services/sqlstore/annotation.go
+++ b/pkg/services/sqlstore/annotation.go
@@ -298,7 +298,7 @@ func (r *SQLAnnotationRepo) FindTags(query *annotations.TagsQuery) (annotations.
 	sql.WriteString(` ORDER BY ` + tagKey + `,` + tagValue)
 	sql.WriteString(` ` + dialect.Limit(query.Limit))
 
-	var items []*annotations.Tags
+	var items []*annotations.Tag
 	if err := x.SQL(sql.String(), params...).Find(&items); err != nil {
 		return annotations.FindTagsResult{Tags: []*annotations.TagsDTO{}}, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes all usage of `util.DynMap` on some api endpoints.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

