### PR TITLE
PasswordField: Prevent a password from being displayed when you click the Enter button

### DIFF
--- a/public/app/core/components/PasswordField/PasswordField.tsx
+++ b/public/app/core/components/PasswordField/PasswordField.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 
-import { Input, IconButton } from '@grafana/ui';
+import { Input, Icon } from '@grafana/ui';
 
 export interface Props {
   autoFocus?: boolean;
@@ -25,13 +25,9 @@ export const PasswordField: FC<Props> = React.forwardRef<HTMLInputElement, Props
         aria-label={selectors.pages.Login.password}
         ref={ref}
         suffix={
-          <IconButton
+          <Icon
             name={showPassword ? 'eye-slash' : 'eye'}
-            surface="header"
-            aria-controls={id}
-            aria-expanded={showPassword}
-            onClick={(e) => {
-              e.preventDefault();
+            onClick={() => {
               setShowPassword(!showPassword);
             }}
           />

--- a/public/app/core/components/PasswordField/PasswordField.tsx
+++ b/public/app/core/components/PasswordField/PasswordField.tsx
@@ -31,7 +31,7 @@ export const PasswordField: FC<Props> = React.forwardRef<HTMLInputElement, Props
             aria-controls={id}
             aria-role="switch"
             aria-checked={showPassword}
-            aria-label="Toggle password visibility"
+            aria-label="Show password"
             onClick={() => {
               setShowPassword(!showPassword);
             }}

--- a/public/app/core/components/PasswordField/PasswordField.tsx
+++ b/public/app/core/components/PasswordField/PasswordField.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 
-import { Input, Icon } from '@grafana/ui';
+import { Input, IconButton } from '@grafana/ui';
 
 export interface Props {
   autoFocus?: boolean;
@@ -25,8 +25,13 @@ export const PasswordField: FC<Props> = React.forwardRef<HTMLInputElement, Props
         aria-label={selectors.pages.Login.password}
         ref={ref}
         suffix={
-          <Icon
+          <IconButton
             name={showPassword ? 'eye-slash' : 'eye'}
+            type="button"
+            aria-controls={id}
+            aria-role="switch"
+            aria-checked={showPassword}
+            aria-label="Toggle password visibility"
             onClick={() => {
               setShowPassword(!showPassword);
             }}


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #37443 #37302

**Special notes for your reviewer**:

The aria labels are unnecessary here, since screen readers handles password fields in their own way.
