### PR TITLE
Alerting: Deduplicate receivers during migration

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/channel.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel.go
@@ -162,6 +162,10 @@ func (m *migration) makeReceiverAndRoute(ruleUid string, channelUids []interface
 	if rn, ok := m.portedChannelGroups[chanKey]; ok {
 		// We have ported these exact set of channels already. Re-use it.
 		receiverName = rn
+		if receiverName == "autogen-contact-point-default" {
+			// We don't need to create new routes if it's the default contact point.
+			return nil, nil, nil
+		}
 	} else {
 		for n := range filteredChannelUids {
 			if err := addChannel(allChannels[n]); err != nil {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -54,8 +54,9 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 			mg.Logger.Error("alert migration error: could not clear alert migration for removing data", "error", err)
 		}
 		mg.AddMigration(migTitle, &migration{
-			seenChannelUIDs:  make(map[string]struct{}),
-			migratedChannels: make(map[*notificationChannel]struct{}),
+			seenChannelUIDs:     make(map[string]struct{}),
+			migratedChannels:    make(map[*notificationChannel]struct{}),
+			portedChannelGroups: make(map[string]string),
 		})
 	case !ngEnabled && migrationRun:
 		// Remove the migration entry that creates unified alerting data. This is so when the feature
@@ -74,9 +75,10 @@ type migration struct {
 	sess *xorm.Session
 	mg   *migrator.Migrator
 
-	seenChannelUIDs  map[string]struct{}
-	migratedChannels map[*notificationChannel]struct{}
-	silences         []*pb.MeshSilence
+	seenChannelUIDs     map[string]struct{}
+	migratedChannels    map[*notificationChannel]struct{}
+	silences            []*pb.MeshSilence
+	portedChannelGroups map[string]string // Channel group key -> receiver name.
 }
 
 func (m *migration) SQL(dialect migrator.Dialect) string {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -114,7 +114,10 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	}
 
 	amConfig := PostableUserConfig{}
-	amConfig.AlertmanagerConfig.Route = &Route{}
+	err = m.addDefaultChannels(&amConfig, allChannels, defaultChannels)
+	if err != nil {
+		return err
+	}
 
 	for _, da := range dashAlerts {
 		newCond, err := transConditions(*da.ParsedSettings, da.OrgId, dsIDMap)
@@ -248,7 +251,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	}
 
 	// Create a separate receiver for all the unmigrated channels.
-	err = m.updateDefaultAndUnmigratedChannels(&amConfig, allChannels, defaultChannels)
+	err = m.addUnmigratedChannels(&amConfig, allChannels, defaultChannels)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -79,6 +79,7 @@ type migration struct {
 	migratedChannels    map[*notificationChannel]struct{}
 	silences            []*pb.MeshSilence
 	portedChannelGroups map[string]string // Channel group key -> receiver name.
+	lastReceiverID      int               // For the auto generated receivers.
 }
 
 func (m *migration) SQL(dialect migrator.Dialect) string {


### PR DESCRIPTION
If 2 panel alerts have the same set of notification channels used, this PR deduplicates them and avoids creating new contact points for such channel groups.

Fixes https://github.com/grafana/grafana/issues/36697
