### PR TITLE
Alerting: Sort notification channels by name to make them easier to locate

### DIFF
--- a/pkg/services/sqlstore/alert_notification.go
+++ b/pkg/services/sqlstore/alert_notification.go
@@ -112,7 +112,7 @@ func GetAlertNotificationsWithUid(query *models.GetAlertNotificationsWithUidQuer
 
 func GetAllAlertNotifications(query *models.GetAllAlertNotificationsQuery) error {
 	results := make([]*models.AlertNotification, 0)
-	if err := x.Where("org_id = ?", query.OrgId).Find(&results); err != nil {
+	if err := x.Where("org_id = ?", query.OrgId).Asc("name").Find(&results); err != nil {
 		return err
 	}
 

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -325,6 +325,10 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 				err := GetAllAlertNotifications(query)
 				So(err, ShouldBeNil)
 				So(len(query.Result), ShouldEqual, 4)
+				So(query.Result[0].Name, ShouldEqual, cmd4.Name)
+				So(query.Result[1].Name, ShouldEqual, cmd1.Name)
+				So(query.Result[2].Name, ShouldEqual, cmd3.Name)
+				So(query.Result[3].Name, ShouldEqual, cmd2.Name)
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As the notification channel list grows, it becomes quite difficult to locate the desired channel to edit, or to select in an alert. By sorting the channel list alphabetically by name, it is easier to scan the list to locate the desired channel.

**Which issue(s) this PR fixes**:

Partially fixes #20067. The issue suggested being able to control the sort order or to filter, but this is a simple increment step in that direction with immediate benefit.

**Special notes for your reviewer**:

I'm new to this codebase so I took a "minimum modifications" approach.