### PR TITLE
Transformation: show message if not applied on single frame

### DIFF
--- a/public/app/core/components/TransformersUI/MergeTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/MergeTransformerEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DataTransformerID, standardTransformers, TransformerRegistryItem, TransformerUIProps } from '@grafana/data';
-import { MergeTransformerOptions } from '@grafana/data/src/transformations/transformers/merge';
+import { MergeTransformerOptions } from '../../../../../packages/grafana-data/src/transformations/transformers/merge';
+import { FieldValidationMessage } from '@grafana/ui';
 
 export const MergeTransformerEditor: React.FC<TransformerUIProps<MergeTransformerOptions>> = ({
   input,
@@ -9,7 +10,7 @@ export const MergeTransformerEditor: React.FC<TransformerUIProps<MergeTransforme
 }) => {
   if (input.length <= 1) {
     // Show warning that merge is useless only apply on a single frame
-    return <div>Merge has no effect when applied on a single frame.</div>;
+    return <FieldValidationMessage>Merge has no effect when applied on a single frame.</FieldValidationMessage>;
   }
   return null;
 };

--- a/public/app/core/components/TransformersUI/MergeTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/MergeTransformerEditor.tsx
@@ -7,6 +7,10 @@ export const MergeTransformerEditor: React.FC<TransformerUIProps<MergeTransforme
   options,
   onChange,
 }) => {
+  if (input.length <= 1) {
+    // Show warning that merge is useless only apply on a single frame
+    return <div>Merge has no effect when applied on a single frame.</div>;
+  }
   return null;
 };
 

--- a/public/app/core/components/TransformersUI/OrganizeFieldsTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/OrganizeFieldsTransformerEditor.tsx
@@ -10,7 +10,7 @@ import {
   TransformerUIProps,
   getFieldDisplayName,
 } from '@grafana/data';
-import { stylesFactory, useTheme, Input, IconButton, Icon } from '@grafana/ui';
+import { stylesFactory, useTheme, Input, IconButton, Icon, FieldValidationMessage } from '@grafana/ui';
 
 import { OrganizeFieldsTransformerOptions } from '@grafana/data/src/transformations/transformers/organize';
 import { createOrderFieldsComparer } from '@grafana/data/src/transformations/transformers/order';
@@ -73,7 +73,11 @@ const OrganizeFieldsTransformerEditor: React.FC<OrganizeFieldsTransformerEditorP
 
   // Show warning that we only apply the first frame
   if (input.length > 1) {
-    return <div>Organize fields only works with a single frame. Consider applying a join transformation first.</div>;
+    return (
+      <FieldValidationMessage>
+        Organize fields only works with a single frame. Consider applying a join transformation first.
+      </FieldValidationMessage>
+    );
   }
 
   return (


### PR DESCRIPTION
**What this PR does / why we need it**:
Since #36407 the merge transform does not apply anymore when it is used with a single frame. Because this changes the behaviour in some circumstances (see comments in #36435) I think it is good to inform the user.

Issues: #36396, #36407, #36435
