### PR TITLE
Explore: Short log rows take full available space

### DIFF
--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -432,6 +432,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
     logRows: css`
       overflow-x: scroll;
+      width: 100%;
     `,
     infoText: css`
       font-size: ${theme.typography.size.sm};


### PR DESCRIPTION
**What this PR does / why we need it**:

This is useful for when we use log context. If the content of the displayed log rows is short, then the log row context is cut off and doesn't take full space. This is specially visible when content of log context is long. This tiny PR fixes it. 

Before
![image](https://user-images.githubusercontent.com/30407135/125755687-ae750f63-36aa-4853-9e72-3e1769055864.png)

After
![image](https://user-images.githubusercontent.com/30407135/125755913-1f088f3e-3353-499a-802e-6bb7ce27849d.png)


