### PR TITLE
Chore: Ease the migration of always using context.Context when interacting with the bus

### DIFF
--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -69,6 +69,22 @@ func TestDispatchCtx(t *testing.T) {
 	require.True(t, invoked, "expected handler to be called")
 }
 
+func TestDispatchCtx_NoContextHandler(t *testing.T) {
+	bus := New()
+
+	var invoked bool
+
+	bus.AddHandler(func(query *testQuery) error {
+		invoked = true
+		return nil
+	})
+
+	err := bus.DispatchCtx(context.Background(), &testQuery{})
+	require.NoError(t, err)
+
+	require.True(t, invoked, "expected handler to be called")
+}
+
 func TestDispatchCtx_NoRegisteredHandler(t *testing.T) {
 	bus := New()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have an ongoing refactoring to use `context.Context` "everywhere". To ease that migration I suggest 
- allowing `bus.DispatchCtx` to be called for a message registered using `bus.AddHandler`. Earlier this returned a "handler not found" error. In addition, if dev mode enabled a warning will be logged similar to this:
`WARN[07-14|00:23:06] DispatchCtx called with message handler registered using AddHandler and should be changed to use AddHandlerCtx logger=bus msgName=GetPreferencesWithDefaultsQuery`
- `bus.Dispatch` is already allowed to be called for a message registered using `bus.AddHandlerCtx`. In addition, if dev mode enabled a warning will be logged similar to this:
`WARN[07-14|00:24:02] Dispatch called with message handler registered using AddHandlerCtx and should be changed to use DispatchCtx logger=bus msgName=GetDashboardQuery`

While spotting these warning messages in the logs you can search for the usage of messages in question and fix accordingly.

In addition, merging changes in OSS Grafana would with these changes suggested allow Enterprise to not break instantly if there's a message being Dispatched using `bus.DispatchCtx` that have been registered using `bus.AddHandler`.

**Which issue(s) this PR fixes**:
Ref #36734 

**Special notes for your reviewer**:
Should we perhaps fail/panic if running in production mode? Could create some unexpected failures for release builds I guess. But maybe we can have something, like a feature toggle that when enabled will fail/panic rather than logging a warning message?
