### PR TITLE
Plugins: Use plugin.pluginDir as source of truth for plugin location

### DIFF
--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -78,7 +78,7 @@ type PluginInstaller interface {
 	// and installs in the provided plugins directory.
 	Install(ctx context.Context, pluginID, version, pluginsDirectory, pluginZipURL, pluginRepoURL string) error
 	// Uninstall removes the specified plugin from the provided plugins directory.
-	Uninstall(ctx context.Context, pluginID, pluginPath string) error
+	Uninstall(ctx context.Context, pluginPath string) error
 }
 
 type PluginInstallerLogger interface {

--- a/pkg/plugins/manager/installer/installer.go
+++ b/pkg/plugins/manager/installer/installer.go
@@ -177,22 +177,20 @@ func (i *Installer) Install(ctx context.Context, pluginID, version, pluginsDir, 
 	return err
 }
 
-// Uninstall removes the specified plugin from the provided plugins directory.
-func (i *Installer) Uninstall(ctx context.Context, pluginID, pluginPath string) error {
-	pluginDir := filepath.Join(pluginPath, pluginID)
-
+// Uninstall removes the specified plugin from the provided plugin directory.
+func (i *Installer) Uninstall(ctx context.Context, pluginDir string) error {
 	// verify it's a plugin directory
 	if _, err := os.Stat(filepath.Join(pluginDir, "plugin.json")); err != nil {
 		if os.IsNotExist(err) {
 			if _, err := os.Stat(filepath.Join(pluginDir, "dist", "plugin.json")); err != nil {
 				if os.IsNotExist(err) {
-					return fmt.Errorf("tried to remove %s, but it doesn't seem to be a plugin", pluginPath)
+					return fmt.Errorf("tried to remove %s, but it doesn't seem to be a plugin", pluginDir)
 				}
 			}
 		}
 	}
 
-	i.log.Infof("Uninstalling plugin %v", pluginID)
+	i.log.Infof("Uninstalling plugin %v", pluginDir)
 
 	return os.RemoveAll(pluginDir)
 }

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -786,7 +786,7 @@ func (pm *PluginManager) Uninstall(ctx context.Context, pluginID string) error {
 		return err
 	}
 
-	return pm.pluginInstaller.Uninstall(ctx, plugin.Id, plugin.PluginDir)
+	return pm.pluginInstaller.Uninstall(ctx, plugin.PluginDir)
 }
 
 func (pm *PluginManager) unregister(plugin *plugins.PluginBase) error {

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -786,7 +786,7 @@ func (pm *PluginManager) Uninstall(ctx context.Context, pluginID string) error {
 		return err
 	}
 
-	return pm.pluginInstaller.Uninstall(ctx, pluginID, pm.Cfg.PluginsPath)
+	return pm.pluginInstaller.Uninstall(ctx, plugin.Id, plugin.PluginDir)
 }
 
 func (pm *PluginManager) unregister(plugin *plugins.PluginBase) error {

--- a/pkg/plugins/manager/manager_test.go
+++ b/pkg/plugins/manager/manager_test.go
@@ -697,7 +697,7 @@ func (f *fakePluginInstaller) Install(ctx context.Context, pluginID, version, pl
 	return nil
 }
 
-func (f *fakePluginInstaller) Uninstall(ctx context.Context, pluginID, pluginPath string) error {
+func (f *fakePluginInstaller) Uninstall(ctx context.Context, pluginPath string) error {
 	f.uninstallCount++
 	return nil
 }


### PR DESCRIPTION
There was a bad assumption made that all plugins would reside in `cfg.PluginsPath + '/' + plugin.Id`, but this may not be the case. This is the most correct approach

Can be tested if trying to remove a nested plugin, or where the plugin folder name doesn't match the plugin ID (a common thing that happens when using the `grafana-cli`)