### PR TITLE
Transformations: Enable / disable toggle for transformation rows 

### DIFF
--- a/packages/grafana-data/src/transformations/transformDataFrame.test.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.test.ts
@@ -1,0 +1,75 @@
+import { ReducerID } from './fieldReducer';
+import { DataTransformerID } from './transformers/ids';
+import { toDataFrame } from '../dataframe/processDataFrame';
+import { mockTransformationsRegistry } from '../utils/tests/mockTransformationsRegistry';
+import { reduceTransformer } from './transformers/reduce';
+import { filterFieldsByNameTransformer } from './transformers/filterByName';
+import { transformDataFrame } from './transformDataFrame';
+import { FieldType } from '../types';
+
+const seriesAWithSingleField = toDataFrame({
+  name: 'A',
+  fields: [
+    { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+    { name: 'temperature', type: FieldType.number, values: [3, 4, 5, 6] },
+  ],
+});
+
+describe('transformDataFrame', () => {
+  beforeAll(() => {
+    mockTransformationsRegistry([reduceTransformer, filterFieldsByNameTransformer]);
+  });
+
+  it('Applies all transforms', async () => {
+    const cfg = [
+      {
+        id: DataTransformerID.reduce,
+        options: {
+          reducers: [ReducerID.first],
+        },
+      },
+      {
+        id: DataTransformerID.filterFieldsByName,
+        options: {
+          include: {
+            pattern: '/First/',
+          },
+        },
+      },
+    ];
+
+    await expect(transformDataFrame(cfg, [seriesAWithSingleField])).toEmitValuesWith((received) => {
+      const processed = received[0];
+      expect(processed[0].length).toEqual(1);
+      expect(processed[0].fields.length).toEqual(1);
+      expect(processed[0].fields[0].values.get(0)).toEqual(3);
+    });
+  });
+
+  it('Skips over disabled transforms', async () => {
+    const cfg = [
+      {
+        id: DataTransformerID.reduce,
+        options: {
+          reducers: [ReducerID.first],
+        },
+      },
+      {
+        id: DataTransformerID.filterFieldsByName,
+        disabled: true,
+        options: {
+          include: {
+            pattern: '/First/',
+          },
+        },
+      },
+    ];
+
+    await expect(transformDataFrame(cfg, [seriesAWithSingleField])).toEmitValuesWith((received) => {
+      const processed = received[0];
+      expect(processed[0].length).toEqual(1);
+      expect(processed[0].fields.length).toEqual(2);
+      expect(processed[0].fields[0].values.get(0)).toEqual('temperature');
+    });
+  });
+});

--- a/packages/grafana-data/src/transformations/transformDataFrame.ts
+++ b/packages/grafana-data/src/transformations/transformDataFrame.ts
@@ -60,6 +60,11 @@ export function transformDataFrame(options: DataTransformerConfig[], data: DataF
 
   for (let index = 0; index < options.length; index++) {
     const config = options[index];
+
+    if (config.disabled) {
+      continue;
+    }
+
     operators.push(getOperator(config));
   }
 

--- a/packages/grafana-data/src/types/transformations.ts
+++ b/packages/grafana-data/src/types/transformations.ts
@@ -20,6 +20,10 @@ export interface DataTransformerConfig<TOptions = any> {
    */
   id: string;
   /**
+   * Disabled transformations are skipped
+   */
+  disabled?: boolean;
+  /**
    * Options to be passed to the transformer
    */
   options: TOptions;

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { Icon, renderOrCallToRender, stylesFactory, useTheme } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { useUpdateEffect } from 'react-use';
 import { Draggable } from 'react-beautiful-dnd';
 
@@ -16,6 +16,7 @@ interface QueryOperationRowProps {
   children: React.ReactNode;
   isOpen?: boolean;
   draggable?: boolean;
+  disabled?: boolean;
 }
 
 export type QueryOperationRowRenderProp = ((props: QueryOperationRowRenderProps) => React.ReactNode) | React.ReactNode;
@@ -34,6 +35,7 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
   onClose,
   onOpen,
   isOpen,
+  disabled,
   draggable,
   index,
   id,
@@ -80,7 +82,7 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
       />
       {title && (
         <div className={styles.titleWrapper} onClick={onRowToggle} aria-label="Query operation row title">
-          <div className={styles.title}>{titleElement}</div>
+          <div className={cx(styles.title, disabled && styles.disabled)}>{titleElement}</div>
         </div>
       )}
       {headerElementRendered}
@@ -166,6 +168,9 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
     content: css`
       margin-top: ${theme.spacing.inlineFormMargin};
       margin-left: ${theme.spacing.lg};
+    `,
+    disabled: css`
+      color: ${theme.colors.textWeak};
     `,
   };
 });

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -34,6 +34,7 @@ export const TransformationOperationRow: React.FC<TransformationOperationRowProp
 }) => {
   const [showDebug, toggleDebug] = useToggle(false);
   const [showHelp, toggleHelp] = useToggle(false);
+  const disabled = configs[index].transformation.disabled;
 
   const onDisableToggle = useCallback(
     (index: number) => {
@@ -47,8 +48,6 @@ export const TransformationOperationRow: React.FC<TransformationOperationRowProp
   );
 
   const renderActions = ({ isOpen }: QueryOperationRowRenderProps) => {
-    const disabled = configs[index].transformation.disabled;
-
     return (
       <HorizontalGroup align="center" width="auto">
         {uiConfig.state && <PluginStateInfo state={uiConfig.state} />}
@@ -71,7 +70,14 @@ export const TransformationOperationRow: React.FC<TransformationOperationRowProp
   };
 
   return (
-    <QueryOperationRow id={id} index={index} title={uiConfig.name} draggable actions={renderActions}>
+    <QueryOperationRow
+      id={id}
+      index={index}
+      title={uiConfig.name}
+      draggable
+      actions={renderActions}
+      disabled={disabled}
+    >
       {showHelp && <OperationRowHelp markdown={prepMarkdown(uiConfig)} />}
       <TransformationEditor
         debugMode={showDebug}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -47,6 +47,8 @@ export const TransformationOperationRow: React.FC<TransformationOperationRowProp
   );
 
   const renderActions = ({ isOpen }: QueryOperationRowRenderProps) => {
+    const disabled = configs[index].transformation.disabled;
+
     return (
       <HorizontalGroup align="center" width="auto">
         {uiConfig.state && <PluginStateInfo state={uiConfig.state} />}
@@ -59,9 +61,9 @@ export const TransformationOperationRow: React.FC<TransformationOperationRowProp
         <QueryOperationAction title="Debug" disabled={!isOpen} icon="bug" onClick={toggleDebug} active={showDebug} />
         <QueryOperationAction
           title="Disable/Enable transformation"
-          icon="eye"
+          icon={disabled ? 'eye-slash' : 'eye'}
           onClick={() => onDisableToggle(index)}
-          active={configs[index].transformation.disabled}
+          active={disabled}
         />
         <QueryOperationAction title="Remove" icon="trash-alt" onClick={() => onRemove(index)} />
       </HorizontalGroup>

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { DataFrame, DataTransformerConfig, TransformerRegistryItem } from '@grafana/data';
 import { HorizontalGroup } from '@grafana/ui';
 
@@ -35,6 +35,17 @@ export const TransformationOperationRow: React.FC<TransformationOperationRowProp
   const [showDebug, toggleDebug] = useToggle(false);
   const [showHelp, toggleHelp] = useToggle(false);
 
+  const onDisableToggle = useCallback(
+    (index: number) => {
+      const current = configs[index].transformation;
+      onChange(index, {
+        ...current,
+        disabled: current.disabled ? undefined : true,
+      });
+    },
+    [onChange, configs]
+  );
+
   const renderActions = ({ isOpen }: QueryOperationRowRenderProps) => {
     return (
       <HorizontalGroup align="center" width="auto">
@@ -46,6 +57,12 @@ export const TransformationOperationRow: React.FC<TransformationOperationRowProp
           active={showHelp}
         />
         <QueryOperationAction title="Debug" disabled={!isOpen} icon="bug" onClick={toggleDebug} active={showDebug} />
+        <QueryOperationAction
+          title="Disable/Enable transformation"
+          icon="eye"
+          onClick={() => onDisableToggle(index)}
+          active={configs[index].transformation.disabled}
+        />
         <QueryOperationAction title="Remove" icon="trash-alt" onClick={() => onRemove(index)} />
       </HorizontalGroup>
     );
@@ -72,8 +89,8 @@ function prepMarkdown(uiConfig: TransformerRegistryItem<any>) {
   return `
 ${helpMarkdown}
 
-<a href="https://grafana.com/docs/grafana/latest/panels/transformations/?utm_source=grafana" target="_blank" rel="noreferrer">
-Read more on the documentation site
-</a>
+Go the <a href="https://grafana.com/docs/grafana/latest/panels/transformations/?utm_source=grafana" target="_blank" rel="noreferrer">
+transformation documentation
+</a> for more.
 `;
 }


### PR DESCRIPTION
Adds a new enable / disable toggle to transformation rows. Disabled transformations are skipped.

![Screenshot from 2021-07-12 16-49-41](https://user-images.githubusercontent.com/10999/125308429-2f377b80-e331-11eb-9389-8292f60396c5.png)
