### PR TITLE
Zipkin: Add ability to upload trace JSON

### DIFF
--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -32,7 +32,7 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 
 - **Data source -** Target data source.
 - **Tags -** The tags that will be used in the Loki query. Default is `'cluster', 'hostname', 'namespace', 'pod'`.
-- **Span start time shift -** Shift in the start time for the Loki query based on the span start time. In order to extend to the past, you need to use a negative value.  Time units can be used here, for example, 5s, 1m, 3h. The default is 0.
+- **Span start time shift -** Shift in the start time for the Loki query based on the span start time. In order to extend to the past, you need to use a negative value. Use time interval units like 5s, 1m, 3h. The default is 0.
 - **Span end time shift -** Shift in the end time for the Loki query based on the span end time. Time units can be used here, for example, 5s, 1m, 3h. The default is 0.
 
 ![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8.png 'Screenshot of the trace to logs settings')
@@ -56,6 +56,36 @@ Use the trace selector to pick particular trace from all traces logged in the ti
 ## Data mapping in the trace UI
 
 Zipkin annotations are shown in the trace view as logs with annotation value shown under annotation key.
+
+## Upload JSON trace file
+
+You can upload a JSON file that contains a single trace to visualize it.
+
+{{< figure src="/static/img/docs/explore/zipkin-upload-json.png" class="docs-image--no-shadow" caption="Screenshot of the Zipkin data source in explore with upload selected" >}}
+
+Here is an example JSON:
+
+```json
+[
+  {
+    "traceId": "efe9cb8857f68c8f",
+    "parentId": "efe9cb8857f68c8f",
+    "id": "8608dc6ce5cafe8e",
+    "kind": "SERVER",
+    "name": "get /api",
+    "timestamp": 1627975249601797,
+    "duration": 23457,
+    "localEndpoint": { "serviceName": "backend", "ipv4": "127.0.0.1", "port": 9000 },
+    "tags": {
+      "http.method": "GET",
+      "http.path": "/api",
+      "jaxrs.resource.class": "Resource",
+      "jaxrs.resource.method": "printDate"
+    },
+    "shared": true
+  }
+]
+```
 
 ## Linking Trace ID from logs
 

--- a/public/app/plugins/datasource/zipkin/QueryField.test.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { QueryField, useLoadOptions, useServices } from './QueryField';
-import { ZipkinDatasource, ZipkinQuery } from './datasource';
-import { shallow } from 'enzyme';
 import { ButtonCascader, CascaderOption } from '@grafana/ui';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { ZipkinDatasource } from './datasource';
+import { QueryField, useLoadOptions, useServices } from './QueryField';
+import { ZipkinQuery } from './types';
 
 describe('QueryField', () => {
   it('renders properly', () => {

--- a/public/app/plugins/datasource/zipkin/mockJsonResponse.json
+++ b/public/app/plugins/datasource/zipkin/mockJsonResponse.json
@@ -1,0 +1,19 @@
+[
+  {
+    "traceId": "efe9cb8857f68c8f",
+    "parentId": "efe9cb8857f68c8f",
+    "id": "8608dc6ce5cafe8e",
+    "kind": "SERVER",
+    "name": "get /api",
+    "timestamp": 1627975249601797,
+    "duration": 23457,
+    "localEndpoint": { "serviceName": "backend", "ipv4": "127.0.0.1", "port": 9000 },
+    "tags": {
+      "http.method": "GET",
+      "http.path": "/api",
+      "jaxrs.resource.class": "Resource",
+      "jaxrs.resource.method": "printDate"
+    },
+    "shared": true
+  }
+]

--- a/public/app/plugins/datasource/zipkin/mockJsonResponse.json
+++ b/public/app/plugins/datasource/zipkin/mockJsonResponse.json
@@ -15,5 +15,31 @@
       "jaxrs.resource.method": "printDate"
     },
     "shared": true
+  },
+  {
+    "traceId": "efe9cb8857f68c8f",
+    "parentId": "efe9cb8857f68c8f",
+    "id": "8608dc6ce5cafe8e",
+    "kind": "CLIENT",
+    "name": "get",
+    "timestamp": 1627975249491667,
+    "duration": 148265,
+    "localEndpoint": { "serviceName": "frontend", "ipv4": "127.0.0.1", "port": 8081 },
+    "tags": { "http.method": "GET", "http.path": "/api" }
+  },
+  {
+    "traceId": "efe9cb8857f68c8f",
+    "id": "efe9cb8857f68c8f",
+    "kind": "SERVER",
+    "name": "get",
+    "timestamp": 1627975249258448,
+    "duration": 413469,
+    "localEndpoint": { "serviceName": "frontend", "ipv4": "127.0.0.1", "port": 8081 },
+    "tags": {
+      "http.method": "GET",
+      "http.path": "/",
+      "jaxrs.resource.class": "Resource",
+      "jaxrs.resource.method": "callBackend"
+    }
   }
 ]

--- a/public/app/plugins/datasource/zipkin/types.ts
+++ b/public/app/plugins/datasource/zipkin/types.ts
@@ -1,3 +1,5 @@
+import { DataQuery } from '@grafana/data';
+
 export type ZipkinSpan = {
   traceId: string;
   parentId?: string;
@@ -23,3 +25,9 @@ export type ZipkinAnnotation = {
   timestamp: number;
   value: string;
 };
+export type ZipkinQueryType = 'traceID' | 'upload';
+
+export interface ZipkinQuery extends DataQuery {
+  query: string;
+  queryType?: ZipkinQueryType;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the upload JSON feature to Zipkin as well.

**Which issue(s) this PR fixes**:

Fixes #37467

**Special notes for your reviewer**:

You can use the zipkin devenv for testing where you can download a trace.

