### PR TITLE
uPlot: fix default value for plot legend visibility

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
@@ -53,7 +53,7 @@ export const PlotLegend: React.FC<PlotLegendProps> = ({
       const seriesColor = scaleColor.color;
 
       return {
-        disabled: !seriesConfig.show ?? false,
+        disabled: !(seriesConfig.show ?? true),
         fieldIndex,
         color: seriesColor,
         label,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed the condition, as the last part of `!seriesConfig.show ?? false`
will never be evaluated because `!seriesConfig.show` always yields a
boolean.

**Special notes for your reviewer**:
Currently the plot legend is disbled if `seriesConfig.show` is `null` or `undefined`. This PR changes that to show the plot legend if `seriesConfig.show` is `null` or `undefined`. Afaics that was the intended behaviour of the original code.