### PR TITLE
DashboardList: Fix issue not re-fetching dashboard list after variable change

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -250,9 +250,10 @@ export class PanelChrome extends Component<Props, State> {
       panel.runAllPanelQueries(this.props.dashboard.id, this.props.dashboard.getTimezone(), timeData, width);
     } else {
       // The panel should render on refresh as well if it doesn't have a query, like clock panel
-      this.setState((prevState) => ({
-        data: { ...prevState.data, timeRange: this.timeSrv.timeRange() },
-      }));
+      this.setState({
+        data: { ...this.state.data, timeRange: this.timeSrv.timeRange() },
+        renderCounter: this.state.renderCounter + 1,
+      });
     }
   };
 


### PR DESCRIPTION
Fixes #18113

renderCounter used in memo dependency list:
https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/dashlist/DashList.tsx#L85