### PR TITLE
Dashboards: load dashboards from a data source

### DIFF
--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -30,6 +30,7 @@ export class DashboardLoaderSrv {
 
   loadDashboard(type: UrlQueryValue, slug: any, uid: any) {
     let promise;
+
     if (type === 'script') {
       promise = this._loadScriptedDashboard(slug);
     } else if (type === 'snapshot') {
@@ -37,7 +38,7 @@ export class DashboardLoaderSrv {
         return this._dashboardLoadFailed('Snapshot not found', true);
       });
     } else if (type === 'ds') {
-      promise = this._loadFromDatasource(slug);
+      promise = this._loadFromDatasource(slug); // explore dashboards as code
     } else {
       promise = backendSrv
         .getDashboardByUid(uid)

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -36,8 +36,8 @@ export class DashboardLoaderSrv {
       promise = backendSrv.get('/api/snapshots/' + slug).catch(() => {
         return this._dashboardLoadFailed('Snapshot not found', true);
       });
-    } else if (type === 'dynamic') {
-      promise = this._loadDynamicDashboard(slug);
+    } else if (type === 'ds') {
+      promise = this._loadFromDatasource(slug);
     } else {
       promise = backendSrv
         .getDashboardByUid(uid)
@@ -93,10 +93,15 @@ export class DashboardLoaderSrv {
       );
   }
 
-  async _loadDynamicDashboard(slug: string) {
-    const ds = await getDatasourceSrv().get(slug);
+  /**
+   * This is a temporary solution to load dashboards dynamically from a datasource
+   * Eventually this should become a plugin type or a special handler in the dashboard
+   * loading code
+   */
+  async _loadFromDatasource(dsid: string) {
+    const ds = await getDatasourceSrv().get(dsid);
     if (!ds) {
-      return Promise.reject('can not find datasource: ' + slug);
+      return Promise.reject('can not find datasource: ' + dsid);
     }
 
     const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
We have danced around "dashboards as code" for a while -- all current strategies require saving JSON into the database.  This PR provides a way to load dashboards from a datasource without saving first.  Although it is not a great final design, this lets us evolve important features without increasing the API surface area much.  Eventually this should be some formal plugin API, but this is pretty easy.

With the URL:
```
http://localhost:3000/dashboard/ds/111?path=dashboard/simple
```

We will call:
```
      .get(`/api/datasources/${ds.id}/resources/${path}`, {})
```

Alternatively, we could add a scripted dashboard that is similar -- but I fear that will be too brittle and for sure do not want to encourage them too much :grimacing: 

See also:  https://github.com/grafana/grafana/pull/27691