### PR TITLE
Run builds on single-build agents

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -235,6 +235,9 @@ services:
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
 
+node:
+  type: no-parallel
+
 trigger:
   event:
   - pull_request
@@ -563,6 +566,9 @@ services:
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
 
+node:
+  type: no-parallel
+
 trigger:
   branch:
   - main
@@ -662,6 +668,9 @@ steps:
       from_secret: grafana_api_key
   depends_on:
   - initialize
+
+node:
+  type: no-parallel
 
 trigger:
   branch:
@@ -1004,6 +1013,9 @@ services:
     MYSQL_PASSWORD: password
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
+
+node:
+  type: no-parallel
 
 trigger:
   ref:
@@ -1477,6 +1489,9 @@ services:
 image_pull_secrets:
 - dockerconfigjson
 
+node:
+  type: no-parallel
+
 trigger:
   ref:
   - refs/tags/v*
@@ -1616,6 +1631,9 @@ steps:
       from_secret: grafana_api_key
   depends_on:
   - initialize
+
+node:
+  type: no-parallel
 
 trigger:
   ref:
@@ -1947,6 +1965,9 @@ services:
     MYSQL_PASSWORD: password
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
+
+node:
+  type: no-parallel
 
 trigger:
   event:
@@ -2414,6 +2435,9 @@ services:
 image_pull_secrets:
 - dockerconfigjson
 
+node:
+  type: no-parallel
+
 trigger:
   event:
   - custom
@@ -2553,6 +2577,9 @@ steps:
       from_secret: grafana_api_key
   depends_on:
   - initialize
+
+node:
+  type: no-parallel
 
 trigger:
   event:
@@ -2859,6 +2886,9 @@ services:
     MYSQL_PASSWORD: password
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
+
+node:
+  type: no-parallel
 
 trigger:
   ref:
@@ -3325,6 +3355,9 @@ services:
 image_pull_secrets:
 - dockerconfigjson
 
+node:
+  type: no-parallel
+
 trigger:
   ref:
   - refs/heads/v*
@@ -3496,6 +3529,6 @@ get:
 
 ---
 kind: signature
-hmac: fa16b4de5ce285e6e9495b3ed797383627ffd4d43539eab58186fe8cc227d3e7
+hmac: 10ffbe8e4bf248916e2b8c7eb293d2389971b25f718f33fb9d6076f3151e4679
 
 ...

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -17,20 +17,28 @@ def pipeline(
     ):
     if platform != 'windows':
         platform_conf = {
-            'os': 'linux',
-            'arch': 'amd64',
+            'platform': {
+                'os': 'linux',
+                'arch': 'amd64'
+            },
+            # A shared cache is used on the host
+            # To avoid issues with parallel builds, we run this repo on single build agents
+            'node': {
+                'type': 'no-parallel'
+            }
         }
     else:
         platform_conf = {
-            'os': 'windows',
-            'arch': 'amd64',
-            'version': '1809',
+            'platform': {
+                'os': 'windows',
+                'arch': 'amd64',
+                'version': '1809',
+            }
         }
 
     pipeline = {
         'kind': 'pipeline',
         'type': 'docker',
-        'platform': platform_conf,
         'name': name,
         'trigger': trigger,
         'services': services,
@@ -39,6 +47,7 @@ def pipeline(
         ) + steps,
         'depends_on': depends_on,
     }
+    pipeline.update(platform_conf)
 
     if edition in ('enterprise', 'enterprise2'):
         pipeline['image_pull_secrets'] = [pull_secret]


### PR DESCRIPTION
This is an effort to reduce cache errors when multiple agents try to build the yarn cache at the same time
https://github.com/grafana/deployment_tools/issues/13329

As discussed here: https://raintank-corp.slack.com/archives/CEXAGGYVC/p1626353614179500