### PR TITLE
Plugins: adding possibility to install enterprise plugins if you have a valid license.

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls.tsx
@@ -80,7 +80,7 @@ export const InstallControls = ({ localPlugin, remotePlugin }: Props) => {
   const isEnterprise = remotePlugin?.status === 'enterprise';
   const hasPermission = isGrafanaAdmin();
 
-  if (isEnterprise) {
+  if (isEnterprise && !config.licenseInfo?.hasValidLicense) {
     return (
       <div className={styles.message}>
         Marketplace doesn&#39;t support installing Enterprise plugins yet. Stay tuned!


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will enable the install capabilities if you are viewing an enterprise plugin and have a valid license installed.
