### PR TITLE
Alerting: Fix the table markdown in docs

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -107,10 +107,10 @@ Labels are key value pairs that categorize or identify an alert. Labels are  use
 
 The following template variables are available when expanding annotations and labels.
 
-/ Name    / Description     /
-/ ------- / --------------- /
-/ $labels / Labels contains the labels from the query or condition. For example, `{{ $labels.instance }}` and `{{ $labels.job }}`. /
-/ $values / Values contains the values of all reduce and math expressions that were evaluated for this alert rule. For example, `{{ $values.A }}`, `{{ $values.A.Labels }}` and `{{ $values.A.Value }}` where `A` is the `refID` of the expression. /
+| Name    | Description     |
+| ------- | --------------- |
+| $labels | Labels contains the labels from the query or condition. For example, `{{ $labels.instance }}` and `{{ $labels.job }}`. |
+| $values | Values contains the values of all reduce and math expressions that were evaluated for this alert rule. For example, `{{ $values.A }}`, `{{ $values.A.Labels }}` and `{{ $values.A.Value }}` where `A` is the `refID` of the expression. |
 
 ## Preview alerts
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I just happen to notice that `/` was being used for the table hence it was not rendering properly. Changing it to `|` in this PR.