### PR TITLE
Select: Block scroll on select instead of trying to hide the menu

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -177,8 +177,6 @@ export function SelectBase<T>({
     closeMenuOnSelect,
     // We don't want to close if we're actually scrolling the menu
     // So only close if none of the parents are the select menu itself
-    closeMenuOnScroll: (scrollEvent: Event) =>
-      !scrollEvent.composedPath().some((pathItem) => (pathItem as Element).classList?.value.includes(styles.menu)),
     defaultValue,
     // Also passing disabled, as this is the new Select API, and I want to use this prop instead of react-select's one
     disabled,
@@ -203,6 +201,7 @@ export function SelectBase<T>({
     menuPlacement,
     menuPortalTarget: document.body,
     menuPosition,
+    menuShouldBlockScroll: true,
     menuShouldScrollIntoView: false,
     onBlur,
     onChange: onChangeWithEmpty,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- follow up to https://github.com/grafana/grafana/pull/36398
- seems like in a small amount of cases on Linux, the `closeMenuOnScroll` logic doesn't work and instead immediately closes the menu. i'm not quite sure why, potentially due to not having support for `composedPath`? 🤔 
- instead, let's use the safer option of `menuShouldBlockScroll`. this will block any scrolling outside of the menu until the menu is closed
- this matches the behaviour of native `<select>` in Chrome, whereas `closeMenuOnScroll` matched the behaviour of native `<select>` in Firefox/Safari

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:

