### PR TITLE
Alerting: deactivate an Alertmanager configuration

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -25,6 +25,7 @@ var timeNow = time.Now
 type Alertmanager interface {
 	// Configuration
 	SaveAndApplyConfig(config *apimodels.PostableUserConfig) error
+	SaveAndApplyDefaultConfig() error
 	GetStatus() apimodels.GettableStatus
 
 	// Silences

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -45,8 +45,15 @@ func (srv AlertmanagerSrv) RouteCreateSilence(c *models.ReqContext, postableSile
 }
 
 func (srv AlertmanagerSrv) RouteDeleteAlertingConfig(c *models.ReqContext) response.Response {
-	// not implemented
-	return NotImplementedResp
+	if !c.HasUserRole(models.ROLE_EDITOR) {
+		return ErrResp(http.StatusForbidden, errors.New("permission denied"), "")
+	}
+	if err := srv.am.SaveAndApplyDefaultConfig(); err != nil {
+		srv.log.Error("unable to save and apply default alertmanager configuration", "err", err)
+		return ErrResp(http.StatusBadRequest, err, "failed to save and apply default Alertmanager configuration")
+	}
+
+	return response.JSON(http.StatusAccepted, util.DynMap{"message": "configuration deleted; the default is applied"})
 }
 
 func (srv AlertmanagerSrv) RouteDeleteSilence(c *models.ReqContext) response.Response {

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -50,7 +50,7 @@ func (srv AlertmanagerSrv) RouteDeleteAlertingConfig(c *models.ReqContext) respo
 	}
 	if err := srv.am.SaveAndApplyDefaultConfig(); err != nil {
 		srv.log.Error("unable to save and apply default alertmanager configuration", "err", err)
-		return ErrResp(http.StatusBadRequest, err, "failed to save and apply default Alertmanager configuration")
+		return ErrResp(http.StatusInternalServerError, err, "failed to save and apply default Alertmanager configuration")
 	}
 
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "configuration deleted; the default is applied"})

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -122,6 +122,30 @@ func TestNotificationChannels(t *testing.T) {
 	mockChannel.matchesExpNotifications(t, expNonEmailNotifications)
 	require.Equal(t, expEmailNotifications, mockEmail.emails)
 	require.NoError(t, mockChannel.Close())
+
+	{
+		// Delete the configuration; so it returns the default configuration.
+		u := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
+		req, err := http.NewRequest(http.MethodDelete, u, nil)
+		require.NoError(t, err)
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 202, resp.StatusCode)
+		require.JSONEq(t, `{"message":"configuration deleted; the default is applied"}`, string(b))
+
+		alertsURL := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
+		resp = getRequest(t, alertsURL, http.StatusOK) // nolint
+		b, err = ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, defaultAlertmanagerConfigJSON, string(b))
+	}
 }
 
 func getAlertmanagerConfig(channelAddr string) string {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It implements DELETE `/api/alertmanager/grafana/config/api/v1/alerts` by storing the default configuration which stops the existing configuration from being in use.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/alerting-squad#171

**Special notes for your reviewer**:

