### PR TITLE
InfluxDB: Correct tag filtering on InfluxDB data

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Editor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Editor.tsx
@@ -130,7 +130,7 @@ export const Editor = (props: Props): JSX.Element => {
           onChange={handleTagsSectionChange}
           getTagKeyOptions={getTagKeys}
           getTagValueOptions={(key: string) =>
-            withTemplateVariableOptions(getTagValues(key, measurement, policy, datasource))
+            withTemplateVariableOptions(getTagValues(key, measurement, policy, query.tags ?? [], datasource))
           }
         />
       </SectionWrap>

--- a/public/app/plugins/datasource/influxdb/influxQLMetadataQuery.ts
+++ b/public/app/plugins/datasource/influxdb/influxQLMetadataQuery.ts
@@ -45,9 +45,10 @@ export async function getTagValues(
   tagKey: string,
   measurement: string | undefined,
   policy: string | undefined,
+  tags: InfluxQueryTag[],
   datasource: InfluxDatasource
 ): Promise<string[]> {
-  const target = { tags: [], measurement, policy };
+  const target = { tags, measurement, policy };
   const data = await runExploreQuery('TAG_VALUES', tagKey, undefined, target, datasource);
   return data.map((item) => item.text);
 }


### PR DESCRIPTION
short version:
filter possible tag-values based on previously chosen tag-values

long version:
imagine that in your data you have these 4 measurements (i only write the tags, the numerical values are not important)
- `{tag1:val1,tag2:val1A}`
- `{tag1:val1,tag2:val1B}`
- `{tag1:val2,tag2:val2A}`
- `{tag1:val2,tag2:val2B}` 

now, you are using the influxdb influxql query editor, and you made a WHERE section like this:
`tag1=val1 AND tag2=<select tag value>` (tag2-value is not chosen yet)

currently, when you open the `<select tag value>` select-box, you get 4 options (`val1A`, `val1B`, `val2A`, `val2B`).
what this PR does, we limit the list of options based on other, already chosen tag-filters. we already chose `tag1=val1`, so we know the only possible tag2-values are `val1A` and `val1B`, so we only show those 2.

(this is how it worked in grafana 7.x, but when it got converted to react in grafana8 this regression happened)

how to test:
we need to create some good test-data so we need to manually insert some measurements into influxdb:
- `make devenv sources=influxdb`
- on the console, use this command
  - `docker exec -it influxdb influx write -b mybucket -o myorg -t mytoken 'test,tag1=val1,tag2=val1A num=42'`
    -  (explanation: we are inserting a measurement with tags tag1 and tag2, and value `num=42` (the value is not important for us))
  - do it 3 more times, but with these values:
    - `'test,tag1=val1,tag2=val1B num=42'`
    - `'test,tag1=val2,tag2=val2A num=42'`
    - `'test,tag1=val2,tag2=val2B num=42'`
- this creates the data as it was described in the example above
- now go to explore-mode in grafana, choose the `gdev-influxdb-influxql` data source
- add a tag to the WHERE section, choose `tag1`, for the value choose `val1`
- add another part to the WHERE section, choose `tag2`, now open the value-selector, it should only show `val1A` and `val1B`

fixes https://github.com/grafana/grafana/issues/36436