### PR TITLE
Live: document allowed_origins

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1514,11 +1514,11 @@ Refer to [Grafana Live configuration documentation]({{< relref "../live/configur
 
 The `allowed_origins` option is a comma-separated list of additional origins (`Origin` header of HTTP Upgrade request during WebSocket connection establishment) that will be accepted by Grafana Live.
 
-If not set (default) then origin is matched over [root_url]({{< relref "#root_url" >}}) which should be sufficient for most scenarios.
+If not set (default), then the origin is matched over [root_url]({{< relref "#root_url" >}}) which should be sufficient for most scenarios.
 
 Origin patterns support wildcard symbol "*".
 
-Example:
+For example:
 
 ```ini
 [live]

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1508,6 +1508,23 @@ Refer to [Grafana Live configuration documentation]({{< relref "../live/configur
 
 0 disables Grafana Live, -1 means unlimited connections.
 
+### allowed_origins
+
+> **Note**: Available in Grafana v8.0.4 and later versions.
+
+The `allowed_origins` option is a comma-separated list of additional origins (`Origin` header of HTTP Upgrade request during WebSocket connection establishment) that will be accepted by Grafana Live.
+
+If not set (default) then origin is matched over [root_url]({{< relref "#root_url" >}}) which should be sufficient for most scenarios.
+
+Origin patterns support wildcard symbol "*".
+
+Example:
+
+```ini
+[live]
+allowed_origins = "https://*.example.com"
+```
+
 <hr>
 
 ## [plugin.grafana-image-renderer]

--- a/docs/sources/live/configure-grafana-live.md
+++ b/docs/sources/live/configure-grafana-live.md
@@ -19,6 +19,14 @@ The number of maximum WebSocket connections users can establish with Grafana is 
 
 In case you want to increase this limit, ensure that your server and infrastructure allow handling more connections. The following sections discuss several common problems which could happen when managing persistent connections, in particular WebSocket connections.
 
+## Request origin check
+
+To avoid hijacking WebSocket connections Grafana Live checks Origin request header sent by a client in HTTP Upgrade request. Requests without Origin header set pass through without any origin check.
+
+By default, Live accepts connections with Origin header that matches configured [root_url]({{< relref "../administration/configuration.md#root_url" >}}) (which is a public Grafana URL).
+
+It's also possible to provide a list of additional origin patterns to allow WebSocket connections from. This can be achieved using [allowed_origins]({{< relref "../administration/configuration.md#allowed_origins" >}}) option of Grafana Live.
+
 ### Resource usage
 
 Each persistent connection costs some memory on a server. Typically, this should be about 50 KB per connection at this moment. Thus a server with 1 GB RAM is expected to handle about 20k connections max. Each active connection consumes additional CPU resources since the client and server send PING/PONG frames to each other to maintain a connection.

--- a/docs/sources/live/configure-grafana-live.md
+++ b/docs/sources/live/configure-grafana-live.md
@@ -21,11 +21,12 @@ In case you want to increase this limit, ensure that your server and infrastruct
 
 ## Request origin check
 
-To avoid hijacking WebSocket connections Grafana Live checks Origin request header sent by a client in HTTP Upgrade request. Requests without Origin header set pass through without any origin check.
+To avoid hijacking of WebSocket connection Grafana Live checks the Origin request header sent by a client in an HTTP Upgrade request. Requests without Origin header pass through without any origin check.
+		
 
 By default, Live accepts connections with Origin header that matches configured [root_url]({{< relref "../administration/configuration.md#root_url" >}}) (which is a public Grafana URL).
 
-It's also possible to provide a list of additional origin patterns to allow WebSocket connections from. This can be achieved using [allowed_origins]({{< relref "../administration/configuration.md#allowed_origins" >}}) option of Grafana Live.
+It is possible to provide a list of additional origin patterns to allow WebSocket connections from. This can be achieved using the [allowed_origins]({{< relref "../administration/configuration.md#allowed_origins" >}}) option of Grafana Live configuration.
 
 ### Resource usage
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents `[live] allowed_origins` option added in v8.0.4 
