### PR TITLE
Annotations: Correct annotations that are displayed upon page refresh

### DIFF
--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -287,9 +287,4 @@ describeInitScenario('Initializing previously canceled dashboard initialization'
     expect(getTimeSrv().init).toBeCalled();
     expect(getDashboardQueryRunner().run).toBeCalled();
   });
-
-  it('Should not initialize other services', () => {
-    expect(getDashboardSrv().setCurrent).not.toBeCalled();
-    expect(keybindingSrv.setupDashboardBindings).not.toBeCalled();
-  });
 });

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -151,6 +151,9 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
     const timeSrv: TimeSrv = getTimeSrv();
     const dashboardSrv: DashboardSrv = getDashboardSrv();
 
+    // legacy srv state, we need this value updated for built-in annotations
+    dashboardSrv.setCurrent(dashboard);
+
     timeSrv.init(dashboard);
     const runner = createDashboardQueryRunner({ dashboard, timeSrv });
     runner.run({ dashboard, range: timeSrv.timeRange() });
@@ -193,9 +196,6 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
       const { panelId, queries } = storeState.dashboard.modifiedQueries;
       updateQueriesWhenComingFromExplore(dispatch, dashboard, panelId, queries);
     }
-
-    // legacy srv state
-    dashboardSrv.setCurrent(dashboard);
 
     // send open dashboard event
     if (args.routeName !== DashboardRoutes.New) {


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

A [new change](https://github.com/grafana/grafana/pull/36377/commits/460ebabac764092f236847995b49250c03cdb926#diff-f1386ecf8e451a84d16e901593385dbecf86e95242c70084a41c1c43f37830a9R55) was introduced for v8.1.0 in built-in annotations, there we started to use this method [`getDashboardSrv().getCurrent()`](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/grafana/datasource.ts#L55) to get the current dashboard instance, and then with the `dashboardId` query the API to get the list of annotations that belong to that dashboard. 

The issue was that when we render let's say dashboard `A` and move back to the parent, the instance of that dashboard `A` is not being cleaned, so next time when we visit another dashboard, let's say Dashboard `B`, the following methods from [initDashboard](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/state/initDashboard.ts#L198) are being called:

```
    const runner = createDashboardQueryRunner({ dashboard, timeSrv });
    runner.run({ dashboard, range: timeSrv.timeRange() });
```

Where this `runner.run` in one point is calling the `query` method from the Grafana datasource used in the built-in annotations, but when this happens the `getCurrent()` dashboard is having the old reference (because was not properly cleaned), that results in calling the API with the wrong dashboard id.


https://user-images.githubusercontent.com/239999/128041377-334581bd-762b-4778-8d7b-2451aaa892bd.mp4




My current PR is a hack, I am moving the `dashboardSrv.setCurrent(dashboard)` before we run the DashboardQueryRunner. This will update the instance and the API will have the right dashboard ID.

The ideal solution will be to clean the old instance when the user moves back to the parent, but I could not find a way to do it :(.

*The hack, seems to work, but I am lacking a lot of context and knowledge in this part of the code.*


https://user-images.githubusercontent.com/239999/128041657-7fad7062-355c-454b-b39b-9f255634055c.mp4



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37160

**Special notes for your reviewer**:

