### PR TITLE
Loki: Allow queries to be made either forward or backward

### DIFF
--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -7,6 +7,7 @@ import { LokiOptionFields } from './LokiOptionFields';
 import LokiDatasource from '../datasource';
 
 interface Props {
+  direction?: 'BACKWARD' | 'FORWARD';
   expr: string;
   maxLines?: number;
   instant?: boolean;
@@ -15,10 +16,11 @@ interface Props {
 }
 
 export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEditor(props: Props) {
-  const { expr, maxLines, instant, datasource, onChange } = props;
+  const { direction, expr, maxLines, instant, datasource, onChange } = props;
 
   const queryWithRefId: LokiQuery = {
     refId: '',
+    direction,
     expr,
     maxLines,
     instant,
@@ -34,6 +36,7 @@ export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEdito
         history={[]}
         ExtraFieldElement={
           <LokiOptionFields
+            queryDirection={queryWithRefId.direction ?? datasource.direction ?? 'BACKWARD'}
             queryType={queryWithRefId.instant ? 'instant' : 'range'}
             lineLimitValue={queryWithRefId?.maxLines?.toString() || ''}
             query={queryWithRefId}

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -24,7 +24,7 @@ export function LokiExploreQueryEditor(props: Props) {
       data={data}
       ExtraFieldElement={
         <LokiOptionFields
-          queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
+          queryDirection={query.direction ?? datasource.direction ?? 'BACKWARD'}
           queryType={query.instant ? 'instant' : 'range'}
           lineLimitValue={query?.maxLines?.toString() || ''}
           query={query}

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -24,6 +24,7 @@ export function LokiExploreQueryEditor(props: Props) {
       data={data}
       ExtraFieldElement={
         <LokiOptionFields
+          queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
           queryType={query.instant ? 'instant' : 'range'}
           lineLimitValue={query?.maxLines?.toString() || ''}
           query={query}

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -8,12 +8,20 @@ import { InlineFormLabel, RadioButtonGroup, InlineField, Input } from '@grafana/
 
 export interface LokiOptionFieldsProps {
   lineLimitValue: string;
+  queryDirection: LokiDirectionType;
   queryType: LokiQueryType;
   query: LokiQuery;
   onChange: (value: LokiQuery) => void;
   onRunQuery: () => void;
   runOnBlur?: boolean;
 }
+
+type LokiDirectionType = 'FORWARD' | 'BACKWARD';
+
+const queryDirectionOptions = [
+  { value: 'FORWARD', label: 'Forward', description: 'Run query forward in time.' },
+  { value: 'BACKWARD', label: 'Backward', description: 'Run query backward in time.' },
+];
 
 type LokiQueryType = 'instant' | 'range';
 
@@ -27,7 +35,7 @@ const queryTypeOptions = [
 ];
 
 export function LokiOptionFields(props: LokiOptionFieldsProps) {
-  const { lineLimitValue, queryType, query, onRunQuery, runOnBlur, onChange } = props;
+  const { lineLimitValue, queryDirection, queryType, query, onRunQuery, runOnBlur, onChange } = props;
 
   function onChangeQueryLimit(value: string) {
     const nextQuery = { ...query, maxLines: preprocessMaxLines(value) };
@@ -41,6 +49,12 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
     } else {
       nextQuery = { ...query, instant: false, range: true };
     }
+    onChange(nextQuery);
+  }
+
+  function onQueryDirectionChange(value: LokiDirectionType) {
+    let nextQuery;
+    nextQuery = { ...query, direction: value };
     onChange(nextQuery);
   }
 
@@ -123,6 +137,30 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
             }}
           />
         </InlineField>
+      </div>
+      {/*Query direction field*/}
+      <div
+        data-testid="queryDirectionField"
+        className={cx(
+          'gf-form explore-input-margin',
+          css`
+            flex-wrap: nowrap;
+          `
+        )}
+        aria-label="Query direction field"
+      >
+        <InlineFormLabel width="auto">Query direction</InlineFormLabel>
+
+        <RadioButtonGroup
+          options={queryDirectionOptions}
+          value={queryDirection}
+          onChange={(direction: LokiDirectionType) => {
+            onQueryDirectionChange(direction);
+            if (runOnBlur) {
+              onRunQuery();
+            }
+          }}
+        />
       </div>
     </div>
   );

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -50,6 +50,7 @@ export function LokiQueryEditor(props: LokiQueryEditorProps) {
       ExtraFieldElement={
         <>
           <LokiOptionFields
+          queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
             queryType={query.instant ? 'instant' : 'range'}
             lineLimitValue={query?.maxLines?.toString() || ''}
             query={query}

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -50,7 +50,7 @@ export function LokiQueryEditor(props: LokiQueryEditorProps) {
       ExtraFieldElement={
         <>
           <LokiOptionFields
-          queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
+            queryDirection={query.direction ?? datasource.direction ?? 'BACKWARD'}
             queryType={query.instant ? 'instant' : 'range'}
             lineLimitValue={query?.maxLines?.toString() || ''}
             query={query}

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
           "refId": "A",
         }
       }
+      queryDirection="BACKWARD"
       queryType="range"
     />
   }

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Render LokiQueryEditor with legend should render 1`] = `
             "refId": "A",
           }
         }
+        queryDirection="BACKWARD"
         queryType="range"
         runOnBlur={true}
       />
@@ -74,6 +75,7 @@ exports[`Render LokiQueryEditor with legend should update timerange 1`] = `
             "refId": "A",
           }
         }
+        queryDirection="BACKWARD"
         queryType="range"
         runOnBlur={true}
       />

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -3,6 +3,7 @@ import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana
 import { DataSourceHttpSettings } from '@grafana/ui';
 import { LokiOptions } from '../types';
 import { MaxLinesField } from './MaxLinesField';
+import { DirectionField } from './DirectionField';
 import { DerivedFields } from './DerivedFields';
 
 export type Props = DataSourcePluginOptionsEditorProps<LokiOptions>;
@@ -21,6 +22,7 @@ const makeJsonUpdater = <T extends any>(field: keyof LokiOptions) => (
 };
 
 const setMaxLines = makeJsonUpdater('maxLines');
+const setDirection = makeJsonUpdater('direction');
 const setDerivedFields = makeJsonUpdater('derivedFields');
 
 export const ConfigEditor = (props: Props) => {
@@ -41,6 +43,10 @@ export const ConfigEditor = (props: Props) => {
             <MaxLinesField
               value={options.jsonData.maxLines || ''}
               onChange={(value) => onOptionsChange(setMaxLines(options, value))}
+            />
+            <DirectionField
+              value={options.jsonData.direction || 'BACKWARD'}
+              onChange={(value) => onOptionsChange(setDirection(options, value))}
             />
           </div>
         </div>

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -22,9 +22,9 @@ export const DirectionField = (props: Props) => {
       inputEl={<RadioButtonGroup options={queryDirectionOptions} value={value} onChange={onChange} />}
       tooltip={
         <>
-          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions. This configuration is the default for
-          the data source but can be changed on a per-query basis. 'FORWARD' queries are processed in chronological
-          order. 'BACKWARD' queries are processed in reverse chronological order.
+          Loki queries can be made in either FORWARD or BACKWARD directions. This configuration is the default for the
+          data source but can be changed on a per-query basis. FORWARD queries are processed in chronological order.
+          BACKWARD queries are processed in reverse chronological order.
         </>
       }
     />

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { LegacyForms, RadioButtonGroup } from '@grafana/ui';
+const { FormField } = LegacyForms;
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+
+const queryDirectionOptions = [
+  { value: 'FORWARD', label: 'Forward', description: 'By default, run queries forward in time.' },
+  { value: 'BACKWARD', label: 'Backward', description: 'By dfault, run queries backward in time.' },
+];
+
+export const DirectionField = (props: Props) => {
+  const { value, onChange } = props;
+  return (
+    <FormField
+      label="Direction"
+      labelWidth={11}
+      inputWidth={20}
+      inputEl={
+        <RadioButtonGroup
+          options={queryDirectionOptions}
+          value={value}
+          onChange={onChange}
+        />
+      }
+      tooltip={
+        <>
+          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions.
+          This configuration is the default for the data source but can be changed on a per-query basis.
+          'FORWARD' queries are processed in chronological order.
+          'BACKWARD' queries are processed in reverse chronological order.
+        </>
+      }
+    />
+  );
+};

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -7,7 +7,6 @@ type Props = {
   onChange: (value: string) => void;
 };
 
-
 const queryDirectionOptions = [
   { value: 'FORWARD', label: 'Forward', description: 'By default, run queries forward in time.' },
   { value: 'BACKWARD', label: 'Backward', description: 'By dfault, run queries backward in time.' },
@@ -20,19 +19,12 @@ export const DirectionField = (props: Props) => {
       label="Direction"
       labelWidth={11}
       inputWidth={20}
-      inputEl={
-        <RadioButtonGroup
-          options={queryDirectionOptions}
-          value={value}
-          onChange={onChange}
-        />
-      }
+      inputEl={<RadioButtonGroup options={queryDirectionOptions} value={value} onChange={onChange} />}
       tooltip={
         <>
-          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions.
-          This configuration is the default for the data source but can be changed on a per-query basis.
-          'FORWARD' queries are processed in chronological order.
-          'BACKWARD' queries are processed in reverse chronological order.
+          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions. This configuration is the default for
+          the data source but can be changed on a per-query basis. 'FORWARD' queries are processed in chronological
+          order. 'BACKWARD' queries are processed in reverse chronological order.
         </>
       }
     />

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -31,11 +31,13 @@ export interface LokiQuery extends DataQuery {
   valueWithRefId?: boolean;
   maxLines?: number;
   range?: boolean;
+  direction?: 'BACKWARD' | 'FORWARD';
   instant?: boolean;
 }
 
 export interface LokiOptions extends DataSourceJsonData {
   maxLines?: string;
+  direction?: 'BACKWARD' | 'FORWARD';
   derivedFields?: DerivedFieldConfig[];
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow Loki queries to be made either forward or backward.
 
This can be configured on a per query basis and on a per data source
basis where query configuration overrides data source configuration.
For backwards compatibility the default direction in the data source
configuration is 'BACKWARDS' which is the only direction previously
supported. The data source configuration becomes the default
configuration for new queries created in Explore or via a panel but
the user can change this with a toggle.

**Which issue(s) this PR fixes**:
Addresses the bulk of https://github.com/grafana/grafana/issues/20394 but does not touch add paging functionality.

Fixes #20394

**Special notes for your reviewer**:
I have essentially no experience with React or frontend development so hacked at syntax until this worked in manual testing. I thought I'd open up a PR early and I would really appreciate some advice on the following:
- What needs to be tested
- Whether the hierarchy of "data source default and specific query override" is a reasonable UX
- Correctness of some of the direction selection logic (`{ query.direction ?? datasource.direction ?? 'BACKWARD' }` for example)
- What can be done to clean this up (perhaps defining an direction type in `types.ts`?) 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>