### PR TITLE
Devenv: Update Loki and Promtail docker block to latest

### DIFF
--- a/devenv/docker/blocks/loki/docker-compose.yaml
+++ b/devenv/docker/blocks/loki/docker-compose.yaml
@@ -1,11 +1,11 @@
   # datasource URL: http://localhost:3100/
   loki:
-    image: grafana/loki:master
+    image: grafana/loki:latest
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
   promtail:
-    image: grafana/promtail:master
+    image: grafana/promtail:latest
     volumes:
       - ./docker/blocks/loki/config.yaml:/etc/promtail/docker-config.yaml
       - /var/log:/var/log


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Loki and Promtail docker block from master tag to latest. 