### PR TITLE
LDAP: validate organization role during parsing

### DIFF
--- a/pkg/models/org_user.go
+++ b/pkg/models/org_user.go
@@ -1,9 +1,9 @@
 package models
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -61,18 +61,14 @@ func (r RoleType) Parents() []RoleType {
 	}
 }
 
-func (r *RoleType) UnmarshalJSON(data []byte) error {
-	var str string
-	err := json.Unmarshal(data, &str)
-	if err != nil {
-		return err
-	}
+func (r *RoleType) UnmarshalText(data []byte) error {
+	// make sure "viewer" and "Viewer" are both correct
+	str := strings.Title(string(data))
 
 	*r = RoleType(str)
-
 	if !r.IsValid() {
 		if (*r) != "" {
-			return fmt.Errorf("JSON validation error: invalid role value: %s", *r)
+			return fmt.Errorf("invalid role value: %s", *r)
 		}
 
 		*r = ROLE_VIEWER

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -153,6 +153,10 @@ func readConfig(configFile string) (*Config, error) {
 		}
 
 		for _, groupMap := range server.Groups {
+			if groupMap.OrgRole == "" {
+				return nil, fmt.Errorf("LDAP group mapping: organization role is required")
+			}
+
 			if groupMap.OrgId == 0 {
 				groupMap.OrgId = 1
 			}

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -153,8 +153,8 @@ func readConfig(configFile string) (*Config, error) {
 		}
 
 		for _, groupMap := range server.Groups {
-			if groupMap.OrgRole == "" {
-				return nil, fmt.Errorf("LDAP group mapping: organization role is required")
+			if groupMap.OrgRole == "" && groupMap.IsGrafanaAdmin == nil {
+				return nil, fmt.Errorf("LDAP group mapping: organization role or grafana admin status is required")
 			}
 
 			if groupMap.OrgId == 0 {

--- a/public/app/features/admin/ldap/LdapUserGroups.tsx
+++ b/public/app/features/admin/ldap/LdapUserGroups.tsx
@@ -33,31 +33,21 @@ export const LdapUserGroups: FC<Props> = ({ groups, showAttributeMapping }) => {
             {items.map((group, index) => {
               return (
                 <tr key={`${group.orgId}-${index}`}>
-                  {showAttributeMapping && (
-                    <>
-                      <td>{group.groupDN}</td>
-                      {!group.orgRole && (
-                        <>
-                          <td />
-                          <td>
-                            <span className="text-warning">
-                              No match
-                              <Tooltip placement="top" content="No matching groups found" theme={'info'}>
-                                <span className="gf-form-help-icon">
-                                  <Icon name="info-circle" />
-                                </span>
-                              </Tooltip>
-                            </span>
-                          </td>
-                        </>
-                      )}
-                    </>
-                  )}
-                  {group.orgName && (
-                    <>
-                      <td>{group.orgName}</td>
-                      <td>{group.orgRole}</td>
-                    </>
+                  {showAttributeMapping && <td>{group.groupDN}</td>}
+                  {group.orgName && group.orgRole ? <td>{group.orgName}</td> : <td />}
+                  {group.orgRole ? (
+                    <td>{group.orgRole}</td>
+                  ) : (
+                    <td>
+                      <span className="text-warning">
+                        No match
+                        <Tooltip placement="top" content="No matching groups found" theme={'info'}>
+                          <span className="gf-form-help-icon">
+                            <Icon name="info-circle" />
+                          </span>
+                        </Tooltip>
+                      </span>
+                    </td>
                   )}
                 </tr>
               );


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds validation of the `org_role`.
It also fixes table on LDAP page to show organization name only when both org name and role are set.

| Before | After |
|--------|-------|
| ![Before](https://user-images.githubusercontent.com/7547604/126907740-50981267-53b6-4d09-ba42-30a0a6d4b3a2.png) | ![After](https://user-images.githubusercontent.com/7547604/126907748-89b987af-3b81-444e-825c-1721d5f49c27.png) |

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**: