### PR TITLE
Loki: Update labels in log browser when time range changes in dashboard

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -8,7 +8,7 @@ import { LokiOptionFields } from './LokiOptionFields';
 import { LokiQueryEditorProps } from './types';
 
 export function LokiQueryEditor(props: LokiQueryEditorProps) {
-  const { query, data, datasource, onChange, onRunQuery } = props;
+  const { query, data, datasource, onChange, onRunQuery, range } = props;
 
   const onLegendChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
     const nextQuery = { ...query, legendFormat: e.currentTarget.value };
@@ -47,6 +47,7 @@ export function LokiQueryEditor(props: LokiQueryEditorProps) {
       history={[]}
       data={data}
       data-testid={testIds.editor}
+      range={range}
       ExtraFieldElement={
         <>
           <LokiOptionFields

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
@@ -56,6 +56,12 @@ exports[`Render LokiQueryEditor with legend should render 1`] = `
       "refId": "A",
     }
   }
+  range={
+    Object {
+      "from": "2020-01-01T00:00:00.000Z",
+      "to": "2020-01-02T00:00:00.000Z",
+    }
+  }
 />
 `;
 
@@ -113,6 +119,12 @@ exports[`Render LokiQueryEditor with legend should update timerange 1`] = `
       "expr": "",
       "legendFormat": "My Legend",
       "refId": "A",
+    }
+  }
+  range={
+    Object {
+      "from": "2019-01-01T00:00:00.000Z",
+      "to": "2020-01-02T00:00:00.000Z",
     }
   }
 />


### PR DESCRIPTION
**What this PR does / why we need it**:
Following up on https://github.com/grafana/grafana/pull/37520 - I have forgotten to pass range to query editor in dashboard.

This PR fixes it.
