### PR TITLE
DataSource: change status code to 404 if datasource and plugin is not found

### DIFF
--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -46,6 +46,10 @@ func (p *DatasourceProxyService) ProxyDatasourceRequestWithID(c *models.ReqConte
 			c.JsonApiErr(http.StatusForbidden, "Access denied to datasource", err)
 			return
 		}
+		if errors.Is(err, models.ErrDataSourceNotFound) {
+			c.JsonApiErr(http.StatusNotFound, "Unable to find datasource", err)
+			return
+		}
 		c.JsonApiErr(http.StatusInternalServerError, "Unable to load datasource meta data", err)
 		return
 	}
@@ -59,7 +63,7 @@ func (p *DatasourceProxyService) ProxyDatasourceRequestWithID(c *models.ReqConte
 	// find plugin
 	plugin := p.PluginManager.GetDataSource(ds.Type)
 	if plugin == nil {
-		c.JsonApiErr(http.StatusInternalServerError, "Unable to find datasource plugin", err)
+		c.JsonApiErr(http.StatusNotFound, "Unable to find datasource plugin", err)
 		return
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: We are returning the status code as `500` if the data source is not found, this PR changes the status code to `404`.

**Which issue(s) this PR fixes**: #36418

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #36418

**Special notes for your reviewer**: Also, changed the status code to `404` if the plugin associated with the data source is not found.

