### PR TITLE
PieChart: Make pie gradient more subtle to match other charts

### DIFF
--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -346,14 +346,14 @@ function getLabelPos(arc: PieArcDatum<FieldDisplay>, outerRadius: number, innerR
 function getGradientColorFrom(color: string, theme: GrafanaTheme2) {
   return tinycolor(color)
     .darken(20 * (theme.isDark ? 1 : -0.7))
-    .spin(8)
+    .spin(4)
     .toRgbString();
 }
 
 function getGradientColorTo(color: string, theme: GrafanaTheme2) {
   return tinycolor(color)
     .darken(10 * (theme.isDark ? 1 : -0.7))
-    .spin(-8)
+    .spin(-4)
     .toRgbString();
 }
 

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -30,7 +30,6 @@ import { css } from '@emotion/css';
 import { useComponentInstanceId } from '@grafana/ui/src/utils/useComponetInstanceId';
 import { getTooltipContainerStyles } from '@grafana/ui/src/themes/mixins';
 import { selectors } from '@grafana/e2e-selectors';
-import { darken, lighten } from '@grafana/data/src/themes/colorManipulator';
 
 /**
  * @beta
@@ -98,7 +97,7 @@ export const PieChart: FC<PieChartProps> = ({
                 key={color}
                 id={getGradientId(color)}
                 from={getGradientColorFrom(color, theme)}
-                to={color}
+                to={getGradientColorTo(color, theme)}
                 fromOffset={layout.gradientFromOffset}
                 toOffset="1"
                 gradientUnits="userSpaceOnUse"
@@ -164,7 +163,7 @@ export const PieChart: FC<PieChartProps> = ({
                         innerRadius={layout.innerRadius}
                         displayLabels={displayLabels}
                         total={total}
-                        color={theme.colors.text.maxContrast}
+                        color={theme.colors.text.primary}
                       />
                     );
                   })}
@@ -345,7 +344,17 @@ function getLabelPos(arc: PieArcDatum<FieldDisplay>, outerRadius: number, innerR
 }
 
 function getGradientColorFrom(color: string, theme: GrafanaTheme2) {
-  return theme.isDark ? darken(color, 0.3) : lighten(color, 0.3);
+  return tinycolor(color)
+    .darken(20 * (theme.isDark ? 1 : -0.7))
+    .spin(8)
+    .toRgbString();
+}
+
+function getGradientColorTo(color: string, theme: GrafanaTheme2) {
+  return tinycolor(color)
+    .darken(10 * (theme.isDark ? 1 : -0.7))
+    .spin(-8)
+    .toRgbString();
 }
 
 interface PieLayout {

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -98,7 +98,7 @@ export const PieChart: FC<PieChartProps> = ({
                 key={color}
                 id={getGradientId(color)}
                 from={getGradientColorFrom(color, theme)}
-                to={getGradientColorTo(color, theme)}
+                to={color}
                 fromOffset={layout.gradientFromOffset}
                 toOffset="1"
                 gradientUnits="userSpaceOnUse"
@@ -164,7 +164,7 @@ export const PieChart: FC<PieChartProps> = ({
                         innerRadius={layout.innerRadius}
                         displayLabels={displayLabels}
                         total={total}
-                        color={theme.colors.text.primary}
+                        color={theme.colors.text.maxContrast}
                       />
                     );
                   })}
@@ -346,10 +346,6 @@ function getLabelPos(arc: PieArcDatum<FieldDisplay>, outerRadius: number, innerR
 
 function getGradientColorFrom(color: string, theme: GrafanaTheme2) {
   return theme.isDark ? darken(color, 0.3) : lighten(color, 0.3);
-}
-
-function getGradientColorTo(color: string, theme: GrafanaTheme2) {
-  return theme.isDark ? darken(color, 0.1) : lighten(color, 0.1);
 }
 
 interface PieLayout {

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -30,6 +30,7 @@ import { css } from '@emotion/css';
 import { useComponentInstanceId } from '@grafana/ui/src/utils/useComponetInstanceId';
 import { getTooltipContainerStyles } from '@grafana/ui/src/themes/mixins';
 import { selectors } from '@grafana/e2e-selectors';
+import { darken, lighten } from '@grafana/data/src/themes/colorManipulator';
 
 /**
  * @beta
@@ -344,17 +345,11 @@ function getLabelPos(arc: PieArcDatum<FieldDisplay>, outerRadius: number, innerR
 }
 
 function getGradientColorFrom(color: string, theme: GrafanaTheme2) {
-  return tinycolor(color)
-    .darken(20 * (theme.isDark ? 1 : -0.7))
-    .spin(8)
-    .toRgbString();
+  return theme.isDark ? darken(color, 0.3) : lighten(color, 0.3);
 }
 
 function getGradientColorTo(color: string, theme: GrafanaTheme2) {
-  return tinycolor(color)
-    .darken(10 * (theme.isDark ? 1 : -0.7))
-    .spin(-8)
-    .toRgbString();
+  return theme.isDark ? darken(color, 0.1) : lighten(color, 0.1);
 }
 
 interface PieLayout {


### PR DESCRIPTION
Closes #36141 

#### Before PieChart and BarChart
<img width="684" alt="beforeDarkChart" src="https://user-images.githubusercontent.com/42276368/126367242-90c5303c-e8ba-4aec-abc8-87d4480c2cae.png">

#### After PieChart and BarChart
<img width="693" alt="afterDarkChart" src="https://user-images.githubusercontent.com/42276368/126367170-aa5e663d-b8f5-4327-92ca-0229f6430990.png">

#### Before PieCharts in Light Mode
<img width="1333" alt="beforeLightPies" src="https://user-images.githubusercontent.com/42276368/126367250-451b039a-e5ee-45e4-af79-10c7280148b0.png">

#### After PieCharts in Light Mode
<img width="1359" alt="afterLightPies" src="https://user-images.githubusercontent.com/42276368/126367197-0aa22acf-a44c-4a61-83bf-5e9b23822c2e.png">