### PR TITLE
Docs: fix link to status-history on visualizations index page

### DIFF
--- a/docs/sources/panels/visualizations/_index.md
+++ b/docs/sources/panels/visualizations/_index.md
@@ -10,7 +10,7 @@ Grafana offers a variety of visualizations to support different use cases. This 
 * Graphs & charts 
   * [Time series]({{< relref "./time-series/_index.md" >}}) is the default and main Graph visualization.    
   * [State timeline]({{< relref "./state-timeline.md" >}}) for state changes over time.   
-  * [Status history]({{< relref "./state-timeline.md" >}}) for periodic state over time. 
+  * [Status history]({{< relref "./status-history.md" >}}) for periodic state over time. 
   * [Bar chart]({{< relref "./bar-chart.md" >}}) shows any categorical data.
   * [Histogram]({{< relref "./histogram.md" >}}) calculates and shows value distribution in a bar chart.
   * [Heatmap]({{< relref "./heatmap.md" >}}).  


### PR DESCRIPTION
fix for https://github.com/grafana/grafana/pull/36756/files#diff-5006421a05fdde39cf5380082bf3f8f35ada1b0067c7ab2c4bc55e8d37f2a2ffR13