### PR TITLE
InfluxDB: InfluxQL: in alerting queries, handle future data correctly

### DIFF
--- a/pkg/tsdb/influxdb/query.go
+++ b/pkg/tsdb/influxdb/query.go
@@ -102,7 +102,7 @@ func (query *Query) renderTimeFilter(queryContext plugins.DataQuery) string {
 
 	// else from dashboard alerting
 	from := "now() - " + queryContext.TimeRange.From
-	to := ""
+	to := " and time < now()"
 
 	if queryContext.TimeRange.To != "now" && queryContext.TimeRange.To != "" {
 		to = " and time < now() - " + strings.Replace(queryContext.TimeRange.To, "now-", "", 1)


### PR DESCRIPTION
(note: this change was already implemented to the "in-browser" part, for influxql-queries, but it was not done for alerting-queries, so this is it for alerting queries)

currently, if you set up a time-range like from: now - 15m to : now, the generated influxql query in alerting will use this time-filter expression: WHERE time  >now() - 15m. if the database contains data for in-the-future timestamps (for example, weather forecast data), those will get included in the query-result. we do not want this.

this happens because currently we special-case time-ranges that end with now.

this pull-request changes this and we always create the whole from-to expression, so the time-filter for the above-mentioned time-range will become: WHERE time >now() - 15m and time <now().

fixes https://github.com/grafana/grafana/issues/36851