### PR TITLE
Snapshots: Fix http: superfluous response.WriteHeader error when deleting an external snapshot

### DIFF
--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -185,9 +185,12 @@ func deleteExternalDashboardSnapshot(externalUrl string) error {
 	if err != nil {
 		return err
 	}
-	if err := response.Body.Close(); err != nil {
-		plog.Warn("Failed closing response body", "err", err)
-	}
+
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			plog.Warn("Failed to close response body", "err", err)
+		}
+	}()
 
 	if response.StatusCode == 200 {
 		return nil

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -171,16 +171,16 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 
 	t.Run("When deleting an external snapshot", func(t *testing.T) {
 		aclMockResp = []*models.DashboardAclInfoDTO{}
-		var writeErr error
 		loggedInUserScenarioWithRole(t,
 			"Should gracefully delete local snapshot when remote snapshot has already been removed when calling DELETE on",
 			"DELETE", "/api/snapshots/12345", "/api/snapshots/:key", models.ROLE_EDITOR, func(sc *scenarioContext) {
 				mockSnapshotResult := setUpSnapshotTest(t)
 				mockSnapshotResult.UserId = testUserID
 
+				var writeErr error
 				ts := setupRemoteServer(func(rw http.ResponseWriter, req *http.Request) {
-					_, writeErr = rw.Write([]byte(`{"message":"Failed to get dashboard snapshot"}`))
 					rw.WriteHeader(500)
+					_, writeErr = rw.Write([]byte(`{"message":"Failed to get dashboard snapshot"}`))
 				})
 
 				mockSnapshotResult.ExternalDeleteUrl = ts.URL


### PR DESCRIPTION
**What this PR does / why we need it**:
Noticed `server.go:3139: http: superfluous response.WriteHeader call from github.com/grafana/grafana/pkg/api.TestDashboardSnapshotAPIEndpoint_singleSnapshot.func7.1.1 (dashboard_snapshot_test.go:183)` when I had a failing test in the API package. This should resolve this. 

Multiple problems here:
- #29751 forgot to close the response body in a defer
- The test for deleting external snapshots had an error creating the superfluous response.WriteHeader error.

Since Grafana v7.4-beta1, in case you had created an external snapshot where the external snapshot don't exist anymore you would probably see an error when deleting snapshot from your local Grafana instance. Not a super bug problem I believe why I suggest to include this in v8.1.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

