### PR TITLE
Alerting API: Restrict access to Alertmanager configuration

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -64,6 +64,9 @@ func (srv AlertmanagerSrv) RouteDeleteSilence(c *models.ReqContext) response.Res
 }
 
 func (srv AlertmanagerSrv) RouteGetAlertingConfig(c *models.ReqContext) response.Response {
+	if !c.HasUserRole(models.ROLE_EDITOR) {
+		return ErrResp(http.StatusForbidden, errors.New("permission denied"), "")
+	}
 	query := ngmodels.GetLatestAlertmanagerConfigurationQuery{}
 	if err := srv.store.GetLatestAlertmanagerConfiguration(&query); err != nil {
 		if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -118,6 +118,78 @@ func TestAMConfigAccess(t *testing.T) {
 		}
 	})
 
+	t.Run("when retrieve alertmanager configuration", func(t *testing.T) {
+		cfgBody := `
+		{
+			"template_files": null,
+			"alertmanager_config": {
+				"route": {
+					"receiver": "grafana-default-email"
+				},
+				"templates": null,
+				"receivers": [{
+					"name": "grafana-default-email",
+					"grafana_managed_receiver_configs": [{
+						"disableResolveMessage": false,
+						"uid": "",
+						"name": "email receiver",
+						"type": "email",
+						"secureFields": {},
+						"settings": {
+							"addresses": "<example@email.com>"
+						}
+					}]
+				}]
+			}
+		}
+		`
+		testCases := []testCase{
+			{
+				desc:      "un-authenticated request should fail",
+				url:       "http://%s/api/alertmanager/grafana/config/api/v1/alerts",
+				expStatus: http.StatusUnauthorized,
+				expBody:   `{"message": "Unauthorized"}`,
+			},
+			{
+				desc:      "viewer request should fail",
+				url:       "http://viewer:viewer@%s/api/alertmanager/grafana/config/api/v1/alerts",
+				expStatus: http.StatusForbidden,
+				expBody:   `{"message": "permission denied"}`,
+			},
+			{
+				desc:      "editor request should succeed",
+				url:       "http://editor:editor@%s/api/alertmanager/grafana/config/api/v1/alerts",
+				expStatus: http.StatusOK,
+				expBody:   cfgBody,
+			},
+			{
+				desc:      "admin request should succeed",
+				url:       "http://admin:admin@%s/api/alertmanager/grafana/config/api/v1/alerts",
+				expStatus: http.StatusOK,
+				expBody:   cfgBody,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.desc, func(t *testing.T) {
+				url := fmt.Sprintf(tc.url, grafanaListedAddr)
+				resp, err := http.Get(url)
+				t.Cleanup(func() {
+					require.NoError(t, resp.Body.Close())
+				})
+				require.NoError(t, err)
+				require.Equal(t, tc.expStatus, resp.StatusCode)
+				b, err := ioutil.ReadAll(resp.Body)
+				if tc.expStatus == http.StatusOK {
+					re := regexp.MustCompile(`"uid":"([\w|-]+)"`)
+					b = re.ReplaceAll(b, []byte(`"uid":""`))
+				}
+				require.NoError(t, err)
+				require.JSONEq(t, tc.expBody, string(b))
+			})
+		}
+	})
+
 	t.Run("when creating silence", func(t *testing.T) {
 		body := `
 		{

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -172,8 +172,7 @@ func TestAMConfigAccess(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.desc, func(t *testing.T) {
-				url := fmt.Sprintf(tc.url, grafanaListedAddr)
-				resp, err := http.Get(url)
+				resp, err := http.Get(fmt.Sprintf(tc.url, grafanaListedAddr))
 				t.Cleanup(func() {
 					require.NoError(t, resp.Body.Close())
 				})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It modifies GET ​/api​/alertmanager​/{Recipient}​/config​/api​/v1​/alerts to restrict access to viewers. [This was the case](https://github.com/grafana/grafana/blob/a241f03167ea4d8a4bddabf27df417bec07796ba/pkg/api/api.go#L403) in the legacy alerts.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

