### PR TITLE
fix: utils deps

### DIFF
--- a/packages/grafana-ui/src/components/MatchersUI/utils.ts
+++ b/packages/grafana-ui/src/components/MatchersUI/utils.ts
@@ -103,5 +103,5 @@ export function useSelectOptions(
       });
     }
     return options;
-  }, [displayNames, currentName]);
+  }, [displayNames, currentName, firstItem]);
 }


### PR DESCRIPTION
This just fixes the warning error while bundling the front-end:

```
WARNING in packages/grafana-ui/src/components/MatchersUI/utils.ts:106:6
react-hooks/exhaustive-deps: React Hook useMemo has a missing dependency: 'firstItem'. Either include it or remove the dependency array.
    104 |     }
    105 |     return options;
  > 106 |   }, [displayNames, currentName]);
        |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    107 | }
    108 |
```
