### PR TITLE
Prometheus: Azure authentication in datasource HTTP transport

### DIFF
--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
@@ -161,6 +161,10 @@ func (c *clientSecretTokenRetriever) GetCacheKey() string {
 }
 
 func (c *clientSecretTokenRetriever) Init() error {
+	if c.authority == "" {
+		err := fmt.Errorf("authority for Azure authentication not configured (unknown Azure cloud or invalid custom authority)")
+		return err
+	}
 	options := &azidentity.ClientSecretCredentialOptions{AuthorityHost: c.authority}
 	if credential, err := azidentity.NewClientSecretCredential(c.tenantId, c.clientId, c.clientSecret, options); err != nil {
 		return err

--- a/pkg/tsdb/prometheus/azure.go
+++ b/pkg/tsdb/prometheus/azure.go
@@ -1,0 +1,139 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azcredentials"
+)
+
+func isAzureAuthenticationEnabled(jsonData *simplejson.Json) bool {
+	return jsonData.Get("azureAuth").MustBool()
+}
+
+func getAzureAuthType(cfg *setting.Cfg, jsonData *simplejson.Json) string {
+	if azureAuthType := jsonData.Get("azureAuthType").MustString(); azureAuthType != "" {
+		return azureAuthType
+	} else {
+		// For datasource with no configuration, managed identity is the default authentication type
+		// if it's enabled in Grafana config
+		if cfg.Azure.ManagedIdentityEnabled {
+			return azcredentials.AzureAuthManagedIdentity
+		} else {
+			return azcredentials.AzureAuthClientSecret
+		}
+	}
+}
+
+func getDefaultAzureCloud(cfg *setting.Cfg) string {
+	cloudName := cfg.Azure.Cloud
+	if cloudName == "" {
+		return setting.AzurePublic
+	}
+	return cloudName
+}
+
+func getAzureCloud(cfg *setting.Cfg, jsonData *simplejson.Json) (string, error) {
+	authType := getAzureAuthType(cfg, jsonData)
+	switch authType {
+	case azcredentials.AzureAuthManagedIdentity:
+		// In case of managed identity, the cloud is always same as where Grafana is hosted
+		return getDefaultAzureCloud(cfg), nil
+	case azcredentials.AzureAuthClientSecret:
+		if cloud := jsonData.Get("azureCloud").MustString(); cloud != "" {
+			return cloud, nil
+		} else {
+			return getDefaultAzureCloud(cfg), nil
+		}
+	default:
+		err := fmt.Errorf("the authentication type '%s' not supported", authType)
+		return "", err
+	}
+}
+
+func getAzureCloudFromCredentials(cfg *setting.Cfg, credentials azcredentials.AzureCredentials) (string, error) {
+	switch c := credentials.(type) {
+	case *azcredentials.AzureManagedIdentityCredentials:
+		// In case of managed identity, the cloud is always same as where Grafana is hosted
+		return getDefaultAzureCloud(cfg), nil
+	case *azcredentials.AzureClientSecretCredentials:
+		return c.AzureCloud, nil
+	default:
+		err := fmt.Errorf("credentials of type '%s' not supported", c.AzureAuthType())
+		return "", err
+	}
+}
+
+func getAzureCredentials(cfg *setting.Cfg, jsonData *simplejson.Json, secureJsonData map[string]string) (azcredentials.AzureCredentials, error) {
+	if !isAzureAuthenticationEnabled(jsonData) {
+		return nil, nil
+	}
+
+	authType := getAzureAuthType(cfg, jsonData)
+
+	switch authType {
+	case azcredentials.AzureAuthManagedIdentity:
+		credentials := &azcredentials.AzureManagedIdentityCredentials{}
+		return credentials, nil
+
+	case azcredentials.AzureAuthClientSecret:
+		cloud, err := getAzureCloud(cfg, jsonData)
+		if err != nil {
+			return nil, err
+		}
+		credentials := &azcredentials.AzureClientSecretCredentials{
+			AzureCloud:   cloud,
+			TenantId:     jsonData.Get("azureTenantId").MustString(),
+			ClientId:     jsonData.Get("azureClientId").MustString(),
+			ClientSecret: secureJsonData["azureClientSecret"],
+		}
+		return credentials, nil
+
+	default:
+		err := fmt.Errorf("the authentication type '%s' not supported", authType)
+		return nil, err
+	}
+}
+
+type azureEndpointInfo struct {
+	cloud      string
+	resourceId string
+}
+
+var (
+	azureEndpoints = map[string]azureEndpointInfo{
+		"https://prometheus.azure.net":         {cloud: setting.AzurePublic, resourceId: "https://prometheus.azure.net/.default"},
+		"https://prometheus.chinacloudapi.cn":  {cloud: setting.AzureChina, resourceId: "https://prometheus.chinacloudapi.cn/.default"},
+		"https://prometheus.usgovcloudapi.net": {cloud: setting.AzureUSGovernment, resourceId: "https://prometheus.usgovcloudapi.net/.default"},
+		"https://prometheus.cloudapi.de":       {cloud: setting.AzureGermany, resourceId: "https://prometheus.cloudapi.de/.default"},
+	}
+)
+
+func getAzureEndpointScopes(cfg *setting.Cfg, credentials azcredentials.AzureCredentials, datasourceUrl string) ([]string, error) {
+	parsedUrl, err := url.Parse(datasourceUrl)
+	if err != nil {
+		err := fmt.Errorf("invalid endpoint URL '%s'", datasourceUrl)
+		return nil, err
+	}
+
+	endpointHost := strings.ToLower(fmt.Sprintf("%s://%s", parsedUrl.Scheme, parsedUrl.Host))
+	if endpoint, ok := azureEndpoints[endpointHost]; !ok {
+		err := fmt.Errorf("given endpoint '%s' is not known Azure endpoint, cannot use Azure authentication", datasourceUrl)
+		return nil, err
+	} else {
+		cloud, err := getAzureCloudFromCredentials(cfg, credentials)
+		if err != nil {
+			return nil, err
+		}
+
+		if endpoint.cloud != cloud {
+			err := fmt.Errorf("given Azure endpoint '%s' doesn't match the cloud of Azure credentials '%s'", datasourceUrl, cloud)
+			return nil, err
+		}
+
+		return []string{endpoint.resourceId}, nil
+	}
+}

--- a/pkg/tsdb/prometheus/httpclient.go
+++ b/pkg/tsdb/prometheus/httpclient.go
@@ -1,0 +1,44 @@
+package prometheus
+
+import (
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/aztokenprovider"
+	"github.com/prometheus/client_golang/api"
+)
+
+func newAPIClient(provider httpclient.Provider, dsInfo *models.DataSource, cfg *setting.Cfg) (api.Client, error) {
+	var middlewares []sdkhttpclient.Middleware
+
+	// Azure authentication
+	if azureCredentials, err := getAzureCredentials(cfg, dsInfo.JsonData, dsInfo.DecryptedValues()); err != nil {
+		return nil, err
+	} else if azureCredentials != nil {
+		tokenProvider, err := aztokenprovider.NewAzureAccessTokenProvider(cfg, azureCredentials)
+		if err != nil {
+			return nil, err
+		}
+		scopes, err := getAzureEndpointScopes(cfg, azureCredentials, dsInfo.Url)
+		if err != nil {
+			return nil, err
+		}
+
+		middlewares = append(middlewares, aztokenprovider.AuthMiddleware(tokenProvider, scopes))
+	}
+
+	middlewares = append(middlewares, customQueryParametersMiddleware(plog))
+
+	transport, err := dsInfo.GetHTTPTransport(provider, middlewares...)
+	if err != nil {
+		return nil, err
+	}
+
+	apiConfig := api.Config{
+		Address:      dsInfo.Url,
+		RoundTripper: transport,
+	}
+
+	return api.NewClient(apiConfig)
+}

--- a/pkg/tsdb/prometheus/httpclient.go
+++ b/pkg/tsdb/prometheus/httpclient.go
@@ -20,7 +20,7 @@ func newAPIClient(provider httpclient.Provider, dsInfo *models.DataSource, cfg *
 		if err != nil {
 			return nil, err
 		}
-		scopes, err := getAzureEndpointScopes(cfg, azureCredentials, dsInfo.Url)
+		scopes, err := getAzureEndpointScopes(dsInfo.JsonData)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/setting"
 	p "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrometheus(t *testing.T) {
+	cfg := setting.NewCfg()
+
 	json, _ := simplejson.NewJson([]byte(`
 		{ "customQueryParameters": "custom=par/am&second=f oo"}
 	`))
@@ -32,7 +35,7 @@ func TestPrometheus(t *testing.T) {
 	provider := httpclient.NewProvider(sdkhttpclient.ProviderOptions{
 		Middlewares: []sdkhttpclient.Middleware{mw},
 	})
-	plug, err := New(provider)(dsInfo)
+	plug, err := New(provider, cfg)(dsInfo)
 	require.NoError(t, err)
 	executor := plug.(*PrometheusExecutor)
 

--- a/pkg/tsdb/service.go
+++ b/pkg/tsdb/service.go
@@ -56,7 +56,7 @@ type Service struct {
 
 // Init initialises the service.
 func (s *Service) Init() error {
-	s.registry["prometheus"] = prometheus.New(s.HTTPClientProvider)
+	s.registry["prometheus"] = prometheus.New(s.HTTPClientProvider, s.Cfg)
 	s.registry["influxdb"] = influxdb.New(s.HTTPClientProvider)
 	s.registry["mssql"] = mssql.NewExecutor
 	s.registry["postgres"] = s.PostgresService.NewExecutor


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for Azure authentication to Prometheus backend HTTP transport using AzureTokenProvider and authentication middleware. Currently it's used for alerts only.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

if Azure authentication not enabled for the datasource (which can be enabled only via configuration UI), then Azure middleware not injected into the HTTP transport, therefore it should not have any impact on the transport. It was intentionally made to avoid possible regressions.

While this code used only for alerts now (queries use plugin proxy routes instead), I expect it to become the only Azure auth implementation in future, once the Prometheus datasource migrates to Plugin SDK and gets rid of routes. It was structured similar to implementation in Azure Monitor datasource.

All Azure specific code placed in `azure.go`, API client initialization was moved out to a separated file `httpclient.go` to not clutter the `prometheus.go` with initialization code (similar to Azure Monitor).

The code references `azcredentials` and `aztokenprovider` from Azure Monitor, but the idea is to move them out to a separated repo in near future. This PR was a good test for reusability of Azure credentials and AzureTokenProvider. As result of it, it looks like some logic like getAzureCloud can be moved to the shared library, but not in this PR.

Authentication of queries via the plugin proxy routes were intentionally left in a separated PR (#36539) because they do not intersect and to make the review easier.