### PR TITLE
Populate dashboard_acl default rules in application logic, rather than in migrations

### DIFF
--- a/pkg/services/sqlstore/migrations/dashboard_acl.go
+++ b/pkg/services/sqlstore/migrations/dashboard_acl.go
@@ -51,8 +51,20 @@ INSERT INTO dashboard_acl
 		"DELETE FROM dashboard_acl WHERE dashboard_id NOT IN (SELECT id FROM dashboard) AND dashboard_id != -1"))
 }
 
-// we now create these default rules as part of the sqlstore initialisation
-func removeDefaultDashboardACLRecords(mg *Migrator) {
-	const rawSQL = `DELETE FROM dashboard_acl WHERE org_id=-1 AND dashboard_id=-1 AND permission IN (1,2) AND role IN ('Viewer','Editor') AND created='2017-06-20' AND updated='2017-06-20'`
+// We now create these default rules as part of the sqlstore initialisation
+func addCleanupDashboardACLRulesMigration(mg *Migrator) {
+	// This query is really specific (including created/updated) because we only
+	// want to delete rules that were created by the "save default acl rules in
+	// dashboard_acl table" migration
+	const rawSQL = `
+		DELETE FROM dashboard_acl
+			WHERE org_id=-1 AND
+			dashboard_id=-1 AND
+			user_id is NULL AND
+			team_id is NULL AND
+			permission IN (1,2)	AND
+			role IN ('Viewer','Editor') AND
+			created='2017-06-20' AND
+			updated='2017-06-20'`
 	mg.AddMigration("remove default acl rules from dashboard_acl table", NewRawSQLMigration(rawSQL))
 }

--- a/pkg/services/sqlstore/migrations/dashboard_acl.go
+++ b/pkg/services/sqlstore/migrations/dashboard_acl.go
@@ -50,3 +50,9 @@ INSERT INTO dashboard_acl
 	mg.AddMigration("delete acl rules for deleted dashboards and folders", NewRawSQLMigration(
 		"DELETE FROM dashboard_acl WHERE dashboard_id NOT IN (SELECT id FROM dashboard) AND dashboard_id != -1"))
 }
+
+// we now create these default rules as part of the sqlstore initialisation
+func removeDefaultDashboardACLRecords(mg *Migrator) {
+	const rawSQL = `DELETE FROM dashboard_acl WHERE org_id=-1 AND dashboard_id=-1 AND permission IN (1,2) AND role IN ('Viewer','Editor') AND created='2017-06-20' AND updated='2017-06-20'`
+	mg.AddMigration("remove default acl rules from dashboard_acl table", NewRawSQLMigration(rawSQL))
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -41,6 +41,7 @@ func AddMigrations(mg *Migrator) {
 	ualert.AddTablesMigrations(mg)
 	ualert.AddDashAlertMigration(mg)
 	addLibraryElementsMigrations(mg)
+	removeDefaultDashboardACLRecords(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -41,7 +41,7 @@ func AddMigrations(mg *Migrator) {
 	ualert.AddTablesMigrations(mg)
 	ualert.AddDashAlertMigration(mg)
 	addLibraryElementsMigrations(mg)
-	removeDefaultDashboardACLRecords(mg)
+	addCleanupDashboardACLRulesMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -157,7 +157,7 @@ func (db *PostgresDialect) TruncateDBTables() error {
 			if _, err := sess.Exec(fmt.Sprintf("DELETE FROM %v WHERE dashboard_id != -1 AND org_id != -1;", db.Quote(table.Name))); err != nil {
 				return errutil.Wrapf(err, "failed to truncate table %q", table.Name)
 			}
-			if _, err := sess.Exec(fmt.Sprintf("ALTER SEQUENCE %v RESTART WITH 3;", db.Quote(fmt.Sprintf("%v_id_seq", table.Name)))); err != nil {
+			if _, err := sess.Exec(fmt.Sprintf("ALTER SEQUENCE %v RESTART WITH 5;", db.Quote(fmt.Sprintf("%v_id_seq", table.Name)))); err != nil {
 				return errutil.Wrapf(err, "failed to reset table %q", table.Name)
 			}
 		default:

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -198,12 +198,12 @@ func (ss *SQLStore) ensureDashboardACLDefaults() error {
 		}{}
 
 		rawSQL := `SELECT COUNT(id) AS count
-FROM dashboard_acl
-WHERE
-	org_id = -1 AND
-	dashboard_id = -1 AND
-	permission IN (1,2) AND
-	role IN ('Viewer', 'Editor')`
+			FROM dashboard_acl
+			WHERE
+				org_id = -1 AND
+				dashboard_id = -1 AND
+				permission IN (1,2) AND
+				role IN ('Viewer', 'Editor')`
 		if _, err := sess.SQL(rawSQL).Get(&result); err != nil {
 			return fmt.Errorf("could not determine existence of default dashboard_acl entries: %w", err)
 		}
@@ -214,22 +214,20 @@ WHERE
 
 		ss.log.Debug("Creating default dashboard_acl records")
 
-		rtEditor := models.ROLE_EDITOR
-		rtViewer := models.ROLE_VIEWER
-
-		if _, err := sess.Exec(`INSERT INTO dashboard_acl (
-	org_id,
-	dashboard_id,
-	permission,
-	role,
-	created,
-	updated
-)
-VALUES
-(?,?,?,?,?,?),
-(?,?,?,?,?,?)`,
-			-1, -1, models.PERMISSION_VIEW, rtViewer, time.Now(), time.Now(),
-			-1, -1, models.PERMISSION_EDIT, rtEditor, time.Now(), time.Now(),
+		if _, err := sess.Exec(`INSERT INTO dashboard_acl 
+			(
+				org_id,
+				dashboard_id,
+				permission,
+				role,
+				created,
+				updated
+			)
+			VALUES
+			(?,?,?,?,?,?),
+			(?,?,?,?,?,?)`,
+			-1, -1, models.PERMISSION_VIEW, models.ROLE_VIEWER, time.Now(), time.Now(),
+			-1, -1, models.PERMISSION_EDIT, models.ROLE_EDITOR, time.Now(), time.Now(),
 		); err != nil {
 			return fmt.Errorf("failed to create default dashboard_acl records: %w", err)
 		}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -191,7 +191,7 @@ func (ss *SQLStore) ensureDashboardACLDefaults() error {
 	ctx := context.Background()
 
 	err := ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
-		ss.log.Debug("Ensuring default dashboard ACL records exist")
+		ss.log.Debug("Ensuring default dashboard ACL rules exist")
 
 		result := struct {
 			Count int64
@@ -202,17 +202,19 @@ func (ss *SQLStore) ensureDashboardACLDefaults() error {
 			WHERE
 				org_id = -1 AND
 				dashboard_id = -1 AND
+				user_id is NULL AND
+				team_id is NULL AND
 				permission IN (1,2) AND
 				role IN ('Viewer', 'Editor')`
 		if _, err := sess.SQL(rawSQL).Get(&result); err != nil {
-			return fmt.Errorf("could not determine existence of default dashboard_acl entries: %w", err)
+			return fmt.Errorf("could not determine existence of default dashboard_acl rules: %w", err)
 		}
 
 		if result.Count > 0 {
 			return nil
 		}
 
-		ss.log.Debug("Creating default dashboard_acl records")
+		ss.log.Debug("Creating default dashboard_acl rules")
 
 		if _, err := sess.Exec(`INSERT INTO dashboard_acl 
 			(
@@ -229,10 +231,10 @@ func (ss *SQLStore) ensureDashboardACLDefaults() error {
 			-1, -1, models.PERMISSION_VIEW, models.ROLE_VIEWER, time.Now(), time.Now(),
 			-1, -1, models.PERMISSION_EDIT, models.ROLE_EDITOR, time.Now(), time.Now(),
 		); err != nil {
-			return fmt.Errorf("failed to create default dashboard_acl records: %w", err)
+			return fmt.Errorf("failed to create default dashboard_acl rules: %w", err)
 		}
 
-		ss.log.Info("Created default dashboard_acl records")
+		ss.log.Info("Created default dashboard_acl rules")
 		return nil
 	})
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR moves the responsibility for creating the two default dashboard_acl rules from the migration to the application logic. This means that even when the migrations aren't run, the application still ensures that these rules exist.

These rules are the only example of records being hard-coded into the grafana database via migrations.

This is required for an internal project related to Hosted Grafana. Please message me if you require more details.

**Which issue(s) this PR fixes**:

https://github.com/grafana/hosted-grafana/issues/918

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

- I think this change will be covered by the [dashboard_acl tests](https://github.com/grafana/grafana/blob/main/pkg/services/sqlstore/dashboard_acl_test.go), but I am very happy to be guided on additional tests to cover this change
- I think everything would still work if we *didn't* remove the default rules via the new migration, but I think adding this migration is a clear signal that these rules are now handled by something else. 
- I used an `Exec` rather than an `Insert` in `ensureDashboardACLDefaults` because I need `user_id` and `team_id` to be `NULL`, not 0, which is what the value would be if we inserted via the model.
- I haven't done any raw SQL statements in this repo before, so I'm happy to be guided on how these are laid out

