### PR TITLE
POC/Geomap: location from label value

### DIFF
--- a/packages/grafana-data/src/field/overrides/processors.ts
+++ b/packages/grafana-data/src/field/overrides/processors.ts
@@ -160,11 +160,6 @@ export interface StatsPickerConfigSettings {
   defaultStat?: string;
 }
 
-interface FieldNamePickerInfoProps {
-  name?: string;
-  field?: Field;
-}
-
 export interface FieldNamePickerConfigSettings {
   /**
    * Function is a predicate, to test each element of the array.
@@ -176,10 +171,4 @@ export interface FieldNamePickerConfigSettings {
    * Show this text when no values are found
    */
   noFieldsMessage?: string;
-
-  /**
-   * When a field is selected, this component can show aditional
-   * information, including validation etc
-   */
-  info?: ComponentType<FieldNamePickerInfoProps> | null;
 }

--- a/packages/grafana-data/src/geo/layer.ts
+++ b/packages/grafana-data/src/geo/layer.ts
@@ -11,6 +11,7 @@ import { ReactNode } from 'react';
  */
 export enum FrameGeometrySourceMode {
   Auto = 'auto', // Will scan fields and find best match
+  Label = 'label',
   Geohash = 'geohash',
   Coords = 'coords', // lon field, lat field
   Lookup = 'lookup', // keys > location
@@ -24,6 +25,7 @@ export enum FrameGeometrySourceMode {
  */
 export interface FrameGeometrySource {
   mode: FrameGeometrySourceMode;
+  labelMode?: FrameGeometrySourceMode; // Geohash, Lookup, H3
 
   // Field mappings
   geohash?: string;
@@ -32,6 +34,7 @@ export interface FrameGeometrySource {
   h3?: string;
   wkt?: string;
   lookup?: string;
+  label?: string;
 
   // Path to Gazetteer
   gazetteer?: string;

--- a/public/app/plugins/panel/geomap/editor/FieldLabelPicker.test.ts
+++ b/public/app/plugins/panel/geomap/editor/FieldLabelPicker.test.ts
@@ -1,0 +1,42 @@
+import { toDataFrame, FieldType } from '@grafana/data';
+import { getLabelInfo } from './FieldLabelPicker';
+
+describe('get labels info', () => {
+  it('simple worldmap', () => {
+    const seriesA = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+        { name: 'value', labels: { state: 'CA' }, type: FieldType.number, values: [3, 4, 5, 6] },
+        { name: 'value', labels: { state: 'NY' }, type: FieldType.number, values: [3, 4, 5, 6] },
+      ],
+    });
+
+    const seriesB = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+        { name: 'value', labels: { state: 'CA', country: 'USA' }, type: FieldType.number, values: [3, 4, 5, 6] },
+        { name: 'value', labels: { country: 'USA' }, type: FieldType.number, values: [3, 4, 5, 6] },
+      ],
+    });
+
+    const info = getLabelInfo([seriesA, seriesB], 'zip');
+    expect(info.options).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": "CA, NY",
+          "label": "state",
+          "value": "state",
+        },
+        Object {
+          "description": "USA",
+          "label": "country",
+          "value": "country",
+        },
+        Object {
+          "label": "zip (not found)",
+          "value": "zip",
+        },
+      ]
+    `);
+  });
+});

--- a/public/app/plugins/panel/geomap/editor/FieldLabelPicker.tsx
+++ b/public/app/plugins/panel/geomap/editor/FieldLabelPicker.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from 'react';
+import { DataFrame, FieldNamePickerConfigSettings, SelectableValue, StandardEditorProps } from '@grafana/data';
+import { Select } from '@grafana/ui';
+import { OptionsPaneOptions } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
+
+export interface FieldLabelPickerConfigSettings {
+  /**
+   * Show this text when no values are found
+   */
+  noLabelsMessage?: string;
+}
+
+// Pick a field name out of the fulds
+export const FieldLabelPicker: React.FC<StandardEditorProps<string, FieldLabelPickerConfigSettings>> = ({
+  value,
+  onChange,
+  context,
+  item,
+}) => {
+  const settings: FieldLabelPickerConfigSettings = item.settings ?? {};
+  const names = useFieldDisplayNames(context.data, settings?.filter);
+  const selectOptions = useSelectOptions(names, value);
+
+  const onSelectChange = useCallback(
+    (selection: SelectableValue<string>) => {
+      if (!frameHasName(selection.value, names)) {
+        return;
+      }
+      return onChange(selection.value!);
+    },
+    [names, onChange]
+  );
+
+  const selectedOption = selectOptions.find((v) => v.value === value);
+  return (
+    <>
+      <Select
+        value={selectedOption}
+        options={selectOptions}
+        onChange={onSelectChange}
+        noOptionsMessage={settings.noFieldsMessage}
+      />
+    </>
+  );
+};
+
+function getLabelInfo(frames: DataFrame[], current?: string) {
+  const info = new Map<string, Set<string>>();
+  const options: Array<SelectableValue<string>> = [];
+  let selected: SelectableValue<string> | undefined = undefined;
+
+  for (const frame of frames) {
+    for (const field of frame.fields) {
+      if (field.labels) {
+        for (const label of Object.keys(field.labels)) {
+          let values = info.get(label);
+          if (!values) {
+            values = new Set<string>();
+            info.set(label, values);
+            const item = {
+              label,
+              value: label,
+            };
+            if (label === current) {
+              selected = item;
+            }
+            options.push(item);
+          }
+        }
+      }
+    }
+  }
+
+  const showValues = 5;
+  for (const option of options) {
+    const allValues = info.get(option.value!)!;
+    const values = new Array(allValues).slice(0);
+    option.description = values.join(', ');
+    if (allValues.size > showValues) {
+      option.description += `, (${allValues.size} values)...`;
+    }
+  }
+
+  return { options, selected, info };
+}

--- a/public/app/plugins/panel/geomap/editor/LayerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/LayerEditor.tsx
@@ -55,6 +55,7 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
               { value: FrameGeometrySourceMode.Coords, label: 'Coords' },
               { value: FrameGeometrySourceMode.Geohash, label: 'Geohash' },
               { value: FrameGeometrySourceMode.Lookup, label: 'Lookup' },
+              { value: FrameGeometrySourceMode.Label, label: 'Labels' },
             ],
           },
         })

--- a/public/app/plugins/panel/geomap/editor/LayerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/LayerEditor.tsx
@@ -15,6 +15,7 @@ import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 import { fillOptionsPaneItems } from 'app/features/dashboard/components/PanelEditor/getVizualizationOptions';
 import { GazetteerPathEditor } from './GazetteerPathEditor';
+import { FieldLabelPicker } from './FieldLabelPicker';
 
 export interface LayerEditorProps<TConfig = any> {
   options?: MapLayerOptions<TConfig>;
@@ -59,6 +60,26 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
             ],
           },
         })
+        .addCustomEditor({
+          id: 'location.label',
+          path: 'location.label',
+          name: 'Location label',
+          editor: FieldLabelPicker,
+          showIf: (opts) => opts.location?.mode === FrameGeometrySourceMode.Label,
+        })
+        .addRadio({
+          path: 'location.labelMode',
+          name: 'Label value',
+          description: '',
+          defaultValue: FrameGeometrySourceMode.Auto,
+          settings: {
+            options: [
+              { value: FrameGeometrySourceMode.Geohash, label: 'Geohash' },
+              { value: FrameGeometrySourceMode.Lookup, label: 'Lookup' },
+            ],
+          },
+          showIf: (opts) => opts.location?.mode === FrameGeometrySourceMode.Label,
+        })
         .addFieldNamePicker({
           path: 'location.latitude',
           name: 'Latitude Field',
@@ -85,8 +106,6 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
             noFieldsMessage: 'No strings fields found',
           },
           showIf: (opts) => opts.location?.mode === FrameGeometrySourceMode.Geohash,
-          // eslint-disable-next-line react/display-name
-          // info: (props) => <div>HELLO</div>,
         })
         .addFieldNamePicker({
           path: 'location.lookup',
@@ -102,7 +121,15 @@ export const LayerEditor: FC<LayerEditorProps> = ({ options, onChange, data, fil
           path: 'location.gazetteer',
           name: 'Gazetteer',
           editor: GazetteerPathEditor,
-          showIf: (opts) => opts.location?.mode === FrameGeometrySourceMode.Lookup,
+          showIf: (opts) => {
+            const mode = opts.location?.mode;
+            if (mode === FrameGeometrySourceMode.Lookup) {
+              return true;
+            }
+            return (
+              mode === FrameGeometrySourceMode.Label && opts?.location?.labelMode === FrameGeometrySourceMode.Lookup
+            );
+          },
         });
     }
     if (layer.registerOptionsUI) {


### PR DESCRIPTION
If we do not need the full history of a timeseries, we can use a transformer like: #37373 to prepare a frame where each row should become a maker.

This PR explores how we could make label a standard option as well... but not wild about  it yet :(

![Peek 2021-07-29 15-23](https://user-images.githubusercontent.com/705951/127573297-c6617939-f507-44c6-bead-cf6e624e5405.gif)

The main problem with this approach is that everything after it can not use field pickers for dimensions :thinking: 
