### PR TITLE
BottomNavLinks: Accessible text for image and icon

### DIFF
--- a/packages/grafana-ui/src/components/Icon/Icon.mdx
+++ b/packages/grafana-ui/src/components/Icon/Icon.mdx
@@ -7,7 +7,6 @@ import { Icon } from './Icon';
 
 Grafana's wrapper component over [Font Awesome](https://fontawesome.com/) and Unicons icons
 
-
 ### Changing icon size
 
 By default `Icon` has width and height of `16px` and font-size of `14px`. Pass `className` to control icon's size:
@@ -15,8 +14,7 @@ By default `Icon` has width and height of `16px` and font-size of `14px`. Pass `
 ```jsx
 import { css } from 'emotion';
 
-<Icon name="check" />
+<Icon name="check" />;
 ```
-
 
 <Props of={Icon} />

--- a/public/app/core/components/sidemenu/BottomNavLinks.tsx
+++ b/public/app/core/components/sidemenu/BottomNavLinks.tsx
@@ -50,8 +50,8 @@ export default class BottomNavLinks extends PureComponent<Props, State> {
       <div className="sidemenu-item dropdown dropup">
         <Link href={link.url} className="sidemenu-link" target={link.target}>
           <span className="icon-circle sidemenu-icon">
-            {link.icon && <Icon name={link.icon as IconName} size="xl" />}
-            {link.img && <img src={link.img} />}
+            {link.icon && <Icon name={link.icon as IconName} size="xl" title="Help icon" />}
+            {link.img && <img src={link.img} alt="Profile picture" />}
           </span>
         </Link>
         <ul className="dropdown-menu dropdown-menu--sidemenu" role="menu">


### PR DESCRIPTION
**What this PR does / why we need it**:
To make the bottom items in the navbar more accessible

Relates to https://github.com/grafana/grafana/issues/36602