### PR TITLE
CloudWatch/Logs: Reestablish Cloud Watch alert behavior

### DIFF
--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -157,7 +157,7 @@ func (s *Service) buildGraph(req *Request) (*simple.DirectedGraph, error) {
 		case dsName == DatasourceName || dsUID == DatasourceUID:
 			node, err = buildCMDNode(dp, rn)
 		default: // If it's not an expression query, it's a data source query.
-			node, err = s.buildDSNode(dp, rn, req.OrgId)
+			node, err = s.buildDSNode(dp, rn, req)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/expr/transform.go
+++ b/pkg/expr/transform.go
@@ -206,6 +206,7 @@ func (s *Service) queryData(ctx context.Context, req *backend.QueryDataRequest) 
 	tQ := plugins.DataQuery{
 		TimeRange: &timeRange,
 		Queries:   queries,
+		Headers:   req.Headers,
 	}
 
 	// Execute the converted queries

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -117,6 +117,10 @@ type AlertExecCtx struct {
 func GetExprRequest(ctx AlertExecCtx, data []models.AlertQuery, now time.Time) (*expr.Request, error) {
 	req := &expr.Request{
 		OrgId: ctx.OrgID,
+		Headers: map[string]string{
+			// Some data sources check this in query method as sometimes alerting needs special considerations.
+			"FromAlert": "true",
+		},
 	}
 
 	for i := range data {

--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -21,10 +21,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(ctx context.Context, model *
 	namespace := model.Get("namespace").MustString("")
 	metricName := model.Get("metricName").MustString("")
 	dimensions := model.Get("dimensions").MustMap()
-	statistics, err := parseStatistics(model)
-	if err != nil {
-		return nil, err
-	}
+	statistics := parseStatistics(model)
 	period := int64(model.Get("period").MustInt(0))
 	if period == 0 && !usePrefixMatch {
 		period = 300


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/36139

The issue stems from Cloud Watch running a bit different query when running from alerting. This was checked by a special header in request but this wasn't transferred to new alerting and so it took different codepath there.

This adds the header in new alerting engine and alters some code to propagate that header down to the data source method.

Ideally cloud watch may be changed not to need this special casing, but right now this seems quicker and also may be good for backward compatibility in case some other data sources also use this.