### PR TITLE
Geomap: make the geomap panel beta and label alpha layers

### DIFF
--- a/packages/grafana-data/src/transformations/standardTransformersRegistry.ts
+++ b/packages/grafana-data/src/transformations/standardTransformersRegistry.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataFrame, DataTransformerInfo, PluginState } from '../types';
+import { DataFrame, DataTransformerInfo } from '../types';
 import { Registry, RegistryItem } from '../utils/Registry';
 
 export interface TransformerUIProps<T> {
@@ -19,11 +19,6 @@ export interface TransformerRegistryItem<TOptions> extends RegistryItem {
    * Object describing transformer configuration
    */
   transformation: DataTransformerInfo<TOptions>;
-
-  /**
-   * Optional feature state
-   */
-  state?: PluginState;
 
   /** Markdown with more detailed description and help */
   help?: string;

--- a/packages/grafana-data/src/utils/Registry.ts
+++ b/packages/grafana-data/src/utils/Registry.ts
@@ -1,3 +1,4 @@
+import { PluginState } from '../types';
 import { SelectableValue } from '../types/select';
 
 export interface RegistryItem {
@@ -11,6 +12,11 @@ export interface RegistryItem {
    *  like: 'all' and 'any' matchers;
    */
   excludeFromPicker?: boolean;
+
+  /**
+   * Optional feature state
+   */
+  state?: PluginState;
 }
 
 export interface RegistryItemWithOptions<TOptions = any> extends RegistryItem {
@@ -104,6 +110,10 @@ export class Registry<T extends RegistryItem> {
         label: ext.name,
         description: ext.description,
       };
+
+      if (ext.state === PluginState.alpha) {
+        option.label += ' (alpha)';
+      }
 
       select.options.push(option);
       if (currentOptions[ext.id]) {

--- a/public/app/core/config.ts
+++ b/public/app/core/config.ts
@@ -1,4 +1,5 @@
 import { config, GrafanaBootConfig } from '@grafana/runtime';
+import { PluginState } from '../../../packages/grafana-data/src';
 // Legacy binding paths
 export { config, GrafanaBootConfig as Settings };
 
@@ -16,3 +17,6 @@ export const updateConfig = (update: Partial<GrafanaBootConfig>) => {
     ...update,
   };
 };
+
+// The `enable_alpha` flag is no exposed directly, this is equivolant
+export const hasAlphaPanels = Boolean(config.panels?.debug?.state === PluginState.alpha);

--- a/public/app/plugins/panel/geomap/editor/BaseLayerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/BaseLayerEditor.tsx
@@ -1,12 +1,23 @@
 import React, { FC } from 'react';
-import { StandardEditorProps, MapLayerOptions } from '@grafana/data';
+import { StandardEditorProps, MapLayerOptions, MapLayerRegistryItem, PluginState } from '@grafana/data';
 import { GeomapPanelOptions } from '../types';
 import { LayerEditor } from './LayerEditor';
+import { hasAlphaPanels } from 'app/core/config';
+
+function baseMapFilter(layer: MapLayerRegistryItem): boolean {
+  if (!layer.isBaseMap) {
+    return false;
+  }
+  if (layer.state === PluginState.alpha) {
+    return hasAlphaPanels;
+  }
+  return true;
+}
 
 export const BaseLayerEditor: FC<StandardEditorProps<MapLayerOptions, any, GeomapPanelOptions>> = ({
   value,
   onChange,
   context,
 }) => {
-  return <LayerEditor options={value} data={context.data} onChange={onChange} filter={(v) => Boolean(v.isBaseMap)} />;
+  return <LayerEditor options={value} data={context.data} onChange={onChange} filter={baseMapFilter} />;
 };

--- a/public/app/plugins/panel/geomap/editor/DataLayersEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/DataLayersEditor.tsx
@@ -1,7 +1,18 @@
 import React, { FC } from 'react';
-import { StandardEditorProps, MapLayerOptions } from '@grafana/data';
+import { StandardEditorProps, MapLayerOptions, PluginState, MapLayerRegistryItem } from '@grafana/data';
 import { GeomapPanelOptions } from '../types';
 import { LayerEditor } from './LayerEditor';
+import { hasAlphaPanels } from 'app/core/config';
+
+function dataLayerFilter(layer: MapLayerRegistryItem): boolean {
+  if (layer.isBaseMap) {
+    return false;
+  }
+  if (layer.state === PluginState.alpha) {
+    return hasAlphaPanels;
+  }
+  return true;
+}
 
 // For now this supports a *single* data layer -- eventually we should support more than one
 export const DataLayersEditor: FC<StandardEditorProps<MapLayerOptions[], any, GeomapPanelOptions>> = ({
@@ -17,7 +28,7 @@ export const DataLayersEditor: FC<StandardEditorProps<MapLayerOptions[], any, Ge
         console.log('Change overlays:', cfg);
         onChange([cfg]);
       }}
-      filter={(v) => !v.isBaseMap}
+      filter={dataLayerFilter}
     />
   );
 };

--- a/public/app/plugins/panel/geomap/layers/data/geojsonMapper.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonMapper.ts
@@ -1,4 +1,4 @@
-import { MapLayerRegistryItem, MapLayerOptions, MapLayerHandler, PanelData, GrafanaTheme2 } from '@grafana/data';
+import { MapLayerRegistryItem, MapLayerOptions, MapLayerHandler, PanelData, GrafanaTheme2, PluginState } from '@grafana/data';
 import Map from 'ol/Map';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -24,6 +24,7 @@ export const geojsonMapper: MapLayerRegistryItem<GeoJSONMapperConfig> = {
   name: 'Map values to GeoJSON file',
   description: 'color features based on query results',
   isBaseMap: false,
+  state: PluginState.alpha,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/data/lastPointTracker.ts
+++ b/public/app/plugins/panel/geomap/layers/data/lastPointTracker.ts
@@ -1,4 +1,4 @@
-import { MapLayerRegistryItem, MapLayerOptions, MapLayerHandler, PanelData, GrafanaTheme2 } from '@grafana/data';
+import { MapLayerRegistryItem, MapLayerOptions, MapLayerHandler, PanelData, GrafanaTheme2, PluginState } from '@grafana/data';
 import Map from 'ol/Map';
 import Feature from 'ol/Feature';
 import * as style from 'ol/style';
@@ -20,6 +20,7 @@ export const lastPointTracker: MapLayerRegistryItem<LastPointConfig> = {
   description: 'Show an icon at the last point',
   isBaseMap: false,
   showLocation: true,
+  state: PluginState.alpha,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/plugin.json
+++ b/public/app/plugins/panel/geomap/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Geomap",
   "id": "geomap",
-  "state": "alpha",
+  "state": "beta",
 
   "info": {
     "description": "Geomap panel",


### PR DESCRIPTION


This PR changes the plugin state from "alpha" to "beta" so it will now show up for everyone.  It also adds the state concept to layer definitions so we can hide "alpha" layers:

![image](https://user-images.githubusercontent.com/705951/126111082-dbff7488-a721-4f10-a804-ddc9f6dc2024.png)
