### PR TITLE
SegmentSelect: Fix closing the menu on click out

### DIFF
--- a/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
@@ -1,5 +1,4 @@
 import React, { HTMLProps, useRef } from 'react';
-import useClickAway from 'react-use/lib/useClickAway';
 import { SelectableValue } from '@grafana/data';
 import { Select } from '../Select/Select';
 import { useTheme2 } from '../../themes/ThemeContext';
@@ -29,19 +28,6 @@ export function SegmentSelect<T>({
   const ref = useRef<HTMLDivElement>(null);
   const theme = useTheme2();
 
-  useClickAway(ref, () => {
-    if (ref && ref.current) {
-      // https://github.com/JedWatson/react-select/issues/188#issuecomment-279240292
-      // Unfortunately there's no other way of retrieving the (not yet) created new option
-      const input = ref.current.querySelector('input[id^="react-select-"]') as HTMLInputElement;
-      if (input && input.value) {
-        onChange({ value: input.value as any, label: input.value });
-      } else {
-        onClickOutside();
-      }
-    }
-  });
-
   let width = widthPixels > 0 ? widthPixels / theme.spacing.gridSize : undefined;
 
   return (
@@ -55,6 +41,18 @@ export function SegmentSelect<T>({
         onChange={onChange}
         options={options}
         value={value}
+        onCloseMenu={() => {
+          if (ref && ref.current) {
+            // https://github.com/JedWatson/react-select/issues/188#issuecomment-279240292
+            // Unfortunately there's no other way of retrieving the value (not yet) created new option
+            const input = ref.current.querySelector('input[id^="react-select-"]') as HTMLInputElement;
+            if (input && input.value) {
+              onChange({ value: input.value as any, label: input.value });
+            } else {
+              onClickOutside();
+            }
+          }
+        }}
         allowCustomValue={allowCustomValue}
       />
     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

After changes in #36398 the dropdown menu in SegmentSelect is no longer dismissed on click away. Clicking outside of the dropdown has no effect and the menu stays open. 

https://user-images.githubusercontent.com/745532/125839489-27dd402c-7b68-4504-91d6-2cf9fb68d9d9.mov

I guess it's because now the menu is detached from the parent div we're referencing in clickAway. Seems to be working fine with `onCloseMenu` handler.

How to test it? 
For example open Elasticsearch query editor, open any segment and try to click outside to close it.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

