### PR TITLE
Timeseries Panel: Retain alerts when migrating from old graph

### DIFF
--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -124,6 +124,7 @@ export interface PanelEditorProps<T = any> {
 export interface PanelModel<TOptions = any> {
   /** ID of the panel within the current dashboard */
   id: number;
+  alert?: any;
   /** Panel options */
   options: TOptions;
   /** Field options configuration */

--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Graph Migrations legend with multiple values 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -53,6 +54,7 @@ Object {
 
 exports[`Graph Migrations legend with single value 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -79,6 +81,7 @@ Object {
 
 exports[`Graph Migrations legend without values 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -103,6 +106,7 @@ Object {
 
 exports[`Graph Migrations preserves colors from series overrides 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -157,6 +161,7 @@ Object {
 
 exports[`Graph Migrations preserves series overrides using a regex alias 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -211,6 +216,7 @@ Object {
 
 exports[`Graph Migrations simple bars 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -237,6 +243,7 @@ Object {
 
 exports[`Graph Migrations stacking groups 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -322,6 +329,7 @@ Object {
 
 exports[`Graph Migrations stacking simple 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -377,6 +385,7 @@ Object {
 
 exports[`Graph Migrations stairscase 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -416,6 +425,7 @@ Object {
 
 exports[`Graph Migrations stepped line 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {
@@ -463,6 +473,7 @@ Object {
 
 exports[`Graph Migrations twoYAxis 1`] = `
 Object {
+  "alert": undefined,
   "fieldConfig": Object {
     "defaults": Object {
       "custom": Object {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -45,6 +45,7 @@ export const graphPanelChangedHandler: PanelTypeChangedHandler = (
       fieldConfig: prevFieldConfig,
     });
     panel.fieldConfig = fieldConfig; // Mutates the incoming panel
+    panel.alert = prevOptions.angular.alert;
     return options;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Retains alerts when switching from an old graph panel to timeseries panel.

**Which issue(s) this PR fixes**:
Closes #36106


