### PR TITLE
Alerting: add option defaults to alert list panel migration handler

### DIFF
--- a/public/app/plugins/panel/alertlist/AlertListMigration.test.ts
+++ b/public/app/plugins/panel/alertlist/AlertListMigration.test.ts
@@ -107,4 +107,30 @@ describe('AlertList Panel Migration', () => {
     expect(panel).not.toHaveProperty('dashboardTags');
     expect(panel).not.toHaveProperty('stateFilter');
   });
+
+  it('should handle config with no options or stateFilter', () => {
+    const panel: Omit<PanelModel, 'fieldConfig'> & Record<string, any> = {
+      id: 7,
+      links: [],
+      pluginVersion: '7.4.0',
+      targets: [],
+      title: 'Usage',
+      type: 'alertlist',
+      onlyAlertsOnDashboard: false,
+      options: {},
+    };
+
+    const newOptions = alertListPanelMigrationHandler(panel as PanelModel);
+    expect(newOptions).toMatchObject({
+      showOptions: ShowOption.Current,
+      maxItems: 10,
+      sortOrder: SortOrder.AlphaAsc,
+      dashboardAlerts: false,
+      alertName: '',
+      dashboardTitle: '',
+      tags: [],
+      stateFilter: {},
+      folderId: undefined,
+    });
+  });
 });

--- a/public/app/plugins/panel/alertlist/AlertListMigrationHandler.ts
+++ b/public/app/plugins/panel/alertlist/AlertListMigrationHandler.ts
@@ -1,21 +1,22 @@
 import { PanelModel } from '@grafana/data';
-import { AlertListOptions } from './types';
+import { AlertListOptions, ShowOption, SortOrder } from './types';
 
 export const alertListPanelMigrationHandler = (
   panel: PanelModel<AlertListOptions> & Record<string, any>
 ): Partial<AlertListOptions> => {
   const newOptions: AlertListOptions = {
-    showOptions: panel.options.showOptions ?? panel.show,
-    maxItems: panel.options.maxItems ?? panel.limit,
-    sortOrder: panel.options.sortOrder ?? panel.sortOrder,
-    dashboardAlerts: panel.options.dashboardAlerts ?? panel.onlyAlertsOnDashboard,
-    alertName: panel.options.alertName ?? panel.nameFilter,
-    dashboardTitle: panel.options.dashboardTitle ?? panel.dashboardFilter,
+    showOptions: panel.options.showOptions ?? panel.show ?? ShowOption.Current,
+    maxItems: panel.options.maxItems ?? panel.limit ?? 10,
+    sortOrder: panel.options.sortOrder ?? panel.sortOrder ?? SortOrder.AlphaAsc,
+    dashboardAlerts: panel.options.dashboardAlerts ?? panel.onlyAlertsOnDashboard ?? false,
+    alertName: panel.options.alertName ?? panel.nameFilter ?? '',
+    dashboardTitle: panel.options.dashboardTitle ?? panel.dashboardFilter ?? '',
     folderId: panel.options.folderId ?? panel.folderId,
-    tags: panel.options.tags ?? panel.dashboardTags,
+    tags: panel.options.tags ?? panel.dashboardTags ?? [],
     stateFilter:
       panel.options.stateFilter ??
-      panel.stateFilter.reduce((filterObj: any, curFilter: any) => ({ ...filterObj, [curFilter]: true }), {}),
+      panel.stateFilter?.reduce((filterObj: any, curFilter: any) => ({ ...filterObj, [curFilter]: true }), {}) ??
+      {},
   };
 
   const previousVersion = parseFloat(panel.pluginVersion || '7.4');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Alert list panel migration errors out when trying to migrate panel from provisioned dashboard if it does not have either `panel.stateFilters` or `panel.options.stateFilters` defined:

```
AlertListMigrationHandler.ts:18 Uncaught (in promise) TypeError: Cannot read property 'reduce' of undefined
    at d.onPanelMigration (AlertListMigrationHandler.ts:18)
    at v.pluginLoaded (PanelModel.ts:370)
    at actions.ts:139
```

This PR adds defaults to the migration handler in case options do not exist in the panel config.

**Which issue(s) this PR fixes**:

Related to problem mentioned in this PR: https://github.com/grafana/hosted-grafana/pull/981

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

