### PR TITLE
Remove unused macaron code

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -569,12 +569,7 @@ func TestDataSourceProxy_requestHandling(t *testing.T) {
 
 		ds := &models.DataSource{Url: backend.URL, Type: models.DS_GRAPHITE}
 
-		responseRecorder := &closeNotifierResponseRecorder{
-			ResponseRecorder: httptest.NewRecorder(),
-		}
-		t.Cleanup(responseRecorder.Close)
-
-		responseWriter := macaron.NewResponseWriter("GET", responseRecorder)
+		responseWriter := macaron.NewResponseWriter("GET", httptest.NewRecorder())
 
 		// XXX: Really unsure why, but setting headers within the HTTP handler function doesn't stick,
 		// so doing it here instead
@@ -749,20 +744,6 @@ func TestNewDataSourceProxy_MSSQL(t *testing.T) {
 			}
 		})
 	}
-}
-
-type closeNotifierResponseRecorder struct {
-	*httptest.ResponseRecorder
-	closeChan chan bool
-}
-
-func (r *closeNotifierResponseRecorder) CloseNotify() <-chan bool {
-	r.closeChan = make(chan bool)
-	return r.closeChan
-}
-
-func (r *closeNotifierResponseRecorder) Close() {
-	close(r.closeChan)
 }
 
 // getDatasourceProxiedRequest is a helper for easier setup of tests based on global config and ReqContext.

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -88,19 +87,10 @@ func validateAndWrapHandler(h Handler) Handler {
 
 // validateAndWrapHandlers preforms validation and wrapping for each input handler.
 // It accepts an optional wrapper function to perform custom wrapping on handlers.
-func validateAndWrapHandlers(handlers []Handler, wrappers ...func(Handler) Handler) []Handler {
-	var wrapper func(Handler) Handler
-	if len(wrappers) > 0 {
-		wrapper = wrappers[0]
-	}
-
+func validateAndWrapHandlers(handlers []Handler) []Handler {
 	wrappedHandlers := make([]Handler, len(handlers))
 	for i, h := range handlers {
-		h = validateAndWrapHandler(h)
-		if wrapper != nil && !IsFastInvoker(h) {
-			h = wrapper(h)
-		}
-		wrappedHandlers[i] = h
+		wrappedHandlers[i] = validateAndWrapHandler(h)
 	}
 
 	return wrappedHandlers
@@ -136,16 +126,6 @@ func New() *Macaron {
 		http.Error(rw, err.Error(), 500)
 	})
 	return m
-}
-
-// Handlers sets the entire middleware stack with the given Handlers.
-// This will clear any current middleware handlers,
-// and panics if any of the handlers is not a callable function
-func (m *Macaron) Handlers(handlers ...Handler) {
-	m.handlers = make([]Handler, 0)
-	for _, handler := range handlers {
-		m.Use(handler)
-	}
 }
 
 // BeforeHandler represents a handler executes at beginning of every request.
@@ -227,18 +207,6 @@ func (m *Macaron) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 	m.Router.ServeHTTP(rw, req)
-}
-
-func getDefaultListenInfo() (string, int) {
-	host := os.Getenv("HOST")
-	if len(host) == 0 {
-		host = "0.0.0.0"
-	}
-	port, _ := strconv.Atoi(os.Getenv("PORT"))
-	if port == 0 {
-		port = 4000
-	}
-	return host, port
 }
 
 // SetURLPrefix sets URL prefix of router layer, so that it support suburl.

--- a/pkg/macaron/response_writer.go
+++ b/pkg/macaron/response_writer.go
@@ -27,7 +27,6 @@ import (
 type ResponseWriter interface {
 	http.ResponseWriter
 	http.Flusher
-	http.Pusher
 	// Status returns the status code of the response or 0 if the response has not been written.
 	Status() int
 	// Written returns whether or not the ResponseWriter has been written.
@@ -97,11 +96,6 @@ func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return hijacker.Hijack()
 }
 
-//nolint
-func (rw *responseWriter) CloseNotify() <-chan bool {
-	return rw.ResponseWriter.(http.CloseNotifier).CloseNotify()
-}
-
 func (rw *responseWriter) callBefore() {
 	for i := len(rw.beforeFuncs) - 1; i >= 0; i-- {
 		rw.beforeFuncs[i](rw)
@@ -113,12 +107,4 @@ func (rw *responseWriter) Flush() {
 	if ok {
 		flusher.Flush()
 	}
-}
-
-func (rw *responseWriter) Push(target string, opts *http.PushOptions) error {
-	pusher, ok := rw.ResponseWriter.(http.Pusher)
-	if !ok {
-		return errors.New("the ResponseWriter doesn't support the Pusher interface")
-	}
-	return pusher.Push(target, opts)
 }

--- a/pkg/macaron/router.go
+++ b/pkg/macaron/router.go
@@ -82,9 +82,6 @@ type Router struct {
 	groups              []group
 	notFound            http.HandlerFunc
 	internalServerError func(*Context, error)
-
-	// handlerWrapper is used to wrap arbitrary function from Handler to inject.FastInvoker.
-	handlerWrapper func(Handler) Handler
 }
 
 func NewRouter() *Router {
@@ -176,7 +173,7 @@ func (r *Router) Handle(method string, pattern string, handlers []Handler) *Rout
 		h = append(h, handlers...)
 		handlers = h
 	}
-	handlers = validateAndWrapHandlers(handlers, r.handlerWrapper)
+	handlers = validateAndWrapHandlers(handlers)
 
 	return r.handle(method, pattern, func(resp http.ResponseWriter, req *http.Request, params Params) {
 		c := r.m.createContext(resp, req)
@@ -279,11 +276,6 @@ func (r *Router) InternalServerError(handlers ...Handler) {
 		c.Map(err)
 		c.run()
 	}
-}
-
-// SetHandlerWrapper sets handlerWrapper for the router.
-func (r *Router) SetHandlerWrapper(f func(Handler) Handler) {
-	r.handlerWrapper = f
 }
 
 func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Another round of code removals. This PR removes:

* CloseNotify() from the ResponseWriter interface (Context is a proper way to go for such things). This API has been deprecated for the last 3+ years.
* closeNotifierResponseRecorder wrapper in tests, that was only used to match the Macaron's ResponseWriter with CloseNotify.
* validateAndWrapHandlers only takes handlers as a parameter, it no longer takes a wrapper function. Why on earth one would want to create middleware for middleware?! Same for SetHandlersWrapper router API.
* Handlers() method is removed, supposed to bulk-insert middleware. It has not been used.
* getDefaultListenInfo() is removed, supposed to use HOST/PORT from the environment. It has not been used.
* Pusher interface is removed from the ResponseWriter. It has not been used.