### PR TITLE
GraphNG: optimize cursor

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/__snapshots__/utils.test.ts.snap
+++ b/packages/grafana-ui/src/components/GraphNG/__snapshots__/utils.test.ts.snap
@@ -118,7 +118,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "dash": Array [
         1,
@@ -138,6 +140,7 @@ Object {
       "show": true,
       "spanGaps": false,
       "stroke": "#ff0000",
+      "value": [Function],
       "width": 2,
     },
     Object {
@@ -159,6 +162,7 @@ Object {
       "show": true,
       "spanGaps": false,
       "stroke": "#ff0000",
+      "value": [Function],
       "width": 2,
     },
     Object {
@@ -180,6 +184,7 @@ Object {
       "show": true,
       "spanGaps": false,
       "stroke": "#ff0000",
+      "value": [Function],
       "width": 2,
     },
     Object {
@@ -201,6 +206,7 @@ Object {
       "show": true,
       "spanGaps": false,
       "stroke": "#ff0000",
+      "value": [Function],
       "width": 2,
     },
     Object {
@@ -222,6 +228,7 @@ Object {
       "show": true,
       "spanGaps": false,
       "stroke": "#ff0000",
+      "value": [Function],
       "width": 2,
     },
   ],

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.test.ts
@@ -40,7 +40,9 @@ describe('UPlotConfigBuilder', () => {
           "scales": Object {},
           "select": undefined,
           "series": Array [
-            Object {},
+            Object {
+              "value": [Function],
+            },
           ],
           "tzDate": [Function],
         }
@@ -104,7 +106,9 @@ describe('UPlotConfigBuilder', () => {
           },
           "select": undefined,
           "series": Array [
-            Object {},
+            Object {
+              "value": [Function],
+            },
           ],
           "tzDate": [Function],
         }
@@ -173,7 +177,9 @@ describe('UPlotConfigBuilder', () => {
             },
             "select": undefined,
             "series": Array [
-              Object {},
+              Object {
+                "value": [Function],
+              },
             ],
             "tzDate": [Function],
           }
@@ -222,7 +228,9 @@ describe('UPlotConfigBuilder', () => {
               },
               "select": undefined,
               "series": Array [
-                Object {},
+                Object {
+                  "value": [Function],
+                },
               ],
               "tzDate": [Function],
             }
@@ -272,7 +280,9 @@ describe('UPlotConfigBuilder', () => {
               },
               "select": undefined,
               "series": Array [
-                Object {},
+                Object {
+                  "value": [Function],
+                },
               ],
               "tzDate": [Function],
             }
@@ -375,7 +385,9 @@ describe('UPlotConfigBuilder', () => {
         "scales": Object {},
         "select": undefined,
         "series": Array [
-          Object {},
+          Object {
+            "value": [Function],
+          },
         ],
         "tzDate": [Function],
       }
@@ -491,7 +503,9 @@ describe('UPlotConfigBuilder', () => {
         "scales": Object {},
         "select": undefined,
         "series": Array [
-          Object {},
+          Object {
+            "value": [Function],
+          },
           Object {
             "fill": [Function],
             "paths": [Function],
@@ -506,6 +520,7 @@ describe('UPlotConfigBuilder', () => {
             "show": true,
             "spanGaps": false,
             "stroke": "#0000ff",
+            "value": [Function],
             "width": 1,
           },
         ],
@@ -601,7 +616,9 @@ describe('UPlotConfigBuilder', () => {
           "scales": Object {},
           "select": undefined,
           "series": Array [
-            Object {},
+            Object {
+              "value": [Function],
+            },
             Object {
               "fill": [Function],
               "paths": [Function],
@@ -616,6 +633,7 @@ describe('UPlotConfigBuilder', () => {
               "show": true,
               "spanGaps": false,
               "stroke": "#0000ff",
+              "value": [Function],
               "width": 1,
             },
             Object {
@@ -632,6 +650,7 @@ describe('UPlotConfigBuilder', () => {
               "show": true,
               "spanGaps": false,
               "stroke": "#00ff00",
+              "value": [Function],
               "width": 1,
             },
             Object {
@@ -648,6 +667,7 @@ describe('UPlotConfigBuilder', () => {
               "show": true,
               "spanGaps": false,
               "stroke": "#ff0000",
+              "value": [Function],
               "width": 1,
             },
           ],

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -170,7 +170,13 @@ export class UPlotConfigBuilder {
   }
 
   getConfig() {
-    const config: PlotConfig = { series: [{}] };
+    const config: PlotConfig = {
+      series: [
+        {
+          value: () => '',
+        },
+      ],
+    };
     config.axes = this.ensureNonOverlappingAxes(Object.values(this.axes)).map((a) => a.getConfig());
     config.series = [...config.series, ...this.series.map((s) => s.getConfig())];
     config.scales = this.scales.reduce((acc, s) => {

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotSeriesBuilder.ts
@@ -30,6 +30,7 @@ export interface SeriesProps extends LineConfig, BarConfig, FillConfig, PointsCo
   show?: boolean;
   dataFrameFieldIndex?: DataFrameFieldIndex;
   theme: GrafanaTheme2;
+  value?: uPlot.Series.Value;
 }
 
 export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
@@ -114,6 +115,7 @@ export class UPlotSeriesBuilder extends PlotConfigBuilder<SeriesProps, Series> {
     return {
       scale: scaleKey,
       spanGaps: typeof spanNulls === 'number' ? false : spanNulls,
+      value: () => '',
       pxAlign,
       show,
       fill: this.getFill(),

--- a/public/app/plugins/panel/barchart/__snapshots__/utils.test.ts.snap
+++ b/public/app/plugins/panel/barchart/__snapshots__/utils.test.ts.snap
@@ -103,7 +103,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -118,6 +120,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],
@@ -228,7 +231,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -243,6 +248,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],
@@ -353,7 +359,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -368,6 +376,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],
@@ -478,7 +487,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -493,6 +504,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],
@@ -603,7 +615,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -618,6 +632,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],
@@ -728,7 +743,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -743,6 +760,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],
@@ -853,7 +871,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -868,6 +888,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],
@@ -978,7 +999,9 @@ Object {
   },
   "select": undefined,
   "series": Array [
-    Object {},
+    Object {
+      "value": [Function],
+    },
     Object {
       "fill": [Function],
       "paths": [Function],
@@ -993,6 +1016,7 @@ Object {
       "show": true,
       "spanGaps": undefined,
       "stroke": "#808080",
+      "value": [Function],
       "width": 2,
     },
   ],


### PR DESCRIPTION
uPlot's `series.value` is designed and used for its native legend.

since we don't use uPlot's legend in Grafana and provide our own formatters for legend and tooltip, the default formatters simply add overhead. this PR makes them super cheap.

~30s cursor move profile over a non-tooltip Time series panel region:

**before:**

![image](https://user-images.githubusercontent.com/43234/127941588-477086de-e3d5-4592-ac6e-97fe87db4101.png)

**after:**

![image](https://user-images.githubusercontent.com/43234/127941602-70baa143-d4e0-4913-9099-cc0be4cbf11c.png)
