### PR TITLE
DataSources: Azure Monitor, enable to query AppInsights()

### DIFF
--- a/docs/sources/datasources/azuremonitor/template-variables.md
+++ b/docs/sources/datasources/azuremonitor/template-variables.md
@@ -14,21 +14,23 @@ types of template variables.
 
 The Azure Monitor data source provides the following queries you can specify in the Query field in the Variable edit view
 
-| Name                                                                               | Description                                                                                            |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `Subscriptions()`                                                                  | Returns subscriptions.                                                                                 |
-| `ResourceGroups()`                                                                 | Returns resource groups.                                                                               |
-| `ResourceGroups(subscriptionID)`                                                   | Returns resource groups for a specified subscription.                                                  |
-| `Namespaces(aResourceGroup)`                                                       | Returns namespaces for the default subscription and specified resource group.                          |
-| `Namespaces(subscriptionID, aResourceGroup)`                                       | Returns namespaces for the specified subscription and resource group.                                  |
-| `ResourceNames(aResourceGroup, aNamespace)`                                        | Returns a list of resource names.                                                                      |
-| `ResourceNames(subscriptionID, aResourceGroup, aNamespace)`                        | Returns a list of resource names for a specified subscription.                                         |
-| `MetricNamespace(aResourceGroup, aNamespace, aResourceName)`                       | Returns a list of metric namespaces.                                                                   |
-| `MetricNamespace(subscriptionID, aResourceGroup, aNamespace, aResourceName)`       | Returns a list of metric namespaces for a specified subscription.                                      |
-| `MetricNames(aResourceGroup, aMetricDefinition, aResourceName, aMetricNamespace)`  | Returns a list of metric names.                                                                        |
-| `MetricNames(aSubscriptionID, aMetricDefinition, aResourceName, aMetricNamespace)` | Returns a list of metric names for a specified subscription.                                           |
-| `workspaces()`                                                                     | Returns a list of workspaces for the default subscription.                                             |
-| `workspaces(subscriptionID)`                                                       | Returns a list of workspaces for the specified subscription (the parameter can be quoted or unquoted). |
+| Name                                                                               | Description                                                                                                      |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `Subscriptions()`                                                                  | Returns subscriptions.                                                                                           |
+| `ResourceGroups()`                                                                 | Returns resource groups.                                                                                         |
+| `ResourceGroups(subscriptionID)`                                                   | Returns resource groups for a specified subscription.                                                            |
+| `Namespaces(aResourceGroup)`                                                       | Returns namespaces for the default subscription and specified resource group.                                    |
+| `Namespaces(subscriptionID, aResourceGroup)`                                       | Returns namespaces for the specified subscription and resource group.                                            |
+| `ResourceNames(aResourceGroup, aNamespace)`                                        | Returns a list of resource names.                                                                                |
+| `ResourceNames(subscriptionID, aResourceGroup, aNamespace)`                        | Returns a list of resource names for a specified subscription.                                                   |
+| `MetricNamespace(aResourceGroup, aNamespace, aResourceName)`                       | Returns a list of metric namespaces.                                                                             |
+| `MetricNamespace(subscriptionID, aResourceGroup, aNamespace, aResourceName)`       | Returns a list of metric namespaces for a specified subscription.                                                |
+| `MetricNames(aResourceGroup, aMetricDefinition, aResourceName, aMetricNamespace)`  | Returns a list of metric names.                                                                                  |
+| `MetricNames(aSubscriptionID, aMetricDefinition, aResourceName, aMetricNamespace)` | Returns a list of metric names for a specified subscription.                                                     |
+| `workspaces()`                                                                     | Returns a list of workspaces for the default subscription.                                                       |
+| `workspaces(subscriptionID)`                                                       | Returns a list of workspaces for the specified subscription (the parameter can be quoted or unquoted).           |
+| `AppInsights()`                                                                    | Returns a list of Application Insights for the default subscription.                                             |
+| `AppInsights(subscriptionID)`                                                      | Returns a list of Application Insights for the specified subscription (the parameter can be quoted or unquoted). |
 
 Where a subscription ID is not specified, a default subscription must be specified in the data source configuration, which will be used.
 

--- a/docs/sources/datasources/azuremonitor/template-variables.md
+++ b/docs/sources/datasources/azuremonitor/template-variables.md
@@ -30,7 +30,7 @@ The Azure Monitor data source provides the following queries you can specify in 
 | `workspaces()`                                                                     | Returns a list of workspaces for the default subscription.                                                       |
 | `workspaces(subscriptionID)`                                                       | Returns a list of workspaces for the specified subscription (the parameter can be quoted or unquoted).           |
 | `AppInsights()`                                                                    | Returns a list of Application Insights for the default subscription.                                             |
-| `AppInsights(subscriptionID)`                                                      | Returns a list of Application Insights for the specified subscription (the parameter can be quoted or unquoted). |
+| `AppInsights(subscriptionID)`                                                      | Returns a list of Application Insights for the specified subscription (the parameter can be within quotes or without). |
 
 Where a subscription ID is not specified, a default subscription must be specified in the data source configuration, which will be used.
 

--- a/docs/sources/datasources/azuremonitor/template-variables.md
+++ b/docs/sources/datasources/azuremonitor/template-variables.md
@@ -18,7 +18,7 @@ The Azure Monitor data source provides the following queries you can specify in 
 | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `Subscriptions()`                                                                  | Returns subscriptions.                                                                                           |
 | `ResourceGroups()`                                                                 | Returns resource groups.                                                                                         |
-| `ResourceGroups(subscriptionID)`                                                   | Returns resource groups for a specified subscription.                                                            |
+| `ResourceGroups(subscriptionID)`                                                   | Returns resource groups for the specified subscription.                                                            |
 | `Namespaces(aResourceGroup)`                                                       | Returns namespaces for the default subscription and specified resource group.                                    |
 | `Namespaces(subscriptionID, aResourceGroup)`                                       | Returns namespaces for the specified subscription and resource group.                                            |
 | `ResourceNames(aResourceGroup, aNamespace)`                                        | Returns a list of resource names.                                                                                |


### PR DESCRIPTION
**What this PR does / why we need it**:
The possibility to fetch available AppInsights, similar to (Log Analytics) "workspaces()", so that it hopefully can be used as a variable in "resource" in a panel query using "Azure Monitor Logs":
https://github.com/grafana/grafana/issues/34622#issuecomment-889780279

**Which issue(s) this PR fixes**:
Maybe it helps with #34622

**Special notes for your reviewer**:
I have no clue how to add the tests, I basically just "copy & pasted" the corresponding "workspaces()" code and adapted adequately. Sadly the build fails with the following (I have no experience in using Go):

``` console
Version: 8.1.0-pre, Linux Version: 8.1.0, Package Iteration: 1627984525pre
go build -ldflags -w -X main.version=8.1.0-pre -X main.commit=28a115cb96 -X main.buildstamp=1627984130 -X main.buildBranch=azure-monitor-query-appinsights -o ./bin/grafana-cli ./pkg/cmd/grafana-cli
build github.com/grafana/grafana/pkg/cmd/grafana-cli: cannot load embed: malformed module path "embed": missing dot in first path element
exit status 1
exit status 1
[Bra] 08-03 11:55:26 [ WARN] Fail to execute command: go [run build.go -dev build-cli] - exit status 1
```

Therefore I open this as a draft PR and hope to get some feedback :)