### PR TITLE
Database: Fix incorrect format of isolation level configuration parameter for MySQL

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -236,7 +236,7 @@ func (ss *SQLStore) buildConnectionString() (string, error) {
 		}
 
 		if isolation := ss.dbCfg.IsolationLevel; isolation != "" {
-			cnnstr += "&tx_isolation=" + isolation
+			cnnstr += "&tx_isolation=" + url.QueryEscape("'"+isolation+"'")
 		}
 
 		cnnstr += ss.buildExtraConnectionString('&')

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -236,7 +236,8 @@ func (ss *SQLStore) buildConnectionString() (string, error) {
 		}
 
 		if isolation := ss.dbCfg.IsolationLevel; isolation != "" {
-			cnnstr += "&tx_isolation=" + url.QueryEscape("'"+isolation+"'")
+			val := url.QueryEscape(fmt.Sprintf("'%s'", isolation))
+			cnnstr += fmt.Sprintf("&tx_isolation=%s", val)
 		}
 
 		cnnstr += ss.buildExtraConnectionString('&')


### PR DESCRIPTION
**What this PR does / why we need it**:
Should resolve the error `CRIT[06-18|08:38:32] alert migration failure: could not get migration log logger=migrator error="failed to check table existence: Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'READ-COMMITTED' at line 1"`

Using the following configuration:
```ini
[database]                                                                                                                                                                                                                                   
type = mysql                                                                                                                                                                                                                                
host = mysql:3306                                                                                                                                  
name = grafana                                                                                                                                               
user = grafana                                                                                                                                               
password = password  
isolation_level = "READ-COMMITTED"

[feature_toggles]
enable = database_metrics
```

**Which issue(s) this PR fixes**:
Ref #31371 
Ref #33830

**Special notes for your reviewer**:
- URL encoding of system variables explained here https://github.com/go-sql-driver/mysql#system-variables
- Tested with MySQL 5.6 and 5.7
