### PR TITLE
Put back signature in drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3494,4 +3494,8 @@ get:
   path: infra/data/ci/drone
   name: machine-user-token
 
+---
+kind: signature
+hmac: 68edb93a18f2e16f8a9b2bf3d21073e181e56d2420feec37ae80b121fc2faeeb
+
 ...


### PR DESCRIPTION
Repository protection will be enabled for grafana/grafana today
I forgot to enable it and the signature was removed in a PR while I was away on vacation