### PR TITLE
Upgrade node version for e2e tests

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
@@ -5,9 +5,9 @@ source "/etc/profile"
 source "./deploy-slim.sh"
 source "./deploy-common.sh"
 
-NODEVER="v12.19.0-linux-x64"
+NODEVER="v14.17.3"
 # Install Node
-wget -O - "https://nodejs.org/dist/v12.19.0/node-${NODEVER}.tar.xz" | tar Jvxf - -C "/tmp"
+wget -O - "https://nodejs.org/dist/${NODEVER}/node-${NODEVER}-linux-x64.tar.xz" | tar Jvxf - -C "/tmp"
 
 # Move node to /usr/local so it's in the path
 pushd /tmp/node-${NODEVER}


### PR DESCRIPTION
**What this PR does / why we need it**:
I recently tried to add e2e tests to a new datasource that specified its node version as `"node": ">= 14"` and the build failed in drone with the error: `The engine "node" is incompatible with this module. Expected version ">=14". Got "12.19.0"`

I have 2 choices to fix as I see it:
- I could not specify a node version in the datasource, which seems to be generally what I see on other external datasources
- or I could upgrade our node version for all our e2e tests. I see that core grafana specifies that it runs on node greater than or equal to 14 to it seems reasonable to me to bump this to the latest stable version. 

I've not worked much in our ci pipeline and am not totally sure if this is enough to bump the version? I'm guessing yes?

