### PR TITLE
Remove verify-drone for Windows

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -590,7 +590,6 @@ steps:
   commands:
   - $$ProgressPreference = "SilentlyContinue"
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.2.8/windows/grabpl.exe -OutFile grabpl.exe
-  - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
@@ -1031,7 +1030,6 @@ steps:
   commands:
   - $$ProgressPreference = "SilentlyContinue"
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.2.8/windows/grabpl.exe -OutFile grabpl.exe
-  - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
@@ -1523,7 +1521,6 @@ steps:
   - rm -force grabpl.exe
   - C:\App\grabpl.exe init-enterprise C:\App\grafana-enterprise
   - cp C:\App\grabpl.exe grabpl.exe
-  - .\grabpl.exe verify-drone
   depends_on:
   - clone
 
@@ -1976,7 +1973,6 @@ steps:
   commands:
   - $$ProgressPreference = "SilentlyContinue"
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.2.8/windows/grabpl.exe -OutFile grabpl.exe
-  - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
@@ -2462,7 +2458,6 @@ steps:
   - rm -force grabpl.exe
   - C:\App\grabpl.exe init-enterprise C:\App\grafana-enterprise
   - cp C:\App\grabpl.exe grabpl.exe
-  - .\grabpl.exe verify-drone
   depends_on:
   - clone
 
@@ -2890,7 +2885,6 @@ steps:
   commands:
   - $$ProgressPreference = "SilentlyContinue"
   - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.2.8/windows/grabpl.exe -OutFile grabpl.exe
-  - .\grabpl.exe verify-drone
 
 - name: build-windows-installer
   image: grafana/ci-wix:0.1.1
@@ -3375,7 +3369,6 @@ steps:
   - rm -force grabpl.exe
   - C:\App\grabpl.exe init-enterprise C:\App\grafana-enterprise
   - cp C:\App\grabpl.exe grabpl.exe
-  - .\grabpl.exe verify-drone
   depends_on:
   - clone
 
@@ -3503,6 +3496,6 @@ get:
 
 ---
 kind: signature
-hmac: 23ae969bde275e3f19150ede65879aa7413c551bbb2412010bfef81dc1a9c921
+hmac: fa16b4de5ce285e6e9495b3ed797383627ffd4d43539eab58186fe8cc227d3e7
 
 ...

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -929,7 +929,6 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
         init_cmds.extend([
             '$$ProgressPreference = "SilentlyContinue"',
             'Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/windows/grabpl.exe -OutFile grabpl.exe'.format(grabpl_version),
-            '.\\grabpl.exe verify-drone',
         ])
     steps = [
         {
@@ -1029,7 +1028,6 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
             'rm -force grabpl.exe',
             'C:\\App\\grabpl.exe init-enterprise C:\\App\\grafana-enterprise{}'.format(source_commit),
             'cp C:\\App\\grabpl.exe grabpl.exe',
-            '.\\grabpl.exe verify-drone',
         ])
 
     return steps


### PR DESCRIPTION
This step checks that there's no drift between star files and yml
It's currently broken for windows: https://raintank-corp.slack.com/archives/C010WU9Q5TJ/p1626270627462700
But it's only needed for PRs really
