### PR TITLE
E2E: Add support for data-test-id over aria labels and add importDashboard flow

### DIFF
--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -160,3 +160,41 @@ describe('List test', () => {
   });
 });
 ```
+
+## Aria-Labels vs test-data-id
+Our selectors are set up to work with both aria-labels and data-test-id attributes. Aria-labels help assistive technologies such as screenreaders identify interactive elements of a page for our users. 
+
+A good example of a time to use an aria-label might be if you have a button with an X to close:
+```
+<button aria-label="close">X<button>
+```
+It might be clear visually that the X closes the modal, but audibly it would not be clear for example.
+```
+<button aria-label="close">Close<button>
+```
+The above example for example might read aloud to a user "Close, Close" or something similar. 
+
+However adding aria-labels to elements that are already clearly labled or not interactive can be confusing and redundant for users with assistive technologies.
+
+In such cases rather than adding unnecessary aria-labels to components so as to make them selectable for testing, it is preferable to use a data attribute that would not be read aloud with an assistive technology for example:
+
+```
+<button data-test-id="modal-close-button">Close<button>
+```
+
+We have added support for this in our selectors, to use:
+
+Prefix your selector string with "data-test-id":
+```typescript
+export const Components = {
+  Login: {
+    openButton: "data-test-id-open", // this would look for a data-test-id
+    closeButton: "close-button" // this would look for an aria-label
+  },
+};
+```
+
+and in your component, import the selectors and add the data test id:
+```
+<button data-test-id={Selectors.Components.Login.openButton}>
+```

--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -161,8 +161,8 @@ describe('List test', () => {
 });
 ```
 
-## Aria-Labels vs test-data-id
-Our selectors are set up to work with both aria-labels and data-test-id attributes. Aria-labels help assistive technologies such as screenreaders identify interactive elements of a page for our users. 
+## Aria-Labels vs data-testid
+Our selectors are set up to work with both aria-labels and data-testid attributes. Aria-labels help assistive technologies such as screenreaders identify interactive elements of a page for our users. 
 
 A good example of a time to use an aria-label might be if you have a button with an X to close:
 ```
@@ -174,21 +174,21 @@ It might be clear visually that the X closes the modal, but audibly it would not
 ```
 The above example for example might read aloud to a user "Close, Close" or something similar. 
 
-However adding aria-labels to elements that are already clearly labled or not interactive can be confusing and redundant for users with assistive technologies.
+However adding aria-labels to elements that are already clearly labeled or not interactive can be confusing and redundant for users with assistive technologies.
 
 In such cases rather than adding unnecessary aria-labels to components so as to make them selectable for testing, it is preferable to use a data attribute that would not be read aloud with an assistive technology for example:
 
 ```
-<button data-test-id="modal-close-button">Close<button>
+<button data-testid="modal-close-button">Close<button>
 ```
 
 We have added support for this in our selectors, to use:
 
-Prefix your selector string with "data-test-id":
+Prefix your selector string with "data-testid":
 ```typescript
 export const Components = {
   Login: {
-    openButton: "data-test-id-open", // this would look for a data-test-id
+    openButton: "data-testid-open", // this would look for a data-testid
     closeButton: "close-button" // this would look for an aria-label
   },
 };
@@ -196,5 +196,5 @@ export const Components = {
 
 and in your component, import the selectors and add the data test id:
 ```
-<button data-test-id={Selectors.Components.Login.openButton}>
+<button data-testid={Selectors.Components.Login.openButton}>
 ```

--- a/e2e/suite1/specs/import-dashboard.spec.ts
+++ b/e2e/suite1/specs/import-dashboard.spec.ts
@@ -1,0 +1,122 @@
+import { e2e } from '@grafana/e2e';
+
+e2e.scenario({
+  describeName: 'Import Dashboard Test',
+  itName: 'Ensure you can import a dashboard',
+  addScenarioDataSource: false,
+  addScenarioDashBoard: false,
+  skipScenario: false,
+  scenario: () => {
+    e2e.flows.importDashboard(TEST_DASHBOARD);
+  },
+});
+
+const TEST_DASHBOARD = {
+  annotations: {
+    list: [
+      {
+        builtIn: 1,
+        datasource: '-- Grafana --',
+        enable: true,
+        hide: true,
+        iconColor: 'rgba(0, 211, 255, 1)',
+        name: 'Annotations & Alerts',
+        type: 'dashboard',
+      },
+    ],
+  },
+  editable: true,
+  gnetId: null,
+  graphTooltip: 0,
+  id: 74,
+  links: [],
+  panels: [
+    {
+      datasource: null,
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: 'palette-classic',
+          },
+          custom: {
+            axisLabel: '',
+            axisPlacement: 'auto',
+            barAlignment: 0,
+            drawStyle: 'line',
+            fillOpacity: 0,
+            gradientMode: 'none',
+            hideFrom: {
+              legend: false,
+              tooltip: false,
+              viz: false,
+            },
+            lineInterpolation: 'linear',
+            lineWidth: 1,
+            pointSize: 5,
+            scaleDistribution: {
+              type: 'linear',
+            },
+            showPoints: 'auto',
+            spanNulls: false,
+            stacking: {
+              group: 'A',
+              mode: 'none',
+            },
+            thresholdsStyle: {
+              mode: 'off',
+            },
+          },
+          mappings: [],
+          thresholds: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'green',
+                value: null,
+              },
+              {
+                color: 'red',
+                value: 80,
+              },
+            ],
+          },
+        },
+        overrides: [],
+      },
+      gridPos: {
+        h: 9,
+        w: 12,
+        x: 0,
+        y: 0,
+      },
+      id: 2,
+      options: {
+        legend: {
+          calcs: [],
+          displayMode: 'list',
+          placement: 'bottom',
+        },
+        tooltip: {
+          mode: 'single',
+        },
+      },
+      title: 'Panel Title',
+      type: 'timeseries',
+    },
+  ],
+  schemaVersion: 30,
+  style: 'dark',
+  tags: [],
+  templating: {
+    list: [],
+  },
+  time: {
+    from: '2021-06-30T04:00:00.000Z',
+    to: '2021-07-02T03:59:59.000Z',
+  },
+  timepicker: {},
+  timezone: '',
+  title: 'An imported dashboard for e2e tests',
+  uid: '6V0Nzyz7k',
+  version: 1,
+};

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1,3 +1,9 @@
+// NOTE: by default Component string selectors are set up to be aria-labels,
+// however there are many cases where your component may not need an aria-label
+// (a <button> with clear text for example does not need an aria-lable as it's already labeled)
+// but you still might need to select it for testing,
+// in that case please use add the attribute data-test-id={selector} in the component and
+// prefix your selector string with 'data-test-id' so that when create the selectors we know to search for it on the right attribute
 export const Components = {
   TimePicker: {
     openButton: 'TimePicker Open Button',
@@ -188,7 +194,7 @@ export const Components = {
     container: 'Folder picker select container',
   },
   DataSourcePicker: {
-    container: 'test-id-data-source-picker-container',
+    container: 'Data source picker select container',
   },
   TimeZonePicker: {
     container: 'Time zone picker select container',
@@ -223,11 +229,11 @@ export const Components = {
     container: 'Code editor container',
   },
   DashboardImportPage: {
-    textarea: 'test-id-import-dashboard-textarea',
-    submit: 'test-id-load-dashboard',
+    textarea: 'data-test-id-import-dashboard-textarea',
+    submit: 'data-test-id-load-dashboard',
   },
   ImportDashboardForm: {
-    name: 'test-id-import-dashboard-title',
-    submit: 'test-id-import-dashboard-submit',
+    name: 'data-test-id-import-dashboard-title',
+    submit: 'data-test-id-import-dashboard-submit',
   },
 };

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1,8 +1,8 @@
 // NOTE: by default Component string selectors are set up to be aria-labels,
 // however there are many cases where your component may not need an aria-label
-// (a <button> with clear text for example does not need an aria-lable as it's already labeled)
+// (a <button> with clear text, for example, does not need an aria-label as it's already labeled)
 // but you still might need to select it for testing,
-// in that case please use add the attribute data-test-id={selector} in the component and
+// in that case please add the attribute data-test-id={selector} in the component and
 // prefix your selector string with 'data-test-id' so that when create the selectors we know to search for it on the right attribute
 export const Components = {
   TimePicker: {

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -188,7 +188,7 @@ export const Components = {
     container: 'Folder picker select container',
   },
   DataSourcePicker: {
-    container: 'Data source picker select container',
+    container: 'test-id-data-source-picker-container',
   },
   TimeZonePicker: {
     container: 'Time zone picker select container',

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -222,4 +222,12 @@ export const Components = {
   CodeEditor: {
     container: 'Code editor container',
   },
+  DashboardImportPage: {
+    textarea: 'test-id-import-dashboard-textarea',
+    submit: 'test-id-load-dashboard',
+  },
+  ImportDashboardForm: {
+    name: 'test-id-import-dashboard-title',
+    submit: 'test-id-import-dashboard-submit',
+  },
 };

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -229,11 +229,11 @@ export const Components = {
     container: 'Code editor container',
   },
   DashboardImportPage: {
-    textarea: 'data-test-id-import-dashboard-textarea',
-    submit: 'data-test-id-load-dashboard',
+    textarea: 'data-testid-import-dashboard-textarea',
+    submit: 'data-testid-load-dashboard',
   },
   ImportDashboardForm: {
-    name: 'data-test-id-import-dashboard-title',
-    submit: 'data-test-id-import-dashboard-submit',
+    name: 'data-testid-import-dashboard-title',
+    submit: 'data-testid-import-dashboard-submit',
   },
 };

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -1,0 +1,12 @@
+import { e2e } from '../index';
+import { fromBaseUrl } from '../support/url';
+
+export const importDashboard = (dashboardName: string, dashboardToImport: { [key: string]: any }) => {
+  e2e().visit(fromBaseUrl('/dashboard/import'));
+
+  // Note: normally we'd use 'click' and then 'type' here, but the json object is so big that using 'val' is much faster
+  e2e.components.DashboardImportPage.textarea().invoke('val', JSON.stringify(dashboardToImport)).click({ force: true });
+  e2e.components.DashboardImportPage.submit().click({ force: true });
+  e2e.components.ImportDashboardForm.name().click({ force: true }).clear().type(dashboardName);
+  e2e.components.ImportDashboardForm.submit().click({ force: true });
+};

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -1,12 +1,55 @@
+import { DeleteDashboardConfig } from '.';
 import { e2e } from '../index';
-import { fromBaseUrl } from '../support/url';
+import { fromBaseUrl, getDashboardUid } from '../support/url';
 
-export const importDashboard = (dashboardName: string, dashboardToImport: { [key: string]: any }) => {
+type Panel = {
+  title: string;
+  [key: string]: any;
+};
+
+type Dashboard = { title: string; panels: Panel[]; [key: string]: any };
+
+/**
+ * Smoke test a datasource by quickly importing a test dashboard for it
+ * @param dashboardToImport a sample dashboard
+ */
+export const importDashboard = (dashboardToImport: Dashboard) => {
   e2e().visit(fromBaseUrl('/dashboard/import'));
 
   // Note: normally we'd use 'click' and then 'type' here, but the json object is so big that using 'val' is much faster
   e2e.components.DashboardImportPage.textarea().invoke('val', JSON.stringify(dashboardToImport)).click({ force: true });
   e2e.components.DashboardImportPage.submit().click({ force: true });
-  e2e.components.ImportDashboardForm.name().click({ force: true }).clear().type(dashboardName);
+  e2e.components.ImportDashboardForm.name().click({ force: true }).clear().type(dashboardToImport.title);
   e2e.components.ImportDashboardForm.submit().click({ force: true });
+  e2e().wait(3000);
+
+  // save the newly imported dashboard to context so it'll get properly deleted later
+  e2e()
+    .url()
+    .should('contain', '/d/')
+    .then((url: string) => {
+      const uid = getDashboardUid(url);
+
+      e2e.getScenarioContext().then(({ addedDashboards }: any) => {
+        e2e.setScenarioContext({
+          addedDashboards: [...addedDashboards, { title: dashboardToImport.title, uid } as DeleteDashboardConfig],
+        });
+      });
+    });
+
+  // inspect first panel and verify data has been processed for it
+  e2e.components.Panels.Panel.title(dashboardToImport.panels[0].title).click({ force: true });
+  e2e.components.Panels.Panel.headerItems('Inspect').click({ force: true });
+  e2e.components.Tab.title('JSON').click({ force: true });
+  e2e().wait(3000);
+  e2e.components.PanelInspector.Json.content().contains('Panel JSON').click({ force: true });
+  e2e().wait(3000);
+  e2e.components.PanelInspector.Json.content().contains('Data').click({ force: true });
+  e2e().wait(3000);
+
+  // ensures that panel has loaded without knowingly hitting an error
+  // note: this does not prove that data came back as we expected it,
+  // it could get `state: Done` for no data for example
+  // but it ensures we didn't hit a 401 or 500 or something like that
+  e2e.components.CodeEditor.container().contains('"state": "Done"');
 };

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -17,7 +17,7 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
   e2e().visit(fromBaseUrl('/dashboard/import'));
 
   // Note: normally we'd use 'click' and then 'type' here, but the json object is so big that using 'val' is much faster
-  e2e.components.DashboardImportPage.textarea().invoke('val', JSON.stringify(dashboardToImport)).click({ force: true });
+  e2e.components.DashboardImportPage.textarea().click({ force: true }).invoke('val', JSON.stringify(dashboardToImport));
   e2e.components.DashboardImportPage.submit().click({ force: true });
   e2e.components.ImportDashboardForm.name().click({ force: true }).clear().type(dashboardToImport.title);
   e2e.components.ImportDashboardForm.submit().click({ force: true });

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -44,7 +44,7 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
   e2e().wait(3000);
   e2e.components.PanelInspector.Json.content().contains('Panel JSON').click({ force: true });
   e2e().wait(3000);
-  e2e.components.PanelInspector.Json.content().contains('Data').click({ force: true });
+  e2e.components.Select.option().contains('Data').click({ force: true });
   e2e().wait(3000);
 
   // ensures that panel has loaded without knowingly hitting an error

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -4,10 +4,10 @@ import { fromBaseUrl, getDashboardUid } from '../support/url';
 
 type Panel = {
   title: string;
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
-type Dashboard = { title: string; panels: Panel[]; [key: string]: any };
+type Dashboard = { title: string; panels: Panel[]; [key: string]: unknown };
 
 /**
  * Smoke test a datasource by quickly importing a test dashboard for it
@@ -30,9 +30,9 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
     .then((url: string) => {
       const uid = getDashboardUid(url);
 
-      e2e.getScenarioContext().then(({ addedDashboards }: any) => {
+      e2e.getScenarioContext().then(({ addedDashboards }: { addedDashboards: DeleteDashboardConfig[] }) => {
         e2e.setScenarioContext({
-          addedDashboards: [...addedDashboards, { title: dashboardToImport.title, uid } as DeleteDashboardConfig],
+          addedDashboards: [...addedDashboards, { title: dashboardToImport.title, uid }],
         });
       });
     });

--- a/packages/grafana-e2e/src/flows/index.ts
+++ b/packages/grafana-e2e/src/flows/index.ts
@@ -12,6 +12,7 @@ export * from './openPanelMenuItem';
 export * from './revertAllChanges';
 export * from './saveDashboard';
 export * from './selectOption';
+export * from './importDashboard';
 
 export {
   VISUALIZATION_ALERT_LIST,

--- a/packages/grafana-e2e/src/support/selector.ts
+++ b/packages/grafana-e2e/src/support/selector.ts
@@ -1,9 +1,11 @@
 export interface SelectorApi {
   fromAriaLabel: (selector: string) => string;
+  fromDataTestId: (selector: string) => string;
   fromSelector: (selector: string) => string;
 }
 
 export const Selector: SelectorApi = {
   fromAriaLabel: (selector: string) => `[aria-label="${selector}"]`,
+  fromDataTestId: (selector: string) => `[data-test-id="${selector}"]`,
   fromSelector: (selector: string) => selector,
 };

--- a/packages/grafana-e2e/src/support/selector.ts
+++ b/packages/grafana-e2e/src/support/selector.ts
@@ -6,6 +6,6 @@ export interface SelectorApi {
 
 export const Selector: SelectorApi = {
   fromAriaLabel: (selector: string) => `[aria-label="${selector}"]`,
-  fromDataTestId: (selector: string) => `[data-test-id="${selector}"]`,
+  fromDataTestId: (selector: string) => `[data-testid="${selector}"]`,
   fromSelector: (selector: string) => selector,
 };

--- a/packages/grafana-e2e/src/support/types.ts
+++ b/packages/grafana-e2e/src/support/types.ts
@@ -61,7 +61,9 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
       // @ts-ignore
       e2eObjects[key] = (options?: CypressOptions) => {
         logOutput(value);
-        return e2e().get(Selector.fromAriaLabel(value), options);
+        const selector = value.startsWith('test-id') ? Selector.fromDataTestId(value) : Selector.fromAriaLabel(value);
+
+        return e2e().get(selector, options);
       };
 
       continue;
@@ -81,8 +83,10 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
         // the input can be (text) or (options)
         if (arguments.length === 1) {
           if (typeof textOrOptions === 'string') {
-            const ariaText = value(textOrOptions);
-            const selector = Selector.fromAriaLabel(ariaText);
+            const selectorText = value(textOrOptions);
+            const selector = textOrOptions.startsWith('test-id')
+              ? Selector.fromDataTestId(selectorText)
+              : Selector.fromAriaLabel(selectorText);
 
             logOutput(selector);
             return e2e().get(selector);
@@ -95,8 +99,11 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
 
         // the input can only be (text, options)
         if (arguments.length === 2) {
-          const ariaText = value(textOrOptions as string);
-          const selector = Selector.fromAriaLabel(ariaText);
+          const text = textOrOptions as string;
+          const selectorText = value(text);
+          const selector = text.startsWith('test-id')
+            ? Selector.fromDataTestId(selectorText)
+            : Selector.fromAriaLabel(selectorText);
 
           logOutput(selector);
           return e2e().get(selector, options);

--- a/packages/grafana-e2e/src/support/types.ts
+++ b/packages/grafana-e2e/src/support/types.ts
@@ -61,7 +61,9 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
       // @ts-ignore
       e2eObjects[key] = (options?: CypressOptions) => {
         logOutput(value);
-        const selector = value.startsWith('test-id') ? Selector.fromDataTestId(value) : Selector.fromAriaLabel(value);
+        const selector = value.startsWith('data-test-id')
+          ? Selector.fromDataTestId(value)
+          : Selector.fromAriaLabel(value);
 
         return e2e().get(selector, options);
       };
@@ -84,7 +86,7 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
         if (arguments.length === 1) {
           if (typeof textOrOptions === 'string') {
             const selectorText = value(textOrOptions);
-            const selector = textOrOptions.startsWith('test-id')
+            const selector = selectorText.startsWith('data-test-id')
               ? Selector.fromDataTestId(selectorText)
               : Selector.fromAriaLabel(selectorText);
 
@@ -101,7 +103,7 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
         if (arguments.length === 2) {
           const text = textOrOptions as string;
           const selectorText = value(text);
-          const selector = text.startsWith('test-id')
+          const selector = text.startsWith('data-test-id')
             ? Selector.fromDataTestId(selectorText)
             : Selector.fromAriaLabel(selectorText);
 

--- a/packages/grafana-e2e/src/support/types.ts
+++ b/packages/grafana-e2e/src/support/types.ts
@@ -100,8 +100,8 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
         }
 
         // the input can only be (text, options)
-        if (arguments.length === 2) {
-          const text = textOrOptions as string;
+        if (arguments.length === 2 && typeof textOrOptions === 'string') {
+          const text = textOrOptions;
           const selectorText = value(text);
           const selector = text.startsWith('data-test-id')
             ? Selector.fromDataTestId(selectorText)

--- a/packages/grafana-e2e/src/support/types.ts
+++ b/packages/grafana-e2e/src/support/types.ts
@@ -61,7 +61,7 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
       // @ts-ignore
       e2eObjects[key] = (options?: CypressOptions) => {
         logOutput(value);
-        const selector = value.startsWith('data-test-id')
+        const selector = value.startsWith('data-testid')
           ? Selector.fromDataTestId(value)
           : Selector.fromAriaLabel(value);
 
@@ -86,7 +86,7 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
         if (arguments.length === 1) {
           if (typeof textOrOptions === 'string') {
             const selectorText = value(textOrOptions);
-            const selector = selectorText.startsWith('data-test-id')
+            const selector = selectorText.startsWith('data-testid')
               ? Selector.fromDataTestId(selectorText)
               : Selector.fromAriaLabel(selectorText);
 
@@ -103,7 +103,7 @@ const processSelectors = <S extends Selectors>(e2eObjects: E2EFunctions<S>, sele
         if (arguments.length === 2 && typeof textOrOptions === 'string') {
           const text = textOrOptions;
           const selectorText = value(text);
-          const selector = text.startsWith('data-test-id')
+          const selector = text.startsWith('data-testid')
             ? Selector.fromDataTestId(selectorText)
             : Selector.fromAriaLabel(selectorText);
 

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -142,7 +142,7 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
     const styles = getStyles();
 
     return (
-      <div aria-label={selectors.components.DataSourcePicker.container}>
+      <div data-test-id={selectors.components.DataSourcePicker.container}>
         <Select
           className={styles.select}
           isMulti={false}

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -142,7 +142,7 @@ export class DataSourcePicker extends PureComponent<DataSourcePickerProps, DataS
     const styles = getStyles();
 
     return (
-      <div data-test-id={selectors.components.DataSourcePicker.container}>
+      <div aria-label={selectors.components.DataSourcePicker.container}>
         <Select
           className={styles.select}
           isMulti={false}

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -122,11 +122,11 @@ class UnthemedDashboardImport extends PureComponent<Props> {
                       required: 'Need a dashboard JSON model',
                       validate: validateDashboardJson,
                     })}
-                    data-test-id={selectors.components.ImportDashboard.textarea}
+                    data-test-id={selectors.components.DashboardImportPage.textarea}
                     rows={10}
                   />
                 </Field>
-                <Button type="submit" data-test-id={selectors.components.ImportDashboard.submit}>
+                <Button type="submit" data-test-id={selectors.components.DashboardImportPage.submit}>
                   Load
                 </Button>
               </>

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent, PureComponent } from 'react';
 import { MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { css } from '@emotion/css';
 import { AppEvents, GrafanaTheme2, NavModel } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import {
   Button,
   stylesFactory,
@@ -121,10 +122,13 @@ class UnthemedDashboardImport extends PureComponent<Props> {
                       required: 'Need a dashboard JSON model',
                       validate: validateDashboardJson,
                     })}
+                    data-test-id={selectors.components.ImportDashboard.textarea}
                     rows={10}
                   />
                 </Field>
-                <Button type="submit">Load</Button>
+                <Button type="submit" data-test-id={selectors.components.ImportDashboard.submit}>
+                  Load
+                </Button>
               </>
             )}
           </Form>

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -122,11 +122,11 @@ class UnthemedDashboardImport extends PureComponent<Props> {
                       required: 'Need a dashboard JSON model',
                       validate: validateDashboardJson,
                     })}
-                    data-test-id={selectors.components.DashboardImportPage.textarea}
+                    data-testid={selectors.components.DashboardImportPage.textarea}
                     rows={10}
                   />
                 </Field>
-                <Button type="submit" data-test-id={selectors.components.DashboardImportPage.submit}>
+                <Button type="submit" data-testid={selectors.components.DashboardImportPage.submit}>
                   Load
                 </Button>
               </>

--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -14,6 +14,7 @@ import { DataSourcePicker } from '@grafana/runtime';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { DashboardInput, DashboardInputs, DataSourceInput, ImportDashboardDTO } from '../state/reducers';
 import { validateTitle, validateUid } from '../utils/validation';
+import { selectors } from '@grafana/e2e-selectors';
 
 interface Props extends Pick<FormAPI<ImportDashboardDTO>, 'register' | 'errors' | 'control' | 'getValues' | 'watch'> {
   uidReset: boolean;
@@ -61,6 +62,7 @@ export const ImportDashboardForm: FC<Props> = ({
             validate: async (v: string) => await validateTitle(v, getValues().folder.id),
           })}
           type="text"
+          data-test-id={selectors.components.ImportDashboardForm.name}
         />
       </Field>
       <Field label="Folder">
@@ -137,6 +139,7 @@ export const ImportDashboardForm: FC<Props> = ({
       <HorizontalGroup>
         <Button
           type="submit"
+          data-test-id={selectors.components.ImportDashboardForm.submit}
           variant={getButtonVariant(errors)}
           onClick={() => {
             setSubmitted(true);

--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -62,7 +62,7 @@ export const ImportDashboardForm: FC<Props> = ({
             validate: async (v: string) => await validateTitle(v, getValues().folder.id),
           })}
           type="text"
-          data-test-id={selectors.components.ImportDashboardForm.name}
+          data-testid={selectors.components.ImportDashboardForm.name}
         />
       </Field>
       <Field label="Folder">
@@ -139,7 +139,7 @@ export const ImportDashboardForm: FC<Props> = ({
       <HorizontalGroup>
         <Button
           type="submit"
-          data-test-id={selectors.components.ImportDashboardForm.submit}
+          data-testid={selectors.components.ImportDashboardForm.submit}
           variant={getButtonVariant(errors)}
           onClick={() => {
             setSubmitted(true);


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr tackles 2 things that are somewhat unrelated but both necessary for e2e testing of external datasources:
1) Fixes an accessibility issue where the primary way we support selectors for e2e testing is with aria-labels which can lead to us adding aria-labels to lots of elements that may not necessarily need an aria-label. [It is ideally meant for places where there is no current text explaining what the element does](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) so for example it doesn't really make sense to add an aria label to a button that has clear button text. Ideally we could instead remove aria labels from e2e testing entirely, as it's not particularly relevant to e2e testing, and shift to data test ids. However, rather than change everything all at once, I tried to write the code to be backwards compatible. If we try out this approach and like it, we slowly swap out the aria labels for data-test-ids and then when  we're ready remove the conditionals I'm adding here to `packages/grafana-e2e/src/support/types.ts`
2) Adding the ability to import a dashboard. For e2e testing of external datasources there are 3 things we want to focus on testing:
* adding the datasource (which we already have a flow for)
* using the query builder to create a dashboard (what the addDashboard flow should let us do)
* importing an existing dashboard and verifying that it can successfully consume that datasource (what this PR is focused on)

**Which issue(s) this PR fixes**:

Fixes #33524, https://github.com/grafana/azure-data-explorer-datasource/issues/245, https://github.com/grafana/azure-data-explorer-datasource/issues/246

**Special notes for your reviewer**:
I have focused on verifying that the Panel recieves data and that it comes back in the state of "Done", if it hits a 401, or 500 it'll return an state of Error, this lets us smoketest that a datasource is set up correctly.

2 other alternatives to this approach that were considered:
1) comparing screenshots, but this felt a bit brittle.
2) trying to get the full Data response back and comparing the object we get back to what we expect. This also seemed a bit brittle (but less so), and there isn't a terribly easy way to do get the full formatted response back without looking at the global Monaco object on the window, which seemed a bit strange and forced ([can see a proof of concept for that here if you'd like](https://github.com/grafana/azure-data-explorer-datasource/pull/240/files#diff-e4ae9ec78970df7f6588749f9e71a9a371025e5b4d7ac97fed6e1a313d67ad8bR57). 

