### PR TITLE
AzureMonitor: Fix issue where resource group name is missing on the resource picker button

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/utils.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/utils.ts
@@ -27,7 +27,7 @@ export function isGUIDish(input: string) {
 
 export function findRow(rows: ResourceRowGroup, id: string): ResourceRow | undefined {
   for (const row of rows) {
-    if (row.id === id) {
+    if (row.id.toLowerCase() === id.toLowerCase()) {
       return row;
     }
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -82,8 +82,6 @@ export default class ResourcePickerData {
   async getResourceURIDisplayProperties(resourceURI: string): Promise<AzureResourceSummaryItem> {
     const { subscriptionID, resourceGroup } = parseResourceURI(resourceURI) ?? {};
 
-    console.log('getResourceURIDisplayProperties', { resourceURI, subscriptionID, resourceGroup });
-
     if (!subscriptionID) {
       throw new Error('Invalid resource URI passed');
     }
@@ -115,11 +113,7 @@ export default class ResourcePickerData {
         | project subscriptionName, resourceGroupName, resourceName
     `;
 
-    console.log({ query });
-
     const { ok, data: response } = await this.makeResourceGraphRequest<AzureResourceSummaryItem[]>(query);
-
-    console.log({ response });
 
     if (!ok || !response.data[0]) {
       throw new Error('unable to fetch resource details');


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes two issues related to when the ID/URI of resources and resource groups were inconsistent:
 - Fixes an issue where the resource group name wouldnt show up on the button to launch the resource picker
 - Fixes an issue where the resource group would not be expanded when opening the resource picker 

**Which issue(s) this PR fixes**:

Fixes #36243

**Special notes for your reviewer**:

