### PR TITLE
AzureMonitor: Remove Angular query editor

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/useDefaultQuery.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/useDefaultQuery.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo } from 'react';
+import { AzureMonitorQuery, AzureQueryType } from '../../types';
+
+const DEFAULT_QUERY_TYPE = AzureQueryType.AzureMonitor;
+
+const createQueryWithDefaults = (query: AzureMonitorQuery) => {
+  // A quick and easy way to set just the default query type. If we want to set any other defaults,
+  // we might want to look into something more robust
+  if (!query.queryType) {
+    return {
+      ...query,
+      queryType: query.queryType ?? DEFAULT_QUERY_TYPE,
+    };
+  }
+
+  return query;
+};
+
+/**
+ * Returns queries with some defaults, and calls onChange function to notify if it changes
+ */
+const useDefaultQuery = (query: AzureMonitorQuery, onChangeQuery: (newQuery: AzureMonitorQuery) => void) => {
+  const queryWithDefaults = useMemo(() => createQueryWithDefaults(query), [query]);
+
+  useEffect(() => {
+    if (queryWithDefaults !== query) {
+      console.log('changing default query');
+      onChangeQuery(queryWithDefaults);
+    }
+  }, [queryWithDefaults, query, onChangeQuery]);
+
+  return queryWithDefaults;
+};
+
+export default useDefaultQuery;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
@@ -1,11 +1,11 @@
 import { DataSourcePlugin } from '@grafana/data';
-import { AzureMonitorQueryCtrl } from './query_ctrl';
 import Datasource from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
+import AzureMonitorQueryEditor from './components/QueryEditor';
 import { AzureMonitorAnnotationsQueryCtrl } from './annotations_query_ctrl';
 import { AzureMonitorQuery, AzureDataSourceJsonData } from './types';
 
 export const plugin = new DataSourcePlugin<Datasource, AzureMonitorQuery, AzureDataSourceJsonData>(Datasource)
   .setConfigEditor(ConfigEditor)
-  .setQueryCtrl(AzureMonitorQueryCtrl)
+  .setQueryEditor(AzureMonitorQueryEditor)
   .setAnnotationQueryCtrl(AzureMonitorAnnotationsQueryCtrl);


### PR DESCRIPTION
**What this PR does / why we need it**:

Completely removes the Angular shell that the Azure Monitor query editor was mounted in.

The angular shell was setting some default query values (which are now all optional since https://github.com/grafana/grafana/pull/36701), which is now mostly fine because we handle it elsewhere. The one exception is setting a default query type, which im open for alternate suggestions on how to do this :) 

**Which issue(s) this PR fixes**:
