### PR TITLE
Explore: page title indicates which datasource is being used 

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/css';
 
 import { ExploreId, ExploreItemState } from 'app/types/explore';
 import { Icon, IconButton, SetInterval, ToolbarButton, ToolbarButtonRow, Tooltip } from '@grafana/ui';
-import { DataSourceInstanceSettings, NavModel, RawTimeRange } from '@grafana/data';
+import { DataSourceInstanceSettings, RawTimeRange } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
 import { StoreState } from 'app/types/store';
 import { createAndCopyShortLink } from 'app/core/utils/shortLinks';
@@ -22,16 +22,10 @@ import { LiveTailControls } from './useLiveTailControls';
 import { cancelQueries, clearQueries, runQueries, clearCache } from './state/query';
 import ReturnToDashboardButton from './ReturnToDashboardButton';
 import { isSplit } from './state/selectors';
-import { getNavModel } from '../../core/selectors/navModel';
-import { Branding } from 'app/core/components/Branding/Branding';
 
 interface OwnProps {
   exploreId: ExploreId;
   onChangeTime: (range: RawTimeRange, changedByScanner?: boolean) => void;
-}
-
-function setDatasourcePageTitle(dsName: string | undefined, navModel: NavModel) {
-  document.title = `${navModel.main.text} - ${dsName} - ${Branding.AppTitle}`;
 }
 
 type Props = OwnProps & ConnectedProps<typeof connector>;
@@ -88,7 +82,6 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
 
     const showSmallDataSourcePicker = (splitted ? containerWidth < 700 : containerWidth < 800) || false;
     const showSmallTimePicker = splitted || containerWidth < 1210;
-    setDatasourcePageTitle(this.props.datasourceName, this.props.navModel);
 
     return (
       <div className={splitted ? 'explore-toolbar splitted' : 'explore-toolbar'}>
@@ -243,7 +236,6 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps) => {
     isPaused,
     syncedTimes,
     containerWidth,
-    navModel: getNavModel(state.navIndex, 'explore'),
   };
 };
 

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/css';
 
 import { ExploreId, ExploreItemState } from 'app/types/explore';
 import { Icon, IconButton, SetInterval, ToolbarButton, ToolbarButtonRow, Tooltip } from '@grafana/ui';
-import { DataSourceInstanceSettings, RawTimeRange } from '@grafana/data';
+import { DataSourceInstanceSettings, NavModel, RawTimeRange } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
 import { StoreState } from 'app/types/store';
 import { createAndCopyShortLink } from 'app/core/utils/shortLinks';
@@ -22,10 +22,16 @@ import { LiveTailControls } from './useLiveTailControls';
 import { cancelQueries, clearQueries, runQueries, clearCache } from './state/query';
 import ReturnToDashboardButton from './ReturnToDashboardButton';
 import { isSplit } from './state/selectors';
+import { getNavModel } from '../../core/selectors/navModel';
+import { Branding } from 'app/core/components/Branding/Branding';
 
 interface OwnProps {
   exploreId: ExploreId;
   onChangeTime: (range: RawTimeRange, changedByScanner?: boolean) => void;
+}
+
+function setDatasourcePageTitle(dsName: string | undefined, navModel: NavModel) {
+  document.title = `${navModel.main.text} - ${dsName} - ${Branding.AppTitle}`;
 }
 
 type Props = OwnProps & ConnectedProps<typeof connector>;
@@ -82,6 +88,7 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
 
     const showSmallDataSourcePicker = (splitted ? containerWidth < 700 : containerWidth < 800) || false;
     const showSmallTimePicker = splitted || containerWidth < 1210;
+    setDatasourcePageTitle(this.props.datasourceName, this.props.navModel);
 
     return (
       <div className={splitted ? 'explore-toolbar splitted' : 'explore-toolbar'}>
@@ -236,6 +243,7 @@ const mapStateToProps = (state: StoreState, { exploreId }: OwnProps) => {
     isPaused,
     syncedTimes,
     containerWidth,
+    navModel: getNavModel(state.navIndex, 'explore'),
   };
 };
 

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -18,6 +18,7 @@ interface OwnProps {}
 const mapStateToProps = (state: StoreState) => {
   return {
     navModel: getNavModel(state.navIndex, 'explore'),
+    exploreState: state.explore,
   };
 };
 
@@ -49,6 +50,16 @@ class WrapperUnconnected extends PureComponent<Props> {
     const richHistory = getRichHistory();
     this.props.richHistoryUpdatedAction({ richHistory });
     this.updatePageDocumentTitle(this.props.navModel);
+  }
+
+  componentDidUpdate() {
+    const { left, right } = this.props.queryParams;
+    const hasSplit = Boolean(left) && Boolean(right);
+    const datasourceTitle = hasSplit
+      ? `${this.props.exploreState.left.datasourceInstance?.name} | ${this.props.exploreState.right?.datasourceInstance?.name}`
+      : `${this.props.exploreState.left.datasourceInstance?.name}`;
+    const documentTitle = `${this.props.navModel.main.text} - ${datasourceTitle} - ${Branding.AppTitle}`;
+    document.title = documentTitle;
   }
 
   render() {

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -6,7 +6,6 @@ import { lastSavedUrl, resetExploreAction, richHistoryUpdatedAction } from './st
 import { getRichHistory } from '../../core/utils/richHistory';
 import { ExplorePaneContainer } from './ExplorePaneContainer';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
-import { NavModel } from '@grafana/data';
 import { Branding } from '../../core/components/Branding/Branding';
 
 import { getNavModel } from '../../core/selectors/navModel';
@@ -31,14 +30,6 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type Props = OwnProps & RouteProps & ConnectedProps<typeof connector>;
 class WrapperUnconnected extends PureComponent<Props> {
-  updatePageDocumentTitle(navModel: NavModel) {
-    if (navModel) {
-      document.title = `${navModel.main.text} - ${Branding.AppTitle}`;
-    } else {
-      document.title = Branding.AppTitle;
-    }
-  }
-
   componentWillUnmount() {
     this.props.resetExploreAction({});
   }
@@ -49,7 +40,6 @@ class WrapperUnconnected extends PureComponent<Props> {
 
     const richHistory = getRichHistory();
     this.props.richHistoryUpdatedAction({ richHistory });
-    this.updatePageDocumentTitle(this.props.navModel);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds information to the page title about which datasource is being used in explore. When using one datasource the page title will look like this for example: **Explore - Loki - Grafana** and for split view: **Explore - Loki | Prometheus - Grafana**

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #36698

**Special notes for your reviewer**:

