### PR TITLE
POC: Alternative solution for fixing app dashboard links

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -70,8 +70,9 @@ func (hs *HTTPServer) TrimDashboard(c *models.ReqContext, cmd models.TrimDashboa
 }
 
 func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
+	slug := c.Params(":slug")
 	uid := c.Params(":uid")
-	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, uid)
+	dash, rsp := getDashboardHelperInternal(c.Req.Context(), c.OrgId, 0, uid, slug)
 	if rsp != nil {
 		return rsp
 	}
@@ -198,12 +199,16 @@ func getUserLogin(ctx context.Context, userID int64) string {
 }
 
 func getDashboardHelper(ctx context.Context, orgID int64, id int64, uid string) (*models.Dashboard, response.Response) {
+	return getDashboardHelperInternal(ctx, orgID, id, uid, "")
+}
+
+func getDashboardHelperInternal(ctx context.Context, orgID int64, id int64, uid string, slug string) (*models.Dashboard, response.Response) {
 	var query models.GetDashboardQuery
 
 	if len(uid) > 0 {
 		query = models.GetDashboardQuery{Uid: uid, Id: id, OrgId: orgID}
 	} else {
-		query = models.GetDashboardQuery{Id: id, OrgId: orgID}
+		query = models.GetDashboardQuery{Slug: slug, Id: id, OrgId: orgID}
 	}
 
 	if err := bus.DispatchCtx(ctx, &query); err != nil {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -110,9 +110,15 @@ func (hs *HTTPServer) getAppLinks(c *models.ReqContext) ([]*dtos.NavLink, error)
 
 			if include.Type == "dashboard" && include.AddToNav {
 				link := &dtos.NavLink{
-					Url:  hs.Cfg.AppSubURL + "/dashboard/db/" + include.Slug,
 					Text: include.Name,
 				}
+
+				if include.UID != "" {
+					link.Url = hs.Cfg.AppSubURL + fmt.Sprintf("/d/%s/%s", include.UID, include.Slug)
+				} else {
+					link.Url = hs.Cfg.AppSubURL + fmt.Sprintf("/plugins/%s/dashboards/slug/%s", plugin.Id, include.Slug)
+				}
+
 				appLink.Children = append(appLink.Children, link)
 			}
 		}

--- a/pkg/plugins/app_plugin.go
+++ b/pkg/plugins/app_plugin.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -117,7 +118,11 @@ func (app *AppPlugin) InitApp(panels map[string]*PanelPlugin, dataSources map[st
 			app.DefaultNavUrl = cfg.AppSubURL + "/plugins/" + app.Id + "/page/" + include.Slug
 		}
 		if include.Type == "dashboard" && include.DefaultNav {
-			app.DefaultNavUrl = cfg.AppSubURL + "/dashboard/db/" + include.Slug
+			if include.UID != "" {
+				app.DefaultNavUrl = cfg.AppSubURL + fmt.Sprintf("/d/%s/%s", include.UID, include.Slug)
+			} else {
+				app.DefaultNavUrl = cfg.AppSubURL + fmt.Sprintf("/plugins/%s/dashboards/slug/%s", app.Id, include.Slug)
+			}
 		}
 	}
 

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -94,6 +94,7 @@ type PluginInclude struct {
 	AddToNav   bool            `json:"addToNav"`
 	DefaultNav bool            `json:"defaultNav"`
 	Slug       string          `json:"slug"`
+	UID        string          `json:"uid"`
 	Icon       string          `json:"icon"`
 
 	Id string `json:"-"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Alternative solution to #35702. Getting something to compare with. This is not optimal introducing deprecated "get plugin dashboard by slug" endpoint I know, but should allow us to get out a short term solution while introducing support for specifying `uid` in plugin includes. Maybe we can remove support for slugs for Grafana 9?

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

