### PR TITLE
InfluxDB: check for flux/not-flux situation

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -181,10 +181,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     return true;
   }
 
-  /**
-   * Only applied on flux queries
-   */
   applyTemplateVariables(query: InfluxQuery, scopedVars: ScopedVars): Record<string, any> {
+    // this only works in flux-mode, it should not be called in non-flux-mode
+    if (!this.isFlux) {
+      throw new Error('applyTemplateVariables called in influxql-mode. this should never happen');
+    }
+
     return {
       ...query,
       query: this.templateSrv.replace(query.query ?? '', scopedVars), // The raw query text


### PR DESCRIPTION
in influxdb,in "datasource.ts" the method `applyTemplateVariables` can only be called in flux-mode. it does not work in influxql-mode.

i added a specific check for this case in the code, to make sure it will not be called accidentally (and then silently doing the wrong thing).