### PR TITLE
influxdb: more robust query-has-variables check

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/QueryEditor.tsx
@@ -7,7 +7,7 @@ import { FluxQueryEditor } from './FluxQueryEditor';
 import { RawInfluxQLEditor } from './RawInfluxQLEditor';
 import { Editor as VisualInfluxQLEditor } from './VisualInfluxQLEditor/Editor';
 import { QueryEditorModeSwitcher } from './QueryEditorModeSwitcher';
-import { buildRawQuery } from './queryUtils';
+import { buildRawQuery } from '../queryUtils';
 
 type Props = QueryEditorProps<InfluxDatasource, InfluxQuery, InfluxOptions>;
 

--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Editor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/Editor.tsx
@@ -22,7 +22,7 @@ import {
   removeGroupByPart,
   changeSelectPart,
   changeGroupByPart,
-} from '../queryUtils';
+} from '../../queryUtils';
 import { FormatAsSection } from './FormatAsSection';
 import { SectionLabel } from './SectionLabel';
 import { SectionFill } from './SectionFill';

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -31,6 +31,7 @@ import { getBackendSrv, DataSourceWithBackend, frameToMetricFindValue } from '@g
 import { Observable, throwError, of } from 'rxjs';
 import { FluxQueryEditor } from './components/FluxQueryEditor';
 import { catchError, map } from 'rxjs/operators';
+import { buildRawQuery } from './queryUtils';
 
 // we detect the field type based on the value-array
 function getFieldType(values: unknown[]): FieldType {
@@ -321,34 +322,11 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
   }
 
   targetContainsTemplate(target: any) {
-    if (this.isFlux) {
-      return this.templateSrv.variableExists(target.query);
-    }
+    // for flux-mode we just take target.query,
+    // for influxql-mode we use InfluxQueryModel to create the text-representation
+    const queryText = this.isFlux ? target.query : buildRawQuery(target);
 
-    // now we know it is an InfluxQL query.
-    // it can be either a raw-query or a not-raw-query
-
-    if (target.rawQuery) {
-      return this.templateSrv.variableExists(target.query);
-    }
-
-    // now we know it is an InfluxQL not-raw-query
-
-    for (const group of target.groupBy) {
-      for (const param of group.params) {
-        if (this.templateSrv.variableExists(param)) {
-          return true;
-        }
-      }
-    }
-
-    for (const i in target.tags) {
-      if (this.templateSrv.variableExists(target.tags[i].value)) {
-        return true;
-      }
-    }
-
-    return false;
+    return this.templateSrv.variableExists(queryText);
   }
 
   interpolateVariablesInQueries(queries: InfluxQuery[], scopedVars: ScopedVars): InfluxQuery[] {

--- a/public/app/plugins/datasource/influxdb/queryUtils.test.ts
+++ b/public/app/plugins/datasource/influxdb/queryUtils.test.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import { InfluxQuery } from '../types';
+import { InfluxQuery } from './types';
 import { buildRawQuery, normalizeQuery, changeSelectPart, changeGroupByPart } from './queryUtils';
 
 describe('InfluxDB query utils', () => {

--- a/public/app/plugins/datasource/influxdb/queryUtils.ts
+++ b/public/app/plugins/datasource/influxdb/queryUtils.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
-import InfluxQueryModel from '../influx_query_model';
-import { InfluxQuery } from '../types';
+import InfluxQueryModel from './influx_query_model';
+import { InfluxQuery } from './types';
 
 // FIXME: these functions are a beginning of a refactoring of influx_query_model.ts
 // into a simpler approach with full typescript types.


### PR DESCRIPTION
his is about old-alerting.

when an query is created in a dashboard panel, and we switch to the "Alert" tab, we check if the query uses template-variables or not. if it does use them, we do not allow the creating of the alert.

this check currently ignores variables in the "measurement" section of the influxdb influxql query editor (visually it is in the FROM section). so, if you have a dashboard-variable, and you open the measurement-dropdown (second dropdown in the FROM section), it offers you the variable, and you can use that variable there, but then when you switch to the "alert" tab, it will say everything is ok, and it allows you to create an alert. it should not.

the fix used here is a little different from what was done in the past:
- in the past we went through the various query-data-structures to find variables
- with this change, we ask influxdb to render the query into a text, and then we simply check the text for variables

NOTE: i moved two files (`queryUtils.ts` and `queryUtils.test.ts` one directory higher, because now i am using a function from there in the datasource directly, until now they were only used in the visual-query-editor)

how to test:
- add variables to a dashboard
- add an influxql-query-editor, try to put the variable to different places, and verify that switching to the alert-tab it detects it (and tells you that you cannot create an alert because you have variables)
- try also the raw influxql mode, you can use this query: `SELECT "usage_idle" FROM "cpu" WHERE ("cpu" = 'cpu2') AND $timeFilter`
  - try replacing "cpu2" with a variable reference, like "${cpu}"
- try also the flux query mode. sample query for the `make devenv sources=influxdb` case: `from(bucket: "mybucket") |> range(start: v.timeRangeStart, stop: v.timeRangeStop) |> filter(fn: (r) => r._measurement == "cpu" and r._field == "usage_idle" and r.cpu == "cpu2" )`
  - try replacing "cpu2" with a variable reference, like "${cpu}"


fixes https://github.com/grafana/grafana/issues/37484