### PR TITLE
Prometheus: Azure authentication in plugin proxy routes

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -266,6 +266,11 @@ func (proxy *DataSourceProxy) validateRequest() error {
 	// found route if there are any
 	if len(proxy.plugin.Routes) > 0 {
 		for _, route := range proxy.plugin.Routes {
+			// host match
+			if !matchHost(route.Host, proxy.ds.Url) {
+				continue
+			}
+
 			// method match
 			if route.Method != "" && route.Method != "*" && route.Method != proxy.ctx.Req.Method {
 				continue
@@ -301,6 +306,19 @@ func (proxy *DataSourceProxy) validateRequest() error {
 	}
 
 	return nil
+}
+
+func matchHost(hostCondition string, datasourceUrl string) bool {
+	if hostCondition == "" || hostCondition == "*" {
+		return true
+	}
+
+	parsedUrl, err := url.Parse(datasourceUrl)
+	if err != nil {
+		return false
+	}
+
+	return hostCondition == parsedUrl.Host
 }
 
 func (proxy *DataSourceProxy) logRequest() {

--- a/pkg/plugins/app_plugin.go
+++ b/pkg/plugins/app_plugin.go
@@ -28,6 +28,7 @@ type AppPlugin struct {
 // AppPluginRoute describes a plugin route that is defined in
 // the plugin.json file for a plugin.
 type AppPluginRoute struct {
+	Host         string                   `json:"host"`
 	Path         string                   `json:"path"`
 	Method       string                   `json:"method"`
 	ReqRole      models.RoleType          `json:"reqRole"`

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -5,6 +5,142 @@
   "category": "tsdb",
   "routes": [
     {
+      "host": "prometheus.azure.net",
+      "method": "POST",
+      "path": "api/v1/query",
+      "reqRole": "Viewer",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
+      "host": "prometheus.azure.net",
+      "method": "POST",
+      "path": "api/v1/query_range",
+      "reqRole": "Viewer",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
+      "host": "prometheus.azure.net",
+      "method": "POST",
+      "path": "api/v1/series",
+      "reqRole": "Viewer",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
+      "host": "prometheus.azure.net",
+      "method": "POST",
+      "path": "api/v1/labels",
+      "reqRole": "Viewer",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
+      "host": "prometheus.azure.net",
+      "method": "POST",
+      "path": "api/v1/query_exemplars",
+      "reqRole": "Viewer",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
+      "host": "prometheus.azure.net",
+      "method": "GET",
+      "path": "/rules",
+      "reqRole": "Viewer",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
+      "host": "prometheus.azure.net",
+      "method": "POST",
+      "path": "/rules",
+      "reqRole": "Editor",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
+      "host": "prometheus.azure.net",
+      "method": "DELETE",
+      "path": "/rules",
+      "reqRole": "Editor",
+      "authType": "{{if .JsonData.azureAuth}}azure{{else}}none{{end}}",
+      "tokenAuth": {
+        "scopes": ["https://management.azure.com/.default"],
+        "params": {
+          "azure_auth_type": "{{.JsonData.azureAuthType | orEmpty}}",
+          "azure_cloud": "AzureCloud",
+          "tenant_id": "{{.JsonData.azureTenantId | orEmpty}}",
+          "client_id": "{{.JsonData.azureClientId | orEmpty}}",
+          "client_secret": "{{.SecureJsonData.azureClientSecret | orEmpty}}"
+        }
+      }
+    },
+    {
       "method": "POST",
       "path": "api/v1/query",
       "reqRole": "Viewer"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds optional Azure authentication for Prometheus datasource controlled by configuration by JsonData (via configuration editor).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Prometheus datasource relies on plugin proxy routing and standard HTTP configuration. It has code that creates HTTP transport ([here](https://github.com/grafana/grafana/blob/a0dac9c6d9297bf0740a8689f37701f18215f588/pkg/tsdb/prometheus/prometheus.go#L40)) but it seems like never called in practice.
So, the only way to tap into the transport of Prometheus plugin is via the plugin proxy routes.

For this purpose I extended the route matcher to support matching by host name (in `ds_proxy.go`) additionally to matching by path. It allows me to specific Azure endpoints and apply Azure authentication to them while keep other endpoins unaffected.