### PR TITLE
InfluxDB: InfluxQL: adds tags to timeseries data

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.ts
+++ b/public/app/plugins/datasource/influxdb/influx_series.ts
@@ -51,7 +51,13 @@ export default class InfluxSeries {
           }
         }
 
-        output.push({ target: seriesName, datapoints: datapoints, meta: this.meta, refId: this.refId });
+        output.push({
+          target: seriesName,
+          datapoints: datapoints,
+          tags: series.tags,
+          meta: this.meta,
+          refId: this.refId,
+        });
       }
     });
 

--- a/public/app/plugins/datasource/influxdb/specs/influx_series.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/influx_series.test.ts
@@ -138,12 +138,20 @@ describe('when generating timeseries from influxdb response', () => {
         expect(result[0].datapoints[0][1]).toBe(1431946625000);
         expect(result[0].datapoints[1][0]).toBe(12);
         expect(result[0].datapoints[1][1]).toBe(1431946626000);
+        expect(result[0].tags).toMatchObject({
+          app: 'test',
+          server: 'server1',
+        });
 
         expect(result[1].target).toBe('cpu.mean {app: test2, server: server2}');
         expect(result[1].datapoints[0][0]).toBe(15);
         expect(result[1].datapoints[0][1]).toBe(1431946625000);
         expect(result[1].datapoints[1][0]).toBe(16);
         expect(result[1].datapoints[1][1]).toBe(1431946626000);
+        expect(result[1].tags).toMatchObject({
+          app: 'test2',
+          server: 'server2',
+        });
       });
     });
 


### PR DESCRIPTION
when the InfluxDB data source in InfluxQL mode returns data, it returns it in the `TimeSeries[]` format. but it does not return the tags. this pull request fixes this.

how to test it works:
- `make devenv sources=influxdb`
- (wait 1 minute for influxdb to get some data stored)
- create a dashboard-panel
- choose `gdev-influxdb-influxql`
  - select `cpu` in `FROM`
  - select `usage_idle` in the `SELECT field`
  - in the `GROUP BY` row click on [+] and add `tag(cpu)`
- you should see 5 lines right now
- go to the settings of the timeseries panel, choose "standard options > display name", and set it to `${__field.labels.cpu}`
- [save]
- now check the legend in the graph, it should say : "cpu-total", "cpu0", "cpu1", "cpu2", "cpu3"
- (for comparison, without this fix on the main branch it says: "${__field.labels.cpu}", "${__field.labels.cpu}", "${__field.labels.cpu}", "${__field.labels.cpu}", "${__field.labels.cpu}"