### PR TITLE
VizTooltip: Use previous positioning calculation

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltip.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltip.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import { css } from '@emotion/css';
+import { Portal } from '../Portal/Portal';
 import { Dimensions, TimeZone } from '@grafana/data';
 import { FlotPosition } from '../Graph/types';
 import { VizTooltipContainer } from './VizTooltipContainer';
+import { useStyles } from '../../themes';
 import { TooltipDisplayMode } from './models.gen';
 
 // Describes active dimensions user interacts with
@@ -46,14 +49,30 @@ export interface VizTooltipProps {
  * @public
  */
 export const VizTooltip: React.FC<VizTooltipProps> = ({ content, position, offset }) => {
+  const styles = useStyles(getStyles);
   if (position) {
     return (
-      <VizTooltipContainer position={position} offset={offset || { x: 0, y: 0 }}>
-        {content}
-      </VizTooltipContainer>
+      <Portal className={styles.portal}>
+        <VizTooltipContainer position={position} offset={offset || { x: 0, y: 0 }}>
+          {content}
+        </VizTooltipContainer>
+      </Portal>
     );
   }
   return null;
 };
 
 VizTooltip.displayName = 'VizTooltip';
+
+const getStyles = () => {
+  return {
+    portal: css`
+      position: absolute;
+      top: 0;
+      left: 0;
+      pointer-events: none;
+      width: 100%;
+      height: 100%;
+    `,
+  };
+};

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
@@ -1,9 +1,10 @@
-import React, { useState, HTMLAttributes, useMemo } from 'react';
+import React, { useState, HTMLAttributes, useMemo, useRef, useLayoutEffect } from 'react';
 import { css, cx } from '@emotion/css';
 import { useStyles2 } from '../../themes';
 import { getTooltipContainerStyles } from '../../themes/mixins';
-import { GrafanaTheme2 } from '@grafana/data';
-import { usePopper } from 'react-popper';
+import useWindowSize from 'react-use/lib/useWindowSize';
+import { Dimensions2D, GrafanaTheme2 } from '@grafana/data';
+import { calculateTooltipPosition } from './utils';
 
 /**
  * @public
@@ -24,47 +25,74 @@ export const VizTooltipContainer: React.FC<VizTooltipContainerProps> = ({
   className,
   ...otherProps
 }) => {
-  const [tooltipRef, setTooltipRef] = useState<HTMLDivElement | null>(null);
-  const virtualElement = useMemo(
-    () => ({
-      getBoundingClientRect() {
-        return { top: positionY, left: positionX, bottom: positionY, right: positionX, width: 0, height: 0 };
-      },
-    }),
-    [positionY, positionX]
-  );
-  const { styles: popperStyles, attributes } = usePopper(virtualElement, tooltipRef, {
-    placement: 'bottom-start',
-    modifiers: [
-      { name: 'arrow', enabled: false },
-      {
-        name: 'preventOverflow',
-        enabled: true,
-        options: {
-          altAxis: true,
-          rootBoundary: 'viewport',
-        },
-      },
-      {
-        name: 'offset',
-        options: {
-          offset: [offsetX, offsetY],
-        },
-      },
-    ],
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [tooltipMeasurement, setTooltipMeasurement] = useState<Dimensions2D>({ width: 0, height: 0 });
+  const { width, height } = useWindowSize();
+  const [placement, setPlacement] = useState({
+    x: positionX + offsetX,
+    y: positionY + offsetY,
   });
+
+  const resizeObserver = useMemo(
+    () =>
+      // TS has hard time playing games with @types/resize-observer-browser, hence the ignore
+      // @ts-ignore
+      new ResizeObserver((entries) => {
+        for (let entry of entries) {
+          const tW = Math.floor(entry.contentRect.width + 2 * 8); //  adding padding until Safari supports borderBoxSize
+          const tH = Math.floor(entry.contentRect.height + 2 * 8);
+          if (tooltipMeasurement.width !== tW || tooltipMeasurement.height !== tH) {
+            setTooltipMeasurement({
+              width: tW,
+              height: tH,
+            });
+          }
+        }
+      }),
+    [tooltipMeasurement]
+  );
+
+  useLayoutEffect(() => {
+    if (tooltipRef.current) {
+      resizeObserver.observe(tooltipRef.current);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [resizeObserver]);
+
+  // Make sure tooltip does not overflow window
+  useLayoutEffect(() => {
+    if (tooltipRef && tooltipRef.current && tooltipMeasurement.width && tooltipMeasurement.height) {
+      const { x, y } = calculateTooltipPosition(
+        positionX,
+        positionY,
+        tooltipMeasurement.width,
+        tooltipMeasurement.height,
+        offsetX,
+        offsetY,
+        width,
+        height
+      );
+
+      setPlacement({ x, y });
+    }
+  }, [width, height, positionX, offsetX, positionY, offsetY, tooltipMeasurement]);
 
   const styles = useStyles2(getStyles);
 
   return (
     <div
-      ref={setTooltipRef}
+      ref={tooltipRef}
       style={{
-        ...popperStyles.popper,
-        display: popperStyles.popper?.transform ? 'block' : 'none',
-        transition: 'all ease-out 0.2s',
+        position: 'fixed',
+        left: 0,
+        top: 0,
+        transform: `translate(${placement.x}px, ${placement.y}px)`,
+        pointerEvents: 'none',
+        transition: 'transform ease-out 0.1s',
       }}
-      {...attributes.popper}
       {...otherProps}
       className={cx(styles.wrapper, className)}
     >

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
@@ -90,7 +90,6 @@ export const VizTooltipContainer: React.FC<VizTooltipContainerProps> = ({
         left: 0,
         top: 0,
         transform: `translate(${placement.x}px, ${placement.y}px)`,
-        pointerEvents: 'none',
         transition: 'transform ease-out 0.1s',
       }}
       {...otherProps}

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
@@ -64,7 +64,7 @@ export const VizTooltipContainer: React.FC<VizTooltipContainerProps> = ({
 
   // Make sure tooltip does not overflow window
   useLayoutEffect(() => {
-    if (tooltipRef && tooltipRef.current && tooltipMeasurement.width && tooltipMeasurement.height) {
+    if (tooltipRef && tooltipRef.current) {
       const { x, y } = calculateTooltipPosition(
         positionX,
         positionY,

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
@@ -88,6 +88,7 @@ export const VizTooltipContainer: React.FC<VizTooltipContainerProps> = ({
       style={{
         position: 'fixed',
         left: 0,
+        pointerEvents: 'none',
         top: 0,
         transform: `translate(${placement.x}px, ${placement.y}px)`,
         transition: 'transform ease-out 0.1s',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
@@ -88,6 +88,8 @@ export const VizTooltipContainer: React.FC<VizTooltipContainerProps> = ({
       style={{
         position: 'fixed',
         left: 0,
+        // disabling pointer-events is to prevent the tooltip from flickering when moving left to right
+        // see e.g. https://github.com/grafana/grafana/pull/33609
         pointerEvents: 'none',
         top: 0,
         transform: `translate(${placement.x}px, ${placement.y}px)`,

--- a/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
@@ -1,0 +1,165 @@
+import { calculateTooltipPosition } from './utils';
+
+describe('utils', () => {
+  describe('calculateTooltipPosition', () => {
+    // let's pick some easy numbers for these, we shouldn't need to change them
+    const tooltipWidth = 100;
+    const tooltipHeight = 100;
+    const xOffset = 10;
+    const yOffset = 10;
+    const windowWidth = 200;
+    const windowHeight = 200;
+
+    it('sticky positions the tooltip to the right if it would overflow at both ends but overflow to the left more', () => {
+      const xPos = 99;
+      const yPos = 50;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 90,
+        y: 60,
+      });
+    });
+
+    it('sticky positions the tooltip to the left if it would overflow at both ends but overflow to the right more', () => {
+      const xPos = 101;
+      const yPos = 50;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 10,
+        y: 60,
+      });
+    });
+
+    it('positions the tooltip to left of the cursor if it would overflow right', () => {
+      const xPos = 150;
+      const yPos = 50;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 40,
+        y: 60,
+      });
+    });
+
+    it('positions the tooltip to the right of the cursor if it would not overflow', () => {
+      const xPos = 50;
+      const yPos = 50;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 60,
+        y: 60,
+      });
+    });
+
+    it('sticky positions the tooltip to the bottom if it would overflow at both ends but overflow to the top more', () => {
+      const xPos = 50;
+      const yPos = 99;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 60,
+        y: 90,
+      });
+    });
+
+    it('sticky positions the tooltip to the top if it would overflow at both ends but overflow to the bottom more', () => {
+      const xPos = 50;
+      const yPos = 101;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 60,
+        y: 10,
+      });
+    });
+
+    it('positions the tooltip above the cursor if it would overflow at the bottom', () => {
+      const xPos = 50;
+      const yPos = 150;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 60,
+        y: 40,
+      });
+    });
+
+    it('positions the tooltip below the cursor if it would not overflow', () => {
+      const xPos = 50;
+      const yPos = 50;
+      const result = calculateTooltipPosition(
+        xPos,
+        yPos,
+        tooltipWidth,
+        tooltipHeight,
+        xOffset,
+        yOffset,
+        windowWidth,
+        windowHeight
+      );
+      expect(result).toEqual({
+        x: 60,
+        y: 60,
+      });
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -1,0 +1,40 @@
+export const calculateTooltipPosition = (
+  xPos = 0,
+  yPos = 0,
+  tooltipWidth = 0,
+  tooltipHeight = 0,
+  xOffset = 0,
+  yOffset = 0,
+  windowWidth = 0,
+  windowHeight = 0
+) => {
+  let x = xPos;
+  let y = yPos;
+
+  const overflowRight = Math.max(xPos + xOffset + tooltipWidth - (windowWidth - xOffset), 0);
+  const overflowLeft = Math.abs(Math.min(xPos - xOffset - tooltipWidth - xOffset, 0));
+  const wouldOverflowRight = overflowRight > 0;
+  const wouldOverflowLeft = overflowLeft > 0;
+
+  const overflowBelow = Math.max(yPos + yOffset + tooltipHeight - (windowHeight - yOffset), 0);
+  const overflowAbove = Math.abs(Math.min(yPos - yOffset - tooltipHeight - yOffset, 0));
+  const wouldOverflowBelow = overflowBelow > 0;
+  const wouldOverflowAbove = overflowAbove > 0;
+
+  if (wouldOverflowRight && wouldOverflowLeft) {
+    x = overflowRight > overflowLeft ? xOffset : windowWidth - xOffset - tooltipWidth;
+  } else if (wouldOverflowRight) {
+    x = xPos - xOffset - tooltipWidth;
+  } else {
+    x = xPos + xOffset;
+  }
+
+  if (wouldOverflowBelow && wouldOverflowAbove) {
+    y = overflowBelow > overflowAbove ? yOffset : windowHeight - yOffset - tooltipHeight;
+  } else if (wouldOverflowBelow) {
+    y = yPos - yOffset - tooltipHeight;
+  } else {
+    y = yPos + yOffset;
+  }
+  return { x, y };
+};

--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -63,12 +63,15 @@ export function getFocusStyles(theme: GrafanaTheme2): CSSObject {
 }
 
 // max-width is set up based on .grafana-tooltip class that's used in dashboard
+// disabling pointer-events is to prevent the tooltip from flickering when moving left to right
+// see e.g. https://github.com/grafana/grafana/pull/33609
 export const getTooltipContainerStyles = (theme: GrafanaTheme2) => `
-  overflow: hidden;
   background: ${theme.colors.background.secondary};
+  border-radius: ${theme.shape.borderRadius()};
   box-shadow: ${theme.shadows.z2};
   max-width: 800px;
+  overflow: hidden;
   padding: ${theme.spacing(1)};
-  border-radius: ${theme.shape.borderRadius()};
+  pointer-events: none;
   z-index: ${theme.zIndex.tooltip};
 `;

--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -72,6 +72,5 @@ export const getTooltipContainerStyles = (theme: GrafanaTheme2) => `
   max-width: 800px;
   overflow: hidden;
   padding: ${theme.spacing(1)};
-  pointer-events: none;
   z-index: ${theme.zIndex.tooltip};
 `;

--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -69,6 +69,6 @@ export const getTooltipContainerStyles = (theme: GrafanaTheme2) => `
   box-shadow: ${theme.shadows.z2};
   max-width: 800px;
   padding: ${theme.spacing(1)};
-  z-index: ${theme.zIndex.tooltip};
   border-radius: ${theme.shape.borderRadius()};
+  z-index: ${theme.zIndex.tooltip};
 `;

--- a/packages/grafana-ui/src/themes/mixins.ts
+++ b/packages/grafana-ui/src/themes/mixins.ts
@@ -63,14 +63,12 @@ export function getFocusStyles(theme: GrafanaTheme2): CSSObject {
 }
 
 // max-width is set up based on .grafana-tooltip class that's used in dashboard
-// disabling pointer-events is to prevent the tooltip from flickering when moving left to right
-// see e.g. https://github.com/grafana/grafana/pull/33609
 export const getTooltipContainerStyles = (theme: GrafanaTheme2) => `
+  overflow: hidden;
   background: ${theme.colors.background.secondary};
-  border-radius: ${theme.shape.borderRadius()};
   box-shadow: ${theme.shadows.z2};
   max-width: 800px;
-  overflow: hidden;
   padding: ${theme.spacing(1)};
   z-index: ${theme.zIndex.tooltip};
+  border-radius: ${theme.shape.borderRadius()};
 `;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- seems https://github.com/grafana/grafana/pull/36440 has regressed the performance of the tooltip
- revert back to the previous method (i.e. without `react-popper`) but with the additional calculation to keep everything on screen
- added `pointer-events: 'none';` to `VizTooltipContainer`, because if you move left to right the container was swallowing some pointer events and causing flickering.
- all in all, more code but the performance and behaviour feels significantly better.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/36831

**Special notes for your reviewer**:

