### PR TITLE
include URL arguments in dashboard resource request

### DIFF
--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -111,8 +111,14 @@ export class DashboardLoaderSrv {
       return Promise.reject('expecting path parameter');
     }
 
+    const queryString: { [key: string]: any } = {};
+
+    params.forEach((value, key) => {
+      queryString[key] = value;
+    });
+
     return getBackendSrv()
-      .get(`/api/datasources/${ds.id}/resources/${path}`, {})
+      .get(`/api/datasources/${ds.id}/resources/${path}`, queryString)
       .then((data) => {
         return {
           meta: {

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -111,14 +111,14 @@ export class DashboardLoaderSrv {
       return Promise.reject('expecting path parameter');
     }
 
-    const queryString: { [key: string]: any } = {};
+    const queryParams: { [key: string]: any } = {};
 
     params.forEach((value, key) => {
-      queryString[key] = value;
+      queryParams[key] = value;
     });
 
     return getBackendSrv()
-      .get(`/api/datasources/${ds.id}/resources/${path}`, queryString)
+      .get(`/api/datasources/${ds.id}/resources/${path}`, queryParams)
       .then((data) => {
         return {
           meta: {


### PR DESCRIPTION
When rendering a dashboard from a datasource resource request, include all of the provided URL arguments.

@ryantxu what do I need to label this PR with?