### PR TITLE
Live: Display stream rate and fix duplicate channels in list response

### DIFF
--- a/pkg/services/live/managedstream/runner.go
+++ b/pkg/services/live/managedstream/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -36,13 +37,22 @@ func NewRunner(publisher models.ChannelPublisher, frameCache FrameCache) *Runner
 }
 
 func (r *Runner) GetManagedChannels(orgID int64) ([]*ManagedChannel, error) {
-	channels := make([]*ManagedChannel, 0)
-	for _, v := range r.Streams(orgID) {
-		streamChannels, err := v.ListChannels(orgID)
-		if err != nil {
-			return nil, err
+	paths, err := r.frameCache.GetActiveChannels(orgID)
+	if err != nil {
+		return []*ManagedChannel{}, fmt.Errorf("error getting active managed stream paths: %v", err)
+	}
+	channels := make([]*ManagedChannel, 0, len(paths))
+	for k, v := range paths {
+		managedChannel := &ManagedChannel{
+			Channel: k,
+			Data:    v,
 		}
-		channels = append(channels, streamChannels...)
+		channel, _ := live.ParseChannel(managedChannel.Channel)
+		namespaceStream, ok := r.streams[orgID][channel.Namespace]
+		if ok {
+			managedChannel.MinuteRate = namespaceStream.minuteRate(channel.Path)
+		}
+		channels = append(channels, managedChannel)
 	}
 
 	// Hardcode sample streams
@@ -54,16 +64,24 @@ func (r *Runner) GetManagedChannels(orgID int64) ([]*ManagedChannel, error) {
 	), data.IncludeSchemaOnly)
 	if err == nil {
 		channels = append(channels, &ManagedChannel{
-			Channel: "plugin/testdata/random-2s-stream",
-			Data:    frameJSON,
+			Channel:    "plugin/testdata/random-2s-stream",
+			Data:       frameJSON,
+			MinuteRate: 30,
 		}, &ManagedChannel{
-			Channel: "plugin/testdata/random-flakey-stream",
-			Data:    frameJSON,
+			Channel:    "plugin/testdata/random-flakey-stream",
+			Data:       frameJSON,
+			MinuteRate: 150,
 		}, &ManagedChannel{
-			Channel: "plugin/testdata/random-20Hz-stream",
-			Data:    frameJSON,
+			Channel:    "plugin/testdata/random-20Hz-stream",
+			Data:       frameJSON,
+			MinuteRate: 1200,
 		})
 	}
+
+	sort.Slice(channels, func(i, j int) bool {
+		return channels[i].Channel < channels[j].Channel
+	})
+
 	return channels, nil
 }
 
@@ -104,6 +122,13 @@ type ManagedStream struct {
 	start      time.Time
 	publisher  models.ChannelPublisher
 	frameCache FrameCache
+	rateMu     sync.RWMutex
+	rates      map[string][60]rateEntry
+}
+
+type rateEntry struct {
+	time  uint32
+	count int32
 }
 
 // NewManagedStream creates new ManagedStream.
@@ -113,30 +138,15 @@ func NewManagedStream(id string, publisher models.ChannelPublisher, schemaUpdate
 		start:      time.Now(),
 		publisher:  publisher,
 		frameCache: schemaUpdater,
+		rates:      map[string][60]rateEntry{},
 	}
 }
 
 // ManagedChannel represents a managed stream.
 type ManagedChannel struct {
-	Channel string          `json:"channel"`
-	Data    json.RawMessage `json:"data"`
-}
-
-// ListChannels returns info for the UI about this stream.
-func (s *ManagedStream) ListChannels(orgID int64) ([]*ManagedChannel, error) {
-	paths, err := s.frameCache.GetActiveChannels(orgID)
-	if err != nil {
-		return []*ManagedChannel{}, fmt.Errorf("error getting active managed stream paths: %v", err)
-	}
-	info := make([]*ManagedChannel, 0, len(paths))
-	for k, v := range paths {
-		managedChannel := &ManagedChannel{
-			Channel: k,
-			Data:    v,
-		}
-		info = append(info, managedChannel)
-	}
-	return info, nil
+	Channel    string          `json:"channel"`
+	MinuteRate int64           `json:"minute_rate"`
+	Data       json.RawMessage `json:"data"`
 }
 
 // Push sends frame to the stream and saves it for later retrieval by subscribers.
@@ -165,7 +175,41 @@ func (s *ManagedStream) Push(orgID int64, path string, frame *data.Frame) error 
 	frameJSON := jsonFrameCache.Bytes(include)
 
 	logger.Debug("Publish data to channel", "channel", channel, "dataLength", len(frameJSON))
+	s.incRate(path, time.Now().Unix())
 	return s.publisher(orgID, channel, frameJSON)
+}
+
+func (s *ManagedStream) incRate(path string, nowUnix int64) {
+	s.rateMu.Lock()
+	pathRate, ok := s.rates[path]
+	if !ok {
+		pathRate = [60]rateEntry{}
+	}
+	now := time.Unix(nowUnix, 0)
+	slot := now.Second() % 60
+	if pathRate[slot].time != uint32(nowUnix) {
+		pathRate[slot].count = 0
+	}
+	pathRate[slot].time = uint32(nowUnix)
+	pathRate[slot].count += 1
+	s.rates[path] = pathRate
+	s.rateMu.Unlock()
+}
+
+func (s *ManagedStream) minuteRate(path string) int64 {
+	var total int64
+	s.rateMu.RLock()
+	defer s.rateMu.RUnlock()
+	pathRate, ok := s.rates[path]
+	if !ok {
+		return 0
+	}
+	for _, val := range pathRate {
+		if val.time > uint32(time.Now().Unix()-60) {
+			total += int64(val.count)
+		}
+	}
+	return total
 }
 
 func (s *ManagedStream) GetHandlerForPath(_ string) (models.ChannelHandler, error) {

--- a/pkg/services/live/managedstream/runner_test.go
+++ b/pkg/services/live/managedstream/runner_test.go
@@ -2,6 +2,7 @@ package managedstream
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -20,4 +21,26 @@ func TestNewManagedStream(t *testing.T) {
 	publisher := &testPublisher{orgID: 1, t: t}
 	c := NewManagedStream("a", publisher.publish, NewMemoryFrameCache())
 	require.NotNil(t, c)
+}
+
+func TestManagedStreamMinuteRate(t *testing.T) {
+	publisher := &testPublisher{orgID: 1, t: t}
+	c := NewManagedStream("a", publisher.publish, NewMemoryFrameCache())
+	require.NotNil(t, c)
+
+	c.incRate("test1", time.Now().Unix())
+	require.Equal(t, int64(1), c.minuteRate("test1"))
+	require.Equal(t, int64(0), c.minuteRate("test2"))
+	c.incRate("test1", time.Now().Unix())
+	require.Equal(t, int64(2), c.minuteRate("test1"))
+
+	nowUnix := time.Now().Unix()
+	for i := 0; i < 1000; i++ {
+		unixTime := nowUnix + int64(i)
+		c.incRate("test3", unixTime)
+	}
+	require.Equal(t, int64(60), c.minuteRate("test3"))
+
+	c.incRate("test3", nowUnix+999)
+	require.Equal(t, int64(61), c.minuteRate("test3"))
 }

--- a/pkg/services/live/managedstream/runner_test.go
+++ b/pkg/services/live/managedstream/runner_test.go
@@ -4,28 +4,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/require"
 )
 
 type testPublisher struct {
-	orgID int64
-	t     *testing.T
+	t *testing.T
 }
 
-func (p *testPublisher) publish(orgID int64, _ string, _ []byte) error {
-	require.Equal(p.t, p.orgID, orgID)
+func (p *testPublisher) publish(_ int64, _ string, _ []byte) error {
 	return nil
 }
 
 func TestNewManagedStream(t *testing.T) {
-	publisher := &testPublisher{orgID: 1, t: t}
-	c := NewManagedStream("a", publisher.publish, NewMemoryFrameCache())
+	publisher := &testPublisher{t: t}
+	c := NewManagedStream("a", 1, publisher.publish, NewMemoryFrameCache())
 	require.NotNil(t, c)
 }
 
 func TestManagedStreamMinuteRate(t *testing.T) {
-	publisher := &testPublisher{orgID: 1, t: t}
-	c := NewManagedStream("a", publisher.publish, NewMemoryFrameCache())
+	publisher := &testPublisher{t: t}
+	c := NewManagedStream("a", 1, publisher.publish, NewMemoryFrameCache())
 	require.NotNil(t, c)
 
 	c.incRate("test1", time.Now().Unix())
@@ -43,4 +42,43 @@ func TestManagedStreamMinuteRate(t *testing.T) {
 
 	c.incRate("test3", nowUnix+999)
 	require.Equal(t, int64(61), c.minuteRate("test3"))
+}
+
+func TestGetManagedStreams(t *testing.T) {
+	publisher := &testPublisher{t: t}
+	frameCache := NewMemoryFrameCache()
+	runner := NewRunner(publisher.publish, frameCache)
+	s1, err := runner.GetOrCreateStream(1, "test1")
+	require.NoError(t, err)
+	s2, err := runner.GetOrCreateStream(1, "test2")
+	require.NoError(t, err)
+
+	managedChannels, err := runner.GetManagedChannels(1)
+	require.NoError(t, err)
+	require.Len(t, managedChannels, 3) // 3 hardcoded testdata streams.
+
+	err = s1.Push("cpu1", data.NewFrame("cpu1"))
+	require.NoError(t, err)
+
+	err = s1.Push("cpu2", data.NewFrame("cpu2"))
+	require.NoError(t, err)
+
+	err = s2.Push("cpu1", data.NewFrame("cpu1"))
+	require.NoError(t, err)
+
+	managedChannels, err = runner.GetManagedChannels(1)
+	require.NoError(t, err)
+	require.Len(t, managedChannels, 6) // 3 hardcoded testdata streams + 3 test channels.
+	require.Equal(t, "stream/test1/cpu1", managedChannels[3].Channel)
+	require.Equal(t, "stream/test1/cpu2", managedChannels[4].Channel)
+	require.Equal(t, "stream/test2/cpu1", managedChannels[5].Channel)
+
+	// Different org.
+	s3, err := runner.GetOrCreateStream(2, "test1")
+	require.NoError(t, err)
+	err = s3.Push("cpu1", data.NewFrame("cpu1"))
+	require.NoError(t, err)
+	managedChannels, err = runner.GetManagedChannels(1)
+	require.NoError(t, err)
+	require.Len(t, managedChannels, 6) // Not affected by other org.
 }

--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -87,7 +87,7 @@ func (g *Gateway) Handle(ctx *models.ReqContext) {
 	// interval = "1s" vs flush_interval = "5s"
 
 	for _, mf := range metricFrames {
-		err := stream.Push(ctx.SignedInUser.OrgId, mf.Key(), mf.Frame())
+		err := stream.Push(mf.Key(), mf.Frame())
 		if err != nil {
 			logger.Error("Error pushing frame", "error", err, "data", string(body))
 			ctx.Resp.WriteHeader(http.StatusInternalServerError)

--- a/pkg/services/live/pushws/push.go
+++ b/pkg/services/live/pushws/push.go
@@ -189,7 +189,7 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, mf := range metricFrames {
-			err := stream.Push(user.OrgId, mf.Key(), mf.Frame())
+			err := stream.Push(mf.Key(), mf.Frame())
 			if err != nil {
 				logger.Error("Error pushing frame", "error", err, "data", string(body))
 				return

--- a/pkg/services/live/survey/survey.go
+++ b/pkg/services/live/survey/survey.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/centrifugal/centrifuge"
@@ -106,6 +107,11 @@ func (c *Caller) CallManagedStreams(orgID int64) ([]*managedstream.ManagedChanne
 		}
 		for _, ch := range res.Channels {
 			if _, ok := channels[ch.Channel]; ok {
+				if strings.HasPrefix(ch.Channel, "plugin/testdata/") {
+					// Skip adding testdata rates since it works over different
+					// mechanism (plugin stream) and the minute rate is hardcoded.
+					continue
+				}
 				channels[ch.Channel].MinuteRate += ch.MinuteRate
 				continue
 			}

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -54,7 +54,7 @@ export class QueryEditor extends PureComponent<Props, State> {
               }
               return {
                 value: c.channel,
-                label: c.channel,
+                label: c.channel + ' [' + c.minute_rate + ' msg/min]',
               };
             });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a last minute window rate for streams, also added to labels in editor, but most probably requires some css. Adds some memory overhead (~5mb for 10k channels – but we obviously can't even display this in current widget). 

While implementing also fixed a bug with duplicate channels returned in list response (in case of streaming into different namespaces/streamIDs) – this is rather unpleasant thing – need to include into 8.1.0 anyway. 

Also now sort channels in list response alphabetically.