### PR TITLE
XYCanvas: useMemo() for className gen

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/geometries/XYCanvas.tsx
+++ b/packages/grafana-ui/src/components/uPlot/geometries/XYCanvas.tsx
@@ -1,5 +1,5 @@
 import { usePlotContext } from '../context';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { css } from '@emotion/css';
 
 interface XYCanvasProps {}
@@ -16,16 +16,14 @@ export const XYCanvas: React.FC<XYCanvasProps> = ({ children }) => {
     return null;
   }
 
-  return (
-    <div
-      className={css`
-        position: absolute;
-        overflow: visible;
-        left: ${plotInstance.bbox.left / window.devicePixelRatio}px;
-        top: ${plotInstance.bbox.top / window.devicePixelRatio}px;
-      `}
-    >
-      {children}
-    </div>
-  );
+  const className = useMemo(() => {
+    return css`
+      position: absolute;
+      overflow: visible;
+      left: ${plotInstance.bbox.left / window.devicePixelRatio}px;
+      top: ${plotInstance.bbox.top / window.devicePixelRatio}px;
+    `;
+  }, [plotInstance.bbox.left, plotInstance.bbox.top]);
+
+  return <div className={className}>{children}</div>;
 };


### PR DESCRIPTION
note: technically `window.devicePixelRatio` _can_ change if the user manually zooms the browser window, but it's quite expensive to read back frequently and a bit of an edge case, so left it out of the invalidation array for now. if/when we need it, uPlot hooks up a global ["dppxchange" event](https://github.com/leeoniya/uPlot/blob/b07903043863d2eb784f1f6fab19fa77d12f5637/src/dom.js#L27) emitter for this which we can listen to.

**before:**

![image](https://user-images.githubusercontent.com/43234/128115379-7ce91f18-696d-4ab9-bcd7-d2daf77779fb.png)

**after:**

![image](https://user-images.githubusercontent.com/43234/128115417-67041207-f32c-44ff-ab4a-e723ff86c8d2.png)