### PR TITLE
Docs: Improve title and documentation for share shortened link in Explore

### DIFF
--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -63,4 +63,4 @@ After you've navigated to Explore, you should notice a "Back" button in the Expl
 
 > **Note:** Available in Grafana 7.3 and later versions.
 
-The Share shortened link capability allows you to create smaller and simpler URLs of the format /goto/:uid instead of using longer URLs with query parameters. To create a shortened link, click the **Share** option in Explore toolbar. Any shortened links that are never used will be automatically deleted after 7 days.
+The Share shortened link capability allows you to create smaller and simpler URLs of the format /goto/:uid instead of using longer URLs with query parameters. To create a shortened link to the executed query, click the **Share** option in Explore toolbar. Any shortened links that are never used will be automatically deleted after 7 days.

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -63,4 +63,4 @@ After you've navigated to Explore, you should notice a "Back" button in the Expl
 
 > **Note:** Available in Grafana 7.3 and later versions.
 
-The Share shortened link capability allows you to create smaller and simpler URLs of the format /goto/:uid instead of using longer URLs with query parameters. To create a shortened link to the executed query, click the **Share** option in Explore toolbar. Any shortened links that are never used will be automatically deleted after 7 days.
+The Share shortened link capability allows you to create smaller and simpler URLs of the format /goto/:uid instead of using longer URLs with query parameters. To create a shortened link to the executed query, click the **Share** option in the Explore toolbar. A shortened link that is never used will automatically get deleted after seven (7) days.

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -148,7 +148,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
                 </ToolbarButton>
               ) : null}
 
-              <Tooltip content={'Copy shortened link'} placement="bottom">
+              <Tooltip content={'Copy shortened link to the executed query'} placement="bottom">
                 <ToolbarButton icon="share-alt" onClick={() => createAndCopyShortLink(window.location.href)} />
               </Tooltip>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on https://github.com/grafana/grafana/issues/35971, it is not very clear that the shorten url is created only for executed query, because it is created from the url that changes after we run the query. This PR improves the tittle and documentation to make it more clear. 

@achatterjee-grafana I wasn't sure if it should be `to executed query` or `of executed query`. Or maybe you can come up with something even better. 🙂

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/35971


