### PR TITLE
Stat: always use data range, not dashboard time range for sparkline

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -118,9 +118,6 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
       range: () => {
         const { sparkline } = this.props;
         if (sparkline.x) {
-          if (sparkline.timeRange && sparkline.x.type === FieldType.time) {
-            return [sparkline.timeRange.from.valueOf(), sparkline.timeRange.to.valueOf()];
-          }
           const vals = sparkline.x.values;
           return [vals.get(0), vals.get(vals.length - 1)];
         }


### PR DESCRIPTION
when the queried time range returns less data than the full range, stat sparklines have an odd gap on the right edge. e.g. gdev stat dashboard: http://localhost:3000/d/EJ8_d9jZk/panel-tests-stat?orgId=1

i haven't seen an instance of grafana sparklines that are not meant to be edge-to-edge (like live data with empty leading space), and the only way to get edge-to-edge consistently is to use the actual result range for the x scale/axis.

not quite sure what the original reasoning was for allowing a custom sparkline range, so maybe someone can clear that up :shrug: 

![image](https://user-images.githubusercontent.com/43234/127596839-a637ebc5-19b9-468c-8492-873499dee3b1.png)

## `main` branch:

![image](https://user-images.githubusercontent.com/43234/127596630-47343bec-35a5-4e27-9214-1cc101d7fb15.png)

## This PR:

![image](https://user-images.githubusercontent.com/43234/127597296-01cb9577-20e5-4f70-96ea-16c252f5c879.png)