### PR TITLE
CloudWatch: Update Period `auto` to take retention into account

### DIFF
--- a/docs/sources/datasources/cloudwatch.md
+++ b/docs/sources/datasources/cloudwatch.md
@@ -180,7 +180,7 @@ Please note that in the case you use the expression field to reference another q
 
 A period is the length of time associated with a specific Amazon CloudWatch statistic. Periods are defined in numbers of seconds, and valid values for period are 1, 5, 10, 30, or any multiple of 60.
 
-If the period field is left blank or set to `auto`, then it calculates automatically based on the time range. The formula used is `time range in seconds / 2000`, and then it snaps to the next higher value in an array of predefined periods `[60, 300, 900, 3600, 21600, 86400]`. By clicking `Show Query Preview` in the query editor, you can see what period Grafana used.
+If the period field is left blank or set to `auto`, then it calculates automatically based on the time range and [cloudwatch's retention policy](https://aws.amazon.com/about-aws/whats-new/2016/11/cloudwatch-extends-metrics-retention-and-new-user-interface/). The formula used is `time range in seconds / 2000`, and then it snaps to the next higher value in an array of predefined periods `[60, 300, 900, 3600, 21600, 86400]` after removing periods based on retention. By clicking `Show Query Preview` in the query editor, you can see what period Grafana used.
 
 ### Deep linking from Grafana panels to the CloudWatch console
 

--- a/go.sum
+++ b/go.sum
@@ -2646,6 +2646,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.zx2c4.com/wireguard v0.0.0-20200121152719-05b03c675090/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
 golang.zx2c4.com/wireguard v0.0.20200121/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200205215550-e35592f146e4/go.mod h1:UdS9frhv65KTfwxME1xE8+rHYoFpbm36gOud1GhBe9c=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=

--- a/go.sum
+++ b/go.sum
@@ -2646,7 +2646,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.zx2c4.com/wireguard v0.0.0-20200121152719-05b03c675090/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
 golang.zx2c4.com/wireguard v0.0.20200121/go.mod h1:P2HsVp8SKwZEufsnezXZA4GRX/T49/HlU7DGuelXsU4=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200205215550-e35592f146e4/go.mod h1:UdS9frhv65KTfwxME1xE8+rHYoFpbm36gOud1GhBe9c=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -69,7 +69,7 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 	var period int
 	if strings.ToLower(p) == "auto" || p == "" {
 		deltaInSeconds := endTime.Sub(startTime).Seconds()
-		periods := []int{60, 300, 900, 3600, 21600, 86400}
+		periods := getPeriodsForRetention(time.Now().Sub(startTime))
 		datapoints := int(math.Ceil(deltaInSeconds / 2000))
 		period = periods[len(periods)-1]
 		for _, value := range periods {
@@ -121,6 +121,16 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 		ReturnData: returnData,
 		MatchExact: matchExact,
 	}, nil
+}
+
+func filterForRetention(timeSince time.Duration) []int {
+	if timeSince > time.Duration(63) * 24 * time.Hour {
+		return []int{3600, 21600, 86400}
+	} else if timeSince > time.Duration(15) * 24 * time.Hour {
+		return []int{300, 900, 3600,21600, 86400}
+	} else {
+		return []int{60, 300, 900, 3600, 21600, 86400}
+	}
 }
 
 func parseStatistics(model *simplejson.Json) []string {

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -208,5 +208,23 @@ func TestRequestParser(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, 86400, res.Period)
 		})
+
+		t.Run("Time range is 2 days, but 16 days ago", func(t *testing.T) {
+			query.Set("period", "auto")
+			to := time.Now().SubDate(0, 0, -14)
+			from := to.AddDate(0, 0, -2)
+			res, err := parseRequestQuery(query, "ref1", from, to)
+			require.NoError(t, err)
+			assert.Equal(t, 300, res.Period)
+		})
+
+		t.Run("Time range is 2 days, but 90 days ago", func(t *testing.T) {
+			query.Set("period", "auto")
+			to := time.Now().SubDate(0, 0, -88)
+			from := to.AddDate(0, 0, -2)
+			res, err := parseRequestQuery(query, "ref1", from, to)
+			require.NoError(t, err)
+			assert.Equal(t, 3600, res.Period)
+		})
 	})
 }

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -211,7 +211,7 @@ func TestRequestParser(t *testing.T) {
 
 		t.Run("Time range is 2 days, but 16 days ago", func(t *testing.T) {
 			query.Set("period", "auto")
-			to := time.Now().SubDate(0, 0, -14)
+			to := time.Now().AddDate(0, 0, -14)
 			from := to.AddDate(0, 0, -2)
 			res, err := parseRequestQuery(query, "ref1", from, to)
 			require.NoError(t, err)
@@ -220,11 +220,20 @@ func TestRequestParser(t *testing.T) {
 
 		t.Run("Time range is 2 days, but 90 days ago", func(t *testing.T) {
 			query.Set("period", "auto")
-			to := time.Now().SubDate(0, 0, -88)
+			to := time.Now().AddDate(0, 0, -88)
 			from := to.AddDate(0, 0, -2)
 			res, err := parseRequestQuery(query, "ref1", from, to)
 			require.NoError(t, err)
 			assert.Equal(t, 3600, res.Period)
+		})
+
+		t.Run("Time range is 2 days, but 456 days ago", func(t *testing.T) {
+			query.Set("period", "auto")
+			to := time.Now().AddDate(0, 0, -454)
+			from := to.AddDate(0, 0, -2)
+			res, err := parseRequestQuery(query, "ref1", from, to)
+			require.NoError(t, err)
+			assert.Equal(t, 21600, res.Period)
 		})
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the Period: `auto` selection to take Cloudwatch's retention policies into account. This allows the user to select in on a time period in the past and have the selection render correctly.

**Which issue(s) this PR fixes**: None - I was not able to find an issue reported for this problem, but I commented on the PR where this behavior was changed https://github.com/grafana/grafana/pull/21574

**Note**: I currently use v7 of grafana. If i want to apply this change to that release should I make a new PR with the changes directed to that base? 
