### PR TITLE
AnnotationEditor: simplify plugin

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
@@ -36,16 +36,16 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
   useLayoutEffect(() => {
     let annotating = false;
 
-    const setSelect = (u: uPlot) => {
+    const setSelect = (u: uPlot, left?: number) => {
       if (annotating) {
         setIsAddingAnnotation(true);
         setSelection({
-          min: u.posToVal(u.select.left, 'x'),
+          min: u.posToVal(left ?? u.select.left, 'x'),
           max: u.posToVal(u.select.left + u.select.width, 'x'),
           bbox: {
-            left: u.select.left,
+            left: left ?? u.select.left,
             top: 0,
-            height: u.select.height,
+            height: u.bbox.height / window.devicePixelRatio,
             width: u.select.width,
           },
         });
@@ -77,6 +77,15 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
         mousedown: (u, targ, handler) => (e) => {
           handler(e);
           annotating = e.button === 0 && (e.metaKey || e.ctrlKey);
+          return null;
+        },
+        // setSelect will not fire on 0-width selections, so handle single-point clicks here
+        mouseup: (u, targ, handler) => (e) => {
+          if (annotating && u.select.width === 0) {
+            setSelect(u, u.cursor.left!);
+          } else {
+            handler(e);
+          }
           return null;
         },
       },

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
@@ -31,25 +31,21 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
       plotInstance.setSelect({ top: 0, left: 0, width: 0, height: 0 });
     }
     setIsAddingAnnotation(false);
-  }, [setSelection, , setIsAddingAnnotation, plotCtx]);
+  }, [setSelection, setIsAddingAnnotation, plotCtx]);
 
   useLayoutEffect(() => {
     let annotating = false;
-    let isClick = false;
 
     const setSelect = (u: uPlot) => {
       if (annotating) {
         setIsAddingAnnotation(true);
-        const min = u.posToVal(u.select.left, 'x');
-        const max = u.posToVal(u.select.left + u.select.width, 'x');
-
         setSelection({
-          min,
-          max,
+          min: u.posToVal(u.select.left, 'x'),
+          max: u.posToVal(u.select.left + u.select.width, 'x'),
           bbox: {
             left: u.select.left,
             top: 0,
-            height: u.bbox.height / window.devicePixelRatio,
+            height: u.select.height,
             width: u.select.width,
           },
         });
@@ -61,19 +57,17 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
 
     config.addHook('init', (u) => {
       // Wrap all setSelect hooks to prevent them from firing if user is annotating
-      const setSelectHooks = u.hooks['setSelect'];
+      const setSelectHooks = u.hooks.setSelect;
+
       if (setSelectHooks) {
         for (let i = 0; i < setSelectHooks.length; i++) {
           const hook = setSelectHooks[i];
-          if (hook === setSelect) {
-            continue;
-          }
 
-          setSelectHooks[i] = (...args) => {
-            if (!annotating) {
-              hook!(...args);
-            }
-          };
+          if (hook !== setSelect) {
+            setSelectHooks[i] = (...args) => {
+              !annotating && hook!(...args);
+            };
+          }
         }
       }
     });
@@ -81,35 +75,8 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
     config.setCursor({
       bind: {
         mousedown: (u, targ, handler) => (e) => {
-          if (e.button === 0) {
-            handler(e);
-            if (e.metaKey || e.ctrlKey) {
-              isClick = true;
-              annotating = true;
-            }
-          }
-
-          return null;
-        },
-        mousemove: (u, targ, handler) => (e) => {
-          if (e.button === 0) {
-            handler(e);
-            // handle cmd+drag
-            if (e.metaKey || e.ctrlKey) {
-              isClick = false;
-              annotating = true;
-            }
-          }
-
-          return null;
-        },
-        mouseup: (u, targ, handler) => (e) => {
-          // handle cmd+click
-          if (isClick && u.cursor.left && e.button === 0 && (e.metaKey || e.ctrlKey)) {
-            u.setSelect({ left: u.cursor.left, width: 0, top: 0, height: 0 });
-            annotating = true;
-          }
           handler(e);
+          annotating = e.button === 0 && e.metaKey;
           return null;
         },
       },

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
@@ -38,12 +38,13 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
 
     const setSelect = (u: uPlot, left?: number) => {
       if (annotating) {
+        left = left ?? u.select.left;
         setIsAddingAnnotation(true);
         setSelection({
-          min: u.posToVal(left ?? u.select.left, 'x'),
-          max: u.posToVal(u.select.left + u.select.width, 'x'),
+          min: u.posToVal(left, 'x'),
+          max: u.posToVal(left + u.select.width, 'x'),
           bbox: {
-            left: left ?? u.select.left,
+            left,
             top: 0,
             height: u.bbox.height / window.devicePixelRatio,
             width: u.select.width,

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
@@ -79,15 +79,12 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
           handler(e);
           return null;
         },
-        // setSelect will not fire on 0-width selections, so handle single-point clicks here
         mouseup: (u, targ, handler) => (e) => {
+          // uPlot will not fire setSelect hooks for 0-width && 0-height selections
+          // so we force it to fire on single-point clicks by mutating left & height
           if (annotating && u.select.width === 0) {
-            u.setSelect({
-              left: u.cursor.left!,
-              top: 0,
-              width: 0,
-              height: u.bbox.height / window.devicePixelRatio,
-            });
+            u.select.left = u.cursor.left!;
+            u.select.height = u.bbox.height / window.devicePixelRatio;
           }
           handler(e);
           return null;

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
@@ -31,7 +31,7 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
       plotInstance.setSelect({ top: 0, left: 0, width: 0, height: 0 });
     }
     setIsAddingAnnotation(false);
-  }, [setSelection, setIsAddingAnnotation, plotCtx]);
+  }, [plotCtx]);
 
   useLayoutEffect(() => {
     let annotating = false;
@@ -76,12 +76,12 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
       bind: {
         mousedown: (u, targ, handler) => (e) => {
           handler(e);
-          annotating = e.button === 0 && e.metaKey;
+          annotating = e.button === 0 && (e.metaKey || e.ctrlKey);
           return null;
         },
       },
     });
-  }, [config, setIsAddingAnnotation]);
+  }, [config]);
 
   const startAnnotating = useCallback<StartAnnotatingFn>(
     ({ coords }) => {
@@ -113,7 +113,7 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
       });
       setIsAddingAnnotation(true);
     },
-    [plotCtx, setSelection, setIsAddingAnnotation]
+    [plotCtx]
   );
 
   return (

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
@@ -36,17 +36,16 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
   useLayoutEffect(() => {
     let annotating = false;
 
-    const setSelect = (u: uPlot, left?: number) => {
+    const setSelect = (u: uPlot) => {
       if (annotating) {
-        left = left ?? u.select.left;
         setIsAddingAnnotation(true);
         setSelection({
-          min: u.posToVal(left, 'x'),
-          max: u.posToVal(left + u.select.width, 'x'),
+          min: u.posToVal(u.select.left, 'x'),
+          max: u.posToVal(u.select.left + u.select.width, 'x'),
           bbox: {
-            left,
+            left: u.select.left,
             top: 0,
-            height: u.bbox.height / window.devicePixelRatio,
+            height: u.select.height,
             width: u.select.width,
           },
         });
@@ -76,17 +75,21 @@ export const AnnotationEditorPlugin: React.FC<AnnotationEditorPluginProps> = ({ 
     config.setCursor({
       bind: {
         mousedown: (u, targ, handler) => (e) => {
-          handler(e);
           annotating = e.button === 0 && (e.metaKey || e.ctrlKey);
+          handler(e);
           return null;
         },
         // setSelect will not fire on 0-width selections, so handle single-point clicks here
         mouseup: (u, targ, handler) => (e) => {
           if (annotating && u.select.width === 0) {
-            setSelect(u, u.cursor.left!);
-          } else {
-            handler(e);
+            u.setSelect({
+              left: u.cursor.left!,
+              top: 0,
+              width: 0,
+              height: u.bbox.height / window.devicePixelRatio,
+            });
           }
+          handler(e);
           return null;
         },
       },

--- a/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
@@ -108,7 +108,7 @@ export const ContextMenuPlugin: React.FC<ContextMenuPluginProps> = ({
       // TODO: remove listeners on unmount
       plotCanvas.current?.addEventListener('mouseup', (e: MouseEvent) => {
         // ignore cmd+click, this is handled by annotation editor
-        if (!isClick || e.metaKey) {
+        if (!isClick || e.metaKey || e.ctrlKey) {
           setPoint(null);
           return;
         }


### PR DESCRIPTION
some possible simplifications/optimizations to `AnnotationEditorPlugin.tsx`.

we now avoid binding `mousemove` events and rely on `u.select.width === 0` to infer `isClick` during mouseups. also removed some effect dependencies that i dont think are required anymore.

this PR now includes a `e.ctrlKey` follow-up fix for context menu that i overlooked when testing https://github.com/grafana/grafana/pull/38034.