### PR TITLE
Alerting: Remove the fixed wait for notification delivery

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -661,7 +661,12 @@ func (am *Alertmanager) createReceiverStage(name string, integrations []notify.I
 }
 
 func waitFunc() time.Duration {
-	return setting.AlertingNotificationTimeout
+	// When it's a single instance, we don't need additional wait. The routing policies will have their own group wait.
+	// We need >0 wait here in case we have peers to sync the notification state with. 0 wait in that case can result
+	// in duplicate notifications being sent.
+	// TODO: we have setting.AlertingNotificationTimeout in legacy settings. Either use that or separate set of config
+	// for clustering with intuitive name, like "PeerTimeout".
+	return 0
 }
 
 func timeoutFunc(d time.Duration) time.Duration {


### PR DESCRIPTION
**What this PR does / why we need it**:

The fixed wait is only required if we have clustering where we have to wait for some time to sync the notification with other peers. We don't need it when it's a single instance.

**Special notes for your reviewer**:

This logic comes from Prometheus Alertmanager, and [here](https://github.com/prometheus/alertmanager/blob/010c683e4e86a82a2280635fd2c494a9d755151a/cmd/alertmanager/main.go#L374-L377) is the code that is upstream for this `waitFunc`.