### PR TITLE
PanelOptions: POC of dynamically provided panel options

### DIFF
--- a/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
+++ b/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
@@ -3,6 +3,7 @@ import { ComponentType } from 'react';
 import { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 import { DataFrame, InterpolateFunction, VariableSuggestionsScope, VariableSuggestion } from '../types';
 import { EventBus } from '../events';
+import { PanelOptionsEditorBuilder } from '../utils';
 
 export interface StandardEditorContext<TOptions> {
   data: DataFrame[]; // All results
@@ -11,6 +12,7 @@ export interface StandardEditorContext<TOptions> {
   getSuggestions?: (scope?: VariableSuggestionsScope) => VariableSuggestion[];
   options?: TOptions;
   isOverride?: boolean;
+  builder?: PanelOptionsEditorBuilder<TOptions>;
 }
 
 export interface StandardEditorProps<TValue = any, TSettings = any, TOptions = any> {

--- a/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
+++ b/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
@@ -3,7 +3,6 @@ import { ComponentType } from 'react';
 import { FieldConfigOptionsRegistry } from './FieldConfigOptionsRegistry';
 import { DataFrame, InterpolateFunction, VariableSuggestionsScope, VariableSuggestion } from '../types';
 import { EventBus } from '../events';
-import { PanelOptionsEditorBuilder } from '../utils';
 
 export interface StandardEditorContext<TOptions> {
   data: DataFrame[]; // All results
@@ -12,14 +11,13 @@ export interface StandardEditorContext<TOptions> {
   getSuggestions?: (scope?: VariableSuggestionsScope) => VariableSuggestion[];
   options?: TOptions;
   isOverride?: boolean;
-  builder?: PanelOptionsEditorBuilder<TOptions>;
 }
 
-export interface StandardEditorProps<TValue = any, TSettings = any, TOptions = any> {
+export interface StandardEditorProps<TValue = any, TSettings = any, TOptions = any, TBuilder = any> {
   value: TValue;
   onChange: (value?: TValue) => void;
   item: StandardEditorsRegistryItem<TValue, TSettings>;
-  context: StandardEditorContext<TOptions>;
+  context: StandardEditorContext<TOptions> & { builder: TBuilder; path: string };
 }
 export interface StandardEditorsRegistryItem<TValue = any, TSettings = any> extends RegistryItem {
   editor: ComponentType<StandardEditorProps<TValue, TSettings>>;

--- a/packages/grafana-data/src/geo/layer.ts
+++ b/packages/grafana-data/src/geo/layer.ts
@@ -5,6 +5,7 @@ import { PanelData } from '../types';
 import { GrafanaTheme2 } from '../themes';
 import { PanelOptionsEditorBuilder } from '../utils';
 import { ReactNode } from 'react';
+import { GeomapPanelOptions } from '../../../../public/app/plugins/panel/geomap/types';
 
 /**
  * This gets saved in panel json
@@ -43,7 +44,7 @@ export interface MapLayerHandler {
  *
  * @alpha
  */
-export interface MapLayerRegistryItem<TConfig = MapLayerConfig> extends RegistryItemWithOptions {
+export interface MapLayerRegistryItem<TConfig = any> extends RegistryItemWithOptions {
   /**
    * This layer can be used as a background
    */
@@ -63,5 +64,5 @@ export interface MapLayerRegistryItem<TConfig = MapLayerConfig> extends Registry
   /**
    * Show custom elements in the panel edit UI
    */
-  registerOptionsUI?: (builder: PanelOptionsEditorBuilder<TConfig>) => void;
+  registerOptionsUI?: (builder: PanelOptionsEditorBuilder<GeomapPanelOptions<TConfig>>, path: string) => void;
 }

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -179,11 +179,8 @@ export class PanelPlugin<
   }
 
   get optionEditors(): PanelOptionEditorsRegistry {
-    console.log(this.optionsBuilder?.getRegistry().list().length, this._optionEditors?.list().length);
     if (!this._optionEditors) {
-      const builder = new PanelOptionsEditorBuilder<TOptions>(() => {
-        this._optionEditors = undefined;
-      });
+      const builder = new PanelOptionsEditorBuilder<TOptions>();
 
       this._optionEditors = builder.getRegistry();
 
@@ -195,9 +192,6 @@ export class PanelPlugin<
 
     if (this._optionsBuilder?.getRegistry().list().length !== this._optionEditors.list().length) {
       this._optionEditors = this._optionsBuilder!.getRegistry();
-      // if (this.registerOptionEditors) {
-      //   this.registerOptionEditors(this._optionsBuilder!);
-      // }
     }
 
     return this._optionEditors;

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -100,6 +100,7 @@ export class PanelPlugin<
   };
 
   private _optionEditors?: PanelOptionEditorsRegistry;
+  private _optionsBuilder?: PanelOptionsEditorBuilder<TOptions>;
   private registerOptionEditors?: (builder: PanelOptionsEditorBuilder<TOptions>) => void;
 
   panel: ComponentType<PanelProps<TOptions>> | null;
@@ -178,16 +179,32 @@ export class PanelPlugin<
   }
 
   get optionEditors(): PanelOptionEditorsRegistry {
+    console.log(this.optionsBuilder?.getRegistry().list().length, this._optionEditors?.list().length);
     if (!this._optionEditors) {
-      const builder = new PanelOptionsEditorBuilder<TOptions>();
+      const builder = new PanelOptionsEditorBuilder<TOptions>(() => {
+        this._optionEditors = undefined;
+      });
+
       this._optionEditors = builder.getRegistry();
 
       if (this.registerOptionEditors) {
         this.registerOptionEditors(builder);
       }
+      this._optionsBuilder = builder;
+    }
+
+    if (this._optionsBuilder?.getRegistry().list().length !== this._optionEditors.list().length) {
+      this._optionEditors = this._optionsBuilder!.getRegistry();
+      // if (this.registerOptionEditors) {
+      //   this.registerOptionEditors(this._optionsBuilder!);
+      // }
     }
 
     return this._optionEditors;
+  }
+
+  get optionsBuilder(): PanelOptionsEditorBuilder<TOptions> | undefined {
+    return this._optionsBuilder;
   }
 
   /**

--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -81,26 +81,42 @@ export abstract class OptionsUIRegistryBuilder<
   TEditorProps,
   T extends OptionsEditorItem<TOptions, any, TEditorProps, any>
 > implements OptionsUIRegistryBuilderAPI<TOptions, TEditorProps, T> {
-  private properties: T[] = [];
+  private properties: Map<string, T> = new Map();
+  private changeHandler?: () => void;
 
-  constructor() {}
   addCustomEditor<TSettings, TValue>(config: T & OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>): this {
-    this.properties.push(config);
-    // if (this.onInvalidate) {
-    //   console.log('invalidate')
-    //   this.onInvalidate();
-    // }
+    if (this.properties.has(config.id)) {
+      return this;
+    }
+
+    this.properties.set(config.id, config);
+    // this.properties.push(config);
+    this.onRegistryChange();
     return this;
   }
 
   remove(id: string): this {
-    this.properties = this.properties.filter((p) => p.id !== id);
+    this.properties.delete(id);
+    // this.properties = this.properties.filter((p) => p.id !== id);
+    this.onRegistryChange();
+
     return this;
+  }
+
+  setRegistryChangeHandler(cb: () => void) {
+    this.changeHandler = cb;
+    return this;
+  }
+
+  onRegistryChange() {
+    if (this.changeHandler) {
+      this.changeHandler();
+    }
   }
 
   getRegistry() {
     return new Registry(() => {
-      return this.properties;
+      return Array.from(this.properties.values());
     });
   }
 }

--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -69,6 +69,7 @@ export interface OptionsUIRegistryBuilderAPI<
    */
   addCustomEditor<TSettings, TValue>(config: OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>): this;
 
+  remove(id: string): this;
   /**
    * Returns registry of option editors
    */
@@ -82,8 +83,18 @@ export abstract class OptionsUIRegistryBuilder<
 > implements OptionsUIRegistryBuilderAPI<TOptions, TEditorProps, T> {
   private properties: T[] = [];
 
+  constructor() {}
   addCustomEditor<TSettings, TValue>(config: T & OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>): this {
     this.properties.push(config);
+    // if (this.onInvalidate) {
+    //   console.log('invalidate')
+    //   this.onInvalidate();
+    // }
+    return this;
+  }
+
+  remove(id: string): this {
+    this.properties = this.properties.filter((p) => p.id !== id);
     return this;
   }
 

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -62,14 +62,15 @@ export interface FieldOverrideContext extends StandardEditorContext<any> {
   dataFrameIndex?: number; // The index for the selected field frame
 }
 export interface FieldConfigEditorProps<TValue, TSettings>
-  extends Omit<StandardEditorProps<TValue, TSettings>, 'item'> {
+  extends Omit<StandardEditorProps<TValue, TSettings>, 'item' | 'context'> {
   item: FieldConfigPropertyItem<any, TValue, TSettings>; // The property info
   value: TValue;
   context: FieldOverrideContext;
   onChange: (value?: TValue) => void;
 }
 
-export interface FieldOverrideEditorProps<TValue, TSettings> extends Omit<StandardEditorProps<TValue>, 'item'> {
+export interface FieldOverrideEditorProps<TValue, TSettings>
+  extends Omit<StandardEditorProps<TValue>, 'item' | 'context'> {
   item: FieldConfigPropertyItem<TValue, TSettings>;
   context: FieldOverrideContext;
 }

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -133,7 +133,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
  */
 export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilder<
   TOptions,
-  StandardEditorProps,
+  StandardEditorProps<any, any, any, PanelOptionsEditorBuilder<TOptions>>,
   PanelOptionsEditorItem<TOptions>
 > {
   addNumberInput<TSettings>(config: PanelOptionsEditorConfig<TOptions, TSettings & NumberFieldConfigSettings, number>) {

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -24,7 +24,7 @@ export const Slider: FunctionComponent<SliderProps> = ({
   const theme = useTheme2();
   const styles = getStyles(theme, isHorizontal);
   const SliderWithTooltip = SliderComponent;
-  const [sliderValue, setSliderValue] = useState<number>(value || min);
+  const [sliderValue, setSliderValue] = useState<number>(value === undefined ? min : value);
 
   const onSliderChange = useCallback(
     (v: number) => {

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -29,10 +29,14 @@ export const OptionsPaneOptions: React.FC<Props> = (props) => {
   const styles = useStyles2(getStyles);
 
   const [panelFrameOptions, vizOptions, justOverrides] = useMemo(
-    () => [getPanelFrameCategory(props), getVizualizationOptions(props), getFieldOverrideCategories(props)],
+    () => [
+      getPanelFrameCategory(props),
+      getVizualizationOptions(props, props.plugin.optionEditors),
+      getFieldOverrideCategories(props),
+    ],
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [panel.configRev, props.data]
+    [panel.configRev, props.data, props.plugin.optionEditors]
   );
 
   const mainBoxElements: React.ReactNode[] = [];

--- a/public/app/features/dashboard/components/PanelEditor/getVizualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVizualizationOptions.tsx
@@ -23,6 +23,7 @@ export function getVizualizationOptions(props: OptionPaneRenderProps): OptionsPa
     getSuggestions: (scope?: VariableSuggestionsScope) => {
       return data ? getDataLinksVariableSuggestions(data.series, scope) : [];
     },
+    builder: plugin.optionsBuilder,
   };
 
   const getOptionsPaneCategory = (categoryNames?: string[]): OptionsPaneCategoryDescriptor => {

--- a/public/app/plugins/panel/dashlist/module.tsx
+++ b/public/app/plugins/panel/dashlist/module.tsx
@@ -1,4 +1,4 @@
-import { PanelModel, PanelPlugin } from '@grafana/data';
+import { PanelModel, PanelOptionsEditorProps, PanelPlugin } from '@grafana/data';
 import { DashList } from './DashList';
 import { DashListOptions } from './types';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
@@ -61,7 +61,7 @@ export const plugin = new PanelPlugin<DashListOptions>(DashList)
         name: 'Tags',
         description: '',
         defaultValue: [],
-        editor(props) {
+        editor(props: PanelOptionsEditorProps<string[]>) {
           return <TagsInput tags={props.value} onChange={props.onChange} />;
         },
       });

--- a/public/app/plugins/panel/geomap/editor/BaseLayerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/BaseLayerEditor.tsx
@@ -7,6 +7,16 @@ export const BaseLayerEditor: FC<StandardEditorProps<MapLayerConfig, any, Geomap
   value,
   onChange,
   context,
+  item,
 }) => {
-  return <LayerEditor config={value} data={context.data} onChange={onChange} filter={(v) => Boolean(v.isBaseMap)} />;
+  return (
+    <LayerEditor
+      context={context}
+      item={item}
+      config={value}
+      data={context.data}
+      onChange={onChange}
+      filter={(v) => Boolean(v.isBaseMap)}
+    />
+  );
 };

--- a/public/app/plugins/panel/geomap/editor/DataLayersEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/DataLayersEditor.tsx
@@ -8,10 +8,13 @@ export const DataLayersEditor: FC<StandardEditorProps<MapLayerConfig[], any, Geo
   value,
   onChange,
   context,
+  item,
 }) => {
   return (
     <LayerEditor
       config={value?.length ? value[0] : undefined}
+      context={context}
+      item={item}
       data={context.data}
       onChange={(cfg) => {
         console.log('Change overlays:', cfg);

--- a/public/app/plugins/panel/geomap/editor/LayerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/LayerEditor.tsx
@@ -1,26 +1,27 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 import { Select } from '@grafana/ui';
 import {
   MapLayerConfig,
   DataFrame,
   MapLayerRegistryItem,
-  PanelOptionsEditorBuilder,
   StandardEditorContext,
+  StandardEditorsRegistryItem,
+  PanelOptionsEditorBuilder,
 } from '@grafana/data';
 import { geomapLayerRegistry } from '../layers/registry';
 import { defaultGrafanaThemedMap } from '../layers/basemaps';
-import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
-import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
-import { fillOptionsPaneItems } from 'app/features/dashboard/components/PanelEditor/getVizualizationOptions';
 
 export interface LayerEditorProps<TConfig = any> {
   config?: MapLayerConfig<TConfig>;
   data: DataFrame[]; // All results
+  // TODO: figure out way to get builder and path into StandardEditorContext
+  context: StandardEditorContext<any> & { builder: PanelOptionsEditorBuilder<any>; path: string };
+  item: StandardEditorsRegistryItem;
   onChange: (config: MapLayerConfig<TConfig>) => void;
   filter: (item: MapLayerRegistryItem) => boolean;
 }
 
-export const LayerEditor: FC<LayerEditorProps> = ({ config, onChange, data, filter }) => {
+export const LayerEditor: FC<LayerEditorProps> = ({ config, onChange, data, filter, item, context }) => {
   // all basemaps
   const layerTypes = useMemo(() => {
     return geomapLayerRegistry.selectOptions(
@@ -31,81 +32,30 @@ export const LayerEditor: FC<LayerEditorProps> = ({ config, onChange, data, filt
     );
   }, [config?.type, filter]);
 
-  // The options change with each layer type
-  const optionsEditorBuilder = useMemo(() => {
+  // The options change with each layer type and are dynamically registered
+  useEffect(() => {
     const layer = geomapLayerRegistry.getIfExists(config?.type);
     if (!layer || !layer.registerOptionsUI) {
-      return null;
+      return;
     }
-    const builder = new PanelOptionsEditorBuilder();
-    layer.registerOptionsUI(builder);
-    return builder;
-  }, [config?.type]);
-
-  // The react componnets
-  const layerOptions = useMemo(() => {
-    const layer = geomapLayerRegistry.getIfExists(config?.type);
-    if (!optionsEditorBuilder || !layer) {
-      return null;
-    }
-
-    const category = new OptionsPaneCategoryDescriptor({
-      id: 'Layer config',
-      title: 'Layer config',
-    });
-
-    const context: StandardEditorContext<any> = {
-      data,
-      options: config?.config,
-    };
-
-    const currentConfig = { ...layer.defaultOptions, ...config?.config };
-    const reg = optionsEditorBuilder.getRegistry();
-
-    // Load the options into categories
-    fillOptionsPaneItems(
-      reg.list(),
-
-      // Always use the same category
-      (categoryNames) => category,
-
-      // Custom upate function
-      (path: string, value: any) => {
-        onChange({
-          ...config,
-          config: setOptionImmutably(currentConfig, path, value),
-        } as MapLayerConfig);
-      },
-      context
-    );
-
-    return (
-      <>
-        <br />
-        {category.items.map((item) => item.render())}
-      </>
-    );
-  }, [optionsEditorBuilder, onChange, data, config]);
+    layer.registerOptionsUI(context.builder!, context.path);
+  }, [config?.type, item, context.builder, context.path]);
 
   return (
-    <div>
-      <Select
-        options={layerTypes.options}
-        value={layerTypes.current}
-        onChange={(v) => {
-          const layer = geomapLayerRegistry.getIfExists(v.value);
-          if (!layer) {
-            console.warn('layer does not exist', v);
-            return;
-          }
-          onChange({
-            type: layer.id,
-            config: layer.defaultOptions, // clone?
-          });
-        }}
-      />
-
-      {layerOptions}
-    </div>
+    <Select
+      options={layerTypes.options}
+      value={layerTypes.current}
+      onChange={(v) => {
+        const layer = geomapLayerRegistry.getIfExists(v.value);
+        if (!layer) {
+          console.warn('layer does not exist', v);
+          return;
+        }
+        onChange({
+          type: layer.id,
+          config: layer.defaultOptions, // clone?
+        });
+      }}
+    />
   );
 };

--- a/public/app/plugins/panel/geomap/editor/MapCenterEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/MapCenterEditor.tsx
@@ -1,17 +1,14 @@
 import React, { FC, useEffect, useMemo } from 'react';
-import { GrafanaTheme, StandardEditorProps } from '@grafana/data';
-import { Select, stylesFactory, useStyles } from '@grafana/ui';
+import { StandardEditorProps } from '@grafana/data';
+import { Select } from '@grafana/ui';
 import { GeomapPanelOptions, MapCenterConfig } from '../types';
 import { centerPointRegistry, MapCenterID } from '../view';
-import { css } from '@emotion/css';
 
 export const MapCenterEditor: FC<StandardEditorProps<MapCenterConfig, any, GeomapPanelOptions>> = ({
   value,
   onChange,
   context,
 }) => {
-  const style = useStyles(getStyles);
-
   const views = useMemo(() => {
     const ids: string[] = [];
     if (value?.id) {
@@ -23,86 +20,55 @@ export const MapCenterEditor: FC<StandardEditorProps<MapCenterConfig, any, Geoma
   }, [value?.id]);
 
   useEffect(() => {
-    if (!context.builder || !value) {
+    if (!context.builder) {
       return;
     }
-    if (value.id === MapCenterID.Coordinates) {
-      context.builder.addNumberInput({
-        path: 'view.center.lat',
-        category: ['Map View'],
-        name: 'Latitude',
-        showIf: (o) => o.view.center.id === MapCenterID.Coordinates,
-      });
+
+    const category = ['Map View'];
+    // let optionsToRemove: string[] = [];
+
+    if (views.current[0].value === MapCenterID.Coordinates) {
+      context.builder
+        .addSliderInput({
+          path: 'view.center.lat',
+          name: 'Latitude',
+          category,
+          settings: {
+            min: -90,
+            max: 90,
+          },
+        })
+        .addSliderInput({
+          path: 'view.center.lon',
+          name: 'longitude',
+          category,
+          settings: {
+            min: -180,
+            max: 180,
+          },
+        });
+      // optionsToRemove = ['view.center.lat', 'view.center.lon'];
     }
-  });
+
+    // return () => {
+    //   if (context.builder && optionsToRemove.length > 0) {
+    //     for (let i = 0; i < optionsToRemove.length; i++) {
+    //       console.log('remove', optionsToRemove[i]);
+    //       context.builder.remove(optionsToRemove[i]);
+    //     }
+    //   }
+    // };
+  }, [views, context.builder]);
 
   return (
-    <div>
-      <Select
-        options={views.options}
-        value={views.current}
-        onChange={(v) => {
-          if (v.value === MapCenterID.Coordinates) {
-            context.builder?.addNumberInput({
-              path: 'view.center.lat',
-              category: ['Map View'],
-              name: 'Latitude',
-              showIf: (o) => o.view.center.id === MapCenterID.Coordinates,
-            });
-          } else {
-            context.builder?.remove('view.center.lat');
-          }
-          onChange({
-            id: v.value!,
-          });
-        }}
-      />
-      {/*{value?.id === MapCenterID.Coordinates && (*/}
-      {/*  <div>*/}
-      {/*    <table className={style.table}>*/}
-      {/*      <tbody>*/}
-      {/*        <tr>*/}
-      {/*          <th className={style.half}>Latitude</th>*/}
-      {/*          <th className={style.half}>Longitude</th>*/}
-      {/*        </tr>*/}
-      {/*        <tr>*/}
-      {/*          <td>*/}
-      {/*            <NumberInput*/}
-      {/*              value={value.lat}*/}
-      {/*              min={-90}*/}
-      {/*              max={90}*/}
-      {/*              placeholder="0"*/}
-      {/*              onChange={(v) => {*/}
-      {/*                onChange({ ...value, lat: v });*/}
-      {/*              }}*/}
-      {/*            />*/}
-      {/*          </td>*/}
-      {/*          <td>*/}
-      {/*            <NumberInput*/}
-      {/*              value={value.lon}*/}
-      {/*              min={-180}*/}
-      {/*              max={180}*/}
-      {/*              placeholder="0"*/}
-      {/*              onChange={(v) => {*/}
-      {/*                onChange({ ...value, lon: v });*/}
-      {/*              }}*/}
-      {/*            />*/}
-      {/*          </td>*/}
-      {/*        </tr>*/}
-      {/*      </tbody>*/}
-      {/*    </table>*/}
-      {/*  </div>*/}
-      {/*)}*/}
-    </div>
+    <Select
+      options={views.options}
+      value={views.current}
+      onChange={(v) => {
+        onChange({
+          id: v.value!,
+        });
+      }}
+    />
   );
 };
-
-const getStyles = stylesFactory((theme: GrafanaTheme) => ({
-  table: css`
-    width: 100%;
-    margin-top: 8px;
-  `,
-  half: css`
-    width: 50%;
-  `,
-}));

--- a/public/app/plugins/panel/geomap/editor/MapCenterEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/MapCenterEditor.tsx
@@ -1,10 +1,9 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 import { GrafanaTheme, StandardEditorProps } from '@grafana/data';
 import { Select, stylesFactory, useStyles } from '@grafana/ui';
 import { GeomapPanelOptions, MapCenterConfig } from '../types';
 import { centerPointRegistry, MapCenterID } from '../view';
 import { css } from '@emotion/css';
-import { NumberInput } from '../components/NumberInput';
 
 export const MapCenterEditor: FC<StandardEditorProps<MapCenterConfig, any, GeomapPanelOptions>> = ({
   value,
@@ -23,53 +22,77 @@ export const MapCenterEditor: FC<StandardEditorProps<MapCenterConfig, any, Geoma
     return centerPointRegistry.selectOptions(ids);
   }, [value?.id]);
 
+  useEffect(() => {
+    if (!context.builder || !value) {
+      return;
+    }
+    if (value.id === MapCenterID.Coordinates) {
+      context.builder.addNumberInput({
+        path: 'view.center.lat',
+        category: ['Map View'],
+        name: 'Latitude',
+        showIf: (o) => o.view.center.id === MapCenterID.Coordinates,
+      });
+    }
+  });
+
   return (
     <div>
       <Select
         options={views.options}
         value={views.current}
         onChange={(v) => {
+          if (v.value === MapCenterID.Coordinates) {
+            context.builder?.addNumberInput({
+              path: 'view.center.lat',
+              category: ['Map View'],
+              name: 'Latitude',
+              showIf: (o) => o.view.center.id === MapCenterID.Coordinates,
+            });
+          } else {
+            context.builder?.remove('view.center.lat');
+          }
           onChange({
             id: v.value!,
           });
         }}
       />
-      {value?.id === MapCenterID.Coordinates && (
-        <div>
-          <table className={style.table}>
-            <tbody>
-              <tr>
-                <th className={style.half}>Latitude</th>
-                <th className={style.half}>Longitude</th>
-              </tr>
-              <tr>
-                <td>
-                  <NumberInput
-                    value={value.lat}
-                    min={-90}
-                    max={90}
-                    placeholder="0"
-                    onChange={(v) => {
-                      onChange({ ...value, lat: v });
-                    }}
-                  />
-                </td>
-                <td>
-                  <NumberInput
-                    value={value.lon}
-                    min={-180}
-                    max={180}
-                    placeholder="0"
-                    onChange={(v) => {
-                      onChange({ ...value, lon: v });
-                    }}
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      )}
+      {/*{value?.id === MapCenterID.Coordinates && (*/}
+      {/*  <div>*/}
+      {/*    <table className={style.table}>*/}
+      {/*      <tbody>*/}
+      {/*        <tr>*/}
+      {/*          <th className={style.half}>Latitude</th>*/}
+      {/*          <th className={style.half}>Longitude</th>*/}
+      {/*        </tr>*/}
+      {/*        <tr>*/}
+      {/*          <td>*/}
+      {/*            <NumberInput*/}
+      {/*              value={value.lat}*/}
+      {/*              min={-90}*/}
+      {/*              max={90}*/}
+      {/*              placeholder="0"*/}
+      {/*              onChange={(v) => {*/}
+      {/*                onChange({ ...value, lat: v });*/}
+      {/*              }}*/}
+      {/*            />*/}
+      {/*          </td>*/}
+      {/*          <td>*/}
+      {/*            <NumberInput*/}
+      {/*              value={value.lon}*/}
+      {/*              min={-180}*/}
+      {/*              max={180}*/}
+      {/*              placeholder="0"*/}
+      {/*              onChange={(v) => {*/}
+      {/*                onChange({ ...value, lon: v });*/}
+      {/*              }}*/}
+      {/*            />*/}
+      {/*          </td>*/}
+      {/*        </tr>*/}
+      {/*      </tbody>*/}
+      {/*    </table>*/}
+      {/*  </div>*/}
+      {/*)}*/}
     </div>
   );
 };

--- a/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
@@ -52,10 +52,11 @@ export const carto: MapLayerRegistryItem<CartoConfig> = {
     },
   }),
 
-  registerOptionsUI: (builder) => {
+  registerOptionsUI: (builder, path: string) => {
+    const category = ['Base Layer'];
     builder
       .addRadio({
-        path: 'theme',
+        path: `${path}.config.theme`,
         name: 'Theme',
         settings: {
           options: [
@@ -64,13 +65,17 @@ export const carto: MapLayerRegistryItem<CartoConfig> = {
             { value: LayerTheme.Dark, label: 'Dark' },
           ],
         },
+        category,
         defaultValue: defaultCartoConfig.theme!,
+        showIf: (o) => o.basemap.type === 'carto',
       })
       .addBooleanSwitch({
-        path: 'showLabels',
+        path: `${path}.config.showLabels`,
         name: 'Show labels',
+        category,
         description: '',
         defaultValue: defaultCartoConfig.showLabels,
+        showIf: (o) => o.basemap.type === 'carto',
       });
   },
 };

--- a/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
@@ -71,31 +71,40 @@ export const esriXYZTiles: MapLayerRegistryItem<ESRIXYZConfig> = {
     },
   }),
 
-  registerOptionsUI: (builder) => {
+  registerOptionsUI: (builder, path) => {
+    const category = ['Base Layer'];
+
     builder
       .addSelect({
-        path: 'server',
+        path: `${path}.config.server`,
         name: 'Server instance',
+        category,
         settings: {
           options: publicServiceRegistry.selectOptions().options,
         },
+        defaultValue: DEFAULT_SERVICE,
+        showIf: (o) => o.basemap.type === 'esri-xyz',
       })
       .addTextInput({
-        path: 'url',
+        path: `${path}.config.url`,
         name: 'URL template',
+        category,
         description: 'Must include {x}, {y} or {-y}, and {z} placeholders',
         settings: {
           placeholder: defaultXYZConfig.url,
         },
-        showIf: (cfg) => cfg.server === CUSTOM_SERVICE,
+        showIf: (o) => {
+          return o.basemap.type === 'esri-xyz' && o.basemap.config?.server === CUSTOM_SERVICE;
+        },
       })
       .addTextInput({
-        path: 'attribution',
+        path: `${path}.config.attribution`,
         name: 'Attribution',
+        category,
         settings: {
           placeholder: defaultXYZConfig.attribution,
         },
-        showIf: (cfg) => cfg.server === CUSTOM_SERVICE,
+        showIf: (o) => o.basemap.type === 'esri-xyz' && o.basemap.config?.server === CUSTOM_SERVICE,
       });
   },
 

--- a/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
@@ -39,22 +39,27 @@ export const xyzTiles: MapLayerRegistryItem<XYZConfig> = {
     },
   }),
 
-  registerOptionsUI: (builder) => {
+  registerOptionsUI: (builder, path) => {
+    const category = ['Base Layer'];
     builder
       .addTextInput({
-        path: 'url',
+        path: `${path}.url`,
         name: 'URL template',
+        category,
         description: 'Must include {x}, {y} or {-y}, and {z} placeholders',
         settings: {
           placeholder: defaultXYZConfig.url,
         },
+        showIf: (o) => o.basemap.type === 'xyz',
       })
       .addTextInput({
-        path: 'attribution',
+        path: `${path}.attribution`,
         name: 'Attribution',
+        category,
         settings: {
           placeholder: defaultXYZConfig.attribution,
         },
+        showIf: (o) => o.basemap.type === 'xyz',
       });
   },
 };

--- a/public/app/plugins/panel/geomap/layers/data/worldmapBehavior.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/worldmapBehavior.tsx
@@ -45,7 +45,7 @@ export const worldmapBehaviorLayer: MapLayerRegistryItem<WorldmapConfig> = {
           for( let y=0; y<40; y+=10) {
             const dot = new Feature({
               geometry: new Point(fromLonLat([x,y])),
-            });  
+            });
             dot.setStyle(new style.Style({
               image: new style.Circle({
                 fill: new style.Fill({

--- a/public/app/plugins/panel/geomap/types.ts
+++ b/public/app/plugins/panel/geomap/types.ts
@@ -44,9 +44,9 @@ export const defaultView: MapViewConfig = {
   zoom: 1,
 };
 
-export interface GeomapPanelOptions {
+export interface GeomapPanelOptions<TBaseLayerConfig = any, TLayerConfig = any> {
   view: MapViewConfig;
   controls: ControlsOptions;
-  basemap: MapLayerConfig;
-  layers: MapLayerConfig[];
+  basemap: MapLayerConfig<TBaseLayerConfig>;
+  layers: Array<MapLayerConfig<TLayerConfig>>;
 }


### PR DESCRIPTION
Ref https://github.com/grafana/grafana/pull/36188

> @ryantxu I wanted to try out dynamic options creation for a while now and here's the POC of my thinking about it (based on your branch): #36607
> 
> It looks promising, required few small API changes. But thanks to it we have dynamic, searchable options and possibility to use options builder directly from the React components. You an test it out on my branch and change Center mode to Coordinates-> latitude will be registered dynamically.

I think this also gives us infinitely nestable/searchable options if anyone provided custom editors all way down the options hierarchy :D

TODO:
- [ ] Add tests 
- [x] Figure out way to pass the builder via StandardEditorContext. This type is used outside of the UI components too- fieldOverrides, FieldOverrideContext extends it. Not sure if it actually should, as StandardEditorContext is more of UI concern, and we probably used it here just as a matter of convinience
- [ ] OptionsUIBuilder now uses Map instead of array to keep track of the registered properties - this way we can simply replace the option that is re-registered dynamically. Otherwise, we would have to remove the options on component unmount - I have encountered several issues with this as thereis quite some memoization going on down the road in the react components in the options pane. The properties are re-registered when the options change triggering PanelOptionsChange event via events bus (to force rendering of the panel options pane). 
