### PR TITLE
Portal: optimizations

### DIFF
--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -1,4 +1,4 @@
-﻿import React, { PropsWithChildren, useEffect, useState } from 'react';
+﻿import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useTheme2 } from '../../themes';
 
@@ -11,21 +11,21 @@ interface Props {
 export function Portal(props: PropsWithChildren<Props>) {
   const { children, className, root = document.body, forwardedRef } = props;
   const theme = useTheme2();
-  const [node] = useState(document.createElement('div'));
+  const [node] = useState(() => document.createElement('div'));
   const portalRoot = root;
 
-  if (className) {
-    node.classList.add(className);
-  }
-  node.style.position = 'relative';
-  node.style.zIndex = `${theme.zIndex.portal}`;
-
   useEffect(() => {
+    if (className) {
+      node.classList.add(className);
+    }
+    node.style.position = 'relative';
+    node.style.zIndex = `${theme.zIndex.portal}`;
+
     portalRoot.appendChild(node);
     return () => {
       portalRoot.removeChild(node);
     };
-  }, [node, portalRoot]);
+  }, [node, portalRoot, className, theme.zIndex.portal]);
 
   return ReactDOM.createPortal(<div ref={forwardedRef}>{children}</div>, node);
 }

--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -1,4 +1,4 @@
-﻿import React, { PropsWithChildren, useEffect, useState } from 'react';
+﻿import React, { PropsWithChildren, useLayoutEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { useTheme2 } from '../../themes';
 
@@ -9,25 +9,30 @@ interface Props {
 }
 
 export function Portal(props: PropsWithChildren<Props>) {
-  const { children, className, root = document.body, forwardedRef } = props;
+  const { children, className, root: portalRoot = document.body, forwardedRef } = props;
   const theme = useTheme2();
-  const [node] = useState(() => document.createElement('div'));
-  const portalRoot = root;
-
-  useEffect(() => {
+  const node = useRef<HTMLDivElement | null>(null);
+  if (!node.current) {
+    node.current = document.createElement('div');
     if (className) {
-      node.classList.add(className);
+      node.current.className = className;
     }
-    node.style.position = 'relative';
-    node.style.zIndex = `${theme.zIndex.portal}`;
+    node.current.style.position = 'relative';
+    node.current.style.zIndex = `${theme.zIndex.portal}`;
+  }
 
-    portalRoot.appendChild(node);
+  useLayoutEffect(() => {
+    if (node.current) {
+      portalRoot.appendChild(node.current);
+    }
     return () => {
-      portalRoot.removeChild(node);
+      if (node.current) {
+        portalRoot.removeChild(node.current);
+      }
     };
-  }, [node, portalRoot, className, theme.zIndex.portal]);
+  }, [portalRoot]);
 
-  return ReactDOM.createPortal(<div ref={forwardedRef}>{children}</div>, node);
+  return ReactDOM.createPortal(<div ref={forwardedRef}>{children}</div>, node.current);
 }
 
 export const RefForwardingPortal = React.forwardRef<HTMLDivElement, Props>((props, ref) => {

--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -1,4 +1,4 @@
-﻿import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+﻿import React, { PropsWithChildren, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useTheme2 } from '../../themes';
 


### PR DESCRIPTION
this showed up as the top item in a simple ~30s cursor movement profile over an empty Time series panel region (without triggering a tooltip).

**before:**

![image](https://user-images.githubusercontent.com/43234/127937078-b4e539dd-6928-4819-ad3c-b2c8452ab2ba.png)

**after:**

![image](https://user-images.githubusercontent.com/43234/127937098-e7053e8c-3ef7-4e24-8a4b-85be06d759f8.png)

please check my React-fu and sanity-check the UI locations that use `<Portal>`:

![image](https://user-images.githubusercontent.com/43234/127937302-de644747-a5ee-4ce3-8637-77e229b8ccf2.png)