### PR TITLE
Security: Add support for AES-GCM encryption

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -310,12 +310,12 @@ func tryGetEncryptedCookie(ctx *models.ReqContext, cookieName string) (string, b
 		return "", false
 	}
 
-	decryptedError, err := util.Decrypt(decoded, setting.SecretKey)
+	decryptedError, err := util.Decrypt(decoded, setting.SecretKey, setting.EncryptionAlgorithm)
 	return string(decryptedError), err == nil
 }
 
 func (hs *HTTPServer) trySetEncryptedCookie(ctx *models.ReqContext, cookieName string, value string, maxAge int) error {
-	encryptedError, err := util.Encrypt([]byte(value), setting.SecretKey)
+	encryptedError, err := util.Encrypt([]byte(value), setting.SecretKey, setting.EncryptionAlgorithm)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -121,7 +121,7 @@ func TestLoginErrorCookieAPIEndpoint(t *testing.T) {
 	setting.OAuthAutoLogin = true
 
 	oauthError := errors.New("User not a member of one of the required organizations")
-	encryptedError, err := util.Encrypt([]byte(oauthError.Error()), setting.SecretKey)
+	encryptedError, err := util.Encrypt([]byte(oauthError.Error()), setting.SecretKey, setting.EncryptionAlgorithm)
 	require.NoError(t, err)
 	expCookiePath := "/"
 	if len(setting.AppSubUrl) > 0 {

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -85,7 +85,7 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 		})
 		setting.SecretKey = "password" //nolint:goconst
 
-		key, err := util.Encrypt([]byte("123"), "password")
+		key, err := util.Encrypt([]byte("123"), "password", util.AesCfb)
 		require.NoError(t, err)
 
 		ds := &models.DataSource{
@@ -223,7 +223,7 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 		})
 		setting.SecretKey = "password"
 
-		key, err := util.Encrypt([]byte("123"), "password")
+		key, err := util.Encrypt([]byte("123"), "password", util.AesCfb)
 		require.NoError(t, err)
 
 		ds := &models.DataSource{

--- a/pkg/api/pluginproxy/pluginproxy_test.go
+++ b/pkg/api/pluginproxy/pluginproxy_test.go
@@ -26,7 +26,7 @@ func TestPluginProxy(t *testing.T) {
 		setting.SecretKey = "password"
 
 		bus.AddHandler("test", func(query *models.GetPluginSettingByIdQuery) error {
-			key, err := util.Encrypt([]byte("123"), "password")
+			key, err := util.Encrypt([]byte("123"), "password", util.AesCfb)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords.go
@@ -109,7 +109,7 @@ func updateRows(session *sqlstore.DBSession, rows []map[string][]byte, passwordF
 }
 
 func getUpdatedSecureJSONData(row map[string][]byte, passwordFieldName string) (map[string]interface{}, error) {
-	encryptedPassword, err := util.Encrypt(row[passwordFieldName], setting.SecretKey)
+	encryptedPassword, err := util.Encrypt(row[passwordFieldName], setting.SecretKey, setting.EncryptionAlgorithm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/components/securedata/securedata.go
+++ b/pkg/components/securedata/securedata.go
@@ -8,9 +8,9 @@ import (
 type SecureData []byte
 
 func Encrypt(data []byte) (SecureData, error) {
-	return util.Encrypt(data, setting.SecretKey)
+	return util.Encrypt(data, setting.SecretKey, setting.EncryptionAlgorithm)
 }
 
 func (s SecureData) Decrypt() ([]byte, error) {
-	return util.Decrypt(s, setting.SecretKey)
+	return util.Decrypt(s, setting.SecretKey, setting.EncryptionAlgorithm)
 }

--- a/pkg/components/securejsondata/securejsondata.go
+++ b/pkg/components/securejsondata/securejsondata.go
@@ -14,7 +14,7 @@ type SecureJsonData map[string][]byte
 // is true if the key exists and false if not.
 func (s SecureJsonData) DecryptedValue(key string) (string, bool) {
 	if value, ok := s[key]; ok {
-		decryptedData, err := util.Decrypt(value, setting.SecretKey)
+		decryptedData, err := util.Decrypt(value, setting.SecretKey, setting.EncryptionAlgorithm)
 		if err != nil {
 			log.Fatalf(4, err.Error())
 		}
@@ -28,7 +28,7 @@ func (s SecureJsonData) DecryptedValue(key string) (string, bool) {
 func (s SecureJsonData) Decrypt() map[string]string {
 	decrypted := make(map[string]string)
 	for key, data := range s {
-		decryptedData, err := util.Decrypt(data, setting.SecretKey)
+		decryptedData, err := util.Decrypt(data, setting.SecretKey, setting.EncryptionAlgorithm)
 		if err != nil {
 			log.Fatalf(4, err.Error())
 		}
@@ -42,7 +42,7 @@ func (s SecureJsonData) Decrypt() map[string]string {
 func GetEncryptedJsonData(sjd map[string]string) SecureJsonData {
 	encrypted := make(SecureJsonData)
 	for key, data := range sjd {
-		encryptedData, err := util.Encrypt([]byte(data), setting.SecretKey)
+		encryptedData, err := util.Encrypt([]byte(data), setting.SecretKey, setting.EncryptionAlgorithm)
 		if err != nil {
 			log.Fatalf(4, err.Error())
 		}

--- a/pkg/models/datasource_cache_test.go
+++ b/pkg/models/datasource_cache_test.go
@@ -65,7 +65,7 @@ func TestDataSource_GetHttpTransport(t *testing.T) {
 		json := simplejson.New()
 		json.Set("tlsAuthWithCACert", true)
 
-		tlsCaCert, err := util.Encrypt([]byte(caCert), "password")
+		tlsCaCert, err := util.Encrypt([]byte(caCert), "password", util.AesCfb)
 		require.NoError(t, err)
 		ds := DataSource{
 			Id:             1,
@@ -111,9 +111,9 @@ func TestDataSource_GetHttpTransport(t *testing.T) {
 		json := simplejson.New()
 		json.Set("tlsAuth", true)
 
-		tlsClientCert, err := util.Encrypt([]byte(clientCert), "password")
+		tlsClientCert, err := util.Encrypt([]byte(clientCert), "password", util.AesCfb)
 		require.NoError(t, err)
-		tlsClientKey, err := util.Encrypt([]byte(clientKey), "password")
+		tlsClientKey, err := util.Encrypt([]byte(clientKey), "password", util.AesCfb)
 		require.NoError(t, err)
 
 		ds := DataSource{
@@ -151,7 +151,7 @@ func TestDataSource_GetHttpTransport(t *testing.T) {
 		json.Set("tlsAuthWithCACert", true)
 		json.Set("serverName", "server-name")
 
-		tlsCaCert, err := util.Encrypt([]byte(caCert), "password")
+		tlsCaCert, err := util.Encrypt([]byte(caCert), "password", util.AesCfb)
 		require.NoError(t, err)
 
 		ds := DataSource{
@@ -215,7 +215,7 @@ func TestDataSource_GetHttpTransport(t *testing.T) {
 		json := simplejson.NewFromAny(map[string]interface{}{
 			"httpHeaderName1": "Authorization",
 		})
-		encryptedData, err := util.Encrypt([]byte(`Bearer xf5yhfkpsnmgo`), setting.SecretKey)
+		encryptedData, err := util.Encrypt([]byte(`Bearer xf5yhfkpsnmgo`), setting.SecretKey, setting.EncryptionAlgorithm)
 		if err != nil {
 			log.Fatal(err.Error())
 		}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -352,7 +352,7 @@ func (c *PostableUserConfig) ProcessConfig() error {
 		case GrafanaReceiverType:
 			for _, gr := range r.PostableGrafanaReceivers.GrafanaManagedReceivers {
 				for k, v := range gr.SecureSettings {
-					encryptedData, err := util.Encrypt([]byte(v), setting.SecretKey)
+					encryptedData, err := util.Encrypt([]byte(v), setting.SecretKey, setting.EncryptionAlgorithm)
 					if err != nil {
 						return fmt.Errorf("failed to encrypt secure settings: %w", err)
 					}
@@ -730,7 +730,7 @@ func (r *PostableGrafanaReceiver) GetDecryptedSecret(key string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	decryptedValue, err := util.Decrypt(decodeValue, setting.SecretKey)
+	decryptedValue, err := util.Decrypt(decodeValue, setting.SecretKey, setting.EncryptionAlgorithm)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/services/sqlstore/migrations/ualert/channel.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel.go
@@ -312,7 +312,7 @@ func (c *PostableUserConfig) EncryptSecureSettings() error {
 	for _, r := range c.AlertmanagerConfig.Receivers {
 		for _, gr := range r.GrafanaManagedReceivers {
 			for k, v := range gr.SecureSettings {
-				encryptedData, err := util.Encrypt([]byte(v), setting.SecretKey)
+				encryptedData, err := util.Encrypt([]byte(v), setting.SecretKey, setting.EncryptionAlgorithm)
 				if err != nil {
 					return fmt.Errorf("failed to encrypt secure settings: %w", err)
 				}

--- a/pkg/services/sqlstore/plugin_setting.go
+++ b/pkg/services/sqlstore/plugin_setting.go
@@ -79,7 +79,7 @@ func UpdatePluginSetting(cmd *models.UpdatePluginSettingCmd) error {
 			return err
 		}
 		for key, data := range cmd.SecureJsonData {
-			encryptedData, err := util.Encrypt([]byte(data), setting.SecretKey)
+			encryptedData, err := util.Encrypt([]byte(data), setting.SecretKey, setting.EncryptionAlgorithm)
 			if err != nil {
 				return err
 			}

--- a/pkg/services/sqlstore/user_auth.go
+++ b/pkg/services/sqlstore/user_auth.go
@@ -271,7 +271,7 @@ func DeleteAuthInfo(cmd *models.DeleteAuthInfoCommand) error {
 // decodeAndDecrypt will decode the string with the standard bas64 decoder
 // and then decrypt it with grafana's secretKey
 func decodeAndDecrypt(s string) (string, error) {
-	// Bail out if empty string since it'll cause a segfault in util.Decrypt
+	// Bail out if empty string since it'll cause a segfault in util.DecryptCFB
 	if s == "" {
 		return "", nil
 	}
@@ -279,7 +279,7 @@ func decodeAndDecrypt(s string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	decrypted, err := util.Decrypt(decoded, setting.SecretKey)
+	decrypted, err := util.Decrypt(decoded, setting.SecretKey, setting.EncryptionAlgorithm)
 	if err != nil {
 		return "", err
 	}
@@ -289,7 +289,7 @@ func decodeAndDecrypt(s string) (string, error) {
 // encryptAndEncode will encrypt a string with grafana's secretKey, and
 // then encode it with the standard bas64 encoder
 func encryptAndEncode(s string) (string, error) {
-	encrypted, err := util.Encrypt([]byte(s), setting.SecretKey)
+	encrypted, err := util.Encrypt([]byte(s), setting.SecretKey, setting.EncryptionAlgorithm)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -92,6 +92,7 @@ var (
 
 	// Security settings.
 	SecretKey              string
+	EncryptionAlgorithm    string
 	DisableGravatar        bool
 	EmailCodeValidMinutes  int
 	DataProxyWhiteList     map[string]bool
@@ -1116,6 +1117,7 @@ func (cfg *Cfg) SectionWithEnvOverrides(s string) *DynamicSection {
 func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	security := iniFile.Section("security")
 	SecretKey = valueAsString(security, "secret_key", "")
+	EncryptionAlgorithm = valueAsString(security, "encryption_algorithm", util.AesCfb)
 	DisableGravatar = security.Key("disable_gravatar").MustBool(true)
 	cfg.DisableBruteForceLoginProtection = security.Key("disable_brute_force_login_protection").MustBool(false)
 

--- a/pkg/util/encryption.go
+++ b/pkg/util/encryption.go
@@ -15,6 +15,7 @@ import (
 const saltLength = 8
 
 const (
+	AesGcm = "aes-gcm"
 	AesCfb = "aes-cfb"
 )
 
@@ -35,9 +36,22 @@ func Decrypt(payload []byte, secret, alg string) ([]byte, error) {
 	}
 
 	switch alg {
+	case AesGcm:
+		return decryptGCM(block, payload)
 	default:
 		return decryptCFB(block, payload)
 	}
+}
+
+func decryptGCM(block cipher.Block, payload []byte) ([]byte, error) {
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := payload[saltLength : saltLength+gcm.NonceSize()]
+	ciphertext := payload[saltLength+gcm.NonceSize():]
+	return gcm.Open(nil, nonce, ciphertext, nil)
 }
 
 func decryptCFB(block cipher.Block, payload []byte) ([]byte, error) {
@@ -75,9 +89,33 @@ func Encrypt(payload []byte, secret string, alg string) ([]byte, error) {
 	}
 
 	switch alg {
+	case AesGcm:
+		return encryptGCM(block, payload, salt)
 	default:
 		return encryptCFB(block, payload, salt)
 	}
+}
+
+func encryptGCM(block cipher.Block, payload []byte, salt string) ([]byte, error) {
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, payload, nil)
+
+	result := make([]byte, saltLength+gcm.NonceSize()+len(ciphertext))
+
+	copy(result[:saltLength], salt)
+	copy(result[saltLength:saltLength+gcm.NonceSize()], nonce)
+	copy(result[saltLength+gcm.NonceSize():], ciphertext)
+
+	return result, nil
 }
 
 func encryptCFB(block cipher.Block, payload []byte, salt string) ([]byte, error) {

--- a/pkg/util/encryption.go
+++ b/pkg/util/encryption.go
@@ -14,11 +14,15 @@ import (
 
 const saltLength = 8
 
-// Decrypt decrypts a payload with a given secret.
-func Decrypt(payload []byte, secret string) ([]byte, error) {
+const (
+	AesCfb = "aes-cfb"
+)
+
+func Decrypt(payload []byte, secret, alg string) ([]byte, error) {
 	if len(payload) < saltLength {
 		return nil, fmt.Errorf("unable to compute salt")
 	}
+
 	salt := payload[:saltLength]
 	key, err := encryptionKeyToBytes(secret, string(salt))
 	if err != nil {
@@ -30,11 +34,19 @@ func Decrypt(payload []byte, secret string) ([]byte, error) {
 		return nil, err
 	}
 
+	switch alg {
+	default:
+		return decryptCFB(block, payload)
+	}
+}
+
+func decryptCFB(block cipher.Block, payload []byte) ([]byte, error) {
 	// The IV needs to be unique, but not secure. Therefore it's common to
 	// include it at the beginning of the ciphertext.
 	if len(payload) < aes.BlockSize {
 		return nil, errors.New("payload too short")
 	}
+
 	iv := payload[saltLength : saltLength+aes.BlockSize]
 	payload = payload[saltLength+aes.BlockSize:]
 	payloadDst := make([]byte, len(payload))
@@ -46,8 +58,7 @@ func Decrypt(payload []byte, secret string) ([]byte, error) {
 	return payloadDst, nil
 }
 
-// Encrypt encrypts a payload with a given secret.
-func Encrypt(payload []byte, secret string) ([]byte, error) {
+func Encrypt(payload []byte, secret string, alg string) ([]byte, error) {
 	salt, err := GetRandomString(saltLength)
 	if err != nil {
 		return nil, err
@@ -57,15 +68,24 @@ func Encrypt(payload []byte, secret string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}
 
+	switch alg {
+	default:
+		return encryptCFB(block, payload, salt)
+	}
+}
+
+func encryptCFB(block cipher.Block, payload []byte, salt string) ([]byte, error) {
 	// The IV needs to be unique, but not secure. Therefore it's common to
 	// include it at the beginning of the ciphertext.
 	ciphertext := make([]byte, saltLength+aes.BlockSize+len(payload))
 	copy(ciphertext[:saltLength], salt)
+
 	iv := ciphertext[saltLength : saltLength+aes.BlockSize]
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 		return nil, err
@@ -73,7 +93,6 @@ func Encrypt(payload []byte, secret string) ([]byte, error) {
 
 	stream := cipher.NewCFBEncrypter(block, iv)
 	stream.XORKeyStream(ciphertext[saltLength+aes.BlockSize:], payload)
-
 	return ciphertext, nil
 }
 

--- a/pkg/util/encryption_test.go
+++ b/pkg/util/encryption_test.go
@@ -18,13 +18,13 @@ func TestEncryption(t *testing.T) {
 		assert.Len(t, key, 32)
 	})
 
-	encAlgorithms := []string{AesCfb}
+	encAlgorithms := []string{AesGcm, AesCfb}
 
 	t.Run("decrypting basic payload", func(t *testing.T) {
 		for _, algorithm := range encAlgorithms {
 			algorithm := algorithm
 
-			t.Run(string(algorithm), func(t *testing.T) {
+			t.Run(algorithm, func(t *testing.T) {
 				encrypted, err := Encrypt([]byte("grafana"), "1234", algorithm)
 				require.NoError(t, err)
 

--- a/pkg/util/encryption_test.go
+++ b/pkg/util/encryption_test.go
@@ -18,20 +18,34 @@ func TestEncryption(t *testing.T) {
 		assert.Len(t, key, 32)
 	})
 
+	encAlgorithms := []string{AesCfb}
+
 	t.Run("decrypting basic payload", func(t *testing.T) {
-		encrypted, err := Encrypt([]byte("grafana"), "1234")
-		require.NoError(t, err)
+		for _, algorithm := range encAlgorithms {
+			algorithm := algorithm
 
-		decrypted, err := Decrypt(encrypted, "1234")
-		require.NoError(t, err)
+			t.Run(string(algorithm), func(t *testing.T) {
+				encrypted, err := Encrypt([]byte("grafana"), "1234", algorithm)
+				require.NoError(t, err)
 
-		assert.Equal(t, []byte("grafana"), decrypted)
+				decrypted, err := Decrypt(encrypted, "1234", algorithm)
+				require.NoError(t, err)
+
+				assert.Equal(t, []byte("grafana"), decrypted)
+			})
+		}
 	})
 
 	t.Run("decrypting empty payload should not fail", func(t *testing.T) {
-		_, err := Decrypt([]byte(""), "1234")
-		require.Error(t, err)
+		for _, algorithm := range encAlgorithms {
+			algorithm := algorithm
 
-		assert.Equal(t, "unable to compute salt", err.Error())
+			t.Run(algorithm, func(t *testing.T) {
+				_, err := Decrypt([]byte(""), "1234", algorithm)
+				require.Error(t, err)
+
+				assert.Equal(t, "unable to compute salt", err.Error())
+			})
+		}
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- It makes the encryption algorithm to be configurable through Grafana settings.
- It adds support for AES-GCM encryption.

**Special notes for your reviewer**:

- I'd appreciate if someone with larger experience on that topic than me could validate the AES-GCM implementation.
- We'll also need to add support for migrating encrypted data through `grafana-cli`.

