### PR TITLE
Fix for Flex compatibility in lower versions of browsers

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -54,6 +54,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       // Need to override normal css class and don't want to count on ordering of the classes in html.
       height: auto !important;
       flex: unset !important;
+      display: unset !important;
       padding: ${theme.panelPadding}px;
     `,
   };


### PR DESCRIPTION
What this PR does / why we need it:

Origin without explicit port should pass a check when compared with root_url.

Which issue(s) this PR fixes:

#36827 