### PR TITLE
Geomap: rename "circles" layer to "markers" layer

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/index.ts
+++ b/public/app/plugins/panel/geomap/layers/data/index.ts
@@ -1,4 +1,4 @@
-import { circlesLayer } from './circlesOverlay';
+import { markersLayer } from './markersLayer';
 import { geojsonMapper } from './geojsonMapper';
 import { lastPointTracker } from './lastPointTracker';
 
@@ -6,7 +6,7 @@ import { lastPointTracker } from './lastPointTracker';
  * Registry for layer handlers
  */
 export const dataLayers = [
-    circlesLayer,
+    markersLayer,
     lastPointTracker,
     geojsonMapper, // dummy for now
 ];

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.ts
@@ -9,7 +9,7 @@ import * as style from 'ol/style';
 import tinycolor from 'tinycolor2';
 
 // Configuration options for Circle overlays
-export interface CircleConfig {
+export interface MarkersConfig {
   queryFormat: QueryFormat,
   fieldMapping: FieldMappingOptions,
   minSize: number,
@@ -17,7 +17,7 @@ export interface CircleConfig {
   opacity: number,
 }
 
-const defaultOptions: CircleConfig = {
+const defaultOptions: MarkersConfig = {
   queryFormat: {
     locationType: 'coordinates',
   },
@@ -32,20 +32,22 @@ const defaultOptions: CircleConfig = {
   opacity: 0.4,
 };
 
+export const MARKERS_LAYER_ID = "markers";
+
 /**
  * Map layer configuration for circle overlay
  */
-export const circlesLayer: MapLayerRegistryItem<CircleConfig> = {
-  id: 'circles',
-  name: 'Circles',
-  description: 'creates circle overlays for data values',
+export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
+  id: MARKERS_LAYER_ID,
+  name: 'Markers',
+  description: 'use markers to render each data point',
   isBaseMap: false,
 
   /**
    * Function that configures transformation and returns a transformer
    * @param options
    */
-  create: (map: Map, options: MapLayerConfig<CircleConfig>, theme: GrafanaTheme2): MapLayerHandler => {
+  create: (map: Map, options: MapLayerConfig<MarkersConfig>, theme: GrafanaTheme2): MapLayerHandler => {
     const config = { ...defaultOptions, ...options.config };
 
     const vectorLayer = new layer.Vector({});

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.ts
@@ -116,6 +116,49 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
   // Circle overlay options
   registerOptionsUI: (builder) => {
     builder
+      .addSelect({
+        path: 'queryFormat.locationType',
+        name: 'Location source',
+        defaultValue: defaultOptions.queryFormat.locationType,
+        settings: {
+          options: [
+            {
+              value: 'coordinates',
+              label: 'Latitude/Longitude fields',
+            },
+            {
+              value: 'geohash',
+              label: 'Geohash field',
+            },
+          ],
+        },
+      })
+      .addTextInput({
+        path: 'fieldMapping.latitudeField',
+        name: 'Latitude Field',
+        defaultValue: defaultOptions.fieldMapping.latitudeField,
+        showIf: (config) =>
+          config.queryFormat.locationType === 'coordinates',
+      })
+      .addTextInput({
+        path: 'fieldMapping.longitudeField',
+        name: 'Longitude Field',
+        defaultValue: defaultOptions.fieldMapping.longitudeField,
+        showIf: (config) =>
+          config.queryFormat.locationType === 'coordinates',
+      })
+      .addTextInput({
+        path: 'fieldMapping.geohashField',
+        name: 'Geohash Field',
+        defaultValue: defaultOptions.fieldMapping.geohashField,
+        showIf: (config) =>
+          config.queryFormat.locationType === 'geohash',
+      })
+      .addTextInput({
+        path: 'fieldMapping.metricField',
+        name: 'Metric Field',
+        defaultValue: defaultOptions.fieldMapping.metricField,
+      })
       .addNumberInput({
         path: 'minSize',
         description: 'configures the min circle size',
@@ -138,49 +181,6 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
           max: 1,
           step: 0.1,
         },
-      })
-      .addSelect({
-        path: 'queryFormat.locationType',
-        name: 'Query Format',
-        defaultValue: defaultOptions.queryFormat.locationType,
-        settings: {
-          options: [
-            {
-              value: 'coordinates',
-              label: 'Coordinates',
-            },
-            {
-              value: 'geohash',
-              label: 'Geohash',
-            },
-          ],
-        },
-      })
-      .addTextInput({
-        path: 'fieldMapping.metricField',
-        name: 'Metric Field',
-        defaultValue: defaultOptions.fieldMapping.metricField,
-      })
-      .addTextInput({
-        path: 'fieldMapping.latitudeField',
-        name: 'Latitude Field',
-        defaultValue: defaultOptions.fieldMapping.latitudeField,
-        showIf: (config) =>
-          config.queryFormat.locationType === 'coordinates',
-      })
-      .addTextInput({
-        path: 'fieldMapping.longitudeField',
-        name: 'Longitude Field',
-        defaultValue: defaultOptions.fieldMapping.longitudeField,
-        showIf: (config) =>
-          config.queryFormat.locationType === 'coordinates',
-      })
-      .addTextInput({
-        path: 'fieldMapping.geohashField',
-        name: 'Geohash Field',
-        defaultValue: defaultOptions.fieldMapping.geohashField,
-        showIf: (config) =>
-          config.queryFormat.locationType === 'geohash',
       });
   },
   // fill in the default values


### PR DESCRIPTION
This renames the new geomap "circles" layer to "markers" -- this will allow us to support more symbols without changing the name.