### PR TITLE
Expand the value of math and reduce expressions in annotations and labels

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -103,6 +103,15 @@ Labels are key value pairs that categorize or identify an alert. Labels are  use
 
 ![Details section](/static/img/docs/alerting/unified/rule-edit-details-8-0.png 'Details section screenshot')
 
+#### Template variables
+
+The following template variables are available when expanding annotations and labels.
+
+/ Name    / Description     /
+/ ------- / --------------- /
+/ $labels / Labels contains the labels from the query or condition. For example, `{{ $labels.instance }}` and `{{ $labels.job }}`. /
+/ $values / Values contains the values of all reduce and math expressions that were evaluated for this alert rule. For example, `{{ $values.A }}`, `{{ $values.A.Labels }}` and `{{ $values.A.Value }}` where `A` is the `refID` of the expression. /
+
 ## Preview alerts
 
 To evaluate the rule and see what alerts it would produce, click **Preview alerts**. It will display a list of alerts with state and value for each one.

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -68,7 +68,7 @@ type Result struct {
 	EvaluatedAt        time.Time
 	EvaluationDuration time.Duration
 
-	// EvaluationSring is a string representation of evaluation data such
+	// EvaluationString is a string representation of evaluation data such
 	// as EvalMatches (from "classic condition"), and in the future from operations
 	// like SSE "math".
 	EvaluationString string
@@ -76,7 +76,7 @@ type Result struct {
 	// Values contains the RefID and value of reduce and math expressions.
 	// It does not contain values for classic conditions as the values
 	// in classic conditions do not have a RefID.
-	Values map[string]*float64
+	Values map[string]NumberValueCapture
 }
 
 // State is an enum of the evaluation State for an alert instance.

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -72,6 +72,11 @@ type Result struct {
 	// as EvalMatches (from "classic condition"), and in the future from operations
 	// like SSE "math".
 	EvaluationString string
+
+	// Values contains the RefID and value of reduce and math expressions.
+	// It does not contain values for classic conditions as the values
+	// in classic conditions do not have a RefID.
+	Values map[string]*float64
 }
 
 // State is an enum of the evaluation State for an alert instance.
@@ -346,6 +351,7 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 			EvaluatedAt:        ts,
 			EvaluationDuration: time.Since(ts),
 			EvaluationString:   extractEvalString(f),
+			Values:             extractValues(f),
 		}
 
 		switch {

--- a/pkg/services/ngalert/eval/extract_md.go
+++ b/pkg/services/ngalert/eval/extract_md.go
@@ -66,11 +66,11 @@ func extractEvalString(frame *data.Frame) (s string) {
 	return ""
 }
 
-// extractValues returns the RefID and value for all reduce and
-// math expressions in the frame. It does not return values for
-// classic conditions as the values in classic conditions do not
-// have a RefID.
-func extractValues(frame *data.Frame) map[string]*float64 {
+// extractValues returns the RefID and value for all reduce and math expressions
+// in the frame. It does not return values for classic conditions as the values
+// in classic conditions do not have a RefID. It returns nil if there are
+// no results in the frame.
+func extractValues(frame *data.Frame) map[string]NumberValueCapture {
 	if frame == nil {
 		return nil
 	}
@@ -78,9 +78,9 @@ func extractValues(frame *data.Frame) map[string]*float64 {
 		return nil
 	}
 	if caps, ok := frame.Meta.Custom.([]NumberValueCapture); ok {
-		v := make(map[string]*float64)
+		v := make(map[string]NumberValueCapture)
 		for _, c := range caps {
-			v[c.Var] = c.Value
+			v[c.Var] = c
 		}
 		return v
 	}

--- a/pkg/services/ngalert/eval/extract_md.go
+++ b/pkg/services/ngalert/eval/extract_md.go
@@ -78,7 +78,7 @@ func extractValues(frame *data.Frame) map[string]NumberValueCapture {
 		return nil
 	}
 	if caps, ok := frame.Meta.Custom.([]NumberValueCapture); ok {
-		v := make(map[string]NumberValueCapture)
+		v := make(map[string]NumberValueCapture, len(caps))
 		for _, c := range caps {
 			v[c.Var] = c
 		}

--- a/pkg/services/ngalert/eval/extract_md.go
+++ b/pkg/services/ngalert/eval/extract_md.go
@@ -65,3 +65,24 @@ func extractEvalString(frame *data.Frame) (s string) {
 
 	return ""
 }
+
+// extractValues returns the RefID and value for all reduce and
+// math expressions in the frame. It does not return values for
+// classic conditions as the values in classic conditions do not
+// have a RefID.
+func extractValues(frame *data.Frame) map[string]*float64 {
+	if frame == nil {
+		return nil
+	}
+	if frame.Meta == nil || frame.Meta.Custom == nil {
+		return nil
+	}
+	if caps, ok := frame.Meta.Custom.([]NumberValueCapture); ok {
+		v := make(map[string]*float64)
+		for _, c := range caps {
+			v[c.Var] = c.Value
+		}
+		return v
+	}
+	return nil
+}

--- a/pkg/services/ngalert/eval/extract_md_test.go
+++ b/pkg/services/ngalert/eval/extract_md_test.go
@@ -47,6 +47,41 @@ func TestExtractEvalString(t *testing.T) {
 	}
 }
 
+func TestExtractValues(t *testing.T) {
+	cases := []struct {
+		desc    string
+		inFrame *data.Frame
+		values  map[string]*float64
+	}{{
+		desc: "Nil value",
+		inFrame: newMetaFrame([]NumberValueCapture{
+			{Var: "A", Labels: data.Labels{"host": "foo"}, Value: nil},
+		}, ptr.Float64(1)),
+		values: map[string]*float64{"A": nil},
+	}, {
+		desc: "1 value",
+		inFrame: newMetaFrame([]NumberValueCapture{
+			{Var: "A", Labels: data.Labels{"host": "foo"}, Value: ptr.Float64(1)},
+		}, ptr.Float64(1)),
+		values: map[string]*float64{"A": ptr.Float64(1)},
+	}, {
+		desc: "2 values",
+		inFrame: newMetaFrame([]NumberValueCapture{
+			{Var: "A", Labels: data.Labels{"host": "foo"}, Value: ptr.Float64(1)},
+			{Var: "B", Labels: nil, Value: ptr.Float64(2)},
+		}, ptr.Float64(1)),
+		values: map[string]*float64{
+			"A": ptr.Float64(1),
+			"B": ptr.Float64(2),
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.values, extractValues(tc.inFrame))
+		})
+	}
+}
+
 func newMetaFrame(custom interface{}, val *float64) *data.Frame {
 	return data.NewFrame("",
 		data.NewField("", nil, []*float64{val})).

--- a/pkg/services/ngalert/eval/extract_md_test.go
+++ b/pkg/services/ngalert/eval/extract_md_test.go
@@ -51,28 +51,42 @@ func TestExtractValues(t *testing.T) {
 	cases := []struct {
 		desc    string
 		inFrame *data.Frame
-		values  map[string]*float64
+		values  map[string]NumberValueCapture
 	}{{
+		desc:    "No values in frame returns nil",
+		inFrame: newMetaFrame(nil, ptr.Float64(1)),
+		values:  nil,
+	}, {
+		desc: "Classic condition frame returns nil",
+		inFrame: newMetaFrame([]classic.EvalMatch{
+			{Metric: "A", Labels: data.Labels{"host": "foo"}, Value: ptr.Float64(1)},
+		}, ptr.Float64(1)),
+		values: nil,
+	}, {
 		desc: "Nil value",
 		inFrame: newMetaFrame([]NumberValueCapture{
 			{Var: "A", Labels: data.Labels{"host": "foo"}, Value: nil},
 		}, ptr.Float64(1)),
-		values: map[string]*float64{"A": nil},
+		values: map[string]NumberValueCapture{
+			"A": {Var: "A", Labels: data.Labels{"host": "foo"}, Value: nil},
+		},
 	}, {
 		desc: "1 value",
 		inFrame: newMetaFrame([]NumberValueCapture{
 			{Var: "A", Labels: data.Labels{"host": "foo"}, Value: ptr.Float64(1)},
 		}, ptr.Float64(1)),
-		values: map[string]*float64{"A": ptr.Float64(1)},
+		values: map[string]NumberValueCapture{
+			"A": {Var: "A", Labels: data.Labels{"host": "foo"}, Value: ptr.Float64(1)},
+		},
 	}, {
 		desc: "2 values",
 		inFrame: newMetaFrame([]NumberValueCapture{
 			{Var: "A", Labels: data.Labels{"host": "foo"}, Value: ptr.Float64(1)},
 			{Var: "B", Labels: nil, Value: ptr.Float64(2)},
 		}, ptr.Float64(1)),
-		values: map[string]*float64{
-			"A": ptr.Float64(1),
-			"B": ptr.Float64(2),
+		values: map[string]NumberValueCapture{
+			"A": {Var: "A", Labels: data.Labels{"host": "foo"}, Value: ptr.Float64(1)},
+			"B": {Var: "B", Value: ptr.Float64(2)},
 		},
 	}}
 	for _, tc := range cases {

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -36,11 +36,8 @@ func (c *cache) getOrCreate(alertRule *ngModels.AlertRule, result eval.Result) *
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
 
-	labels := make(map[string]string)
 	// clone the labels so we don't change eval.Result
-	for k, v := range result.Instance {
-		labels[k] = v
-	}
+	labels := result.Instance.Copy()
 	attachRuleLabels(labels, alertRule)
 	ruleLabels, annotations := c.expandRuleLabelsAndAnnotations(alertRule, labels, result.Values)
 
@@ -110,7 +107,7 @@ func (c *cache) expandRuleLabelsAndAnnotations(alertRule *ngModels.AlertRule, la
 }
 
 // templateCaptureValue represents each value in .Values in the annotations
-// and labels template
+// and labels template.
 type templateCaptureValue struct {
 	Labels map[string]string
 	Value  *float64

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -1,0 +1,47 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/stretchr/testify/require"
+	ptr "github.com/xorcare/pointer"
+)
+
+func TestBuildTemplateData(t *testing.T) {
+	cases := []struct {
+		name   string
+		result eval.Result
+		labels map[string]string
+		values map[string]string
+	}{{
+		name: "assert nil value is returned as null",
+		result: eval.Result{
+			Values: map[string]*float64{"A": nil},
+		},
+		labels: make(map[string]string),
+		values: map[string]string{
+			"A": "null",
+		},
+	}, {
+		name: "assert non-nil values are returned as string without exponent",
+		result: eval.Result{
+			Values: map[string]*float64{
+				"A": ptr.Float64(1),
+				"B": ptr.Float64(1.5)},
+		},
+		labels: make(map[string]string),
+		values: map[string]string{
+			"A": "1",
+			"B": "1.5",
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l, v := buildTemplateData(tc.result)
+			require.Equal(t, tc.labels, l)
+			require.Equal(t, tc.values, v)
+		})
+	}
+}

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -3,45 +3,32 @@ package state
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/ngalert/eval"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	ptr "github.com/xorcare/pointer"
 )
 
-func TestBuildTemplateData(t *testing.T) {
+func TestTemplateCaptureValueStringer(t *testing.T) {
 	cases := []struct {
-		name   string
-		result eval.Result
-		labels map[string]string
-		values map[string]string
+		name     string
+		value    templateCaptureValue
+		expected string
 	}{{
-		name: "assert nil value is returned as null",
-		result: eval.Result{
-			Values: map[string]*float64{"A": nil},
-		},
-		labels: make(map[string]string),
-		values: map[string]string{
-			"A": "null",
-		},
+		name:     "nil value returns null",
+		value:    templateCaptureValue{Value: nil},
+		expected: "null",
 	}, {
-		name: "assert non-nil values are returned as string without exponent",
-		result: eval.Result{
-			Values: map[string]*float64{
-				"A": ptr.Float64(1),
-				"B": ptr.Float64(1.5)},
-		},
-		labels: make(map[string]string),
-		values: map[string]string{
-			"A": "1",
-			"B": "1.5",
-		},
+		name:     "1.0 is returned as integer value",
+		value:    templateCaptureValue{Value: ptr.Float64(1.0)},
+		expected: "1",
+	}, {
+		name:     "1.1 is returned as decimal value",
+		value:    templateCaptureValue{Value: ptr.Float64(1.1)},
+		expected: "1.1",
 	}}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			l, v := buildTemplateData(tc.result)
-			require.Equal(t, tc.labels, l)
-			require.Equal(t, tc.values, v)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, c.value.String())
 		})
 	}
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -155,6 +155,7 @@ func (st *Manager) setNextState(alertRule *ngModels.AlertRule, result eval.Resul
 		EvaluationTime:   result.EvaluatedAt,
 		EvaluationState:  result.State,
 		EvaluationString: result.EvaluationString,
+		Values:           result.Values,
 	})
 	currentState.TrimResults(alertRule)
 	oldState := currentState.State

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -155,7 +155,7 @@ func (st *Manager) setNextState(alertRule *ngModels.AlertRule, result eval.Resul
 		EvaluationTime:   result.EvaluatedAt,
 		EvaluationState:  result.State,
 		EvaluationString: result.EvaluationString,
-		Values:           result.Values,
+		Values:           NewEvaluationValues(result.Values),
 	})
 	currentState.TrimResults(alertRule)
 	oldState := currentState.State

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -70,6 +70,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					LastEvaluationTime: evaluationTime,
@@ -122,6 +123,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					LastEvaluationTime: evaluationTime,
@@ -144,6 +146,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Alerting,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime,
@@ -200,10 +203,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(1 * time.Minute),
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					LastEvaluationTime: evaluationTime.Add(1 * time.Minute),
@@ -258,10 +263,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(1 * time.Minute),
 							EvaluationState: eval.Alerting,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(1 * time.Minute),
@@ -327,14 +334,17 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(80 * time.Second),
 							EvaluationState: eval.Alerting,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(80 * time.Second),
@@ -392,10 +402,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -453,10 +465,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Alerting,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime,
@@ -514,10 +528,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -575,10 +591,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -636,10 +654,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -698,10 +718,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -760,10 +782,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Error,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -815,6 +839,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
 						},
 					},
 					LastEvaluationTime: evaluationTime,

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -28,7 +28,28 @@ type Evaluation struct {
 	EvaluationTime   time.Time
 	EvaluationState  eval.State
 	EvaluationString string
-	Values           map[string]*float64
+	// Values contains the RefID and value of reduce and math expressions.
+	// It does not contain values for classic conditions as the values
+	// in classic conditions do not have a RefID.
+	Values map[string]EvaluationValue
+}
+
+// EvaluationValue contains the labels and value for a RefID in an evaluation.
+type EvaluationValue struct {
+	Labels data.Labels
+	Value  *float64
+}
+
+// NewEvaluationValues returns the labels and values for each RefID in the capture.
+func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]EvaluationValue {
+	result := make(map[string]EvaluationValue)
+	for k, v := range m {
+		result[k] = EvaluationValue{
+			Labels: v.Labels,
+			Value:  v.Value,
+		}
+	}
+	return result
 }
 
 func (a *State) resultNormal(alertRule *ngModels.AlertRule, result eval.Result) {

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -42,7 +42,7 @@ type EvaluationValue struct {
 
 // NewEvaluationValues returns the labels and values for each RefID in the capture.
 func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]EvaluationValue {
-	result := make(map[string]EvaluationValue)
+	result := make(map[string]EvaluationValue, len(m))
 	for k, v := range m {
 		result[k] = EvaluationValue{
 			Labels: v.Labels,

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -28,6 +28,7 @@ type Evaluation struct {
 	EvaluationTime   time.Time
 	EvaluationState  eval.State
 	EvaluationString string
+	Values           map[string]*float64
 }
 
 func (a *State) resultNormal(alertRule *ngModels.AlertRule, result eval.Result) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit makes it possible to use the values of reduce and math expressions in annotations and labels via their RefIDs. An example of such an annotation could be "The value of A is `{{ $values.A }}"`.

**Which issue(s) this PR fixes**:

Fixes #36020 

**Special notes for your reviewer**: