### PR TITLE
Alerting: do not over write alerting rule duration in /rules 

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -144,7 +144,6 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 					newGroup.LastEvaluation = alertState.LastEvaluationTime
 				}
 
-				alertingRule.Duration = alertState.EvaluationDuration.Seconds()
 				newRule.EvaluationTime = alertState.EvaluationDuration.Seconds()
 
 				switch alertState.State {


### PR DESCRIPTION
**What this PR does / why we need it**:
Correctly sets `Duration` when returning an alerting rule

**Special notes for your reviewer**:
Setting this correctly will be essential for users wanting to use the API to re-create rules from existing alerting configuration