### PR TITLE
Explore: Support custom display label for derived fields buttons for Loki datasource

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -16,7 +16,7 @@ visualize logs or metrics stored in Elasticsearch. You can also annotate your gr
 1. Open the side menu by clicking the Grafana icon in the top header.
 1. In the side menu under the `Dashboards` link you should find a link named `Data Sources`.
 1. Click the `+ Add data source` button in the top header.
-1. Select *Elasticsearch* from the *Type* dropdown.
+1. Select **Elasticsearch** from the **Type** dropdown.
 
 > **Note:** If you're not seeing the `Data Sources` link in your side menu it means that your current user does not have the `Admin` role for the current organization.
 

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -16,7 +16,7 @@ visualize logs or metrics stored in Elasticsearch. You can also annotate your gr
 1. Open the side menu by clicking the Grafana icon in the top header.
 1. In the side menu under the `Dashboards` link you should find a link named `Data Sources`.
 1. Click the `+ Add data source` button in the top header.
-1. Select _Elasticsearch_ from the _Type_ dropdown.
+1. Select *Elasticsearch* from the *Type* dropdown.
 
 > **Note:** If you're not seeing the `Data Sources` link in your side menu it means that your current user does not have the `Admin` role for the current organization.
 
@@ -61,7 +61,7 @@ Available Elasticsearch versions are `2.x`, `5.x`, `5.6+`, `6.0+`, `7.0+`, `7.7+
 
 Grafana assumes that you are running the lowest possible version for a specified range. This ensures that new features or breaking changes in a future Elasticsearch release will not affect your configuration.
 
-For example, suppose you are running Elasticsearch `7.6.1` and you selected `7.0+`. If a new feature is made available for Elasticsearch `7.5.0` or newer releases, then a `7.5+` option will be available. However, your configuration will not be affected until you explicitly select the new `7.5+` option in your settings.
+For example, suppose you are running Elasticsearch `7.6.1` and you selected `7.0+`. If a new feature is made available for Elasticsearch `7.5.0` or newer releases, then a `7.5+` option will be available.  However, your configuration will not be affected until you explicitly select the new `7.5+` option in your settings.
 
 ### Min time interval
 
@@ -87,7 +87,6 @@ Enables `X-Pack` specific features and options, providing the query editor with 
 #### Include frozen indices
 
 When `X-Pack enabled` is active and the configured Elasticsearch version is higher than `6.6.0`, you can configure Grafana to not ignore [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
-
 ### Logs
 
 There are two parameters, `Message field name` and `Level field name`, that can optionally be configured from the data source settings page that determine
@@ -95,7 +94,7 @@ which fields will be used for log messages and log levels when visualizing logs 
 
 For example, if you're using a default setup of Filebeat for shipping logs to Elasticsearch the following configuration should work:
 
-- **Message field name:** message
+- **Message field name:**  message
 - **Level field name:** fields.level
 
 ### Data links
@@ -103,7 +102,6 @@ For example, if you're using a default setup of Filebeat for shipping logs to El
 Data links create a link from a specified field that can be accessed in logs view in Explore.
 
 Each data link configuration consists of:
-
 - **Field -** Name of the field used by the data link.
 - **URL/query -** If the link is external, then enter the full link URL. If the link is internal link, then this input serves as query for the target data source. In both cases, you can interpolate the value from the field with `${__value.raw }` macro.
 - **URL Label -** (Optional) Set a custom display label for the link. The link label defaults to the full external URL or name of the linked internal data source and is overridden by this setting.
@@ -128,7 +126,7 @@ You can control the name for time series via the `Alias` input field.
 
 ## Pipeline metrics
 
-Some metric aggregations are called Pipeline aggregations, for example, _Moving Average_ and _Derivative_. Elasticsearch pipeline metrics require another metric to be based on. Use the eye icon next to the metric to hide metrics from appearing in the graph. This is useful for metrics you only have in the query for use in a pipeline metric.
+Some metric aggregations are called Pipeline aggregations, for example, *Moving Average* and *Derivative*. Elasticsearch pipeline metrics require another metric to be based on. Use the eye icon next to the metric to hide metrics from appearing in the graph. This is useful for metrics you only have in the query for use in a pipeline metric.
 
 ![Pipeline aggregation editor](/static/img/docs/elasticsearch/pipeline-aggregation-editor-7-4.png)
 
@@ -143,7 +141,7 @@ types of template variables.
 
 ### Query variable
 
-The Elasticsearch data source supports two types of queries you can use in the _Query_ field of _Query_ variables. The query is written using a custom JSON string.
+The Elasticsearch data source supports two types of queries you can use in the *Query* field of *Query* variables. The query is written using a custom JSON string.
 
 | Query                                                                | Description                                                                                                                                                           |
 | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -174,16 +172,16 @@ To keep terms in the doc count order, set the variable's Sort dropdown to **Disa
 
 There are two syntaxes:
 
-- `$<varname>` Example: @hostname:$hostname
+- `$<varname>`  Example: @hostname:$hostname
 - `[[varname]]` Example: @hostname:[[hostname]]
 
-Why two ways? The first syntax is easier to read and write but does not allow you to use a variable in the middle of a word. When the _Multi-value_ or _Include all value_
+Why two ways? The first syntax is easier to read and write but does not allow you to use a variable in the middle of a word. When the *Multi-value* or *Include all value*
 options are enabled, Grafana converts the labels from plain text to a lucene compatible condition.
 
 ![Query with template variables](/static/img/docs/elasticsearch/elastic-templating-query-7-4.png)
 
-In the above example, we have a lucene query that filters documents based on the `@hostname` property using a variable named `$hostname`. It is also using
-a variable in the _Terms_ group by field input box. This allows you to use a variable to quickly change how the data is grouped.
+In the above example, we have a lucene query that filters documents based on the `@hostname`  property using a variable named `$hostname`. It is also using
+a variable in the *Terms* group by field input box. This allows you to use a variable to quickly change how the data is grouped.
 
 Example dashboard:
 [Elasticsearch Templated Dashboard](https://play.grafana.org/d/CknOEXDMk/elasticsearch-templated?orgId=1d)
@@ -195,7 +193,7 @@ queries via the Dashboard menu / Annotations view. Grafana can query any Elastic
 for annotation events.
 
 | Name       | Description                                                                                                                                |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| --------   | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `Query`    | You can leave the search query blank or specify a lucene query.                                                                            |
 | `Time`     | The name of the time field, needs to be date field.                                                                                        |
 | `Time End` | Optional name of the time end field needs to be date field. If set, then annotations will be marked as a region between time and time-end. |
@@ -232,11 +230,11 @@ datasources:
   - name: Elastic
     type: elasticsearch
     access: proxy
-    database: '[metrics-]YYYY.MM.DD'
+    database: "[metrics-]YYYY.MM.DD"
     url: http://localhost:9200
     jsonData:
       interval: Daily
-      timeField: '@timestamp'
+      timeField: "@timestamp"
 ```
 
 or, for logs:
@@ -248,18 +246,18 @@ datasources:
   - name: elasticsearch-v7-filebeat
     type: elasticsearch
     access: proxy
-    database: '[filebeat-]YYYY.MM.DD'
+    database: "[filebeat-]YYYY.MM.DD"
     url: http://localhost:9200
     jsonData:
       interval: Daily
-      timeField: '@timestamp'
-      esVersion: '7.0.0'
+      timeField: "@timestamp"
+      esVersion: "7.0.0"
       logMessageField: message
       logLevelField: fields.level
       dataLinks:
         - datasourceUid: my_jaeger_uid # Target UID needs to be known
           field: traceID
-          url: '$${__value.raw}' # Careful about the double "$$" because of env var expansion
+          url: "$${__value.raw}" # Careful about the double "$$" because of env var expansion
 ```
 
 ## Amazon Elasticsearch Service

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -16,7 +16,7 @@ visualize logs or metrics stored in Elasticsearch. You can also annotate your gr
 1. Open the side menu by clicking the Grafana icon in the top header.
 1. In the side menu under the `Dashboards` link you should find a link named `Data Sources`.
 1. Click the `+ Add data source` button in the top header.
-1. Select *Elasticsearch* from the *Type* dropdown.
+1. Select _Elasticsearch_ from the _Type_ dropdown.
 
 > **Note:** If you're not seeing the `Data Sources` link in your side menu it means that your current user does not have the `Admin` role for the current organization.
 
@@ -61,7 +61,7 @@ Available Elasticsearch versions are `2.x`, `5.x`, `5.6+`, `6.0+`, `7.0+`, `7.7+
 
 Grafana assumes that you are running the lowest possible version for a specified range. This ensures that new features or breaking changes in a future Elasticsearch release will not affect your configuration.
 
-For example, suppose you are running Elasticsearch `7.6.1` and you selected `7.0+`. If a new feature is made available for Elasticsearch `7.5.0` or newer releases, then a `7.5+` option will be available.  However, your configuration will not be affected until you explicitly select the new `7.5+` option in your settings.
+For example, suppose you are running Elasticsearch `7.6.1` and you selected `7.0+`. If a new feature is made available for Elasticsearch `7.5.0` or newer releases, then a `7.5+` option will be available. However, your configuration will not be affected until you explicitly select the new `7.5+` option in your settings.
 
 ### Min time interval
 
@@ -87,6 +87,7 @@ Enables `X-Pack` specific features and options, providing the query editor with 
 #### Include frozen indices
 
 When `X-Pack enabled` is active and the configured Elasticsearch version is higher than `6.6.0`, you can configure Grafana to not ignore [frozen indices](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/frozen-indices.html) when performing search requests.
+
 ### Logs
 
 There are two parameters, `Message field name` and `Level field name`, that can optionally be configured from the data source settings page that determine
@@ -94,7 +95,7 @@ which fields will be used for log messages and log levels when visualizing logs 
 
 For example, if you're using a default setup of Filebeat for shipping logs to Elasticsearch the following configuration should work:
 
-- **Message field name:**  message
+- **Message field name:** message
 - **Level field name:** fields.level
 
 ### Data links
@@ -102,8 +103,10 @@ For example, if you're using a default setup of Filebeat for shipping logs to El
 Data links create a link from a specified field that can be accessed in logs view in Explore.
 
 Each data link configuration consists of:
+
 - **Field -** Name of the field used by the data link.
 - **URL/query -** If the link is external, then enter the full link URL. If the link is internal link, then this input serves as query for the target data source. In both cases, you can interpolate the value from the field with `${__value.raw }` macro.
+- **URL Label -** (Optional) Set a custom display label for the link. The link label defaults to the full external URL or name of the linked internal data source and is overridden by this setting.
 - **Internal link -** Select if the link is internal or external. In case of internal link, a data source selector allows you to select the target data source. Only tracing data sources are supported.
 
 ## Metric Query editor
@@ -125,7 +128,7 @@ You can control the name for time series via the `Alias` input field.
 
 ## Pipeline metrics
 
-Some metric aggregations are called Pipeline aggregations, for example, *Moving Average* and *Derivative*. Elasticsearch pipeline metrics require another metric to be based on. Use the eye icon next to the metric to hide metrics from appearing in the graph. This is useful for metrics you only have in the query for use in a pipeline metric.
+Some metric aggregations are called Pipeline aggregations, for example, _Moving Average_ and _Derivative_. Elasticsearch pipeline metrics require another metric to be based on. Use the eye icon next to the metric to hide metrics from appearing in the graph. This is useful for metrics you only have in the query for use in a pipeline metric.
 
 ![Pipeline aggregation editor](/static/img/docs/elasticsearch/pipeline-aggregation-editor-7-4.png)
 
@@ -140,7 +143,7 @@ types of template variables.
 
 ### Query variable
 
-The Elasticsearch data source supports two types of queries you can use in the *Query* field of *Query* variables. The query is written using a custom JSON string.
+The Elasticsearch data source supports two types of queries you can use in the _Query_ field of _Query_ variables. The query is written using a custom JSON string.
 
 | Query                                                                | Description                                                                                                                                                           |
 | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -171,16 +174,16 @@ To keep terms in the doc count order, set the variable's Sort dropdown to **Disa
 
 There are two syntaxes:
 
-- `$<varname>`  Example: @hostname:$hostname
+- `$<varname>` Example: @hostname:$hostname
 - `[[varname]]` Example: @hostname:[[hostname]]
 
-Why two ways? The first syntax is easier to read and write but does not allow you to use a variable in the middle of a word. When the *Multi-value* or *Include all value*
+Why two ways? The first syntax is easier to read and write but does not allow you to use a variable in the middle of a word. When the _Multi-value_ or _Include all value_
 options are enabled, Grafana converts the labels from plain text to a lucene compatible condition.
 
 ![Query with template variables](/static/img/docs/elasticsearch/elastic-templating-query-7-4.png)
 
-In the above example, we have a lucene query that filters documents based on the `@hostname`  property using a variable named `$hostname`. It is also using
-a variable in the *Terms* group by field input box. This allows you to use a variable to quickly change how the data is grouped.
+In the above example, we have a lucene query that filters documents based on the `@hostname` property using a variable named `$hostname`. It is also using
+a variable in the _Terms_ group by field input box. This allows you to use a variable to quickly change how the data is grouped.
 
 Example dashboard:
 [Elasticsearch Templated Dashboard](https://play.grafana.org/d/CknOEXDMk/elasticsearch-templated?orgId=1d)
@@ -192,7 +195,7 @@ queries via the Dashboard menu / Annotations view. Grafana can query any Elastic
 for annotation events.
 
 | Name       | Description                                                                                                                                |
-| --------   | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `Query`    | You can leave the search query blank or specify a lucene query.                                                                            |
 | `Time`     | The name of the time field, needs to be date field.                                                                                        |
 | `Time End` | Optional name of the time end field needs to be date field. If set, then annotations will be marked as a region between time and time-end. |
@@ -229,11 +232,11 @@ datasources:
   - name: Elastic
     type: elasticsearch
     access: proxy
-    database: "[metrics-]YYYY.MM.DD"
+    database: '[metrics-]YYYY.MM.DD'
     url: http://localhost:9200
     jsonData:
       interval: Daily
-      timeField: "@timestamp"
+      timeField: '@timestamp'
 ```
 
 or, for logs:
@@ -245,18 +248,18 @@ datasources:
   - name: elasticsearch-v7-filebeat
     type: elasticsearch
     access: proxy
-    database: "[filebeat-]YYYY.MM.DD"
+    database: '[filebeat-]YYYY.MM.DD'
     url: http://localhost:9200
     jsonData:
       interval: Daily
-      timeField: "@timestamp"
-      esVersion: "7.0.0"
+      timeField: '@timestamp'
+      esVersion: '7.0.0'
       logMessageField: message
       logLevelField: fields.level
       dataLinks:
         - datasourceUid: my_jaeger_uid # Target UID needs to be known
           field: traceID
-          url: "$${__value.raw}" # Careful about the double "$$" because of env var expansion
+          url: '$${__value.raw}' # Careful about the double "$$" because of env var expansion
 ```
 
 ## Amazon Elasticsearch Service

--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -21,8 +21,8 @@ To access Loki settings, click the **Configuration** (gear) icon, then click **D
 | Name                  | Description                                                                                                                                               |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Name`                | The data source name. This is how you refer to the data source in panels, queries, and Explore.                                                           |
-| `Default`             | Default data source that is pre-selected for new panels.                                                                                    |
-| `URL`                 | URL of the Loki instance, e.g., `http://localhost:3100`.                                                                                             |
+| `Default`             | Default data source that is pre-selected for new panels.                                                                                                  |
+| `URL`                 | URL of the Loki instance, e.g., `http://localhost:3100`.                                                                                                  |
 | `Whitelisted Cookies` | Grafana Proxy deletes forwarded cookies by default. Specify cookies by name that should be forwarded to the data source.                                  |
 | `Maximum lines`       | Upper limit for the number of log lines returned by Loki (default is 1000). Lower this limit if your browser is sluggish when displaying logs in Explore. |
 
@@ -33,13 +33,14 @@ The Derived Fields configuration allows you to:
 - Add fields parsed from the log message.
 - Add a link that uses the value of the field.
 
-You can use this functionality to link to your tracing backend directly from your logs, or link to a user profile page if a userId is present in the log line. These links appear in the [log details]({{< relref "../explore/logs-integration/#labels-and-detected-fields" >}}).
+For example, you can use this functionality to link to your tracing backend directly from your logs, or link to a user profile page if a userId is present in the log line. These links appear in the [log details]({{< relref "../explore/logs-integration/#labels-and-detected-fields" >}}).
 
 Each derived field consists of:
 
 - **Name -** Shown in the log details as a label.
 - **Regex -** A Regex pattern that runs on the log message and captures part of it as the value of the new field. Can only contain a single capture group.
 - **URL/query -** If the link is external, then enter the full link URL. If the link is internal link, then this input serves as query for the target data source. In both cases, you can interpolate the value from the field with `${__value.raw }` macro.
+- **URL Label -** (Optional) Set a custom display label for the link. The link label defaults to the full external URL or name of the linked internal data source and is overridden by this setting.
 - **Internal link -** Select if the link is internal or external. In case of internal link, a data source selector allows you to select the target data source. Only tracing data sources are supported.
 
 You can use a debug section to see what your fields extract and how the URL is interpolated. Click **Show example log message** to show the text area where you can enter a log message.
@@ -148,18 +149,20 @@ Check out the [Templating]({{< relref "../variables/_index.md" >}}) documentatio
 Variable of the type _Query_ allows you to query Loki for a list labels or label values. The Loki data source plugin
 provides the following functions you can use in the `Query` input field.
 
-| Name                                       | Description                                                                          |
-| -------------------------------------------| -------------------------------------------------------------------------------------|
-| `label_names()`                            | Returns a list of label names.                                                       |
-| `label_values(label)`                      | Returns a list of label values for the `label`.                                      |
-| `label_values(log stream selector, label)` | Returns a list of label values for the `label` in the specified `log stream selector`.|
+| Name                                       | Description                                                                            |
+| ------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `label_names()`                            | Returns a list of label names.                                                         |
+| `label_values(label)`                      | Returns a list of label values for the `label`.                                        |
+| `label_values(log stream selector, label)` | Returns a list of label values for the `label` in the specified `log stream selector`. |
 
 ### Ad hoc filters variable
+
 Loki supports the special ad hoc filters variable type. It allows you to specify any number of label/value filters on the fly. These filters are automatically applied to all your Loki queries.
 
 ### Using interval and range variables
 
 You can use some global built-in variables in query variables; `$__interval`, `$__interval_ms`, `$__range`, `$__range_s` and `$__range_ms`. For more information, refer to [Global built-in variables]({{< relref "../variables/variable-types/global-variables.md" >}}).
+
 ## Annotations
 
 You can use any non-metric Loki query as a source for [annotations]({{< relref "../dashboards/annotations" >}}). Log content will be used as annotation text and your log stream labels as tags, so there is no need for additional mapping.

--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -21,8 +21,8 @@ To access Loki settings, click the **Configuration** (gear) icon, then click **D
 | Name                  | Description                                                                                                                                               |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Name`                | The data source name. This is how you refer to the data source in panels, queries, and Explore.                                                           |
-| `Default`             | Default data source that is pre-selected for new panels.                                                                                                  |
-| `URL`                 | URL of the Loki instance, e.g., `http://localhost:3100`.                                                                                                  |
+| `Default`             | Default data source that is pre-selected for new panels.                                                                                    |
+| `URL`                 | URL of the Loki instance, e.g., `http://localhost:3100`.                                                                                             |
 | `Whitelisted Cookies` | Grafana Proxy deletes forwarded cookies by default. Specify cookies by name that should be forwarded to the data source.                                  |
 | `Maximum lines`       | Upper limit for the number of log lines returned by Loki (default is 1000). Lower this limit if your browser is sluggish when displaying logs in Explore. |
 
@@ -149,20 +149,18 @@ Check out the [Templating]({{< relref "../variables/_index.md" >}}) documentatio
 Variable of the type _Query_ allows you to query Loki for a list labels or label values. The Loki data source plugin
 provides the following functions you can use in the `Query` input field.
 
-| Name                                       | Description                                                                            |
-| ------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `label_names()`                            | Returns a list of label names.                                                         |
-| `label_values(label)`                      | Returns a list of label values for the `label`.                                        |
-| `label_values(log stream selector, label)` | Returns a list of label values for the `label` in the specified `log stream selector`. |
+| Name                                       | Description                                                                          |
+| -------------------------------------------| -------------------------------------------------------------------------------------|
+| `label_names()`                            | Returns a list of label names.                                                       |
+| `label_values(label)`                      | Returns a list of label values for the `label`.                                      |
+| `label_values(log stream selector, label)` | Returns a list of label values for the `label` in the specified `log stream selector`.|
 
 ### Ad hoc filters variable
-
 Loki supports the special ad hoc filters variable type. It allows you to specify any number of label/value filters on the fly. These filters are automatically applied to all your Loki queries.
 
 ### Using interval and range variables
 
 You can use some global built-in variables in query variables; `$__interval`, `$__interval_ms`, `$__range`, `$__range_s` and `$__range_ms`. For more information, refer to [Global built-in variables]({{< relref "../variables/variable-types/global-variables.md" >}}).
-
 ## Annotations
 
 You can use any non-metric Loki query as a source for [annotations]({{< relref "../dashboards/annotations" >}}). Log content will be used as annotation text and your log stream labels as tags, so there is no need for additional mapping.

--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLink.tsx
@@ -21,6 +21,12 @@ const getStyles = stylesFactory(() => ({
     display: flex;
     align-items: baseline;
   `,
+  urlField: css`
+    flex: 1;
+  `,
+  urlDisplayLabelField: css`
+    flex: 1;
+  `,
 }));
 
 type Props = {
@@ -83,9 +89,16 @@ export const DataLink = (props: Props) => {
               suggestions={suggestions}
             />
           }
-          className={css`
-            width: 100%;
-          `}
+          className={styles.urlField}
+        />
+        <FormField
+          className={styles.urlDisplayLabelField}
+          inputWidth={null}
+          label="URL Label"
+          type="text"
+          value={value.urlDisplayLabel}
+          onChange={handleChange('urlDisplayLabel')}
+          tooltip={'Use to override the button label.'}
         />
       </div>
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -3,6 +3,7 @@ import { Observable, of, throwError } from 'rxjs';
 import {
   ArrayVector,
   CoreApp,
+  DataLink,
   DataQueryRequest,
   DataSourceInstanceSettings,
   DataSourcePluginMeta,
@@ -255,14 +256,16 @@ describe('ElasticDatasource', function (this: any) {
           {
             field: 'host',
             url: 'http://localhost:3000/${__value.raw}',
+            urlDisplayLabel: 'Custom Label',
           },
         ],
       });
 
       expect(response.data.length).toBe(1);
-      const links = response.data[0].fields.find((field: Field) => field.name === 'host').config.links;
+      const links: DataLink[] = response.data[0].fields.find((field: Field) => field.name === 'host').config.links;
       expect(links.length).toBe(1);
       expect(links[0].url).toBe('http://localhost:3000/${__value.raw}');
+      expect(links[0].title).toBe('Custom Label');
     });
   });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -896,7 +896,7 @@ export function enhanceDataFrame(dataFrame: DataFrame, dataLinks: DataLinkConfig
       const dsSettings = dataSourceSrv.getInstanceSettings(dataLinkConfig.datasourceUid);
 
       link = {
-        title: '',
+        title: dataLinkConfig.urlDisplayLabel || '',
         url: '',
         internal: {
           query: { query: dataLinkConfig.url },
@@ -906,7 +906,7 @@ export function enhanceDataFrame(dataFrame: DataFrame, dataLinks: DataLinkConfig
       };
     } else {
       link = {
-        title: '',
+        title: dataLinkConfig.urlDisplayLabel || '',
         url: dataLinkConfig.url,
       };
     }

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -75,5 +75,6 @@ export interface ElasticsearchQuery extends DataQuery {
 export type DataLinkConfig = {
   field: string;
   url: string;
+  urlDisplayLabel?: string;
   datasourceUid?: string;
 };

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -120,7 +120,7 @@ export const DerivedField = (props: Props) => {
           type="text"
           value={value.urlDisplayLabel}
           onChange={handleChange('urlDisplayLabel')}
-          tooltip={'Use to override the button text when this derived field is found in a log.'}
+          tooltip={'Use to override the button label when this derived field is found in a log.'}
         />
       </div>
 

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.tsx
@@ -19,6 +19,12 @@ const getStyles = stylesFactory(() => ({
   regexField: css`
     flex: 3;
   `,
+  urlField: css`
+    flex: 1;
+  `,
+  urlDisplayLabelField: css`
+    flex: 1;
+  `,
 }));
 
 type Props = {
@@ -89,26 +95,34 @@ export const DerivedField = (props: Props) => {
         />
       </div>
 
-      <FormField
-        label={showInternalLink ? 'Query' : 'URL'}
-        labelWidth={5}
-        inputEl={
-          <DataLinkInput
-            placeholder={showInternalLink ? '${__value.raw}' : 'http://example.com/${__value.raw}'}
-            value={value.url || ''}
-            onChange={(newValue) =>
-              onChange({
-                ...value,
-                url: newValue,
-              })
-            }
-            suggestions={suggestions}
-          />
-        }
-        className={css`
-          width: 100%;
-        `}
-      />
+      <div className={styles.row}>
+        <FormField
+          label={showInternalLink ? 'Query' : 'URL'}
+          inputEl={
+            <DataLinkInput
+              placeholder={showInternalLink ? '${__value.raw}' : 'http://example.com/${__value.raw}'}
+              value={value.url || ''}
+              onChange={(newValue) =>
+                onChange({
+                  ...value,
+                  url: newValue,
+                })
+              }
+              suggestions={suggestions}
+            />
+          }
+          className={styles.urlField}
+        />
+        <FormField
+          className={styles.urlDisplayLabelField}
+          inputWidth={null}
+          label="URL Label"
+          type="text"
+          value={value.urlDisplayLabel}
+          onChange={handleChange('urlDisplayLabel')}
+          tooltip={'Use to override the button text when this derived field is found in a log.'}
+        />
+      </div>
 
       <div className={styles.row}>
         <Switch

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -260,6 +260,7 @@ describe('enhanceDataFrame', () => {
           name: 'trace2',
           url: 'test',
           datasourceUid: 'uid2',
+          urlDisplayLabel: 'Custom Label',
         },
       ],
     });
@@ -279,7 +280,7 @@ describe('enhanceDataFrame', () => {
       url: '',
     });
     expect(fc.getFieldByName('trace2')!.config.links![1]).toEqual({
-      title: '',
+      title: 'Custom Label',
       internal: { datasourceName: 'Loki1', datasourceUid: 'uid2', query: { query: 'test' } },
       url: '',
     });

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -427,7 +427,7 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
 
       acc.push({
         // Will be filled out later
-        title: '',
+        title: derivedFieldConfig.urlDisplayLabel || '',
         url: '',
         // This is hardcoded for Jaeger or Zipkin not way right now to specify datasource specific query object
         internal: {
@@ -439,7 +439,7 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
     } else if (derivedFieldConfig.url) {
       acc.push({
         // We do not know what title to give here so we count on presentation layer to create a title from metadata.
-        title: '',
+        title: derivedFieldConfig.urlDisplayLabel || '',
         // This is hardcoded for Jaeger or Zipkin not way right now to specify datasource specific query object
         url: derivedFieldConfig.url,
       });

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -112,6 +112,7 @@ export type DerivedFieldConfig = {
   matcherRegex: string;
   name: string;
   url?: string;
+  urlDisplayLabel?: string;
   datasourceUid?: string;
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a configuration option for a custom URL label for derived fields. Sets the label when generated DataLinks. Updates docs and tests as well. 

**Which issue(s) this PR fixes**:
Fixes #31417

**Special notes for your reviewer**:

