### PR TITLE
DashboardPrompt: Implement `beforeunload` handler

### DIFF
--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
@@ -50,6 +50,22 @@ export const DashboardPrompt = React.memo(({ dashboard }: Props) => {
     };
   }, [dashboard]);
 
+  useEffect(() => {
+    const handleUnload = (event: BeforeUnloadEvent) => {
+      if (ignoreChanges(dashboard, original)) {
+        return;
+      }
+      if (hasChanges(dashboard, original)) {
+        event.preventDefault();
+        // No browser actually displays this message anymore.
+        // But Chrome requires it to be defined else the popup won't show.
+        event.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', handleUnload);
+    return () => window.removeEventListener('beforeunload', handleUnload);
+  }, [dashboard, original]);
+
   // Handle saved events
   useEffect(() => {
     const savedEventUnsub = appEvents.subscribe(DashboardSavedEvent, () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- adds a `beforeunload` handler to `DashboardPrompt` to show a prompt when closing/reloading the page if there are unsaved changes.
- similar functionality used to exist in `ChangeTracker` previously: https://github.com/grafana/grafana/blob/v7.5.4/public/app/features/dashboard/services/ChangeTracker.ts#L42

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/36871

**Special notes for your reviewer**:

