### PR TITLE
fix alerting docs aliases so we redirect instead of 404 old urls

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -1,12 +1,11 @@
 +++
 title = "Alerts"
-aliases = ["/docs/grafana/latest/alerting/rules/", "/docs/grafana/latest/alerting/metrics/"]
 weight = 110
 +++
 
 # Grafana alerts
 
-Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services. 
+Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
 
 Grafana 8.0 has new and improved alerts. The new alerting system are an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
 

--- a/docs/sources/alerting/old-alerting/_index.md
+++ b/docs/sources/alerting/old-alerting/_index.md
@@ -1,6 +1,5 @@
 +++
 title = "Legacy Grafana Alerts"
-aliases = ["/docs/grafana/latest/alerting/rules/", "/docs/grafana/latest/alerting/metrics/"]
 weight = 114
 +++
 

--- a/docs/sources/alerting/old-alerting/add-notification-template.md
+++ b/docs/sources/alerting/old-alerting/add-notification-template.md
@@ -2,6 +2,7 @@
 title = "Alert notification templating"
 keywords = ["grafana", "documentation", "alerting", "alerts", "notification", "templating"]
 weight = 110
+aliases = ["/docs/grafana/latest/alerting/add-notification-template/"]
 +++
 
 # Alert notification templating

--- a/docs/sources/alerting/old-alerting/create-alerts.md
+++ b/docs/sources/alerting/old-alerting/create-alerts.md
@@ -3,6 +3,7 @@ title = "Create alerts"
 description = "Configure alert rules"
 keywords = ["grafana", "alerting", "guide", "rules"]
 weight = 200
+aliases = ["/docs/grafana/latest/alerting/create-alerts/"]
 +++
 
 # Create alerts

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -3,6 +3,7 @@ title = "Alert notifications"
 description = "Alerting notifications guide"
 keywords = ["Grafana", "alerting", "guide", "notifications"]
 weight = 100
+aliases = ["/docs/grafana/latest/alerting/notifications/"]
 +++
 
 # Alert notifications
@@ -222,8 +223,8 @@ In DingTalk PC Client:
 
 ### Discord
 
-To set up Discord, you must create a Discord channel webhook. For instructions on how to create the channel, refer to 
-[Intro to Webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) f.
+To set up Discord, you must create a Discord channel webhook. For instructions on how to create the channel, refer to
+[Intro to Webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
 
 Setting | Description
 ---------- | -----------

--- a/docs/sources/alerting/old-alerting/pause-an-alert-rule.md
+++ b/docs/sources/alerting/old-alerting/pause-an-alert-rule.md
@@ -3,6 +3,7 @@ title = "Pause alert rule"
 description = "Pause an existing alert rule"
 keywords = ["grafana", "alerting", "guide", "rules", "view"]
 weight = 400
+aliases = ["/docs/grafana/latest/alerting/pause-an-alert-rule/"]
 +++
 
 # Pause an alert rule

--- a/docs/sources/alerting/old-alerting/troubleshoot-alerts.md
+++ b/docs/sources/alerting/old-alerting/troubleshoot-alerts.md
@@ -3,6 +3,7 @@ title = "Troubleshoot alerts"
 description = "Troubleshoot alert rules"
 keywords = ["grafana", "alerting", "guide", "rules", "troubleshoot"]
 weight = 500
+aliases = ["/docs/grafana/latest/alerting/troubleshoot-alerts/"]
 +++
 
 # Troubleshoot alerts

--- a/docs/sources/alerting/old-alerting/view-alerts.md
+++ b/docs/sources/alerting/old-alerting/view-alerts.md
@@ -3,6 +3,7 @@ title = "View alerts"
 description = "View existing alert rules"
 keywords = ["grafana", "alerting", "guide", "rules", "view"]
 weight = 400
+aliases = ["/docs/grafana/latest/alerting/view-alerts/"]
 +++
 
 # View existing alert rules


### PR DESCRIPTION
The old URLs were not properly aliased when alerting content was restructured in #34659 which has resulted in high-traffic pages becoming 404.  There were also alias entries duplicated when copying _index.md files around.

This PR adds aliases to redirect those broken links and removed the invalid alias entries.

@sfingerhut 