### PR TITLE
Transformations: Skip merge when there is only a single data frame

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/merge.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/merge.test.ts
@@ -16,6 +16,20 @@ describe('Merge multiple to single', () => {
     mockTransformationsRegistry([mergeTransformer]);
   });
 
+  it('skip combine one serie', async () => {
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000] },
+        { name: 'Temp', type: FieldType.number, values: [1] },
+      ],
+    });
+    await expect(transformDataFrame([cfg], [seriesA])).toEmitValuesWith((received) => {
+      const result = received[0];
+      expect(seriesA).toBe(result[0]);
+    });
+  });
+
   it('combine two series into one', async () => {
     const seriesA = toDataFrame({
       name: 'A',

--- a/packages/grafana-data/src/transformations/transformers/merge.ts
+++ b/packages/grafana-data/src/transformations/transformers/merge.ts
@@ -22,7 +22,7 @@ export const mergeTransformer: DataTransformerInfo<MergeTransformerOptions> = {
   operator: (options) => (source) =>
     source.pipe(
       map((dataFrames) => {
-        if (!Array.isArray(dataFrames) || dataFrames.length === 0) {
+        if (!Array.isArray(dataFrames) || dataFrames.length <= 1) {
           return dataFrames;
         }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If I understand correctly, the issue describes a case where the user tries to apply a merge transformation when there's only one dataframe. 

Currently, the merge operator attempts to perform the operation even though the output must be equal to the input. As part of the execution of metadata is lost, such as the transformation to rename a field, which may confuse the user.

The proposed change just skips the merge logic when there's nothing to change.

**Which issue(s) this PR fixes**:
Fixes #36396
