### PR TITLE
Cloudwatch: Add StreamName dimension for AWS/KinesisVideo namespace

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -194,7 +194,7 @@ var dimensionsMap = map[string][]string{
 	"AWS/Kafka":                   {"Broker ID", "Cluster Name", "Topic"},
 	"AWS/Kinesis":                 {"ShardId", "StreamName"},
 	"AWS/KinesisAnalytics":        {"Application", "Flow", "Id"},
-	"AWS/KinesisVideo":            {},
+	"AWS/KinesisVideo":            {"StreamName"},
 	"AWS/Lambda":                  {"Alias", "ExecutedVersion", "FunctionName", "Resource"},
 	"AWS/Lex":                     {"BotAlias", "BotChannelName", "BotName", "BotVersion", "InputMode", "Operation", "Source"},
 	"AWS/Logs":                    {"DestinationType", "FilterName", "LogGroupName"},


### PR DESCRIPTION
What this PR does / why we need it:

Add StreamName dimension for AWS/KinesisVideo namespace on cloudwatch backend

Which issue(s) this PR fixes:

Fixes #36266

Special notes for your reviewer:


