### PR TITLE
Annotations: Add custom label for custom values in builtin annotations

### DIFF
--- a/public/app/core/components/TagFilter/TagFilter.tsx
+++ b/public/app/core/components/TagFilter/TagFilter.tsx
@@ -15,6 +15,7 @@ export interface TermCount {
 
 export interface Props {
   allowCustomValue?: boolean;
+  formatCreateLabel?: (input: string) => string;
   /** Do not show selected values inside Select. Useful when the values need to be shown in some other components */
   hideValues?: boolean;
   inputId?: string;
@@ -33,6 +34,7 @@ const filterOption = (option: any, searchQuery: string) => {
 
 export const TagFilter: FC<Props> = ({
   allowCustomValue = false,
+  formatCreateLabel,
   hideValues,
   inputId,
   isClearable,
@@ -65,6 +67,7 @@ export const TagFilter: FC<Props> = ({
 
   const selectOptions = {
     allowCustomValue,
+    formatCreateLabel,
     defaultOptions: true,
     filterOption,
     getOptionLabel: (i: any) => i.label,

--- a/public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx
@@ -65,6 +65,8 @@ export default function AnnotationQueryEditor({ query, onChange }: Props) {
       tags,
     });
 
+  const onFormatCreateLabel = (input: string) => `Use custom value: ${input}`;
+
   return (
     <FieldSet className={styles.container}>
       <Field label="Filter by">
@@ -92,6 +94,7 @@ export default function AnnotationQueryEditor({ query, onChange }: Props) {
           <Field label="Tags" description={tagsTooltipContent}>
             <TagFilter
               allowCustomValue
+              formatCreateLabel={onFormatCreateLabel}
               inputId="grafana-annotations__tags"
               onChange={onTagsChange}
               tagOptions={getAnnotationTags}


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:


Add custom label in the AnnotationsQueryEditor when using a custom label, instead of the default `create _input_` now it will be `use custom value _input_`. The change is needed to avoid confusion, we don't create tags, currently, we get typeahead to support the existing tags or we can use custom values like template variables.

![custom-value](https://user-images.githubusercontent.com/239999/125411808-8f283380-e3be-11eb-950f-7123db8ad85d.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

 For #36107

**Special notes for your reviewer**:

