### PR TITLE
Config: Fix alternative Azure cloud names

### DIFF
--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -31,28 +31,39 @@ func normalizeAzureCloud(cloudName string) string {
 	switch strings.ToLower(cloudName) {
 	// Public
 	case "azurecloud":
+		fallthrough
 	case "azurepublic":
+		fallthrough
 	case "azurepubliccloud":
+		fallthrough
 	case "public":
 		return AzurePublic
 
 	// China
 	case "azurechina":
+		fallthrough
 	case "azurechinacloud":
+		fallthrough
 	case "china":
 		return AzureChina
 
 	// US Government
 	case "azureusgovernment":
+		fallthrough
 	case "azureusgovernmentcloud":
+		fallthrough
 	case "usgov":
+		fallthrough
 	case "usgovernment":
 		return AzureUSGovernment
 
 	// Germany
 	case "azuregermancloud":
+		fallthrough
 	case "azuregermany":
+		fallthrough
 	case "german":
+		fallthrough
 	case "germany":
 		return AzureGermany
 	}

--- a/pkg/setting/setting_azure_test.go
+++ b/pkg/setting/setting_azure_test.go
@@ -1,0 +1,65 @@
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureSettings(t *testing.T) {
+	t.Run("cloud name", func(t *testing.T) {
+		testCases := []struct {
+			name            string
+			configuredValue string
+			resolvedValue   string
+		}{
+			{
+				name:            "should be Public if not set",
+				configuredValue: "",
+				resolvedValue:   AzurePublic,
+			},
+			{
+				name:            "should be Public if set to Public",
+				configuredValue: AzurePublic,
+				resolvedValue:   AzurePublic,
+			},
+			{
+				name:            "should be Public if set to Public using alternative name",
+				configuredValue: "AzurePublicCloud",
+				resolvedValue:   AzurePublic,
+			},
+			{
+				name:            "should be China if set to China",
+				configuredValue: AzureChina,
+				resolvedValue:   AzureChina,
+			},
+			{
+				name:            "should be US Government if set to US Government using alternative name",
+				configuredValue: "usgov",
+				resolvedValue:   AzureUSGovernment,
+			},
+			{
+				name:            "should be same as set if not known",
+				configuredValue: "Custom123",
+				resolvedValue:   "Custom123",
+			},
+		}
+
+		for _, c := range testCases {
+			t.Run(c.name, func(t *testing.T) {
+				cfg := NewCfg()
+
+				azureSection, err := cfg.Raw.NewSection("azure")
+				require.NoError(t, err)
+				_, err = azureSection.NewKey("cloud", c.configuredValue)
+				require.NoError(t, err)
+
+				cfg.readAzureSettings()
+				require.NotNil(t, cfg.Azure)
+
+				assert.Equal(t, c.resolvedValue, cfg.Azure.Cloud)
+			})
+		}
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to lack of `fallthrough`s all known alternative cloud names were not normalized to primary name.
Configurations which were using primary name were not affected.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This is a bug and needs to be merged to 8.1