### PR TITLE
Dashboard: Avoid migration breaking on fieldConfig without defaults field in folded panel

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -1382,6 +1382,44 @@ describe('DashboardModel', () => {
       `);
     });
   });
+
+  describe('when migrating folded panel without fieldConfig.defaults', () => {
+    let model: DashboardModel;
+
+    beforeEach(() => {
+      model = new DashboardModel({
+        schemaVersion: 29,
+        panels: [
+          {
+            id: 1,
+            type: 'timeseries',
+            panels: [
+              {
+                id: 2,
+                fieldConfig: {
+                  overrides: [
+                    {
+                      matcher: { id: 'byName', options: 'D-series' },
+                      properties: [
+                        {
+                          id: 'displayName',
+                          value: 'foobar',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should ignore fieldConfig.defaults', () => {
+      expect(model.panels[0].panels[0].fieldConfig.defaults).toEqual(undefined);
+    });
+  });
 });
 
 function createRow(options: any, panelDescriptions: any[]) {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -955,7 +955,12 @@ function upgradeValueMappingsForPanel(panel: PanelModel) {
     return panel;
   }
 
-  fieldConfig.defaults.mappings = upgradeValueMappings(fieldConfig.defaults.mappings, fieldConfig.defaults.thresholds);
+  if (fieldConfig.defaults) {
+    fieldConfig.defaults.mappings = upgradeValueMappings(
+      fieldConfig.defaults.mappings,
+      fieldConfig.defaults.thresholds
+    );
+  }
 
   // Protect against no overrides
   if (Array.isArray(fieldConfig.overrides)) {


### PR DESCRIPTION
**Background**

We noticed that one of our dashboards broke after upgrading to grafana 8.x with the `Dashboard init failed` error. We were able to use the workaround described in https://github.com/grafana/grafana/issues/34788 where if you expand all rows first and save before you upgrade the migration would work, but the ultimate fix for that issue did not fix the issue we encountered. The temporary workaround did not last however, as we generate our our dashboards using [grafonnet-lib](https://github.com/grafana/grafonnet-lib), and so the next time the dashboard was updated it would break.

I managed to track down the issue to `grafonnet-lib` not creating the `fieldsConfig.defaults`, and the migration script assuming that it exists.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Only migrate `fieldsConfig.defaults.mappings` if `fieldsConfig.defaults` is defined. I'm not sure if this is supposed to be a "required" field of `fieldsConfig`, but in any case I think this is better than breaking the dashboard.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**To Reproduce**

Import this dashboard in grafana 8.x:
```json
{
  "editable": true,
  "gnetId": null,
  "graphTooltip": 0,
  "id": 5,
  "links": [],
  "panels": [
    {
      "collapsed": true,
      "datasource": null,
      "gridPos": {
        "h": 1,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "panels": [
        {
          "datasource": null,
          "fieldConfig": {
            "overrides": []
          },
          "gridPos": {
            "h": 8,
            "w": 12,
            "x": 0,
            "y": 1
          },
          "id": 4,
          "options": {
            "legend": {
              "calcs": [],
              "displayMode": "list",
              "placement": "bottom"
            },
            "tooltip": {
              "mode": "single"
            }
          },
          "targets": [
            {
              "queryType": "randomWalk",
              "refId": "A"
            }
          ],
          "title": "Panel Title",
          "type": "timeseries"
        }
      ],
      "title": "Row title",
      "type": "row"
    }
  ],
  "refresh": false,
  "schemaVersion": 29,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-5m",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "New dashboard Copy",
  "uid": "2O1vnAi7z",
  "version": 2
}
```