### PR TITLE
Docs: Add  $__rate_interval variable to global variables

### DIFF
--- a/docs/sources/variables/variable-types/global-variables.md
+++ b/docs/sources/variables/variable-types/global-variables.md
@@ -74,7 +74,7 @@ Currently only supported for Prometheus data sources. This variable represents t
 
 ## $__rate_interval
 
-Currently only supported for Prometheus data sources. The `$__rate_interval` variable is meant to be used in the rate function. For detailed information, refer to [Prometheus query variables]({{< relref "../datasources/prometheus.md">}}).
+Currently only supported for Prometheus data sources. The `$__rate_interval` variable is meant to be used in the rate function. Refer to [Prometheus query variables]({{< relref "../datasources/prometheus.md">}}) for details. 
 
 ## $timeFilter or $__timeFilter
 

--- a/docs/sources/variables/variable-types/global-variables.md
+++ b/docs/sources/variables/variable-types/global-variables.md
@@ -72,6 +72,10 @@ This variable is the ID of the current organization.
 
 Currently only supported for Prometheus data sources. This variable represents the range for the current dashboard. It is calculated by `to - from`. It has a millisecond and a second representation called `$__range_ms` and `$__range_s`.
 
+## $__rate_interval
+
+Currently only supported for Prometheus data sources. The `$__rate_interval` variable is meant to be used in the rate function. For detailed information, refer to [Prometheus query variables]({{< relref "../datasources/prometheus.md">}}).
+
 ## $timeFilter or $__timeFilter
 
 The `$timeFilter` variable returns the currently selected time range as an expression. For example, the time range interval `Last 7 days` expression is `time > now() - 7d`.


### PR DESCRIPTION
**What this PR does / why we need it**:

In [Global variables documentation](https://grafana.com/docs/grafana/latest/variables/variable-types/global-variables/#__range) we have also data-source specific variables such as `$__range` that is only supported in Prometheus or `$__timeFilter` supported in SQL data sources. I've noticed that `$__rate_variable` that is also only supported in Prometheus in  is not documented here. This PR adds this missing documentation