### PR TITLE
POC: Resolve dashboard UID by slug with caching

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -82,6 +82,7 @@ type HTTPServer struct {
 	SettingsProvider       setting.Provider                        `inject:""`
 	HooksService           *hooks.HooksService                     `inject:""`
 	CacheService           *localcache.CacheService                `inject:""`
+	DashboardCache         *localcache.CacheService                `inject:""`
 	DatasourceCache        datasources.CacheService                `inject:""`
 	AuthTokenService       models.UserTokenService                 `inject:""`
 	QuotaService           *quota.QuotaService                     `inject:""`

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -86,6 +86,7 @@ type PluginDependencies struct {
 }
 
 type PluginInclude struct {
+	UID        string          `json:"uid"`
 	Name       string          `json:"name"`
 	Path       string          `json:"path"`
 	Type       string          `json:"type"`


### PR DESCRIPTION
Another approach to #35702, which resolves UIDs for all the dashboards on each page load, however it does cache the query results for better performance. I realise the cache is currently shared with other services, but if the approach looks valid a separate LRU cache can be added.