### PR TITLE
Field: use 0-based field.state.seriesIndex

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -169,15 +169,15 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
         range = { min, max, delta: max! - min! };
       }
 
+      field.state!.seriesIndex = seriesIndex;
+      field.state!.range = range;
+      field.type = type;
+
       // Some color modes needs series index to assign field color so we count
       // up series index here but ignore time fields
       if (field.type !== FieldType.time) {
         seriesIndex++;
       }
-
-      field.state!.seriesIndex = seriesIndex;
-      field.state!.range = range;
-      field.type = type;
 
       // and set the display processor using it
       field.display = getDisplayProcessor({


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/36385

this ensures we use a 0-based `field.state.seriesIndex`, so colors start at green when calling `field.display()`.

the reason it "works" without this PR is because many panels adjust the seriesIndex to be 0-based during frame/field prep & filtering:

![image](https://user-images.githubusercontent.com/43234/128226039-30d70a81-57c5-4956-8113-c17d10101d70.png)

also fixes pie charts not having green slices:

before:

![image](https://user-images.githubusercontent.com/43234/128225823-897cdc95-2e46-48df-9e2f-611c4a4b54a4.png)

after:

![image](https://user-images.githubusercontent.com/43234/128225843-b560d7cb-5c6d-4501-94e6-653e76f8af8e.png)
