### PR TITLE
Loki: Add autocomplete option for $__range variable

### DIFF
--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -32,6 +32,7 @@ const NS_IN_MS = 1000000;
 // @see public/app/plugins/datasource/prometheus/promql.ts
 const RATE_RANGES: CompletionItem[] = [
   { label: '$__interval', sortValue: '$__interval' },
+  { label: '$__range', sortValue: '$__range' },
   { label: '1m', sortValue: '00:01:00' },
   { label: '5m', sortValue: '00:05:00' },
   { label: '10m', sortValue: '00:10:00' },

--- a/public/app/plugins/datasource/prometheus/language_provider.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.test.ts
@@ -124,8 +124,9 @@ describe('Language completion provider', () => {
       expect(result.suggestions).toMatchObject([
         {
           items: [
-            { label: '$__interval', sortValue: '$__interval' }, // TODO: figure out why this row and sortValue is needed
+            { label: '$__interval', sortValue: '$__interval' },
             { label: '$__rate_interval', sortValue: '$__rate_interval' },
+            { label: '$__range', sortValue: '$__range' },
             { label: '1m', sortValue: '00:01:00' },
             { label: '5m', sortValue: '00:05:00' },
             { label: '10m', sortValue: '00:10:00' },

--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -6,6 +6,7 @@ import { CompletionItem } from '@grafana/ui';
 export const RATE_RANGES: CompletionItem[] = [
   { label: '$__interval', sortValue: '$__interval' },
   { label: '$__rate_interval', sortValue: '$__rate_interval' },
+  { label: '$__range', sortValue: '$__range' },
   { label: '1m', sortValue: '00:01:00' },
   { label: '5m', sortValue: '00:05:00' },
   { label: '10m', sortValue: '00:10:00' },


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki and Prometheus both support $__range variable, but we didn't have this variable in autocomplete options. This PR adds it for both data sources.

Prometheus docs: https://grafana.com/docs/grafana/latest/datasources/prometheus/#query-variable
Loki https://github.com/grafana/grafana/pull/36175

![image](https://user-images.githubusercontent.com/30407135/125485856-93950ced-dda2-4f3c-b455-e8dbdaa8eb82.png)
![image](https://user-images.githubusercontent.com/30407135/125485919-d9884971-f5f1-4c3e-9910-b4bc796420c3.png)
