### PR TITLE
live: Add support to handle origin without a value for the port when matching with root_url

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -402,9 +402,17 @@ func checkAllowedOrigin(origin string, appURL *url.URL, originGlobs []glob.Glob)
 		logger.Warn("Failed to parse request origin", "error", err, "origin", origin)
 		return false, err
 	}
-	if strings.EqualFold(originURL.Scheme, appURL.Scheme) && strings.EqualFold(originURL.Host, appURL.Host) {
-		return true, nil
+	// Try to match over configured [server] root_url first.
+	if originURL.Port() == "" {
+		if strings.EqualFold(originURL.Scheme, appURL.Scheme) && strings.EqualFold(originURL.Host, appURL.Hostname()) {
+			return true, nil
+		}
+	} else {
+		if strings.EqualFold(originURL.Scheme, appURL.Scheme) && strings.EqualFold(originURL.Host, appURL.Host) {
+			return true, nil
+		}
 	}
+	// If there is still no match try [live] allowed_origins patterns.
 	for _, pattern := range originGlobs {
 		if pattern.Match(origin) {
 			return true, nil

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -76,6 +76,12 @@ func TestCheckOrigin(t *testing.T) {
 			success: true,
 		},
 		{
+			name:    "valid_origin_no_port",
+			origin:  "https://www.example.com",
+			appURL:  "https://www.example.com:443/grafana/",
+			success: true,
+		},
+		{
 			name:    "unauthorized_origin",
 			origin:  "http://localhost:8000",
 			appURL:  "http://localhost:3000/",


### PR DESCRIPTION
**What this PR does / why we need it**:

Origin without explicit port should pass a check when compared with root_url.

**Which issue(s) this PR fixes**:

#36822 