### PR TITLE
Image Renderer: update env variable in docs and custom Docker files

### DIFF
--- a/docs/sources/administration/image_rendering.md
+++ b/docs/sources/administration/image_rendering.md
@@ -208,5 +208,5 @@ instead of the pre-packaged version of Chromium.
 To override the path to the Chrome/Chromium executable, set an environment variable and make sure that it's available for the Grafana process. For example:
 
 ```bash
-export GF_RENDERER_PLUGIN_CHROME_BIN="/usr/bin/chromium-browser"
+export GF_PLUGIN_RENDERING_CHROME_BIN="/usr/bin/chromium-browser"
 ```

--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -24,7 +24,7 @@ fi
 
 USER grafana
 
-ENV GF_RENDERER_PLUGIN_CHROME_BIN="/usr/bin/chromium-browser"
+ENV GF_PLUGIN_RENDERING_CHROME_BIN="/usr/bin/chromium-browser"
 
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
     grafana-cli \

--- a/packaging/docker/custom/ubuntu.Dockerfile
+++ b/packaging/docker/custom/ubuntu.Dockerfile
@@ -28,7 +28,7 @@ fi
 
 USER grafana
 
-ENV GF_RENDERER_PLUGIN_CHROME_BIN="/usr/bin/google-chrome"
+ENV GF_PLUGIN_RENDERING_CHROME_BIN="/usr/bin/google-chrome"
 
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
     grafana-cli \


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace the env variable `GF_RENDERER_PLUGIN_CHROME_BIN` used in the image renderer plugin V1 with `GF_PLUGIN_RENDERING_CHROME_BIN` in the documentation and in the custom Docker files.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/36476


