### PR TITLE
Plugins: Switch to JSON response for static plugin file API errors 

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -261,7 +261,7 @@ func (hs *HTTPServer) GetPluginAssets(c *models.ReqContext) {
 	pluginID := c.Params("pluginId")
 	plugin := hs.PluginManager.GetPlugin(pluginID)
 	if plugin == nil {
-		c.Handle(hs.Cfg, 404, "Plugin not found", nil)
+		c.JsonApiErr(404, "Plugin not found", nil)
 		return
 	}
 
@@ -274,10 +274,10 @@ func (hs *HTTPServer) GetPluginAssets(c *models.ReqContext) {
 	f, err := os.Open(pluginFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			c.Handle(hs.Cfg, 404, "Plugin file not found", err)
+			c.JsonApiErr(404, "Plugin file not found", err)
 			return
 		}
-		c.Handle(hs.Cfg, 500, "Could not open plugin file", err)
+		c.JsonApiErr(500, "Could not open plugin file", err)
 		return
 	}
 	defer func() {
@@ -288,12 +288,12 @@ func (hs *HTTPServer) GetPluginAssets(c *models.ReqContext) {
 
 	fi, err := f.Stat()
 	if err != nil {
-		c.Handle(hs.Cfg, 500, "Plugin file exists but could not open", err)
+		c.JsonApiErr(500, "Plugin file exists but could not open", err)
 		return
 	}
 
 	if shouldExclude(fi) {
-		c.Handle(hs.Cfg, 403, "Plugin file access forbidden",
+		c.JsonApiErr(403, "Plugin file access forbidden",
 			fmt.Errorf("access is forbidden to executable plugin file %s", pluginFilePath))
 		return
 	}


### PR DESCRIPTION
This makes the response much easier to deal with on the frontend