### PR TITLE
Remove Licensing as dependency of UsageStats

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/login/social"
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/alerting"
@@ -38,7 +37,6 @@ type UsageStatsService struct {
 	Bus                bus.Bus                    `inject:""`
 	SQLStore           *sqlstore.SQLStore         `inject:""`
 	AlertingUsageStats alerting.UsageStatsQuerier `inject:""`
-	License            models.Licensing           `inject:""`
 	PluginManager      plugins.Manager            `inject:""`
 	SocialService      social.Service             `inject:""`
 

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -36,13 +36,12 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 		edition = "enterprise"
 	}
 	report := UsageReport{
-		Version:         version,
-		Metrics:         metrics,
-		Os:              runtime.GOOS,
-		Arch:            runtime.GOARCH,
-		Edition:         edition,
-		HasValidLicense: uss.License.HasValidLicense(),
-		Packaging:       uss.Cfg.Packaging,
+		Version:   version,
+		Metrics:   metrics,
+		Os:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+		Edition:   edition,
+		Packaging: uss.Cfg.Packaging,
 	}
 
 	statsQuery := models.GetSystemStatsQuery{}
@@ -78,11 +77,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.dashboards_viewers_can_admin.count"] = statsQuery.Result.DashboardsViewersCanAdmin
 	metrics["stats.folders_viewers_can_edit.count"] = statsQuery.Result.FoldersViewersCanEdit
 	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
-	validLicCount := 0
-	if uss.License.HasValidLicense() {
-		validLicCount = 1
-	}
-	metrics["stats.valid_license.count"] = validLicCount
+
 	ossEditionCount := 1
 	enterpriseEditionCount := 0
 	if uss.Cfg.IsEnterprise {
@@ -93,6 +88,12 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.edition.enterprise.count"] = enterpriseEditionCount
 
 	uss.registerExternalMetrics(metrics)
+
+	if v, ok := metrics["stats.valid_license.count"]; ok {
+		report.HasValidLicense = v == 1
+	} else {
+		metrics["stats.valid_license.count"] = 0
+	}
 
 	userCount := statsQuery.Result.Users
 	avgAuthTokensPerUser := statsQuery.Result.AuthTokens

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -89,6 +89,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 
 	uss.registerExternalMetrics(metrics)
 
+	// must run after registration of external metrics
 	if v, ok := metrics["stats.valid_license.count"]; ok {
 		report.HasValidLicense = v == 1
 	} else {

--- a/pkg/infra/usagestats/usage_stats_service_test.go
+++ b/pkg/infra/usagestats/usage_stats_service_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
-	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +20,6 @@ func TestUsageStatsService_GetConcurrentUsersStats(t *testing.T) {
 	uss := &UsageStatsService{
 		Bus:      bus.New(),
 		SQLStore: sqlStore,
-		License:  &licensing.OSSLicensingService{},
 	}
 
 	createConcurrentTokens(t, sqlStore)

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/services/alerting"
-	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
@@ -606,7 +605,6 @@ func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
 		Bus:                bus.New(),
 		Cfg:                &cfg,
 		SQLStore:           sqlstore.InitTestDB(t),
-		License:            &licensing.OSSLicensingService{},
 		AlertingUsageStats: &alertingUsageMock{},
 		externalMetrics:    make([]MetricsFunc, 0),
 		PluginManager:      &fakePluginManager{},


### PR DESCRIPTION
**What this PR does / why we need it**:
When working on wire migration we noticed that there was a circular dependency between licensing and usage stats
This pr removes licencing dependency from UsageStats and calculate valid license from externally registered count

[Enterprise Pr](https://github.com/grafana/grafana-enterprise/pull/1727)