### PR TITLE
Angular: Fixing some annoying depreaction warnings

### DIFF
--- a/public/app/angular/AngularLocationWrapper.ts
+++ b/public/app/angular/AngularLocationWrapper.ts
@@ -18,10 +18,14 @@ export class AngularLocationWrapper {
     this.url = this.wrapInDeprecationWarning(this.url);
   }
 
-  wrapInDeprecationWarning = (fn: Function, replacement?: string) => {
-    deprecationWarning('$location', fn.name, replacement || 'locationService');
-    return fn.bind(this);
-  };
+  wrapInDeprecationWarning(fn: Function, replacement?: string) {
+    let self = this;
+
+    return function wrapper() {
+      deprecationWarning('$location', fn.name, replacement || 'locationService');
+      return fn.apply(self, arguments);
+    };
+  }
 
   absUrl(): string {
     return `${window.location.origin}${this.url()}`;

--- a/public/app/features/panel/panel_ctrl.ts
+++ b/public/app/features/panel/panel_ctrl.ts
@@ -11,6 +11,7 @@ import {
   EventBusSrv,
 } from '@grafana/data';
 import { DashboardModel } from '../dashboard/state';
+import { AngularLocationWrapper } from 'app/angular/AngularLocationWrapper';
 
 export class PanelCtrl {
   panel: any;
@@ -21,7 +22,6 @@ export class PanelCtrl {
   editorTabs: any;
   $scope: any;
   $injector: auto.IInjectorService;
-  $location: any;
   $timeout: any;
   editModeInitiated = false;
   height: number;
@@ -30,15 +30,16 @@ export class PanelCtrl {
   events: EventBusExtended;
   loading = false;
   timing: any;
+  $location: AngularLocationWrapper;
 
   constructor($scope: any, $injector: auto.IInjectorService) {
     this.panel = this.panel ?? $scope.$parent.panel;
     this.dashboard = this.dashboard ?? $scope.$parent.dashboard;
     this.$injector = $injector;
-    this.$location = $injector.get('$location');
     this.$scope = $scope;
     this.$timeout = $injector.get('$timeout');
     this.editorTabs = [];
+    this.$location = new AngularLocationWrapper();
     this.events = new EventBusSrv();
     this.timing = {}; // not used but here to not break plugins
 


### PR DESCRIPTION
Fixes some annoying deprecation warnings. Also fixes the wrapInDeprecationWarning so that i actually wraps the function and calls the log when the function is called instead of when the Location wrapper is created :)

We got these warnings even though we never used these functions
![Screenshot from 2021-07-06 12-03-59](https://user-images.githubusercontent.com/10999/124582438-4a4a4d00-de52-11eb-9176-4140d85202d8.png)
