### PR TITLE
Exemplars: Fix disable exemplars only on the query that failed

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExemplarField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExemplarField.tsx
@@ -3,25 +3,27 @@ import { IconButton, InlineLabel, Tooltip, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 import React, { useEffect, useState } from 'react';
 import { PrometheusDatasource } from '../datasource';
+import { filter } from 'rxjs/operators';
 
 interface Props {
   isEnabled: boolean;
   onChange: (isEnabled: boolean) => void;
   datasource: PrometheusDatasource;
+  refId: string;
 }
 
-export function PromExemplarField({ datasource, onChange, isEnabled }: Props) {
-  const [error, setError] = useState<string>();
+export function PromExemplarField({ datasource, onChange, isEnabled, refId }: Props) {
+  const [error, setError] = useState<string | null>(null);
   const styles = useStyles2(getStyles);
 
   useEffect(() => {
-    const subscription = datasource.exemplarErrors.subscribe((err) => {
-      setError(err);
+    const subscription = datasource.exemplarErrors.pipe(filter((value) => refId === value.refId)).subscribe((err) => {
+      setError(err.error);
     });
     return () => {
       subscription.unsubscribe();
     };
-  }, [datasource]);
+  }, [datasource, refId]);
 
   const iconButtonStyles = cx(
     {

--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -78,6 +78,7 @@ export const PromExploreExtraField: React.FC<PromExploreExtraFieldProps> = memo(
         </div>
 
         <PromExemplarField
+          refId={query.refId}
           isEnabled={Boolean(query.exemplar)}
           onChange={(isEnabled) => onChange({ ...query, exemplar: isEnabled })}
           datasource={datasource}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -223,7 +223,12 @@ export class PromQueryEditor extends PureComponent<PromQueryEditorProps, State> 
                 />
               </InlineFormLabel>
             </div>
-            <PromExemplarField isEnabled={exemplar} onChange={this.onExemplarChange} datasource={datasource} />
+            <PromExemplarField
+              refId={query.refId}
+              isEnabled={exemplar}
+              onChange={this.onExemplarChange}
+              datasource={datasource}
+            />
           </div>
         }
       />

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromQueryEditor.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`Render PromQueryEditor with basic options should render 1`] = `
         }
         isEnabled={true}
         onChange={[Function]}
+        refId="A"
       />
     </div>
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue of the Prometheus query editor when all the exemplars buttons go to disabled state if any of the exemplars query returns error.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/support-escalations/issues/658

**Special notes for your reviewer**:

For testing I used the tns demo app.
Add two queries in explore or dashboard. From the developer tools block one of the exemplars request. It should not disable the other query's exemplar button when queried again.. 
