### PR TITLE
Postgres/MySQL/MSSQL: Change time field to "Time" for time series queries

### DIFF
--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -373,7 +373,7 @@ func TestMySQL(t *testing.T) {
 
 			frames, _ := queryResult.Dataframes.Decoded()
 			require.Len(t, frames, 1)
-			require.Equal(t, "Time", frames[0].Fields[0].Name)
+			require.Equal(t, data.TimeSeriesTimeFieldName, frames[0].Fields[0].Name)
 			require.Equal(t, 7, frames[0].Fields[0].Len())
 			require.Equal(t, 1.5, *frames[0].Fields[1].At(3).(*float64))
 		})
@@ -506,7 +506,7 @@ func TestMySQL(t *testing.T) {
 			frames, err := queryResult.Dataframes.Decoded()
 			require.NoError(t, err)
 			require.Len(t, frames, 1)
-			require.Equal(t, "Time", frames[0].Fields[0].Name)
+			require.Equal(t, data.TimeSeriesTimeFieldName, frames[0].Fields[0].Name)
 			require.True(t, tInitial.Equal(*frames[0].Fields[0].At(0).(*time.Time)))
 		})
 

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -373,6 +373,7 @@ func TestMySQL(t *testing.T) {
 
 			frames, _ := queryResult.Dataframes.Decoded()
 			require.Len(t, frames, 1)
+			require.Equal(t, "Time", frames[0].Fields[0].Name)
 			require.Equal(t, 7, frames[0].Fields[0].Len())
 			require.Equal(t, 1.5, *frames[0].Fields[1].At(3).(*float64))
 		})
@@ -505,6 +506,7 @@ func TestMySQL(t *testing.T) {
 			frames, err := queryResult.Dataframes.Decoded()
 			require.NoError(t, err)
 			require.Len(t, frames, 1)
+			require.Equal(t, "Time", frames[0].Fields[0].Name)
 			require.True(t, tInitial.Equal(*frames[0].Fields[0].At(0).(*time.Time)))
 		})
 

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -285,7 +285,7 @@ func (e *dataPlugin) executeQuery(query plugins.DataSubQuery, wg *sync.WaitGroup
 		}
 
 		// Make sure to name the time field 'Time' to be backward compatible with Grafana pre-v8.
-		frame.Fields[qm.timeIndex].Name = "Time"
+		frame.Fields[qm.timeIndex].Name = data.TimeSeriesTimeFieldName
 
 		for i := range qm.columnNames {
 			if i == qm.timeIndex || i == qm.metricIndex {

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -283,6 +283,10 @@ func (e *dataPlugin) executeQuery(query plugins.DataSubQuery, wg *sync.WaitGroup
 			errAppendDebug("db has no time column", errors.New("no time column found"), interpolatedQuery)
 			return
 		}
+
+		// Make sure to name the time field 'Time' to be backward compatible with Grafana pre-v8.
+		frame.Fields[qm.timeIndex].Name = "Time"
+
 		for i := range qm.columnNames {
 			if i == qm.timeIndex || i == qm.metricIndex {
 				continue


### PR DESCRIPTION
**What this PR does / why we need it**:
Name of time field changed in v8 for time series queries from `Time` to the name of the selected time column, i.e. `time` or `time_sec`. These changes should make sure that the name of time field is always returned as `Time` for time series queries.

**Which issue(s) this PR fixes**:
Fixes #36059

**Special notes for your reviewer**:

