### PR TITLE
InfluxDB: better query-has-variable check

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -321,6 +321,19 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
   }
 
   targetContainsTemplate(target: any) {
+    if (this.isFlux) {
+      return this.templateSrv.variableExists(target.query);
+    }
+
+    // now we know it is an InfluxQL query.
+    // it can be either a raw-query or a not-raw-query
+
+    if (target.rawQuery) {
+      return this.templateSrv.variableExists(target.query);
+    }
+
+    // now we know it is an InfluxQL not-raw-query
+
     for (const group of target.groupBy) {
       for (const param of group.params) {
         if (this.templateSrv.variableExists(param)) {


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/37238

this is about old-alerting.

when you have a dashboard panel with a query, and you switch to the "alert" tab, we check if you have template-variables in the query and if you do have, we do not allow alerting.

the check happens in the datasource's `targetContainsTemplate` method.

when an influxdb query is checked, there are 3 possible cases (note we will refer to these cases by their number a lot on the following text):
1. it is a Flux query
2. it is an InfluxQL query and it is a "raw" query, meaning the influxql-query is written manually, without the visual query editor
3. it is an InfluxQL query and it is not a "raw" query, meaning it is defined using the query-editor's widgets.

currently in `main`-branch, only the case [3] is handled correctly, for the other cases it returns "no variables" or throws an exception.

this pull-request adds code to handle the additional cases.

NOTE: this problem was there in the past too, but before grafana8.0.0 it did not produce an error. before grafana8.0.0, for cases [1] and [2] it simply answered "there are no template-variables in the query", even if there were.

how to test:
- (make sure you are in old-alerting mode)
- start with `make devenv sources=influxdb`
- in a dashboard
- add a variable
  - name `cpu`
  - type `custom`
  - value `cpu1, cpu2`
  - [save dashboard]
- add a dashboard panel
- we are testing two cases:
  - case [1] (flux query)
    - choose `gdev-influxdb-flux` as the datasource
    - add a query like this: `from(bucket: "mybucket")
  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
  |> filter(fn: (r) =>
        r._measurement == "cpu" and
        r._field == "usage_idle" and
        r.cpu == "cpu2"
  )`
    - click on the "alert tab", it should work and offer you the "create alert" button
    - now go back to the query, modify it and replace `cpu2` with `${cpu}`
    - click on the "alert tab", it should show a message saying "Template variables are not supported in alert queries", and provide no way to create an alert
  - case [2] ( influxql raw query)
    - delete the existing flux query in the panel, choose the datasource "gdev-influxdb-influxql", add a query
    - do not change anything in the visual editor, only press the pencil-icon to switch to raw-mode, and enter this query: `SELECT "usage_idle" FROM "cpu" WHERE ("cpu" = 'cpu2') AND $timeFilter` 
    - click on the "alert tab", it should work and offer you the "create alert" button
    - now go back to the query, modify it and replace `cpu2` with `${cpu}`
    - click on the "alert tab", it should show a message saying "Template variables are not supported in alert queries", and provide no way to create an alert
