### PR TITLE
Variables: Fix url util converting `false` into `true`

### DIFF
--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -22,6 +22,14 @@ describe('toUrlParams', () => {
     });
     expect(url).toBe('server=:@');
   });
+
+  it('should keep booleans', () => {
+    const url = urlUtil.toUrlParams({
+      bool1: true,
+      bool2: false,
+    });
+    expect(url).toBe('bool1&bool2=false');
+  });
 });
 
 describe('parseKeyValue', () => {

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -48,7 +48,8 @@ function toUrlParams(a: any) {
     if (typeof v !== 'boolean') {
       s[s.length] = encodeURIComponentAsAngularJS(k, true) + '=' + encodeURIComponentAsAngularJS(v, true);
     } else {
-      s[s.length] = encodeURIComponentAsAngularJS(k, true);
+      const valueQueryPart = v ? '' : '=' + encodeURIComponentAsAngularJS('false', true);
+      s[s.length] = encodeURIComponentAsAngularJS(k, true) + valueQueryPart;
     }
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A value of key-value pair is stripped for boolean values. While this is ok for `true`, it kind of inverts `false`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37403

