### PR TITLE
Alerting: Expand the value string in alert annotations and labels

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -109,8 +109,9 @@ The following template variables are available when expanding annotations and la
 
 | Name    | Description     |
 | ------- | --------------- |
-| $labels | Labels contains the labels from the query or condition. For example, `{{ $labels.instance }}` and `{{ $labels.job }}`. |
-| $values | Values contains the values of all reduce and math expressions that were evaluated for this alert rule. For example, `{{ $values.A }}`, `{{ $values.A.Labels }}` and `{{ $values.A.Value }}` where `A` is the `refID` of the expression. |
+| $labels | The labels from the query or condition. For example, `{{ $labels.instance }}` and `{{ $labels.job }}`. |
+| $values | The values of all reduce and math expressions that were evaluated for this alert rule. For example, `{{ $values.A }}`, `{{ $values.A.Labels }}` and `{{ $values.A.Value }}` where `A` is the `refID` of the expression. |
+| $value  | The value string of the alert instance. For example, `[ var='A' labels={instance=foo} value=10 ]`. |
 
 ## Preview alerts
 

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -1,9 +1,13 @@
 package state
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ptr "github.com/xorcare/pointer"
 )
 
@@ -29,6 +33,68 @@ func TestTemplateCaptureValueStringer(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			assert.Equal(t, c.expected, c.value.String())
+		})
+	}
+}
+
+func TestExpandTemplate(t *testing.T) {
+	cases := []struct {
+		name          string
+		text          string
+		alertInstance eval.Result
+		labels        data.Labels
+		expected      string
+		expectedError error
+	}{{
+		name:     "instance labels are expanded into $labels",
+		text:     "{{ $labels.instance }} is down",
+		labels:   data.Labels{"instance": "foo"},
+		expected: "foo is down",
+	}, {
+		name:          "missing instance label returns error",
+		text:          "{{ $labels.instance }} is down",
+		labels:        data.Labels{},
+		expectedError: errors.New("error executing template __alert_test: template: __alert_test:1:86: executing \"__alert_test\" at <$labels.instance>: map has no entry for key \"instance\""),
+	}, {
+		name: "values are expanded into $values",
+		text: "{{ $values.A.Labels.instance }} has value {{ $values.A }}",
+		alertInstance: eval.Result{
+			Values: map[string]eval.NumberValueCapture{
+				"A": {
+					Var:    "A",
+					Labels: data.Labels{"instance": "foo"},
+					Value:  ptr.Float64(10),
+				},
+			},
+		},
+		expected: "foo has value 10",
+	}, {
+		name: "missing label in $values returns error",
+		text: "{{ $values.A.Labels.instance }} has value {{ $values.A }}",
+		alertInstance: eval.Result{
+			Values: map[string]eval.NumberValueCapture{
+				"A": {
+					Var:    "A",
+					Labels: data.Labels{},
+					Value:  ptr.Float64(10),
+				},
+			},
+		},
+		expectedError: errors.New("error executing template __alert_test: template: __alert_test:1:86: executing \"__alert_test\" at <$values.A.Labels.instance>: map has no entry for key \"instance\""),
+	}, {
+		name: "value string is expanded into $value",
+		text: "{{ $value }}",
+		alertInstance: eval.Result{
+			EvaluationString: "[ var='A' labels={instance=foo} value=10 ]",
+		},
+		expected: "[ var='A' labels={instance=foo} value=10 ]",
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v, err := expandTemplate("test", c.text, c.labels, c.alertInstance)
+			require.Equal(t, c.expectedError, err)
+			require.Equal(t, c.expected, v)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit makes it possible to use the value string in annotations and labels for alerts with "{{ $value }}"