### PR TITLE
Allow using context.Context in middleware and handlers

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -333,13 +333,13 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 
 	m.Use(middleware.RequestTracing())
 
-	m.Use(middleware.Logger(hs.Cfg))
+	m.UseLegacy(middleware.Logger(hs.Cfg))
 
 	if hs.Cfg.EnableGzip {
-		m.Use(middleware.Gziper())
+		m.UseLegacy(middleware.Gziper())
 	}
 
-	m.Use(middleware.Recovery(hs.Cfg))
+	m.UseLegacy(middleware.Recovery(hs.Cfg))
 
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "build", "public/build")
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "", "public")
@@ -349,13 +349,13 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 		hs.mapStatic(m, hs.Cfg.ImagesDir, "", "/public/img/attachments")
 	}
 
-	m.Use(middleware.AddDefaultResponseHeaders(hs.Cfg))
+	m.UseLegacy(middleware.AddDefaultResponseHeaders(hs.Cfg))
 
 	if hs.Cfg.ServeFromSubPath && hs.Cfg.AppSubURL != "" {
 		m.SetURLPrefix(hs.Cfg.AppSubURL)
 	}
 
-	m.Use(macaron.Renderer(macaron.RenderOptions{
+	m.UseLegacy(macaron.Renderer(macaron.RenderOptions{
 		Directory:  filepath.Join(hs.Cfg.StaticRootPath, "views"),
 		IndentJSON: macaron.Env != macaron.PROD,
 		Delims:     macaron.Delims{Left: "[[", Right: "]]"},
@@ -363,23 +363,23 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 
 	// These endpoints are used for monitoring the Grafana instance
 	// and should not be redirected or rejected.
-	m.Use(hs.healthzHandler)
-	m.Use(hs.apiHealthHandler)
-	m.Use(hs.metricsEndpoint)
+	m.UseLegacy(hs.healthzHandler)
+	m.UseLegacy(hs.apiHealthHandler)
+	m.UseLegacy(hs.metricsEndpoint)
 
-	m.Use(hs.ContextHandler.Middleware)
-	m.Use(middleware.OrgRedirect(hs.Cfg))
+	m.UseLegacy(hs.ContextHandler.Middleware)
+	m.UseLegacy(middleware.OrgRedirect(hs.Cfg))
 
 	// needs to be after context handler
 	if hs.Cfg.EnforceDomain {
-		m.Use(middleware.ValidateHostHeader(hs.Cfg))
+		m.UseLegacy(middleware.ValidateHostHeader(hs.Cfg))
 	}
 
-	m.Use(middleware.HandleNoCacheHeader)
-	m.Use(middleware.AddCSPHeader(hs.Cfg, hs.log))
+	m.UseLegacy(middleware.HandleNoCacheHeader)
+	m.UseLegacy(middleware.AddCSPHeader(hs.Cfg, hs.log))
 
 	for _, mw := range hs.middlewares {
-		m.Use(mw)
+		m.UseLegacy(mw)
 	}
 }
 
@@ -469,7 +469,7 @@ func (hs *HTTPServer) mapStatic(m *macaron.Macaron, rootDir string, dir string, 
 		}
 	}
 
-	m.Use(httpstatic.Static(
+	m.UseLegacy(httpstatic.Static(
 		path.Join(rootDir, dir),
 		httpstatic.StaticOptions{
 			SkipLogging: true,

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -333,7 +333,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 
 	m.Use(middleware.RequestTracing())
 
-	m.UseLegacy(middleware.Logger(hs.Cfg))
+	m.Use(middleware.Logger(hs.Cfg))
 
 	if hs.Cfg.EnableGzip {
 		m.UseLegacy(middleware.Gziper())

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -336,7 +336,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	m.Use(middleware.Logger(hs.Cfg))
 
 	if hs.Cfg.EnableGzip {
-		m.UseLegacy(middleware.Gziper())
+		m.Use(middleware.Gziper())
 	}
 
 	m.UseLegacy(middleware.Recovery(hs.Cfg))

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -569,13 +569,7 @@ func TestDataSourceProxy_requestHandling(t *testing.T) {
 
 		ds := &models.DataSource{Url: backend.URL, Type: models.DS_GRAPHITE}
 
-		responseRecorder := &closeNotifierResponseRecorder{
-			ResponseRecorder: httptest.NewRecorder(),
-		}
-		t.Cleanup(responseRecorder.Close)
-
-		responseWriter := macaron.NewResponseWriter("GET", responseRecorder)
-
+		responseWriter := macaron.NewResponseWriter("GET", httptest.NewRecorder())
 		// XXX: Really unsure why, but setting headers within the HTTP handler function doesn't stick,
 		// so doing it here instead
 		for _, cfg := range cfgs {

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -745,20 +745,6 @@ func TestNewDataSourceProxy_MSSQL(t *testing.T) {
 	}
 }
 
-type closeNotifierResponseRecorder struct {
-	*httptest.ResponseRecorder
-	closeChan chan bool
-}
-
-func (r *closeNotifierResponseRecorder) CloseNotify() <-chan bool {
-	r.closeChan = make(chan bool)
-	return r.closeChan
-}
-
-func (r *closeNotifierResponseRecorder) Close() {
-	close(r.closeChan)
-}
-
 // getDatasourceProxiedRequest is a helper for easier setup of tests based on global config and ReqContext.
 func getDatasourceProxiedRequest(t *testing.T, ctx *models.ReqContext, cfg *setting.Cfg) *http.Request {
 	plugin := &plugins.DataSourcePlugin{}

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -153,7 +153,7 @@ func FromContext(c context.Context) *Context {
 // Use adds a middleware Handler to the stack,
 // and panics if the handler is not a callable func.
 // Middleware Handlers are invoked in the order that they are added.
-func (m *Macaron) Use(middleware func(http.Handler) http.Handler) {
+func (m *Macaron) UseMiddleware(middleware func(http.Handler) http.Handler) {
 	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		c := FromContext(req.Context())
 		c.Req.Request = req
@@ -163,7 +163,7 @@ func (m *Macaron) Use(middleware func(http.Handler) http.Handler) {
 	m.handlers = append(m.handlers, Handler(middleware(next)))
 }
 
-func (m *Macaron) UseLegacy(middleware Handler) {
+func (m *Macaron) Use(middleware Handler) {
 	h := validateAndWrapHandler(middleware)
 	m.handlers = append(m.handlers, h)
 }

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -88,21 +88,12 @@ func validateAndWrapHandler(h Handler) Handler {
 
 // validateAndWrapHandlers preforms validation and wrapping for each input handler.
 // It accepts an optional wrapper function to perform custom wrapping on handlers.
-func validateAndWrapHandlers(handlers []Handler, wrappers ...func(Handler) Handler) []Handler {
-	var wrapper func(Handler) Handler
-	if len(wrappers) > 0 {
-		wrapper = wrappers[0]
-	}
-
+func validateAndWrapHandlers(handlers []Handler) []Handler {
 	wrappedHandlers := make([]Handler, len(handlers))
 	for i, h := range handlers {
 		h = validateAndWrapHandler(h)
-		if wrapper != nil && !IsFastInvoker(h) {
-			h = wrapper(h)
-		}
 		wrappedHandlers[i] = h
 	}
-
 	return wrappedHandlers
 }
 
@@ -141,12 +132,12 @@ func New() *Macaron {
 // Handlers sets the entire middleware stack with the given Handlers.
 // This will clear any current middleware handlers,
 // and panics if any of the handlers is not a callable function
-func (m *Macaron) Handlers(handlers ...Handler) {
-	m.handlers = make([]Handler, 0)
-	for _, handler := range handlers {
-		m.Use(handler)
-	}
-}
+// func (m *Macaron) Handlers(handlers ...Handler) {
+// 	m.handlers = make([]Handler, 0)
+// 	for _, handler := range handlers {
+// 		m.Use(handler)
+// 	}
+// }
 
 // BeforeHandler represents a handler executes at beginning of every request.
 // Macaron stops future process when it returns true.
@@ -162,9 +153,19 @@ func FromContext(c context.Context) *Context {
 // Use adds a middleware Handler to the stack,
 // and panics if the handler is not a callable func.
 // Middleware Handlers are invoked in the order that they are added.
-func (m *Macaron) Use(handler Handler) {
-	handler = validateAndWrapHandler(handler)
-	m.handlers = append(m.handlers, handler)
+func (m *Macaron) Use(middleware func(http.Handler) http.Handler) {
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		c := FromContext(req.Context())
+		c.Req.Request = req
+		c.Map(req)
+		c.Next()
+	})
+	m.handlers = append(m.handlers, Handler(middleware(next)))
+}
+
+func (m *Macaron) UseLegacy(middleware Handler) {
+	h := validateAndWrapHandler(middleware)
+	m.handlers = append(m.handlers, h)
 }
 
 func (m *Macaron) createContext(rw http.ResponseWriter, req *http.Request) *Context {

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -129,16 +128,6 @@ func New() *Macaron {
 	return m
 }
 
-// Handlers sets the entire middleware stack with the given Handlers.
-// This will clear any current middleware handlers,
-// and panics if any of the handlers is not a callable function
-// func (m *Macaron) Handlers(handlers ...Handler) {
-// 	m.handlers = make([]Handler, 0)
-// 	for _, handler := range handlers {
-// 		m.Use(handler)
-// 	}
-// }
-
 // BeforeHandler represents a handler executes at beginning of every request.
 // Macaron stops future process when it returns true.
 type BeforeHandler func(rw http.ResponseWriter, req *http.Request) bool
@@ -214,18 +203,6 @@ func (m *Macaron) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 	m.Router.ServeHTTP(rw, req)
-}
-
-func getDefaultListenInfo() (string, int) {
-	host := os.Getenv("HOST")
-	if len(host) == 0 {
-		host = "0.0.0.0"
-	}
-	port, _ := strconv.Atoi(os.Getenv("PORT"))
-	if port == 0 {
-		port = 4000
-	}
-	return host, port
 }
 
 // SetURLPrefix sets URL prefix of router layer, so that it support suburl.

--- a/pkg/macaron/response_writer.go
+++ b/pkg/macaron/response_writer.go
@@ -27,7 +27,6 @@ import (
 type ResponseWriter interface {
 	http.ResponseWriter
 	http.Flusher
-	http.Pusher
 	// Status returns the status code of the response or 0 if the response has not been written.
 	Status() int
 	// Written returns whether or not the ResponseWriter has been written.
@@ -97,11 +96,6 @@ func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return hijacker.Hijack()
 }
 
-//nolint
-func (rw *responseWriter) CloseNotify() <-chan bool {
-	return rw.ResponseWriter.(http.CloseNotifier).CloseNotify()
-}
-
 func (rw *responseWriter) callBefore() {
 	for i := len(rw.beforeFuncs) - 1; i >= 0; i-- {
 		rw.beforeFuncs[i](rw)
@@ -113,12 +107,4 @@ func (rw *responseWriter) Flush() {
 	if ok {
 		flusher.Flush()
 	}
-}
-
-func (rw *responseWriter) Push(target string, opts *http.PushOptions) error {
-	pusher, ok := rw.ResponseWriter.(http.Pusher)
-	if !ok {
-		return errors.New("the ResponseWriter doesn't support the Pusher interface")
-	}
-	return pusher.Push(target, opts)
 }

--- a/pkg/macaron/router.go
+++ b/pkg/macaron/router.go
@@ -82,9 +82,6 @@ type Router struct {
 	groups              []group
 	notFound            http.HandlerFunc
 	internalServerError func(*Context, error)
-
-	// handlerWrapper is used to wrap arbitrary function from Handler to inject.FastInvoker.
-	handlerWrapper func(Handler) Handler
 }
 
 func NewRouter() *Router {
@@ -176,7 +173,7 @@ func (r *Router) Handle(method string, pattern string, handlers []Handler) *Rout
 		h = append(h, handlers...)
 		handlers = h
 	}
-	handlers = validateAndWrapHandlers(handlers, r.handlerWrapper)
+	handlers = validateAndWrapHandlers(handlers)
 
 	return r.handle(method, pattern, func(resp http.ResponseWriter, req *http.Request, params Params) {
 		c := r.m.createContext(resp, req)
@@ -279,11 +276,6 @@ func (r *Router) InternalServerError(handlers ...Handler) {
 		c.Map(err)
 		c.run()
 	}
-}
-
-// SetHandlerWrapper sets handlerWrapper for the router.
-func (r *Router) SetHandlerWrapper(f func(Handler) Handler) {
-	r.handlerWrapper = f
 }
 
 func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -1,12 +1,14 @@
 package middleware
 
 import (
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"log"
+	"net"
 	"net/http"
 	"strings"
 
-	"github.com/go-macaron/gzip"
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"gopkg.in/macaron.v1"
 )
 
@@ -20,27 +22,65 @@ var gzipIgnoredPathPrefixes = []string{
 	"/api/live/push", // WebSocket does not support gzip compression.
 }
 
-func Gziper() macaron.Handler {
-	gziperLogger := log.New("gziper")
-	gziper := gzip.Gziper()
+type gzipResponseWriter struct {
+	w *gzip.Writer
+	macaron.ResponseWriter
+}
 
-	return func(w http.ResponseWriter, r *http.Request) {
-		c := contexthandler.FromContext(r.Context())
-		requestPath := r.URL.RequestURI()
+func (grw *gzipResponseWriter) WriteHeader(c int) {
+	grw.Header().Del("Content-Length")
+	grw.ResponseWriter.WriteHeader(c)
+}
 
-		for _, pathPrefix := range gzipIgnoredPathPrefixes {
-			if strings.HasPrefix(requestPath, pathPrefix) {
+func (grw gzipResponseWriter) Write(p []byte) (int, error) {
+	fmt.Println("GZIP WRITE", grw.Header())
+	if grw.Header().Get("Content-Type") == "" {
+		grw.Header().Set("Content-Type", http.DetectContentType(p))
+	}
+	grw.Header().Del("Content-Length")
+	return grw.w.Write(p)
+}
+
+func (grw gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := grw.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, fmt.Errorf("GZIP ResponseWriter doesn't implement the Hijacker interface")
+}
+
+func Gziper() Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestPath := r.URL.RequestURI()
+
+			for _, pathPrefix := range gzipIgnoredPathPrefixes {
+				if strings.HasPrefix(requestPath, pathPrefix) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			// ignore resources
+			if (strings.HasPrefix(requestPath, "/api/datasources/") || strings.HasPrefix(requestPath, "/api/plugins/")) && strings.Contains(requestPath, resourcesPath) {
+				next.ServeHTTP(w, r)
 				return
 			}
-		}
 
-		// ignore resources
-		if (strings.HasPrefix(requestPath, "/api/datasources/") || strings.HasPrefix(requestPath, "/api/plugins/")) && strings.Contains(requestPath, resourcesPath) {
-			return
-		}
+			if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+				next.ServeHTTP(w, r)
+				return
+			}
 
-		if _, err := c.Invoke(gziper); err != nil {
-			gziperLogger.Error("Invoking gzip handler failed", "err", err)
-		}
+			log.Println("USE GZIP", requestPath)
+			grw := &gzipResponseWriter{gzip.NewWriter(w), w.(macaron.ResponseWriter)}
+			defer grw.w.Close()
+			ctx := macaron.FromContext(r.Context())
+			ctx.Resp = grw
+			ctx.MapTo(grw, (*http.ResponseWriter)(nil))
+			grw.Header().Set("Content-Encoding", "gzip")
+			grw.Header().Set("Vary", "Accept-Encoding")
+
+			next.ServeHTTP(grw, r)
+		})
 	}
 }

--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -71,9 +71,6 @@ func Gziper() Middleware {
 			}
 
 			grw := &gzipResponseWriter{gzip.NewWriter(w), w.(macaron.ResponseWriter)}
-			ctx := macaron.FromContext(r.Context())
-			ctx.Resp = grw
-			ctx.MapTo(grw, (*http.ResponseWriter)(nil))
 			grw.Header().Set("Content-Encoding", "gzip")
 			grw.Header().Set("Vary", "Accept-Encoding")
 

--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -71,9 +70,7 @@ func Gziper() Middleware {
 				return
 			}
 
-			log.Println("USE GZIP", requestPath)
 			grw := &gzipResponseWriter{gzip.NewWriter(w), w.(macaron.ResponseWriter)}
-			defer grw.w.Close()
 			ctx := macaron.FromContext(r.Context())
 			ctx.Resp = grw
 			ctx.MapTo(grw, (*http.ResponseWriter)(nil))
@@ -81,6 +78,8 @@ func Gziper() Middleware {
 			grw.Header().Set("Vary", "Accept-Encoding")
 
 			next.ServeHTTP(grw, r)
+			// We can't really handle close errors at this point and we can't report them to the caller
+			_ = grw.w.Close()
 		})
 	}
 }

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -27,7 +27,8 @@ import (
 )
 
 func Logger(cfg *setting.Cfg) macaron.Handler {
-	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
+	return func(res http.ResponseWriter, req *http.Request) {
+		c := macaron.FromContext(req.Context())
 		start := time.Now()
 		c.Data["perfmon.start"] = start
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	macaron "gopkg.in/macaron.v1"
@@ -20,6 +21,8 @@ var (
 	ReqEditorRole          = RoleAuth(models.ROLE_EDITOR, models.ROLE_ADMIN)
 	ReqOrgAdmin            = RoleAuth(models.ROLE_ADMIN)
 )
+
+type Middleware = func(next http.Handler) http.Handler
 
 func HandleNoCacheHeader(ctx *models.ReqContext) {
 	ctx.SkipCache = ctx.Req.Header.Get("X-Grafana-NoCache") == "true"

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -86,6 +86,7 @@ func (h *ContextHandler) Middleware(mContext *macaron.Context) {
 	}
 
 	mContext.Req.Request = mContext.Req.WithContext(context.WithValue(mContext.Req.Context(), reqContextKey{}, reqContext))
+	mContext.Map(mContext.Req.Request)
 
 	traceID, exists := cw.ExtractTraceID(mContext.Req.Request.Context())
 	if exists {


### PR DESCRIPTION
This PR allows getting macaron.Context and models.ReqContext from a standard context.Context (or request.Context()) and is the next step to replacing Macaron.

As a demonstration, it also includes Tracing, Logging and GZip middleware rewritten in a traditional manner.