### PR TITLE
DataLinks: support 'onClick' from table panels

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -398,7 +398,15 @@ export const getLinksSupplier = (
         href: '#',
         title: replaceVariables(link.title || '', variables),
         target: link.targetBlank ? '_blank' : undefined,
-        onClick: link.onClick,
+        onClick: (evt) => {
+          link.onClick!({
+            origin: {
+              field,
+            },
+            e: evt,
+            replaceVariables: (v) => replaceVariables(v, variables),
+          });
+        },
         origin: field,
       };
     }

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -395,14 +395,12 @@ export const getLinksSupplier = (
 
     if (link.onClick) {
       return {
-        href: '#',
+        href: link.url,
         title: replaceVariables(link.title || '', variables),
         target: link.targetBlank ? '_blank' : undefined,
-        onClick: (evt) => {
+        onClick: (evt, origin) => {
           link.onClick!({
-            origin: {
-              field,
-            },
+            origin: origin ?? field,
             e: evt,
             replaceVariables: (v) => replaceVariables(v, variables),
           });

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -393,6 +393,16 @@ export const getLinksSupplier = (
       },
     };
 
+    if (link.onClick) {
+      return {
+        href: '#',
+        title: replaceVariables(link.title || '', variables),
+        target: link.targetBlank ? '_blank' : undefined,
+        onClick: link.onClick,
+        origin: field,
+      };
+    }
+
     if (link.internal) {
       // For internal links at the moment only destination is Explore.
       return mapInternalLinkToExplore({
@@ -403,20 +413,19 @@ export const getLinksSupplier = (
         range: {} as any,
         replaceVariables,
       });
-    } else {
-      let href = locationUtil.assureBaseUrl(link.url.replace(/\n/g, ''));
-      href = replaceVariables(href, variables);
-      href = locationUtil.processUrl(href);
-
-      const info: LinkModel<Field> = {
-        href,
-        title: replaceVariables(link.title || '', variables),
-        target: link.targetBlank ? '_blank' : undefined,
-        origin: field,
-      };
-
-      return info;
     }
+
+    let href = locationUtil.assureBaseUrl(link.url.replace(/\n/g, ''));
+    href = replaceVariables(href, variables);
+    href = locationUtil.processUrl(href);
+
+    const info: LinkModel<Field> = {
+      href,
+      title: replaceVariables(link.title || '', variables),
+      target: link.targetBlank ? '_blank' : undefined,
+      origin: field,
+    };
+    return info;
   });
 };
 

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -58,7 +58,7 @@ export interface LinkModel<T = any> {
   origin: T;
 
   // When a click callback exists, this is passed the raw mouse|react event
-  onClick?: (e: any) => void;
+  onClick?: (e: any, origin?: any) => void;
 }
 
 /**

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -58,7 +58,7 @@ export interface LinkModel<T = any> {
   origin: T;
 
   // When a click callback exists, this is passed the raw mouse|react event
-  onClick?: (e: React.SyntheticEvent) => void;
+  onClick?: (e: any) => void;
 }
 
 /**

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -58,7 +58,7 @@ export interface LinkModel<T = any> {
   origin: T;
 
   // When a click callback exists, this is passed the raw mouse|react event
-  onClick?: (e: React.MouseEvent) => void;
+  onClick?: (e: React.SyntheticEvent) => void;
 }
 
 /**

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -58,7 +58,7 @@ export interface LinkModel<T = any> {
   origin: T;
 
   // When a click callback exists, this is passed the raw mouse|react event
-  onClick?: (e: DataLinkClickEvent) => void;
+  onClick?: (e: React.MouseEvent) => void;
 }
 
 /**

--- a/packages/grafana-data/src/types/dataLink.ts
+++ b/packages/grafana-data/src/types/dataLink.ts
@@ -58,7 +58,7 @@ export interface LinkModel<T = any> {
   origin: T;
 
   // When a click callback exists, this is passed the raw mouse|react event
-  onClick?: (e: any) => void;
+  onClick?: (e: DataLinkClickEvent) => void;
 }
 
 /**

--- a/packages/grafana-ui/src/utils/dataLinks.ts
+++ b/packages/grafana-ui/src/utils/dataLinks.ts
@@ -14,7 +14,7 @@ export const linkModelToContextMenuItems: (links: () => LinkModel[]) => MenuItem
       url: link.href,
       target: link.target,
       icon: `${link.target === '_self' ? 'link' : 'external-link-alt'}` as IconName,
-      onClick: link.onClick as any, // MouseEvent
+      onClick: link.onClick,
     };
   });
 };

--- a/packages/grafana-ui/src/utils/dataLinks.ts
+++ b/packages/grafana-ui/src/utils/dataLinks.ts
@@ -14,7 +14,7 @@ export const linkModelToContextMenuItems: (links: () => LinkModel[]) => MenuItem
       url: link.href,
       target: link.target,
       icon: `${link.target === '_self' ? 'link' : 'external-link-alt'}` as IconName,
-      onClick: link.onClick,
+      onClick: link.onClick as any, // MouseEvent
     };
   });
 };

--- a/packages/grafana-ui/src/utils/table.ts
+++ b/packages/grafana-ui/src/utils/table.ts
@@ -20,7 +20,10 @@ export const getCellLinks = (field: Field, row: Row<any>) => {
       // Allow opening in new tab
       if (!(event.ctrlKey || event.metaKey || event.shiftKey)) {
         event.preventDefault();
-        link!.onClick!(event); // TODO -- get the row index in there somehow
+        link!.onClick!(event, {
+          field,
+          rowIndex: row.index,
+        });
       }
     };
   }

--- a/packages/grafana-ui/src/utils/table.ts
+++ b/packages/grafana-ui/src/utils/table.ts
@@ -14,20 +14,13 @@ export const getCellLinks = (field: Field, row: Row<any>) => {
     })[0];
   }
 
-  // Handle explicit `onClick` callbacks
-  if (link && link.onClick) {
+  //const fieldLink = link?.onClick;
+  if (link?.onClick) {
     onClick = (event) => {
       // Allow opening in new tab
-      if (!(event.ctrlKey || event.metaKey || event.shiftKey) && link!.onClick) {
+      if (!(event.ctrlKey || event.metaKey || event.shiftKey)) {
         event.preventDefault();
-        link!.onClick({
-          origin: {
-            field,
-            row: row.index,
-          },
-          e: event,
-          replaceVariables: (v) => v,
-        });
+        link!.onClick!(event); // TODO -- get the row index in there somehow
       }
     };
   }

--- a/packages/grafana-ui/src/utils/table.ts
+++ b/packages/grafana-ui/src/utils/table.ts
@@ -14,6 +14,7 @@ export const getCellLinks = (field: Field, row: Row<any>) => {
     })[0];
   }
 
+  // Handle explicit `onClick` callbacks
   if (link && link.onClick) {
     onClick = (event) => {
       // Allow opening in new tab

--- a/packages/grafana-ui/src/utils/table.ts
+++ b/packages/grafana-ui/src/utils/table.ts
@@ -19,7 +19,14 @@ export const getCellLinks = (field: Field, row: Row<any>) => {
       // Allow opening in new tab
       if (!(event.ctrlKey || event.metaKey || event.shiftKey) && link!.onClick) {
         event.preventDefault();
-        link!.onClick(event);
+        link!.onClick({
+          origin: {
+            field,
+            row: row.index,
+          },
+          e: event,
+          replaceVariables: (v) => v,
+        });
       }
     };
   }

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -24,7 +24,6 @@ import {
   VariableSuggestionsScope,
 } from '@grafana/data';
 import { getVariablesUrlParams } from '../../variables/getAllVariableValuesForUrl';
-import React from '@visx/tooltip/node_modules/@types/react';
 
 const timeRangeVars = [
   {
@@ -318,20 +317,21 @@ export class LinkSrv implements LinkService {
       title: link.title ?? '',
       target: link.targetBlank ? '_blank' : undefined,
       origin,
-      onClick: link.onClick
-        ? (e: React.SyntheticEvent) => {
-            link.onClick!({
-              origin,
-              replaceVariables,
-              e,
-            });
-          }
-        : undefined,
     };
 
     if (replaceVariables) {
       info.href = replaceVariables(info.href);
       info.title = replaceVariables(link.title);
+    }
+
+    if (link.onClick) {
+      info.onClick = (e) => {
+        link.onClick!({
+          origin,
+          replaceVariables,
+          e,
+        });
+      };
     }
 
     info.href = getConfig().disableSanitizeHtml ? info.href : textUtil.sanitizeUrl(info.href);

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -7,7 +7,6 @@ import {
   DataFrame,
   DataLink,
   DataLinkBuiltInVars,
-  DataLinkClickEvent,
   deprecationWarning,
   Field,
   FieldType,
@@ -25,6 +24,7 @@ import {
   VariableSuggestionsScope,
 } from '@grafana/data';
 import { getVariablesUrlParams } from '../../variables/getAllVariableValuesForUrl';
+import React from '@visx/tooltip/node_modules/@types/react';
 
 const timeRangeVars = [
   {
@@ -313,30 +313,25 @@ export class LinkSrv implements LinkService {
       });
     }
 
-    let onClick: ((event: DataLinkClickEvent) => void) | undefined = undefined;
-
-    if (link.onClick) {
-      onClick = (e: DataLinkClickEvent) => {
-        if (link.onClick) {
-          link.onClick({
-            origin,
-            replaceVariables,
-            e,
-          });
-        }
-      };
-    }
-
     const info: LinkModel<T> = {
       href: locationUtil.assureBaseUrl(href.replace(/\n/g, '')),
-      title: replaceVariables ? replaceVariables(link.title || '') : link.title,
+      title: link.title ?? '',
       target: link.targetBlank ? '_blank' : undefined,
       origin,
-      onClick,
+      onClick: link.onClick
+        ? (e: React.SyntheticEvent) => {
+            link.onClick!({
+              origin,
+              replaceVariables,
+              e,
+            });
+          }
+        : undefined,
     };
 
     if (replaceVariables) {
       info.href = replaceVariables(info.href);
+      info.title = replaceVariables(link.title);
     }
 
     info.href = getConfig().disableSanitizeHtml ? info.href : textUtil.sanitizeUrl(info.href);


### PR DESCRIPTION
I have been digging into why the `onClick` behavior for DataLinks is not working as expected.  It looks like the `onClick` behavior was only implemented for PanelLinks, but not with in data.

This PR extends the current click processing so that explicit click behavior also works from data sources 