### PR TITLE
Update "Settings Update" documentation with the information about fine-grained access control

### DIFF
--- a/docs/sources/enterprise/settings-updates.md
+++ b/docs/sources/enterprise/settings-updates.md
@@ -36,9 +36,12 @@ For example, if you provide the following `updates`:
 
 ```json
 {
-  "auth.saml": {
-    "enabled": "true",
-    "single_logout": "false"
+  "updates": {
+    "auth.saml": {
+      "enabled": "true",
+      "single_logout": "false"
+    }
+  }
 }
 ```
 it would enable SAML and disable single logouts. And, if you provide the following `removals`:
@@ -78,3 +81,8 @@ settings updates. If there are updates, it reloads the Grafana services affected
 
 The background job synchronizes settings between instances in high availability set-ups. So, after you perform some changes through the
 HTTP API, then the other instances are synchronized through the database and the background job.
+
+## Control access with fine-grained access control
+
+If you have [Fine-grained access Control]({{< relref "../enterprise/access-control/_index.md" >}}) enabled, you can control who can read or update settings. 
+Refer to the [Admin API]({{< relref "../http_api/admin.md#update-settings" >}}) for more information.

--- a/docs/sources/http_api/admin.md
+++ b/docs/sources/http_api/admin.md
@@ -184,6 +184,14 @@ Updates / removes and reloads database settings. You must provide either `update
 
 This endpoint only supports changes to `auth.saml` configuration.
 
+#### Required permissions
+
+See note in the [introduction]({{< ref "#admin-api" >}}) for an explanation.
+
+Action | Scope
+--- | --- | 
+settings:write | settings:**<br>settings:auth.saml:*<br>settings:auth.saml:enabled (property level)
+
 **Example request:**
 
 ```http


### PR DESCRIPTION
**What this PR does / why we need it**:

It is possible to control access for reading and updating settings using fine-grained access control permissions. The PR updates the documentation to reflect that change.