### PR TITLE
InfluxDB: Fix InfluxQL dataframe column-names

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -85,7 +85,9 @@ function timeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
   const valueField = {
     name: TIME_SERIES_VALUE_FIELD_NAME,
     type: getFieldType(values),
-    config: {},
+    config: {
+      displayNameFromDS: timeSeries.title,
+    },
     values: new ArrayVector<unknown>(values),
     labels: timeSeries.tags,
   };

--- a/public/app/plugins/datasource/influxdb/influx_series.ts
+++ b/public/app/plugins/datasource/influxdb/influx_series.ts
@@ -52,6 +52,7 @@ export default class InfluxSeries {
         }
 
         output.push({
+          title: seriesName,
           target: seriesName,
           datapoints: datapoints,
           tags: series.tags,


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/37151

when https://github.com/grafana/grafana/pull/36702 happened, we started sending the tags in the timeseries format (we did not do this before for some reason). this is good, but now grafana's generic format-dataframe-column-name code adds this tag-info to the names, and now the names are not like they were before.

basically, influxdb already formats the name itself, and the rest of grafana should just use it. the way to do it is using the `displayNameFromDS` attribute, so that's what we do here.

for more info see the discussion in the issue (https://github.com/grafana/grafana/issues/37151)

how to test:
- `make devenv sources=influxdb`
- add a dashboard-panel, choose the `gdev-influxdb-influxql` datasource
- in FROM choose `default.cpu`, in `SELECT` choose `field(usage_idle)`
- remove everything in the GROUP_BY, then add `tag(cpu)` to the GROUP_BY
- set ALIAS to `$tag_cpu`
- look at the legend, it should be : `cpu-total`, `cpu0`, `cpu1`, `cpu2`, `cpu3`
    - for reference, on main-branch, the incorrect legend says `cpu-total cpu-total`, `cpu0 cpu0`, `cpu1 cpu1`, `cpu2 cpu2`, `cpu3 cpu3`
