### PR TITLE
Alerting: Allow space in label and annotation names

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -183,6 +183,36 @@ func TestPutAlert(t *testing.T) {
 				}
 			},
 		}, {
+			title: "Allow spaces in label and annotation name",
+			postableAlerts: apimodels.PostableAlerts{
+				PostableAlerts: []models.PostableAlert{
+					{
+						Annotations: models.LabelSet{"Dashboard URL": "http://localhost:3000"},
+						Alert: models.Alert{
+							Labels:       models.LabelSet{"alertname": "Alert4", "Spaced Label": "works"},
+							GeneratorURL: "http://localhost/url1",
+						},
+						StartsAt: strfmt.DateTime{},
+						EndsAt:   strfmt.DateTime{},
+					},
+				},
+			},
+			expAlerts: func(now time.Time) []*types.Alert {
+				return []*types.Alert{
+					{
+						Alert: model.Alert{
+							Annotations:  model.LabelSet{"Dashboard URL": "http://localhost:3000"},
+							Labels:       model.LabelSet{"alertname": "Alert4", "Spaced Label": "works"},
+							StartsAt:     now,
+							EndsAt:       now.Add(defaultResolveTimeout),
+							GeneratorURL: "http://localhost/url1",
+						},
+						UpdatedAt: now,
+						Timeout:   true,
+					},
+				}
+			},
+		}, {
 			title: "Invalid labels",
 			postableAlerts: apimodels.PostableAlerts{
 				PostableAlerts: []models.PostableAlert{


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements custom validation of alerts in the notifier to allow spaces in label and annotation names. 

**Which issue(s) this PR fixes**:

Fixes #36094

**Special notes for your reviewer**:

All validation is a copy paste from upstream Prometheus with `isValidLabelName` modified to support a space. Here are some references for the copy paste:

https://github.com/prometheus/common/blob/a1b6ede20323252d2b99a0f57178a4b7d364d0ca/model/alert.go#L84-L102

https://github.com/prometheus/common/blob/a1b6ede20323252d2b99a0f57178a4b7d364d0ca/model/labelset.go#L30-L42

https://github.com/prometheus/common/blob/a1b6ede20323252d2b99a0f57178a4b7d364d0ca/model/labels.go#L91-L113