### PR TITLE
Explore: Fix query cancellation when opening an url with split panes

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -16,6 +16,7 @@ import store from 'app/core/store';
 import { dateTime, ExploreUrlState, LogsSortOrder } from '@grafana/data';
 import { RefreshPicker } from '@grafana/ui';
 import { serializeStateToUrlParam } from '@grafana/data/src/utils/url';
+import { ExploreId } from '../../types';
 
 const DEFAULT_EXPLORE_STATE: ExploreUrlState = {
   datasource: '',
@@ -417,21 +418,21 @@ describe('when buildQueryTransaction', () => {
     const queries = [{ refId: 'A' }];
     const queryOptions = { maxDataPoints: 1000, minInterval: '15s' };
     const range = { from: dateTime().subtract(1, 'd'), to: dateTime(), raw: { from: '1h', to: '1h' } };
-    const transaction = buildQueryTransaction(queries, queryOptions, range, false);
+    const transaction = buildQueryTransaction(ExploreId.left, queries, queryOptions, range, false);
     expect(transaction.request.intervalMs).toEqual(60000);
   });
   it('it should calculate interval taking minInterval into account', () => {
     const queries = [{ refId: 'A' }];
     const queryOptions = { maxDataPoints: 1000, minInterval: '15s' };
     const range = { from: dateTime().subtract(1, 'm'), to: dateTime(), raw: { from: '1h', to: '1h' } };
-    const transaction = buildQueryTransaction(queries, queryOptions, range, false);
+    const transaction = buildQueryTransaction(ExploreId.left, queries, queryOptions, range, false);
     expect(transaction.request.intervalMs).toEqual(15000);
   });
   it('it should calculate interval taking maxDataPoints into account', () => {
     const queries = [{ refId: 'A' }];
     const queryOptions = { maxDataPoints: 10, minInterval: '15s' };
     const range = { from: dateTime().subtract(1, 'd'), to: dateTime(), raw: { from: '1h', to: '1h' } };
-    const transaction = buildQueryTransaction(queries, queryOptions, range, false);
+    const transaction = buildQueryTransaction(ExploreId.left, queries, queryOptions, range, false);
     expect(transaction.request.interval).toEqual('2h');
   });
 });

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -29,7 +29,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getNextRefIdChar } from './query';
 // Types
 import { RefreshPicker } from '@grafana/ui';
-import { QueryOptions, QueryTransaction } from 'app/types/explore';
+import { ExploreId, QueryOptions, QueryTransaction } from 'app/types/explore';
 import { config } from '../config';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DataSourceSrv } from '@grafana/runtime';
@@ -116,6 +116,7 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
 }
 
 export function buildQueryTransaction(
+  exploreId: ExploreId,
   queries: DataQuery[],
   queryOptions: QueryOptions,
   range: TimeRange,
@@ -148,7 +149,7 @@ export function buildQueryTransaction(
     panelId: panelId as any,
     targets: queries, // Datasources rely on DataQueries being passed under the targets key.
     range,
-    requestId: 'explore',
+    requestId: 'explore_' + exploreId,
     rangeRaw: range.raw,
     scopedVars: {
       __interval: { text: interval, value: interval },

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -383,7 +383,7 @@ export const runQueries = (
 
       const datasourceName = datasourceInstance.name;
       const timeZone = getTimeZone(getState().user);
-      const transaction = buildQueryTransaction(queries, queryOptions, range, scanning, timeZone);
+      const transaction = buildQueryTransaction(exploreId, queries, queryOptions, range, scanning, timeZone);
 
       let firstResponse = true;
       dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/36531

We have a cancellation logic here https://github.com/grafana/grafana/blob/9ace8686a1abffe21d2b3b115db795900b67590c/public/app/core/services/backend_srv.ts#L340 that checks for requestId and cancels duplicate requests but in explore we just use `explore` for both panes which resulted in race condition and possible cancellation of one request by the other one. 