### PR TITLE
Plugins: Don't show uninstall button for core plugins in catalog

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls.tsx
@@ -78,7 +78,12 @@ export const InstallControls = ({ localPlugin, remotePlugin }: Props) => {
 
   const isDevelopmentBuild = Boolean(localPlugin?.dev);
   const isEnterprise = remotePlugin?.status === 'enterprise';
+  const isCore = remotePlugin?.internal || localPlugin?.signature === 'internal';
   const hasPermission = isGrafanaAdmin();
+
+  if (isCore) {
+    return null;
+  }
 
   if (isEnterprise && !config.licenseInfo?.hasValidLicense) {
     return (

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -17,7 +17,9 @@ jest.mock('@grafana/runtime', () => {
           case `${GRAFANA_API_ROOT}/plugins/enterprise/versions`:
             return Promise.resolve([]);
           case API_ROOT:
-            return Promise.resolve([localPlugin()]);
+            return Promise.resolve([localPlugin(), corePlugin()]);
+          case `${GRAFANA_API_ROOT}/plugins/core`:
+            return Promise.resolve(corePlugin());
           case `${GRAFANA_API_ROOT}/plugins/not-installed`:
             return Promise.resolve(remotePlugin());
           case `${GRAFANA_API_ROOT}/plugins/enterprise`:
@@ -48,8 +50,7 @@ describe('Plugin details page', () => {
 
     const expected = 'Install';
 
-    await waitFor(() => getByText(expected));
-    expect(getByText(expected)).toBeInTheDocument();
+    await waitFor(() => expect(getByText(expected)).toBeInTheDocument());
   });
 
   it('should not display install button for enterprise plugins', async () => {
@@ -57,8 +58,12 @@ describe('Plugin details page', () => {
 
     const expected = "Marketplace doesn't support installing Enterprise plugins yet. Stay tuned!";
 
-    await waitFor(() => getByText(expected));
-    expect(getByText(expected)).toBeInTheDocument();
+    await waitFor(() => expect(getByText(expected)).toBeInTheDocument());
+  });
+
+  it('should not display install / uninstall buttons for core plugins', async () => {
+    const { queryByRole } = setup('core');
+    await waitFor(() => expect(queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument());
   });
 });
 
@@ -127,6 +132,38 @@ function localPlugin(plugin: Partial<LocalPlugin> = {}): LocalPlugin {
     state: 'alpha',
     type: 'datasource',
     dev: false,
+    ...plugin,
+  };
+}
+
+function corePlugin(plugin: Partial<LocalPlugin> = {}): LocalPlugin {
+  return {
+    category: 'sql',
+    defaultNavUrl: '/plugins/postgres/',
+    dev: false,
+    enabled: true,
+    hasUpdate: false,
+    id: 'core',
+    info: {
+      author: { name: 'Grafana Labs', url: 'https://grafana.com' },
+      build: {},
+      description: 'Data source for PostgreSQL and compatible databases',
+      links: [],
+      logos: {
+        small: 'public/app/plugins/datasource/postgres/img/postgresql_logo.svg',
+        large: 'public/app/plugins/datasource/postgres/img/postgresql_logo.svg',
+      },
+      updated: '',
+      version: '',
+    },
+    latestVersion: '',
+    name: 'PostgreSQL',
+    pinned: false,
+    signature: 'internal',
+    signatureOrg: '',
+    signatureType: '',
+    state: '',
+    type: 'datasource',
     ...plugin,
   };
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The catalog is rendering uninstall buttons for core plugins which throws an error if clicked. This PR adds logic to check if the plugin is considered a "core" plugin and prevents rendering uninstall / install buttons.



| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2021-07-12 at 17 10 54" src="https://user-images.githubusercontent.com/73201/125311782-f6e56c80-e333-11eb-97b3-753232a48ee8.png"> | <img width="500" alt="Screenshot 2021-07-12 at 17 10 54" src="https://user-images.githubusercontent.com/73201/125312018-33b16380-e334-11eb-8a18-8a5bd5367ae5.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #36229


