### PR TITLE
Stat: Fix shared y scale range, reduce plot re-inits

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -2,7 +2,7 @@ import uPlot, { Scale, Range } from 'uplot';
 import { PlotConfigBuilder } from '../types';
 import { ScaleOrientation, ScaleDirection } from '../config';
 import { ScaleDistribution } from '../models.gen';
-import { isBooleanUnit, NumericRange } from '@grafana/data';
+import { isBooleanUnit } from '@grafana/data';
 
 export interface ScaleProps {
   scaleKey: string;
@@ -16,7 +16,6 @@ export interface ScaleProps {
   orientation: ScaleOrientation;
   direction: ScaleDirection;
   log?: number;
-  getDataMinMax?: () => NumericRange | undefined;
 }
 
 export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
@@ -63,15 +62,6 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
 
     // uPlot range function
     const rangeFn = (u: uPlot, dataMin: number, dataMax: number, scaleKey: string) => {
-      let { getDataMinMax } = this.props;
-
-      // cumulative data min/max across multiple charts, usually via VizRepeater
-      if (getDataMinMax) {
-        let dataRange = getDataMinMax()!;
-        dataMin = dataRange.min!;
-        dataMax = dataRange.max!;
-      }
-
       const scale = u.scales[scaleKey];
 
       let minMax: uPlot.Range.MinMax = [dataMin, dataMax];


### PR DESCRIPTION
this fixes a regression i caused in https://github.com/grafana/grafana/pull/36497, which would use a stale aligned DataFrame to return outdated min/max even after data updates, causing things to cut off like this:

![image](https://user-images.githubusercontent.com/43234/127432284-de33a975-3f0a-4304-bf80-11cdc9b4e62b.png)

this PR also prevents the sparkline from being re-initialized on every data update by doing a shallow compare rather than relying on referential integrity of `props.config`.

finally, it removes the extra padding that's normally added to line plots above/below the dataMin/dataMax range. now the data limits occupy the full available space.