### PR TITLE
SegmentSelect: Do not call onCloseMenu when a value was selected

### DIFF
--- a/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
@@ -3,7 +3,10 @@ import { SelectableValue } from '@grafana/data';
 import { Select } from '../Select/Select';
 import { useTheme2 } from '../../themes/ThemeContext';
 
-/** @internal */
+/** @internal
+ * Should be used only internally by Segment/SegmentAsync which can guarantee that SegmentSelect is hidden
+ * when a value is selected. See comment below on closeMenuOnSelect()
+ */
 export interface Props<T> extends Omit<HTMLProps<HTMLDivElement>, 'value' | 'onChange'> {
   value?: SelectableValue<T>;
   options: Array<SelectableValue<T>>;
@@ -41,7 +44,9 @@ export function SegmentSelect<T>({
         onChange={onChange}
         options={options}
         value={value}
-        // disable close menu on select to avoid calling onChange() in onCloseMenu() when a value is selected
+        // Disable "close menu on select" option to avoid calling onChange() in onCloseMenu() when a value is selected.
+        // Once the value is selected the Select component (with the menu) will be hidden anyway by the parent component:
+        // Segment or SegmentAsync - hence setting this option has no UX effect.
         closeMenuOnSelect={false}
         onCloseMenu={() => {
           if (ref && ref.current) {

--- a/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentSelect.tsx
@@ -41,6 +41,8 @@ export function SegmentSelect<T>({
         onChange={onChange}
         options={options}
         value={value}
+        // disable close menu on select to avoid calling onChange() in onCloseMenu() when a value is selected
+        closeMenuOnSelect={false}
         onCloseMenu={() => {
           if (ref && ref.current) {
             // https://github.com/JedWatson/react-select/issues/188#issuecomment-279240292


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Follow-up on #36816. I've moved the logic from `useClickAway` to `onMenuClose` but the behavior is actually slightly different because `onMenuClose` is also called when a value is selected, not only when the user clicks away or presses ESC.

This is causing a bug where incorrect value is passed to `onChange` callback, for example, in Elastic use input to search for value but then select the value from the dropdown (it won't be selected).

<img width="399" alt="Screen Shot 2021-07-19 at 11 28 40" src="https://user-images.githubusercontent.com/745532/126137896-60fea89b-6a7e-4691-bf70-896f1b9c9f8a.png">

The fix is to avoid calling closeMenu on select - it shouldn't affect the UX because the component gets hidden when the value is selected plus the menu is always opened by default when it shows up.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes N/A

**Special notes for your reviewer**:

