### PR TITLE
QueryVariable: Default to first option when none is set

### DIFF
--- a/public/app/features/variables/state/sharedReducer.test.ts
+++ b/public/app/features/variables/state/sharedReducer.test.ts
@@ -343,6 +343,36 @@ describe('sharedReducer', () => {
     });
   });
 
+  describe('when setCurrentVariableValue is dispatched and current.value is nothing', () => {
+    it('then the first available option should be selected', () => {
+      const adapter = createQueryVariableAdapter();
+      const { initialState } = getVariableTestContext(adapter, {
+        options: [
+          { text: 'A', value: 'A', selected: false },
+          { text: 'B', value: 'B', selected: false },
+          { text: 'C', value: 'C', selected: false },
+        ],
+      });
+      const current = { text: '', value: '', selected: false };
+      const payload = toVariablePayload({ id: '0', type: 'query' }, { option: current });
+      reducerTester<VariablesState>()
+        .givenReducer(sharedReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(setCurrentVariableValue(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          '0': ({
+            ...initialState[0],
+            options: [
+              { selected: true, text: 'A', value: 'A' },
+              { selected: false, text: 'B', value: 'B' },
+              { selected: false, text: 'C', value: 'C' },
+            ],
+            current: { selected: true, text: 'A', value: 'A' },
+          } as unknown) as QueryVariableModel,
+        });
+    });
+  });
+
   describe('when setCurrentVariableValue is dispatched and current.value is an Array with values containing All value', () => {
     it('then state should be correct', () => {
       const adapter = createQueryVariableAdapter();

--- a/public/app/features/variables/state/sharedReducer.test.ts
+++ b/public/app/features/variables/state/sharedReducer.test.ts
@@ -343,7 +343,7 @@ describe('sharedReducer', () => {
     });
   });
 
-  describe('when setCurrentVariableValue is dispatched and current.value is nothing', () => {
+  describe('when setCurrentVariableValue is dispatched and current.value has no value', () => {
     it('then the first available option should be selected', () => {
       const adapter = createQueryVariableAdapter();
       const { initialState } = getVariableTestContext(adapter, {
@@ -368,6 +368,28 @@ describe('sharedReducer', () => {
               { selected: false, text: 'C', value: 'C' },
             ],
             current: { selected: true, text: 'A', value: 'A' },
+          } as unknown) as QueryVariableModel,
+        });
+    });
+  });
+
+  describe('when setCurrentVariableValue is dispatched and current.value has no value and there are no options', () => {
+    it('then no option should be selected', () => {
+      const adapter = createQueryVariableAdapter();
+      const { initialState } = getVariableTestContext(adapter, {
+        options: [],
+      });
+      const current = { text: '', value: '', selected: false };
+      const payload = toVariablePayload({ id: '0', type: 'query' }, { option: current });
+      reducerTester<VariablesState>()
+        .givenReducer(sharedReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(setCurrentVariableValue(payload))
+        .thenStateShouldEqual({
+          ...initialState,
+          '0': ({
+            ...initialState[0],
+            options: [],
+            current: { selected: false, text: '', value: '' },
           } as unknown) as QueryVariableModel,
         });
     });

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -121,6 +121,15 @@ const sharedReducerSlice = createSlice({
       const { option } = action.payload.data;
       const current = { ...option, text: ensureStringValues(option?.text), value: ensureStringValues(option?.value) };
 
+      // If no value is set, default to the first avilable
+      if (!current.value) {
+        instanceState.current = { ...instanceState.options[0], selected: true };
+        instanceState.options = instanceState.options.map((option, index) =>
+          index === 0 ? instanceState.current : { ...option, selected: false }
+        );
+        return;
+      }
+
       instanceState.current = current;
       instanceState.options = instanceState.options.map((option) => {
         option.value = ensureStringValues(option.value);

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -123,11 +123,10 @@ const sharedReducerSlice = createSlice({
 
       // If no value is set, default to the first avilable
       if (!current.value && instanceState.options.length) {
-        instanceState.current = { ...instanceState.options[0], selected: true };
-        instanceState.options.forEach((option) => {
-          option.selected = false;
+        instanceState.options.forEach((option, index) => {
+          option.selected = !Boolean(index);
         });
-        instanceState.options[0] = instanceState.current;
+        instanceState.current = instanceState.options[0];
         return;
       }
 

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -122,11 +122,12 @@ const sharedReducerSlice = createSlice({
       const current = { ...option, text: ensureStringValues(option?.text), value: ensureStringValues(option?.value) };
 
       // If no value is set, default to the first avilable
-      if (!current.value) {
+      if (!current.value && instanceState.options.length) {
         instanceState.current = { ...instanceState.options[0], selected: true };
-        instanceState.options = instanceState.options.map((option, index) =>
-          index === 0 ? instanceState.current : { ...option, selected: false }
-        );
+        instanceState.options.forEach((option) => {
+          option.selected = false;
+        });
+        instanceState.options[0] = instanceState.current;
         return;
       }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
To make sure that query variables do not break when the current dashboard is navigated to via an anchor tag.

**Which issue(s) this PR fixes**:
Fixes #35471

**Special notes for your reviewer**:

1. Create query variable with onDashboardLoad
2. Create a panel link that leads to `/d/${__dashboard.uid}`
3. Select a non default value for the query variable
4. Click the panel link
5. The query variables should now be set to default values as opposed to nothing