### PR TITLE
Explore: Fix showing of full log context

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -22,9 +22,9 @@ interface LogRowContextProps {
 
 const getLogRowContextStyles = (theme: GrafanaTheme, wrapLogMessage?: boolean) => {
   /**
-   * This is workaround for displaying context and not hididing it when we are not wrapping log message and using
-   * overflow-x: scroll for log message. We are using margins to correctly position context. Because non-wrapped log
-   * has alwways 1 line of log and 1 line of Show/Hide context switch, correct position can be achieved by using margins.
+   * This is workaround for displaying uncropped context when we have unwrapping log messages.
+   * We are using margins to correctly position context. Because non-wrapped logs have always 1 line of log
+   * and 1 line of Show/Hide context switch. Therefore correct position can be reliably achieved by margins.
    */
 
   const afterContext = wrapLogMessage

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -52,8 +52,8 @@ const getLogRowContextStyles = (theme: GrafanaTheme, wrapLogMessage?: boolean) =
       box-shadow: 0 0 10px ${theme.colors.dropdownShadow};
       border: 1px solid ${theme.colors.bg2};
       border-radius: ${theme.border.radius.md};
-      width: ${wrapLogMessage ? 'calc(100% + 20px)' : 'unset'};
-      left: ${wrapLogMessage ? '-13px' : 'unset'};
+      width: ${wrapLogMessage ? 'calc(100% + 20px)' : 'auto'};
+      left: ${wrapLogMessage ? '-13px' : 'auto'};
     `,
     header: css`
       height: 30px;

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -52,8 +52,6 @@ const getLogRowContextStyles = (theme: GrafanaTheme, wrapLogMessage?: boolean) =
       box-shadow: 0 0 10px ${theme.colors.dropdownShadow};
       border: 1px solid ${theme.colors.bg2};
       border-radius: ${theme.border.radius.md};
-      width: ${wrapLogMessage ? 'calc(100% + 20px)' : 'auto'};
-      left: ${wrapLogMessage ? '-13px' : 'auto'};
     `,
     header: css`
       height: 30px;

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -25,6 +25,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme, wrapLogMessage?: boolean) =
    * This is workaround for displaying uncropped context when we have unwrapping log messages.
    * We are using margins to correctly position context. Because non-wrapped logs have always 1 line of log
    * and 1 line of Show/Hide context switch. Therefore correct position can be reliably achieved by margins.
+   * We also adjust width to 75%.
    */
 
   const afterContext = wrapLogMessage
@@ -33,6 +34,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme, wrapLogMessage?: boolean) =
       `
     : css`
         margin-top: -250px;
+        width: 75%;
       `;
 
   const beforeContext = wrapLogMessage
@@ -41,6 +43,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme, wrapLogMessage?: boolean) =
       `
     : css`
         margin-top: 40px;
+        width: 75%;
       `;
   return {
     commonStyles: css`
@@ -52,6 +55,7 @@ const getLogRowContextStyles = (theme: GrafanaTheme, wrapLogMessage?: boolean) =
       box-shadow: 0 0 10px ${theme.colors.dropdownShadow};
       border: 1px solid ${theme.colors.bg2};
       border-radius: ${theme.border.radius.md};
+      width: 100%;
     `,
     header: css`
       height: 30px;
@@ -144,11 +148,11 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
   };
 
   return (
-    <div className={cx(className, commonStyles)}>
+    <div className={cx(commonStyles, className)}>
       {/* When displaying "after" context */}
       {shouldScrollToBottom && !error && <LogRowContextGroupHeader {...headerProps} />}
       <div className={logs}>
-        <CustomScrollbar autoHide scrollTop={scrollTop}>
+        <CustomScrollbar autoHide scrollTop={scrollTop} autoHeightMin={'210px'}>
           <div ref={listContainerRef}>
             {!error && (
               <List

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -51,6 +51,9 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       label: verticalScroll;
       white-space: pre;
     `,
+    contextNewline: css`
+      display: block;
+    `,
   };
 });
 
@@ -124,12 +127,15 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
 
     return (
       <td className={style.logsRowMessage}>
-        <div className={cx(styles.positionRelative, { [styles.horizontalScroll]: !wrapLogMessage })}>
+        <div
+          className={cx({ [styles.positionRelative]: wrapLogMessage }, { [styles.horizontalScroll]: !wrapLogMessage })}
+        >
           {contextIsOpen && context && (
             <LogRowContext
               row={row}
               context={context}
               errors={errors}
+              wrapLogMessage={wrapLogMessage}
               hasMoreContextRows={hasMoreContextRows}
               onOutsideClick={onToggleContext}
               onLoadMoreContext={() => {
@@ -143,7 +149,10 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
             {renderLogMessage(hasAnsi, restructuredEntry, highlights, highlightClassName)}
           </span>
           {showContextToggle?.(row) && (
-            <span onClick={this.onContextToggle} className={cx('log-row-context', style.context)}>
+            <span
+              onClick={this.onContextToggle}
+              className={cx('log-row-context', style.context, { [styles.contextNewline]: !wrapLogMessage })}
+            >
               {contextIsOpen ? 'Hide' : 'Show'} context
             </span>
           )}

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -53,6 +53,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     `,
     contextNewline: css`
       display: block;
+      margin-left: 0px;
     `,
   };
 });

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -48,7 +48,6 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       font-family: ${theme.typography.fontFamily.monospace};
       font-size: ${theme.typography.size.sm};
       width: 100%;
-      overflow: hidden;
     `,
     context: css`
       label: context;

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -54,6 +54,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
       visibility: hidden;
       white-space: nowrap;
       position: relative;
+      margin-left: 10px;
     `,
     logsRow: css`
       label: logs-row;
@@ -65,7 +66,6 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme, logLevel?: Lo
         .log-row-context {
           visibility: visible;
           z-index: 1;
-          margin-left: 10px;
           text-decoration: underline;
           &:hover {
             color: ${theme.palette.yellow};

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -283,7 +283,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
       forceEscape,
     } = this.state;
 
-    const styles = getStyles(theme);
+    const styles = getStyles(theme, wrapLogMessage);
     const hasData = logRows && logRows.length > 0;
     const hasUnescapedContent = this.checkUnescapedContent(logRows);
 
@@ -420,7 +420,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
 
 export const Logs = withTheme(UnthemedLogs);
 
-const getStyles = stylesFactory((theme: GrafanaTheme) => {
+const getStyles = stylesFactory((theme: GrafanaTheme, wrapLogMessage: boolean) => {
   return {
     noData: css`
       > * {
@@ -450,7 +450,8 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       justify-content: space-between;
     `,
     logRows: css`
-      overflow-x: scroll;
+      overflow-x: ${wrapLogMessage ? 'unset' : 'scroll'};
+      overflow-y: visible;
       width: 100%;
     `,
     infoText: css`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue with cropped log context for the first and last ~10 lines. Moreover, it make "Show context" button more accessible for unwrapped logs by pushing it to second line instead of the having it at the end of the line.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/27262
Fixes https://github.com/grafana/grafana/issues/32870

**Special notes for your reviewer**:

This PR tackles 3 areas:
1.  Add `display: block` for the `Show/Hide context` button for unwrapped lines. This way, it is always visible and accessible for users. Otherwise, users would have to scroll to the end of the line to discover this button & feature.
2. For wrapped logs, we are fixing the issue with cropped log context by adding following styling below. The issue in this case was the fact, that if `overflow-x` would be always `scroll` (even for wrapped logs that are not scrolled), `overflow-y` would be always switched to `auto`, as combination of `scroll` and `visible` overflows is not possible. You can learn more here: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y#syntax 
```
      overflow-x: ${wrapLogMessage ? 'unset' : 'scroll'};
      overflow-y: visible;
```

3. For unwrapped logs, we need to set `overflow-x: scroll`. Therefore solution above won't work. This was tricky to solve and I have decided to use a solution, where we remove relative position on log line and use the relative positioning of log container, that doesn't have use `overflow: scroll` styling. And then just position log context by margins. This works nicely because non-wrapped logs have always 1 line of log and 1 line of Show/Hide context button, so the correct position can be calculated and achieved by using margins.


**Non-wrapped log lines:**
![image](https://user-images.githubusercontent.com/30407135/127837087-c8f15654-b46a-4e24-a95c-372714984415.png)


**Wrapped log lines:**
![image](https://user-images.githubusercontent.com/30407135/127836425-c53f77b5-a309-4e4d-a3d7-044e802cce95.png)

Another options that I considered and decided not to go with:
- Using Portal - with Portal, if you scroll, your context will be out of place. You could only display 1 context.
- Using javascript - We would have to do calculations for wrapped/unwrapped log lines. If we wanted to use this in LogsPanel, it could be more complicated than when we are using css.