### PR TITLE
Fix: Handle withCredentials option properly for loki datasource

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -87,6 +87,12 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     const baseUrl = this.instanceSettings.url;
     const params = data ? serializeParams(data) : '';
     const url = `${baseUrl}${apiUrl}${params.length ? `?${params}` : ''}`;
+    if (this.instanceSettings.withCredentials || this.instanceSettings.basicAuth) {
+      options = { ...options, withCredentials: true };
+      if (this.instanceSettings.basicAuth) {
+        options.headers = { ...options.headers, Authorization: this.instanceSettings.basicAuth };
+      }
+    }
     const req = {
       ...options,
       url,


### PR DESCRIPTION
The loki datasource was not passing the credentials info to the fetch()
API when loki was in Browser access mode.

This is similar to:
https://github.com/grafana/grafana/pull/23380
