### PR TITLE
Added Grafana cloud references to add to Enterprise mentions.

### DIFF
--- a/docs/sources/auth/ldap.md
+++ b/docs/sources/auth/ldap.md
@@ -11,7 +11,7 @@ weight = 300
 The LDAP integration in Grafana allows your Grafana users to login with their LDAP credentials. You can also specify mappings between LDAP
 group memberships and Grafana Organization user roles.
 
-> [Enhanced LDAP authentication]({{< relref "../enterprise/enhanced_ldap.md" >}}) is available in [Grafana Enterprise]({{< relref "../enterprise" >}}).
+> [Enhanced LDAP authentication]({{< relref "../enterprise/enhanced_ldap.md" >}}) is available in [Grafana Cloud](https://grafana.com/docs/grafana-cloud/) and [Grafana Enterprise]({{< relref "../enterprise" >}}).
 
 ## Supported LDAP Servers
 

--- a/docs/sources/auth/saml.md
+++ b/docs/sources/auth/saml.md
@@ -10,4 +10,4 @@ weight = 1100
 
 The SAML authentication integration allows your Grafana users to log in by using an external SAML Identity Provider (IdP). To enable this, Grafana becomes a Service Provider (SP) in the authentication flow, interacting with the IdP to exchange user information.
 
-> SAML authentication integration is only available in Grafana Enterprise v6.3 or later. For more information, refer to [SAML authentication]({{< relref "../enterprise/saml.md" >}}) in [Grafana Enterprise]({{< relref "../enterprise" >}}).
+> SAML authentication integration is available in Grafana Cloud and in Enterprise v6.3 or later. For more information, refer to [SAML authentication]({{< relref "../enterprise/saml.md" >}}) in [Grafana Enterprise]({{< relref "../enterprise" >}}).

--- a/docs/sources/auth/team-sync.md
+++ b/docs/sources/auth/team-sync.md
@@ -19,4 +19,4 @@ This mechanism allows Grafana to remove an existing synchronized user from a tea
 
 <div class="clearfix"></div>
 
-> Team Sync is only available in Grafana Enterprise.  For more information, refer to [Team sync]({{< relref "../enterprise/team-sync.md" >}}) in [Grafana Enterprise]({{< relref "../enterprise" >}}).
+> Team Sync is available in Grafana Enterprise Cloud and Grafana Enterprise.  For more information, refer to [Team sync]({{< relref "../enterprise/team-sync.md" >}}) in [Grafana Enterprise]({{< relref "../enterprise" >}}).

--- a/docs/sources/enterprise/reporting.md
+++ b/docs/sources/enterprise/reporting.md
@@ -8,9 +8,7 @@ weight = 800
 
 # Reporting
 
-Reporting allows you to automatically generate PDFs from any of your dashboards and have Grafana email them to interested parties on a schedule.
-
-> Only available in Grafana Enterprise v6.4+.
+Reporting allows you to automatically generate PDFs from any of your dashboards and have Grafana email them to interested parties on a schedule. This is available in Grafana Cloud and in Grafana Enterprise.
 
 > If you have [Fine-grained access Control]({{< relref "../enterprise/access-control/_index.md" >}}) enabled, for some actions you would need to have relevant permissions.
 Refer to specific guides to understand what permissions are required.


### PR DESCRIPTION
To 5 topics:

/docs/grafana/latest/enterprise/reporting/
/docs/grafana/latest/auth/saml/
/grafana/latest/auth/ldap/
/docs/grafana/latest/auth/team-sync/
/docs/grafana/latest/enterprise/team-sync/
