### PR TITLE
Annotations: Fix **Enabled** button that disappeared from Grafana v8.0.6

### DIFF
--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
@@ -81,6 +81,9 @@ export const AnnotationSettingsEdit: React.FC<Props> = ({ editIdx, dashboard }) 
       <Field label="Data source">
         <DataSourcePicker width={50} annotations current={annotation.datasource} onChange={onDataSourceChange} />
       </Field>
+      <Field label="Enabled" description="When enabled the annotation query is issued every dashboard refresh">
+        <Checkbox name="enable" id="enable" value={annotation.enable} onChange={onChange} />
+      </Field>
       <Field
         label="Hidden"
         description="Annotation queries can be toggled on or of at the top of the dashboard. With this option checked this toggle will be hidden."


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

In this [commit]( https://github.com/grafana/grafana/pull/31950/commits/6978ccc6fccf23a3f1a02cca9c2709848bd3af2a#diff-22449a0c484754f6788c6dbadd40409bd6539180711db6e7b1c3a990d1e7bd76L83
), the "Enable" button was removed, but it seems it was an accident? I am putting back the button, but I am not sure, opening this PR for discussion.

We can add the button or update the documentation with the new functionality.

Before (v.7.5)

![AnnotationsEnabledBefore](https://user-images.githubusercontent.com/239999/127879542-022d2d72-24d6-4876-8aee-679211a0268c.png)

After (v.8.0.x)
![AnnotationsEnabledAfter](https://user-images.githubusercontent.com/239999/127879570-76943deb-9b96-401e-a86f-d4be0cdaebf6.png)


Change in this PR targeting v.8.1
![AnnotationsEnabledBack](https://user-images.githubusercontent.com/239999/127879987-e0a74dab-bf2f-4c8a-9e1c-557add251f3a.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37422

**Special notes for your reviewer**:

