### PR TITLE
Dashboard variables: new DateTime picker

### DIFF
--- a/packages/grafana-data/src/types/templateVars.ts
+++ b/packages/grafana-data/src/types/templateVars.ts
@@ -1,4 +1,13 @@
-export type VariableType = 'query' | 'adhoc' | 'constant' | 'datasource' | 'interval' | 'textbox' | 'custom' | 'system';
+export type VariableType =
+  | 'query'
+  | 'adhoc'
+  | 'constant'
+  | 'datasource'
+  | 'interval'
+  | 'datetime'
+  | 'textbox'
+  | 'custom'
+  | 'system';
 
 export interface VariableModel {
   type: VariableType;

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.mdx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.mdx
@@ -1,0 +1,28 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+import { DatePickerWithEmpty } from './DatePickerWithEmpty';
+
+# DatePickerWithEmpty
+
+An input with a calendar view, used to select a date also with possible empty value. Value is optional.
+
+### Usage
+
+```tsx
+import React, { useState } from 'react';
+import { DatePickerWithEmpty } from '@grafana/ui';
+
+const [date, setDate] = useState<Date | string>(new Date());
+return (
+  <DatePickerWithEmpty
+    width={40}
+    value={date}
+    isDateInput={true}
+    onClose={() => {}}
+    onChange={(newDate) => setDate(newDate)}
+  />
+);
+```
+
+### Props
+
+<ArgsTable of={DatePickerWithInput} />

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.mdx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.mdx
@@ -13,16 +13,10 @@ import { DatePickerWithEmpty } from '@grafana/ui';
 
 const [date, setDate] = useState<Date | string>(new Date());
 return (
-  <DatePickerWithEmpty
-    width={40}
-    value={date}
-    isDateInput={true}
-    onClose={() => {}}
-    onChange={(newDate) => setDate(newDate)}
-  />
+  <DatePickerWithEmpty value={date} isDateInput={true} onClose={() => {}} onChange={(newDate) => setDate(newDate)} />
 );
 ```
 
 ### Props
 
-<ArgsTable of={DatePickerWithInput} />
+<ArgsTable of={DatePickerWithEmpty} />

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.story.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.story.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { DatePickerWithEmpty } from './DatePickerWithEmpty';
+import { withCenteredStory } from '../../../utils/storybook/withCenteredStory';
+import mdx from './DatePickerWithInput.mdx';
+
+export default {
+  title: 'Pickers and Editors/TimePickers/DatePickerWithEmpty',
+  component: DatePickerWithEmpty,
+  decorators: [withCenteredStory],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Basic = () => {
+  const [date, setDate] = useState<Date | undefined>(new Date());
+
+  return (
+    <DatePickerWithEmpty
+      onClose={() => {}}
+      isDateInput={true}
+      isOpen={true}
+      value={date}
+      onChange={(newDate) => setDate(newDate)}
+    />
+  );
+};

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DatePickerWithEmpty } from './DatePickerWithEmpty';
+
+describe('DatePickerWithEmpty', () => {
+  it('renders date input', () => {
+    render(
+      <DatePickerWithEmpty
+        isDateInput={false}
+        isOpen={true}
+        onChange={jest.fn()}
+        onClose={jest.fn()}
+        value={new Date(1400000000000)}
+      />
+    );
+
+    expect(screen.getAllByText('May 2014')[0]).toBeInTheDocument();
+  });
+  it('renders date input without a value', () => {
+    render(<DatePickerWithEmpty isDateInput={false} isOpen={true} onChange={jest.fn()} onClose={jest.fn()} />);
+    expect(
+      screen.getAllByText(`${new Date().toLocaleString('default', { month: 'long' })} ${new Date().getFullYear()}`)[0]
+    ).toBeInTheDocument();
+  });
+  it('should not render, isOpen = false', () => {
+    render(<DatePickerWithEmpty isDateInput={false} isOpen={false} onChange={jest.fn()} onClose={jest.fn()} />);
+    expect(screen.queryByTestId('date-picker')).not.toBeInTheDocument();
+  });
+  describe('input is clicked', () => {
+    it('should click on a date and change it according to that', () => {
+      const onChange = jest.fn();
+
+      render(
+        <DatePickerWithEmpty
+          isDateInput={true}
+          isOpen={true}
+          onChange={onChange}
+          onClose={jest.fn()}
+          value={new Date(1383346799999)}
+        />
+      );
+      const ninethOfTheMonth = screen.getByText('31');
+      const button = ninethOfTheMonth.parentElement;
+      button?.click();
+      expect(screen.getAllByText('October 2013')[0]).toBeInTheDocument();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+    it('onChange has been called', () => {
+      const onChange = jest.fn();
+
+      render(
+        <DatePickerWithEmpty
+          isDateInput={true}
+          isOpen={true}
+          onChange={onChange}
+          onClose={jest.fn()}
+          value={new Date(1383346799999)}
+        />
+      );
+      const ninethOfTheMonth = screen.getByText('31');
+      const button = ninethOfTheMonth.parentElement;
+      button?.click();
+      expect(screen.getAllByText('October 2013')[0]).toBeInTheDocument();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+    it('closes calendar after outside wrapper is clicked', () => {
+      const onClose = jest.fn();
+
+      render(
+        <DatePickerWithEmpty
+          isDateInput={true}
+          isOpen={true}
+          onChange={jest.fn()}
+          onClose={onClose}
+          value={new Date(1383346799999)}
+        />
+      );
+
+      expect(screen.getByTestId('date-picker')).toBeInTheDocument();
+
+      fireEvent.click(document);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
@@ -16,6 +16,7 @@ export interface DatePickerWithEmptyProps {
   onChange: (value: Date, isDateInput: boolean) => void;
   isDateInput: boolean;
   value?: Date;
+  returnValue?: 'start' | 'end';
 }
 
 /** @public */
@@ -38,7 +39,7 @@ export const DatePickerWithEmpty = memo<DatePickerWithEmptyProps>((props) => {
 
 DatePickerWithEmpty.displayName = 'DatePickerWithEmpty';
 
-const Body = memo<DatePickerWithEmptyProps>(({ value, onChange, isDateInput }) => {
+const Body = memo<DatePickerWithEmptyProps>(({ value, onChange, isDateInput, returnValue }) => {
   const styles = useStyles2(getBodyStyles);
 
   return (
@@ -53,6 +54,7 @@ const Body = memo<DatePickerWithEmptyProps>(({ value, onChange, isDateInput }) =
         />
       </InlineField>
       <Calendar
+        returnValue={returnValue || 'start'}
         className={styles.body}
         tileClassName={styles.title}
         value={value || new Date()}

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
@@ -1,0 +1,85 @@
+import React, { ChangeEvent, memo } from 'react';
+import Calendar from 'react-calendar/dist/entry.nostyle';
+import { css } from 'emotion';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '../../../themes';
+import { ClickOutsideWrapper } from '../../ClickOutsideWrapper/ClickOutsideWrapper';
+import { Icon } from '../../Icon/Icon';
+import { getBodyStyles } from '../TimeRangePicker/TimePickerCalendar';
+import { InlineField } from '../../Forms/InlineField';
+import { InlineSwitch } from '../../Switch/Switch';
+
+/** @public */
+export interface DatePickerWithEmptyProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onChange: (value: Date, isDateInput: boolean) => void;
+  isDateInput: boolean;
+  value?: Date;
+}
+
+/** @public */
+export const DatePickerWithEmpty = memo<DatePickerWithEmptyProps>((props) => {
+  const styles = useStyles2(getStyles);
+  const { isOpen, onClose } = props;
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <ClickOutsideWrapper useCapture={true} includeButtonPress={false} onClick={onClose}>
+      <div className={styles.modal} data-testid="date-picker">
+        <Body {...props} />
+      </div>
+    </ClickOutsideWrapper>
+  );
+});
+
+DatePickerWithEmpty.displayName = 'DatePickerWithEmpty';
+
+const Body = memo<DatePickerWithEmptyProps>(({ value, onChange, isDateInput }) => {
+  const styles = useStyles2(getBodyStyles);
+
+  return (
+    <div>
+      <InlineField label={'Date Input'} labelWidth={20}>
+        <InlineSwitch
+          label={'Date Input'}
+          value={isDateInput}
+          onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+            onChange(value || new Date(), ev.target.checked);
+          }}
+        />
+      </InlineField>
+      <Calendar
+        className={styles.body}
+        tileClassName={styles.title}
+        value={value || new Date()}
+        nextLabel={<Icon name="angle-right" />}
+        prevLabel={<Icon name="angle-left" />}
+        onChange={(date) => {
+          if (!Array.isArray(date)) {
+            onChange(date, true);
+          }
+        }}
+        locale="en"
+      />
+    </div>
+  );
+});
+
+Body.displayName = 'Body';
+
+export const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    modal: css`
+      z-index: ${theme.zIndex.modal};
+      position: absolute;
+      box-shadow: ${theme.shadows.z3};
+      background-color: ${theme.colors.background.primary};
+      border: 1px solid ${theme.colors.border.weak};
+      border-radius: 2px 0 0 2px;
+    `,
+  };
+};

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
@@ -5,12 +5,10 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '../../../themes';
 import { ClickOutsideWrapper } from '../../ClickOutsideWrapper/ClickOutsideWrapper';
 import { Icon } from '../../Icon/Icon';
-// import { getBodyStyles } from '../TimeRangePicker/TimePickerCalendar';
 import { getBodyStyles } from '../TimeRangePicker/CalendarBody';
 
 import { InlineField } from '../../Forms/InlineField';
 import { InlineSwitch } from '../../Switch/Switch';
-
 /** @public */
 export interface DatePickerWithEmptyProps {
   isOpen?: boolean;

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmpty/DatePickerWithEmpty.tsx
@@ -1,11 +1,13 @@
 import React, { ChangeEvent, memo } from 'react';
-import Calendar from 'react-calendar/dist/entry.nostyle';
-import { css } from 'emotion';
+import Calendar from 'react-calendar';
+import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '../../../themes';
 import { ClickOutsideWrapper } from '../../ClickOutsideWrapper/ClickOutsideWrapper';
 import { Icon } from '../../Icon/Icon';
-import { getBodyStyles } from '../TimeRangePicker/TimePickerCalendar';
+// import { getBodyStyles } from '../TimeRangePicker/TimePickerCalendar';
+import { getBodyStyles } from '../TimeRangePicker/CalendarBody';
+
 import { InlineField } from '../../Forms/InlineField';
 import { InlineSwitch } from '../../Switch/Switch';
 
@@ -60,7 +62,7 @@ const Body = memo<DatePickerWithEmptyProps>(({ value, onChange, isDateInput, ret
         value={value || new Date()}
         nextLabel={<Icon name="angle-right" />}
         prevLabel={<Icon name="angle-left" />}
-        onChange={(date) => {
+        onChange={(date: Date | Date[]) => {
           if (!Array.isArray(date)) {
             onChange(date, true);
           }

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.mdx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.mdx
@@ -1,0 +1,27 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+import { DatePickerWithEmptyWithInput } from './DatePickerWithEmptyWithInput';
+
+# DatePickerWithEmptyWithInput
+
+An input with a calendar view, used to select a date also with possible empty value and and input field. Value is optional.
+
+### Usage
+
+```tsx
+import React, { useState } from 'react';
+import { DatePickerWithEmptyWithInput } from '@grafana/ui';
+
+const [date, setDate] = useState<Date | string>(new Date());
+return (
+  <DatePickerWithEmptyWithInput
+    value={date}
+    isDateInput={true}
+    returnValue={'start'}
+    onChange={(newDate) => setDate(newDate)}
+  />
+);
+```
+
+### Props
+
+<ArgsTable of={DatePickerWithEmptyWithInput} />

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.story.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.story.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { DatePickerWithEmpty } from './DatePickerWithEmpty';
+import { DatePickerWithEmptyWithInput } from './DatePickerWithEmptyWithInput';
 import { withCenteredStory } from '../../../utils/storybook/withCenteredStory';
-import mdx from './DatePickerWithEmpty.mdx';
+import mdx from './DatePickerWithEmptyWithInput.mdx';
 
 export default {
-  title: 'Pickers and Editors/TimePickers/DatePickerWithEmpty',
-  component: DatePickerWithEmpty,
+  title: 'Pickers and Editors/TimePickers/DatePickerWithEmptyWithInput',
+  component: DatePickerWithEmptyWithInput,
   decorators: [withCenteredStory],
   parameters: {
     docs: {
@@ -15,19 +15,18 @@ export default {
 };
 
 export const Basic = () => {
-  const [date, setDate] = useState<Date | undefined>(new Date());
+  const [date, setDate] = useState<Date | string>(new Date());
   const [dateInput, setDateInput] = useState<boolean>(true);
 
   return (
-    <DatePickerWithEmpty
-      onClose={() => {}}
+    <DatePickerWithEmptyWithInput
       isDateInput={dateInput}
-      isOpen={true}
       value={date}
       onChange={(newDate, dateInput) => {
         setDate(newDate);
         setDateInput(dateInput);
       }}
+      returnValue={'start'}
     />
   );
 };

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.tsx
@@ -12,6 +12,7 @@ export interface DatePickerWithEmptyWithInputProps extends Omit<InputProps, 'ref
   value?: Date | string;
   onChange: (value: Date | string, isDateInput: boolean) => void;
   isDateInput: boolean;
+  returnValue: 'start' | 'end';
   closeOnSelect?: boolean;
   placeholder?: string;
 }
@@ -21,6 +22,7 @@ export const DatePickerWithEmptyWithInput = ({
   value,
   onChange,
   isDateInput,
+  returnValue,
   closeOnSelect,
   placeholder = 'Date',
   ...rest
@@ -56,6 +58,7 @@ export const DatePickerWithEmptyWithInput = ({
         }}
         onClose={() => setOpen(false)}
         isDateInput={isDateInput}
+        returnValue={returnValue}
       />
     </div>
   );

--- a/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput.tsx
@@ -1,0 +1,77 @@
+import React, { ChangeEvent } from 'react';
+import { css } from '@emotion/css';
+import { dateTime } from '@grafana/data';
+import { DatePickerWithEmpty } from '../DatePickerWithEmpty/DatePickerWithEmpty';
+import { Props as InputProps, Input } from '../../Input/Input';
+import { useStyles } from '../../../themes';
+
+export const formatDate = (date: Date | string) => dateTime(date).format('L');
+
+/** @public */
+export interface DatePickerWithEmptyWithInputProps extends Omit<InputProps, 'ref' | 'value' | 'onChange'> {
+  value?: Date | string;
+  onChange: (value: Date | string, isDateInput: boolean) => void;
+  isDateInput: boolean;
+  closeOnSelect?: boolean;
+  placeholder?: string;
+}
+
+/** @public */
+export const DatePickerWithEmptyWithInput = ({
+  value,
+  onChange,
+  isDateInput,
+  closeOnSelect,
+  placeholder = 'Date',
+  ...rest
+}: DatePickerWithEmptyWithInputProps) => {
+  const [open, setOpen] = React.useState(false);
+  const styles = useStyles(getStyles);
+
+  return (
+    <div className={styles.container}>
+      <Input
+        type="text"
+        autoComplete={'off'}
+        placeholder={placeholder}
+        value={isDateInput ? (value ? formatDate(value) : value) : ''}
+        onClick={() => setOpen(true)}
+        onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+          // Allow resetting the date
+          if (ev.target.value === '') {
+            onChange(value ? value : new Date(), false);
+          }
+        }}
+        className={styles.input}
+        {...rest}
+      />
+      <DatePickerWithEmpty
+        isOpen={open}
+        value={value && typeof value !== 'string' ? value : dateTime().toDate()}
+        onChange={(ev, isDateInput) => {
+          onChange(ev, isDateInput);
+          if (closeOnSelect) {
+            setOpen(false);
+          }
+        }}
+        onClose={() => setOpen(false)}
+        isDateInput={isDateInput}
+      />
+    </div>
+  );
+};
+
+const getStyles = () => {
+  return {
+    container: css`
+      position: relative;
+    `,
+    input: css`
+    /* hides the native Calendar picker icon given when using type=date */
+    input[type='date']::-webkit-inner-spin-button,
+    input[type='date']::-webkit-calendar-picker-indicator {
+    display: none;
+    -webkit-appearance: none;
+    `,
+  };
+};

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -31,6 +31,7 @@ export {
   DatePickerWithInput,
   DatePickerWithInputProps,
 } from './DateTimePickers/DatePickerWithInput/DatePickerWithInput';
+export { DatePickerWithEmptyWithInput } from './DateTimePickers/DatePickerWithEmptyWithInput/DatePickerWithEmptyWithInput';
 export { DateTimePicker } from './DateTimePickers/DateTimePicker/DateTimePicker';
 export { List } from './List/List';
 export { TagsInput } from './TagsInput/TagsInput';

--- a/packages/grafana-ui/tsconfig.json
+++ b/packages/grafana-ui/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "baseUrl": "./",
     "declarationDir": "dist",
     "outDir": "compiled",

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -70,6 +70,7 @@ import { createTextBoxVariableAdapter } from './features/variables/textbox/adapt
 import { createConstantVariableAdapter } from './features/variables/constant/adapter';
 import { createDataSourceVariableAdapter } from './features/variables/datasource/adapter';
 import { createIntervalVariableAdapter } from './features/variables/interval/adapter';
+import { createDateTimeVariableAdapter } from './features/variables/datetime/adapter';
 import { createAdHocVariableAdapter } from './features/variables/adhoc/adapter';
 import { createSystemVariableAdapter } from './features/variables/system/adapter';
 
@@ -114,6 +115,7 @@ export class GrafanaApp {
         createConstantVariableAdapter(),
         createDataSourceVariableAdapter(),
         createIntervalVariableAdapter(),
+        createDateTimeVariableAdapter(),
         createAdHocVariableAdapter(),
         createSystemVariableAdapter(),
       ]);

--- a/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
+++ b/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, ReactElement, useCallback } from 'react';
+import React, { ChangeEvent, FormEvent, ReactElement, useCallback } from 'react';
 
 import { DateTimeVariableModel } from '../types';
 import { VariableEditorProps } from '../editor/types';
@@ -20,9 +20,12 @@ export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue, ret
   );
 
   const updateReturnValueVariable = useCallback(
-    (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
-      event.preventDefault();
-      onPropChange({ propName: 'returnValue', propValue: event.currentTarget.value ? 'end' : 'start', updateOptions });
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onPropChange({
+        propName: 'returnValue',
+        propValue: event.currentTarget.checked ? 'end' : 'start',
+        updateOptions: true,
+      });
     },
     [onPropChange]
   );
@@ -30,13 +33,14 @@ export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue, ret
   const onAllChange = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, true), [updateAllVariable]);
   const onAllBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, false), [updateAllVariable]);
 
-  const onReturnValueChanged = useCallback((e: FormEvent<HTMLInputElement>) => updateReturnValueVariable(e, true), [
+  const onReturnValueChanged = useCallback((e: ChangeEvent<HTMLInputElement>) => updateReturnValueVariable(e), [
     updateReturnValueVariable,
   ]);
 
   return (
-    <VerticalGroup spacing="xs">
+    <VerticalGroup spacing="none">
       <VariableSectionHeader name="Date options" />
+
       <VariableTextField
         value={allValue ?? ''}
         name="No Date Input Value"
@@ -47,13 +51,14 @@ export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue, ret
         grow
         ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
       />
+
       <InlineFieldRow>
         <VariableSwitchField
           value={returnValue === 'end'}
-          name="Use end of day"
+          name="Use end of the day"
           tooltip="Return the end of the selected day instead of its start"
           onChange={onReturnValueChanged}
-          ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsMultiSwitch}
+          ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsIncludeAllSwitch}
         />
       </InlineFieldRow>
     </VerticalGroup>

--- a/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
+++ b/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
@@ -33,9 +33,10 @@ export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue, ret
   const onAllChange = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, true), [updateAllVariable]);
   const onAllBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, false), [updateAllVariable]);
 
-  const onReturnValueChanged = useCallback((e: ChangeEvent<HTMLInputElement>) => updateReturnValueVariable(e), [
-    updateReturnValueVariable,
-  ]);
+  const onReturnValueChanged = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => updateReturnValueVariable(e),
+    [updateReturnValueVariable]
+  );
 
   return (
     <VerticalGroup spacing="none">
@@ -49,7 +50,6 @@ export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue, ret
         onBlur={onAllBlur}
         labelWidth={20}
         grow
-        ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
       />
 
       <InlineFieldRow>

--- a/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
+++ b/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
@@ -4,12 +4,13 @@ import { DateTimeVariableModel } from '../types';
 import { VariableEditorProps } from '../editor/types';
 import { VariableSectionHeader } from '../editor/VariableSectionHeader';
 import { VariableTextField } from '../editor/VariableTextField';
-import { VerticalGroup } from '@grafana/ui';
+import { InlineFieldRow, VerticalGroup } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
+import { VariableSwitchField } from '../editor/VariableSwitchField';
 
 export interface Props extends VariableEditorProps<DateTimeVariableModel> {}
 
-export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue } }: Props): ReactElement => {
+export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue, returnValue } }: Props): ReactElement => {
   const updateAllVariable = useCallback(
     (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
       event.preventDefault();
@@ -18,8 +19,20 @@ export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue } }:
     [onPropChange]
   );
 
+  const updateReturnValueVariable = useCallback(
+    (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
+      event.preventDefault();
+      onPropChange({ propName: 'returnValue', propValue: event.currentTarget.value ? 'end' : 'start', updateOptions });
+    },
+    [onPropChange]
+  );
+
   const onAllChange = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, true), [updateAllVariable]);
   const onAllBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, false), [updateAllVariable]);
+
+  const onReturnValueChanged = useCallback((e: FormEvent<HTMLInputElement>) => updateReturnValueVariable(e, true), [
+    updateReturnValueVariable,
+  ]);
 
   return (
     <VerticalGroup spacing="xs">
@@ -34,6 +47,15 @@ export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue } }:
         grow
         ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
       />
+      <InlineFieldRow>
+        <VariableSwitchField
+          value={returnValue === 'end'}
+          name="Use end of day"
+          tooltip="Return the end of the selected day instead of its start"
+          onChange={onReturnValueChanged}
+          ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsMultiSwitch}
+        />
+      </InlineFieldRow>
     </VerticalGroup>
   );
 };

--- a/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
+++ b/public/app/features/variables/datetime/DateTimeVariableEditor.tsx
@@ -1,0 +1,39 @@
+import React, { FormEvent, ReactElement, useCallback } from 'react';
+
+import { DateTimeVariableModel } from '../types';
+import { VariableEditorProps } from '../editor/types';
+import { VariableSectionHeader } from '../editor/VariableSectionHeader';
+import { VariableTextField } from '../editor/VariableTextField';
+import { VerticalGroup } from '@grafana/ui';
+import { selectors } from '@grafana/e2e-selectors';
+
+export interface Props extends VariableEditorProps<DateTimeVariableModel> {}
+
+export const DateTimeVariableEditor = ({ onPropChange, variable: { allValue } }: Props): ReactElement => {
+  const updateAllVariable = useCallback(
+    (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
+      event.preventDefault();
+      onPropChange({ propName: 'allValue', propValue: event.currentTarget.value, updateOptions });
+    },
+    [onPropChange]
+  );
+
+  const onAllChange = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, true), [updateAllVariable]);
+  const onAllBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateAllVariable(e, false), [updateAllVariable]);
+
+  return (
+    <VerticalGroup spacing="xs">
+      <VariableSectionHeader name="Date options" />
+      <VariableTextField
+        value={allValue ?? ''}
+        name="No Date Input Value"
+        placeholder="value if date input is disabled"
+        onChange={onAllChange}
+        onBlur={onAllBlur}
+        labelWidth={20}
+        grow
+        ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
+      />
+    </VerticalGroup>
+  );
+};

--- a/public/app/features/variables/datetime/DateTimeVariablePicker.tsx
+++ b/public/app/features/variables/datetime/DateTimeVariablePicker.tsx
@@ -33,7 +33,7 @@ export function DateTimeVariablePicker({ variable, onVariableChange }: Props): R
   }, [variable]);
 
   const updateVariable = useCallback(
-    (value: Date, isDateInput: boolean) => {
+    (value: Date | string, isDateInput: boolean) => {
       dispatch(
         changeVariableProp(
           toVariablePayload(
@@ -56,7 +56,7 @@ export function DateTimeVariablePicker({ variable, onVariableChange }: Props): R
     [dispatch, variable, onVariableChange]
   );
 
-  const onChange = (value: Date, isDateInput: boolean) => {
+  const onChange = (value: Date | string, isDateInput: boolean) => {
     setDate(value);
     setIsDateInput(isDateInput);
     updateVariable(value, isDateInput);

--- a/public/app/features/variables/datetime/DateTimeVariablePicker.tsx
+++ b/public/app/features/variables/datetime/DateTimeVariablePicker.tsx
@@ -62,5 +62,12 @@ export function DateTimeVariablePicker({ variable, onVariableChange }: Props): R
     updateVariable(value, isDateInput);
   };
 
-  return <DatePickerWithEmptyWithInput value={date} onChange={onChange} isDateInput={isDateInput} />;
+  return (
+    <DatePickerWithEmptyWithInput
+      value={date}
+      onChange={onChange}
+      isDateInput={isDateInput}
+      returnValue={variable.returnValue || 'start'}
+    />
+  );
 }

--- a/public/app/features/variables/datetime/DateTimeVariablePicker.tsx
+++ b/public/app/features/variables/datetime/DateTimeVariablePicker.tsx
@@ -1,0 +1,66 @@
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+
+import { DateTimeVariableModel } from '../types';
+import { toVariablePayload } from '../utils';
+import { changeVariableProp } from '../state/sharedReducer';
+import { VariablePickerProps } from '../pickers/types';
+import { DatePickerWithEmptyWithInput } from '@grafana/ui';
+import { variableAdapters } from '../adapters';
+import { useDispatch } from 'react-redux';
+import { ALL_VARIABLE_VALUE } from '../constants';
+
+export interface Props extends VariablePickerProps<DateTimeVariableModel> {}
+
+export function DateTimeVariablePicker({ variable, onVariableChange }: Props): ReactElement {
+  const dispatch = useDispatch();
+  const [date, setDate] = useState<Date | string>(() => {
+    const currentValue = variable.current.value;
+    if (currentValue === ALL_VARIABLE_VALUE) {
+      return ALL_VARIABLE_VALUE;
+    }
+    return new Date(+currentValue);
+  });
+  const [isDateInput, setIsDateInput] = useState(true);
+
+  useEffect(() => {
+    if (variable.current.value !== ALL_VARIABLE_VALUE) {
+      setDate(new Date(+variable.current.value));
+      setIsDateInput(true);
+    } else {
+      setDate(new Date());
+      setIsDateInput(false);
+    }
+  }, [variable]);
+
+  const updateVariable = useCallback(
+    (value: Date, isDateInput: boolean) => {
+      dispatch(
+        changeVariableProp(
+          toVariablePayload(
+            { id: variable.id, type: variable.type },
+            { propName: 'query', propValue: isDateInput ? value.valueOf().toString() : ALL_VARIABLE_VALUE }
+          )
+        )
+      );
+
+      if (onVariableChange) {
+        onVariableChange({
+          ...variable,
+          current: { ...variable.current, value: value.valueOf().toString() },
+        });
+        return;
+      }
+
+      variableAdapters.get(variable.type).updateOptions(variable);
+    },
+    [dispatch, variable, onVariableChange]
+  );
+
+  const onChange = (value: Date, isDateInput: boolean) => {
+    setDate(value);
+    setIsDateInput(isDateInput);
+    updateVariable(value, isDateInput);
+  };
+
+  return <DatePickerWithEmptyWithInput value={date} onChange={onChange} isDateInput={isDateInput} />;
+}

--- a/public/app/features/variables/datetime/actions.test.ts
+++ b/public/app/features/variables/datetime/actions.test.ts
@@ -1,0 +1,163 @@
+import { variableAdapters } from '../adapters';
+import { setDateTimeVariableOptionsFromUrl, updateDateTimeVariableOptions } from './actions';
+import { createDateTimeVariableAdapter } from './adapter';
+import { reduxTester } from '../../../../test/core/redux/reduxTester';
+import { getRootReducer, RootReducerType } from '../state/helpers';
+import { DateTimeVariableModel, initialVariableModelState, VariableOption } from '../types';
+import { toVariableIdentifier, toVariablePayload } from '../state/types';
+import { addVariable, changeVariableProp, setCurrentVariableValue } from '../state/sharedReducer';
+import { createDateTimeOptions } from './reducer';
+
+describe('datetime  actions', () => {
+  variableAdapters.setInit(() => [createDateTimeVariableAdapter()]);
+
+  describe('when updateDateTimeVariableOptions is dispatched', () => {
+    it('then correct actions are dispatched', async () => {
+      const option: VariableOption = {
+        value: '1645138799999',
+        text: '1645138799999',
+        selected: false,
+      };
+
+      const variable: DateTimeVariableModel = {
+        ...initialVariableModelState,
+        id: 'query0',
+        index: 0,
+        type: 'datetime',
+        name: 'query0',
+        current: {
+          value: '',
+          text: '',
+          selected: false,
+        },
+        options: [
+          {
+            selected: false,
+            text: '1644966000000',
+            value: '1644966000000',
+          },
+        ],
+        query: '1645138799999',
+        returnValue: 'end',
+      };
+
+      const tester = await reduxTester<RootReducerType>()
+        .givenRootReducer(getRootReducer())
+        .whenActionIsDispatched(
+          addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
+        )
+        .whenAsyncActionIsDispatched(updateDateTimeVariableOptions(toVariableIdentifier(variable)), true);
+
+      tester.thenDispatchedActionsShouldEqual(
+        createDateTimeOptions(toVariablePayload(variable)),
+        setCurrentVariableValue(toVariablePayload(variable, { option }))
+      );
+    });
+    it('then correct actions are dispatched when returnValue = start', async () => {
+      const option = {
+        value: '1644966000000',
+        text: '1644966000000',
+        selected: false,
+      };
+      const variable: DateTimeVariableModel = {
+        ...initialVariableModelState,
+        id: 'query0',
+        index: 0,
+        type: 'datetime',
+        name: 'query0',
+        current: {
+          value: '',
+          text: '',
+          selected: false,
+        },
+        options: [
+          {
+            value: '1644966000000',
+            text: '1644966000000',
+            selected: false,
+          },
+        ],
+        query: '1644966000000',
+        returnValue: 'start',
+      };
+
+      const tester = await reduxTester<RootReducerType>()
+        .givenRootReducer(getRootReducer())
+        .whenActionIsDispatched(
+          addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
+        )
+        .whenAsyncActionIsDispatched(updateDateTimeVariableOptions(toVariableIdentifier(variable)), true);
+
+      tester.thenDispatchedActionsShouldEqual(
+        createDateTimeOptions(toVariablePayload(variable)),
+        setCurrentVariableValue(toVariablePayload(variable, { option }))
+      );
+    });
+  });
+  describe('when setDateTimeVariableOptionsFromUrl is dispatched', () => {
+    it('then correct actions are dispatched', async () => {
+      const urlValue = '1645138799998';
+      const variable: DateTimeVariableModel = {
+        ...initialVariableModelState,
+        id: 'query0',
+        index: 0,
+        type: 'datetime',
+        name: 'query0',
+        current: {
+          value: '',
+          text: '',
+          selected: false,
+        },
+        options: [],
+        query: '1645138799999',
+        returnValue: 'end',
+      };
+
+      const tester = await reduxTester<RootReducerType>()
+        .givenRootReducer(getRootReducer())
+        .whenActionIsDispatched(
+          addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
+        )
+        .whenAsyncActionIsDispatched(setDateTimeVariableOptionsFromUrl(toVariableIdentifier(variable), urlValue), true);
+
+      tester.thenDispatchedActionsShouldEqual(
+        changeVariableProp(toVariablePayload(variable, { propName: 'query', propValue: urlValue })),
+        setCurrentVariableValue(
+          toVariablePayload(variable, { option: { text: urlValue, value: urlValue, selected: false } })
+        )
+      );
+    });
+    it('then correct actions are dispatched returnValue = start', async () => {
+      const urlValue = '1644966000000';
+      const variable: DateTimeVariableModel = {
+        ...initialVariableModelState,
+        id: 'query0',
+        index: 0,
+        type: 'datetime',
+        name: 'query0',
+        current: {
+          value: '',
+          text: '',
+          selected: false,
+        },
+        options: [],
+        query: '1644966000000',
+        returnValue: 'start',
+      };
+
+      const tester = await reduxTester<RootReducerType>()
+        .givenRootReducer(getRootReducer())
+        .whenActionIsDispatched(
+          addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
+        )
+        .whenAsyncActionIsDispatched(setDateTimeVariableOptionsFromUrl(toVariableIdentifier(variable), urlValue), true);
+
+      tester.thenDispatchedActionsShouldEqual(
+        changeVariableProp(toVariablePayload(variable, { propName: 'query', propValue: urlValue })),
+        setCurrentVariableValue(
+          toVariablePayload(variable, { option: { text: urlValue, value: urlValue, selected: false } })
+        )
+      );
+    });
+  });
+});

--- a/public/app/features/variables/datetime/actions.test.ts
+++ b/public/app/features/variables/datetime/actions.test.ts
@@ -4,9 +4,9 @@ import { createDateTimeVariableAdapter } from './adapter';
 import { reduxTester } from '../../../../test/core/redux/reduxTester';
 import { getRootReducer, RootReducerType } from '../state/helpers';
 import { DateTimeVariableModel, initialVariableModelState, VariableOption } from '../types';
-import { toVariableIdentifier, toVariablePayload } from '../state/types';
 import { addVariable, changeVariableProp, setCurrentVariableValue } from '../state/sharedReducer';
 import { createDateTimeOptions } from './reducer';
+import { toKeyedVariableIdentifier, toVariablePayload } from '../utils';
 
 describe('datetime  actions', () => {
   variableAdapters.setInit(() => [createDateTimeVariableAdapter()]);
@@ -46,7 +46,7 @@ describe('datetime  actions', () => {
         .whenActionIsDispatched(
           addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
         )
-        .whenAsyncActionIsDispatched(updateDateTimeVariableOptions(toVariableIdentifier(variable)), true);
+        .whenAsyncActionIsDispatched(updateDateTimeVariableOptions(toKeyedVariableIdentifier(variable)), true);
 
       tester.thenDispatchedActionsShouldEqual(
         createDateTimeOptions(toVariablePayload(variable)),
@@ -86,7 +86,7 @@ describe('datetime  actions', () => {
         .whenActionIsDispatched(
           addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
         )
-        .whenAsyncActionIsDispatched(updateDateTimeVariableOptions(toVariableIdentifier(variable)), true);
+        .whenAsyncActionIsDispatched(updateDateTimeVariableOptions(toKeyedVariableIdentifier(variable)), true);
 
       tester.thenDispatchedActionsShouldEqual(
         createDateTimeOptions(toVariablePayload(variable)),
@@ -118,7 +118,10 @@ describe('datetime  actions', () => {
         .whenActionIsDispatched(
           addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
         )
-        .whenAsyncActionIsDispatched(setDateTimeVariableOptionsFromUrl(toVariableIdentifier(variable), urlValue), true);
+        .whenAsyncActionIsDispatched(
+          setDateTimeVariableOptionsFromUrl(toKeyedVariableIdentifier(variable), urlValue),
+          true
+        );
 
       tester.thenDispatchedActionsShouldEqual(
         changeVariableProp(toVariablePayload(variable, { propName: 'query', propValue: urlValue })),
@@ -150,7 +153,10 @@ describe('datetime  actions', () => {
         .whenActionIsDispatched(
           addVariable(toVariablePayload(variable, { global: false, index: variable.index, model: variable }))
         )
-        .whenAsyncActionIsDispatched(setDateTimeVariableOptionsFromUrl(toVariableIdentifier(variable), urlValue), true);
+        .whenAsyncActionIsDispatched(
+          setDateTimeVariableOptionsFromUrl(toKeyedVariableIdentifier(variable), urlValue),
+          true
+        );
 
       tester.thenDispatchedActionsShouldEqual(
         changeVariableProp(toVariablePayload(variable, { propName: 'query', propValue: urlValue })),

--- a/public/app/features/variables/datetime/actions.ts
+++ b/public/app/features/variables/datetime/actions.ts
@@ -14,6 +14,7 @@ export const updateDateTimeVariableOptions = (identifier: VariableIdentifier): T
     await dispatch(createDateTimeOptions(toVariablePayload(identifier)));
 
     const variableInState = getVariable<DateTimeVariableModel>(identifier.id, getState());
+
     await variableAdapters.get(identifier.type).setValue(variableInState, variableInState.options[0], true);
   };
 };

--- a/public/app/features/variables/datetime/actions.ts
+++ b/public/app/features/variables/datetime/actions.ts
@@ -3,29 +3,37 @@ import { ThunkResult } from '../../../types';
 import { getVariable } from '../state/selectors';
 import { variableAdapters } from '../adapters';
 import { createDateTimeOptions } from './reducer';
-import { toVariableIdentifier, toVariablePayload, VariableIdentifier } from '../state/types';
+import { KeyedVariableIdentifier } from '../state/types';
 import { setOptionFromUrl } from '../state/actions';
 import { UrlQueryValue } from '@grafana/data';
 import { changeVariableProp } from '../state/sharedReducer';
-import { ensureStringValues } from '../utils';
-
-export const updateDateTimeVariableOptions = (identifier: VariableIdentifier): ThunkResult<void> => {
+import { ensureStringValues, toKeyedVariableIdentifier, toVariablePayload } from '../utils';
+import { toKeyedAction } from '../state/keyedVariablesReducer';
+export const updateDateTimeVariableOptions = (identifier: KeyedVariableIdentifier): ThunkResult<void> => {
   return async (dispatch, getState) => {
-    await dispatch(createDateTimeOptions(toVariablePayload(identifier)));
+    const { rootStateKey, type } = identifier;
+    dispatch(toKeyedAction(rootStateKey, createDateTimeOptions(toVariablePayload(identifier))));
 
-    const variableInState = getVariable<DateTimeVariableModel>(identifier.id, getState());
+    const variableInState = getVariable<DateTimeVariableModel>(identifier, getState());
 
-    await variableAdapters.get(identifier.type).setValue(variableInState, variableInState.options[0], true);
+    await variableAdapters.get(type).setValue(variableInState, variableInState.options[0], true);
   };
 };
 
 export const setDateTimeVariableOptionsFromUrl =
-  (identifier: VariableIdentifier, urlValue: UrlQueryValue): ThunkResult<void> =>
+  (identifier: KeyedVariableIdentifier, urlValue: UrlQueryValue): ThunkResult<void> =>
   async (dispatch, getState) => {
-    const variableInState = getVariable<DateTimeVariableModel>(identifier.id, getState());
+    const { rootStateKey } = identifier;
+
+    const variableInState = getVariable<DateTimeVariableModel>(identifier, getState());
 
     const stringUrlValue = ensureStringValues(urlValue);
-    dispatch(changeVariableProp(toVariablePayload(variableInState, { propName: 'query', propValue: stringUrlValue })));
+    dispatch(
+      toKeyedAction(
+        rootStateKey,
+        changeVariableProp(toVariablePayload(variableInState, { propName: 'query', propValue: stringUrlValue }))
+      )
+    );
 
-    await dispatch(setOptionFromUrl(toVariableIdentifier(variableInState), stringUrlValue));
+    await dispatch(setOptionFromUrl(toKeyedVariableIdentifier(variableInState), stringUrlValue));
   };

--- a/public/app/features/variables/datetime/actions.ts
+++ b/public/app/features/variables/datetime/actions.ts
@@ -1,0 +1,30 @@
+import { DateTimeVariableModel } from '../types';
+import { ThunkResult } from '../../../types';
+import { getVariable } from '../state/selectors';
+import { variableAdapters } from '../adapters';
+import { createDateTimeOptions } from './reducer';
+import { toVariableIdentifier, toVariablePayload, VariableIdentifier } from '../state/types';
+import { setOptionFromUrl } from '../state/actions';
+import { UrlQueryValue } from '@grafana/data';
+import { changeVariableProp } from '../state/sharedReducer';
+import { ensureStringValues } from '../utils';
+
+export const updateDateTimeVariableOptions = (identifier: VariableIdentifier): ThunkResult<void> => {
+  return async (dispatch, getState) => {
+    await dispatch(createDateTimeOptions(toVariablePayload(identifier)));
+
+    const variableInState = getVariable<DateTimeVariableModel>(identifier.id, getState());
+    await variableAdapters.get(identifier.type).setValue(variableInState, variableInState.options[0], true);
+  };
+};
+
+export const setDateTimeVariableOptionsFromUrl =
+  (identifier: VariableIdentifier, urlValue: UrlQueryValue): ThunkResult<void> =>
+  async (dispatch, getState) => {
+    const variableInState = getVariable<DateTimeVariableModel>(identifier.id, getState());
+
+    const stringUrlValue = ensureStringValues(urlValue);
+    dispatch(changeVariableProp(toVariablePayload(variableInState, { propName: 'query', propValue: stringUrlValue })));
+
+    await dispatch(setOptionFromUrl(toVariableIdentifier(variableInState), stringUrlValue));
+  };

--- a/public/app/features/variables/datetime/adapter.test.ts
+++ b/public/app/features/variables/datetime/adapter.test.ts
@@ -1,6 +1,6 @@
 import { variableAdapters } from '../adapters';
 import { createDateTimeVariableAdapter } from './adapter';
-import { textboxBuilder } from '../shared/testing/builders';
+// import { textboxBuilder } from '../shared/testing/builders';
 import { DateTimeVariableModel, initialVariableModelState, VariableHide } from '../types';
 
 variableAdapters.setInit(() => [createDateTimeVariableAdapter()]);

--- a/public/app/features/variables/datetime/adapter.test.ts
+++ b/public/app/features/variables/datetime/adapter.test.ts
@@ -1,0 +1,86 @@
+import { variableAdapters } from '../adapters';
+import { createDateTimeVariableAdapter } from './adapter';
+import { textboxBuilder } from '../shared/testing/builders';
+import { DateTimeVariableModel, initialVariableModelState, VariableHide } from '../types';
+
+variableAdapters.setInit(() => [createDateTimeVariableAdapter()]);
+
+describe('createDateTimeVariableAdapter', () => {
+  describe('getSaveModel', () => {
+    describe('when called and query differs from the original query and saving current as default', () => {
+      it('then the model should be correct', () => {
+        const variable: DateTimeVariableModel = {
+          ...initialVariableModelState,
+          id: 'query0',
+          index: 0,
+          type: 'datetime',
+          name: 'query0',
+          current: {
+            value: '',
+            text: '',
+            selected: false,
+          },
+          options: [
+            {
+              selected: false,
+              text: '1644966000000',
+              value: '1644966000000',
+            },
+          ],
+          query: '1645138799999',
+          returnValue: 'end',
+        };
+
+        const adapter = variableAdapters.get('datetime');
+
+        const result = adapter.getSaveModel(variable, true);
+        expect(result).toEqual({
+          name: 'query0',
+          query: '1645138799999',
+          current: { selected: false, text: '', value: '' },
+          options: [{ selected: false, text: '1644966000000', value: '1644966000000' }],
+          type: 'datetime',
+          label: null,
+          hide: VariableHide.dontHide,
+          skipUrlSync: false,
+          error: null,
+          description: null,
+          returnValue: 'end',
+        });
+      });
+    });
+  });
+
+  describe('getValueForUrl', () => {
+    describe('when called', () => {
+      it('then current value should be returned', () => {
+        const variable: DateTimeVariableModel = {
+          ...initialVariableModelState,
+          id: 'query0',
+          index: 0,
+          type: 'datetime',
+          name: 'query0',
+          current: {
+            value: '1644966000000',
+            text: '1644966000000',
+            selected: false,
+          },
+          options: [
+            {
+              selected: false,
+              text: '1644966000000',
+              value: '1644966000000',
+            },
+          ],
+          query: '1645138799999',
+          returnValue: 'end',
+        };
+
+        const adapter = variableAdapters.get('datetime');
+
+        const result = adapter.getValueForUrl(variable);
+        expect(result).toEqual('1644966000000');
+      });
+    });
+  });
+});

--- a/public/app/features/variables/datetime/adapter.ts
+++ b/public/app/features/variables/datetime/adapter.ts
@@ -8,7 +8,8 @@ import { VariableAdapter } from '../adapters';
 import { DateTimeVariableEditor } from './DateTimeVariableEditor';
 import { DateTimeVariablePicker } from './DateTimeVariablePicker';
 import { updateDateTimeVariableOptions, setDateTimeVariableOptionsFromUrl } from './actions';
-import { ALL_VARIABLE_VALUE, toVariableIdentifier } from '../state/types';
+import { toKeyedVariableIdentifier } from '../utils';
+import { ALL_VARIABLE_VALUE } from '../constants';
 
 export const createDateTimeVariableAdapter = (): VariableAdapter<DateTimeVariableModel> => {
   return {
@@ -23,7 +24,7 @@ export const createDateTimeVariableAdapter = (): VariableAdapter<DateTimeVariabl
       return false;
     },
     setValue: async (variable, option, emitChanges = false) => {
-      await dispatch(setOptionAsCurrent(toVariableIdentifier(variable), option, emitChanges));
+      await dispatch(setOptionAsCurrent(toKeyedVariableIdentifier(variable), option, emitChanges));
     },
     setValueFromUrl: async (variable, urlValue) => {
       if (urlValue) {
@@ -32,10 +33,10 @@ export const createDateTimeVariableAdapter = (): VariableAdapter<DateTimeVariabl
         }
       }
 
-      await dispatch(setDateTimeVariableOptionsFromUrl(toVariableIdentifier(variable), urlValue));
+      await dispatch(setDateTimeVariableOptionsFromUrl(toKeyedVariableIdentifier(variable), urlValue));
     },
     updateOptions: async (variable) => {
-      await dispatch(updateDateTimeVariableOptions(toVariableIdentifier(variable)));
+      await dispatch(updateDateTimeVariableOptions(toKeyedVariableIdentifier(variable)));
     },
     getSaveModel: (variable) => {
       const { index, id, state, global, ...rest } = cloneDeep(variable);

--- a/public/app/features/variables/datetime/adapter.ts
+++ b/public/app/features/variables/datetime/adapter.ts
@@ -1,0 +1,42 @@
+import { cloneDeep } from 'lodash';
+
+import { DateTimeVariableModel } from '../types';
+import { initialDateTimeVariableModelState, dateTimeVariableReducer } from './reducer';
+import { dispatch } from '../../../store/store';
+import { setOptionAsCurrent } from '../state/actions';
+import { VariableAdapter } from '../adapters';
+import { DateTimeVariableEditor } from './DateTimeVariableEditor';
+import { DateTimeVariablePicker } from './DateTimeVariablePicker';
+import { updateDateTimeVariableOptions, setDateTimeVariableOptionsFromUrl } from './actions';
+import { toVariableIdentifier } from '../state/types';
+
+export const createDateTimeVariableAdapter = (): VariableAdapter<DateTimeVariableModel> => {
+  return {
+    id: 'datetime',
+    description: 'Define a datetime with a datepicker',
+    name: 'DateTime',
+    initialState: initialDateTimeVariableModelState,
+    reducer: dateTimeVariableReducer,
+    picker: DateTimeVariablePicker,
+    editor: DateTimeVariableEditor,
+    dependsOn: (variable, variableToTest) => {
+      return false;
+    },
+    setValue: async (variable, option, emitChanges = false) => {
+      await dispatch(setOptionAsCurrent(toVariableIdentifier(variable), option, emitChanges));
+    },
+    setValueFromUrl: async (variable, urlValue) => {
+      await dispatch(setDateTimeVariableOptionsFromUrl(toVariableIdentifier(variable), urlValue));
+    },
+    updateOptions: async (variable) => {
+      await dispatch(updateDateTimeVariableOptions(toVariableIdentifier(variable)));
+    },
+    getSaveModel: (variable) => {
+      const { index, id, state, global, ...rest } = cloneDeep(variable);
+      return rest;
+    },
+    getValueForUrl: (variable) => {
+      return variable.current.value;
+    },
+  };
+};

--- a/public/app/features/variables/datetime/adapter.ts
+++ b/public/app/features/variables/datetime/adapter.ts
@@ -8,7 +8,7 @@ import { VariableAdapter } from '../adapters';
 import { DateTimeVariableEditor } from './DateTimeVariableEditor';
 import { DateTimeVariablePicker } from './DateTimeVariablePicker';
 import { updateDateTimeVariableOptions, setDateTimeVariableOptionsFromUrl } from './actions';
-import { toVariableIdentifier } from '../state/types';
+import { ALL_VARIABLE_VALUE, toVariableIdentifier } from '../state/types';
 
 export const createDateTimeVariableAdapter = (): VariableAdapter<DateTimeVariableModel> => {
   return {
@@ -26,6 +26,12 @@ export const createDateTimeVariableAdapter = (): VariableAdapter<DateTimeVariabl
       await dispatch(setOptionAsCurrent(toVariableIdentifier(variable), option, emitChanges));
     },
     setValueFromUrl: async (variable, urlValue) => {
+      if (urlValue) {
+        if (isNaN(new Date(+urlValue).getTime())) {
+          urlValue = ALL_VARIABLE_VALUE;
+        }
+      }
+
       await dispatch(setDateTimeVariableOptionsFromUrl(toVariableIdentifier(variable), urlValue));
     },
     updateOptions: async (variable) => {

--- a/public/app/features/variables/datetime/reducer.test.ts
+++ b/public/app/features/variables/datetime/reducer.test.ts
@@ -65,34 +65,4 @@ describe('dateTimeVariableReducer', () => {
         });
     });
   });
-
-  //   describe('when createTextBoxOptions is dispatched and query contains spaces', () => {
-  //     it('then state should be correct', () => {
-  //       const query = '  ABC  ';
-  //       const id = '0';
-  //       const { initialState } = getVariableTestContext(adapter, { id, query });
-  //       const payload = toVariablePayload({ id: '0', type: 'textbox' });
-
-  //       reducerTester<VariablesState>()
-  //         .givenReducer(textBoxVariableReducer, cloneDeep(initialState))
-  //         .whenActionIsDispatched(createTextBoxOptions(payload))
-  //         .thenStateShouldEqual({
-  //           [id]: {
-  //             ...initialState[id],
-  //             options: [
-  //               {
-  //                 text: query.trim(),
-  //                 value: query.trim(),
-  //                 selected: false,
-  //               },
-  //             ],
-  //             current: {
-  //               text: query.trim(),
-  //               value: query.trim(),
-  //               selected: false,
-  //             },
-  //           } as TextBoxVariableModel,
-  //         });
-  //     });
-  //   });
 });

--- a/public/app/features/variables/datetime/reducer.test.ts
+++ b/public/app/features/variables/datetime/reducer.test.ts
@@ -1,10 +1,11 @@
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
 import { cloneDeep } from 'lodash';
 import { getVariableTestContext } from '../state/helpers';
-import { toVariablePayload, VariablesState } from '../state/types';
+import { VariablesState } from '../state/types';
 import { createDateTimeOptions, dateTimeVariableReducer } from './reducer';
 import { DateTimeVariableModel } from '../types';
 import { createDateTimeVariableAdapter } from './adapter';
+import { toVariablePayload } from '../utils';
 
 describe('dateTimeVariableReducer', () => {
   const adapter = createDateTimeVariableAdapter();

--- a/public/app/features/variables/datetime/reducer.test.ts
+++ b/public/app/features/variables/datetime/reducer.test.ts
@@ -1,0 +1,98 @@
+import { reducerTester } from '../../../../test/core/redux/reducerTester';
+import { cloneDeep } from 'lodash';
+import { getVariableTestContext } from '../state/helpers';
+import { toVariablePayload, VariablesState } from '../state/types';
+import { createDateTimeOptions, dateTimeVariableReducer } from './reducer';
+import { DateTimeVariableModel } from '../types';
+import { createDateTimeVariableAdapter } from './adapter';
+
+describe('dateTimeVariableReducer', () => {
+  const adapter = createDateTimeVariableAdapter();
+
+  describe('when createDateTimeOptions is dispatched', () => {
+    it('then state should be correct', () => {
+      const query = '1645138799999';
+      const id = '0';
+      const { initialState } = getVariableTestContext(adapter, { id, query, returnValue: 'end' });
+      const payload = toVariablePayload({ id: '0', type: 'datetime' });
+
+      reducerTester<VariablesState>()
+        .givenReducer(dateTimeVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(createDateTimeOptions(payload))
+        .thenStateShouldEqual({
+          [id]: {
+            ...initialState[id],
+            options: [
+              {
+                text: query,
+                value: query,
+                selected: false,
+              },
+            ],
+            current: {
+              text: query,
+              value: query,
+              selected: false,
+            },
+          } as DateTimeVariableModel,
+        });
+    });
+    it('then state should be correct returnValue=start', () => {
+      const query = '1645138799999';
+      const id = '0';
+      const { initialState } = getVariableTestContext(adapter, { id, query, returnValue: 'start' });
+      const payload = toVariablePayload({ id: '0', type: 'datetime' });
+
+      reducerTester<VariablesState>()
+        .givenReducer(dateTimeVariableReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(createDateTimeOptions(payload))
+        .thenStateShouldEqual({
+          [id]: {
+            ...initialState[id],
+            options: [
+              {
+                text: query,
+                value: query,
+                selected: false,
+              },
+            ],
+            current: {
+              text: query,
+              value: query,
+              selected: false,
+            },
+          } as DateTimeVariableModel,
+        });
+    });
+  });
+
+  //   describe('when createTextBoxOptions is dispatched and query contains spaces', () => {
+  //     it('then state should be correct', () => {
+  //       const query = '  ABC  ';
+  //       const id = '0';
+  //       const { initialState } = getVariableTestContext(adapter, { id, query });
+  //       const payload = toVariablePayload({ id: '0', type: 'textbox' });
+
+  //       reducerTester<VariablesState>()
+  //         .givenReducer(textBoxVariableReducer, cloneDeep(initialState))
+  //         .whenActionIsDispatched(createTextBoxOptions(payload))
+  //         .thenStateShouldEqual({
+  //           [id]: {
+  //             ...initialState[id],
+  //             options: [
+  //               {
+  //                 text: query.trim(),
+  //                 value: query.trim(),
+  //                 selected: false,
+  //               },
+  //             ],
+  //             current: {
+  //               text: query.trim(),
+  //               value: query.trim(),
+  //               selected: false,
+  //             },
+  //           } as TextBoxVariableModel,
+  //         });
+  //     });
+  //   });
+});

--- a/public/app/features/variables/datetime/reducer.ts
+++ b/public/app/features/variables/datetime/reducer.ts
@@ -20,12 +20,6 @@ export const dateTimeVariableSlice = createSlice({
       const option = { text: instanceState.query.trim(), value: instanceState.query.trim(), selected: false };
       instanceState.current = option;
       instanceState.options = [option];
-
-      // if (instanceState.returnValue === 'end') {
-      //   instanceState.options = [option];
-      // } else {
-      //   instanceState.options = [];
-      // }
     },
   },
 });

--- a/public/app/features/variables/datetime/reducer.ts
+++ b/public/app/features/variables/datetime/reducer.ts
@@ -1,7 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { initialVariableModelState, DateTimeVariableModel, VariableOption } from '../types';
-import { getInstanceState, VariablePayload, initialVariablesState, VariablesState } from '../state/types';
+import { VariablePayload, initialVariablesState, VariablesState } from '../state/types';
+import { getInstanceState } from '../state/selectors';
 
 export const initialDateTimeVariableModelState: DateTimeVariableModel = {
   ...initialVariableModelState,
@@ -18,8 +19,8 @@ export const dateTimeVariableSlice = createSlice({
     createDateTimeOptions: (state: VariablesState, action: PayloadAction<VariablePayload>) => {
       const instanceState = getInstanceState<DateTimeVariableModel>(state, action.payload.id);
       const option = { text: instanceState.query.trim(), value: instanceState.query.trim(), selected: false };
-      instanceState.current = option;
       instanceState.options = [option];
+      instanceState.current = option;
     },
   },
 });

--- a/public/app/features/variables/datetime/reducer.ts
+++ b/public/app/features/variables/datetime/reducer.ts
@@ -18,8 +18,12 @@ export const dateTimeVariableSlice = createSlice({
     createDateTimeOptions: (state: VariablesState, action: PayloadAction<VariablePayload>) => {
       const instanceState = getInstanceState<DateTimeVariableModel>(state, action.payload.id);
       const option = { text: instanceState.query.trim(), value: instanceState.query.trim(), selected: false };
-      instanceState.options = [option];
       instanceState.current = option;
+      if (instanceState.returnValue === 'end') {
+        instanceState.options = [option];
+      } else {
+        instanceState.options = [];
+      }
     },
   },
 });

--- a/public/app/features/variables/datetime/reducer.ts
+++ b/public/app/features/variables/datetime/reducer.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { initialVariableModelState, DateTimeVariableModel, VariableOption } from '../types';
+import { getInstanceState, VariablePayload, initialVariablesState, VariablesState } from '../state/types';
+
+export const initialDateTimeVariableModelState: DateTimeVariableModel = {
+  ...initialVariableModelState,
+  type: 'datetime',
+  query: new Date().valueOf().toString(),
+  current: {} as VariableOption,
+  options: [],
+};
+
+export const dateTimeVariableSlice = createSlice({
+  name: 'templating/datetime',
+  initialState: initialVariablesState,
+  reducers: {
+    createDateTimeOptions: (state: VariablesState, action: PayloadAction<VariablePayload>) => {
+      const instanceState = getInstanceState<DateTimeVariableModel>(state, action.payload.id);
+      const option = { text: instanceState.query.trim(), value: instanceState.query.trim(), selected: false };
+      instanceState.options = [option];
+      instanceState.current = option;
+    },
+  },
+});
+
+export const dateTimeVariableReducer = dateTimeVariableSlice.reducer;
+
+export const { createDateTimeOptions } = dateTimeVariableSlice.actions;

--- a/public/app/features/variables/datetime/reducer.ts
+++ b/public/app/features/variables/datetime/reducer.ts
@@ -19,11 +19,13 @@ export const dateTimeVariableSlice = createSlice({
       const instanceState = getInstanceState<DateTimeVariableModel>(state, action.payload.id);
       const option = { text: instanceState.query.trim(), value: instanceState.query.trim(), selected: false };
       instanceState.current = option;
-      if (instanceState.returnValue === 'end') {
-        instanceState.options = [option];
-      } else {
-        instanceState.options = [];
-      }
+      instanceState.options = [option];
+
+      // if (instanceState.returnValue === 'end') {
+      //   instanceState.options = [option];
+      // } else {
+      //   instanceState.options = [];
+      // }
     },
   },
 });

--- a/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
@@ -9,12 +9,23 @@ import { selectors } from '@grafana/e2e-selectors';
 
 export interface Props extends VariableEditorProps<TextBoxVariableModel> {}
 
-export function TextBoxVariableEditor({ onPropChange, variable: { query, placeholder } }: Props): ReactElement {
+export function TextBoxVariableEditor({
+  onPropChange,
+  variable: { query, allValue, placeholder },
+}: Props): ReactElement {
   const updateDefaultVariable = useCallback(
     (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
       event.preventDefault();
       onPropChange({ propName: 'originalQuery', propValue: event.currentTarget.value, updateOptions: false });
       onPropChange({ propName: 'query', propValue: event.currentTarget.value, updateOptions });
+    },
+    [onPropChange]
+  );
+
+  const updateEmptyVariable = useCallback(
+    (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
+      event.preventDefault();
+      onPropChange({ propName: 'allValue', propValue: event.currentTarget.value, updateOptions });
     },
     [onPropChange]
   );
@@ -27,19 +38,32 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query, placeho
     [onPropChange]
   );
 
-  const onDefaultChange = useCallback((e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, false), [
-    updateDefaultVariable,
-  ]);
-  const onDefaultBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, true), [
-    updateDefaultVariable,
-  ]);
+  const onDefaultChange = useCallback(
+    (e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, false),
+    [updateDefaultVariable]
+  );
+  const onDefaultBlur = useCallback(
+    (e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, true),
+    [updateDefaultVariable]
+  );
 
-  const onPlaceholderChange = useCallback((e: FormEvent<HTMLInputElement>) => updatePlaceholderVariable(e, false), [
-    updatePlaceholderVariable,
-  ]);
-  const onPlaceholderBlur = useCallback((e: FormEvent<HTMLInputElement>) => updatePlaceholderVariable(e, false), [
-    updatePlaceholderVariable,
-  ]);
+  const onEmptyChange = useCallback(
+    (e: FormEvent<HTMLInputElement>) => updateEmptyVariable(e, true),
+    [updateEmptyVariable]
+  );
+  const onEmptyBlur = useCallback(
+    (e: FormEvent<HTMLInputElement>) => updateEmptyVariable(e, false),
+    [updateEmptyVariable]
+  );
+
+  const onPlaceholderChange = useCallback(
+    (e: FormEvent<HTMLInputElement>) => updatePlaceholderVariable(e, false),
+    [updatePlaceholderVariable]
+  );
+  const onPlaceholderBlur = useCallback(
+    (e: FormEvent<HTMLInputElement>) => updatePlaceholderVariable(e, false),
+    [updatePlaceholderVariable]
+  );
 
   return (
     <VerticalGroup spacing="xs">
@@ -53,6 +77,16 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query, placeho
         labelWidth={20}
         grow
         testId={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInputV2}
+      />
+      <VariableTextField
+        value={allValue ?? ''}
+        name="Empty Value"
+        placeholder="empty value, if cleared"
+        onChange={onEmptyChange}
+        onBlur={onEmptyBlur}
+        labelWidth={20}
+        grow
+        ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
       />
       <VariableTextField
         value={placeholder ?? ''}

--- a/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
@@ -10,7 +10,7 @@ import { selectors } from '@grafana/e2e-selectors';
 export interface Props extends VariableEditorProps<TextBoxVariableModel> {}
 
 export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Props): ReactElement {
-  const updateVariable = useCallback(
+  const updateDefaultVariable = useCallback(
     (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
       event.preventDefault();
       onPropChange({ propName: 'originalQuery', propValue: event.currentTarget.value, updateOptions: false });
@@ -19,8 +19,12 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Pro
     [onPropChange]
   );
 
-  const onChange = useCallback((e: FormEvent<HTMLInputElement>) => updateVariable(e, false), [updateVariable]);
-  const onBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateVariable(e, true), [updateVariable]);
+  const onDefaultChange = useCallback((e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, false), [
+    updateDefaultVariable,
+  ]);
+  const onDefaultBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, true), [
+    updateDefaultVariable,
+  ]);
 
   return (
     <VerticalGroup spacing="xs">
@@ -29,8 +33,8 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Pro
         value={query}
         name="Default value"
         placeholder="default value, if any"
-        onChange={onChange}
-        onBlur={onBlur}
+        onChange={onDefaultChange}
+        onBlur={onDefaultBlur}
         labelWidth={20}
         grow
         testId={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInputV2}

--- a/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
@@ -9,7 +9,7 @@ import { selectors } from '@grafana/e2e-selectors';
 
 export interface Props extends VariableEditorProps<TextBoxVariableModel> {}
 
-export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Props): ReactElement {
+export function TextBoxVariableEditor({ onPropChange, variable: { query, placeholder } }: Props): ReactElement {
   const updateDefaultVariable = useCallback(
     (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
       event.preventDefault();
@@ -19,11 +19,26 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Pro
     [onPropChange]
   );
 
+  const updatePlaceholderVariable = useCallback(
+    (event: FormEvent<HTMLInputElement>, updateOptions: boolean) => {
+      event.preventDefault();
+      onPropChange({ propName: 'placeholder', propValue: event.currentTarget.value, updateOptions });
+    },
+    [onPropChange]
+  );
+
   const onDefaultChange = useCallback((e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, false), [
     updateDefaultVariable,
   ]);
   const onDefaultBlur = useCallback((e: FormEvent<HTMLInputElement>) => updateDefaultVariable(e, true), [
     updateDefaultVariable,
+  ]);
+
+  const onPlaceholderChange = useCallback((e: FormEvent<HTMLInputElement>) => updatePlaceholderVariable(e, false), [
+    updatePlaceholderVariable,
+  ]);
+  const onPlaceholderBlur = useCallback((e: FormEvent<HTMLInputElement>) => updatePlaceholderVariable(e, false), [
+    updatePlaceholderVariable,
   ]);
 
   return (
@@ -38,6 +53,16 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Pro
         labelWidth={20}
         grow
         testId={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInputV2}
+      />
+      <VariableTextField
+        value={placeholder ?? ''}
+        name="Placeholder"
+        placeholder="placeholder for empty field"
+        onChange={onPlaceholderChange}
+        onBlur={onPlaceholderBlur}
+        labelWidth={20}
+        grow
+        ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
       />
     </VerticalGroup>
   );

--- a/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
@@ -86,7 +86,6 @@ export function TextBoxVariableEditor({
         onBlur={onEmptyBlur}
         labelWidth={20}
         grow
-        ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
       />
       <VariableTextField
         value={placeholder ?? ''}
@@ -96,7 +95,6 @@ export function TextBoxVariableEditor({
         onBlur={onPlaceholderBlur}
         labelWidth={20}
         grow
-        ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
       />
     </VerticalGroup>
   );

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -8,6 +8,7 @@ import { variableAdapters } from '../adapters';
 import { useDispatch } from 'react-redux';
 import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { toVariablePayload } from '../utils';
+import { ALL_VARIABLE_VALUE } from '../constants';
 
 export interface Props extends VariablePickerProps<TextBoxVariableModel> {}
 
@@ -30,12 +31,16 @@ export function TextBoxVariablePicker({ variable, onVariableChange }: Props): Re
       return;
     }
 
+    const data = { propName: 'query', propValue: updatedValue };
+
+    if (updatedValue === '') {
+      data.propValue = ALL_VARIABLE_VALUE;
+    }
+
     dispatch(
       toKeyedAction(
         variable.rootStateKey,
-        changeVariableProp(
-          toVariablePayload({ id: variable.id, type: variable.type }, { propName: 'query', propValue: updatedValue })
-        )
+        changeVariableProp(toVariablePayload({ id: variable.id, type: variable.type }, data))
       )
     );
 
@@ -49,6 +54,16 @@ export function TextBoxVariablePicker({ variable, onVariableChange }: Props): Re
 
     variableAdapters.get(variable.type).updateOptions(variable);
   }, [variable, updatedValue, dispatch, onVariableChange]);
+
+  const checkForOnEmptyValue = () => {
+    if (updatedValue !== '' && updatedValue !== ALL_VARIABLE_VALUE) {
+      return updatedValue;
+    } else {
+      return '';
+    }
+  };
+
+  const valueToDisplay = checkForOnEmptyValue();
 
   const onChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => setUpdatedValue(event.target.value),
@@ -66,7 +81,7 @@ export function TextBoxVariablePicker({ variable, onVariableChange }: Props): Re
   return (
     <Input
       type="text"
-      value={updatedValue}
+      value={valueToDisplay ?? ''}
       onChange={onChange}
       onBlur={onBlur}
       onKeyDown={onKeyDown}

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -14,6 +14,8 @@ export interface Props extends VariablePickerProps<TextBoxVariableModel> {}
 export function TextBoxVariablePicker({ variable, onVariableChange }: Props): ReactElement {
   const dispatch = useDispatch();
   const [updatedValue, setUpdatedValue] = useState(variable.current.value);
+  const placeholder = variable.placeholder;
+
   useEffect(() => {
     setUpdatedValue(variable.current.value);
   }, [variable]);
@@ -68,7 +70,7 @@ export function TextBoxVariablePicker({ variable, onVariableChange }: Props): Re
       onChange={onChange}
       onBlur={onBlur}
       onKeyDown={onKeyDown}
-      placeholder="Enter variable value"
+      placeholder={placeholder ?? ''}
       id={variable.id}
     />
   );

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -84,6 +84,7 @@ export interface QueryVariableModel extends DataSourceVariableModel {
 
 export interface TextBoxVariableModel extends VariableWithOptions {
   originalQuery: string | null;
+  allValue?: string | null;
   placeholder?: string | null;
 }
 

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -69,6 +69,7 @@ export interface IntervalVariableModel extends VariableWithOptions {
 
 export interface DateTimeVariableModel extends VariableWithOptions {
   allValue?: string | null;
+  returnValue?: 'start' | 'end';
 }
 
 export interface CustomVariableModel extends VariableWithMultiSupport {}

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -67,6 +67,10 @@ export interface IntervalVariableModel extends VariableWithOptions {
   refresh: VariableRefresh;
 }
 
+export interface DateTimeVariableModel extends VariableWithOptions {
+  allValue?: string | null;
+}
+
 export interface CustomVariableModel extends VariableWithMultiSupport {}
 
 export interface DataSourceVariableModel extends VariableWithMultiSupport {

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -84,6 +84,7 @@ export interface QueryVariableModel extends DataSourceVariableModel {
 
 export interface TextBoxVariableModel extends VariableWithOptions {
   originalQuery: string | null;
+  placeholder?: string | null;
 }
 
 export interface ConstantVariableModel extends VariableWithOptions {}


### PR DESCRIPTION
![Bildschirmfoto von 2021-06-30 11-43-11](https://user-images.githubusercontent.com/1222379/124112440-953b1d80-da6a-11eb-8359-c468cf6d7997.png)

**What this PR does / why we need it**:
This PR introduces a DateTime-picker as a new Type for dashboard-variables


**Special notes for your reviewer**:
This is basically an adjusted copy of TextBox

**Todo**:
* Unittests
* Options
  * seconds vs milliseconds (currently only milliseconds)
  * time (currently only date)
  * if `time` is false: start or end of day? (i.e. 00:00:00 or 23:59:59 like in the timerange-picker or add one day)
  * maybe timezone
  * allow null-value¹

¹ I currently don't really know how this should be implemented. We are using this picker for a lucene-query in elasticsearch where an empty-value shold be resolved to `*` so I can query like `creationTimestamp:[${creationFrom} TO *]`. This might work for other datasources as well but not for all. On the frontend/picker-side a `<InlineSwitch />` could be used to disable the datepicker. Maybe another text-option for "null-value replacement" can do the job, we could then type `*` in there.


Are you interested in this feature in general? We are fine if you say “nah, grafana doesn't need this feature, even if it has clean and tested code” but it would be nice to know for better planning reliability ;).