### PR TITLE
GraphNG: Fix y-axis autosizing

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -71,7 +71,6 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       size: this.props.size ?? calculateAxisSize,
       gap,
 
-      // @ts-ignore (TODO: remove once uPlot adds this in 1.6.15)
       labelGap: 0,
 
       grid: {
@@ -94,7 +93,6 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       config.label = label;
       config.labelSize = fontSize + labelPad;
       config.labelFont = font;
-      // @ts-ignore (TODO: remove once uPlot adds this in 1.6.15)
       config.labelGap = labelPad;
     }
 
@@ -146,8 +144,7 @@ function calculateAxisSize(self: uPlot, values: string[], axisIdx: number) {
     axisSize += axis!.gap! + fontSize;
   } else if (values?.length) {
     let longestValue = values.reduce((acc, value) => (value.length > acc.length ? value : acc), '');
-    // @ts-ignore (TODO: remove axis!.labelGap! once uPlot adds this in 1.6.15)
-    axisSize += axis!.gap! + axis!.labelGap! + measureText(longestValue, fontSize).width;
+    axisSize += axis!.gap! + axis!.labelGap! + measureText('0'.repeat(longestValue.length), fontSize).width;
   }
 
   return Math.ceil(axisSize);


### PR DESCRIPTION
Fixes #37347

as before, we find the longest tick label by character count, but now instead of measuring that label, we measure the equivalent of `0` repeated that many chars. so values like `-111` are measured as `0000` to account for the case when there are also values like `8000`. a side effect of this updated strategy is that we'll overshoot things like `-0.11` by assuming a significantly wider `00000` and end up with some extra axis padding.

this fix is still a compromise that avoids re-measuring every tick label (quite expensive in 50ms streaming update scenarios).