### PR TITLE
Select: Portal select menu to document.body

### DIFF
--- a/e2e/shared/smokeTestScenario.ts
+++ b/e2e/shared/smokeTestScenario.ts
@@ -15,9 +15,9 @@ export const smokeTestScenario = {
       .should('be.visible')
       .within(() => {
         e2e.components.Select.input().should('be.visible').click();
-
-        cy.contains('CSV Metric Values').scrollIntoView().should('be.visible').click();
       });
+
+    cy.contains('CSV Metric Values').scrollIntoView().should('be.visible').click();
 
     // Make sure the graph renders via checking legend
     e2e.components.VizLegend.seriesName('A-series').should('be.visible');

--- a/e2e/suite1/specs/dashboard-time-zone.spec.ts
+++ b/e2e/suite1/specs/dashboard-time-zone.spec.ts
@@ -47,9 +47,9 @@ e2e.scenario({
         e2e.components.Select.singleValue().should('be.visible').should('have.text', fromTimeZone);
 
         e2e.components.Select.input().should('be.visible').click();
-
-        e2e.components.Select.option().should('be.visible').contains(toTimeZone).click();
       });
+
+    e2e.components.Select.option().should('be.visible').contains(toTimeZone).click();
 
     // click to go back to the dashboard.
     e2e.components.BackButton.backArrow().click({ force: true }).wait(2000);

--- a/e2e/suite1/specs/exemplars.spec.ts
+++ b/e2e/suite1/specs/exemplars.spec.ts
@@ -4,7 +4,7 @@ const dataSourceName = 'PromExemplar';
 const addDataSource = () => {
   e2e.flows.addDataSource({
     type: 'Prometheus',
-    expectedAlertMessage: 'HTTP error Bad Gateway',
+    expectedAlertMessage: 'Bad Gateway',
     name: dataSourceName,
     form: () => {
       e2e.components.DataSource.Prometheus.configPage.exemplarsAddButton().click();
@@ -54,9 +54,8 @@ describe('Exemplars', () => {
       .should('be.visible')
       .within(() => {
         e2e.components.Select.input().should('be.visible').click();
-
-        e2e().contains(dataSourceName).scrollIntoView().should('be.visible').click();
       });
+    e2e().contains(dataSourceName).scrollIntoView().should('be.visible').click();
     e2e.components.TimePicker.openButton().click();
     e2e.components.TimePicker.fromField().clear().type('2021-05-11 19:30:00');
     e2e.components.TimePicker.toField().clear().type('2021-05-11 21:40:00');

--- a/e2e/suite1/specs/exemplars.spec.ts
+++ b/e2e/suite1/specs/exemplars.spec.ts
@@ -13,9 +13,9 @@ const addDataSource = () => {
         .should('be.visible')
         .within(() => {
           e2e.components.Select.input().should('be.visible').click({ force: true });
-
-          e2e().contains('gdev-tempo').scrollIntoView().should('be.visible').click();
         });
+
+      e2e().contains('gdev-tempo').scrollIntoView().should('be.visible').click();
     },
   });
 };

--- a/e2e/suite1/specs/explore.spec.ts
+++ b/e2e/suite1/specs/explore.spec.ts
@@ -15,9 +15,9 @@ e2e.scenario({
       .should('be.visible')
       .within(() => {
         e2e.components.Select.input().should('be.visible').click();
-
-        cy.contains('CSV Metric Values').scrollIntoView().should('be.visible').click();
       });
+
+    cy.contains('CSV Metric Values').scrollIntoView().should('be.visible').click();
 
     const canvases = e2e().get('canvas');
     canvases.should('have.length', 1);

--- a/e2e/suite1/specs/panelEdit_queries.spec.ts
+++ b/e2e/suite1/specs/panelEdit_queries.spec.ts
@@ -51,9 +51,9 @@ e2e.scenario({
       .should('be.visible')
       .within(() => {
         e2e.components.Select.input().eq(0).should('be.visible').click();
-
-        cy.contains('CSV Metric Values').scrollIntoView().should('be.visible').eq(0).click();
       });
+
+    cy.contains('CSV Metric Values').scrollIntoView().should('be.visible').eq(0).click();
 
     // Disable / enable row
     expectInspectorResultAndClose((keys) => {

--- a/e2e/suite1/specs/query-editor.spec.ts
+++ b/e2e/suite1/specs/query-editor.spec.ts
@@ -12,9 +12,9 @@ e2e.scenario({
       .should('be.visible')
       .within(() => {
         e2e.components.Select.input().should('be.visible').click();
-
-        cy.contains('gdev-prometheus').scrollIntoView().should('be.visible').click();
       });
+
+    cy.contains('gdev-prometheus').scrollIntoView().should('be.visible').click();
     const queryText = 'http_requests_total';
 
     e2e.components.QueryField.container().should('be.visible').type(queryText).type('{backspace}');

--- a/e2e/suite1/specs/select-focus.spec.ts
+++ b/e2e/suite1/specs/select-focus.spec.ts
@@ -14,9 +14,13 @@ e2e.scenario({
       .should('be.visible')
       .within(() => {
         e2e.components.Select.input().should('be.visible').click();
+      });
 
-        e2e.components.Select.option().should('be.visible').first().click();
+    e2e.components.Select.option().should('be.visible').first().click();
 
+    e2e.components.FolderPicker.container()
+      .should('be.visible')
+      .within(() => {
         e2e.components.Select.input().should('exist').should('have.focus');
       });
 

--- a/e2e/suite1/specs/trace-view-scrolling.spec.ts
+++ b/e2e/suite1/specs/trace-view-scrolling.spec.ts
@@ -15,9 +15,9 @@ describe('Trace view', () => {
       .should('be.visible')
       .within(() => {
         e2e.components.Select.input().should('be.visible').click();
-
-        e2e().contains('gdev-jaeger').scrollIntoView().should('be.visible').click();
       });
+
+    e2e().contains('gdev-jaeger').scrollIntoView().should('be.visible').click();
 
     e2e.components.DataSource.Jaeger.traceIDInput().should('be.visible').type('long-trace');
 

--- a/packages/grafana-data/src/themes/createV1Theme.ts
+++ b/packages/grafana-data/src/themes/createV1Theme.ts
@@ -98,15 +98,7 @@ export function createV1Theme(theme: Omit<GrafanaTheme2, 'v1'>): GrafanaTheme {
     },
     panelPadding: theme.components.panel.padding * theme.spacing.gridSize,
     panelHeaderHeight: theme.spacing.gridSize * theme.components.panel.headerHeight,
-    zIndex: {
-      navbarFixed: theme.zIndex.navbarFixed,
-      sidemenu: theme.zIndex.sidemenu,
-      dropdown: theme.zIndex.dropdown,
-      typeahead: theme.zIndex.typeahead,
-      tooltip: theme.zIndex.tooltip,
-      modalBackdrop: theme.zIndex.modalBackdrop,
-      modal: theme.zIndex.modal,
-    },
+    zIndex: theme.zIndex,
   };
 
   const basicColors = {

--- a/packages/grafana-data/src/themes/zIndex.ts
+++ b/packages/grafana-data/src/themes/zIndex.ts
@@ -7,7 +7,9 @@ export const zIndex = {
   typeahead: 1030,
   tooltip: 1040,
   modalBackdrop: 1050,
+  portal: 1051,
   modal: 1060,
+  selectPortal: 1061,
 };
 
 /** @beta */

--- a/packages/grafana-data/src/themes/zIndex.ts
+++ b/packages/grafana-data/src/themes/zIndex.ts
@@ -7,9 +7,8 @@ export const zIndex = {
   typeahead: 1030,
   tooltip: 1040,
   modalBackdrop: 1050,
-  portal: 1051,
   modal: 1060,
-  selectPortal: 1061,
+  portal: 1061,
 };
 
 /** @beta */

--- a/packages/grafana-data/src/types/theme.ts
+++ b/packages/grafana-data/src/types/theme.ts
@@ -108,6 +108,8 @@ export interface GrafanaThemeCommons {
     tooltip: number;
     modalBackdrop: number;
     modal: number;
+    portal: number;
+    selectPortal: number;
     typeahead: number;
   };
 }

--- a/packages/grafana-data/src/types/theme.ts
+++ b/packages/grafana-data/src/types/theme.ts
@@ -109,7 +109,6 @@ export interface GrafanaThemeCommons {
     modalBackdrop: number;
     modal: number;
     portal: number;
-    selectPortal: number;
     typeahead: number;
   };
 }

--- a/packages/grafana-e2e/src/flows/selectOption.ts
+++ b/packages/grafana-e2e/src/flows/selectOption.ts
@@ -17,23 +17,22 @@ export const selectOption = (config: SelectOptionConfig): any => {
 
   const { clickToOpen, container, forceClickOption, optionText } = fullConfig;
 
-  return container.within(() => {
+  container.within(() => {
     if (clickToOpen) {
       e2e().get('[class$="-input-suffix"]').click();
     }
-
-    e2e.components.Select.option()
-      .filter((_, { textContent }) => {
-        if (textContent === null) {
-          return false;
-        } else if (typeof optionText === 'string') {
-          return textContent.includes(optionText);
-        } else {
-          return optionText.test(textContent);
-        }
-      })
-      .scrollIntoView()
-      .click({ force: forceClickOption });
-    e2e().root().scrollIntoView();
   });
+
+  return e2e.components.Select.option()
+    .filter((_, { textContent }) => {
+      if (textContent === null) {
+        return false;
+      } else if (typeof optionText === 'string') {
+        return textContent.includes(optionText);
+      } else {
+        return optionText.test(textContent);
+      }
+    })
+    .scrollIntoView()
+    .click({ force: forceClickOption });
 };

--- a/packages/grafana-e2e/src/flows/setDashboardTimeRange.ts
+++ b/packages/grafana-e2e/src/flows/setDashboardTimeRange.ts
@@ -1,7 +1,5 @@
-import { e2e } from '../index';
 import { setTimeRange, TimeRangeConfig } from './setTimeRange';
 
 export { TimeRangeConfig };
 
-export const setDashboardTimeRange = (config: TimeRangeConfig) =>
-  e2e.components.PageToolbar.container().within(() => setTimeRange(config));
+export const setDashboardTimeRange = (config: TimeRangeConfig) => setTimeRange(config);

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -71,6 +71,10 @@ export function Modal(props: PropsWithChildren<Props>) {
 
   return (
     <Portal>
+      <div
+        className={styles.modalBackdrop}
+        onClick={onClickBackdrop || (closeOnBackdropClick ? onDismiss : undefined)}
+      />
       <div className={cx(styles.modal, className)}>
         <div className={headerClass}>
           {typeof title === 'string' && <DefaultModalHeader {...props} title={title} />}
@@ -81,10 +85,6 @@ export function Modal(props: PropsWithChildren<Props>) {
         </div>
         <div className={cx(styles.modalContent, contentClassName)}>{children}</div>
       </div>
-      <div
-        className={styles.modalBackdrop}
-        onClick={onClickBackdrop || (closeOnBackdropClick ? onDismiss : undefined)}
-      />
     </Portal>
   );
 }

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -32,7 +32,6 @@ export const getModalStyles = stylesFactory((theme: GrafanaTheme2) => {
       right: 0;
       bottom: 0;
       left: 0;
-      z-index: ${theme.zIndex.modalBackdrop};
       background-color: ${theme.components.overlay.background};
       backdrop-filter: blur(1px);
     `,

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -22,6 +22,9 @@ export const getModalStyles = stylesFactory((theme: GrafanaTheme2) => {
       margin-left: auto;
       margin-right: auto;
       top: 10%;
+      max-height: 80%;
+      display: flex;
+      flex-direction: column;
     `,
     modalBackdrop: css`
       position: fixed;
@@ -67,6 +70,7 @@ export const getModalStyles = stylesFactory((theme: GrafanaTheme2) => {
       justify-content: flex-end;
     `,
     modalContent: css`
+      overflow: auto;
       padding: ${theme.spacing(3)};
       width: 100%;
     `,

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -22,9 +22,6 @@ export const getModalStyles = stylesFactory((theme: GrafanaTheme2) => {
       margin-left: auto;
       margin-right: auto;
       top: 10%;
-      max-height: 80%;
-      display: flex;
-      flex-direction: column;
     `,
     modalBackdrop: css`
       position: fixed;
@@ -69,7 +66,6 @@ export const getModalStyles = stylesFactory((theme: GrafanaTheme2) => {
       justify-content: flex-end;
     `,
     modalContent: css`
-      overflow: auto;
       padding: ${theme.spacing(3)};
       width: 100%;
     `,

--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -1,5 +1,6 @@
 ﻿import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
+import { appZIndexes } from '../../themes/default';
 
 interface Props {
   className?: string;
@@ -19,6 +20,8 @@ export class Portal extends PureComponent<Props> {
       this.node.classList.add(className);
     }
 
+    this.node.style.position = 'relative';
+    this.node.style.zIndex = `${appZIndexes.portal}`;
     this.portalRoot = root;
     this.portalRoot.appendChild(this.node);
   }
@@ -29,12 +32,7 @@ export class Portal extends PureComponent<Props> {
 
   render() {
     // Default z-index is high to make sure
-    return ReactDOM.createPortal(
-      <div style={{ zIndex: 1051, position: 'relative' }} ref={this.props.forwardedRef}>
-        {this.props.children}
-      </div>,
-      this.node
-    );
+    return ReactDOM.createPortal(<div ref={this.props.forwardedRef}>{this.props.children}</div>, this.node);
   }
 }
 

--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -1,6 +1,6 @@
-﻿import React, { PureComponent } from 'react';
+﻿import React, { PropsWithChildren, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
-import { appZIndexes } from '../../themes/default';
+import { useTheme2 } from '../../themes';
 
 interface Props {
   className?: string;
@@ -8,34 +8,29 @@ interface Props {
   forwardedRef?: any;
 }
 
-export class Portal extends PureComponent<Props> {
-  node: HTMLElement = document.createElement('div');
-  portalRoot: HTMLElement;
+export function Portal(props: PropsWithChildren<Props>) {
+  const { children, className, root = document.body, forwardedRef } = props;
+  const theme = useTheme2();
+  const [node] = useState(document.createElement('div'));
+  const portalRoot = root;
 
-  constructor(props: Props) {
-    super(props);
-    const { className, root = document.body } = this.props;
-
-    if (className) {
-      this.node.classList.add(className);
-    }
-
-    this.node.style.position = 'relative';
-    this.node.style.zIndex = `${appZIndexes.portal}`;
-    this.portalRoot = root;
-    this.portalRoot.appendChild(this.node);
+  if (className) {
+    node.classList.add(className);
   }
+  node.style.position = 'relative';
+  node.style.zIndex = `${theme.zIndex.portal}`;
 
-  componentWillUnmount() {
-    this.portalRoot.removeChild(this.node);
-  }
+  useEffect(() => {
+    portalRoot.appendChild(node);
+    return () => {
+      portalRoot.removeChild(node);
+    };
+  }, [node, portalRoot]);
 
-  render() {
-    // Default z-index is high to make sure
-    return ReactDOM.createPortal(<div ref={this.props.forwardedRef}>{this.props.children}</div>, this.node);
-  }
+  return ReactDOM.createPortal(<div ref={forwardedRef}>{children}</div>, node);
 }
 
 export const RefForwardingPortal = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
   return <Portal {...props} forwardedRef={ref} />;
 });
+RefForwardingPortal.displayName = 'RefForwardingPortal';

--- a/packages/grafana-ui/src/components/Select/SelectBase.test.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.test.tsx
@@ -1,44 +1,38 @@
 import React, { useState } from 'react';
-import { mount, ReactWrapper } from 'enzyme';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import selectEvent from 'react-select-event';
-import { SelectBase } from './SelectBase';
-import { SelectBaseProps } from './types';
 import { SelectableValue } from '@grafana/data';
-import { MultiValueContainer } from './MultiValue';
-
-const onChangeHandler = () => jest.fn();
-const findMenuElement = (container: ReactWrapper) => container.find({ 'aria-label': 'Select options menu' });
-const options: Array<SelectableValue<number>> = [
-  {
-    label: 'Option 1',
-    value: 1,
-  },
-  {
-    label: 'Option 2',
-    value: 2,
-  },
-];
+import { SelectBase } from './SelectBase';
 
 describe('SelectBase', () => {
+  const onChangeHandler = () => jest.fn();
+  const options: Array<SelectableValue<number>> = [
+    {
+      label: 'Option 1',
+      value: 1,
+    },
+    {
+      label: 'Option 2',
+      value: 2,
+    },
+  ];
+
   it('renders without error', () => {
-    mount(<SelectBase onChange={onChangeHandler} />);
+    render(<SelectBase onChange={onChangeHandler} />);
   });
 
   it('renders empty options information', () => {
-    const container = mount(<SelectBase onChange={onChangeHandler} isOpen />);
-    const noopt = container.find({ 'aria-label': 'No options provided' });
-    expect(noopt).toHaveLength(1);
+    render(<SelectBase onChange={onChangeHandler} />);
+    userEvent.click(screen.getByText(/choose/i));
+    expect(screen.queryByText(/no options found/i)).toBeVisible();
   });
 
   it('is selectable via its label text', async () => {
-    const onChange = jest.fn();
-
     render(
       <>
         <label htmlFor="my-select">My select</label>
-        <SelectBase onChange={onChange} options={options} inputId="my-select" />
+        <SelectBase onChange={onChangeHandler} options={options} inputId="my-select" />
       </>
     );
 
@@ -67,11 +61,9 @@ describe('SelectBase', () => {
   describe('when openMenuOnFocus prop', () => {
     describe('is provided', () => {
       it('opens on focus', () => {
-        const container = mount(<SelectBase onChange={onChangeHandler} openMenuOnFocus />);
-        container.find('input').simulate('focus');
-
-        const menu = findMenuElement(container);
-        expect(menu).toHaveLength(1);
+        render(<SelectBase onChange={onChangeHandler} openMenuOnFocus />);
+        fireEvent.focus(screen.getByRole('textbox'));
+        expect(screen.queryByText(/no options found/i)).toBeVisible();
       });
     });
     describe('is not provided', () => {
@@ -81,12 +73,10 @@ describe('SelectBase', () => {
         ${'ArrowUp'}
         ${' '}
       `('opens on arrow down/up or space', ({ key }) => {
-        const container = mount(<SelectBase onChange={onChangeHandler} />);
-        const input = container.find('input');
-        input.simulate('focus');
-        input.simulate('keydown', { key });
-        const menu = findMenuElement(container);
-        expect(menu).toHaveLength(1);
+        render(<SelectBase onChange={onChangeHandler} />);
+        fireEvent.focus(screen.getByRole('textbox'));
+        fireEvent.keyDown(screen.getByRole('textbox'), { key });
+        expect(screen.queryByText(/no options found/i)).toBeVisible();
       });
     });
   });
@@ -120,7 +110,7 @@ describe('SelectBase', () => {
 
     describe('is provided', () => {
       it('should only display maxVisibleValues options, and additional number of values should be displayed as indicator', () => {
-        const container = mount(
+        render(
           <SelectBase
             onChange={onChangeHandler}
             isMulti={true}
@@ -130,14 +120,13 @@ describe('SelectBase', () => {
             isOpen={false}
           />
         );
-
-        expect(container.find(MultiValueContainer)).toHaveLength(3);
-        expect(container.find('#excess-values').text()).toBe('(+2)');
+        expect(screen.queryAllByText(/option/i).length).toBe(3);
+        expect(screen.queryByText(/\(\+2\)/i)).toBeVisible();
       });
 
       describe('and showAllSelectedWhenOpen prop is true', () => {
         it('should show all selected options when menu is open', () => {
-          const container = mount(
+          render(
             <SelectBase
               onChange={onChangeHandler}
               isMulti={true}
@@ -149,14 +138,14 @@ describe('SelectBase', () => {
             />
           );
 
-          expect(container.find(MultiValueContainer)).toHaveLength(5);
-          expect(container.find('#excess-values')).toHaveLength(0);
+          expect(screen.queryAllByText(/option/i).length).toBe(5);
+          expect(screen.queryByText(/\(\+2\)/i)).not.toBeInTheDocument();
         });
       });
 
       describe('and showAllSelectedWhenOpen prop is false', () => {
         it('should not show all selected options when menu is open', () => {
-          const container = mount(
+          render(
             <SelectBase
               onChange={onChangeHandler}
               isMulti={true}
@@ -168,15 +157,15 @@ describe('SelectBase', () => {
             />
           );
 
-          expect(container.find('#excess-values').text()).toBe('(+2)');
-          expect(container.find(MultiValueContainer)).toHaveLength(3);
+          expect(screen.queryAllByText(/option/i).length).toBe(3);
+          expect(screen.queryByText(/\(\+2\)/i)).toBeVisible();
         });
       });
     });
 
     describe('is not provided', () => {
       it('should always show all selected options', () => {
-        const container = mount(
+        render(
           <SelectBase
             onChange={onChangeHandler}
             isMulti={true}
@@ -186,15 +175,16 @@ describe('SelectBase', () => {
           />
         );
 
-        expect(container.find(MultiValueContainer)).toHaveLength(5);
-        expect(container.find('#excess-values')).toHaveLength(0);
+        expect(screen.queryAllByText(/option/i).length).toBe(5);
+        expect(screen.queryByText(/\(\+2\)/i)).not.toBeInTheDocument();
       });
     });
   });
 
   describe('options', () => {
     it('renders menu with provided options', () => {
-      render(<SelectBase options={options} onChange={onChangeHandler} isOpen />);
+      render(<SelectBase options={options} onChange={onChangeHandler} />);
+      userEvent.click(screen.getByText(/choose/i));
       const menuOptions = screen.getAllByLabelText('Select option');
       expect(menuOptions).toHaveLength(2);
     });
@@ -207,60 +197,11 @@ describe('SelectBase', () => {
       const selectEl = screen.getByLabelText('My select');
       expect(selectEl).toBeInTheDocument();
 
-      await selectEvent.select(selectEl, 'Option 2');
+      await selectEvent.select(selectEl, 'Option 2', { container: document.body });
       expect(spy).toHaveBeenCalledWith({
         label: 'Option 2',
         value: 2,
       });
-    });
-  });
-
-  describe('When allowCustomValue is set to true', () => {
-    it('Should allow creating a new option', async () => {
-      const valueIsStrictlyEqual: SelectBaseProps<string>['filterOption'] = (option, value) => option.value === value;
-      const valueIsStrictlyNotEqual: SelectBaseProps<string>['isValidNewOption'] = (newOption, _, options) =>
-        options.every(({ value }) => value !== newOption);
-
-      const spy = jest.fn();
-      render(
-        <SelectBase
-          onChange={spy}
-          isOpen
-          allowCustomValue
-          filterOption={valueIsStrictlyEqual}
-          isValidNewOption={valueIsStrictlyNotEqual}
-        />
-      );
-
-      const textBox = screen.getByRole('textbox');
-      userEvent.type(textBox, 'NOT AN OPTION');
-
-      let creatableOption = screen.getByLabelText('Select option');
-      expect(creatableOption).toBeInTheDocument();
-      expect(creatableOption).toHaveTextContent('Create: NOT AN OPTION');
-
-      userEvent.click(creatableOption);
-      expect(spy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          label: 'NOT AN OPTION',
-          value: 'NOT AN OPTION',
-        })
-      );
-
-      // Should also create options in a case-insensitive way.
-      userEvent.type(textBox, 'not an option');
-
-      creatableOption = screen.getByLabelText('Select option');
-      expect(creatableOption).toBeInTheDocument();
-      expect(creatableOption).toHaveTextContent('Create: not an option');
-
-      userEvent.click(creatableOption);
-      expect(spy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          label: 'not an option',
-          value: 'not an option',
-        })
-      );
     });
   });
 });

--- a/packages/grafana-ui/src/components/Select/SelectBase.test.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.test.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from './test-utils';
 import { SelectableValue } from '@grafana/data';
 import { SelectBase } from './SelectBase';
 
@@ -197,7 +197,7 @@ describe('SelectBase', () => {
       const selectEl = screen.getByLabelText('My select');
       expect(selectEl).toBeInTheDocument();
 
-      await selectEvent.select(selectEl, 'Option 2', { container: document.body });
+      await selectOptionInTest(selectEl, 'Option 2');
       expect(spy).toHaveBeenCalledWith({
         label: 'Option 2',
         value: 2,

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -336,7 +336,7 @@ export function SelectBase<T>({
           ...resetSelectStyles(),
           menuPortal: (base: any) => ({
             ...base,
-            zIndex: theme.zIndex.selectPortal,
+            zIndex: theme.zIndex.portal,
           }),
           //These are required for the menu positioning to function
           menu: ({ top, bottom, position }: any) => ({

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -116,6 +116,7 @@ export function SelectBase<T>({
   minMenuHeight,
   maxVisibleValues,
   menuPlacement = 'bottom',
+  menuPortalTarget,
   menuPosition,
   noOptionsMessage = 'No options found',
   onBlur,
@@ -197,6 +198,7 @@ export function SelectBase<T>({
     maxVisibleValues,
     menuIsOpen: isOpen,
     menuPlacement,
+    menuPortalTarget,
     menuPosition,
     menuShouldScrollIntoView: false,
     onBlur,
@@ -329,10 +331,9 @@ export function SelectBase<T>({
         }}
         styles={{
           ...resetSelectStyles(),
-          menuPortal: ({ position, width }: any) => ({
-            position,
-            width,
-            zIndex: theme.zIndex.dropdown,
+          menuPortal: (base: any) => ({
+            ...base,
+            zIndex: theme.zIndex.modal,
           }),
           //These are required for the menu positioning to function
           menu: ({ top, bottom, position }: any) => ({

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -336,7 +336,7 @@ export function SelectBase<T>({
           ...resetSelectStyles(),
           menuPortal: (base: any) => ({
             ...base,
-            zIndex: theme.zIndex.modal,
+            zIndex: theme.zIndex.selectPortal,
           }),
           //These are required for the menu positioning to function
           menu: ({ top, bottom, position }: any) => ({
@@ -344,7 +344,6 @@ export function SelectBase<T>({
             bottom,
             position,
             minWidth: '100%',
-            zIndex: theme.zIndex.dropdown,
           }),
           container: () => ({
             position: 'relative',

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -115,8 +115,7 @@ export function SelectBase<T>({
   maxMenuHeight = 300,
   minMenuHeight,
   maxVisibleValues,
-  menuPlacement = 'bottom',
-  menuPortalTarget,
+  menuPlacement = 'auto',
   menuPosition,
   noOptionsMessage = 'No options found',
   onBlur,
@@ -176,6 +175,10 @@ export function SelectBase<T>({
     backspaceRemovesValue,
     captureMenuScroll: false,
     closeMenuOnSelect,
+    // We don't want to close if we're actually scrolling the menu
+    // So only close if none of the parents are the select menu itself
+    closeMenuOnScroll: (scrollEvent: Event) =>
+      !scrollEvent.composedPath().some((pathItem) => (pathItem as Element).classList?.value.includes(styles.menu)),
     defaultValue,
     // Also passing disabled, as this is the new Select API, and I want to use this prop instead of react-select's one
     disabled,
@@ -198,7 +201,7 @@ export function SelectBase<T>({
     maxVisibleValues,
     menuIsOpen: isOpen,
     menuPlacement,
-    menuPortalTarget,
+    menuPortalTarget: document.body,
     menuPosition,
     menuShouldScrollIntoView: false,
     onBlur,
@@ -340,7 +343,6 @@ export function SelectBase<T>({
             top,
             bottom,
             position,
-            marginBottom: !!bottom ? '10px' : '0',
             minWidth: '100%',
             zIndex: theme.zIndex.dropdown,
           }),

--- a/packages/grafana-ui/src/components/Select/test-utils.ts
+++ b/packages/grafana-ui/src/components/Select/test-utils.ts
@@ -1,0 +1,7 @@
+import { select } from 'react-select-event';
+
+// Used to select an option or options from a Select in unit tests
+export const selectOptionInTest = async (
+  input: HTMLElement,
+  optionOrOptions: string | RegExp | Array<string | RegExp>
+) => await select(input, optionOrOptions, { container: document.body });

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -41,7 +41,6 @@ export interface SelectCommonProps<T> {
   minMenuHeight?: number;
   maxVisibleValues?: number;
   menuPlacement?: 'auto' | 'bottom' | 'top';
-  menuPortalTarget?: HTMLElement;
   menuPosition?: 'fixed' | 'absolute';
   /** The message to display when no options could be found */
   noOptionsMessage?: string;

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -41,6 +41,7 @@ export interface SelectCommonProps<T> {
   minMenuHeight?: number;
   maxVisibleValues?: number;
   menuPlacement?: 'auto' | 'bottom' | 'top';
+  menuPortalTarget?: HTMLElement;
   menuPosition?: 'fixed' | 'absolute';
   /** The message to display when no options could be found */
   noOptionsMessage?: string;

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { ValueMappingsEditorModal, Props } from './ValueMappingsEditorModal';
 import { MappingType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import selectEvent from 'react-select-event';
 
 const setup = (spy?: any, propOverrides?: object) => {
   const props: Props = {
@@ -80,9 +80,7 @@ describe('When adding and updating value mapp', () => {
     fireEvent.click(screen.getByLabelText(selectors.components.ValuePicker.button('Add a new mapping')));
     const selectComponent = await screen.findByLabelText(selectors.components.ValuePicker.select('Add a new mapping'));
 
-    userEvent.click(selectComponent);
-    const valueOption = screen.getByText('Value');
-    userEvent.click(valueOption);
+    await selectEvent.select(selectComponent, 'Value', { container: document.body });
 
     const input = (await screen.findAllByPlaceholderText('Exact value to match'))[1];
 
@@ -126,9 +124,7 @@ describe('When adding and updating range map', () => {
 
     fireEvent.click(screen.getByLabelText(selectors.components.ValuePicker.button('Add a new mapping')));
     const selectComponent = await screen.findByLabelText(selectors.components.ValuePicker.select('Add a new mapping'));
-    userEvent.click(selectComponent);
-    const rangeOption = screen.getByText('Range');
-    userEvent.click(rangeOption);
+    await selectEvent.select(selectComponent, 'Range', { container: document.body });
 
     fireEvent.change(screen.getByPlaceholderText('Range start'), { target: { value: '10' } });
     fireEvent.change(screen.getByPlaceholderText('Range end'), { target: { value: '20' } });

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ValueMappingsEditorModal, Props } from './ValueMappingsEditorModal';
 import { MappingType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import selectEvent from 'react-select-event';
 
 const setup = (spy?: any, propOverrides?: object) => {
   const props: Props = {
@@ -79,7 +79,10 @@ describe('When adding and updating value mapp', () => {
 
     fireEvent.click(screen.getByLabelText(selectors.components.ValuePicker.button('Add a new mapping')));
     const selectComponent = await screen.findByLabelText(selectors.components.ValuePicker.select('Add a new mapping'));
-    await selectEvent.select(selectComponent, 'Value');
+
+    userEvent.click(selectComponent);
+    const valueOption = screen.getByText('Value');
+    userEvent.click(valueOption);
 
     const input = (await screen.findAllByPlaceholderText('Exact value to match'))[1];
 
@@ -123,7 +126,9 @@ describe('When adding and updating range map', () => {
 
     fireEvent.click(screen.getByLabelText(selectors.components.ValuePicker.button('Add a new mapping')));
     const selectComponent = await screen.findByLabelText(selectors.components.ValuePicker.select('Add a new mapping'));
-    await selectEvent.select(selectComponent, 'Range');
+    userEvent.click(selectComponent);
+    const rangeOption = screen.getByText('Range');
+    userEvent.click(rangeOption);
 
     fireEvent.change(screen.getByPlaceholderText('Range start'), { target: { value: '10' } });
     fireEvent.change(screen.getByPlaceholderText('Range end'), { target: { value: '20' } });

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ValueMappingsEditorModal, Props } from './ValueMappingsEditorModal';
 import { MappingType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '../Select/test-utils';
 
 const setup = (spy?: any, propOverrides?: object) => {
   const props: Props = {
@@ -80,7 +80,7 @@ describe('When adding and updating value mapp', () => {
     fireEvent.click(screen.getByLabelText(selectors.components.ValuePicker.button('Add a new mapping')));
     const selectComponent = await screen.findByLabelText(selectors.components.ValuePicker.select('Add a new mapping'));
 
-    await selectEvent.select(selectComponent, 'Value', { container: document.body });
+    await selectOptionInTest(selectComponent, 'Value');
 
     const input = (await screen.findAllByPlaceholderText('Exact value to match'))[1];
 
@@ -124,7 +124,7 @@ describe('When adding and updating range map', () => {
 
     fireEvent.click(screen.getByLabelText(selectors.components.ValuePicker.button('Add a new mapping')));
     const selectComponent = await screen.findByLabelText(selectors.components.ValuePicker.select('Add a new mapping'));
-    await selectEvent.select(selectComponent, 'Range', { container: document.body });
+    await selectOptionInTest(selectComponent, 'Range');
 
     fireEvent.change(screen.getByPlaceholderText('Range start'), { target: { value: '10' } });
     fireEvent.change(screen.getByPlaceholderText('Range end'), { target: { value: '20' } });

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.tsx
@@ -119,7 +119,6 @@ export function ValueMappingsEditorModal({ value, onChange, onClose }: Props) {
         variant="secondary"
         size="md"
         icon="plus"
-        menuPortalTarget={document.body}
         menuPlacement="auto"
         isFullWidth={false}
         options={mappingTypes}

--- a/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.tsx
+++ b/packages/grafana-ui/src/components/ValueMappingsEditor/ValueMappingsEditorModal.tsx
@@ -119,6 +119,7 @@ export function ValueMappingsEditorModal({ value, onChange, onClose }: Props) {
         variant="secondary"
         size="md"
         icon="plus"
+        menuPortalTarget={document.body}
         menuPlacement="auto"
         isFullWidth={false}
         options={mappingTypes}

--- a/packages/grafana-ui/src/components/ValuePicker/ValuePicker.tsx
+++ b/packages/grafana-ui/src/components/ValuePicker/ValuePicker.tsx
@@ -6,9 +6,8 @@ import { Select } from '../Select/Select';
 import { FullWidthButtonContainer } from '../Button/FullWidthButtonContainer';
 import { ComponentSize } from '../../types/size';
 import { selectors } from '@grafana/e2e-selectors';
-import { SelectCommonProps } from '../Select/types';
 
-export interface ValuePickerProps<T> extends SelectCommonProps<T> {
+export interface ValuePickerProps<T> {
   /** Label to display on the picker button */
   label: string;
   /** Icon to display on the picker button */
@@ -36,7 +35,6 @@ export function ValuePicker<T>({
   size = 'sm',
   isFullWidth = true,
   menuPlacement,
-  ...selectProps
 }: ValuePickerProps<T>) {
   const [isPicking, setIsPicking] = useState(false);
 
@@ -69,7 +67,6 @@ export function ValuePicker<T>({
               onChange(value);
             }}
             menuPlacement={menuPlacement}
-            {...selectProps}
           />
         </span>
       )}

--- a/packages/grafana-ui/src/components/ValuePicker/ValuePicker.tsx
+++ b/packages/grafana-ui/src/components/ValuePicker/ValuePicker.tsx
@@ -6,8 +6,9 @@ import { Select } from '../Select/Select';
 import { FullWidthButtonContainer } from '../Button/FullWidthButtonContainer';
 import { ComponentSize } from '../../types/size';
 import { selectors } from '@grafana/e2e-selectors';
+import { SelectCommonProps } from '../Select/types';
 
-export interface ValuePickerProps<T> {
+export interface ValuePickerProps<T> extends SelectCommonProps<T> {
   /** Label to display on the picker button */
   label: string;
   /** Icon to display on the picker button */
@@ -35,6 +36,7 @@ export function ValuePicker<T>({
   size = 'sm',
   isFullWidth = true,
   menuPlacement,
+  ...selectProps
 }: ValuePickerProps<T>) {
   const [isPicking, setIsPicking] = useState(false);
 
@@ -67,6 +69,7 @@ export function ValuePicker<T>({
               onChange(value);
             }}
             menuPlacement={menuPlacement}
+            {...selectProps}
           />
         </span>
       )}

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -186,6 +186,7 @@ export { InlineFieldRow } from './Forms/InlineFieldRow';
 export { FieldArray } from './Forms/FieldArray';
 
 export { default as resetSelectStyles } from './Select/resetSelectStyles';
+export { selectOptionInTest } from './Select/test-utils';
 export * from './Select/Select';
 
 export { HorizontalGroup, VerticalGroup, Container } from './Layout/Layout';

--- a/packages/grafana-ui/src/themes/default.ts
+++ b/packages/grafana-ui/src/themes/default.ts
@@ -25,6 +25,18 @@ export const commonColorsPalette = {
   red88: '#e02f44',
 };
 
+export const appZIndexes = {
+  navbarFixed: 1000,
+  sidemenu: 1020,
+  dropdown: 1030,
+  typeahead: 1030,
+  tooltip: 1040,
+  modalBackdrop: 1050,
+  portal: 1051,
+  modal: 1060,
+  selectPortal: 1061,
+};
+
 const SPACING_BASE = 8;
 
 const theme: GrafanaThemeCommons = {
@@ -123,15 +135,7 @@ const theme: GrafanaThemeCommons = {
   },
   panelPadding: 8,
   panelHeaderHeight: 28,
-  zIndex: {
-    navbarFixed: 1000,
-    sidemenu: 1020,
-    dropdown: 1030,
-    typeahead: 1030,
-    tooltip: 1040,
-    modalBackdrop: 1050,
-    modal: 1060,
-  },
+  zIndex: appZIndexes,
 };
 
 export default theme;

--- a/packages/grafana-ui/src/themes/default.ts
+++ b/packages/grafana-ui/src/themes/default.ts
@@ -25,18 +25,6 @@ export const commonColorsPalette = {
   red88: '#e02f44',
 };
 
-export const appZIndexes = {
-  navbarFixed: 1000,
-  sidemenu: 1020,
-  dropdown: 1030,
-  typeahead: 1030,
-  tooltip: 1040,
-  modalBackdrop: 1050,
-  portal: 1051,
-  modal: 1060,
-  selectPortal: 1061,
-};
-
 const SPACING_BASE = 8;
 
 const theme: GrafanaThemeCommons = {
@@ -135,7 +123,16 @@ const theme: GrafanaThemeCommons = {
   },
   panelPadding: 8,
   panelHeaderHeight: 28,
-  zIndex: appZIndexes,
+  zIndex: {
+    navbarFixed: 1000,
+    sidemenu: 1020,
+    dropdown: 1030,
+    typeahead: 1030,
+    tooltip: 1040,
+    modalBackdrop: 1050,
+    modal: 1060,
+    portal: 1061,
+  },
 };
 
 export default theme;

--- a/public/app/core/components/TransformersUI/configFromQuery/ConfigFromQueryTransformerEditor.test.tsx
+++ b/public/app/core/components/TransformersUI/configFromQuery/ConfigFromQueryTransformerEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { toDataFrame, FieldType } from '@grafana/data';
 import { fireEvent, render, screen } from '@testing-library/react';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 import { Props, ConfigFromQueryTransformerEditor } from './ConfigFromQueryTransformerEditor';
 
 beforeEach(() => {
@@ -40,7 +40,7 @@ describe('ConfigFromQueryTransformerEditor', () => {
 
     let select = (await screen.findByText('Config query')).nextSibling!;
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await selectEvent.select(select as HTMLElement, 'A', { container: document.body });
+    await selectOptionInTest(select as HTMLElement, 'A');
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/public/app/core/components/TransformersUI/configFromQuery/ConfigFromQueryTransformerEditor.test.tsx
+++ b/public/app/core/components/TransformersUI/configFromQuery/ConfigFromQueryTransformerEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { toDataFrame, FieldType } from '@grafana/data';
-import { fireEvent, render, screen, getByText } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@testing-library/react';
+import selectEvent from 'react-select-event';
 import { Props, ConfigFromQueryTransformerEditor } from './ConfigFromQueryTransformerEditor';
 
 beforeEach(() => {
@@ -40,7 +40,7 @@ describe('ConfigFromQueryTransformerEditor', () => {
 
     let select = (await screen.findByText('Config query')).nextSibling!;
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await userEvent.click(getByText(select as HTMLElement, 'A'));
+    await selectEvent.select(select as HTMLElement, 'A', { container: document.body });
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/public/app/core/components/TransformersUI/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
+++ b/public/app/core/components/TransformersUI/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { toDataFrame, FieldType } from '@grafana/data';
 import { fireEvent, render, screen, getByText, getByLabelText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 import { Props, FieldToConfigMappingEditor } from './FieldToConfigMappingEditor';
 
 beforeEach(() => {
@@ -46,7 +46,7 @@ describe('FieldToConfigMappingEditor', () => {
 
     const select = (await screen.findByTestId('Miiin-config-key')).childNodes[0];
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await selectEvent.select(select as HTMLElement, 'Min', { container: document.body });
+    await selectOptionInTest(select as HTMLElement, 'Min');
 
     expect(mockOnChange).toHaveBeenCalledWith(expect.arrayContaining([{ fieldName: 'Miiin', handlerKey: 'min' }]));
   });
@@ -81,7 +81,7 @@ describe('FieldToConfigMappingEditor', () => {
     const reducer = await (await screen.findByTestId('max-reducer')).childNodes[0];
 
     await fireEvent.keyDown(reducer, { keyCode: 40 });
-    await selectEvent.select(reducer as HTMLElement, 'Last', { container: document.body });
+    await selectOptionInTest(reducer as HTMLElement, 'Last');
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.arrayContaining([{ fieldName: 'max', handlerKey: 'max', reducerId: 'last' }])

--- a/public/app/core/components/TransformersUI/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
+++ b/public/app/core/components/TransformersUI/fieldToConfigMapping/FieldToConfigMappingEditor.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { toDataFrame, FieldType } from '@grafana/data';
 import { fireEvent, render, screen, getByText, getByLabelText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import selectEvent from 'react-select-event';
 import { Props, FieldToConfigMappingEditor } from './FieldToConfigMappingEditor';
 
 beforeEach(() => {
@@ -45,7 +46,7 @@ describe('FieldToConfigMappingEditor', () => {
 
     const select = (await screen.findByTestId('Miiin-config-key')).childNodes[0];
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await userEvent.click(getByText(select as HTMLElement, 'Min'));
+    await selectEvent.select(select as HTMLElement, 'Min', { container: document.body });
 
     expect(mockOnChange).toHaveBeenCalledWith(expect.arrayContaining([{ fieldName: 'Miiin', handlerKey: 'min' }]));
   });
@@ -80,7 +81,7 @@ describe('FieldToConfigMappingEditor', () => {
     const reducer = await (await screen.findByTestId('max-reducer')).childNodes[0];
 
     await fireEvent.keyDown(reducer, { keyCode: 40 });
-    await userEvent.click(getByText(reducer as HTMLElement, 'Last'));
+    await selectEvent.select(reducer as HTMLElement, 'Last', { container: document.body });
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.arrayContaining([{ fieldName: 'max', handlerKey: 'max', reducerId: 'last' }])

--- a/public/app/core/components/TransformersUI/rowsToFields/RowsToFieldsTransformerEditor.test.tsx
+++ b/public/app/core/components/TransformersUI/rowsToFields/RowsToFieldsTransformerEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { toDataFrame, FieldType } from '@grafana/data';
-import { fireEvent, render, screen, getByText } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@testing-library/react';
+import selectEvent from 'react-select-event';
 import { Props, RowsToFieldsTransformerEditor } from './RowsToFieldsTransformerEditor';
 
 beforeEach(() => {
@@ -37,7 +37,7 @@ describe('RowsToFieldsTransformerEditor', () => {
 
     const select = (await screen.findByTestId('Name-config-key')).childNodes[0];
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await userEvent.click(getByText(select as HTMLElement, 'Field name'));
+    await selectEvent.select(select as HTMLElement, 'Field name', { container: document.body });
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -51,7 +51,7 @@ describe('RowsToFieldsTransformerEditor', () => {
 
     const select = (await screen.findByTestId('Value-config-key')).childNodes[0];
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await userEvent.click(getByText(select as HTMLElement, 'Field value'));
+    await selectEvent.select(select as HTMLElement, 'Field value', { container: document.body });
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/public/app/core/components/TransformersUI/rowsToFields/RowsToFieldsTransformerEditor.test.tsx
+++ b/public/app/core/components/TransformersUI/rowsToFields/RowsToFieldsTransformerEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { toDataFrame, FieldType } from '@grafana/data';
 import { fireEvent, render, screen } from '@testing-library/react';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 import { Props, RowsToFieldsTransformerEditor } from './RowsToFieldsTransformerEditor';
 
 beforeEach(() => {
@@ -37,7 +37,7 @@ describe('RowsToFieldsTransformerEditor', () => {
 
     const select = (await screen.findByTestId('Name-config-key')).childNodes[0];
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await selectEvent.select(select as HTMLElement, 'Field name', { container: document.body });
+    await selectOptionInTest(select as HTMLElement, 'Field name');
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -51,7 +51,7 @@ describe('RowsToFieldsTransformerEditor', () => {
 
     const select = (await screen.findByTestId('Value-config-key')).childNodes[0];
     await fireEvent.keyDown(select, { keyCode: 40 });
-    await selectEvent.select(select as HTMLElement, 'Field value', { container: document.body });
+    await selectOptionInTest(select as HTMLElement, 'Field value');
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/public/app/features/alerting/unified/AmRoutes.test.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.test.tsx
@@ -13,6 +13,7 @@ import { mockDataSource, MockDataSourceSrv } from './mocks';
 import { getAllDataSources } from './utils/config';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 import userEvent from '@testing-library/user-event';
+import selectEvent from 'react-select-event';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -239,7 +240,7 @@ describe('AmRoutes', () => {
 
     // configure receiver & group by
     const receiverSelect = await ui.receiverSelect.find();
-    clickSelectOption(receiverSelect, 'critical');
+    await clickSelectOption(receiverSelect, 'critical');
 
     const groupSelect = ui.groupSelect.get();
     await userEvent.type(byRole('textbox').get(groupSelect), 'namespace{enter}');
@@ -298,7 +299,7 @@ describe('AmRoutes', () => {
 
     // configure receiver & group by
     const receiverSelect = await ui.receiverSelect.find();
-    clickSelectOption(receiverSelect, 'default');
+    await clickSelectOption(receiverSelect, 'default');
 
     const groupSelect = ui.groupSelect.get();
     await userEvent.type(byRole('textbox').get(groupSelect), 'severity{enter}');
@@ -343,7 +344,7 @@ describe('AmRoutes', () => {
 
 const clickSelectOption = async (selectElement: HTMLElement, optionText: string): Promise<void> => {
   userEvent.click(byRole('textbox').get(selectElement));
-  userEvent.click(byText(optionText).get(selectElement));
+  await selectEvent.select(selectElement, optionText, { container: document.body });
 };
 
 const updateTiming = async (selectElement: HTMLElement, value: string, timeUnit: string): Promise<void> => {
@@ -351,5 +352,5 @@ const updateTiming = async (selectElement: HTMLElement, value: string, timeUnit:
   expect(inputs).toHaveLength(2);
   await userEvent.type(inputs[0], value);
   userEvent.click(inputs[1]);
-  userEvent.click(byText(timeUnit).get(selectElement));
+  await selectEvent.select(selectElement, timeUnit, { container: document.body });
 };

--- a/public/app/features/alerting/unified/AmRoutes.test.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.test.tsx
@@ -13,7 +13,7 @@ import { mockDataSource, MockDataSourceSrv } from './mocks';
 import { getAllDataSources } from './utils/config';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -344,7 +344,7 @@ describe('AmRoutes', () => {
 
 const clickSelectOption = async (selectElement: HTMLElement, optionText: string): Promise<void> => {
   userEvent.click(byRole('textbox').get(selectElement));
-  await selectEvent.select(selectElement, optionText, { container: document.body });
+  await selectOptionInTest(selectElement, optionText);
 };
 
 const updateTiming = async (selectElement: HTMLElement, value: string, timeUnit: string): Promise<void> => {
@@ -352,5 +352,5 @@ const updateTiming = async (selectElement: HTMLElement, value: string, timeUnit:
   expect(inputs).toHaveLength(2);
   await userEvent.type(inputs[0], value);
   userEvent.click(inputs[1]);
-  await selectEvent.select(selectElement, timeUnit, { container: document.body });
+  await selectOptionInTest(selectElement, timeUnit);
 };

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -23,6 +23,7 @@ import userEvent from '@testing-library/user-event';
 import { ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, ALERTMANAGER_NAME_QUERY_KEY } from './utils/constants';
 import store from 'app/core/store';
 import { contextSrv } from 'app/core/services/context_srv';
+import selectEvent from 'react-select-event';
 
 jest.mock('./api/alertmanager');
 jest.mock('./api/grafana');
@@ -94,7 +95,7 @@ const ui = {
 
 const clickSelectOption = async (selectElement: HTMLElement, optionText: string): Promise<void> => {
   userEvent.click(byRole('textbox').get(selectElement));
-  userEvent.click(byText(optionText).get(selectElement));
+  await selectEvent.select(selectElement, optionText, { container: document.body });
 };
 
 describe('Receivers', () => {
@@ -166,7 +167,7 @@ describe('Receivers', () => {
     await ui.inputs.name.find();
 
     // select hipchat
-    clickSelectOption(byTestId('items.0.type').get(), 'HipChat');
+    await clickSelectOption(byTestId('items.0.type').get(), 'HipChat');
 
     // check that email options are gone and hipchat options appear
     expect(ui.inputs.email.addresses.query()).not.toBeInTheDocument();

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -23,7 +23,7 @@ import userEvent from '@testing-library/user-event';
 import { ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, ALERTMANAGER_NAME_QUERY_KEY } from './utils/constants';
 import store from 'app/core/store';
 import { contextSrv } from 'app/core/services/context_srv';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 
 jest.mock('./api/alertmanager');
 jest.mock('./api/grafana');
@@ -95,7 +95,7 @@ const ui = {
 
 const clickSelectOption = async (selectElement: HTMLElement, optionText: string): Promise<void> => {
   userEvent.click(byRole('textbox').get(selectElement));
-  await selectEvent.select(selectElement, optionText, { container: document.body });
+  await selectOptionInTest(selectElement, optionText);
 };
 
 describe('Receivers', () => {

--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -6,7 +6,7 @@ import RuleEditor from './RuleEditor';
 import { Router, Route } from 'react-router-dom';
 import React from 'react';
 import { byLabelText, byRole, byTestId, byText } from 'testing-library-selector';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { mockDataSource, MockDataSourceSrv } from './mocks';
 import userEvent from '@testing-library/user-event';
@@ -328,5 +328,5 @@ describe('RuleEditor', () => {
 
 const clickSelectOption = async (selectElement: HTMLElement, optionText: Matcher): Promise<void> => {
   userEvent.click(byRole('textbox').get(selectElement));
-  await selectEvent.select(selectElement, optionText as string, { container: document.body });
+  await selectOptionInTest(selectElement, optionText as string);
 };

--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -6,6 +6,7 @@ import RuleEditor from './RuleEditor';
 import { Router, Route } from 'react-router-dom';
 import React from 'react';
 import { byLabelText, byRole, byTestId, byText } from 'testing-library-selector';
+import selectEvent from 'react-select-event';
 import { contextSrv } from 'app/core/services/context_srv';
 import { mockDataSource, MockDataSourceSrv } from './mocks';
 import userEvent from '@testing-library/user-event';
@@ -124,13 +125,13 @@ describe('RuleEditor', () => {
 
     await renderRuleEditor();
     await userEvent.type(await ui.inputs.name.find(), 'my great new rule');
-    clickSelectOption(ui.inputs.alertType.get(), /Cortex\/Loki managed alert/);
+    await clickSelectOption(ui.inputs.alertType.get(), /Cortex\/Loki managed alert/);
     const dataSourceSelect = ui.inputs.dataSource.get();
     userEvent.click(byRole('textbox').get(dataSourceSelect));
-    userEvent.click(await byText('Prom (default)').find(dataSourceSelect));
+    await clickSelectOption(dataSourceSelect, 'Prom (default)');
     await waitFor(() => expect(mocks.api.fetchRulerRules).toHaveBeenCalled());
-    clickSelectOption(ui.inputs.namespace.get(), 'namespace2');
-    clickSelectOption(ui.inputs.group.get(), 'group2');
+    await clickSelectOption(ui.inputs.namespace.get(), 'namespace2');
+    await clickSelectOption(ui.inputs.group.get(), 'group2');
 
     await userEvent.type(ui.inputs.expr.get(), 'up == 1');
 
@@ -192,10 +193,10 @@ describe('RuleEditor', () => {
     // fill out the form
     await renderRuleEditor();
     userEvent.type(await ui.inputs.name.find(), 'my great new rule');
-    clickSelectOption(ui.inputs.alertType.get(), /Classic Grafana alerts based on thresholds/);
+    await clickSelectOption(ui.inputs.alertType.get(), /Classic Grafana alerts based on thresholds/);
     const folderInput = await ui.inputs.folder.find();
     await waitFor(() => expect(searchFolderMock).toHaveBeenCalled());
-    clickSelectOption(folderInput, 'Folder A');
+    await clickSelectOption(folderInput, 'Folder A');
 
     await userEvent.type(ui.inputs.annotationValue(0).get(), 'some summary');
     await userEvent.type(ui.inputs.annotationValue(1).get(), 'some description');
@@ -308,7 +309,7 @@ describe('RuleEditor', () => {
     // render rule editor, select cortex/loki managed alerts
     await renderRuleEditor();
     await ui.inputs.name.find();
-    clickSelectOption(ui.inputs.alertType.get(), /Cortex\/Loki managed alert/);
+    await clickSelectOption(ui.inputs.alertType.get(), /Cortex\/Loki managed alert/);
 
     // wait for ui theck each datasource if it supports rule editing
     await waitFor(() => expect(mocks.api.fetchRulerRulesGroup).toHaveBeenCalledTimes(4));
@@ -316,16 +317,16 @@ describe('RuleEditor', () => {
     // check that only rules sources that have ruler available are there
     const dataSourceSelect = ui.inputs.dataSource.get();
     userEvent.click(byRole('textbox').get(dataSourceSelect));
-    expect(await byText('loki with ruler').find(dataSourceSelect)).toBeInTheDocument();
-    expect(byText('cortex with ruler').query(dataSourceSelect)).toBeInTheDocument();
-    expect(byText('loki with local rule store').query(dataSourceSelect)).not.toBeInTheDocument();
-    expect(byText('prom without ruler api').query(dataSourceSelect)).not.toBeInTheDocument();
-    expect(byText('splunk').query(dataSourceSelect)).not.toBeInTheDocument();
-    expect(byText('loki disabled for alerting').query(dataSourceSelect)).not.toBeInTheDocument();
+    expect(await byText('loki with ruler').query()).toBeInTheDocument();
+    expect(byText('cortex with ruler').query()).toBeInTheDocument();
+    expect(byText('loki with local rule store').query()).not.toBeInTheDocument();
+    expect(byText('prom without ruler api').query()).not.toBeInTheDocument();
+    expect(byText('splunk').query()).not.toBeInTheDocument();
+    expect(byText('loki disabled for alerting').query()).not.toBeInTheDocument();
   });
 });
 
-const clickSelectOption = (selectElement: HTMLElement, optionText: Matcher): void => {
+const clickSelectOption = async (selectElement: HTMLElement, optionText: Matcher): Promise<void> => {
   userEvent.click(byRole('textbox').get(selectElement));
-  userEvent.click(byText(optionText).get(selectElement));
+  await selectEvent.select(selectElement, optionText as string, { container: document.body });
 };

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import selectEvent from 'react-select-event';
 
-import { byRole, byText } from 'testing-library-selector';
+import { byRole } from 'testing-library-selector';
 import { Props, GeneralSettingsUnconnected as GeneralSettings } from './GeneralSettings';
 import { DashboardModel } from '../../state';
 
@@ -45,11 +46,6 @@ const setupTestContext = (options: Partial<Props>) => {
   return { rerender, props };
 };
 
-const clickSelectOption = async (selectElement: HTMLElement, optionText: string): Promise<void> => {
-  userEvent.click(byRole('textbox').get(selectElement));
-  userEvent.click(byText(optionText).get(selectElement));
-};
-
 describe('General Settings', () => {
   describe('when component is mounted with timezone', () => {
     it('should render correctly', () => {
@@ -66,7 +62,9 @@ describe('General Settings', () => {
     it('should call update function', async () => {
       const { props } = setupTestContext({});
       userEvent.click(screen.getByLabelText('Time zone picker select container'));
-      await clickSelectOption(screen.getByLabelText('Time zone picker select container'), 'Browser Time');
+      const timeZonePicker = screen.getByLabelText('Time zone picker select container');
+      userEvent.click(byRole('textbox').get(timeZonePicker));
+      await selectEvent.select(timeZonePicker, 'Browser Time', { container: document.body });
       expect(props.updateTimeZone).toHaveBeenCalledWith('browser');
       expect(props.dashboard.timezone).toBe('browser');
     });

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 
 import { byRole } from 'testing-library-selector';
 import { Props, GeneralSettingsUnconnected as GeneralSettings } from './GeneralSettings';
@@ -64,7 +64,7 @@ describe('General Settings', () => {
       userEvent.click(screen.getByLabelText('Time zone picker select container'));
       const timeZonePicker = screen.getByLabelText('Time zone picker select container');
       userEvent.click(byRole('textbox').get(timeZonePicker));
-      await selectEvent.select(timeZonePicker, 'Browser Time', { container: document.body });
+      await selectOptionInTest(timeZonePicker, 'Browser Time');
       expect(props.updateTimeZone).toHaveBeenCalledWith('browser');
       expect(props.dashboard.timezone).toBe('browser');
     });

--- a/public/app/features/search/components/DashboardSearch.test.tsx
+++ b/public/app/features/search/components/DashboardSearch.test.tsx
@@ -105,7 +105,7 @@ describe('DashboardSearch', () => {
     await waitFor(() => screen.getByLabelText('Tag filter'));
 
     const tagComponent = screen.getByLabelText('Tag filter');
-    await selectEvent.select(tagComponent, 'tag1');
+    await selectEvent.select(tagComponent, 'tag1', { container: document.body });
 
     expect(tagComponent).toBeInTheDocument();
 

--- a/public/app/features/search/components/DashboardSearch.test.tsx
+++ b/public/app/features/search/components/DashboardSearch.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 import * as SearchSrv from 'app/core/services/search_srv';
 import * as MockSearchSrv from 'app/core/services/__mocks__/search_srv';
 import { DashboardSearch, Props } from './DashboardSearch';
@@ -105,7 +105,7 @@ describe('DashboardSearch', () => {
     await waitFor(() => screen.getByLabelText('Tag filter'));
 
     const tagComponent = screen.getByLabelText('Tag filter');
-    await selectEvent.select(tagComponent, 'tag1', { container: document.body });
+    await selectOptionInTest(tagComponent, 'tag1');
 
     expect(tagComponent).toBeInTheDocument();
 

--- a/public/app/features/search/components/SearchResultsFilter.test.tsx
+++ b/public/app/features/search/components/SearchResultsFilter.test.tsx
@@ -82,7 +82,7 @@ describe('SearchResultsFilter', () => {
       query: { ...searchQuery, tag: [] },
     });
     const tagComponent = await screen.findByLabelText('Tag filter');
-    await selectEvent.select(tagComponent, 'tag1');
+    await selectEvent.select(tagComponent, 'tag1', { container: document.body });
 
     expect(mockFilterByTags).toHaveBeenCalledTimes(1);
     expect(mockFilterByTags).toHaveBeenCalledWith(['tag1']);

--- a/public/app/features/search/components/SearchResultsFilter.test.tsx
+++ b/public/app/features/search/components/SearchResultsFilter.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 import { Props, SearchResultsFilter } from './SearchResultsFilter';
 import { SearchLayout } from '../types';
 
@@ -82,7 +82,7 @@ describe('SearchResultsFilter', () => {
       query: { ...searchQuery, tag: [] },
     });
     const tagComponent = await screen.findByLabelText('Tag filter');
-    await selectEvent.select(tagComponent, 'tag1', { container: document.body });
+    await selectOptionInTest(tagComponent, 'tag1');
 
     expect(mockFilterByTags).toHaveBeenCalledTimes(1);
     expect(mockFilterByTags).toHaveBeenCalledWith(['tag1']);

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -56,7 +56,7 @@ describe('Azure Monitor QueryEditor', () => {
     );
 
     const subscriptions = await screen.findByLabelText('Subscription');
-    await selectEvent.select(subscriptions, 'Another Subscription');
+    await selectEvent.select(subscriptions, 'Another Subscription', { container: document.body });
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockQuery,
@@ -102,7 +102,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
 
     const metrics = await screen.findByLabelText('Metric');
-    await selectEvent.select(metrics, 'Metric B');
+    await selectEvent.select(metrics, 'Metric B', { container: document.body });
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...mockQuery,
@@ -141,7 +141,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
 
     const metrics = await screen.findByLabelText('Metric');
-    await selectEvent.select(metrics, 'Metric B');
+    await selectEvent.select(metrics, 'Metric B', { container: document.body });
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...mockQuery,
@@ -170,7 +170,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
 
     const aggregation = await screen.findByLabelText('Aggregation');
-    await selectEvent.select(aggregation, 'Maximum');
+    await selectEvent.select(aggregation, 'Maximum', { container: document.body });
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...mockQuery,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 
 import MetricsQueryEditor from './MetricsQueryEditor';
 
@@ -56,7 +56,7 @@ describe('Azure Monitor QueryEditor', () => {
     );
 
     const subscriptions = await screen.findByLabelText('Subscription');
-    await selectEvent.select(subscriptions, 'Another Subscription', { container: document.body });
+    await selectOptionInTest(subscriptions, 'Another Subscription');
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockQuery,
@@ -102,7 +102,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
 
     const metrics = await screen.findByLabelText('Metric');
-    await selectEvent.select(metrics, 'Metric B', { container: document.body });
+    await selectOptionInTest(metrics, 'Metric B');
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...mockQuery,
@@ -141,7 +141,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
 
     const metrics = await screen.findByLabelText('Metric');
-    await selectEvent.select(metrics, 'Metric B', { container: document.body });
+    await selectOptionInTest(metrics, 'Metric B');
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...mockQuery,
@@ -170,7 +170,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
 
     const aggregation = await screen.findByLabelText('Aggregation');
-    await selectEvent.select(aggregation, 'Maximum', { container: document.body });
+    await selectOptionInTest(aggregation, 'Maximum');
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...mockQuery,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
@@ -110,7 +110,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-query-editor')).toBeInTheDocument());
 
     const metrics = await screen.findByLabelText('Service');
-    await selectEvent.select(metrics, 'Logs');
+    await selectEvent.select(metrics, 'Logs', { container: document.body });
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockQuery,
@@ -179,7 +179,7 @@ describe('Azure Monitor QueryEditor', () => {
     expect(screen.queryByText('Application Insights')).toBeInTheDocument();
 
     const metrics = await screen.findByLabelText('Service');
-    await selectEvent.select(metrics, 'Logs');
+    await selectEvent.select(metrics, 'Logs', { container: document.body });
 
     expect(screen.queryByText('Application Insights')).toBeInTheDocument();
   });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
@@ -110,7 +110,7 @@ describe('Azure Monitor QueryEditor', () => {
     await waitFor(() => expect(screen.getByTestId('azure-monitor-query-editor')).toBeInTheDocument());
 
     const metrics = await screen.findByLabelText('Service');
-    await selectEvent.select(metrics, 'Logs', { container: document.body });
+    await ui.selectOptionInTest(metrics, 'Logs');
 
     expect(onChange).toHaveBeenCalledWith({
       ...mockQuery,
@@ -179,7 +179,7 @@ describe('Azure Monitor QueryEditor', () => {
     expect(screen.queryByText('Application Insights')).toBeInTheDocument();
 
     const metrics = await screen.findByLabelText('Service');
-    await selectEvent.select(metrics, 'Logs', { container: document.body });
+    await ui.selectOptionInTest(metrics, 'Logs');
 
     expect(screen.queryByText('Application Insights')).toBeInTheDocument();
   });

--- a/public/app/plugins/datasource/influxdb/components/RawInfluxQLEditor.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/RawInfluxQLEditor.test.tsx
@@ -57,7 +57,7 @@ describe('RawInfluxQLEditor', () => {
     const formatSelect = screen.getByLabelText('Format as');
     expect(formatSelect).toBeInTheDocument();
 
-    await select(formatSelect, 'Time series');
+    await select(formatSelect, 'Time series', { container: document.body });
 
     expect(onChange).toHaveBeenCalledWith({ ...query, resultFormat: 'time_series' });
   });

--- a/public/app/plugins/datasource/influxdb/components/RawInfluxQLEditor.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/RawInfluxQLEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { select } from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
 import { RawInfluxQLEditor } from './RawInfluxQLEditor';
 import { InfluxQuery } from '../types';
 
@@ -57,7 +57,7 @@ describe('RawInfluxQLEditor', () => {
     const formatSelect = screen.getByLabelText('Format as');
     expect(formatSelect).toBeInTheDocument();
 
-    await select(formatSelect, 'Time series', { container: document.body });
+    await selectOptionInTest(formatSelect, 'Time series');
 
     expect(onChange).toHaveBeenCalledWith({ ...query, resultFormat: 'time_series' });
   });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- portals the `Select` menu to `document.body`
- `auto` positions the `Select` menu for better placement
- closes the `Select` menu when scrolling anywhere outside of the `Select` menu
- adds a new `portal` z-index value set to higher than the modal
- rewrites `Portal` component as a functional component so it can utilise `useTheme2`
- rewrites `SelectBase` tests as RTL tests
- updates other unit tests
  - `react-select-event` has an extra option to specify where the menu is contained. e.g.
    ```javascript
    await selectEvent.select(selectEl, 'Option 2');
    ```
    becomes
    ```javascript
    await selectEvent.select(selectEl, 'Option 2', { container: document.body });
    ```
    or use the new util method exposed from `@grafana/ui`:
    ```javascript
    import { selectOptionInTest } from '@grafana/ui';
    await selectOptionInTest(selectEl, 'Option 2');
    ```
- updates e2e tests
  - as the menu is no longer within the `Select` container, need to look for options on the body. e.g.
    ```javascript
    e2e.components.TimeZonePicker.container()
      .should('be.visible')
      .within(() => {
        e2e.components.Select.input().should('be.visible').click();
        e2e.components.Select.option().should('be.visible').contains(toTimeZone).click();
      });
    ``` 
    should now be written as 
    ```javascript
    e2e.components.TimeZonePicker.container()
      .should('be.visible')
      .within(() => {
        e2e.components.Select.input().should('be.visible').click();
      });
    e2e.components.Select.option().should('be.visible').contains(toTimeZone).click();
    ```
- have also updated the e2e util method `selectOption` here: https://github.com/grafana/grafana/blob/main/packages/grafana-e2e/src/flows/selectOption.ts to work with the new structure.
- since the menu is portalled to body, wrapping the `Select` in something like `ClickOutsideWrapper` will no longer work. the same functionality can be achieved using `Select`'s `onCloseMenu`/`isOpen` props.

some screenshots:
![image](https://user-images.githubusercontent.com/20999846/125436201-86808ed6-b0f8-4a48-baee-7fe8ce6e21ee.png)
![image](https://user-images.githubusercontent.com/20999846/125436228-915e45ad-ba4f-4947-a679-f7d37d19359d.png)
![image](https://user-images.githubusercontent.com/20999846/125436281-290dca2f-aade-4c98-a0a8-1cbf561f027e.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

