### PR TITLE
Dashboard: Add Max time range and Oldest 'From' settings

### DIFF
--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -190,13 +190,11 @@ export function registerAngularDirectives() {
     'timePickerHidden',
     'nowDelay',
     'maxTimeRange',
-    'oldestFrom',
     'timezone',
     ['onTimeZoneChange', { watchDepth: 'reference', wrapApply: true }],
     ['onRefreshIntervalChange', { watchDepth: 'reference', wrapApply: true }],
     ['onNowDelayChange', { watchDepth: 'reference', wrapApply: true }],
     ['onMaxTimeRangeChange', { watchDepth: 'reference', wrapApply: true }],
-    ['onOldestFromChange', { watchDepth: 'reference', wrapApply: true }],
     ['onHideTimePickerChange', { watchDepth: 'reference', wrapApply: true }],
   ]);
 

--- a/public/app/core/angular_wrappers.ts
+++ b/public/app/core/angular_wrappers.ts
@@ -189,10 +189,14 @@ export function registerAngularDirectives() {
     'refreshIntervals',
     'timePickerHidden',
     'nowDelay',
+    'maxTimeRange',
+    'oldestFrom',
     'timezone',
     ['onTimeZoneChange', { watchDepth: 'reference', wrapApply: true }],
     ['onRefreshIntervalChange', { watchDepth: 'reference', wrapApply: true }],
     ['onNowDelayChange', { watchDepth: 'reference', wrapApply: true }],
+    ['onMaxTimeRangeChange', { watchDepth: 'reference', wrapApply: true }],
+    ['onOldestFromChange', { watchDepth: 'reference', wrapApply: true }],
     ['onHideTimePickerChange', { watchDepth: 'reference', wrapApply: true }],
   ]);
 

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -52,10 +52,6 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }: Props)
     dashboard.timepicker.maxTimeRange = maxTimeRange;
   };
 
-  const onOldestFromChange = (oldestFrom: string) => {
-    dashboard.timepicker.oldestFrom = oldestFrom;
-  };
-
   const onHideTimePickerChange = (hide: boolean) => {
     dashboard.timepicker.hidden = hide;
     setRenderCounter(renderCounter + 1);
@@ -120,13 +116,11 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }: Props)
         onRefreshIntervalChange={onRefreshIntervalChange}
         onNowDelayChange={onNowDelayChange}
         onMaxTimeRangeChange={onMaxTimeRangeChange}
-        onOldestFromChange={onOldestFromChange}
         onHideTimePickerChange={onHideTimePickerChange}
         refreshIntervals={dashboard.timepicker.refresh_intervals}
         timePickerHidden={dashboard.timepicker.hidden}
         nowDelay={dashboard.timepicker.nowDelay}
         maxTimeRange={dashboard.timepicker.maxTimeRange}
-        oldestFrom={dashboard.timepicker.oldestFrom}
         timezone={dashboard.timezone}
       />
 

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -48,6 +48,14 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }: Props)
     dashboard.timepicker.nowDelay = nowDelay;
   };
 
+  const onMaxTimeRangeChange = (maxTimeRange: string) => {
+    dashboard.timepicker.maxTimeRange = maxTimeRange;
+  };
+
+  const onOldestFromChange = (oldestFrom: string) => {
+    dashboard.timepicker.oldestFrom = oldestFrom;
+  };
+
   const onHideTimePickerChange = (hide: boolean) => {
     dashboard.timepicker.hidden = hide;
     setRenderCounter(renderCounter + 1);
@@ -111,10 +119,14 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone }: Props)
         onTimeZoneChange={onTimeZoneChange}
         onRefreshIntervalChange={onRefreshIntervalChange}
         onNowDelayChange={onNowDelayChange}
+        onMaxTimeRangeChange={onMaxTimeRangeChange}
+        onOldestFromChange={onOldestFromChange}
         onHideTimePickerChange={onHideTimePickerChange}
         refreshIntervals={dashboard.timepicker.refresh_intervals}
         timePickerHidden={dashboard.timepicker.hidden}
         nowDelay={dashboard.timepicker.nowDelay}
+        maxTimeRange={dashboard.timepicker.maxTimeRange}
+        oldestFrom={dashboard.timepicker.oldestFrom}
         timezone={dashboard.timezone}
       />
 

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -10,24 +10,21 @@ interface Props {
   onRefreshIntervalChange: (interval: string[]) => void;
   onNowDelayChange: (nowDelay: string) => void;
   onMaxTimeRangeChange: (maxTimeRange: string) => void;
-  onOldestFromChange: (oldestFrom: string) => void;
   onHideTimePickerChange: (hide: boolean) => void;
   refreshIntervals: string[];
   timePickerHidden: boolean;
   nowDelay: string;
   maxTimeRange: string;
-  oldestFrom: string;
   timezone: TimeZone;
 }
 
 interface State {
   isNowDelayValid: boolean;
   isMaxTimeRangeValid: boolean;
-  isOldestFromValid: boolean;
 }
 
 export class TimePickerSettings extends PureComponent<Props, State> {
-  state: State = { isNowDelayValid: true, isMaxTimeRangeValid: true, isOldestFromValid: true };
+  state: State = { isNowDelayValid: true, isMaxTimeRangeValid: true };
 
   onNowDelayChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value;
@@ -59,22 +56,6 @@ export class TimePickerSettings extends PureComponent<Props, State> {
     }
 
     this.setState({ isMaxTimeRangeValid: false });
-  };
-
-  onOldestFromChange = (event: React.FormEvent<HTMLInputElement>) => {
-    const value = event.currentTarget.value;
-
-    if (isEmpty(value)) {
-      this.setState({ isOldestFromValid: true });
-      return this.props.onOldestFromChange(value);
-    }
-
-    if (value.match(/^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])$/)) {
-      this.setState({ isOldestFromValid: true });
-      return this.props.onOldestFromChange(value);
-    }
-
-    this.setState({ isOldestFromValid: false });
   };
 
   onHideTimePickerChange = () => {
@@ -122,16 +103,6 @@ export class TimePickerSettings extends PureComponent<Props, State> {
             invalid={!this.state.isMaxTimeRangeValid}
             onChange={this.onMaxTimeRangeChange}
             defaultValue={this.props.maxTimeRange}
-          />
-        </Field>
-        <Field
-           label="Oldest 'from' time"
-           description="Prevents the user from selecting a time range starting further back in the past than the specified interval."
-        >
-          <Input
-            invalid={!this.state.isOldestFromValid}
-            onChange={this.onOldestFromChange}
-            defaultValue={this.props.oldestFrom}
           />
         </Field>
         <Field label="Hide time picker">

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -53,7 +53,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
       return this.props.onMaxTimeRangeChange(value);
     }
 
-    if (value.match(/^[1-9]\d*[yMwdhms]$/)) {
+    if (value.match(/^[1-9]\d*(ms|[yMwdhms])$/)) {
       this.setState({ isMaxTimeRangeValid: true });
       return this.props.onMaxTimeRangeChange(value);
     }
@@ -69,7 +69,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
       return this.props.onOldestFromChange(value);
     }
 
-    if (value.match(/^[1-9]\d*[yMwdhms]$/)) {
+    if (value.match(/^[1-9]\d*(ms|[yMwdhms])$/)) {
       this.setState({ isOldestFromValid: true });
       return this.props.onOldestFromChange(value);
     }
@@ -116,8 +116,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
         </Field>
         <Field
            label="Max time range"
-           description="Limits users to the specified time interval. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds).
-"
+           description="Limits users to the specified time interval."
         >
           <Input
             invalid={!this.state.isMaxTimeRangeValid}

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -127,7 +127,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
         </Field>
         <Field
            label="Oldest 'From' now -"
-           description="Limit how far back the start of the time range can go from now. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds)."
+           description="Prevents the user from selecting a time range starting further back in the past than the specified interval."
         >
           <Input
             invalid={!this.state.isOldestFromValid}

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -116,7 +116,8 @@ export class TimePickerSettings extends PureComponent<Props, State> {
         </Field>
         <Field
            label="Max time range"
-           description="Prevent users from choosing a time range larger than a specified time interval. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds)."
+           description="Limits users to the specified time interval. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds).
+"
         >
           <Input
             invalid={!this.state.isMaxTimeRangeValid}

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -28,6 +28,7 @@ interface State {
 
 export class TimePickerSettings extends PureComponent<Props, State> {
   state: State = { isNowDelayValid: true, isMaxTimeRangeValid: true, isOldestFromValid: true };
+  const interval_regex = /^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])$/;
 
   onNowDelayChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value;
@@ -53,7 +54,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
       return this.props.onMaxTimeRangeChange(value);
     }
 
-    if (value.match(/^[1-9]\d*(ms|[yMwdhms])$/)) {
+    if (value.match(interval_regex)) {
       this.setState({ isMaxTimeRangeValid: true });
       return this.props.onMaxTimeRangeChange(value);
     }
@@ -69,7 +70,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
       return this.props.onOldestFromChange(value);
     }
 
-    if (value.match(/^[1-9]\d*(ms|[yMwdhms])$/)) {
+    if (value.match(interval_regex)) {
       this.setState({ isOldestFromValid: true });
       return this.props.onOldestFromChange(value);
     }

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -28,7 +28,6 @@ interface State {
 
 export class TimePickerSettings extends PureComponent<Props, State> {
   state: State = { isNowDelayValid: true, isMaxTimeRangeValid: true, isOldestFromValid: true };
-  const interval_regex = /^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])$/;
 
   onNowDelayChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value;
@@ -54,7 +53,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
       return this.props.onMaxTimeRangeChange(value);
     }
 
-    if (value.match(interval_regex)) {
+    if (value.match(/^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])$/)) {
       this.setState({ isMaxTimeRangeValid: true });
       return this.props.onMaxTimeRangeChange(value);
     }
@@ -70,7 +69,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
       return this.props.onOldestFromChange(value);
     }
 
-    if (value.match(interval_regex)) {
+    if (value.match(/^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])$/)) {
       this.setState({ isOldestFromValid: true });
       return this.props.onOldestFromChange(value);
     }

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -125,7 +125,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
           />
         </Field>
         <Field
-           label="Oldest 'From' now -"
+           label="Oldest 'from' time"
            description="Prevents the user from selecting a time range starting further back in the past than the specified interval."
         >
           <Input

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -9,19 +9,25 @@ interface Props {
   onTimeZoneChange: (timeZone: TimeZone) => void;
   onRefreshIntervalChange: (interval: string[]) => void;
   onNowDelayChange: (nowDelay: string) => void;
+  onMaxTimeRangeChange: (maxTimeRange: string) => void;
+  onOldestFromChange: (oldestFrom: string) => void;
   onHideTimePickerChange: (hide: boolean) => void;
   refreshIntervals: string[];
   timePickerHidden: boolean;
   nowDelay: string;
+  maxTimeRange: string;
+  oldestFrom: string;
   timezone: TimeZone;
 }
 
 interface State {
   isNowDelayValid: boolean;
+  isMaxTimeRangeValid: boolean;
+  isOldestFromValid: boolean;
 }
 
 export class TimePickerSettings extends PureComponent<Props, State> {
-  state: State = { isNowDelayValid: true };
+  state: State = { isNowDelayValid: true, isMaxTimeRangeValid: true, isOldestFromValid: true };
 
   onNowDelayChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value;
@@ -37,6 +43,38 @@ export class TimePickerSettings extends PureComponent<Props, State> {
     }
 
     this.setState({ isNowDelayValid: false });
+  };
+
+  onMaxTimeRangeChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.value;
+
+    if (isEmpty(value)) {
+      this.setState({ isMaxTimeRangeValid: true });
+      return this.props.onMaxTimeRangeChange(value);
+    }
+
+    if (value.match(/^[1-9]\d*[yMwdhms]$/)) {
+      this.setState({ isMaxTimeRangeValid: true });
+      return this.props.onMaxTimeRangeChange(value);
+    }
+
+    this.setState({ isMaxTimeRangeValid: false });
+  };
+
+  onOldestFromChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.value;
+
+    if (isEmpty(value)) {
+      this.setState({ isOldestFromValid: true });
+      return this.props.onOldestFromChange(value);
+    }
+
+    if (value.match(/^[1-9]\d*[yMwdhms]$/)) {
+      this.setState({ isOldestFromValid: true });
+      return this.props.onOldestFromChange(value);
+    }
+
+    this.setState({ isOldestFromValid: false });
   };
 
   onHideTimePickerChange = () => {
@@ -74,6 +112,26 @@ export class TimePickerSettings extends PureComponent<Props, State> {
             placeholder="0m"
             onChange={this.onNowDelayChange}
             defaultValue={this.props.nowDelay}
+          />
+        </Field>
+        <Field
+           label="Max time range"
+           description="Prevent users from choosing a time range larger than a specified time interval. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds)."
+        >
+          <Input
+            invalid={!this.state.isMaxTimeRangeValid}
+            onChange={this.onMaxTimeRangeChange}
+            defaultValue={this.props.maxTimeRange}
+          />
+        </Field>
+        <Field
+           label="Oldest 'From' now -"
+           description="Limit how far back the start of the time range can go from now. The supported units are y(years), M(months), w(weeks), d(days), h(hours), m(minutes), s(seconds)."
+        >
+          <Input
+            invalid={!this.state.isOldestFromValid}
+            onChange={this.onOldestFromChange}
+            defaultValue={this.props.oldestFrom}
           />
         </Field>
         <Field label="Hide time picker">

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -76,7 +76,7 @@ export class TimeSrv {
     if (this.dashboard?.timepicker.maxTimeRange) {
       maxTimeRangeInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.maxTimeRange);
     }
-    if (this.dashboard.timepicker.oldestFrom) {
+    if (this.dashboard?.timepicker.oldestFrom) {
       oldestFromInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.oldestFrom);
     }
     let min = 0;
@@ -296,15 +296,15 @@ export class TimeSrv {
   }
 
   setTime(time: RawTimeRange, fromRouteUpdate?: boolean) {
-    let isSetTime = true;
+    let shouldSetTime = true;
     let maxTimeRangeInMillis = 0,
       oldestFromInMillis = 0;
 
-    if (this.dashboard.timepicker.maxTimeRange) {
+    if (this.dashboard?.timepicker.maxTimeRange) {
       maxTimeRangeInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.maxTimeRange);
     }
 
-    if (this.dashboard.timepicker.oldestFrom) {
+    if (this.dashboard?.timepicker.oldestFrom) {
       oldestFromInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.oldestFrom);
     }
 
@@ -324,17 +324,17 @@ export class TimeSrv {
       appEvents.emit(AppEvents.alertWarning, [
         'Timerange can not be longer than ' + this.dashboard?.timepicker.maxTimeRange + '. Please select a shorter duration.',
       ]);
-      isSetTime = false;
+      shouldSetTime = false;
     }
 
     if (oldestFromInMillis !== 0 && Date.now() - from.valueOf() > oldestFromInMillis) {
       appEvents.emit(AppEvents.alertWarning, [
         'The start of the time range can not be more than ' + this.dashboard?.timepicker.oldestFrom + ' ago. Please select a later from time.',
       ]);
-      isSetTime = false;
+      shouldSetTime = false;
     }
 
-    if (!isSetTime) {
+    if (!shouldSetTime) {
       return;
     }
 

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -110,7 +110,7 @@ export class TimeSrv {
       this.time.to = 'now';
       this.setTime(this.time);
       appEvents.emit(AppEvents.alertWarning, [
-        'Timerange of this dashboard has changed.',
+        'Previous time span of this dashboard has changed.',
       ]);
     }
   }

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -58,7 +58,7 @@ export class TimeSrv {
     this.initTimeFromUrl();
     this.parseTime();
 
-    if (this.dashboard.timepicker.maxTimeRange || this.dashboard.timepicker.oldestFrom) {
+    if (this.dashboard?.timepicker.maxTimeRange || this.dashboard?.timepicker.oldestFrom) {
       this.checkTimeAtLoad();
     }
 

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -329,7 +329,7 @@ export class TimeSrv {
 
     if (oldestFromInMillis !== 0 && Date.now() - from.valueOf() > oldestFromInMillis) {
       appEvents.emit(AppEvents.alertWarning, [
-        'The start of the timerange can not be more than ' + this.dashboard.timepicker.oldestFrom + ' old from now',
+        'The start of the time range can not be more than ' + this.dashboard?.timepicker.oldestFrom + ' ago. Please select a later from time.',
       ]);
       isSetTime = false;
     }

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -322,7 +322,7 @@ export class TimeSrv {
 
     if (maxTimeRangeInMillis !== 0 && to.valueOf() - from.valueOf() > maxTimeRangeInMillis) {
       appEvents.emit(AppEvents.alertWarning, [
-        'Timerange can not be more than ' + this.dashboard.timepicker.maxTimeRange,
+        'Timerange can not be longer than ' + this.dashboard?.timepicker.maxTimeRange + '. Please select a shorter duration.',
       ]);
       isSetTime = false;
     }

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -73,7 +73,7 @@ export class TimeSrv {
   checkTimeAtLoad() {
     let maxTimeRangeInMillis = 0,
       oldestFromInMillis = 0;
-    if (this.dashboard.timepicker.maxTimeRange) {
+    if (this.dashboard?.timepicker.maxTimeRange) {
       maxTimeRangeInMillis = rangeUtil.intervalToMs(this.dashboard.timepicker.maxTimeRange);
     }
     if (this.dashboard.timepicker.oldestFrom) {

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -109,6 +109,9 @@ export class TimeSrv {
       this.time.from = 'now-' + str;
       this.time.to = 'now';
       this.setTime(this.time);
+      appEvents.emit(AppEvents.alertWarning, [
+        'Timerange of this dashboard has changed.',
+      ]);
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it:**

The current Grafana UI allows users to set the time range to go arbitrarily far back using the time picker, calendar picker, and zoom-out feature. However, going too far back may cause significant performance degradation and potentially result in the data source crashing depending on how it was set up. In addition to this, TSDBs usually have a specific data retention time, and therefore it does not make sense to go any further back than the retained time.

Two additional fields have been added under “Time Options” in Admin’s Dashboard Setting to choose an appropriate time range and time limit.

     1. Max time range: prevent users from choosing a time range larger than a specified time interval
     2. Oldest 'From': limit how far back the start of the time range can go from now

The input for both of these options must be valid time spans or empty, otherwise, the option will default to the last valid input. By default, both inputs are empty. If either input is empty, there will be no restriction for their corresponding setting. You can see how it looks like in the image below.

![Screenshot (47)](https://user-images.githubusercontent.com/71486417/124270015-402a0500-db59-11eb-8b87-60ee8b03a3b3.png)

From a user perspective, there will be no change in the time range controls UI. If the user picks or zooms out to a valid time range, then the dashboard should update exactly as before. If the user picks an invalid time range, then the dashboard should not update, the current time range settings should remain the same, and he or she will get an error message. If the user clicks the zoom-out control, it should only zoom out if the new time range would be valid, otherwise, he or she will get an error message. You can see how the error looks like in the dashboard in the image below.

![Screenshot (50)](https://user-images.githubusercontent.com/71486417/124270059-4c15c700-db59-11eb-9e75-649b700f2dd8.png)

Note that if the dashboard's default time range is more than the configuration settings then it will set the time range of the dashboard to the minimum value of "Oldest From" and "Max time range" before now via a page load. 
For example: 
Suppose **Max time range**: 5h and **Oldest 'From'**: now - 7h and default time range is "last 6 hours". Then the default time range of the dashboard is more than the input values. So here, Grafana will set the time range as "last 5 hours" (Minimum of 7h and 5h is 5h).

 Also, if the user enters an invalid time range via URL time control, they will be taken to the valid time range by applying the above-mentioned technique.