### PR TITLE
A11y: Improve accessibility by hiding ﻿image/link duplicate in news panel

### DIFF
--- a/public/app/plugins/panel/news/NewsPanel.tsx
+++ b/public/app/plugins/panel/news/NewsPanel.tsx
@@ -87,8 +87,9 @@ export class NewsPanel extends PureComponent<Props, State> {
                   target="_blank"
                   rel="noopener noreferrer"
                   className={cx(styles.socialImage, useWideLayout && styles.socialImageWide)}
+                  aria-hidden
                 >
-                  <img src={item.ogImage} />
+                  <img src={item.ogImage} alt={item.title} />
                 </a>
               )}
               <div className={styles.body}>

--- a/public/app/plugins/panel/news/NewsPanel.tsx
+++ b/public/app/plugins/panel/news/NewsPanel.tsx
@@ -80,7 +80,7 @@ export class NewsPanel extends PureComponent<Props, State> {
       <CustomScrollbar autoHeightMin="100%" autoHeightMax="100%">
         {news.map((item, index) => {
           return (
-            <div key={index} className={cx(styles.item, useWideLayout && styles.itemWide)}>
+            <article key={index} className={cx(styles.item, useWideLayout && styles.itemWide)}>
               {showImage && item.ogImage && (
                 <a
                   href={textUtil.sanitizeUrl(item.link)}
@@ -93,18 +93,20 @@ export class NewsPanel extends PureComponent<Props, State> {
                 </a>
               )}
               <div className={styles.body}>
-                <div className={styles.date}>{dateTimeFormat(item.date, { format: 'MMM DD' })} </div>
+                <time className={styles.date} dateTime={dateTimeFormat(item.date, { format: 'MMM DD' })}>
+                  {dateTimeFormat(item.date, { format: 'MMM DD' })}{' '}
+                </time>
                 <a
                   className={styles.link}
                   href={textUtil.sanitizeUrl(item.link)}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <div className={styles.title}>{item.title}</div>
+                  <h3 className={styles.title}>{item.title}</h3>
                 </a>
                 <div className={styles.content} dangerouslySetInnerHTML={{ __html: textUtil.sanitize(item.content) }} />
               </div>
-            </div>
+            </article>
           );
         })}
       </CustomScrollbar>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

I wanted to see some of the low-hanging a11y issues we can solve. The most critical ones we have are images without alt text. This doesn't matter in this case, since the image link is a duplicate of the text link, and there is no way to add a good alt description dynamically here.

Before
![Screenshot from 2021-07-09 14-20-34](https://user-images.githubusercontent.com/1438972/125247176-f4aeee00-e2f2-11eb-9372-4dd784527051.png)
After
![Screenshot from 2021-07-09 14-21-34](https://user-images.githubusercontent.com/1438972/125247376-2aec6d80-e2f3-11eb-8dd8-2fcac81a5cbf.png)

**Special notes for your reviewer**:
Firefox and the Axe extension were used.