### PR TITLE
AzureMonitor: Fail rather than warn if Log credentials are set

### DIFF
--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -135,7 +135,8 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 		return dataResponse
 	}
 
-	if !dsInfo.Settings.AzureLogAnalyticsSameAs {
+	// If azureLogAnalyticsSameAs is defined and set to false, return an error
+	if sameAs, ok := dsInfo.JSONData["azureLogAnalyticsSameAs"]; ok && !sameAs.(bool) {
 		return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials")) //nolint:golint,stylecheck
 	}
 

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go
@@ -135,7 +135,12 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 		return dataResponse
 	}
 
+	if !dsInfo.Settings.AzureLogAnalyticsSameAs {
+		return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials")) //nolint:golint,stylecheck
+	}
+
 	req, err := e.createRequest(ctx, dsInfo)
+
 	if err != nil {
 		dataResponse.Error = err
 		return dataResponse
@@ -163,9 +168,6 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 	azlog.Debug("AzureLogAnalytics", "Request ApiURL", req.URL.String())
 	res, err := ctxhttp.Do(ctx, dsInfo.Services[azureLogAnalytics].HTTPClient, req)
 	if err != nil {
-		if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-			return dataResponseErrorWithExecuted(fmt.Errorf("Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials")) //nolint:golint,stylecheck
-		}
 		return dataResponseErrorWithExecuted(err)
 	}
 
@@ -208,10 +210,6 @@ func (e *AzureLogAnalyticsDatasource) executeQuery(ctx context.Context, query *A
 				frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "could not convert frame to time series, returning raw table: " + err.Error()})
 			}
 		}
-	}
-
-	if !dsInfo.Settings.AzureLogAnalyticsSameAs {
-		frame.AppendNotices(data.Notice{Severity: data.NoticeSeverityWarning, Text: "Log Analytics credentials are no longer supported. Go to the data source configuration to update Azure Monitor credentials"})
 	}
 
 	dataResponse.Frames = data.Frames{frame}

--- a/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/azure-log-analytics-datasource_test.go
@@ -222,7 +222,9 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 		Services: map[string]datasourceService{
 			azureLogAnalytics: {URL: "http://ds"},
 		},
-		Settings: azureMonitorSettings{AzureLogAnalyticsSameAs: false},
+		JSONData: map[string]interface{}{
+			"azureLogAnalyticsSameAs": false,
+		},
 	}
 	ctx := context.TODO()
 	query := &AzureLogAnalyticsQuery{

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -49,7 +49,6 @@ type azureMonitorSettings struct {
 	SubscriptionId               string `json:"subscriptionId"`
 	LogAnalyticsDefaultWorkspace string `json:"logAnalyticsDefaultWorkspace"`
 	AppInsightsAppId             string `json:"appInsightsAppId"`
-	AzureLogAnalyticsSameAs      bool   `json:"azureLogAnalyticsSameAs"`
 }
 
 type datasourceInfo struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Following a conversation with @kostrse and @joshhunt it may be better to fail if the credentials for Azure Logs are set rather than attempting to retrieve these using Azure Monitor creds.

![Screenshot from 2021-07-12 11-20-40](https://user-images.githubusercontent.com/4025665/125270127-a822dd00-e309-11eb-8d42-ed96e293a773.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

