### PR TITLE
Select: Expose `menuPortalTarget` on `SelectBase`

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -116,6 +116,7 @@ export function SelectBase<T>({
   minMenuHeight,
   maxVisibleValues,
   menuPlacement = 'auto',
+  menuPortalTarget = document.body,
   menuPosition,
   noOptionsMessage = 'No options found',
   onBlur,
@@ -135,7 +136,6 @@ export function SelectBase<T>({
   value,
   width,
   isValidNewOption,
-  ...selectProps
 }: SelectBaseProps<T>) {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
@@ -200,7 +200,7 @@ export function SelectBase<T>({
     maxVisibleValues,
     menuIsOpen: isOpen,
     menuPlacement,
-    menuPortalTarget: document.body,
+    menuPortalTarget,
     menuPosition,
     menuShouldBlockScroll: true,
     menuShouldScrollIntoView: false,
@@ -358,7 +358,6 @@ export function SelectBase<T>({
         {...commonSelectProps}
         {...creatableProps}
         {...asyncSelectProps}
-        {...selectProps}
       />
     </>
   );

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -135,6 +135,7 @@ export function SelectBase<T>({
   value,
   width,
   isValidNewOption,
+  ...selectProps
 }: SelectBaseProps<T>) {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
@@ -357,6 +358,7 @@ export function SelectBase<T>({
         {...commonSelectProps}
         {...creatableProps}
         {...asyncSelectProps}
+        {...selectProps}
       />
     </>
   );

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -20,6 +20,7 @@ import { useTheme2 } from '../../themes';
 import { getSelectStyles } from './getSelectStyles';
 import { cleanValue, findSelectedValue } from './utils';
 import { SelectBaseProps, SelectValue } from './types';
+import { deprecationWarning } from '@grafana/data';
 
 interface ExtraValuesIndicatorProps {
   maxVisibleValues?: number | undefined;
@@ -116,7 +117,7 @@ export function SelectBase<T>({
   minMenuHeight,
   maxVisibleValues,
   menuPlacement = 'auto',
-  menuPortalTarget = document.body,
+  menuPortalTarget,
   menuPosition,
   noOptionsMessage = 'No options found',
   onBlur,
@@ -137,6 +138,11 @@ export function SelectBase<T>({
   width,
   isValidNewOption,
 }: SelectBaseProps<T>) {
+  if (menuPortalTarget !== undefined) {
+    deprecationWarning('SelectBase', 'menuPortalTarget');
+  } else {
+    menuPortalTarget = document.body;
+  }
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
   const onChangeWithEmpty = useCallback(

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -41,6 +41,11 @@ export interface SelectCommonProps<T> {
   minMenuHeight?: number;
   maxVisibleValues?: number;
   menuPlacement?: 'auto' | 'bottom' | 'top';
+  /**
+   * @deprecated Setting `menuPortalTarget` to null will revert to previous `Select` behaviour.
+   * This is provided as an escape hatch for cases where portalling is a breaking change (e.g. `Select` wrapped in `ClickOutsideWrapper`).
+   * It's recommended to achieve the same behaviour using `onCloseMenu`, as this will be removed at some point.
+   */
   menuPortalTarget?: HTMLElement | null;
   menuPosition?: 'fixed' | 'absolute';
   /** The message to display when no options could be found */

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -70,6 +70,7 @@ export interface SelectCommonProps<T> {
     value: SelectableValue<T> | null,
     options: Readonly<Array<SelectableValue<T>>>
   ) => boolean;
+  [key: string]: any;
 }
 
 export interface SelectAsyncProps<T> {

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -41,6 +41,7 @@ export interface SelectCommonProps<T> {
   minMenuHeight?: number;
   maxVisibleValues?: number;
   menuPlacement?: 'auto' | 'bottom' | 'top';
+  menuPortalTarget?: HTMLElement | null;
   menuPosition?: 'fixed' | 'absolute';
   /** The message to display when no options could be found */
   noOptionsMessage?: string;
@@ -70,7 +71,6 @@ export interface SelectCommonProps<T> {
     value: SelectableValue<T> | null,
     options: Readonly<Array<SelectableValue<T>>>
   ) => boolean;
-  [key: string]: any;
 }
 
 export interface SelectAsyncProps<T> {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- exposes `menuPortalTarget` on `SelectBase` that is directly passed to `ReactSelect`
- this way, can revert to the old `Select` behaviour by passing `menuPortalTarget={null}`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/plugins-private/issues/566

**Special notes for your reviewer**:

