### PR TITLE
Stat: use shared data min/max for y auto-ranging

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -143,6 +143,7 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
         direction: ScaleDirection.Up,
         min: field.config.min,
         max: field.config.max,
+        getDataMinMax: () => field.state?.range,
       });
 
       builder.addAxis({

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -2,7 +2,7 @@ import uPlot, { Scale, Range } from 'uplot';
 import { PlotConfigBuilder } from '../types';
 import { ScaleOrientation, ScaleDirection } from '../config';
 import { ScaleDistribution } from '../models.gen';
-import { isBooleanUnit } from '@grafana/data';
+import { isBooleanUnit, NumericRange } from '@grafana/data';
 
 export interface ScaleProps {
   scaleKey: string;
@@ -16,6 +16,7 @@ export interface ScaleProps {
   orientation: ScaleOrientation;
   direction: ScaleDirection;
   log?: number;
+  getDataMinMax?: () => NumericRange | undefined;
 }
 
 export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
@@ -62,6 +63,15 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
 
     // uPlot range function
     const rangeFn = (u: uPlot, dataMin: number, dataMax: number, scaleKey: string) => {
+      let { getDataMinMax } = this.props;
+
+      // cumulative data min/max across multiple charts, usually via VizRepeater
+      if (getDataMinMax) {
+        let dataRange = getDataMinMax()!;
+        dataMin = dataRange.min!;
+        dataMax = dataRange.max!;
+      }
+
       const scale = u.scales[scaleKey];
 
       let minMax: uPlot.Range.MinMax = [dataMin, dataMax];


### PR DESCRIPTION
Fixes #32765

this brings back the previous behavior of VizRepeater'd Stat panels sharing a y min/max data range across all repeated viz charts.

without PR:

![image](https://user-images.githubusercontent.com/43234/124706673-4ef81b00-debd-11eb-86bb-09b08a947b1e.png)

with PR:

![image](https://user-images.githubusercontent.com/43234/124706717-5e776400-debd-11eb-8bf4-f8400f4157f4.png)