### PR TITLE
influxdb: influxql: handle null-cases in timeseries data

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -34,13 +34,16 @@ import { catchError, map } from 'rxjs/operators';
 
 // we detect the field type based on the value-array
 function getFieldType(values: unknown[]): FieldType {
-  if (values.length === 0) {
-    // if we get called with an empty value-array,
-    // we will assume the values are numbers
+  // the values-array may contain a lot of nulls.
+  // we need the first not-null item
+  const firstNotNull = values.find((v) => v !== null);
+
+  if (firstNotNull === undefined) {
+    // we could not find any not-null values
     return FieldType.number;
   }
 
-  const valueType = typeof values[0];
+  const valueType = typeof firstNotNull;
 
   switch (valueType) {
     case 'string':


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/36850 we implemented a way to auto-detect the data-format in an influxdb-response (it can be `string`/`number`/`boolean`). the detection works by looking at the first item from the result-array and checking it's type.

unfortunately, the result-array can also contain `null`s, and that case was not handled before.

with this fix, we go through the result-array and find the first not-null item.

how to test:
1. `make devenv sources=influxdb`
2. wait 1 minute so that data is inserted into influxdb
3. create a dashboard-panel, choose the `gdev-influxdb-influxql` data source
4. set FROM to `default.cpu`, set SELECT to `field(usage_idle)`
5. make sure the `GROUP BY` line contains `fill(null)` (it should by default)
5. open the browser's network-inspector, look at the ajax-requests
6. click the refresh-button in the panel to trigger a request
7. verify that you can see a graph, and also in the network-inspector open the response-data, and dig into it and verify that the first item in the `values` array has `null` as the second field (it should be a two-item array `[timestamp, value]` with `value` being `null`)
8. (just for reference, on main-branch at this point you would get an empty graph-panel with the error "InfluxQL: invalid value type object"