### PR TITLE
Alerting: Avoid a potential panic while initializing Alertmanager

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -153,6 +153,9 @@ func (srv AlertmanagerSrv) RouteGetAMAlerts(c *models.ReqContext) response.Respo
 		if errors.Is(err, notifier.ErrGetAlertsBadPayload) {
 			return ErrResp(http.StatusBadRequest, err, "")
 		}
+		if errors.Is(err, notifier.ErrGetAlertsUnavailable) {
+			return ErrResp(http.StatusServiceUnavailable, err, "")
+		}
 		// any other error here should be an unexpected failure and thus an internal error
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}

--- a/pkg/services/ngalert/notifier/alerts.go
+++ b/pkg/services/ngalert/notifier/alerts.go
@@ -27,6 +27,10 @@ func (am *Alertmanager) GetAlerts(active, silenced, inhibited bool, filter []str
 		res = apimodels.GettableAlerts{}
 	)
 
+	if !am.initialised {
+		return res, nil
+	}
+
 	matchers, err := parseFilter(filter)
 	if err != nil {
 		am.logger.Error("failed to parse matchers", "err", err)

--- a/pkg/services/ngalert/notifier/alerts.go
+++ b/pkg/services/ngalert/notifier/alerts.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	ErrGetAlertsInternal        = fmt.Errorf("unable to retrieve alerts(s) due to an internal error")
+	ErrGetAlertsUnavailable     = fmt.Errorf("unable to retrieve alerts(s) as alertmanager is not initialised yet")
 	ErrGetAlertsBadPayload      = fmt.Errorf("unable to retrieve alerts")
 	ErrGetAlertGroupsBadPayload = fmt.Errorf("unable to retrieve alerts groups")
 )
@@ -28,7 +29,7 @@ func (am *Alertmanager) GetAlerts(active, silenced, inhibited bool, filter []str
 	)
 
 	if !am.initialised {
-		return res, nil
+		return res, ErrGetAlertsUnavailable
 	}
 
 	matchers, err := parseFilter(filter)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a potential panic which was reported in #36099.

If anyone tries to view alerts in the UI (or via API) before Alertmanager is initialised, it can panic, because some objects are still `nil` until Alertmanager is initialised. 

The panic this intends to fix is accessing `am.route` [here](https://github.com/grafana/grafana/blob/94d2520a843f57c1e8d64cdd998364264a3b913b/pkg/services/ngalert/notifier/alerts.go#L54)