### PR TITLE
Geomap: zoom full extent

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -203,6 +203,7 @@ export class GeomapPanel extends Component<Props> {
     let view = new View({
       center: [0, 0],
       zoom: 1,
+      showFullExtent: true, // alows zooming so the full range is visiable
     });
 
     // With shared views, all panels use the same view instance


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/37155

The default open layers settings constrains the zoom so you can not zoom past min or max width/height.  This seeting changes it so you can zoom way out even if it needs to duplicate parts of the map:

![image](https://user-images.githubusercontent.com/705951/126845567-a9d69d09-c88c-48a0-b66a-455af9688558.png)
