### PR TITLE
Alerting: Send alerts to external Alertmanager(s)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/xorcare/pointer v1.1.0
 	github.com/yudai/gojsondiff v1.0.0
 	go.opentelemetry.io/collector v0.31.0
-	go.opentelemetry.io/collector/model v0.31.0 // indirect
+	go.opentelemetry.io/collector/model v0.31.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/exp v0.0.0-20210220032938-85be41e4509f // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 h1:AUNCr9CiJuwrRYS3XieqF+Z9B9gNxo/eANAJCF2eiN4=
 github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -102,13 +102,13 @@ func (api *API) RegisterAdminAPIEndpoints(srv AdminSrv, m *metrics.Metrics) {
 			toMacaronPath("/api/v1/ngalert/admin_config"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/v1/ngalert/configuration",
+				"/api/v1/ngalert/admin_config",
 				srv.RouteGetAdminConfig,
 				m,
 			),
 		)
 		group.Post(
-			"/api/v1/ngalert/configuration",
+			"/api/v1/ngalert/admin_config",
 			binding.Bind(apimodels.PostableNGalertConfig{}),
 			metrics.Instrument(
 				http.MethodPost,
@@ -118,7 +118,7 @@ func (api *API) RegisterAdminAPIEndpoints(srv AdminSrv, m *metrics.Metrics) {
 			),
 		)
 		group.Delete(
-			"api/v1/ngalert/configuration",
+			"api/v1/ngalert/admin_config",
 			metrics.Instrument(
 				http.MethodDelete,
 				"api/v1/ngalert/admin_config",

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -109,7 +109,7 @@ func (api *API) RegisterAdminAPIEndpoints(srv AdminSrv, m *metrics.Metrics) {
 		)
 		group.Post(
 			"/api/v1/ngalert/configuration",
-			binding.Bind(apimodels.AdminConfiguration{}),
+			binding.Bind(apimodels.PostableNGalertConfig{}),
 			metrics.Instrument(
 				http.MethodPost,
 				"/api/v1/ngalert/admin_config",

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -99,7 +99,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.Metrics) {
 func (api *API) RegisterAdminAPIEndpoints(srv AdminSrv, m *metrics.Metrics) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Get(
-			toMacaronPath("/api/v1/ngalert/configuration"),
+			toMacaronPath("/api/v1/ngalert/admin_config"),
 			metrics.Instrument(
 				http.MethodGet,
 				"/api/v1/ngalert/configuration",
@@ -112,7 +112,7 @@ func (api *API) RegisterAdminAPIEndpoints(srv AdminSrv, m *metrics.Metrics) {
 			binding.Bind(apimodels.AdminConfiguration{}),
 			metrics.Instrument(
 				http.MethodPost,
-				"/api/v1/ngalert/configuration",
+				"/api/v1/ngalert/admin_config",
 				srv.RouteUpdateAdminConfig,
 				m,
 			),
@@ -121,7 +121,7 @@ func (api *API) RegisterAdminAPIEndpoints(srv AdminSrv, m *metrics.Metrics) {
 			"api/v1/ngalert/configuration",
 			metrics.Instrument(
 				http.MethodDelete,
-				"api/v1/ngalert/configuration",
+				"api/v1/ngalert/admin_config",
 				srv.RouteDeleteAdminConfig,
 				m,
 			),

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -1,12 +1,10 @@
 package api
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/services/datasourceproxy"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -17,8 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
-
-	"github.com/go-macaron/binding"
 )
 
 // timeNow makes it possible to test usage of time
@@ -90,41 +86,8 @@ func (api *API) RegisterAPIEndpoints(m *metrics.Metrics) {
 		DatasourceCache: api.DatasourceCache,
 		log:             logger,
 	}, m)
-	api.RegisterAdminAPIEndpoints(AdminSrv{
+	api.RegisterConfigurationApiEndpoints(AdminSrv{
 		store: api.AdminConfigStore,
 		log:   logger,
 	}, m)
-}
-
-func (api *API) RegisterAdminAPIEndpoints(srv AdminSrv, m *metrics.Metrics) {
-	api.RouteRegister.Group("", func(group routing.RouteRegister) {
-		group.Get(
-			toMacaronPath("/api/v1/ngalert/admin_config"),
-			metrics.Instrument(
-				http.MethodGet,
-				"/api/v1/ngalert/admin_config",
-				srv.RouteGetAdminConfig,
-				m,
-			),
-		)
-		group.Post(
-			"/api/v1/ngalert/admin_config",
-			binding.Bind(apimodels.PostableNGalertConfig{}),
-			metrics.Instrument(
-				http.MethodPost,
-				"/api/v1/ngalert/admin_config",
-				srv.RouteUpdateAdminConfig,
-				m,
-			),
-		)
-		group.Delete(
-			"api/v1/ngalert/admin_config",
-			metrics.Instrument(
-				http.MethodDelete,
-				"api/v1/ngalert/admin_config",
-				srv.RouteDeleteAdminConfig,
-				m,
-			),
-		)
-	}, middleware.ReqOrgAdmin)
 }

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -29,13 +29,13 @@ func (srv AdminSrv) RouteGetAdminConfig(c *models.ReqContext) response.Response 
 		return ErrResp(http.StatusInternalServerError, err, msg)
 	}
 
-	resp := apimodels.AdminConfiguration{
+	resp := apimodels.GettableNGalertconfig{
 		Alertmanagers: cfg.Alertmanagers,
 	}
 	return response.JSON(http.StatusOK, resp)
 }
 
-func (srv AdminSrv) RouteUpdateAdminConfig(c *models.ReqContext, body apimodels.AdminConfiguration) response.Response {
+func (srv AdminSrv) RouteUpdateAdminConfig(c *models.ReqContext, body apimodels.PostableNGalertConfig) response.Response {
 	cfg := &ngmodels.AdminConfiguration{
 		Alertmanagers: body.Alertmanagers,
 		OrgID:         c.OrgId,
@@ -48,10 +48,10 @@ func (srv AdminSrv) RouteUpdateAdminConfig(c *models.ReqContext, body apimodels.
 		return ErrResp(http.StatusBadRequest, err, msg)
 	}
 
-	return response.JSON(http.StatusOK, "admin configuration updated")
+	return response.JSON(http.StatusCreated, "admin configuration updated")
 }
 
-func (srv AdminSrv) RouteDeleteAdminConfig(c *models.ReqContext, body apimodels.AdminConfiguration) response.Response {
+func (srv AdminSrv) RouteDeleteAdminConfig(c *models.ReqContext) response.Response {
 	err := srv.store.DeleteAdminConfiguration(c.OrgId)
 	if err != nil {
 		srv.log.Error("unable to delete configuration", "err", err)

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -29,7 +29,7 @@ func (srv AdminSrv) RouteGetAdminConfig(c *models.ReqContext) response.Response 
 		return ErrResp(http.StatusInternalServerError, err, msg)
 	}
 
-	resp := apimodels.GettableNGalertconfig{
+	resp := apimodels.GettableNGalertConfig{
 		Alertmanagers: cfg.Alertmanagers,
 	}
 	return response.JSON(http.StatusOK, resp)

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+)
+
+type AdminSrv struct {
+	store store.AdminConfigurationStore
+	log   log.Logger
+}
+
+func (srv AdminSrv) RouteGetAdminConfig(c *models.ReqContext) response.Response {
+	cfg, err := srv.store.GetAdminConfiguration(c.OrgId)
+	if err != nil {
+		if errors.Is(err, store.ErrNoAdminConfiguration) {
+			return ErrResp(http.StatusNotFound, err, "")
+		}
+
+		msg := "failed to fetch admin configuration from the database"
+		srv.log.Error(msg, "err", err)
+		return ErrResp(http.StatusInternalServerError, err, msg)
+	}
+
+	resp := apimodels.AdminConfiguration{
+		Alertmanagers: cfg.Alertmanagers,
+	}
+	return response.JSON(http.StatusOK, resp)
+}
+
+func (srv AdminSrv) RouteUpdateAdminConfig(c *models.ReqContext, body apimodels.AdminConfiguration) response.Response {
+	cfg := &ngmodels.AdminConfiguration{
+		Alertmanagers: body.Alertmanagers,
+		OrgID:         c.OrgId,
+	}
+
+	cmd := store.UpdateAdminConfigurationCmd{AdminConfiguration: cfg}
+	if err := srv.store.UpdateAdminConfiguration(cmd); err != nil {
+		msg := "failed to save the admin configuration to the database"
+		srv.log.Error(msg, "err", err)
+		return ErrResp(http.StatusBadRequest, err, msg)
+	}
+
+	return response.JSON(http.StatusOK, "admin configuration updated")
+}
+
+func (srv AdminSrv) RouteDeleteAdminConfig(c *models.ReqContext, body apimodels.AdminConfiguration) response.Response {
+	err := srv.store.DeleteAdminConfiguration(c.OrgId)
+	if err != nil {
+		srv.log.Error("unable to delete configuration", "err", err)
+		return ErrResp(http.StatusInternalServerError, err, "")
+	}
+
+	return response.JSON(http.StatusOK, "admin configuration deleted")
+}

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -17,7 +17,11 @@ type AdminSrv struct {
 	log   log.Logger
 }
 
-func (srv AdminSrv) RouteGetAdminConfig(c *models.ReqContext) response.Response {
+func (srv AdminSrv) RouteGetNGalertConfig(c *models.ReqContext) response.Response {
+	if c.OrgRole != models.ROLE_ADMIN {
+		return accessForbiddenResp()
+	}
+
 	cfg, err := srv.store.GetAdminConfiguration(c.OrgId)
 	if err != nil {
 		if errors.Is(err, store.ErrNoAdminConfiguration) {
@@ -35,7 +39,11 @@ func (srv AdminSrv) RouteGetAdminConfig(c *models.ReqContext) response.Response 
 	return response.JSON(http.StatusOK, resp)
 }
 
-func (srv AdminSrv) RouteUpdateAdminConfig(c *models.ReqContext, body apimodels.PostableNGalertConfig) response.Response {
+func (srv AdminSrv) RoutePostNGalertConfig(c *models.ReqContext, body apimodels.PostableNGalertConfig) response.Response {
+	if c.OrgRole != models.ROLE_ADMIN {
+		return accessForbiddenResp()
+	}
+
 	cfg := &ngmodels.AdminConfiguration{
 		Alertmanagers: body.Alertmanagers,
 		OrgID:         c.OrgId,
@@ -51,7 +59,11 @@ func (srv AdminSrv) RouteUpdateAdminConfig(c *models.ReqContext, body apimodels.
 	return response.JSON(http.StatusCreated, "admin configuration updated")
 }
 
-func (srv AdminSrv) RouteDeleteAdminConfig(c *models.ReqContext) response.Response {
+func (srv AdminSrv) RouteDeleteNGalertConfig(c *models.ReqContext) response.Response {
+	if c.OrgRole != models.ROLE_ADMIN {
+		return accessForbiddenResp()
+	}
+
 	err := srv.store.DeleteAdminConfiguration(c.OrgId)
 	if err != nil {
 		srv.log.Error("unable to delete configuration", "err", err)

--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -4,7 +4,6 @@
  *
  *Do not manually edit these files, please find ngalert/api/swagger-codegen/ for commands on how to generate them.
  */
-
 package api
 
 import (

--- a/pkg/services/ngalert/api/generated_base_api_configuration.go
+++ b/pkg/services/ngalert/api/generated_base_api_configuration.go
@@ -19,41 +19,39 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
 
-type TestingApiService interface {
-	RouteEvalQueries(*models.ReqContext, apimodels.EvalQueriesPayload) response.Response
-	RouteTestReceiverConfig(*models.ReqContext, apimodels.ExtendedReceiver) response.Response
-	RouteTestRuleConfig(*models.ReqContext, apimodels.TestRulePayload) response.Response
+type ConfigurationApiService interface {
+	RouteDeleteNGalertConfig(*models.ReqContext) response.Response
+	RouteGetNGalertConfig(*models.ReqContext) response.Response
+	RoutePostNGalertConfig(*models.ReqContext, apimodels.PostableNGalertConfig) response.Response
 }
 
-func (api *API) RegisterTestingApiEndpoints(srv TestingApiService, m *metrics.Metrics) {
+func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApiService, m *metrics.Metrics) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
-		group.Post(
-			toMacaronPath("/api/v1/eval"),
-			binding.Bind(apimodels.EvalQueriesPayload{}),
+		group.Delete(
+			toMacaronPath("/api/v1/ngalert/admin_config"),
 			metrics.Instrument(
-				http.MethodPost,
-				"/api/v1/eval",
-				srv.RouteEvalQueries,
+				http.MethodDelete,
+				"/api/v1/ngalert/admin_config",
+				srv.RouteDeleteNGalertConfig,
+				m,
+			),
+		)
+		group.Get(
+			toMacaronPath("/api/v1/ngalert/admin_config"),
+			metrics.Instrument(
+				http.MethodGet,
+				"/api/v1/ngalert/admin_config",
+				srv.RouteGetNGalertConfig,
 				m,
 			),
 		)
 		group.Post(
-			toMacaronPath("/api/v1/receiver/test/{Recipient}"),
-			binding.Bind(apimodels.ExtendedReceiver{}),
+			toMacaronPath("/api/v1/ngalert/admin_config"),
+			binding.Bind(apimodels.PostableNGalertConfig{}),
 			metrics.Instrument(
 				http.MethodPost,
-				"/api/v1/receiver/test/{Recipient}",
-				srv.RouteTestReceiverConfig,
-				m,
-			),
-		)
-		group.Post(
-			toMacaronPath("/api/v1/rule/test/{Recipient}"),
-			binding.Bind(apimodels.TestRulePayload{}),
-			metrics.Instrument(
-				http.MethodPost,
-				"/api/v1/rule/test/{Recipient}",
-				srv.RouteTestRuleConfig,
+				"/api/v1/ngalert/admin_config",
+				srv.RoutePostNGalertConfig,
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/generated_base_api_prometheus.go
+++ b/pkg/services/ngalert/api/generated_base_api_prometheus.go
@@ -4,7 +4,6 @@
  *
  *Do not manually edit these files, please find ngalert/api/swagger-codegen/ for commands on how to generate them.
  */
-
 package api
 
 import (

--- a/pkg/services/ngalert/api/generated_base_api_ruler.go
+++ b/pkg/services/ngalert/api/generated_base_api_ruler.go
@@ -4,7 +4,6 @@
  *
  *Do not manually edit these files, please find ngalert/api/swagger-codegen/ for commands on how to generate them.
  */
-
 package api
 
 import (

--- a/pkg/services/ngalert/api/tooling/definitions/admin.go
+++ b/pkg/services/ngalert/api/tooling/definitions/admin.go
@@ -1,6 +1,6 @@
 package definitions
 
-// swagger:route GET /api/v1/ngalert/configuration configuration RouteGetNGalertConfig
+// swagger:route GET /api/v1/ngalert/admin_config configuration RouteGetNGalertConfig
 //
 //  Get the NGalert configuration of the user's organization, returns 404 if no configuration is present.
 //
@@ -8,11 +8,11 @@ package definitions
 //     - application/json
 //
 //     Responses:
-//		 200: GettableNGalertconfig
+//		 200: GettableNGalertConfig
 //		 404: Failure
 //		 500: Failure
 
-// swagger:route POST /api/v1/ngalert/configuration configuration RoutePostNGalertConfig
+// swagger:route POST /api/v1/ngalert/admin_config configuration RoutePostNGalertConfig
 //
 // Creates or updates the NGalert configuration of the user's organization.
 //
@@ -23,7 +23,7 @@ package definitions
 //       201: Ack
 //       400: ValidationError
 
-// swagger:route DELETE /api/v1/ngalert/configuration configuration RouteDeleteNGalertConfig
+// swagger:route DELETE /api/v1/ngalert/admin_config configuration RouteDeleteNGalertConfig
 //
 // Deletes the NGalert configuration of the user's organization.
 //
@@ -46,6 +46,6 @@ type PostableNGalertConfig struct {
 }
 
 // swagger:model
-type GettableNGalertconfig struct {
+type GettableNGalertConfig struct {
 	Alertmanagers []string `json:"alertmanagers"`
 }

--- a/pkg/services/ngalert/api/tooling/definitions/admin.go
+++ b/pkg/services/ngalert/api/tooling/definitions/admin.go
@@ -1,0 +1,51 @@
+package definitions
+
+// swagger:route GET /api/v1/ngalert/configuration configuration RouteGetNGalertConfig
+//
+//  Get the NGalert configuration of the user's organization, returns 404 if no configuration is present.
+//
+//     Produces:
+//     - application/json
+//
+//     Responses:
+//		 200: GettableNGalertconfig
+//		 404: Failure
+//		 500: Failure
+
+// swagger:route POST /api/v1/ngalert/configuration configuration RoutePostNGalertConfig
+//
+// Creates or updates the NGalert configuration of the user's organization.
+//
+//     Consumes:
+//     - application/json
+//
+//     Responses:
+//       201: Ack
+//       400: ValidationError
+
+// swagger:route DELETE /api/v1/ngalert/configuration configuration RouteDeleteNGalertConfig
+//
+// Deletes the NGalert configuration of the user's organization.
+//
+//     Consumes:
+//     - application/json
+//
+//     Responses:
+//       200: Ack
+//       500: Failure
+
+// swagger:parameters RoutePostNGalertConfig RouteGetNGalertConfig
+type NGalertConfig struct {
+	// in:body
+	Body PostableNGalertConfig
+}
+
+// swagger:model
+type PostableNGalertConfig struct {
+	Alertmanagers []string `json:"alertmanagers"`
+}
+
+// swagger:model
+type GettableNGalertconfig struct {
+	Alertmanagers []string `json:"alertmanagers"`
+}

--- a/pkg/services/ngalert/api/tooling/definitions/admin.go
+++ b/pkg/services/ngalert/api/tooling/definitions/admin.go
@@ -34,7 +34,7 @@ package definitions
 //       200: Ack
 //       500: Failure
 
-// swagger:parameters RoutePostNGalertConfig RouteGetNGalertConfig
+// swagger:parameters RoutePostNGalertConfig
 type NGalertConfig struct {
 	// in:body
 	Body PostableNGalertConfig

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -318,7 +318,3 @@ type GettableGrafanaRule struct {
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
 }
-
-type AdminConfiguration struct {
-	Alertmanagers []string `json:"alertmanagers"`
-}

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -318,3 +318,7 @@ type GettableGrafanaRule struct {
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
 }
+
+type AdminConfiguration struct {
+	Alertmanagers []string `json:"alertmanagers"`
+}

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -58,9 +58,7 @@
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
   "AlertGroup": {},
-  "AlertGroups": {
-   "$ref": "#/definitions/alertGroups"
-  },
+  "AlertGroups": {},
   "AlertInstancesResponse": {
    "properties": {
     "instances": {
@@ -475,12 +473,8 @@
   "Failure": {
    "$ref": "#/definitions/ResponseDetails"
   },
-  "GettableAlert": {
-   "$ref": "#/definitions/gettableAlert"
-  },
-  "GettableAlerts": {
-   "$ref": "#/definitions/gettableAlerts"
-  },
+  "GettableAlert": {},
+  "GettableAlerts": {},
   "GettableApiAlertingConfig": {
    "properties": {
     "global": {
@@ -746,6 +740,19 @@
      "format": "int64",
      "type": "integer",
      "x-go-name": "Version"
+    }
+   },
+   "type": "object",
+   "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+  },
+  "GettableNGalertconfig": {
+   "properties": {
+    "alertmanagers": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array",
+     "x-go-name": "Alertmanagers"
     }
    },
    "type": "object",
@@ -1545,6 +1552,19 @@
    "type": "object",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
+  "PostableNGalertConfig": {
+   "properties": {
+    "alertmanagers": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array",
+     "x-go-name": "Alertmanagers"
+    }
+   },
+   "type": "object",
+   "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+  },
   "PostableRuleGroupConfig": {
    "properties": {
     "interval": {
@@ -1565,7 +1585,9 @@
    "type": "object",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
-  "PostableSilence": {},
+  "PostableSilence": {
+   "$ref": "#/definitions/postableSilence"
+  },
   "PostableUserConfig": {
    "properties": {
     "alertmanager_config": {
@@ -2449,7 +2471,7 @@
   "alertGroups": {
    "description": "AlertGroups alert groups",
    "items": {
-    "$ref": "#/definitions/alertGroup"
+    "$ref": "#/definitions/AlertGroup"
    },
    "type": "array",
    "x-go-name": "AlertGroups",
@@ -2601,7 +2623,7 @@
     "receivers": {
      "description": "receivers",
      "items": {
-      "$ref": "#/definitions/receiver"
+      "$ref": "#/definitions/Receiver"
      },
      "type": "array",
      "x-go-name": "Receivers"
@@ -3318,7 +3340,7 @@
       "in": "body",
       "name": "Silence",
       "schema": {
-       "$ref": "#/definitions/postableSilence"
+       "$ref": "#/definitions/PostableSilence"
       }
      },
      {
@@ -3772,6 +3794,89 @@
     },
     "tags": [
      "testing"
+    ]
+   }
+  },
+  "/api/v1/ngalert/configuration": {
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RouteDeleteNGalertConfig",
+    "responses": {
+     "200": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     }
+    },
+    "summary": "Deletes the NGalert configuration of the user's organization.",
+    "tags": [
+     "configuration"
+    ]
+   },
+   "get": {
+    "operationId": "RouteGetNGalertConfig",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/PostableNGalertConfig"
+      }
+     }
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "200": {
+      "$ref": "#/responses/GettableNgalertconfig"
+     },
+     "404": {
+      "description": "Failure",
+      "schema": {
+       "$ref": "#/definitions/Failure"
+      }
+     },
+     "500": {
+      "description": "Failure",
+      "schema": {
+       "$ref": "#/definitions/Failure"
+      }
+     }
+    },
+    "summary": "Get the NGalert configuration of the user's organization, returns 404 if no configuration is present.",
+    "tags": [
+     "configuration"
+    ]
+   },
+   "post": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePostNGalertConfig",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/PostableNGalertConfig"
+      }
+     }
+    ],
+    "responses": {
+     "201": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     }
+    },
+    "summary": "Creates or updates the NGalert configuration of the user's organization.",
+    "tags": [
+     "configuration"
     ]
    }
   },

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -57,8 +57,12 @@
    "type": "object",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
-  "AlertGroup": {},
-  "AlertGroups": {},
+  "AlertGroup": {
+   "$ref": "#/definitions/alertGroup"
+  },
+  "AlertGroups": {
+   "$ref": "#/definitions/alertGroups"
+  },
   "AlertInstancesResponse": {
    "properties": {
     "instances": {
@@ -473,8 +477,12 @@
   "Failure": {
    "$ref": "#/definitions/ResponseDetails"
   },
-  "GettableAlert": {},
-  "GettableAlerts": {},
+  "GettableAlert": {
+   "$ref": "#/definitions/gettableAlert"
+  },
+  "GettableAlerts": {
+   "$ref": "#/definitions/gettableAlerts"
+  },
   "GettableApiAlertingConfig": {
    "properties": {
     "global": {
@@ -745,7 +753,7 @@
    "type": "object",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
-  "GettableNGalertconfig": {
+  "GettableNGalertConfig": {
    "properties": {
     "alertmanagers": {
      "items": {
@@ -778,12 +786,8 @@
    "type": "object",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
-  "GettableSilence": {
-   "$ref": "#/definitions/gettableSilence"
-  },
-  "GettableSilences": {
-   "$ref": "#/definitions/gettableSilences"
-  },
+  "GettableSilence": {},
+  "GettableSilences": {},
   "GettableStatus": {
    "properties": {
     "cluster": {
@@ -1585,9 +1589,7 @@
    "type": "object",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
   },
-  "PostableSilence": {
-   "$ref": "#/definitions/postableSilence"
-  },
+  "PostableSilence": {},
   "PostableUserConfig": {
    "properties": {
     "alertmanager_config": {
@@ -2447,7 +2449,7 @@
     "alerts": {
      "description": "alerts",
      "items": {
-      "$ref": "#/definitions/GettableAlert"
+      "$ref": "#/definitions/gettableAlert"
      },
      "type": "array",
      "x-go-name": "Alerts"
@@ -2456,7 +2458,7 @@
      "$ref": "#/definitions/labelSet"
     },
     "receiver": {
-     "$ref": "#/definitions/receiver"
+     "$ref": "#/definitions/Receiver"
     }
    },
    "required": [
@@ -2471,7 +2473,7 @@
   "alertGroups": {
    "description": "AlertGroups alert groups",
    "items": {
-    "$ref": "#/definitions/AlertGroup"
+    "$ref": "#/definitions/alertGroup"
    },
    "type": "array",
    "x-go-name": "AlertGroups",
@@ -2661,7 +2663,7 @@
   "gettableAlerts": {
    "description": "GettableAlerts gettable alerts",
    "items": {
-    "$ref": "#/definitions/GettableAlert"
+    "$ref": "#/definitions/gettableAlert"
    },
    "type": "array",
    "x-go-name": "GettableAlerts",
@@ -2727,7 +2729,7 @@
   "gettableSilences": {
    "description": "GettableSilences gettable silences",
    "items": {
-    "$ref": "#/definitions/gettableSilence"
+    "$ref": "#/definitions/GettableSilence"
    },
    "type": "array",
    "x-go-name": "GettableSilences",
@@ -3340,7 +3342,7 @@
       "in": "body",
       "name": "Silence",
       "schema": {
-       "$ref": "#/definitions/PostableSilence"
+       "$ref": "#/definitions/postableSilence"
       }
      },
      {
@@ -3797,7 +3799,7 @@
     ]
    }
   },
-  "/api/v1/ngalert/configuration": {
+  "/api/v1/ngalert/admin_config": {
    "delete": {
     "consumes": [
      "application/json"
@@ -3809,6 +3811,12 @@
       "schema": {
        "$ref": "#/definitions/Ack"
       }
+     },
+     "500": {
+      "description": "Failure",
+      "schema": {
+       "$ref": "#/definitions/Failure"
+      }
      }
     },
     "summary": "Deletes the NGalert configuration of the user's organization.",
@@ -3818,21 +3826,15 @@
    },
    "get": {
     "operationId": "RouteGetNGalertConfig",
-    "parameters": [
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/PostableNGalertConfig"
-      }
-     }
-    ],
     "produces": [
      "application/json"
     ],
     "responses": {
      "200": {
-      "$ref": "#/responses/GettableNgalertconfig"
+      "description": "GettableNGalertConfig",
+      "schema": {
+       "$ref": "#/definitions/GettableNGalertConfig"
+      }
      },
      "404": {
       "description": "Failure",
@@ -3871,6 +3873,12 @@
       "description": "Ack",
       "schema": {
        "$ref": "#/definitions/Ack"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
       }
      }
     },

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -327,7 +327,7 @@
             "name": "Silence",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/postableSilence"
+              "$ref": "#/definitions/PostableSilence"
             }
           },
           {
@@ -781,6 +781,89 @@
         }
       }
     },
+    "/api/v1/ngalert/configuration": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "configuration"
+        ],
+        "summary": "Get the NGalert configuration of the user's organization, returns 404 if no configuration is present.",
+        "operationId": "RouteGetNGalertConfig",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/PostableNGalertConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/GettableNgalertconfig"
+          },
+          "404": {
+            "description": "Failure",
+            "schema": {
+              "$ref": "#/definitions/Failure"
+            }
+          },
+          "500": {
+            "description": "Failure",
+            "schema": {
+              "$ref": "#/definitions/Failure"
+            }
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "configuration"
+        ],
+        "summary": "Creates or updates the NGalert configuration of the user's organization.",
+        "operationId": "RoutePostNGalertConfig",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/PostableNGalertConfig"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          }
+        }
+      },
+      "delete": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "configuration"
+        ],
+        "summary": "Deletes the NGalert configuration of the user's organization.",
+        "operationId": "RouteDeleteNGalertConfig",
+        "responses": {
+          "200": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          }
+        }
+      }
+    },
     "/api/v1/receiver/test/{Recipient}": {
       "post": {
         "description": "Test receiver",
@@ -930,7 +1013,7 @@
       "$ref": "#/definitions/AlertGroup"
     },
     "AlertGroups": {
-      "$ref": "#/definitions/alertGroups"
+      "$ref": "#/definitions/AlertGroups"
     },
     "AlertInstancesResponse": {
       "type": "object",
@@ -1350,10 +1433,10 @@
       "$ref": "#/definitions/ResponseDetails"
     },
     "GettableAlert": {
-      "$ref": "#/definitions/gettableAlert"
+      "$ref": "#/definitions/GettableAlert"
     },
     "GettableAlerts": {
-      "$ref": "#/definitions/gettableAlerts"
+      "$ref": "#/definitions/GettableAlerts"
     },
     "GettableApiAlertingConfig": {
       "type": "object",
@@ -1621,6 +1704,19 @@
           "type": "integer",
           "format": "int64",
           "x-go-name": "Version"
+        }
+      },
+      "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+    },
+    "GettableNGalertconfig": {
+      "type": "object",
+      "properties": {
+        "alertmanagers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Alertmanagers"
         }
       },
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -2420,6 +2516,19 @@
       },
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
+    "PostableNGalertConfig": {
+      "type": "object",
+      "properties": {
+        "alertmanagers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Alertmanagers"
+        }
+      },
+      "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+    },
     "PostableRuleGroupConfig": {
       "type": "object",
       "properties": {
@@ -2441,7 +2550,7 @@
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
     "PostableSilence": {
-      "$ref": "#/definitions/PostableSilence"
+      "$ref": "#/definitions/postableSilence"
     },
     "PostableUserConfig": {
       "type": "object",
@@ -3328,7 +3437,7 @@
       "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/alertGroup"
+        "$ref": "#/definitions/AlertGroup"
       },
       "x-go-name": "AlertGroups",
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
@@ -3491,7 +3600,7 @@
           "description": "receivers",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/receiver"
+            "$ref": "#/definitions/Receiver"
           },
           "x-go-name": "Receivers"
         },

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -327,7 +327,7 @@
             "name": "Silence",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/PostableSilence"
+              "$ref": "#/definitions/postableSilence"
             }
           },
           {
@@ -781,7 +781,7 @@
         }
       }
     },
-    "/api/v1/ngalert/configuration": {
+    "/api/v1/ngalert/admin_config": {
       "get": {
         "produces": [
           "application/json"
@@ -791,18 +791,12 @@
         ],
         "summary": "Get the NGalert configuration of the user's organization, returns 404 if no configuration is present.",
         "operationId": "RouteGetNGalertConfig",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/PostableNGalertConfig"
-            }
-          }
-        ],
         "responses": {
           "200": {
-            "$ref": "#/responses/GettableNgalertconfig"
+            "description": "GettableNGalertConfig",
+            "schema": {
+              "$ref": "#/definitions/GettableNGalertConfig"
+            }
           },
           "404": {
             "description": "Failure",
@@ -842,6 +836,12 @@
             "schema": {
               "$ref": "#/definitions/Ack"
             }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
           }
         }
       },
@@ -859,6 +859,12 @@
             "description": "Ack",
             "schema": {
               "$ref": "#/definitions/Ack"
+            }
+          },
+          "500": {
+            "description": "Failure",
+            "schema": {
+              "$ref": "#/definitions/Failure"
             }
           }
         }
@@ -1010,10 +1016,10 @@
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
     "AlertGroup": {
-      "$ref": "#/definitions/AlertGroup"
+      "$ref": "#/definitions/alertGroup"
     },
     "AlertGroups": {
-      "$ref": "#/definitions/AlertGroups"
+      "$ref": "#/definitions/alertGroups"
     },
     "AlertInstancesResponse": {
       "type": "object",
@@ -1433,10 +1439,10 @@
       "$ref": "#/definitions/ResponseDetails"
     },
     "GettableAlert": {
-      "$ref": "#/definitions/GettableAlert"
+      "$ref": "#/definitions/gettableAlert"
     },
     "GettableAlerts": {
-      "$ref": "#/definitions/GettableAlerts"
+      "$ref": "#/definitions/gettableAlerts"
     },
     "GettableApiAlertingConfig": {
       "type": "object",
@@ -1708,7 +1714,7 @@
       },
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
-    "GettableNGalertconfig": {
+    "GettableNGalertConfig": {
       "type": "object",
       "properties": {
         "alertmanagers": {
@@ -1742,10 +1748,10 @@
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
     "GettableSilence": {
-      "$ref": "#/definitions/gettableSilence"
+      "$ref": "#/definitions/GettableSilence"
     },
     "GettableSilences": {
-      "$ref": "#/definitions/gettableSilences"
+      "$ref": "#/definitions/GettableSilences"
     },
     "GettableStatus": {
       "type": "object",
@@ -2550,7 +2556,7 @@
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
     "PostableSilence": {
-      "$ref": "#/definitions/postableSilence"
+      "$ref": "#/definitions/PostableSilence"
     },
     "PostableUserConfig": {
       "type": "object",
@@ -3419,7 +3425,7 @@
           "description": "alerts",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/GettableAlert"
+            "$ref": "#/definitions/gettableAlert"
           },
           "x-go-name": "Alerts"
         },
@@ -3427,7 +3433,7 @@
           "$ref": "#/definitions/labelSet"
         },
         "receiver": {
-          "$ref": "#/definitions/receiver"
+          "$ref": "#/definitions/Receiver"
         }
       },
       "x-go-name": "AlertGroup",
@@ -3437,7 +3443,7 @@
       "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/AlertGroup"
+        "$ref": "#/definitions/alertGroup"
       },
       "x-go-name": "AlertGroups",
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
@@ -3627,7 +3633,7 @@
       "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/GettableAlert"
+        "$ref": "#/definitions/gettableAlert"
       },
       "x-go-name": "GettableAlerts",
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
@@ -3693,7 +3699,7 @@
       "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/gettableSilence"
+        "$ref": "#/definitions/GettableSilence"
       },
       "x-go-name": "GettableSilences",
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -257,3 +257,8 @@ func ErrResp(status int, err error, msg string, args ...interface{}) *response.N
 	}
 	return response.Error(status, err.Error(), nil)
 }
+
+// accessForbiddenResp creates a response of forbidden access.
+func accessForbiddenResp() response.Response {
+	return ErrResp(http.StatusForbidden, errors.New("Permission denied"), "")
+}

--- a/pkg/services/ngalert/models/admin_configuration.go
+++ b/pkg/services/ngalert/models/admin_configuration.go
@@ -19,12 +19,10 @@ type AdminConfiguration struct {
 
 func (ac *AdminConfiguration) AsSHA256() string {
 	h := sha256.New()
-	_, _ = h.Write([]byte(fmt.Sprintf("%v", ac)))
+	_, _ = h.Write([]byte(fmt.Sprintf("%v", ac.Alertmanagers)))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 type GetOrgAdminConfiguration struct {
-	OrgIDs []int64
-
 	Result []*AdminConfiguration
 }

--- a/pkg/services/ngalert/models/admin_configuration.go
+++ b/pkg/services/ngalert/models/admin_configuration.go
@@ -22,7 +22,3 @@ func (ac *AdminConfiguration) AsSHA256() string {
 	_, _ = h.Write([]byte(fmt.Sprintf("%v", ac.Alertmanagers)))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
-
-type GetOrgAdminConfiguration struct {
-	Result []*AdminConfiguration
-}

--- a/pkg/services/ngalert/models/admin_configuration.go
+++ b/pkg/services/ngalert/models/admin_configuration.go
@@ -19,8 +19,7 @@ type AdminConfiguration struct {
 
 func (ac *AdminConfiguration) AsSHA256() string {
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%v", ac)))
-
+	_, _ = h.Write([]byte(fmt.Sprintf("%v", ac)))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 

--- a/pkg/services/ngalert/models/admin_configuration.go
+++ b/pkg/services/ngalert/models/admin_configuration.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// AdminConfiguration represents the ngalert administration configuration settings.
+type AdminConfiguration struct {
+	ID    int64 `xorm:"pk autoincr 'id'"`
+	OrgID int64 `xorm:"org_id"`
+
+	// List of Alertmanager(s) URL to push alerts to.
+	Alertmanagers []string
+
+	CreatedAt int64 `xorm:"created"`
+	UpdatedAt int64 `xorm:"updated"`
+}
+
+func (ac *AdminConfiguration) AsSHA256() string {
+	h := sha256.New()
+	h.Write([]byte(fmt.Sprintf("%v", ac)))
+
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+type GetOrgAdminConfiguration struct {
+	OrgIDs []int64
+
+	Result []*AdminConfiguration
+}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -83,7 +83,7 @@ func (ng *AlertNG) Init() error {
 	schedCfg := schedule.SchedulerCfg{
 		C:                clock.New(),
 		BaseInterval:     baseInterval,
-		Logger:           ng.Log,
+		Logger:           log.New("ngalert.scheduler"),
 		MaxAttempts:      maxAttempts,
 		Evaluator:        eval.Evaluator{Cfg: ng.Cfg, Log: ng.Log},
 		InstanceStore:    store,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -35,24 +35,27 @@ const (
 	// with intervals that are not exactly divided by this number
 	// not to be evaluated
 	baseIntervalSeconds = 10
-	// default alert definiiton interval
+	// default alert definition interval
 	defaultIntervalSeconds int64 = 6 * baseIntervalSeconds
 )
 
 // AlertNG is the service for evaluating the condition of an alert definition.
 type AlertNG struct {
-	Cfg             *setting.Cfg                            `inject:""`
+	Cfg     *setting.Cfg `inject:""`
+	Log     log.Logger
+	Metrics *metrics.Metrics `inject:""`
+
 	DatasourceCache datasources.CacheService                `inject:""`
 	RouteRegister   routing.RouteRegister                   `inject:""`
 	SQLStore        *sqlstore.SQLStore                      `inject:""`
 	DataService     *tsdb.Service                           `inject:""`
 	DataProxy       *datasourceproxy.DatasourceProxyService `inject:""`
 	QuotaService    *quota.QuotaService                     `inject:""`
-	Metrics         *metrics.Metrics                        `inject:""`
-	Log             log.Logger
 	schedule        schedule.ScheduleService
 	stateManager    *state.Manager
-	Alertmanager    *notifier.Alertmanager
+
+	// Alerting notification services
+	Alertmanager *notifier.Alertmanager
 }
 
 func init() {
@@ -78,32 +81,34 @@ func (ng *AlertNG) Init() error {
 	}
 
 	schedCfg := schedule.SchedulerCfg{
-		C:             clock.New(),
-		BaseInterval:  baseInterval,
-		Logger:        ng.Log,
-		MaxAttempts:   maxAttempts,
-		Evaluator:     eval.Evaluator{Cfg: ng.Cfg, Log: ng.Log},
-		InstanceStore: store,
-		RuleStore:     store,
-		Notifier:      ng.Alertmanager,
-		Metrics:       ng.Metrics,
+		C:                clock.New(),
+		BaseInterval:     baseInterval,
+		Logger:           ng.Log,
+		MaxAttempts:      maxAttempts,
+		Evaluator:        eval.Evaluator{Cfg: ng.Cfg, Log: ng.Log},
+		InstanceStore:    store,
+		RuleStore:        store,
+		AdminConfigStore: store,
+		Notifier:         ng.Alertmanager,
+		Metrics:          ng.Metrics,
 	}
 	ng.stateManager = state.NewManager(ng.Log, ng.Metrics, store, store)
 	ng.schedule = schedule.NewScheduler(schedCfg, ng.DataService, ng.Cfg.AppURL, ng.stateManager)
 
 	api := api.API{
-		Cfg:             ng.Cfg,
-		DatasourceCache: ng.DatasourceCache,
-		RouteRegister:   ng.RouteRegister,
-		DataService:     ng.DataService,
-		Schedule:        ng.schedule,
-		DataProxy:       ng.DataProxy,
-		QuotaService:    ng.QuotaService,
-		InstanceStore:   store,
-		RuleStore:       store,
-		AlertingStore:   store,
-		Alertmanager:    ng.Alertmanager,
-		StateManager:    ng.stateManager,
+		Cfg:              ng.Cfg,
+		DatasourceCache:  ng.DatasourceCache,
+		RouteRegister:    ng.RouteRegister,
+		DataService:      ng.DataService,
+		Schedule:         ng.schedule,
+		DataProxy:        ng.DataProxy,
+		QuotaService:     ng.QuotaService,
+		InstanceStore:    store,
+		RuleStore:        store,
+		AlertingStore:    store,
+		AdminConfigStore: store,
+		Alertmanager:     ng.Alertmanager,
+		StateManager:     ng.stateManager,
 	}
 	api.RegisterAPIEndpoints(ng.Metrics)
 

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -511,6 +511,7 @@ func (am *Alertmanager) PutAlerts(postableAlerts apimodels.PostableAlerts) error
 			},
 			UpdatedAt: now,
 		}
+
 		for k, v := range a.Labels {
 			if len(v) == 0 || k == ngmodels.NamespaceUIDLabel { // Skip empty and namespace UID labels.
 				continue

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -26,7 +26,7 @@ import (
 var timeNow = time.Now
 
 // PollingInterval of how often we sync admin configuration.
-var PollingInterval = 1 * time.Minute
+var AdminConfigPollingInterval = 1 * time.Minute
 
 // ScheduleService handles scheduling
 type ScheduleService interface {

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -176,16 +176,16 @@ func (sch *schedule) Run(ctx context.Context) error {
 // SyncAndApplyConfigFromDatabase looks for the admin configuration in the database and adjusts the sender(s) accordingly.
 func (sch *schedule) SyncAndApplyConfigFromDatabase() error {
 	sch.log.Debug("start of admin configuration sync")
-	q := &models.GetOrgAdminConfiguration{}
-	if err := sch.adminConfigStore.GetAdminConfigurations(q); err != nil {
+	cfgs, err := sch.adminConfigStore.GetAdminConfigurations()
+	if err != nil {
 		return err
 	}
 
-	sch.log.Debug("found admin configurations", "count", len(q.Result))
+	sch.log.Debug("found admin configurations", "count", len(cfgs))
 
-	orgsFound := make(map[int64]struct{}, len(q.Result))
+	orgsFound := make(map[int64]struct{}, len(cfgs))
 	sch.sendersMtx.Lock()
-	for _, cfg := range q.Result {
+	for _, cfg := range cfgs {
 		orgsFound[cfg.OrgID] = struct{}{} // keep track of the which senders we need to keep.
 
 		existing, ok := sch.senders[cfg.OrgID]

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -214,6 +214,7 @@ func (sch *schedule) SyncAndApplyConfigFromDatabase() error {
 			err := existing.ApplyConfig(cfg)
 			if err != nil {
 				sch.log.Error("failed to apply configuration", "err", err, "org", cfg.OrgID)
+				continue
 			}
 			sch.sendersCfgHash[cfg.OrgID] = cfg.AsSHA256()
 			continue

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -274,7 +274,7 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond)
 
 	go func() {
-		schedule.AdminConfigPollingInterval = 1 * time.Second
+		schedule.AdminConfigPollingInterval = 10 * time.Minute // Do not poll in unit tests.
 		err := sched.Run(ctx)
 		require.NoError(t, err)
 	}()
@@ -411,7 +411,7 @@ func (am *fakeExternalAlertmanager) AlertNamesCompare(expected []string) bool {
 		}
 	}
 
-	return cmp.Equal(expected, n)
+	return assert.ObjectsAreEqual(expected, n)
 }
 
 func (am *fakeExternalAlertmanager) AlertsCount() int {

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -274,7 +274,7 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond)
 
 	go func() {
-		schedule.PollingInterval = 1 * time.Second
+		schedule.AdminConfigPollingInterval = 1 * time.Second
 		err := sched.Run(ctx)
 		require.NoError(t, err)
 	}()

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -397,6 +397,12 @@ func newFakeExternalAlertmanager(t *testing.T) *fakeExternalAlertmanager {
 
 func (am *fakeExternalAlertmanager) AlertNamesCompare(expected []string) bool {
 	n := []string{}
+	alerts := am.Alerts()
+
+	if len(expected) != len(alerts) {
+		return false
+	}
+
 	for _, a := range am.Alerts() {
 		for k, v := range a.Alert.Labels {
 			if k == model.AlertNameLabel {

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -2,36 +2,26 @@ package schedule_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry"
-	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests"
-	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/benbjohnson/clock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -228,78 +218,6 @@ func TestAlertingTicker(t *testing.T) {
 	})
 }
 
-func TestSendingToExternalAlertmanager(t *testing.T) {
-	dbstore := tests.SetupTestEnv(t, 1)
-	t.Cleanup(registry.ClearOverrides)
-
-	// create alert rule with one second interval
-	alertRule := tests.CreateTestAlertRule(t, dbstore, 1)
-
-	fakeAM := newFakeExternalAlertmanager(t)
-	defer fakeAM.Close()
-
-	// First, let's create an admin configuration that holds an alertmanager.
-	adminConfig := &models.AdminConfiguration{OrgID: 1, Alertmanagers: []string{fakeAM.server.URL}}
-	cmd := store.UpdateAdminConfigurationCmd{AdminConfiguration: adminConfig}
-	require.NoError(t, dbstore.UpdateAdminConfiguration(cmd))
-
-	mockedClock := clock.NewMock()
-	baseInterval := time.Second
-
-	logger := log.New("ngalert schedule test")
-	schedCfg := schedule.SchedulerCfg{
-		C:                mockedClock,
-		BaseInterval:     baseInterval,
-		MaxAttempts:      1,
-		Evaluator:        eval.Evaluator{Cfg: &setting.Cfg{ExpressionsEnabled: true}, Log: logger},
-		RuleStore:        dbstore,
-		InstanceStore:    dbstore,
-		AdminConfigStore: dbstore,
-		Notifier:         &fakeNotifier{},
-		Logger:           logger,
-		Metrics:          metrics.NewMetrics(prometheus.NewRegistry()),
-	}
-	st := state.NewManager(schedCfg.Logger, nilMetrics, dbstore, dbstore)
-	sched := schedule.NewScheduler(schedCfg, nil, "http://localhost", st)
-
-	ctx := context.Background()
-
-	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
-	// when the first alert triggers.
-	require.NoError(t, sched.SyncAndApplyConfigFromDatabase())
-
-	// Then, ensure we've discovered the Alertmanager.
-	require.Eventually(t, func() bool {
-		return len(sched.AlertmanagersFor(1)) == 1 && len(sched.DroppedAlertmanagersFor(1)) == 0
-	}, 10*time.Second, 200*time.Millisecond)
-
-	go func() {
-		schedule.AdminConfigPollingInterval = 10 * time.Minute // Do not poll in unit tests.
-		err := sched.Run(ctx)
-		require.NoError(t, err)
-	}()
-
-	// With everything up and running, let's advance the time to make sure we get at least one alert iteration.
-	mockedClock.Add(2 * time.Second)
-
-	// Eventually, our Alertmanager should have received at least one alert.
-	require.Eventually(t, func() bool {
-		return fakeAM.AlertsCount() >= 1 && fakeAM.AlertNamesCompare([]string{alertRule.Title})
-	}, 10*time.Second, 200*time.Millisecond)
-
-	// Now, let's remove the Alertmanager from the admin configuration.
-	adminConfig.Alertmanagers = []string{}
-	cmd = store.UpdateAdminConfigurationCmd{AdminConfiguration: adminConfig}
-	require.NoError(t, dbstore.UpdateAdminConfiguration(cmd))
-
-	// Again, make sure we sync.
-	require.NoError(t, sched.SyncAndApplyConfigFromDatabase())
-
-	// Then, ensure we've dropped the Alertmanager.
-	require.Eventually(t, func() bool {
-		return len(sched.AlertmanagersFor(1)) == 0 && len(sched.DroppedAlertmanagersFor(1)) == 0
-	}, 10*time.Second, 200*time.Millisecond)
-}
 func assertEvalRun(t *testing.T, ch <-chan evalAppliedInfo, tick time.Time, keys ...models.AlertRuleKey) {
 	timeout := time.After(time.Second)
 
@@ -367,80 +285,4 @@ func concatenate(keys []models.AlertRuleKey) string {
 		s = append(s, k.String())
 	}
 	return fmt.Sprintf("[%s]", strings.Join(s, ","))
-}
-
-// fakeNotifier represents a fake internal Alertmanager.
-type fakeNotifier struct{}
-
-func (n *fakeNotifier) PutAlerts(alerts apimodels.PostableAlerts) error {
-	return nil
-}
-
-type fakeExternalAlertmanager struct {
-	t      *testing.T
-	mtx    sync.Mutex
-	alerts amv2.PostableAlerts
-	server *httptest.Server
-}
-
-func newFakeExternalAlertmanager(t *testing.T) *fakeExternalAlertmanager {
-	t.Helper()
-
-	am := &fakeExternalAlertmanager{
-		t:      t,
-		alerts: amv2.PostableAlerts{},
-	}
-	am.server = httptest.NewServer(http.HandlerFunc(am.Handler()))
-
-	return am
-}
-
-func (am *fakeExternalAlertmanager) AlertNamesCompare(expected []string) bool {
-	n := []string{}
-	alerts := am.Alerts()
-
-	if len(expected) != len(alerts) {
-		return false
-	}
-
-	for _, a := range am.Alerts() {
-		for k, v := range a.Alert.Labels {
-			if k == model.AlertNameLabel {
-				n = append(n, v)
-			}
-		}
-	}
-
-	return assert.ObjectsAreEqual(expected, n)
-}
-
-func (am *fakeExternalAlertmanager) AlertsCount() int {
-	am.mtx.Lock()
-	defer am.mtx.Unlock()
-
-	return len(am.alerts)
-}
-
-func (am *fakeExternalAlertmanager) Alerts() amv2.PostableAlerts {
-	am.mtx.Lock()
-	defer am.mtx.Unlock()
-	return am.alerts
-}
-
-func (am *fakeExternalAlertmanager) Handler() func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
-		require.NoError(am.t, err)
-
-		a := amv2.PostableAlerts{}
-		require.NoError(am.t, json.Unmarshal(b, &a))
-
-		am.mtx.Lock()
-		am.alerts = append(am.alerts, a...)
-		am.mtx.Unlock()
-	}
-}
-
-func (am *fakeExternalAlertmanager) Close() {
-	am.server.Close()
 }

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -1,0 +1,448 @@
+package schedule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/util"
+
+	models2 "github.com/grafana/grafana/pkg/models"
+
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/prometheus/common/model"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/setting"
+
+	"github.com/benbjohnson/clock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendingToExternalAlertmanager(t *testing.T) {
+	t.Cleanup(registry.ClearOverrides)
+
+	fakeAM := newFakeExternalAlertmanager(t)
+	defer fakeAM.Close()
+	fakeRuleStore := newFakeRuleStore(t)
+	fakeInstanceStore := &fakeInstanceStore{}
+	fakeAdminConfigStore := newFakeAdminConfigStore(t)
+
+	// create alert rule with one second interval
+	alertRule := CreateTestAlertRule(t, fakeRuleStore, 1)
+
+	// First, let's create an admin configuration that holds an alertmanager.
+	adminConfig := &models.AdminConfiguration{OrgID: 1, Alertmanagers: []string{fakeAM.server.URL}}
+	cmd := store.UpdateAdminConfigurationCmd{AdminConfiguration: adminConfig}
+	require.NoError(t, fakeAdminConfigStore.UpdateAdminConfiguration(cmd))
+
+	mockedClock := clock.NewMock()
+	baseInterval := time.Second
+
+	logger := log.New("ngalert schedule test")
+	nilMetrics := metrics.NewMetrics(nil)
+	schedCfg := SchedulerCfg{
+		C:                mockedClock,
+		BaseInterval:     baseInterval,
+		MaxAttempts:      1,
+		Evaluator:        eval.Evaluator{Cfg: &setting.Cfg{ExpressionsEnabled: true}, Log: logger},
+		RuleStore:        fakeRuleStore,
+		InstanceStore:    fakeInstanceStore,
+		AdminConfigStore: fakeAdminConfigStore,
+		Notifier:         &fakeNotifier{},
+		Logger:           logger,
+		Metrics:          metrics.NewMetrics(prometheus.NewRegistry()),
+	}
+	st := state.NewManager(schedCfg.Logger, nilMetrics, fakeRuleStore, fakeInstanceStore)
+	sched := NewScheduler(schedCfg, nil, "http://localhost", st)
+
+	ctx := context.Background()
+
+	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
+	// when the first alert triggers.
+	require.NoError(t, sched.SyncAndApplyConfigFromDatabase())
+
+	// Then, ensure we've discovered the Alertmanager.
+	require.Eventually(t, func() bool {
+		return len(sched.AlertmanagersFor(1)) == 1 && len(sched.DroppedAlertmanagersFor(1)) == 0
+	}, 10*time.Second, 200*time.Millisecond)
+
+	go func() {
+		AdminConfigPollingInterval = 10 * time.Minute // Do not poll in unit tests.
+		err := sched.Run(ctx)
+		require.NoError(t, err)
+	}()
+
+	// With everything up and running, let's advance the time to make sure we get at least one alert iteration.
+	mockedClock.Add(2 * time.Second)
+
+	// Eventually, our Alertmanager should have received at least one alert.
+	require.Eventually(t, func() bool {
+		return fakeAM.AlertsCount() >= 1 && fakeAM.AlertNamesCompare([]string{alertRule.Title})
+	}, 10*time.Second, 200*time.Millisecond)
+
+	// Now, let's remove the Alertmanager from the admin configuration.
+	adminConfig.Alertmanagers = []string{}
+	cmd = store.UpdateAdminConfigurationCmd{AdminConfiguration: adminConfig}
+	fakeAdminConfigStore.UpdateAdminConfiguration(cmd)
+	require.NoError(t, fakeAdminConfigStore.UpdateAdminConfiguration(cmd))
+
+	// Again, make sure we sync.
+	require.NoError(t, sched.SyncAndApplyConfigFromDatabase())
+
+	// Then, ensure we've dropped the Alertmanager.
+	require.Eventually(t, func() bool {
+		return len(sched.AlertmanagersFor(1)) == 0 && len(sched.DroppedAlertmanagersFor(1)) == 0
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+// createTestAlertRule creates a dummy alert definition to be used by the tests.
+func CreateTestAlertRule(t *testing.T, dbstore *fakeRuleStore, intervalSeconds int64) *models.AlertRule {
+	d := rand.Intn(1000)
+	ruleGroup := fmt.Sprintf("ruleGroup-%d", d)
+	err := dbstore.UpdateRuleGroup(store.UpdateRuleGroupCmd{
+		OrgID:        1,
+		NamespaceUID: "namespace",
+		RuleGroupConfig: apimodels.PostableRuleGroupConfig{
+			Name:     ruleGroup,
+			Interval: model.Duration(time.Duration(intervalSeconds) * time.Second),
+			Rules: []apimodels.PostableExtendedRuleNode{
+				{
+					ApiRuleNode: &apimodels.ApiRuleNode{
+						Annotations: map[string]string{"testAnnoKey": "testAnnoValue"},
+					},
+					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
+						Title:     fmt.Sprintf("an alert definition %d", d),
+						Condition: "A",
+						Data: []models.AlertQuery{
+							{
+								Model: json.RawMessage(`{
+										"datasourceUid": "-100",
+										"type":"math",
+										"expression":"2 + 2 > 1"
+									}`),
+								RelativeTimeRange: models.RelativeTimeRange{
+									From: models.Duration(5 * time.Hour),
+									To:   models.Duration(3 * time.Hour),
+								},
+								RefID: "A",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	q := models.ListRuleGroupAlertRulesQuery{
+		OrgID:        1,
+		NamespaceUID: "namespace",
+		RuleGroup:    ruleGroup,
+	}
+	err = dbstore.GetRuleGroupAlertRules(&q)
+	require.NoError(t, err)
+	require.NotEmpty(t, q.Result)
+
+	rule := q.Result[0]
+	t.Logf("alert definition: %v with interval: %d created", rule.GetKey(), rule.IntervalSeconds)
+	return rule
+}
+
+func newFakeRuleStore(t *testing.T) *fakeRuleStore {
+	return &fakeRuleStore{t: t, rules: map[int64]map[string]map[string][]*models.AlertRule{}}
+}
+
+type fakeRuleStore struct {
+	t     *testing.T
+	mtx   sync.Mutex
+	rules map[int64]map[string]map[string][]*models.AlertRule
+}
+
+func (f *fakeRuleStore) DeleteAlertRuleByUID(_ int64, _ string) error { return nil }
+func (f *fakeRuleStore) DeleteNamespaceAlertRules(_ int64, _ string) ([]string, error) {
+	return []string{}, nil
+}
+func (f *fakeRuleStore) DeleteRuleGroupAlertRules(_ int64, _ string, _ string) ([]string, error) {
+	return []string{}, nil
+}
+func (f *fakeRuleStore) DeleteAlertInstancesByRuleUID(_ int64, _ string) error { return nil }
+func (f *fakeRuleStore) GetAlertRuleByUID(q *models.GetAlertRuleByUIDQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	rgs, ok := f.rules[q.OrgID]
+	if !ok {
+		return nil
+	}
+
+	for _, rg := range rgs {
+		for _, rules := range rg {
+			for _, r := range rules {
+				if r.UID == q.UID {
+					q.Result = r
+					break
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// For now, we're not implementing namespace filtering.
+func (f *fakeRuleStore) GetAlertRulesForScheduling(q *models.ListAlertRulesQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	for _, rg := range f.rules {
+		for _, n := range rg {
+			for _, r := range n {
+				q.Result = append(q.Result, r...)
+			}
+		}
+	}
+
+	return nil
+}
+func (f *fakeRuleStore) GetOrgAlertRules(_ *models.ListAlertRulesQuery) error { return nil }
+func (f *fakeRuleStore) GetNamespaceAlertRules(_ *models.ListNamespaceAlertRulesQuery) error {
+	return nil
+}
+func (f *fakeRuleStore) GetRuleGroupAlertRules(q *models.ListRuleGroupAlertRulesQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	rgs, ok := f.rules[q.OrgID]
+	if !ok {
+		return nil
+	}
+
+	rg, ok := rgs[q.RuleGroup]
+	if !ok {
+		return nil
+	}
+
+	if q.NamespaceUID != "" {
+		r, ok := rg[q.NamespaceUID]
+		if !ok {
+			return nil
+		}
+		q.Result = r
+		return nil
+	}
+
+	for _, r := range rg {
+		q.Result = append(q.Result, r...)
+	}
+
+	return nil
+}
+func (f *fakeRuleStore) GetNamespaces(_ int64, _ *models2.SignedInUser) (map[string]*models2.Folder, error) {
+	return nil, nil
+}
+func (f *fakeRuleStore) GetNamespaceByTitle(_ string, _ int64, _ *models2.SignedInUser, _ bool) (*models2.Folder, error) {
+	return nil, nil
+}
+func (f *fakeRuleStore) GetOrgRuleGroups(_ *models.ListOrgRuleGroupsQuery) error { return nil }
+func (f *fakeRuleStore) UpsertAlertRules(_ []store.UpsertRule) error             { return nil }
+func (f *fakeRuleStore) UpdateRuleGroup(cmd store.UpdateRuleGroupCmd) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	rgs, ok := f.rules[cmd.OrgID]
+	if !ok {
+		f.rules[cmd.OrgID] = map[string]map[string][]*models.AlertRule{}
+	}
+
+	rg, ok := rgs[cmd.RuleGroupConfig.Name]
+	if !ok {
+		f.rules[cmd.OrgID][cmd.RuleGroupConfig.Name] = map[string][]*models.AlertRule{}
+	}
+
+	_, ok = rg[cmd.NamespaceUID]
+	if !ok {
+		f.rules[cmd.OrgID][cmd.RuleGroupConfig.Name][cmd.NamespaceUID] = []*models.AlertRule{}
+	}
+
+	rules := []*models.AlertRule{}
+	for _, r := range cmd.RuleGroupConfig.Rules {
+		for i := range r.GrafanaManagedAlert.Data {
+			r.GrafanaManagedAlert.Data[i].DatasourceUID = "-100"
+		}
+		new := &models.AlertRule{
+			OrgID:           cmd.OrgID,
+			Title:           r.GrafanaManagedAlert.Title,
+			Condition:       r.GrafanaManagedAlert.Condition,
+			Data:            r.GrafanaManagedAlert.Data,
+			UID:             util.GenerateShortUID(),
+			IntervalSeconds: int64(time.Duration(cmd.RuleGroupConfig.Interval).Seconds()),
+			NamespaceUID:    cmd.NamespaceUID,
+			RuleGroup:       cmd.RuleGroupConfig.Name,
+			NoDataState:     models.NoDataState(r.GrafanaManagedAlert.NoDataState),
+			ExecErrState:    models.ExecutionErrorState(r.GrafanaManagedAlert.ExecErrState),
+			Version:         1,
+		}
+
+		if r.ApiRuleNode != nil {
+			new.For = time.Duration(r.ApiRuleNode.For)
+			new.Annotations = r.ApiRuleNode.Annotations
+			new.Labels = r.ApiRuleNode.Labels
+		}
+
+		if new.NoDataState == "" {
+			new.NoDataState = models.NoData
+		}
+
+		if new.ExecErrState == "" {
+			new.ExecErrState = models.AlertingErrState
+		}
+
+		err := new.PreSave(time.Now)
+		require.NoError(f.t, err)
+
+		rules = append(rules, new)
+	}
+
+	f.rules[cmd.OrgID][cmd.RuleGroupConfig.Name][cmd.NamespaceUID] = rules
+	return nil
+}
+
+type fakeInstanceStore struct{}
+
+func (f *fakeInstanceStore) GetAlertInstance(_ *models.GetAlertInstanceQuery) error     { return nil }
+func (f *fakeInstanceStore) ListAlertInstances(_ *models.ListAlertInstancesQuery) error { return nil }
+func (f *fakeInstanceStore) SaveAlertInstance(_ *models.SaveAlertInstanceCommand) error { return nil }
+func (f *fakeInstanceStore) FetchOrgIds() ([]int64, error)                              { return []int64{}, nil }
+func (f *fakeInstanceStore) DeleteAlertInstance(_ int64, _, _ string) error             { return nil }
+
+func newFakeAdminConfigStore(t *testing.T) *fakeAdminConfigStore {
+	t.Helper()
+	return &fakeAdminConfigStore{configs: map[int64]*models.AdminConfiguration{}}
+}
+
+type fakeAdminConfigStore struct {
+	mtx     sync.Mutex
+	configs map[int64]*models.AdminConfiguration
+}
+
+func (f *fakeAdminConfigStore) GetAdminConfiguration(orgID int64) (*models.AdminConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	return f.configs[orgID], nil
+}
+
+func (f *fakeAdminConfigStore) GetAdminConfigurations() ([]*models.AdminConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	acs := make([]*models.AdminConfiguration, 0, len(f.configs))
+	for _, ac := range f.configs {
+		acs = append(acs, ac)
+	}
+
+	return acs, nil
+}
+
+func (f *fakeAdminConfigStore) DeleteAdminConfiguration(orgID int64) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	delete(f.configs, orgID)
+	return nil
+}
+func (f *fakeAdminConfigStore) UpdateAdminConfiguration(cmd store.UpdateAdminConfigurationCmd) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.configs[cmd.AdminConfiguration.OrgID] = cmd.AdminConfiguration
+
+	return nil
+}
+
+// fakeNotifier represents a fake internal Alertmanager.
+type fakeNotifier struct{}
+
+func (n *fakeNotifier) PutAlerts(alerts apimodels.PostableAlerts) error {
+	return nil
+}
+
+type fakeExternalAlertmanager struct {
+	t      *testing.T
+	mtx    sync.Mutex
+	alerts amv2.PostableAlerts
+	server *httptest.Server
+}
+
+func newFakeExternalAlertmanager(t *testing.T) *fakeExternalAlertmanager {
+	t.Helper()
+
+	am := &fakeExternalAlertmanager{
+		t:      t,
+		alerts: amv2.PostableAlerts{},
+	}
+	am.server = httptest.NewServer(http.HandlerFunc(am.Handler()))
+
+	return am
+}
+
+func (am *fakeExternalAlertmanager) AlertNamesCompare(expected []string) bool {
+	n := []string{}
+	alerts := am.Alerts()
+
+	if len(expected) != len(alerts) {
+		return false
+	}
+
+	for _, a := range am.Alerts() {
+		for k, v := range a.Alert.Labels {
+			if k == model.AlertNameLabel {
+				n = append(n, v)
+			}
+		}
+	}
+
+	return assert.ObjectsAreEqual(expected, n)
+}
+
+func (am *fakeExternalAlertmanager) AlertsCount() int {
+	am.mtx.Lock()
+	defer am.mtx.Unlock()
+
+	return len(am.alerts)
+}
+
+func (am *fakeExternalAlertmanager) Alerts() amv2.PostableAlerts {
+	am.mtx.Lock()
+	defer am.mtx.Unlock()
+	return am.alerts
+}
+
+func (am *fakeExternalAlertmanager) Handler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b, err := ioutil.ReadAll(r.Body)
+		require.NoError(am.t, err)
+
+		a := amv2.PostableAlerts{}
+		require.NoError(am.t, json.Unmarshal(b, &a))
+
+		am.mtx.Lock()
+		am.alerts = append(am.alerts, a...)
+		am.mtx.Unlock()
+	}
+}
+
+func (am *fakeExternalAlertmanager) Close() {
+	am.server.Close()
+}

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -77,7 +77,7 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 	// Now, let's remove the Alertmanager from the admin configuration.
 	adminConfig.Alertmanagers = []string{}
 	cmd = store.UpdateAdminConfigurationCmd{AdminConfiguration: adminConfig}
-	fakeAdminConfigStore.UpdateAdminConfiguration(cmd)
+	require.NoError(t, fakeAdminConfigStore.UpdateAdminConfiguration(cmd))
 	require.NoError(t, fakeAdminConfigStore.UpdateAdminConfiguration(cmd))
 
 	// Again, make sure we sync and verify the senders.
@@ -188,8 +188,8 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond)
 
 	// Finally, remove everything.
-	fakeAdminConfigStore.DeleteAdminConfiguration(1)
-	fakeAdminConfigStore.DeleteAdminConfiguration(2)
+	require.NoError(t, fakeAdminConfigStore.DeleteAdminConfiguration(1))
+	require.NoError(t, fakeAdminConfigStore.DeleteAdminConfiguration(2))
 	require.NoError(t, sched.SyncAndApplyConfigFromDatabase())
 	sched.sendersMtx.Lock()
 	require.Equal(t, 0, len(sched.senders))

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -1,0 +1,1 @@
+package schedule

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -1,1 +1,307 @@
 package schedule
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	models2 "github.com/grafana/grafana/pkg/models"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/util"
+
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newFakeRuleStore(t *testing.T) *fakeRuleStore {
+	return &fakeRuleStore{t: t, rules: map[int64]map[string]map[string][]*models.AlertRule{}}
+}
+
+// FakeRuleStore mocks the RuleStore of the scheduler.
+type fakeRuleStore struct {
+	t     *testing.T
+	mtx   sync.Mutex
+	rules map[int64]map[string]map[string][]*models.AlertRule
+}
+
+func (f *fakeRuleStore) DeleteAlertRuleByUID(_ int64, _ string) error { return nil }
+func (f *fakeRuleStore) DeleteNamespaceAlertRules(_ int64, _ string) ([]string, error) {
+	return []string{}, nil
+}
+func (f *fakeRuleStore) DeleteRuleGroupAlertRules(_ int64, _ string, _ string) ([]string, error) {
+	return []string{}, nil
+}
+func (f *fakeRuleStore) DeleteAlertInstancesByRuleUID(_ int64, _ string) error { return nil }
+func (f *fakeRuleStore) GetAlertRuleByUID(q *models.GetAlertRuleByUIDQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	rgs, ok := f.rules[q.OrgID]
+	if !ok {
+		return nil
+	}
+
+	for _, rg := range rgs {
+		for _, rules := range rg {
+			for _, r := range rules {
+				if r.UID == q.UID {
+					q.Result = r
+					break
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// For now, we're not implementing namespace filtering.
+func (f *fakeRuleStore) GetAlertRulesForScheduling(q *models.ListAlertRulesQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	for _, rg := range f.rules {
+		for _, n := range rg {
+			for _, r := range n {
+				q.Result = append(q.Result, r...)
+			}
+		}
+	}
+
+	return nil
+}
+func (f *fakeRuleStore) GetOrgAlertRules(_ *models.ListAlertRulesQuery) error { return nil }
+func (f *fakeRuleStore) GetNamespaceAlertRules(_ *models.ListNamespaceAlertRulesQuery) error {
+	return nil
+}
+func (f *fakeRuleStore) GetRuleGroupAlertRules(q *models.ListRuleGroupAlertRulesQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	rgs, ok := f.rules[q.OrgID]
+	if !ok {
+		return nil
+	}
+
+	rg, ok := rgs[q.RuleGroup]
+	if !ok {
+		return nil
+	}
+
+	if q.NamespaceUID != "" {
+		r, ok := rg[q.NamespaceUID]
+		if !ok {
+			return nil
+		}
+		q.Result = r
+		return nil
+	}
+
+	for _, r := range rg {
+		q.Result = append(q.Result, r...)
+	}
+
+	return nil
+}
+func (f *fakeRuleStore) GetNamespaces(_ int64, _ *models2.SignedInUser) (map[string]*models2.Folder, error) {
+	return nil, nil
+}
+func (f *fakeRuleStore) GetNamespaceByTitle(_ string, _ int64, _ *models2.SignedInUser, _ bool) (*models2.Folder, error) {
+	return nil, nil
+}
+func (f *fakeRuleStore) GetOrgRuleGroups(_ *models.ListOrgRuleGroupsQuery) error { return nil }
+func (f *fakeRuleStore) UpsertAlertRules(_ []store.UpsertRule) error             { return nil }
+func (f *fakeRuleStore) UpdateRuleGroup(cmd store.UpdateRuleGroupCmd) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	rgs, ok := f.rules[cmd.OrgID]
+	if !ok {
+		f.rules[cmd.OrgID] = map[string]map[string][]*models.AlertRule{}
+	}
+
+	rg, ok := rgs[cmd.RuleGroupConfig.Name]
+	if !ok {
+		f.rules[cmd.OrgID][cmd.RuleGroupConfig.Name] = map[string][]*models.AlertRule{}
+	}
+
+	_, ok = rg[cmd.NamespaceUID]
+	if !ok {
+		f.rules[cmd.OrgID][cmd.RuleGroupConfig.Name][cmd.NamespaceUID] = []*models.AlertRule{}
+	}
+
+	rules := []*models.AlertRule{}
+	for _, r := range cmd.RuleGroupConfig.Rules {
+		//TODO: Not sure why this is not being set properly, where is the code that sets this?
+		for i := range r.GrafanaManagedAlert.Data {
+			r.GrafanaManagedAlert.Data[i].DatasourceUID = "-100"
+		}
+
+		new := &models.AlertRule{
+			OrgID:           cmd.OrgID,
+			Title:           r.GrafanaManagedAlert.Title,
+			Condition:       r.GrafanaManagedAlert.Condition,
+			Data:            r.GrafanaManagedAlert.Data,
+			UID:             util.GenerateShortUID(),
+			IntervalSeconds: int64(time.Duration(cmd.RuleGroupConfig.Interval).Seconds()),
+			NamespaceUID:    cmd.NamespaceUID,
+			RuleGroup:       cmd.RuleGroupConfig.Name,
+			NoDataState:     models.NoDataState(r.GrafanaManagedAlert.NoDataState),
+			ExecErrState:    models.ExecutionErrorState(r.GrafanaManagedAlert.ExecErrState),
+			Version:         1,
+		}
+
+		if r.ApiRuleNode != nil {
+			new.For = time.Duration(r.ApiRuleNode.For)
+			new.Annotations = r.ApiRuleNode.Annotations
+			new.Labels = r.ApiRuleNode.Labels
+		}
+
+		if new.NoDataState == "" {
+			new.NoDataState = models.NoData
+		}
+
+		if new.ExecErrState == "" {
+			new.ExecErrState = models.AlertingErrState
+		}
+
+		err := new.PreSave(time.Now)
+		require.NoError(f.t, err)
+
+		rules = append(rules, new)
+	}
+
+	f.rules[cmd.OrgID][cmd.RuleGroupConfig.Name][cmd.NamespaceUID] = rules
+	return nil
+}
+
+type fakeInstanceStore struct{}
+
+func (f *fakeInstanceStore) GetAlertInstance(_ *models.GetAlertInstanceQuery) error     { return nil }
+func (f *fakeInstanceStore) ListAlertInstances(_ *models.ListAlertInstancesQuery) error { return nil }
+func (f *fakeInstanceStore) SaveAlertInstance(_ *models.SaveAlertInstanceCommand) error { return nil }
+func (f *fakeInstanceStore) FetchOrgIds() ([]int64, error)                              { return []int64{}, nil }
+func (f *fakeInstanceStore) DeleteAlertInstance(_ int64, _, _ string) error             { return nil }
+
+func newFakeAdminConfigStore(t *testing.T) *fakeAdminConfigStore {
+	t.Helper()
+	return &fakeAdminConfigStore{configs: map[int64]*models.AdminConfiguration{}}
+}
+
+type fakeAdminConfigStore struct {
+	mtx     sync.Mutex
+	configs map[int64]*models.AdminConfiguration
+}
+
+func (f *fakeAdminConfigStore) GetAdminConfiguration(orgID int64) (*models.AdminConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	return f.configs[orgID], nil
+}
+
+func (f *fakeAdminConfigStore) GetAdminConfigurations() ([]*models.AdminConfiguration, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	acs := make([]*models.AdminConfiguration, 0, len(f.configs))
+	for _, ac := range f.configs {
+		acs = append(acs, ac)
+	}
+
+	return acs, nil
+}
+
+func (f *fakeAdminConfigStore) DeleteAdminConfiguration(orgID int64) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	delete(f.configs, orgID)
+	return nil
+}
+func (f *fakeAdminConfigStore) UpdateAdminConfiguration(cmd store.UpdateAdminConfigurationCmd) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.configs[cmd.AdminConfiguration.OrgID] = cmd.AdminConfiguration
+
+	return nil
+}
+
+// fakeNotifier represents a fake internal Alertmanager.
+type fakeNotifier struct{}
+
+func (n *fakeNotifier) PutAlerts(alerts apimodels.PostableAlerts) error {
+	return nil
+}
+
+type fakeExternalAlertmanager struct {
+	t      *testing.T
+	mtx    sync.Mutex
+	alerts amv2.PostableAlerts
+	server *httptest.Server
+}
+
+func newFakeExternalAlertmanager(t *testing.T) *fakeExternalAlertmanager {
+	t.Helper()
+
+	am := &fakeExternalAlertmanager{
+		t:      t,
+		alerts: amv2.PostableAlerts{},
+	}
+	am.server = httptest.NewServer(http.HandlerFunc(am.Handler()))
+
+	return am
+}
+
+func (am *fakeExternalAlertmanager) AlertNamesCompare(expected []string) bool {
+	n := []string{}
+	alerts := am.Alerts()
+
+	if len(expected) != len(alerts) {
+		return false
+	}
+
+	for _, a := range am.Alerts() {
+		for k, v := range a.Alert.Labels {
+			if k == model.AlertNameLabel {
+				n = append(n, v)
+			}
+		}
+	}
+
+	return assert.ObjectsAreEqual(expected, n)
+}
+
+func (am *fakeExternalAlertmanager) AlertsCount() int {
+	am.mtx.Lock()
+	defer am.mtx.Unlock()
+
+	return len(am.alerts)
+}
+
+func (am *fakeExternalAlertmanager) Alerts() amv2.PostableAlerts {
+	am.mtx.Lock()
+	defer am.mtx.Unlock()
+	return am.alerts
+}
+
+func (am *fakeExternalAlertmanager) Handler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b, err := ioutil.ReadAll(r.Body)
+		require.NoError(am.t, err)
+
+		a := amv2.PostableAlerts{}
+		require.NoError(am.t, json.Unmarshal(b, &a))
+
+		am.mtx.Lock()
+		am.alerts = append(am.alerts, a...)
+		am.mtx.Unlock()
+	}
+}
+
+func (am *fakeExternalAlertmanager) Close() {
+	am.server.Close()
+}

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -177,18 +177,14 @@ func alertToNotifierAlert(alert models.PostableAlert) *notifier.Alert {
 	ls := make(labels.Labels, 0, len(alert.Alert.Labels))
 	a := make(labels.Labels, 0, len(alert.Annotations))
 
+	// Prometheus does not allow spaces in labels or annotations while Grafana does, we need to make sure we
+	// remove them before sending the alerts.
 	for k, v := range alert.Alert.Labels {
-		ls = append(
-			ls,
-			labels.Label{Name: removeSpaces(k), Value: v},
-		)
+		ls = append(ls, labels.Label{Name: removeSpaces(k), Value: v})
 	}
 
 	for k, v := range alert.Annotations {
-		a = append(
-			a,
-			labels.Label{Name: removeSpaces(k), Value: v},
-		)
+		a = append(a, labels.Label{Name: removeSpaces(k), Value: v})
 	}
 
 	return &notifier.Alert{
@@ -200,8 +196,6 @@ func alertToNotifierAlert(alert models.PostableAlert) *notifier.Alert {
 	}
 }
 
-// Prometheus does not allow spaces in labels while Grafana does, we need to make sure we remove them before sending
-// the alerts.
 func removeSpaces(labelName string) string {
 	return strings.Join(strings.Fields(labelName), "")
 }

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -1,0 +1,207 @@
+package sender
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/logging"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+
+	gokit_log "github.com/go-kit/kit/log"
+	"github.com/prometheus/alertmanager/api/v2/models"
+	common_config "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/notifier"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+const (
+	defaultMaxQueueCapacity = 10000
+	defaultTimeout          = 10 * time.Second
+)
+
+// Sender is responsible for dispatching alert notifications to an external Alertmanager service.
+type Sender struct {
+	logger      log.Logger
+	gokitLogger gokit_log.Logger
+	wg          sync.WaitGroup
+
+	manager *notifier.Manager
+
+	sdCancel  context.CancelFunc
+	sdManager *discovery.Manager
+}
+
+func New(metrics *metrics.Metrics) (*Sender, error) {
+	l := log.New("sender")
+	sdCtx, sdCancel := context.WithCancel(context.Background())
+	s := &Sender{
+		logger:      l,
+		gokitLogger: gokit_log.NewLogfmtLogger(logging.NewWrapper(l)),
+		sdCancel:    sdCancel,
+	}
+
+	s.manager = notifier.NewManager(
+		&notifier.Options{QueueCapacity: defaultMaxQueueCapacity, Registerer: metrics.Registerer},
+		s.gokitLogger,
+	)
+
+	s.sdManager = discovery.NewManager(sdCtx, s.gokitLogger)
+
+	return s, nil
+}
+
+// ApplyConfig syncs a configuration with the sender.
+func (s *Sender) ApplyConfig(cfg *ngmodels.AdminConfiguration) error {
+	notifierCfg, err := buildNotifierConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := s.manager.ApplyConfig(notifierCfg); err != nil {
+		return err
+	}
+
+	sdCfgs := make(map[string]discovery.Configs)
+	for k, v := range notifierCfg.AlertingConfig.AlertmanagerConfigs.ToMap() {
+		sdCfgs[k] = v.ServiceDiscoveryConfigs
+	}
+
+	return s.sdManager.ApplyConfig(sdCfgs)
+}
+
+func (s *Sender) Run() {
+	s.wg.Add(2)
+
+	go func() {
+		if err := s.sdManager.Run(); err != nil {
+			s.logger.Error("failed to start the sender service discovery manager", "err", err)
+		}
+		s.wg.Done()
+	}()
+
+	go func() {
+		s.manager.Run(s.sdManager.SyncCh())
+		s.wg.Done()
+	}()
+}
+
+// SendAlerts sends a set of alerts to the configured Alertmanager(s).
+func (s *Sender) SendAlerts(alerts apimodels.PostableAlerts) {
+	if len(alerts.PostableAlerts) == 0 {
+		s.logger.Debug("no alerts to send to external Alertmanager(s)")
+		return
+	}
+	as := make([]*notifier.Alert, 0, len(alerts.PostableAlerts))
+	for _, a := range alerts.PostableAlerts {
+		na := alertToNotifierAlert(a)
+		as = append(as, na)
+	}
+
+	s.logger.Debug("sending alerts to the external Alertmanager(s)", "am_count", len(s.manager.Alertmanagers()), "alert_count", len(as))
+	s.manager.Send(as...)
+}
+
+// Stop shuts down the sender.
+func (s *Sender) Stop() {
+	s.sdCancel()
+	s.manager.Stop()
+	s.wg.Wait()
+}
+
+// Alertmanagers returns a list of the discovered Alertmanager(s).
+func (s *Sender) Alertmanagers() []*url.URL {
+	return s.manager.Alertmanagers()
+}
+
+// DroppedAlertmanagers returns a list of Alertmanager(s) we no longer send alerts to.
+func (s *Sender) DroppedAlertmanagers() []*url.URL {
+	return s.manager.DroppedAlertmanagers()
+}
+
+func buildNotifierConfig(cfg *ngmodels.AdminConfiguration) (*config.Config, error) {
+	amConfigs := make([]*config.AlertmanagerConfig, 0, len(cfg.Alertmanagers))
+	for _, amURL := range cfg.Alertmanagers {
+		u, err := url.Parse(amURL)
+		if err != nil {
+			return nil, err
+		}
+
+		sdConfig := discovery.Configs{
+			discovery.StaticConfig{
+				{
+					Targets: []model.LabelSet{{model.AddressLabel: model.LabelValue(u.Host)}},
+				},
+			},
+		}
+
+		amConfig := &config.AlertmanagerConfig{
+			APIVersion:              config.AlertmanagerAPIVersionV2,
+			Scheme:                  u.Scheme,
+			PathPrefix:              u.Path,
+			Timeout:                 model.Duration(defaultTimeout),
+			ServiceDiscoveryConfigs: sdConfig,
+		}
+
+		// Check the URL for basic authentication information first
+		if u.User != nil {
+			amConfig.HTTPClientConfig.BasicAuth = &common_config.BasicAuth{
+				Username: u.User.Username(),
+			}
+
+			if password, isSet := u.User.Password(); isSet {
+				amConfig.HTTPClientConfig.BasicAuth.Password = common_config.Secret(password)
+			}
+		}
+		amConfigs = append(amConfigs, amConfig)
+	}
+
+	notifierConfig := &config.Config{
+		AlertingConfig: config.AlertingConfig{
+			AlertmanagerConfigs: amConfigs,
+		},
+	}
+
+	return notifierConfig, nil
+}
+
+func alertToNotifierAlert(alert models.PostableAlert) *notifier.Alert {
+	ls := make(labels.Labels, 0, len(alert.Alert.Labels))
+	a := make(labels.Labels, 0, len(alert.Annotations))
+
+	for k, v := range alert.Alert.Labels {
+		ls = append(
+			ls,
+			labels.Label{Name: removeSpaces(k), Value: v},
+		)
+	}
+
+	for k, v := range alert.Annotations {
+		a = append(
+			a,
+			labels.Label{Name: removeSpaces(k), Value: v},
+		)
+	}
+
+	return &notifier.Alert{
+		Labels:       ls,
+		Annotations:  a,
+		StartsAt:     time.Time(alert.StartsAt),
+		EndsAt:       time.Time(alert.EndsAt),
+		GeneratorURL: alert.Alert.GeneratorURL.String(),
+	}
+}
+
+// Prometheus does not allow spaces in labels while Grafana does, we need to make sure we remove them before sending
+// the alerts.
+func removeSpaces(labelName string) string {
+	return strings.Join(strings.Fields(labelName), "")
+}

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/logging"
@@ -17,6 +15,7 @@ import (
 
 	gokit_log "github.com/go-kit/kit/log"
 	"github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/prometheus/client_golang/prometheus"
 	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/logging"
@@ -50,7 +52,7 @@ func New(metrics *metrics.Metrics) (*Sender, error) {
 	}
 
 	s.manager = notifier.NewManager(
-		&notifier.Options{QueueCapacity: defaultMaxQueueCapacity, Registerer: metrics.Registerer},
+		&notifier.Options{QueueCapacity: defaultMaxQueueCapacity, Registerer: prometheus.NewRegistry()},
 		s.gokitLogger,
 	)
 

--- a/pkg/services/ngalert/store/admin_configuration.go
+++ b/pkg/services/ngalert/store/admin_configuration.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	// ErrNoAlertmanagerConfiguration is an error for when no alertmanager configuration is found.
+	// ErrNoAdminConfiguration is an error for when no admin configuration is found.
 	ErrNoAdminConfiguration = fmt.Errorf("no admin configuration available")
 )
 

--- a/pkg/services/ngalert/store/admin_configuration.go
+++ b/pkg/services/ngalert/store/admin_configuration.go
@@ -22,7 +22,6 @@ type AdminConfigurationStore interface {
 	GetAdminConfigurations(query *ngmodels.GetOrgAdminConfiguration) error
 	DeleteAdminConfiguration(orgID int64) error
 	UpdateAdminConfiguration(UpdateAdminConfigurationCmd) error
-	GetOrgsWithAdminConfiguration() ([]int64, error)
 }
 
 func (st *DBstore) GetAdminConfiguration(orgID int64) (*ngmodels.AdminConfiguration, error) {
@@ -50,7 +49,7 @@ func (st *DBstore) GetAdminConfiguration(orgID int64) (*ngmodels.AdminConfigurat
 func (st DBstore) GetAdminConfigurations(q *ngmodels.GetOrgAdminConfiguration) error {
 	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		cfg := []*ngmodels.AdminConfiguration{}
-		if err := sess.Table("alert_admin_configuration").In("org_id", q.OrgIDs).Find(&cfg); err != nil {
+		if err := sess.Table("alert_admin_configuration").Find(&cfg); err != nil {
 			return nil
 		}
 
@@ -85,16 +84,4 @@ func (st DBstore) UpdateAdminConfiguration(cmd UpdateAdminConfigurationCmd) erro
 		_, err = sess.Table("alert_admin_configuration").AllCols().Update(cmd.AdminConfiguration)
 		return err
 	})
-}
-
-func (st DBstore) GetOrgsWithAdminConfiguration() ([]int64, error) {
-	orgIds := []int64{}
-	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-		if err := sess.Table("alert_admin_configuration").Distinct("org_id").Find(&orgIds); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	return orgIds, err
 }

--- a/pkg/services/ngalert/store/admin_configuration.go
+++ b/pkg/services/ngalert/store/admin_configuration.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+var (
+	// ErrNoAlertmanagerConfiguration is an error for when no alertmanager configuration is found.
+	ErrNoAdminConfiguration = fmt.Errorf("no admin configuration available")
+)
+
+type UpdateAdminConfigurationCmd struct {
+	AdminConfiguration *ngmodels.AdminConfiguration
+}
+
+type AdminConfigurationStore interface {
+	GetAdminConfiguration(orgID int64) (*ngmodels.AdminConfiguration, error)
+	GetAdminConfigurations(query *ngmodels.GetOrgAdminConfiguration) error
+	DeleteAdminConfiguration(orgID int64) error
+	UpdateAdminConfiguration(UpdateAdminConfigurationCmd) error
+	GetOrgsWithAdminConfiguration() ([]int64, error)
+}
+
+func (st *DBstore) GetAdminConfiguration(orgID int64) (*ngmodels.AdminConfiguration, error) {
+	cfg := &ngmodels.AdminConfiguration{}
+	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		ok, err := sess.Table("alert_admin_configuration").Where("org_id = ?", orgID).Limit(1).Get(cfg)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			return ErrNoAdminConfiguration
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func (st DBstore) GetAdminConfigurations(q *ngmodels.GetOrgAdminConfiguration) error {
+	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		cfg := []*ngmodels.AdminConfiguration{}
+		if err := sess.Table("alert_admin_configuration").In("org_id", q.OrgIDs).Find(&cfg); err != nil {
+			return nil
+		}
+
+		q.Result = cfg
+		return nil
+	})
+}
+
+func (st DBstore) DeleteAdminConfiguration(orgID int64) error {
+	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		_, err := sess.Exec("DELETE FROM alert_admin_configuration WHERE org_id = ?", orgID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (st DBstore) UpdateAdminConfiguration(cmd UpdateAdminConfigurationCmd) error {
+	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		has, err := sess.Table("alert_admin_configuration").Where("org_id = ?", cmd.AdminConfiguration.OrgID).Limit(1, 0).Exist()
+		if err != nil {
+			return err
+		}
+
+		if !has {
+			_, err := sess.Table("alert_admin_configuration").Insert(cmd.AdminConfiguration)
+			return err
+		}
+
+		_, err = sess.Table("alert_admin_configuration").AllCols().Update(cmd.AdminConfiguration)
+		return err
+	})
+}
+
+func (st DBstore) GetOrgsWithAdminConfiguration() ([]int64, error) {
+	orgIds := []int64{}
+	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		if err := sess.Table("alert_admin_configuration").Distinct("org_id").Find(&orgIds); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	return orgIds, err
+}

--- a/pkg/services/ngalert/store/admin_configuration.go
+++ b/pkg/services/ngalert/store/admin_configuration.go
@@ -75,7 +75,7 @@ func (st DBstore) DeleteAdminConfiguration(orgID int64) error {
 }
 
 func (st DBstore) UpdateAdminConfiguration(cmd UpdateAdminConfigurationCmd) error {
-	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	return st.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		has, err := sess.Table("ngalert_configuration").Where("org_id = ?", cmd.AdminConfiguration.OrgID).Limit(1, 0).Exist()
 		if err != nil {
 			return err

--- a/pkg/services/ngalert/store/admin_configuration.go
+++ b/pkg/services/ngalert/store/admin_configuration.go
@@ -27,7 +27,7 @@ type AdminConfigurationStore interface {
 func (st *DBstore) GetAdminConfiguration(orgID int64) (*ngmodels.AdminConfiguration, error) {
 	cfg := &ngmodels.AdminConfiguration{}
 	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-		ok, err := sess.Table("ngalert_configuration").Where("org_id = ?", orgID).Limit(1).Get(cfg)
+		ok, err := sess.Table("ngalert_configuration").Where("org_id = ?", orgID).Get(cfg)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ func (st DBstore) DeleteAdminConfiguration(orgID int64) error {
 
 func (st DBstore) UpdateAdminConfiguration(cmd UpdateAdminConfigurationCmd) error {
 	return st.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-		has, err := sess.Table("ngalert_configuration").Where("org_id = ?", cmd.AdminConfiguration.OrgID).Limit(1, 0).Exist()
+		has, err := sess.Table("ngalert_configuration").Where("org_id = ?", cmd.AdminConfiguration.OrgID).Exist()
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -285,5 +285,5 @@ func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {
 		},
 	}
 
-	mg.AddMigration("create_alert_admin_configuration_table", migrator.NewAddTableMigration(adminConfiguration))
+	mg.AddMigration("create_ngalert_configuration_table", migrator.NewAddTableMigration(adminConfiguration))
 }

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -271,7 +271,7 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 
 func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {
 	adminConfiguration := migrator.Table{
-		Name: "alert_admin_configuration",
+		Name: "ngalert_configuration",
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -19,6 +19,9 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 
 	// Create Alertmanager configurations
 	AddAlertmanagerConfigMigrations(mg)
+
+	// Create Admin Configuration
+	AddAlertAdminConfigMigrations(mg)
 }
 
 // AddAlertDefinitionMigrations should not be modified.
@@ -264,4 +267,23 @@ func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {
 
 	mg.AddMigration("alert alert_configuration alertmanager_configuration column from TEXT to MEDIUMTEXT if mysql", migrator.NewRawSQLMigration("").
 		Mysql("ALTER TABLE alert_configuration MODIFY alertmanager_configuration MEDIUMTEXT;"))
+}
+
+func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {
+	adminConfiguration := migrator.Table{
+		Name: "alert_admin_configuration",
+		Columns: []*migrator.Column{
+			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "alertmanagers", Type: migrator.DB_Text, Nullable: true},
+
+			{Name: "created_at", Type: migrator.DB_Int, Nullable: false},
+			{Name: "updated_at", Type: migrator.DB_Int, Nullable: false},
+		},
+		Indices: []*migrator.Index{
+			{Cols: []string{"org_id"}, Type: migrator.UniqueIndex},
+		},
+	}
+
+	mg.AddMigration("create_alert_admin_configuration_table", migrator.NewAddTableMigration(adminConfiguration))
 }

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -286,4 +286,5 @@ func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {
 	}
 
 	mg.AddMigration("create_ngalert_configuration_table", migrator.NewAddTableMigration(adminConfiguration))
+	mg.AddMigration("add index in ngalert_configuration on org_id column", migrator.NewAddIndexMigration(adminConfiguration, adminConfiguration.Indices[0]))
 }


### PR DESCRIPTION
Within this PR we're adding support for registering or unregistering sending to a set of external alertmanagers. A few of the things that are going are:

- Introduce a new table to hold "admin" (either org or global) the configuration we can change at runtime.
- A new periodic check that polls for this configuration and adjusts the "senders" accordingly.
- Introduces a new concept of "senders" that are responsible for shipping the alerts to the external Alertmanager(s). In a nutshell, this is the Prometheus notifier (the one in charge of sending the alert) mapped to a multi-tenant map.

There are a few code movements here and there but those are minor, I tried to keep things intact as much as possible so that we could have an easier diff.