### PR TITLE
add key/value store service

### DIFF
--- a/pkg/infra/kvstore/kvstore.go
+++ b/pkg/infra/kvstore/kvstore.go
@@ -1,0 +1,46 @@
+package kvstore
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+func ProvideService(sqlStore *sqlstore.SQLStore) KVStore {
+	s := &KVStoreSQL{
+		sqlStore: sqlStore,
+		log:      log.New("infra.kvstore.sql"),
+	}
+
+	return s
+}
+
+// Interface for kvstore
+type KVStore interface {
+	Get(ctx context.Context, orgId int64, namespace string, key string) (string, error)
+	Set(ctx context.Context, orgId int64, namespace string, key string, value string) error
+}
+
+// Returns a kvstore wrapper with fixed orgId and namespace
+func WithNamespace(kv KVStore, orgId int64, namespace string) *NamespacedKVStore {
+	return &NamespacedKVStore{
+		kvStore:   kv,
+		orgId:     orgId,
+		namespace: namespace,
+	}
+}
+
+type NamespacedKVStore struct {
+	kvStore   KVStore
+	orgId     int64
+	namespace string
+}
+
+func (kv *NamespacedKVStore) Get(ctx context.Context, key string) (string, error) {
+	return kv.kvStore.Get(ctx, kv.orgId, kv.namespace, key)
+}
+
+func (kv *NamespacedKVStore) Set(ctx context.Context, key string, value string) error {
+	return kv.kvStore.Set(ctx, kv.orgId, kv.namespace, key, value)
+}

--- a/pkg/infra/kvstore/kvstore.go
+++ b/pkg/infra/kvstore/kvstore.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ProvideService(sqlStore *sqlstore.SQLStore) KVStore {
-	s := &KVStoreSQL{
+	s := &kvStoreSQL{
 		sqlStore: sqlStore,
 		log:      log.New("infra.kvstore.sql"),
 	}

--- a/pkg/infra/kvstore/kvstore.go
+++ b/pkg/infra/kvstore/kvstore.go
@@ -8,21 +8,20 @@ import (
 )
 
 func ProvideService(sqlStore *sqlstore.SQLStore) KVStore {
-	s := &kvStoreSQL{
+	return &kvStoreSQL{
 		sqlStore: sqlStore,
 		log:      log.New("infra.kvstore.sql"),
 	}
-
-	return s
 }
 
-// Interface for kvstore
+// KVStore is an interface for k/v store.
 type KVStore interface {
-	Get(ctx context.Context, orgId int64, namespace string, key string) (string, error)
+	Get(ctx context.Context, orgId int64, namespace string, key string) (string, bool, error)
 	Set(ctx context.Context, orgId int64, namespace string, key string, value string) error
+	Del(ctx context.Context, orgId int64, namespace string, key string) error
 }
 
-// Returns a kvstore wrapper with fixed orgId and namespace
+// WithNamespace returns a kvstore wrapper with fixed orgId and namespace.
 func WithNamespace(kv KVStore, orgId int64, namespace string) *NamespacedKVStore {
 	return &NamespacedKVStore{
 		kvStore:   kv,
@@ -31,16 +30,21 @@ func WithNamespace(kv KVStore, orgId int64, namespace string) *NamespacedKVStore
 	}
 }
 
+// NamespacedKVStore is a KVStore wrapper with fixed orgId and namespace.
 type NamespacedKVStore struct {
 	kvStore   KVStore
 	orgId     int64
 	namespace string
 }
 
-func (kv *NamespacedKVStore) Get(ctx context.Context, key string) (string, error) {
+func (kv *NamespacedKVStore) Get(ctx context.Context, key string) (string, bool, error) {
 	return kv.kvStore.Get(ctx, kv.orgId, kv.namespace, key)
 }
 
 func (kv *NamespacedKVStore) Set(ctx context.Context, key string, value string) error {
 	return kv.kvStore.Set(ctx, kv.orgId, kv.namespace, key, value)
+}
+
+func (kv *NamespacedKVStore) Del(ctx context.Context, key string) error {
+	return kv.kvStore.Del(ctx, kv.orgId, kv.namespace, key)
 }

--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -17,7 +17,7 @@ func createTestableKVStore(t *testing.T) KVStore {
 
 	sqlstore := sqlstore.InitTestDB(t)
 
-	kv := &KVStoreSQL{
+	kv := &kvStoreSQL{
 		sqlStore: sqlstore,
 		log:      log.New("infra.kvstore.sql"),
 	}

--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -1,0 +1,141 @@
+package kvstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+func createTestableKVStore(t *testing.T) KVStore {
+	t.Helper()
+
+	sqlstore := sqlstore.InitTestDB(t)
+
+	kv := &KVStoreSQL{
+		sqlStore: sqlstore,
+		log:      log.New("infra.kvstore.sql"),
+	}
+
+	return kv
+}
+
+type TestCase struct {
+	OrgId     int64
+	Namespace string
+	Key       string
+	Revision  int64
+}
+
+func (t *TestCase) Value() string {
+	return fmt.Sprintf("%d:%s:%s:%d", t.OrgId, t.Namespace, t.Key, t.Revision)
+}
+
+func TestKVStore(t *testing.T) {
+	kv := createTestableKVStore(t)
+
+	ctx := context.Background()
+
+	testCases := []*TestCase{
+		{
+			OrgId:     0,
+			Namespace: "testing1",
+			Key:       "key1",
+		},
+		{
+			OrgId:     0,
+			Namespace: "testing2",
+			Key:       "key1",
+		},
+		{
+			OrgId:     1,
+			Namespace: "testing1",
+			Key:       "key1",
+		},
+		{
+			OrgId:     1,
+			Namespace: "testing3",
+			Key:       "key1",
+		},
+	}
+
+	for _, tc := range testCases {
+		err := kv.Set(ctx, tc.OrgId, tc.Namespace, tc.Key, tc.Value())
+		require.NoError(t, err)
+	}
+
+	t.Run("get existing keys", func(t *testing.T) {
+		for _, tc := range testCases {
+			value, err := kv.Get(ctx, tc.OrgId, tc.Namespace, tc.Key)
+			require.NoError(t, err)
+			assert.Equal(t, tc.Value(), value)
+		}
+	})
+
+	t.Run("get nonexistent keys", func(t *testing.T) {
+		tcs := []*TestCase{
+			{
+				OrgId:     0,
+				Namespace: "testing1",
+				Key:       "key2",
+			},
+			{
+				OrgId:     1,
+				Namespace: "testing2",
+				Key:       "key1",
+			},
+			{
+				OrgId:     1,
+				Namespace: "testing3",
+				Key:       "key2",
+			},
+		}
+
+		for _, tc := range tcs {
+			value, err := kv.Get(ctx, tc.OrgId, tc.Namespace, tc.Key)
+			assert.Equal(t, ErrNotFound, err)
+			assert.Equal(t, "", value)
+		}
+	})
+
+	t.Run("modify existing key", func(t *testing.T) {
+		tc := testCases[0]
+
+		value, err := kv.Get(ctx, tc.OrgId, tc.Namespace, tc.Key)
+		require.NoError(t, err)
+		assert.Equal(t, tc.Value(), value)
+
+		tc.Revision += 1
+
+		err = kv.Set(ctx, tc.OrgId, tc.Namespace, tc.Key, tc.Value())
+		require.NoError(t, err)
+
+		value, err = kv.Get(ctx, tc.OrgId, tc.Namespace, tc.Key)
+		require.NoError(t, err)
+		assert.Equal(t, tc.Value(), value)
+	})
+
+	t.Run("use namespaced client", func(t *testing.T) {
+		tc := testCases[0]
+
+		client := WithNamespace(kv, tc.OrgId, tc.Namespace)
+
+		value, err := client.Get(ctx, tc.Key)
+		require.NoError(t, err)
+		assert.Equal(t, tc.Value(), value)
+
+		tc.Revision += 1
+
+		err = client.Set(ctx, tc.Key, tc.Value())
+		require.NoError(t, err)
+
+		value, err = client.Get(ctx, tc.Key)
+		require.NoError(t, err)
+		assert.Equal(t, tc.Value(), value)
+	})
+}

--- a/pkg/infra/kvstore/model.go
+++ b/pkg/infra/kvstore/model.go
@@ -1,0 +1,25 @@
+package kvstore
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrNotFound = errors.New("key/value item not found")
+)
+
+type KVStoreItem struct {
+	Id        int64
+	OrgId     *int64
+	Namespace *string
+	Key       *string
+	Value     string
+
+	Created time.Time
+	Updated time.Time
+}
+
+func (k *KVStoreItem) TableName() string {
+	return "kv_store"
+}

--- a/pkg/infra/kvstore/model.go
+++ b/pkg/infra/kvstore/model.go
@@ -1,15 +1,11 @@
 package kvstore
 
 import (
-	"errors"
 	"time"
 )
 
-var (
-	ErrNotFound = errors.New("key/value item not found")
-)
-
-type KVStoreItem struct {
+// Item stored in k/v store.
+type Item struct {
 	Id        int64
 	OrgId     *int64
 	Namespace *string
@@ -20,6 +16,6 @@ type KVStoreItem struct {
 	Updated time.Time
 }
 
-func (k *KVStoreItem) TableName() string {
+func (i *Item) TableName() string {
 	return "kv_store"
 }

--- a/pkg/infra/kvstore/sql.go
+++ b/pkg/infra/kvstore/sql.go
@@ -8,14 +8,14 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
-// KVStoreSQL provides a key/value store backed by the Grafana database
-type KVStoreSQL struct {
+// kvStoreSQL provides a key/value store backed by the Grafana database
+type kvStoreSQL struct {
 	log      log.Logger
 	sqlStore *sqlstore.SQLStore
 }
 
 // Get an item from the store
-func (kv *KVStoreSQL) Get(ctx context.Context, orgId int64, namespace string, key string) (string, error) {
+func (kv *kvStoreSQL) Get(ctx context.Context, orgId int64, namespace string, key string) (string, error) {
 	item := KVStoreItem{
 		OrgId:     &orgId,
 		Namespace: &namespace,
@@ -41,7 +41,7 @@ func (kv *KVStoreSQL) Get(ctx context.Context, orgId int64, namespace string, ke
 }
 
 // Set an item in the store
-func (kv *KVStoreSQL) Set(ctx context.Context, orgId int64, namespace string, key string, value string) error {
+func (kv *kvStoreSQL) Set(ctx context.Context, orgId int64, namespace string, key string, value string) error {
 	return kv.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
 		item := KVStoreItem{
 			OrgId:     &orgId,

--- a/pkg/infra/kvstore/sql.go
+++ b/pkg/infra/kvstore/sql.go
@@ -1,0 +1,85 @@
+package kvstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+// KVStoreSQL provides a key/value store backed by the Grafana database
+type KVStoreSQL struct {
+	log      log.Logger
+	sqlStore *sqlstore.SQLStore
+}
+
+// Get an item from the store
+func (kv *KVStoreSQL) Get(ctx context.Context, orgId int64, namespace string, key string) (string, error) {
+	item := KVStoreItem{
+		OrgId:     &orgId,
+		Namespace: &namespace,
+		Key:       &key,
+	}
+
+	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		has, err := dbSession.Get(&item)
+		if err != nil {
+			kv.log.Debug("error getting kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "err", err)
+			return err
+		}
+		if !has {
+			kv.log.Debug("kvstore value not found", "orgId", orgId, "namespace", namespace, "key", key)
+			return ErrNotFound
+		}
+
+		kv.log.Debug("got kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", item.Value)
+		return nil
+	})
+
+	return item.Value, err
+}
+
+// Set an item in the store
+func (kv *KVStoreSQL) Set(ctx context.Context, orgId int64, namespace string, key string, value string) error {
+	return kv.sqlStore.WithTransactionalDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		item := KVStoreItem{
+			OrgId:     &orgId,
+			Namespace: &namespace,
+			Key:       &key,
+		}
+
+		has, err := dbSession.Get(&item)
+		if err != nil {
+			kv.log.Debug("error checking kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
+			return err
+		}
+
+		if has && item.Value == value {
+			kv.log.Debug("kvstore value not changed", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
+			return nil
+		}
+
+		item.Value = value
+		item.Updated = time.Now()
+
+		if has {
+			_, err = dbSession.ID(item.Id).Update(&item)
+			if err != nil {
+				kv.log.Debug("error updating kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
+			} else {
+				kv.log.Debug("kvstore value updated", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
+			}
+			return err
+		}
+
+		item.Created = item.Updated
+		_, err = dbSession.Insert(&item)
+		if err != nil {
+			kv.log.Debug("error inserting kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
+		} else {
+			kv.log.Debug("kvstore value inserted", "orgId", orgId, "namespace", namespace, "key", key, "value", value)
+		}
+		return err
+	})
+}

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/httpclient/httpclientprovider"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
@@ -79,6 +80,7 @@ var wireBasicSet = wire.NewSet(
 	routing.ProvideRegister,
 	wire.Bind(new(routing.RouteRegister), new(*routing.RouteRegisterImpl)),
 	hooks.ProvideService,
+	kvstore.ProvideService,
 	localcache.ProvideService,
 	usagestats.ProvideService,
 	wire.Bind(new(usagestats.UsageStats), new(*usagestats.UsageStatsService)),

--- a/pkg/services/sqlstore/migrations/kv_store_mig.go
+++ b/pkg/services/sqlstore/migrations/kv_store_mig.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+func addKVStoreMigrations(mg *Migrator) {
+	kvStoreV1 := Table{
+		Name: "kv_store",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, Nullable: false, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "org_id", Type: DB_BigInt, Nullable: false},
+			{Name: "namespace", Type: DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "key", Type: DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "value", Type: DB_Text, Nullable: false},
+			{Name: "created", Type: DB_DateTime, Nullable: false},
+			{Name: "updated", Type: DB_DateTime, Nullable: false},
+		},
+		Indices: []*Index{
+			{Cols: []string{"org_id", "namespace", "key"}, Type: UniqueIndex},
+		},
+	}
+
+	mg.AddMigration("create kv_store table v1", NewAddTableMigration(kvStoreV1))
+
+	mg.AddMigration("add index kv_store.org_id-namespace-key", NewAddIndexMigration(kvStoreV1, kvStoreV1.Indices[0]))
+}

--- a/pkg/services/sqlstore/migrations/kv_store_mig.go
+++ b/pkg/services/sqlstore/migrations/kv_store_mig.go
@@ -12,7 +12,7 @@ func addKVStoreMigrations(mg *Migrator) {
 			{Name: "org_id", Type: DB_BigInt, Nullable: false},
 			{Name: "namespace", Type: DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "key", Type: DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "value", Type: DB_Text, Nullable: false},
+			{Name: "value", Type: DB_MediumText, Nullable: false},
 			{Name: "created", Type: DB_DateTime, Nullable: false},
 			{Name: "updated", Type: DB_DateTime, Nullable: false},
 		},

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -52,6 +52,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 		addLiveChannelMigrations(mg)
 	}
 	ualert.RerunDashAlertMigration(mg)
+	addKVStoreMigrations(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {


### PR DESCRIPTION
This PR adds a simple key/value store, which we can use to store items that don't necessarily need their own separate table.

It currently uses the SQLStore as the backend, but can easily support other backends if that is desired.