### PR TITLE
Alerting: Fix improper alert by changing the handling of empty labels

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -123,7 +123,7 @@ func expandTemplate(name, text string, data map[string]string) (result string, r
 		}
 	}()
 
-	tmpl, err := text_template.New(name).Option("missingkey=zero").Parse(text)
+	tmpl, err := text_template.New(name).Option("missingkey=error").Parse(text)
 	if err != nil {
 		return "", fmt.Errorf("error parsing template %v: %s", name, err.Error())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Change behavior for label/annotation expansion when missing key to `error` so that labels with empty values are no longer being set

**Which issue(s) this PR fixes**:

Fixes #35943

**Special notes for your reviewer**:
This will introduce/expose a different, undesirable behavior of the state cache where cache entries are never expired. An example of this can be found here: https://github.com/grafana/grafana/issues/36645 I will create a PR to address this issue separately. 
