### PR TITLE
CloudWatch Logs: If Grafana Live isn't enabled, don't use the Live Channel

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -64,6 +64,7 @@ import { CloudWatchLanguageProvider } from './language_provider';
 import { VariableWithMultiSupport } from 'app/features/variables/types';
 import { AwsUrl, encodeUrl } from './aws_url';
 import { increasingInterval } from './utils/rxjs/increasingInterval';
+import config from 'app/core/config';
 
 const DS_QUERY_ENDPOINT = '/api/ds/query';
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -126,8 +126,11 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
 
     const dataQueryResponses: Array<Observable<DataQueryResponse>> = [];
     if (logQueries.length > 0) {
-      dataQueryResponses.push(this.handleLiveLogQueries(logQueries, options));
-      //  dataQueryResponses.push(this.handleLogQueries(logQueries, options));
+      if (config.liveEnabled) {
+        dataQueryResponses.push(this.handleLiveLogQueries(logQueries, options));
+      } else {
+        dataQueryResponses.push(this.handleLogQueries(logQueries, options));
+      }
     }
 
     if (metricsQueries.length > 0) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: When the config setting for Live -> `max_connections` is `0`, this disables Grafana Live. Based on the following snippet, `liveEnabled` is set when `max_connections` is `0`: https://github.com/grafana/grafana/blob/d2f18f8b7d0be2d06a364a38d49c7e98a2ba4ec9/pkg/api/frontendsettings.go#L206

When this happens, we don't want CloudWatch Logs to send the results via the websocket streams because the client doesn't have them open! Instead, we'll fallback on the existing logic pre-Grafana Live.

It's likely deployments might currently disable Grafana Live, given that it doesn't support HA yet (I'm looking forward to when that happens though 🙌)

**Which issue(s) this PR fixes**: #35448

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35448

**Special notes for your reviewer**: Please be gentle; it's my first contribution!

