### PR TITLE
Catalog: Add breadcrumb to plugin details page

### DIFF
--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -59,17 +59,25 @@ export default function PluginDetails({ match }: PluginDetailsProps): JSX.Elemen
             />
 
             <div className={styles.headerWrapper}>
-              <h1 className={styles.header}>
-                <a
-                  className={css`
-                    text-decoration: underline;
-                  `}
-                  href={'/plugins'}
-                >
-                  Plugins
-                </a>{' '}
-                / {plugin.name}
-              </h1>
+              <nav className={styles.breadcrumb} aria-label="Breadcrumb">
+                <ol>
+                  <li>
+                    <a
+                      className={css`
+                        text-decoration: underline;
+                      `}
+                      href={'/plugins'}
+                    >
+                      Plugins
+                    </a>
+                  </li>
+                  <li>
+                    <a href={`/plugins/${pluginId}`} aria-current="page">
+                      {plugin.name}
+                    </a>
+                  </li>
+                </ol>
+              </nav>
               <div className={styles.headerLinks}>
                 <span>{plugin.orgName}</span>
                 {plugin.links.map((link: any) => (
@@ -141,8 +149,19 @@ export const getStyles = (theme: GrafanaTheme2) => {
     headerWrapper: css`
       margin-left: ${theme.spacing(3)};
     `,
-    header: css`
+    breadcrumb: css`
       font-size: ${theme.typography.h2.fontSize};
+      li {
+        display: inline;
+        list-style: none;
+        &::after {
+          content: '/';
+          padding: 0 0.25ch;
+        }
+        &:last-child::after {
+          content: '';
+        }
+      }
     `,
     headerLinks: css`
       display: flex;
@@ -155,9 +174,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
           content: '|';
           padding: 0 ${theme.spacing()};
         }
-      }
-      & > *:last-child {
-        &::after {
+        &:last-child::after {
           content: '';
           padding-right: 0;
         }

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -51,7 +51,7 @@ export default function PluginDetails({ match }: PluginDetailsProps): JSX.Elemen
             <PluginLogo
               src={plugin.info.logos.small}
               className={css`
-                object-fit: cover;
+                object-fit: contain;
                 width: 100%;
                 height: 68px;
                 max-width: 68px;
@@ -59,11 +59,19 @@ export default function PluginDetails({ match }: PluginDetailsProps): JSX.Elemen
             />
 
             <div className={styles.headerWrapper}>
-              <h1>{plugin.name}</h1>
+              <h1 className={styles.header}>
+                <a
+                  className={css`
+                    text-decoration: underline;
+                  `}
+                  href={'/plugins'}
+                >
+                  Plugins
+                </a>{' '}
+                / {plugin.name}
+              </h1>
               <div className={styles.headerLinks}>
-                <a className={styles.headerOrgName} href={'/plugins'}>
-                  {plugin.orgName}
-                </a>
+                <span>{plugin.orgName}</span>
                 {plugin.links.map((link: any) => (
                   <a key={link.name} href={link.url}>
                     {link.name}
@@ -126,12 +134,15 @@ export const getStyles = (theme: GrafanaTheme2) => {
   return {
     headerContainer: css`
       display: flex;
-      margin-bottom: 24px;
-      margin-top: 24px;
+      margin-bottom: ${theme.spacing(3)};
+      margin-top: ${theme.spacing(3)};
       min-height: 120px;
     `,
     headerWrapper: css`
       margin-left: ${theme.spacing(3)};
+    `,
+    header: css`
+      font-size: ${theme.typography.h2.fontSize};
     `,
     headerLinks: css`
       display: flex;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds the ability for a user to return to the plugins page from the plugin details page without using the back button.

- [x] add breadcrumb to header
- [x] fix bug with plugin icon size in header
- [x] prefer theme variables over hardcoded spacing values

| Before | After |
| --- | --- |
| <img width="1678" alt="Screenshot 2021-07-22 at 11 40 56" src="https://user-images.githubusercontent.com/73201/126619443-ff59c32d-8876-4ef4-935a-d34a9ea1d831.png"> | <img width="1679" alt="Screenshot 2021-07-22 at 11 39 51" src="https://user-images.githubusercontent.com/73201/126619360-91e86f2c-7744-4766-a8bd-dfb34c6c5cf3.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #36229

