### PR TITLE
Handle enterprise data source tab refreshes

### DIFF
--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -4,6 +4,7 @@ import {
   InitDataSourceSettingDependencies,
   testDataSource,
   TestDataSourceDependencies,
+  getDataSourceUsingUidOrId,
 } from './actions';
 import { getMockPlugin, getMockPlugins } from '../../plugins/__mocks__/pluginMocks';
 import { thunkTester } from 'test/core/thunk/thunkTester';
@@ -17,6 +18,13 @@ import {
 import { initDataSourceSettings } from '../state/actions';
 import { ThunkResult, ThunkDispatch } from 'app/types';
 import { GenericDataSourcePlugin } from '../settings/PluginSettings';
+import { getBackendSrv } from 'app/core/services/backend_srv';
+
+jest.mock('app/core/services/backend_srv');
+jest.mock('@grafana/runtime', () => ({
+  ...((jest.requireActual('@grafana/runtime') as unknown) as object),
+  getBackendSrv: jest.fn(),
+}));
 
 const getBackendSrvMock = () =>
   ({
@@ -53,6 +61,79 @@ const failDataSourceTest = async (error: object) => {
 
   return dispatchedActions;
 };
+
+describe('getDataSourceUsingUidOrId', () => {
+  const uidResponse = {
+    ok: true,
+    data: {
+      id: 111,
+      uid: 'abcdefg',
+    },
+  };
+
+  const idResponse = {
+    ok: true,
+    data: {
+      id: 222,
+      uid: 'xyz',
+    },
+  };
+
+  it('should return UID response data', async () => {
+    (getBackendSrv as jest.Mock).mockReturnValueOnce({
+      fetch: () => ({
+        toPromise: jest.fn().mockResolvedValue(uidResponse),
+      }),
+    });
+
+    expect(await getDataSourceUsingUidOrId('abcdefg')).toBe(uidResponse.data);
+  });
+
+  it('should return ID response data', async () => {
+    const uidResponse = {
+      ok: false,
+    };
+
+    (getBackendSrv as jest.Mock)
+      .mockReturnValueOnce({
+        fetch: () => ({
+          toPromise: jest.fn().mockResolvedValue(uidResponse),
+        }),
+      })
+      .mockReturnValueOnce({
+        fetch: () => ({
+          toPromise: jest.fn().mockResolvedValue(idResponse),
+        }),
+      });
+
+    expect(await getDataSourceUsingUidOrId(222)).toBe(idResponse.data);
+  });
+
+  it('should return empty response data', async () => {
+    // @ts-ignore
+    delete window.location;
+    window.location = {} as any;
+
+    const uidResponse = {
+      ok: false,
+    };
+
+    (getBackendSrv as jest.Mock)
+      .mockReturnValueOnce({
+        fetch: () => ({
+          toPromise: jest.fn().mockResolvedValue(uidResponse),
+        }),
+      })
+      .mockReturnValueOnce({
+        fetch: () => ({
+          toPromise: jest.fn().mockResolvedValue(idResponse),
+        }),
+      });
+
+    expect(await getDataSourceUsingUidOrId('222')).toStrictEqual({});
+    expect(window.location.href).toBe('/datasources/edit/xyz');
+  });
+});
 
 describe('Name exists', () => {
   const plugins = getMockPlugins(5);

--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -19,6 +19,8 @@ import { initDataSourceSettings } from '../state/actions';
 import { ThunkResult, ThunkDispatch } from 'app/types';
 import { GenericDataSourcePlugin } from '../settings/PluginSettings';
 import { getBackendSrv } from 'app/core/services/backend_srv';
+import { BackendSrvRequest, FetchResponse } from '@grafana/runtime';
+import { of } from 'rxjs';
 
 jest.mock('app/core/services/backend_srv');
 jest.mock('@grafana/runtime', () => ({
@@ -81,9 +83,9 @@ describe('getDataSourceUsingUidOrId', () => {
 
   it('should return UID response data', async () => {
     (getBackendSrv as jest.Mock).mockReturnValueOnce({
-      fetch: () => ({
-        toPromise: jest.fn().mockResolvedValue(uidResponse),
-      }),
+      fetch: (options: BackendSrvRequest) => {
+        return of(uidResponse as FetchResponse);
+      },
     });
 
     expect(await getDataSourceUsingUidOrId('abcdefg')).toBe(uidResponse.data);
@@ -96,14 +98,14 @@ describe('getDataSourceUsingUidOrId', () => {
 
     (getBackendSrv as jest.Mock)
       .mockReturnValueOnce({
-        fetch: () => ({
-          toPromise: jest.fn().mockResolvedValue(uidResponse),
-        }),
+        fetch: (options: BackendSrvRequest) => {
+          return of(uidResponse as FetchResponse);
+        },
       })
       .mockReturnValueOnce({
-        fetch: () => ({
-          toPromise: jest.fn().mockResolvedValue(idResponse),
-        }),
+        fetch: (options: BackendSrvRequest) => {
+          return of(idResponse as FetchResponse);
+        },
       });
 
     expect(await getDataSourceUsingUidOrId(222)).toBe(idResponse.data);
@@ -120,14 +122,14 @@ describe('getDataSourceUsingUidOrId', () => {
 
     (getBackendSrv as jest.Mock)
       .mockReturnValueOnce({
-        fetch: () => ({
-          toPromise: jest.fn().mockResolvedValue(uidResponse),
-        }),
+        fetch: (options: BackendSrvRequest) => {
+          return of(uidResponse as FetchResponse);
+        },
       })
       .mockReturnValueOnce({
-        fetch: () => ({
-          toPromise: jest.fn().mockResolvedValue(idResponse),
-        }),
+        fetch: (options: BackendSrvRequest) => {
+          return of(idResponse as FetchResponse);
+        },
       });
 
     expect(await getDataSourceUsingUidOrId('222')).toStrictEqual({});

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -138,7 +138,7 @@ export function loadDataSource(uid: string): ThunkResult<void> {
 /**
  * Get data source by uid or id, if old id detected handles redirect
  */
-async function getDataSourceUsingUidOrId(uid: string): Promise<DataSourceSettings> {
+export async function getDataSourceUsingUidOrId(uid: string | number): Promise<DataSourceSettings> {
   // Try first with uid api
   try {
     const byUid = await lastValueFrom(
@@ -157,7 +157,7 @@ async function getDataSourceUsingUidOrId(uid: string): Promise<DataSourceSetting
   }
 
   // try lookup by old db id
-  const id = parseInt(uid, 10);
+  const id = typeof uid === 'string' ? parseInt(uid, 10) : uid;
   if (!Number.isNaN(id)) {
     const response = await lastValueFrom(
       getBackendSrv().fetch<DataSourceSettings>({
@@ -166,6 +166,12 @@ async function getDataSourceUsingUidOrId(uid: string): Promise<DataSourceSetting
         showErrorAlert: false,
       })
     );
+
+    // If the uid is a number, then this is a refresh on one of the settings tabs
+    // and we can return the response data
+    if (response.ok && typeof uid === 'number' && response.data.id === uid) {
+      return response.data;
+    }
 
     // Not ideal to do a full page reload here but so tricky to handle this
     // otherwise We can update the location using react router, but need to

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -69,9 +69,9 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
     navModel.children!.push({
       active: false,
       icon: 'database',
-      id: `datasource-cache-${dataSource.id}`,
+      id: `datasource-cache-${dataSource.uid}`,
       text: 'Cache',
-      url: `datasources/edit/${dataSource.id}/cache`,
+      url: `datasources/edit/${dataSource.uid}/cache`,
       hideFromTabs: !pluginMeta.isBackend || !config.caching.enabled,
     });
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enterprise data source settings tabs are using numeric data source IDs. There is currently an issue that will cause breakage if the user refreshes the page on a tab that uses a numeric ID. This also updates the caching routes to use UIDs instead of numeric IDs.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/1461

**Special notes for your reviewer**:

The changes in https://github.com/grafana/grafana-enterprise/pull/1742 are required to fully test this.