### PR TITLE
Alerting: Handle marshaling Inf values

### DIFF
--- a/pkg/components/null/float.go
+++ b/pkg/components/null/float.go
@@ -98,9 +98,9 @@ func (f *Float) UnmarshalText(text []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler.
-// It will encode null if this Float is null.
+// It will encode null if this Float is null, NaN, of Inf.
 func (f Float) MarshalJSON() ([]byte, error) {
-	if !f.Valid || math.IsNaN(f.Float64) {
+	if !f.Valid || math.IsNaN(f.Float64) || math.IsInf(f.Float64, 0) {
 		return []byte(nullString), nil
 	}
 	return []byte(strconv.FormatFloat(f.Float64, 'f', -1, 64)), nil

--- a/pkg/expr/classic/classic.go
+++ b/pkg/expr/classic/classic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/expr/mathexp"
@@ -61,10 +62,27 @@ func (ccc *ConditionsCmd) NeedsVars() []string {
 }
 
 // EvalMatch represents the series violating the threshold.
+// It goes into the metadata of data frames so it can be extracted.
 type EvalMatch struct {
 	Value  *float64    `json:"value"`
 	Metric string      `json:"metric"`
 	Labels data.Labels `json:"labels"`
+}
+
+func (em EvalMatch) MarshalJSON() ([]byte, error) {
+	fs := ""
+	if em.Value != nil {
+		fs = strconv.FormatFloat(*em.Value, 'f', -1, 64)
+	}
+	return json.Marshal(struct {
+		Value  string      `json:"value"`
+		Metric string      `json:"metric"`
+		Labels data.Labels `json:"labels"`
+	}{
+		fs,
+		em.Metric,
+		em.Labels,
+	})
 }
 
 // Execute runs the command and returns the results or an error if the command


### PR DESCRIPTION
**What this PR does / why we need it**:
SSE/AlertNG:
Server side expressions captures values and puts them in Frame metadata for alerting when the classic condition is used.

When this is done, if the frame is serialized the metadata is serialized with json. If the numeric float is nan/inf this fails, so this adds a separate marshal method to encode as string.

Legacy Alerting:
Changes `null.Float64` (use for older time series type used with legacy/dashboard alerting) to marshal Inf as null (before it it gave `body json marshal` error:
![image](https://user-images.githubusercontent.com/1692624/126342766-e7446874-9e11-48d7-bd2b-cfc5ff7f87a2.png)

**Which issue(s) this PR fixes**:

fixes #36424

**Special notes for your reviewer**:
Produced this with:

![image](https://user-images.githubusercontent.com/1692624/126491644-8839b06b-11a9-4c00-a69d-0dc0741b36e5.png)

Which spits the following in the server log:
`EROR[07-21|08:53:30] Error writing to response                logger=context userId=1 orgId=1 uname=admin err="data.FrameMeta.Custom: []classic.EvalMatch: classic.EvalMatch.Labels: Metric: Value: unsupported value: +Inf"`

Or with classic alerting, by making a prom alert on `1/0`
