### PR TITLE
Loki: Update labels in log browser when time range changes

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -11,7 +11,7 @@ import { LokiOptionFields } from './LokiOptionFields';
 type Props = ExploreQueryFieldProps<LokiDatasource, LokiQuery, LokiOptions>;
 
 export function LokiExploreQueryEditor(props: Props) {
-  const { query, data, datasource, history, onChange, onRunQuery } = props;
+  const { query, data, datasource, history, onChange, onRunQuery, range } = props;
 
   return (
     <LokiQueryField
@@ -22,6 +22,7 @@ export function LokiExploreQueryEditor(props: Props) {
       onRunQuery={onRunQuery}
       history={history}
       data={data}
+      range={range}
       ExtraFieldElement={
         <LokiOptionFields
           queryType={query.instant ? 'instant' : 'range'}

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
@@ -1,0 +1,78 @@
+import React, { ComponentProps } from 'react';
+import { render } from '@testing-library/react';
+import { LokiQueryField } from './LokiQueryField';
+import { dateTime } from '@grafana/data';
+
+type Props = ComponentProps<typeof LokiQueryField>;
+
+const defaultProps: Props = {
+  datasource: {
+    languageProvider: {
+      start: () => Promise.resolve(['label1']),
+      fetchLabels: Promise.resolve(['label1']),
+      getSyntax: () => {},
+      getLabelKeys: () => ['label1'],
+      getLabelValues: () => ['value1'],
+    } as any,
+    getInitHints: () => [],
+  } as any,
+  range: {
+    from: dateTime([2021, 1, 11, 12, 0, 0]),
+    to: dateTime([2021, 1, 11, 18, 0, 0]),
+    raw: {
+      from: 'now-1h',
+      to: 'now',
+    },
+  },
+  query: { expr: '', refId: '' },
+  onRunQuery: () => {},
+  onChange: () => {},
+  history: [],
+};
+
+describe('LokiQueryField', () => {
+  it('refreshes metrics when time range changes over 1 minute', async () => {
+    const fetchLabelsMock = jest.fn();
+    const props = defaultProps;
+    props.datasource.languageProvider.fetchLabels = fetchLabelsMock;
+
+    const { rerender } = render(<LokiQueryField {...props} />);
+
+    expect(fetchLabelsMock).not.toHaveBeenCalled();
+
+    const newRange = {
+      from: dateTime([2021, 1, 11, 12, 2, 0]),
+      to: dateTime([2021, 1, 11, 18, 2, 0]),
+      raw: {
+        from: 'now-1h',
+        to: 'now',
+      },
+    };
+
+    rerender(<LokiQueryField {...props} range={newRange} />);
+    expect(fetchLabelsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refreshes metrics when time range deso not change', async () => {
+    const fetchLabelsMock = jest.fn();
+    const props = defaultProps;
+    props.datasource.languageProvider.fetchLabels = fetchLabelsMock;
+
+    const { rerender } = render(<LokiQueryField {...props} />);
+
+    expect(fetchLabelsMock).not.toHaveBeenCalled();
+
+    //same as def
+    const newRange = {
+      from: dateTime([2021, 1, 11, 12, 0, 20]),
+      to: dateTime([2021, 1, 11, 18, 0, 20]),
+      raw: {
+        from: 'now-1h',
+        to: 'now',
+      },
+    };
+
+    rerender(<LokiQueryField {...props} range={newRange} />);
+    expect(fetchLabelsMock).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
@@ -40,6 +40,7 @@ describe('LokiQueryField', () => {
 
     expect(fetchLabelsMock).not.toHaveBeenCalled();
 
+    // 2 minutes difference over the initial time
     const newRange = {
       from: dateTime([2021, 1, 11, 12, 2, 0]),
       to: dateTime([2021, 1, 11, 18, 2, 0]),
@@ -53,7 +54,7 @@ describe('LokiQueryField', () => {
     expect(fetchLabelsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('does not refreshes metrics when time range deso not change', async () => {
+  it('does not refreshes metrics when time range change by less than 1 minute', async () => {
     const fetchLabelsMock = jest.fn();
     const props = defaultProps;
     props.datasource.languageProvider.fetchLabels = fetchLabelsMock;
@@ -62,7 +63,7 @@ describe('LokiQueryField', () => {
 
     expect(fetchLabelsMock).not.toHaveBeenCalled();
 
-    //same as def
+    // 20 seconds difference over the initial time
     const newRange = {
       from: dateTime([2021, 1, 11, 12, 0, 20]),
       to: dateTime([2021, 1, 11, 18, 0, 20]),

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -97,9 +97,9 @@ export class LokiQueryField extends React.PureComponent<LokiQueryFieldProps, Lok
       range,
       datasource: { languageProvider },
     } = this.props;
-    const changedRangeToRefresh = shouldRefreshLabels(range, prevProps.range);
+    const refreshLabels = shouldRefreshLabels(range, prevProps.range);
     // We want to refresh labels when range changes (we round up intervals to a minute)
-    if (changedRangeToRefresh) {
+    if (refreshLabels) {
       await languageProvider.fetchLabels();
     }
   }

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -100,7 +100,7 @@ export class LokiQueryField extends React.PureComponent<LokiQueryFieldProps, Lok
     const refreshLabels = shouldRefreshLabels(range, prevProps.range);
     // We want to refresh labels when range changes (we round up intervals to a minute)
     if (refreshLabels) {
-      await languageProvider.fetchLabels();
+      languageProvider.fetchLabels();
     }
   }
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -92,7 +92,7 @@ export class LokiQueryField extends React.PureComponent<LokiQueryFieldProps, Lok
     this.setState({ labelsLoaded: true });
   }
 
-  async componentDidUpdate(prevProps: LokiQueryFieldProps) {
+  componentDidUpdate(prevProps: LokiQueryFieldProps) {
     const {
       range,
       datasource: { languageProvider },

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -115,5 +115,15 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
       "refId": "A",
     }
   }
+  range={
+    Object {
+      "from": "2020-01-01T00:00:00.000Z",
+      "raw": Object {
+        "from": "2020-01-01T00:00:00.000Z",
+        "to": "2020-01-02T00:00:00.000Z",
+      },
+      "to": "2020-01-02T00:00:00.000Z",
+    }
+  }
 />
 `;

--- a/public/app/plugins/datasource/loki/language_utils.ts
+++ b/public/app/plugins/datasource/loki/language_utils.ts
@@ -1,7 +1,19 @@
-export function roundMsToMin(milliseconds: number): number {
+import { TimeRange } from '@grafana/data';
+
+function roundMsToMin(milliseconds: number): number {
   return roundSecToMin(milliseconds / 1000);
 }
 
-export function roundSecToMin(seconds: number): number {
+function roundSecToMin(seconds: number): number {
   return Math.floor(seconds / 60);
+}
+
+export function shouldRefreshLabels(range?: TimeRange, prevRange?: TimeRange): boolean {
+  if (range && prevRange) {
+    const sameMinuteFrom = roundMsToMin(range.from.valueOf()) === roundMsToMin(prevRange.from.valueOf());
+    const sameMinuteTo = roundMsToMin(range.to.valueOf()) === roundMsToMin(prevRange.to.valueOf());
+    // If both are same, don't need to refresh
+    return !(sameMinuteFrom && sameMinuteTo);
+  }
+  return false;
 }

--- a/public/app/plugins/datasource/loki/language_utils.ts
+++ b/public/app/plugins/datasource/loki/language_utils.ts
@@ -1,0 +1,7 @@
+export function roundMsToMin(milliseconds: number): number {
+  return roundSecToMin(milliseconds / 1000);
+}
+
+export function roundSecToMin(seconds: number): number {
+  return Math.floor(seconds / 60);
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Loki log browser fetched the labels with initial time range and doesn't update labels when time range changes. This PR fixes t in the similar way as it is done in Prometheus metrics browser.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/36278


