### PR TITLE
Plugins: Fix gzipped plugin asset response

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -133,7 +133,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/api/login/ping", quota("session"), routing.Wrap(hs.LoginAPIPing))
 
 	// expose plugin file system assets
-	r.Get("/public/plugins/:pluginId/*", routing.Wrap(hs.GetPluginAssets))
+	r.Get("/public/plugins/:pluginId/*", hs.GetPluginAssets)
 
 	// authed api
 	r.Group("/api", func(apiRoute routing.RouteRegister) {


### PR DESCRIPTION
In migrating to use the `response.Response` interfaces for the plugin asset endpoint - we incorrectly ignored the response context, losing information that helps construct a valid response. 

This reverts the change made here #36352

Will be resumed at a later point