### PR TITLE
Catalog: Fix InstallControls for externally managed users

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls.tsx
@@ -94,8 +94,9 @@ export const InstallControls = ({ plugin, isInflight, hasUpdate, isInstalled, ha
     );
   }
 
-  if (!hasPermission) {
-    const message = `You need server admin privileges to ${isInstalled ? 'uninstall' : 'install'} this plugin.`;
+  if (!hasPermission && !isExternallyManaged) {
+    const pluginStatus = isInstalled ? 'uninstall' : hasUpdate ? 'update' : 'install';
+    const message = `You do not have permission to ${pluginStatus} this plugin.`;
     return <div className={styles.message}>{message}</div>;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
PR #37504 hid buttons for Grafana instances that are using the `pluginAdminExternalManageEnabled` ini flag rather than shown the button with link to the external site. This PR fixes that.

