### PR TITLE
Tooltip: Make active series more noticeable

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/SeriesTable.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/SeriesTable.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { GrafanaTheme, GraphSeriesValue } from '@grafana/data';
+import { GrafanaTheme2, GraphSeriesValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { SeriesIcon } from '../VizLegend/SeriesIcon';
-import { useStyles } from '../../themes';
+import { useStyles2 } from '../../themes';
 
 /**
  * @public
@@ -14,10 +14,10 @@ export interface SeriesTableRowProps {
   isActive?: boolean;
 }
 
-const getSeriesTableRowStyles = (theme: GrafanaTheme) => {
+const getSeriesTableRowStyles = (theme: GrafanaTheme2) => {
   return {
     icon: css`
-      margin-right: ${theme.spacing.xs};
+      margin-right: ${theme.v1.spacing.xs};
       vertical-align: middle;
     `,
     seriesTable: css`
@@ -34,13 +34,14 @@ const getSeriesTableRowStyles = (theme: GrafanaTheme) => {
       word-break: break-all;
     `,
     value: css`
-      padding-left: ${theme.spacing.md};
+      padding-left: ${theme.v1.spacing.md};
     `,
     activeSeries: css`
-      font-weight: ${theme.typography.weight.bold};
+      font-weight: ${theme.typography.fontWeightBold};
+      color: ${theme.colors.text.maxContrast};
     `,
     timestamp: css`
-      font-weight: ${theme.typography.weight.bold};
+      font-weight: ${theme.typography.fontWeightBold};
       font-size: ${theme.typography.size.sm};
     `,
   };
@@ -50,7 +51,7 @@ const getSeriesTableRowStyles = (theme: GrafanaTheme) => {
  * @public
  */
 export const SeriesTableRow: React.FC<SeriesTableRowProps> = ({ color, label, value, isActive }) => {
-  const styles = useStyles(getSeriesTableRowStyles);
+  const styles = useStyles2(getSeriesTableRowStyles);
 
   return (
     <div className={cx(styles.seriesTableRow, isActive && styles.activeSeries)}>
@@ -77,7 +78,7 @@ export interface SeriesTableProps {
  * @public
  */
 export const SeriesTable: React.FC<SeriesTableProps> = ({ timestamp, series }) => {
-  const styles = useStyles(getSeriesTableRowStyles);
+  const styles = useStyles2(getSeriesTableRowStyles);
 
   return (
     <>

--- a/packages/grafana-ui/src/components/VizTooltip/SeriesTable.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/SeriesTable.tsx
@@ -17,7 +17,7 @@ export interface SeriesTableRowProps {
 const getSeriesTableRowStyles = (theme: GrafanaTheme2) => {
   return {
     icon: css`
-      margin-right: ${theme.v1.spacing.xs};
+      margin-right: ${theme.spacing(1)};
       vertical-align: middle;
     `,
     seriesTable: css`
@@ -25,7 +25,7 @@ const getSeriesTableRowStyles = (theme: GrafanaTheme2) => {
     `,
     seriesTableRow: css`
       display: table-row;
-      font-size: ${theme.typography.size.sm};
+      font-size: ${theme.typography.bodySmall.fontSize};
     `,
     seriesTableCell: css`
       display: table-cell;
@@ -34,7 +34,7 @@ const getSeriesTableRowStyles = (theme: GrafanaTheme2) => {
       word-break: break-all;
     `,
     value: css`
-      padding-left: ${theme.v1.spacing.md};
+      padding-left: ${theme.spacing(2)};
     `,
     activeSeries: css`
       font-weight: ${theme.typography.fontWeightBold};
@@ -42,7 +42,7 @@ const getSeriesTableRowStyles = (theme: GrafanaTheme2) => {
     `,
     timestamp: css`
       font-weight: ${theme.typography.fontWeightBold};
-      font-size: ${theme.typography.size.sm};
+      font-size: ${theme.typography.bodySmall.fontSize};
     `,
   };
 };


### PR DESCRIPTION

Fixes #35397

### It was previously harder to see the difference between the active series and the other series. 

_The following screenshots are taken on Firefox on macOS._

Before the tooltip looked like this:
<img width="174" alt="before" src="https://user-images.githubusercontent.com/42276368/125870329-2e88735d-28d8-4518-8b46-739976bda2d4.png">

Currently in this PR the color is set to the maxContrast color but it also could be changed to warning or info text, whichever is preferred.

**MaxContrast Color**
<img width="178" alt="colors-text-maxContrast" src="https://user-images.githubusercontent.com/42276368/125870331-3a6228af-7fb0-4797-ac1d-80541be2a06e.png">

**Warning Text Color**
<img width="182" alt="colors-warning-text" src="https://user-images.githubusercontent.com/42276368/125870330-039c7055-73f8-49ff-a364-eb71d62aaa86.png">
<img width="200" alt="colors-warning-text2" src="https://user-images.githubusercontent.com/42276368/125870332-805abb1f-d99d-4a5d-993e-6f9cd46170b7.png">

**Info Text Color**
<img width="190" alt="colors-info-text" src="https://user-images.githubusercontent.com/42276368/125870333-203533f4-2eed-4f23-b417-018a71f3c077.png">
<img width="193" alt="colors-info-text2" src="https://user-images.githubusercontent.com/42276368/125870335-fa0325d8-69b2-4e35-a2e7-60508b8ab75a.png">