### PR TITLE
TimeSeries: Do not show series in tooltip if it's hidden in the viz

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -163,7 +163,8 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
           field === xField ||
           field.type === FieldType.time ||
           field.type !== FieldType.number ||
-          field.config.custom?.hideFrom?.tooltip
+          field.config.custom?.hideFrom?.tooltip ||
+          field.config.custom?.hideFrom?.viz
         ) {
           continue;
         }


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/36290

It doesn't make much sense to have series shown in the tooltip when it's not visible in the visualization. This will skip series in the tooltip in such cases now.