### PR TITLE
Graphite: Update text editor state on initial load

### DIFF
--- a/public/app/plugins/datasource/graphite/components/GraphiteTextEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteTextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import { QueryField } from '@grafana/ui';
 import { actions } from '../state/actions';
 import { Dispatch } from 'redux';
@@ -9,29 +9,24 @@ type Props = {
 };
 
 export function GraphiteTextEditor({ rawQuery, dispatch }: Props) {
-  const [currentQuery, updateCurrentQuery] = useState<string>(rawQuery);
+  const updateQuery = useCallback(
+    (query: string) => {
+      dispatch(actions.updateQuery({ query }));
+    },
+    [dispatch]
+  );
 
-  const applyChanges = useCallback(() => {
-    dispatch(actions.updateQuery({ query: currentQuery }));
-  }, [dispatch, currentQuery]);
-
-  // Needed for migration to React. State in QueryCtrl is initialized asynchronously (using init action) meaning
-  // the angular js partial is rendered first with rawQuery=undefined and only once the state is initialized the
-  // rawQuery is updated with the current query. At the same time in GraphiteTextEditor we need to keep track of
-  // the query with managed state because onRunQuery callback doesn't provide the current value. This means that
-  // the managed state is not updated when props change after the init action finishes and we need to use effect
-  // to update it.
-  useEffect(() => {
-    updateCurrentQuery(rawQuery);
-  }, [rawQuery]);
+  const runQuery = useCallback(() => {
+    dispatch(actions.runQuery());
+  }, [dispatch]);
 
   return (
     <>
       <QueryField
-        query={currentQuery}
-        onChange={updateCurrentQuery}
-        onBlur={applyChanges}
-        onRunQuery={applyChanges}
+        query={rawQuery}
+        onChange={updateQuery}
+        onBlur={runQuery}
+        onRunQuery={runQuery}
         placeholder={'Enter a Graphite query (run with Shift+Enter)'}
         portalOrigin="graphite"
       />

--- a/public/app/plugins/datasource/graphite/components/GraphiteTextEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteTextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { QueryField } from '@grafana/ui';
 import { actions } from '../state/actions';
 import { Dispatch } from 'redux';
@@ -15,10 +15,20 @@ export function GraphiteTextEditor({ rawQuery, dispatch }: Props) {
     dispatch(actions.updateQuery({ query: currentQuery }));
   }, [dispatch, currentQuery]);
 
+  // Needed for migration to React. State in QueryCtrl is initialized asynchronously (using init action) meaning
+  // the angular js partial is rendered first with rawQuery=undefined and only once the state is initialized the
+  // rawQuery is updated with the current query. At the same time in GraphiteTextEditor we need to keep track of
+  // the query with managed state because onRunQuery callback doesn't provide the current value. This means that
+  // the managed state is not updated when props change after the init action finishes and we need to use effect
+  // to update it.
+  useEffect(() => {
+    updateCurrentQuery(rawQuery);
+  }, [rawQuery]);
+
   return (
     <>
       <QueryField
-        query={rawQuery}
+        query={currentQuery}
         onChange={updateCurrentQuery}
         onBlur={applyChanges}
         onRunQuery={applyChanges}

--- a/public/app/plugins/datasource/graphite/query_ctrl.ts
+++ b/public/app/plugins/datasource/graphite/query_ctrl.ts
@@ -142,7 +142,7 @@ export class GraphiteQueryCtrl extends QueryCtrl {
   }
 
   async targetTextChanged(event: ChangeEvent<HTMLInputElement>) {
-    await this.dispatch(actions.updateQuery({ query: event.target.value }));
+    // WIP: removed, handled by GraphiteTextEditor
   }
 
   updateModelTarget() {

--- a/public/app/plugins/datasource/graphite/state/actions.ts
+++ b/public/app/plugins/datasource/graphite/state/actions.ts
@@ -28,6 +28,7 @@ const updateFunctionParam = createAction<{ func: FuncInstance }>('update-functio
 
 // Text editor
 const updateQuery = createAction<{ query: string }>('update-query');
+const runQuery = createAction('run-current-query');
 const toggleEditorMode = createAction('toggle-editor');
 
 export const actions = {
@@ -41,5 +42,6 @@ export const actions = {
   moveFunction,
   updateFunctionParam,
   updateQuery,
+  runQuery,
   toggleEditorMode,
 };

--- a/public/app/plugins/datasource/graphite/state/store.ts
+++ b/public/app/plugins/datasource/graphite/state/store.ts
@@ -151,6 +151,8 @@ const reducer = async (action: Action, state: GraphiteQueryEditorState): Promise
   if (actions.updateQuery.match(action)) {
     state.target.target = action.payload.query;
     handleTargetChanged(state);
+  }
+  if (actions.runQuery.match(action)) {
     // handleTargetChanged() builds target from segments/tags/functions only,
     // it doesn't handle refresh when target is change explicitly
     state.panelCtrl.refresh();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is a fix for bug introduced in #36797. To reproduce:

* Create any query
* Refresh the page
* Switch to text editor
* Click on the text editor but do not change the content
* Click away from the input
* Bug: the content of the input disappears

https://user-images.githubusercontent.com/745532/126976745-59dfcb1a-41c8-40f2-b7a3-48d3d14fb7e1.mov



**Which issue(s) this PR fixes**: N/A

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

Store state is initialized asynchronously (init() action) meaning. At the same time the init() action is called from Angular controller that is already rendering directives meaning the text editor component is first rendered with props 
 of `{rawQuery=undefined}` and once the state is initialized new props are passed `{rawQuery=whatever}`. But GraphiteTextEditor ignored the latter update because it used internally managed state. This is no longer needed as updating the query and running the query actions have been split and the store's state is updated on each input change accordingly (not only before the run)

