### PR TITLE
Alerting: Add a Test button to test contact point

### DIFF
--- a/packages/grafana-ui/src/types/icon.ts
+++ b/packages/grafana-ui/src/types/icon.ts
@@ -100,6 +100,7 @@ export const getAvailableIcons = () =>
     'list-ui-alt',
     'list-ul',
     'lock',
+    'message',
     'minus',
     'minus-circle',
     'mobile-android',

--- a/pkg/services/ngalert/notifier/receivers.go
+++ b/pkg/services/ngalert/notifier/receivers.go
@@ -63,12 +63,11 @@ func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 	testAlert := &types.Alert{
 		Alert: model.Alert{
 			Labels: model.LabelSet{
-				model.LabelName("alertname"): "TestAlertAlwaysFiring",
+				model.LabelName("alertname"): "TestAlert",
 				model.LabelName("instance"):  "Grafana",
 			},
 			Annotations: model.LabelSet{
-				model.LabelName("summary"):     "TestAlertAlwaysFiring",
-				model.LabelName("description"): "This is a test alert from Grafana",
+				model.LabelName("summary"): "Notification test",
 			},
 			StartsAt: now,
 		},

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -4,10 +4,10 @@ import { Router } from 'react-router-dom';
 import Receivers from './Receivers';
 import React from 'react';
 import { locationService, setDataSourceSrv } from '@grafana/runtime';
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { getAllDataSources } from './utils/config';
 import { typeAsJestMock } from 'test/helpers/typeAsJestMock';
-import { updateAlertManagerConfig, fetchAlertManagerConfig, fetchStatus } from './api/alertmanager';
+import { updateAlertManagerConfig, fetchAlertManagerConfig, fetchStatus, testReceivers } from './api/alertmanager';
 import {
   mockDataSource,
   MockDataSourceSrv,
@@ -37,6 +37,7 @@ const mocks = {
     fetchStatus: typeAsJestMock(fetchStatus),
     updateConfig: typeAsJestMock(updateAlertManagerConfig),
     fetchNotifiers: typeAsJestMock(fetchNotifiers),
+    testReceivers: typeAsJestMock(testReceivers),
   },
 };
 
@@ -68,6 +69,7 @@ const ui = {
   newContactPointButton: byRole('link', { name: /new contact point/i }),
   saveContactButton: byRole('button', { name: /save contact point/i }),
   newContactPointTypeButton: byRole('button', { name: /new contact point type/i }),
+  testContactPointButton: byRole('button', { name: /Test contact point/ }),
 
   receiversTable: byTestId('receivers-table'),
   templatesTable: byTestId('templates-table'),
@@ -78,7 +80,7 @@ const ui = {
   inputs: {
     name: byLabelText('Name'),
     email: {
-      addresses: byLabelText('Addresses'),
+      addresses: byLabelText(/Addresses/),
     },
     hipchat: {
       url: byLabelText('Hip Chat Url'),
@@ -149,6 +151,46 @@ describe('Receivers', () => {
     expect(locationService.getSearchObject()[ALERTMANAGER_NAME_QUERY_KEY]).toEqual('CloudManager');
   });
 
+  it('Grafana receiver can be tested', async () => {
+    mocks.api.fetchConfig.mockResolvedValue(someGrafanaAlertManagerConfig);
+
+    await renderReceivers();
+
+    // go to new contact point page
+    userEvent.click(await ui.newContactPointButton.find());
+
+    await byRole('heading', { name: /create contact point/i }).find();
+    expect(locationService.getLocation().pathname).toEqual('/alerting/notifications/receivers/new');
+
+    // type in a name for the new receiver
+    await userEvent.type(ui.inputs.name.get(), 'my new receiver');
+
+    // enter some email
+    const email = ui.inputs.email.addresses.get();
+    userEvent.clear(email);
+    await userEvent.type(email, 'tester@grafana.com');
+
+    // try to test the contact point
+    userEvent.click(ui.testContactPointButton.get());
+
+    await waitFor(() => expect(mocks.api.testReceivers).toHaveBeenCalled());
+
+    expect(mocks.api.testReceivers).toHaveBeenCalledWith('grafana', [
+      {
+        grafana_managed_receiver_configs: [
+          {
+            disableResolveMessage: false,
+            name: 'test',
+            secureSettings: {},
+            settings: { addresses: 'tester@grafana.com', singleEmail: false },
+            type: 'email',
+          },
+        ],
+        name: 'test',
+      },
+    ]);
+  });
+
   it('Grafana receiver can be created', async () => {
     mocks.api.fetchConfig.mockResolvedValue(someGrafanaAlertManagerConfig);
     mocks.api.updateConfig.mockResolvedValue();
@@ -164,7 +206,7 @@ describe('Receivers', () => {
     await userEvent.type(byLabelText('Name').get(), 'my new receiver');
 
     // check that default email form is rendered
-    await ui.inputs.name.find();
+    await ui.inputs.email.addresses.find();
 
     // select hipchat
     await clickSelectOption(byTestId('items.0.type').get(), 'HipChat');

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -69,7 +69,7 @@ const ui = {
   newContactPointButton: byRole('link', { name: /new contact point/i }),
   saveContactButton: byRole('button', { name: /save contact point/i }),
   newContactPointTypeButton: byRole('button', { name: /new contact point type/i }),
-  testContactPointButton: byRole('button', { name: /Test contact point/ }),
+  testContactPointButton: byRole('button', { name: /Test/ }),
 
   receiversTable: byTestId('receivers-table'),
   templatesTable: byTestId('templates-table'),

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -8,6 +8,8 @@ import {
   SilenceCreatePayload,
   Matcher,
   AlertmanagerStatus,
+  Receiver,
+  TestReceiversPayload,
 } from 'app/plugins/datasource/alertmanager/types';
 import { getDatasourceAPIId, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 
@@ -153,6 +155,21 @@ export async function fetchStatus(alertManagerSourceName: string): Promise<Alert
     .toPromise();
 
   return result.data;
+}
+
+export async function testReceivers(alertManagerSourceName: string, receivers: Receiver[]): Promise<void> {
+  const data: TestReceiversPayload = {
+    receivers,
+  };
+  await getBackendSrv()
+    .fetch<void>({
+      method: 'POST',
+      data,
+      url: `/api/alertmanager/${getDatasourceAPIId(alertManagerSourceName)}/config/api/v1/receivers/test`,
+      showErrorAlert: false,
+      showSuccessAlert: false,
+    })
+    .toPromise();
 }
 
 function escapeQuotes(value: string): string {

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -7,12 +7,14 @@ import { useFormContext, FieldErrors } from 'react-hook-form';
 import { ChannelValues, CommonSettingsComponentType } from '../../../types/receiver-form';
 import { ChannelOptions } from './ChannelOptions';
 import { CollapsibleSection } from './CollapsibleSection';
+import { useUnifiedAlertingSelector } from '../../../hooks/useUnifiedAlertingSelector';
 
 interface Props<R> {
   defaultValues: R;
   pathPrefix: string;
   notifiers: NotifierDTO[];
   onDuplicate: () => void;
+  onTest?: () => void;
   commonSettingsComponent: CommonSettingsComponentType;
 
   secureFields?: Record<string, boolean>;
@@ -25,6 +27,7 @@ export function ChannelSubForm<R extends ChannelValues>({
   pathPrefix,
   onDuplicate,
   onDelete,
+  onTest,
   notifiers,
   errors,
   secureFields,
@@ -34,6 +37,7 @@ export function ChannelSubForm<R extends ChannelValues>({
   const name = (fieldName: string) => `${pathPrefix}${fieldName}`;
   const { control, watch, register } = useFormContext();
   const selectedType = watch(name('type')) ?? defaultValues.type; // nope, setting "default" does not work at all.
+  const { loading: testingReceiver } = useUnifiedAlertingSelector((state) => state.testReceivers);
 
   useEffect(() => {
     register(`${pathPrefix}.__id`);
@@ -89,6 +93,18 @@ export function ChannelSubForm<R extends ChannelValues>({
           </Field>
         </div>
         <div className={styles.buttons}>
+          {onTest && (
+            <Button
+              disabled={testingReceiver}
+              size="xs"
+              variant="secondary"
+              type="button"
+              onClick={() => onTest()}
+              icon={testingReceiver ? 'fa fa-spinner' : 'message'}
+            >
+              Test contact point
+            </Button>
+          )}
           <Button size="xs" variant="secondary" type="button" onClick={() => onDuplicate()} icon="copy">
             Duplicate
           </Button>

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -102,7 +102,7 @@ export function ChannelSubForm<R extends ChannelValues>({
               onClick={() => onTest()}
               icon={testingReceiver ? 'fa fa-spinner' : 'message'}
             >
-              Test contact point
+              Test
             </Button>
           )}
           <Button size="xs" variant="secondary" type="button" onClick={() => onDuplicate()} icon="copy">

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -7,10 +7,15 @@ import {
 import React, { FC, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useUnifiedAlertingSelector } from '../../../hooks/useUnifiedAlertingSelector';
-import { fetchGrafanaNotifiersAction, updateAlertManagerConfigAction } from '../../../state/actions';
+import {
+  fetchGrafanaNotifiersAction,
+  testReceiversAction,
+  updateAlertManagerConfigAction,
+} from '../../../state/actions';
 import { GrafanaChannelValues, ReceiverFormValues } from '../../../types/receiver-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 import {
+  formChannelValuesToGrafanaChannelConfig,
   formValuesToGrafanaReceiver,
   grafanaReceiverToFormValues,
   updateConfigWithReceiver,
@@ -68,6 +73,22 @@ export const GrafanaReceiverForm: FC<Props> = ({ existing, alertManagerSourceNam
     );
   };
 
+  const onTestChannel = (values: GrafanaChannelValues) => {
+    const existing: GrafanaManagedReceiverConfig | undefined = id2original[values.__id];
+    const chan = formChannelValuesToGrafanaChannelConfig(values, defaultChannelValues, 'test', existing);
+    dispatch(
+      testReceiversAction({
+        alertManagerSourceName,
+        receivers: [
+          {
+            name: 'test',
+            grafana_managed_receiver_configs: [chan],
+          },
+        ],
+      })
+    );
+  };
+
   const takenReceiverNames = useMemo(
     () => config.alertmanager_config.receivers?.map(({ name }) => name).filter((name) => name !== existing?.name) ?? [],
     [config, existing]
@@ -79,6 +100,7 @@ export const GrafanaReceiverForm: FC<Props> = ({ existing, alertManagerSourceNam
         config={config}
         onSubmit={onSubmit}
         initialValues={existingValue}
+        onTestChannel={onTestChannel}
         notifiers={grafanaNotifiers.result}
         alertManagerSourceName={alertManagerSourceName}
         defaultItem={defaultChannelValues}

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -19,6 +19,7 @@ interface Props<R extends ChannelValues> {
   notifiers: NotifierDTO[];
   defaultItem: R;
   alertManagerSourceName: string;
+  onTestChannel?: (channel: R) => void;
   onSubmit: (values: ReceiverFormValues<R>) => void;
   takenReceiverNames: string[]; // will validate that user entered receiver name is not one of these
   commonSettingsComponent: CommonSettingsComponentType;
@@ -32,6 +33,7 @@ export function ReceiverForm<R extends ChannelValues>({
   notifiers,
   alertManagerSourceName,
   onSubmit,
+  onTestChannel,
   takenReceiverNames,
   commonSettingsComponent,
 }: Props<R>): JSX.Element {
@@ -117,6 +119,14 @@ export function ReceiverForm<R extends ChannelValues>({
                 const currentValues: R = getValues().items[index];
                 append({ ...currentValues, __id: String(Math.random()) });
               }}
+              onTest={
+                onTestChannel
+                  ? () => {
+                      const currentValues: R = getValues().items[index];
+                      onTestChannel(currentValues);
+                    }
+                  : undefined
+              }
               onDelete={() => remove(index)}
               pathPrefix={pathPrefix}
               notifiers={notifiers}

--- a/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
@@ -75,7 +75,13 @@ export function RuleListErrors(): ReactElement {
             <>
               <div>{errors[0]}</div>
               {errors.length >= 2 && (
-                <Button className={styles.moreButton} variant="link" size="sm" onClick={() => setExpanded(true)}>
+                <Button
+                  className={styles.moreButton}
+                  variant="link"
+                  icon="angle-right"
+                  size="sm"
+                  onClick={() => setExpanded(true)}
+                >
                   {errors.length - 1} more {pluralize('error', errors.length - 1)}
                 </Button>
               )}

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -4,6 +4,7 @@ import {
   AlertmanagerAlert,
   AlertManagerCortexConfig,
   AlertmanagerGroup,
+  Receiver,
   Silence,
   SilenceCreatePayload,
 } from 'app/plugins/datasource/alertmanager/types';
@@ -26,6 +27,7 @@ import {
   updateAlertManagerConfig,
   fetchStatus,
   deleteAlertManagerConfig,
+  testReceivers,
 } from '../api/alertmanager';
 import { fetchRules } from '../api/prometheus';
 import {
@@ -602,5 +604,20 @@ export const deleteAlertManagerConfigAction = createAsyncThunk(
         successMessage: 'Alertmanager configuration reset.',
       }
     );
+  }
+);
+
+interface TestReceiversOptions {
+  alertManagerSourceName: string;
+  receivers: Receiver[];
+}
+
+export const testReceiversAction = createAsyncThunk(
+  'unifiedalerting/testReceivers',
+  ({ alertManagerSourceName, receivers }: TestReceiversOptions): Promise<void> => {
+    return withAppEvents(withSerializedError(testReceivers(alertManagerSourceName, receivers)), {
+      errorMessage: 'Failed to send test alert.',
+      successMessage: 'Test alert sent.',
+    });
   }
 );

--- a/public/app/features/alerting/unified/state/reducers.ts
+++ b/public/app/features/alerting/unified/state/reducers.ts
@@ -15,6 +15,7 @@ import {
   fetchAlertGroupsAction,
   checkIfLotexSupportsEditingRulesAction,
   deleteAlertManagerConfigAction,
+  testReceiversAction,
 } from './actions';
 
 export const reducer = combineReducers({
@@ -48,6 +49,7 @@ export const reducer = combineReducers({
     checkIfLotexSupportsEditingRulesAction,
     (source) => source
   ).reducer,
+  testReceivers: createAsyncSlice('testReceivers', testReceiversAction).reducer,
 });
 
 export type UnifiedAlertingState = ReturnType<typeof reducer>;

--- a/public/app/features/alerting/unified/utils/receiver-form.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.ts
@@ -207,7 +207,7 @@ function grafanaChannelConfigToFormChannelValues(
   return values;
 }
 
-function formChannelValuesToGrafanaChannelConfig(
+export function formChannelValuesToGrafanaChannelConfig(
   values: GrafanaChannelValues,
   defaults: GrafanaChannelValues,
   name: string,

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -226,3 +226,7 @@ export interface AlertmanagerStatus {
     version: string;
   };
 }
+
+export interface TestReceiversPayload {
+  receivers?: Receiver[];
+}

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -230,3 +230,19 @@ export interface AlertmanagerStatus {
 export interface TestReceiversPayload {
   receivers?: Receiver[];
 }
+
+interface TestReceiversResultGrafanaReceiverConfig {
+  name: string;
+  uid?: string;
+  error?: string;
+  status: 'failed';
+}
+
+interface TestReceiversResultReceiver {
+  name: string;
+  grafana_managed_receiver_configs: TestReceiversResultGrafanaReceiverConfig[];
+}
+export interface TestReceiversResult {
+  notified_at: string;
+  receivers: TestReceiversResultReceiver[];
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This builds on https://github.com/grafana/grafana/pull/37308 to add a test button for grafana contact points. User is able to test one contact point at a time.

Known issues:
* ~~Testing existing contact points with secrets fails, seems backend does not load secrets from existing config as it should~~
* ~~If backend fails to send test noficiation, API still returns 200, so we don't tell the user that it failed~~

Todos:
- [x] tests
- [x] rename button to "test"


https://user-images.githubusercontent.com/847684/129747439-b1a9b651-459e-4c56-ab96-740ba19dbf6f.mp4



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35700

**Special notes for your reviewer**:

