### PR TITLE
Theme: Add margin-bottom to .markdown-html tables

### DIFF
--- a/public/sass/base/_type.scss
+++ b/public/sass/base/_type.scss
@@ -214,6 +214,10 @@ a.external-link {
   }
 
   table {
+    margin-bottom: $line-height-base;
+  }
+
+  table {
     td,
     th {
       padding: $spacer * 0.5 $spacer;


### PR DESCRIPTION
This uses `$line-height-base` which is already used for e.g. [`address`](https://github.com/grafana/grafana/blob/354789edc94b2e5e26967d2d7a46180f5f53c9e6/public/sass/base/_type.scss#L177).

Reviewers added based on recent contributions to the file.

# Before
![PS 2021-07-04 à 09 30 16](https://user-images.githubusercontent.com/2117580/124377410-13d2cd80-dcac-11eb-9572-ce80ec588907.png)
![PS 2021-07-04 à 09 30 41](https://user-images.githubusercontent.com/2117580/124377412-159c9100-dcac-11eb-9b2c-d02bc4efdaa9.png)

# After
![PS 2021-07-04 à 09 31 44](https://user-images.githubusercontent.com/2117580/124377418-1c2b0880-dcac-11eb-9787-54dbf95e1b48.png)
![PS 2021-07-04 à 09 32 18](https://user-images.githubusercontent.com/2117580/124377422-1d5c3580-dcac-11eb-89b4-65e3cd82bd19.png)