### PR TITLE
Auth: implement auto_sign_up for auth.jwt

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -564,6 +564,7 @@ jwk_set_file =
 cache_ttl = 60m
 expected_claims = {}
 key_file =
+auto_sign_up = false
 
 #################################### Auth LDAP ###########################
 [auth.ldap]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -548,6 +548,7 @@
 ;cache_ttl = 60m
 ;expected_claims = {"aud": ["foo", "bar"]}
 ;key_file = /path/to/key/file
+;auto_sign_up = false
 
 #################################### Auth LDAP ##########################
 [auth.ldap]

--- a/docs/sources/auth/jwt.md
+++ b/docs/sources/auth/jwt.md
@@ -44,7 +44,12 @@ username_claim = sub
 
 # Specify a claim to use as an email to sign in.
 email_claim = sub
+
+# auto-create users if they are not already matched
+# auto_sign_up = true
 ```
+
+If `auto_sign_up` is enabled, the `sub` claim will be used as the "external Auth ID" and (if present) the `name` claim will be used as the user's full name.
 
 ## Signature verification
 

--- a/docs/sources/auth/jwt.md
+++ b/docs/sources/auth/jwt.md
@@ -49,7 +49,7 @@ email_claim = sub
 # auto_sign_up = true
 ```
 
-If `auto_sign_up` is enabled, the `sub` claim is used as the "external Auth ID" and the `name` claim, if present, is used as the user's full name.
+If `auto_sign_up` is enabled, then the `sub` claim is used as the "external Auth ID". The `name` claim is used as the user's full name if it is present.
 
 ## Signature verification
 

--- a/docs/sources/auth/jwt.md
+++ b/docs/sources/auth/jwt.md
@@ -49,7 +49,7 @@ email_claim = sub
 # auto_sign_up = true
 ```
 
-If `auto_sign_up` is enabled, the `sub` claim is used as the "external Auth ID" and the `name` claim, is present, is used as the user's full name.
+If `auto_sign_up` is enabled, the `sub` claim is used as the "external Auth ID" and the `name` claim, if present, is used as the user's full name.
 
 ## Signature verification
 

--- a/docs/sources/auth/jwt.md
+++ b/docs/sources/auth/jwt.md
@@ -49,7 +49,7 @@ email_claim = sub
 # auto_sign_up = true
 ```
 
-If `auto_sign_up` is enabled, the `sub` claim will be used as the "external Auth ID" and (if present) the `name` claim will be used as the user's full name.
+If `auto_sign_up` is enabled, the `sub` claim is used as the "external Auth ID" and the `name` claim, is present, is used as the user's full name.
 
 ## Signature verification
 

--- a/pkg/middleware/middleware_jwt_auth_test.go
+++ b/pkg/middleware/middleware_jwt_auth_test.go
@@ -41,7 +41,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
 			return models.JWTClaims{
-				"sub": myUsername,
+				"sub":          myUsername,
 				"foo-username": myUsername,
 			}, nil
 		}
@@ -69,7 +69,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
 			return models.JWTClaims{
-				"sub": myEmail,
+				"sub":       myEmail,
 				"foo-email": myEmail,
 			}, nil
 		}
@@ -97,8 +97,8 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
 			return models.JWTClaims{
-				"sub": myEmail,
-				"name": "Vladimir Example",
+				"sub":       myEmail,
+				"name":      "Vladimir Example",
 				"foo-email": myEmail,
 			}, nil
 		}
@@ -118,8 +118,8 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
 			return models.JWTClaims{
-				"sub": myEmail,
-				"name": "Vladimir Example",
+				"sub":       myEmail,
+				"name":      "Vladimir Example",
 				"foo-email": myEmail,
 			}, nil
 		}
@@ -132,9 +132,9 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 			return nil
 		})
 		bus.AddHandlerCtx("upsert-user", func(ctx context.Context, command *models.UpsertUserCommand) error {
-			command.Result = &models.User {
-				Id: id,
-				Name: command.ExternalUser.Name,
+			command.Result = &models.User{
+				Id:    id,
+				Name:  command.ExternalUser.Name,
 				Email: command.ExternalUser.Email,
 			}
 			return nil

--- a/pkg/middleware/middleware_jwt_auth_test.go
+++ b/pkg/middleware/middleware_jwt_auth_test.go
@@ -29,6 +29,10 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		cfg.JWTAuthEmailClaim = "foo-email"
 	}
 
+	configureAutoSignUp := func(cfg *setting.Cfg) {
+		cfg.JWTAuthAutoSignUp = true
+	}
+
 	token := "some-token"
 
 	middlewareScenario(t, "Valid token with valid login claim", func(t *testing.T, sc *scenarioContext) {
@@ -37,6 +41,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
 			return models.JWTClaims{
+				"sub": myUsername,
 				"foo-username": myUsername,
 			}, nil
 		}
@@ -64,6 +69,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
 			return models.JWTClaims{
+				"sub": myEmail,
 				"foo-email": myEmail,
 			}, nil
 		}
@@ -85,11 +91,72 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		assert.Equal(t, myEmail, sc.context.Email)
 	}, configure, configureEmailClaim)
 
+	middlewareScenario(t, "Valid token with no user and auto_sign_up disabled", func(t *testing.T, sc *scenarioContext) {
+		myEmail := "vladimir@example.com"
+		var verifiedToken string
+		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
+			verifiedToken = token
+			return models.JWTClaims{
+				"sub": myEmail,
+				"name": "Vladimir Example",
+				"foo-email": myEmail,
+			}, nil
+		}
+		bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+			return models.ErrUserNotFound
+		})
+
+		sc.fakeReq("GET", "/").withJWTAuthHeader(token).exec()
+		assert.Equal(t, verifiedToken, token)
+		assert.Equal(t, 401, sc.resp.Code)
+		assert.Equal(t, contexthandler.UserNotFound, sc.respJson["message"])
+	}, configure, configureEmailClaim)
+
+	middlewareScenario(t, "Valid token with no user and auto_sign_up enabled", func(t *testing.T, sc *scenarioContext) {
+		myEmail := "vladimir@example.com"
+		var verifiedToken string
+		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
+			verifiedToken = token
+			return models.JWTClaims{
+				"sub": myEmail,
+				"name": "Vladimir Example",
+				"foo-email": myEmail,
+			}, nil
+		}
+		bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+			query.Result = &models.SignedInUser{
+				UserId: id,
+				OrgId:  orgID,
+				Email:  query.Email,
+			}
+			return nil
+		})
+		bus.AddHandlerCtx("upsert-user", func(ctx context.Context, command *models.UpsertUserCommand) error {
+			command.Result = &models.User {
+				Id: id,
+				Name: command.ExternalUser.Name,
+				Email: command.ExternalUser.Email,
+			}
+			return nil
+		})
+
+		sc.fakeReq("GET", "/").withJWTAuthHeader(token).exec()
+		assert.Equal(t, verifiedToken, token)
+		assert.Equal(t, 200, sc.resp.Code)
+		assert.True(t, sc.context.IsSignedIn)
+		assert.Equal(t, orgID, sc.context.OrgId)
+		assert.Equal(t, id, sc.context.UserId)
+		assert.Equal(t, myEmail, sc.context.Email)
+	}, configure, configureEmailClaim, configureAutoSignUp)
+
 	middlewareScenario(t, "Valid token without a login claim", func(t *testing.T, sc *scenarioContext) {
 		var verifiedToken string
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
-			return models.JWTClaims{"foo": "bar"}, nil
+			return models.JWTClaims{
+				"sub": "baz",
+				"foo": "bar",
+			}, nil
 		}
 
 		sc.fakeReq("GET", "/").withJWTAuthHeader(token).exec()
@@ -102,7 +169,10 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		var verifiedToken string
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
 			verifiedToken = token
-			return models.JWTClaims{"foo": "bar"}, nil
+			return models.JWTClaims{
+				"sub": "baz",
+				"foo": "bar",
+			}, nil
 		}
 
 		sc.fakeReq("GET", "/").withJWTAuthHeader(token).exec()

--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -9,6 +9,7 @@ import (
 )
 
 const InvalidJWT = "Invalid JWT"
+const UserNotFound = "User not found"
 
 func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64) bool {
 	if !h.Cfg.JWTAuthEnabled || h.Cfg.JWTAuthHeaderName == "" {
@@ -29,11 +30,29 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 
 	query := models.GetSignedInUserQuery{OrgId: orgId}
 
+	sub, _ := claims["sub"].(string)
+
+	if sub == "" {
+		ctx.Logger.Warn("Got a JWT without the mandatory 'sub' claim", "error", err)
+		ctx.JsonApiErr(401, InvalidJWT, err)
+		return true
+	}
+	extUser := &models.ExternalUserInfo{
+		AuthModule: "jwt",
+		AuthId: sub,
+	}
+
 	if key := h.Cfg.JWTAuthUsernameClaim; key != "" {
 		query.Login, _ = claims[key].(string)
+		extUser.Login, _ = claims[key].(string)
 	}
 	if key := h.Cfg.JWTAuthEmailClaim; key != "" {
 		query.Email, _ = claims[key].(string)
+		extUser.Email, _ = claims[key].(string)
+	}
+
+	if name, _ := claims["name"].(string); name != "" {
+		extUser.Name = name
 	}
 
 	if query.Login == "" && query.Email == "" {
@@ -41,7 +60,17 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 		ctx.JsonApiErr(401, InvalidJWT, err)
 		return true
 	}
-
+	if h.Cfg.JWTAuthAutoSignUp {
+		upsert := &models.UpsertUserCommand{
+			ReqContext:    ctx,
+			SignupAllowed: h.Cfg.JWTAuthAutoSignUp,
+			ExternalUser:  extUser,
+		}
+		if err := bus.Dispatch(upsert); err != nil {
+			ctx.Logger.Error("Failed to upsert JWT user", "error", err)
+			return false
+		}
+	}
 	if err := bus.DispatchCtx(ctx.Req.Context(), &query); err != nil {
 		if errors.Is(err, models.ErrUserNotFound) {
 			ctx.Logger.Debug(
@@ -50,10 +79,11 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 				"username_claim", query.Login,
 			)
 			err = login.ErrInvalidCredentials
+			ctx.JsonApiErr(401, UserNotFound, err)
 		} else {
 			ctx.Logger.Error("Failed to get signed in user", "error", err)
+			ctx.JsonApiErr(401, InvalidJWT, err)
 		}
-		ctx.JsonApiErr(401, InvalidJWT, err)
 		return true
 	}
 

--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -66,7 +66,7 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 			SignupAllowed: h.Cfg.JWTAuthAutoSignUp,
 			ExternalUser:  extUser,
 		}
-		if err := bus.Dispatch(upsert); err != nil {
+		if err := bus.DispatchCtx(ctx.Req.Context(), upsert); err != nil {
 			ctx.Logger.Error("Failed to upsert JWT user", "error", err)
 			return false
 		}

--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -39,7 +39,7 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 	}
 	extUser := &models.ExternalUserInfo{
 		AuthModule: "jwt",
-		AuthId: sub,
+		AuthId:     sub,
 	}
 
 	if key := h.Cfg.JWTAuthUsernameClaim; key != "" {

--- a/pkg/services/searchusers/searchusers.go
+++ b/pkg/services/searchusers/searchusers.go
@@ -96,6 +96,8 @@ func GetAuthProviderLabel(authModule string) string {
 		return "SAML"
 	case "ldap", "":
 		return "LDAP"
+	case "jwt":
+		return "JWT"
 	default:
 		return "OAuth"
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -319,6 +319,7 @@ type Cfg struct {
 	JWTAuthCacheTTL      time.Duration
 	JWTAuthKeyFile       string
 	JWTAuthJWKSetFile    string
+	JWTAuthAutoSignUp    bool
 
 	// Dataproxy
 	SendUserHeader                 bool
@@ -1304,6 +1305,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	cfg.JWTAuthCacheTTL = authJWT.Key("cache_ttl").MustDuration(time.Minute * 60)
 	cfg.JWTAuthKeyFile = valueAsString(authJWT, "key_file", "")
 	cfg.JWTAuthJWKSetFile = valueAsString(authJWT, "jwk_set_file", "")
+	cfg.JWTAuthAutoSignUp = authJWT.Key("auto_sign_up").MustBool(false)
 
 	authProxy := iniFile.Section("auth.proxy")
 	AuthProxyEnabled = authProxy.Key("enabled").MustBool(false)


### PR DESCRIPTION
Uses the RFC 7519-mandated "sub" field as the external Auth ID. If present, uses the IANA-registered "name" field as the full name of the auto-created user.

**What this PR does / why we need it**: Adds the `auto_sign_up` option to JWT authentication, matching other auth providers

**Which issue(s) this PR fixes**: Fixes #34497
