### PR TITLE
Alerting: Ability to edit alertmanager config as JSON via UI

### DIFF
--- a/public/app/features/alerting/unified/Admin.test.tsx
+++ b/public/app/features/alerting/unified/Admin.test.tsx
@@ -16,7 +16,6 @@ import { contextSrv } from 'app/core/services/context_srv';
 import store from 'app/core/store';
 import userEvent from '@testing-library/user-event';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
-import defaultConfig from '../../../../../packages/jaeger-ui-components/src/constants/default-config';
 
 jest.mock('./api/alertmanager');
 jest.mock('./api/grafana');

--- a/public/app/features/alerting/unified/Admin.test.tsx
+++ b/public/app/features/alerting/unified/Admin.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { typeAsJestMock } from 'test/helpers/typeAsJestMock';
 import { getAllDataSources } from './utils/config';
-import { fetchAlertManagerConfig, deleteAlertManagerConfig } from './api/alertmanager';
+import { fetchAlertManagerConfig, deleteAlertManagerConfig, updateAlertManagerConfig } from './api/alertmanager';
 import { configureStore } from 'app/store/configureStore';
 import { locationService, setDataSourceSrv } from '@grafana/runtime';
 import Admin from './Admin';
@@ -9,12 +9,14 @@ import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { ALERTMANAGER_NAME_LOCAL_STORAGE_KEY, ALERTMANAGER_NAME_QUERY_KEY } from './utils/constants';
 import { render, waitFor } from '@testing-library/react';
-import { byRole } from 'testing-library-selector';
+import { byLabelText, byRole } from 'testing-library-selector';
 import { mockDataSource, MockDataSourceSrv } from './mocks';
 import { DataSourceType } from './utils/datasource';
 import { contextSrv } from 'app/core/services/context_srv';
 import store from 'app/core/store';
 import userEvent from '@testing-library/user-event';
+import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
+import defaultConfig from '../../../../../packages/jaeger-ui-components/src/constants/default-config';
 
 jest.mock('./api/alertmanager');
 jest.mock('./api/grafana');
@@ -26,6 +28,7 @@ const mocks = {
   api: {
     fetchConfig: typeAsJestMock(fetchAlertManagerConfig),
     deleteAlertManagerConfig: typeAsJestMock(deleteAlertManagerConfig),
+    updateAlertManagerConfig: typeAsJestMock(updateAlertManagerConfig),
   },
 };
 
@@ -55,7 +58,9 @@ const dataSources = {
 
 const ui = {
   confirmButton: byRole('button', { name: /Confirm Modal Danger Button/ }),
-  resetButton: byRole('button', { name: /Reset Alertmanager configuration/ }),
+  resetButton: byRole('button', { name: /Reset configuration/ }),
+  saveButton: byRole('button', { name: /Save/ }),
+  configInput: byLabelText<HTMLTextAreaElement>(/Configuration/),
 };
 
 describe('Alerting Admin', () => {
@@ -82,5 +87,35 @@ describe('Alerting Admin', () => {
     userEvent.click(ui.confirmButton.get());
     await waitFor(() => expect(mocks.api.deleteAlertManagerConfig).toHaveBeenCalled());
     expect(ui.confirmButton.query()).not.toBeInTheDocument();
+  });
+
+  it('Edit and save alertmanager config', async () => {
+    let savedConfig: AlertManagerCortexConfig | undefined = undefined;
+
+    const defaultConfig = {
+      template_files: {
+        foo: 'bar',
+      },
+      alertmanager_config: {},
+    };
+
+    const newConfig = {
+      template_files: {
+        bar: 'baz',
+      },
+      alertmanager_config: {},
+    };
+
+    mocks.api.fetchConfig.mockImplementation(() => Promise.resolve(savedConfig ?? defaultConfig));
+    mocks.api.updateAlertManagerConfig.mockResolvedValue();
+    await renderAdminPage(dataSources.alertManager.name);
+    const input = await ui.configInput.find();
+    expect(input.value).toEqual(JSON.stringify(defaultConfig, null, 2));
+    userEvent.clear(input);
+    await userEvent.type(input, JSON.stringify(newConfig, null, 2));
+    userEvent.click(ui.saveButton.get());
+    await waitFor(() => expect(mocks.api.updateAlertManagerConfig).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.api.fetchConfig).toHaveBeenCalledTimes(3));
+    expect(input.value).toEqual(JSON.stringify(newConfig, null, 2));
   });
 });

--- a/public/app/features/alerting/unified/Admin.tsx
+++ b/public/app/features/alerting/unified/Admin.tsx
@@ -1,18 +1,39 @@
-import React, { useState } from 'react';
-import { Button, ConfirmModal } from '@grafana/ui';
+import React, { useEffect, useState, useMemo } from 'react';
+import { Alert, Button, ConfirmModal, TextArea, HorizontalGroup, Field, Form } from '@grafana/ui';
 import { useAlertManagerSourceName } from './hooks/useAlertManagerSourceName';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { AlertManagerPicker } from './components/AlertManagerPicker';
 import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 import { useDispatch } from 'react-redux';
-import { deleteAlertManagerConfigAction } from './state/actions';
+import {
+  deleteAlertManagerConfigAction,
+  fetchAlertManagerConfigAction,
+  updateAlertManagerConfigAction,
+} from './state/actions';
 import { useUnifiedAlertingSelector } from './hooks/useUnifiedAlertingSelector';
+import { initialAsyncRequestState } from './utils/redux';
+
+interface FormValues {
+  configJSON: string;
+}
 
 export default function Admin(): JSX.Element {
   const dispatch = useDispatch();
   const [alertManagerSourceName, setAlertManagerSourceName] = useAlertManagerSourceName();
   const [showConfirmDeleteAMConfig, setShowConfirmDeleteAMConfig] = useState(false);
-  const { loading } = useUnifiedAlertingSelector((state) => state.deleteAMConfig);
+  const { loading: isDeleting } = useUnifiedAlertingSelector((state) => state.deleteAMConfig);
+  const { loading: isSaving } = useUnifiedAlertingSelector((state) => state.saveAMConfig);
+
+  const configRequests = useUnifiedAlertingSelector((state) => state.amConfigs);
+
+  const { result: config, loading: isLoadingConfig, error: loadingError } =
+    (alertManagerSourceName && configRequests[alertManagerSourceName]) || initialAsyncRequestState;
+
+  useEffect(() => {
+    if (alertManagerSourceName) {
+      dispatch(fetchAlertManagerConfigAction(alertManagerSourceName));
+    }
+  }, [alertManagerSourceName, dispatch]);
 
   const resetConfig = () => {
     if (alertManagerSourceName) {
@@ -21,29 +42,98 @@ export default function Admin(): JSX.Element {
     setShowConfirmDeleteAMConfig(false);
   };
 
+  const defaultValues = useMemo(
+    (): FormValues => ({
+      configJSON: config ? JSON.stringify(config, null, 2) : '',
+    }),
+    [config]
+  );
+
+  const loading = isDeleting || isLoadingConfig || isSaving;
+
+  const onSubmit = (values: FormValues) => {
+    if (alertManagerSourceName) {
+      dispatch(
+        updateAlertManagerConfigAction({
+          newConfig: JSON.parse(values.configJSON),
+          oldConfig: config,
+          alertManagerSourceName,
+          successMessage: 'Alertmanager configuration updated.',
+          refetch: true,
+        })
+      );
+    }
+  };
+
   return (
     <AlertingPageWrapper pageId="alerting-admin">
       <AlertManagerPicker current={alertManagerSourceName} onChange={setAlertManagerSourceName} />
-      {alertManagerSourceName && (
-        <>
-          <Button disabled={loading} variant="destructive" onClick={() => setShowConfirmDeleteAMConfig(true)}>
-            Reset Alertmanager configuration
-          </Button>
-          {!!showConfirmDeleteAMConfig && (
-            <ConfirmModal
-              isOpen={true}
-              title="Reset Alertmanager configuration"
-              body={`Are you sure you want to reset configuration ${
-                alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME
-                  ? 'for the Grafana Alertmanager'
-                  : `for "${alertManagerSourceName}"`
-              }? Contact points and notification policies will be reset to their defaults.`}
-              confirmText="Yes, reset configuration"
-              onConfirm={resetConfig}
-              onDismiss={() => setShowConfirmDeleteAMConfig(false)}
-            />
+      {loadingError && !loading && (
+        <Alert severity="error" title="Error loading Alertmanager configuration">
+          {loadingError.message || 'Unknown error.'}
+        </Alert>
+      )}
+      {isDeleting && alertManagerSourceName !== GRAFANA_RULES_SOURCE_NAME && (
+        <Alert severity="info" title="Resetting Alertmanager configuration">
+          It might take a while...
+        </Alert>
+      )}
+      {alertManagerSourceName && config && (
+        <Form defaultValues={defaultValues} onSubmit={onSubmit} key={defaultValues.configJSON}>
+          {({ register, errors }) => (
+            <>
+              <Field
+                disabled={loading}
+                label="Configuration"
+                invalid={!!errors.configJSON}
+                error={errors.configJSON?.message}
+              >
+                <TextArea
+                  {...register('configJSON', {
+                    required: { value: true, message: 'Required.' },
+                    validate: (v) => {
+                      try {
+                        JSON.parse(v);
+                        return true;
+                      } catch (e) {
+                        return e.message;
+                      }
+                    },
+                  })}
+                  id="configuration"
+                  rows={25}
+                />
+              </Field>
+              <HorizontalGroup>
+                <Button type="submit" variant="primary" disabled={loading}>
+                  Save
+                </Button>
+                <Button
+                  type="button"
+                  disabled={loading}
+                  variant="destructive"
+                  onClick={() => setShowConfirmDeleteAMConfig(true)}
+                >
+                  Reset configuration
+                </Button>
+              </HorizontalGroup>
+              {!!showConfirmDeleteAMConfig && (
+                <ConfirmModal
+                  isOpen={true}
+                  title="Reset Alertmanager configuration"
+                  body={`Are you sure you want to reset configuration ${
+                    alertManagerSourceName === GRAFANA_RULES_SOURCE_NAME
+                      ? 'for the Grafana Alertmanager'
+                      : `for "${alertManagerSourceName}"`
+                  }? Contact points and notification policies will be reset to their defaults.`}
+                  confirmText="Yes, reset configuration"
+                  onConfirm={resetConfig}
+                  onDismiss={() => setShowConfirmDeleteAMConfig(false)}
+                />
+              )}
+            </>
           )}
-        </>
+        </Form>
       )}
     </AlertingPageWrapper>
   );


### PR DESCRIPTION




<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Adds ability to edit the Alertmanager config as json in a textare field in the "admin" view. This has been requested to enable users/support to fix broken config that cannot be fixed using "normal" UI. See linked issue for more details.

Extra: after deleting Cortex Alertmanager user config, GET config returns "alertamnager store object not found" error for a while before it starts returning empty config. Keep polling it and only complete the action once proper empty config is returned after the reset, for bettter ux.

https://user-images.githubusercontent.com/847684/127273369-9b9c94a2-7720-4db1-a7d4-db12cc3b3b61.mp4

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37213

**Special notes for your reviewer**:

