### PR TITLE
Renderer: Remove debug.log file when Grafana is stopped

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -113,6 +114,17 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 		rs.renderAction = rs.renderViaPlugin
 		rs.renderCSVAction = rs.renderCSVViaPlugin
 		<-ctx.Done()
+
+		// On Windows, Chromium is generating a debug.log file that breaks signature check on next restart
+		debugFilePath := path.Join(rs.pluginInfo.PluginDir, "chrome-win/debug.log")
+		if _, err := os.Stat(debugFilePath); err == nil {
+			err = os.Remove(debugFilePath)
+			if err != nil {
+				rs.log.Warn("Couldn't remove debug.log file, the renderer plugin will not be able to pass the signature check until this file is deleted",
+					"err", err)
+			}
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Chromium (inside the grafana-image-renderer plugin) can generate a `debug.log` file on Windows in the plugin directory that breaks the signature check when Grafana is restarted. This PR ensures that this file is deleted every time Grafana stops. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-image-renderer/issues/260

**Special notes for your reviewer**:
This is not a perfect solution but the only way I found as I couldn't find any Chromium settings to completely disable logging. (The Chromium flags `--disable-logging`, `--log-level=3` or even the env variable `CHROME_LOG_FILE=XXX` have no effect on this file)

Alternatives can be:
- Move this file in a temporary folder instead of delete it.
- _It may be related to the default Chromium flag that we use in the plugin: `--no-sandbox`. For me, removing this flag stopped the creation of the `debug.log` file but I'm unable to tell if it's because it solved the errors that were causing the file to be created or if it just stops the file to be created. However, without this flag, the plugin crashes in Docker (and I think on Linux in general) so if we want to use this solution, we'll need to find a way to have different default settings according to the OS._
  **_Note: According to [this comment](https://github.com/grafana/grafana-image-renderer/issues/260#issuecomment-879896286) saying that `"rendering_args" = --disable-gpu` didn't solve the issue, I think removing the `--no-sandbox` flag just solved my errors._**  

