### PR TITLE
Plugins: automatically search plugins when typing in plugin list search box.

### DIFF
--- a/public/app/features/plugins/admin/components/SearchField.tsx
+++ b/public/app/features/plugins/admin/components/SearchField.tsx
@@ -13,7 +13,7 @@ export const SearchField = ({ value, onSearch }: Props) => {
   const [query, setQuery] = useState(value);
   const styles = useStyles2(getStyles);
 
-  useDebounce(() => onSearch(query ?? ''), 600, [query]);
+  useDebounce(() => onSearch(query ?? ''), 500, [query]);
 
   return (
     <input

--- a/public/app/features/plugins/admin/components/SearchField.tsx
+++ b/public/app/features/plugins/admin/components/SearchField.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
+import { useDebounce } from 'react-use';
 
 interface Props {
   value?: string;
@@ -11,6 +12,8 @@ interface Props {
 export const SearchField = ({ value, onSearch }: Props) => {
   const [query, setQuery] = useState(value);
   const styles = useStyles2(getStyles);
+
+  useDebounce(() => onSearch(query ?? ''), 600, [query]);
 
   return (
     <input


### PR DESCRIPTION
**What this PR does / why we need it**:
This will improve the experience of finding plugins since you don't have to press enter to search for a plugin.
