### PR TITLE
GraphNG: make sure we update when children changes

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -97,15 +97,6 @@ export class UPlotChart extends React.Component<PlotProps, UPlotChartState> {
     this.state.ctx.plot?.destroy();
   }
 
-  shouldComponentUpdate(nextProps: PlotProps, nextState: UPlotChartState) {
-    return (
-      nextState.ctx !== this.state.ctx ||
-      !sameDims(this.props, nextProps) ||
-      !sameData(this.props, nextProps) ||
-      !sameConfig(this.props, nextProps)
-    );
-  }
-
   componentDidUpdate(prevProps: PlotProps) {
     let { ctx } = this.state;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changing the tooltip mode for a time series does not reflect the change in edit mode as described in #35266

Changing the tooltip mode changes the properties of the TooltipPlugin that is a child element to UPlotChart. However, UPlotChart overrides shouldComponentUpdate and ignores changes to the children, so the tooltip component and it's children is never re-rendered when the tooltip mode is changed.

I didn't find any really good solution to comparing the children. Need some help figuring out the performance implications of just dropping the shouldComponentUpdate. Most heavy lifting seems to be behind a different set of conditionals in componentDidUpdate.

**Which issue(s) this PR fixes**:

Fixes #35266
