### PR TITLE
Datasource: Pass access type to data source instance settings

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -599,7 +599,7 @@ export interface DataSourceInstanceSettings<T extends DataSourceJsonData = DataS
   password?: string; // when access is direct, for some legacy datasources
   database?: string;
   isDefault?: boolean;
-  access: string;
+  access: 'direct' | 'proxy'; // direct == browser; proxy == server
 
   /**
    * This is the full Authorization header if basic auth is enabled.

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -599,6 +599,7 @@ export interface DataSourceInstanceSettings<T extends DataSourceJsonData = DataS
   password?: string; // when access is direct, for some legacy datasources
   database?: string;
   isDefault?: boolean;
+  access?: string;
 
   /**
    * This is the full Authorization header if basic auth is enabled.

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -599,7 +599,7 @@ export interface DataSourceInstanceSettings<T extends DataSourceJsonData = DataS
   password?: string; // when access is direct, for some legacy datasources
   database?: string;
   isDefault?: boolean;
-  access: 'direct' | 'proxy'; // direct == browser; proxy == server
+  access: 'direct' | 'proxy'; // Currently we support 2 options - direct (browser) and proxy (server)
 
   /**
    * This is the full Authorization header if basic auth is enabled.

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -599,7 +599,7 @@ export interface DataSourceInstanceSettings<T extends DataSourceJsonData = DataS
   password?: string; // when access is direct, for some legacy datasources
   database?: string;
   isDefault?: boolean;
-  access?: string;
+  access: string;
 
   /**
    * This is the full Authorization header if basic auth is enabled.

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -58,6 +58,7 @@ func (hs *HTTPServer) getFSDataSources(c *models.ReqContext, enabledPlugins *plu
 			"name":      ds.Name,
 			"url":       url,
 			"isDefault": ds.IsDefault,
+			"access":    ds.Access,
 		}
 
 		meta, exists := enabledPlugins.DataSources[ds.Type]

--- a/plugins-bundled/internal/input-datasource/src/InputDatasource.test.ts
+++ b/plugins-bundled/internal/input-datasource/src/InputDatasource.test.ts
@@ -19,6 +19,7 @@ describe('InputDatasource', () => {
     type: 'x',
     name: 'xxx',
     meta: {} as PluginMeta,
+    access: 'proxy',
     jsonData: {
       data,
     },

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -38,6 +38,7 @@ const mockRuleSourceByName = () => {
     id: 1,
     meta: {} as PluginMeta,
     jsonData: {} as DataSourceJsonData,
+    access: 'proxy',
   });
 };
 
@@ -95,6 +96,7 @@ const mockedRules: CombinedRule[] = [
         id: 1,
         meta: {} as PluginMeta,
         jsonData: {} as DataSourceJsonData,
+        access: 'proxy',
       },
     },
   },
@@ -123,6 +125,7 @@ const mockedRules: CombinedRule[] = [
         id: 1,
         meta: {} as PluginMeta,
         jsonData: {} as DataSourceJsonData,
+        access: 'proxy',
       },
     },
   },

--- a/public/app/features/alerting/unified/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.test.tsx
@@ -122,6 +122,7 @@ const mockCloudRule = {
       id: 1,
       meta: {} as PluginMeta,
       jsonData: {} as DataSourceJsonData,
+      access: 'proxy',
     },
   },
 };

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -25,6 +25,7 @@ export const mockDataSource = (
     uid: `mock-ds-${nextDataSourceId}`,
     type: 'prometheus',
     name: `Prometheus-${id}`,
+    access: 'proxy',
     jsonData: {},
     meta: ({
       info: {

--- a/public/app/features/alerting/unified/utils/query.test.ts
+++ b/public/app/features/alerting/unified/utils/query.test.ts
@@ -50,6 +50,7 @@ describe('alertRuleToQueries', () => {
           type: 'prometheus',
           uid: 'asdf23',
           id: 1,
+          access: 'proxy',
           meta: {} as PluginMeta,
           jsonData: {} as DataSourceJsonData,
         },

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -377,6 +377,7 @@ function makeDatasourceSetup({ name = 'loki', id = 1 }: { name?: string; id?: nu
       type: 'logs',
       name,
       meta,
+      access: 'proxy',
       jsonData: {},
     },
     api: {

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -34,6 +34,7 @@ export const instanceSettings: DataSourceInstanceSettings = {
   uid: ExpressionDatasourceUID,
   name: ExpressionDatasourceID,
   type: 'grafana-expression',
+  access: 'proxy',
   meta: {
     baseUrl: '',
     module: '',

--- a/public/app/features/variables/shared/testing/helpers.ts
+++ b/public/app/features/variables/shared/testing/helpers.ts
@@ -7,6 +7,7 @@ export function getDataSourceInstanceSetting(name: string, meta: DataSourcePlugi
     type: '',
     name,
     meta,
+    access: 'proxy',
     jsonData: ({} as unknown) as DataSourceJsonData,
   };
 }

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -100,6 +100,7 @@ function getTestContext({
     name: 'test-elastic',
     type: 'type',
     uid: 'uid',
+    access: 'proxy',
     url: ELASTICSEARCH_MOCK_URL,
     database,
     jsonData,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/instanceSettings.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/instanceSettings.ts
@@ -6,6 +6,7 @@ export const createMockInstanceSetttings = (): AzureDataSourceInstanceSettings =
   id: 1,
   uid: 'abc',
   type: 'azuremonitor',
+  access: 'proxy',
   meta: {} as DataSourcePluginMeta,
   name: 'azure',
 

--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -215,6 +215,7 @@ const defaultSettings: DataSourceInstanceSettings = {
   type: 'tracing',
   name: 'jaeger',
   url: 'http://grafana.com',
+  access: 'proxy',
   meta: {
     id: 'jaeger',
     name: 'jaeger',

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -91,6 +91,7 @@ const defaultSettings: DataSourceInstanceSettings = {
   uid: '0',
   type: 'tracing',
   name: 'jaeger',
+  access: 'proxy',
   meta: {
     id: 'jaeger',
     name: 'jaeger',

--- a/public/app/plugins/datasource/zipkin/datasource.test.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.test.ts
@@ -52,4 +52,5 @@ const defaultSettings: DataSourceInstanceSettings = {
   name: 'zipkin',
   meta: {} as any,
   jsonData: {},
+  access: 'proxy',
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
As a part of data source backend migration (for Elastic, Prometheus, ...) we need to know on frontend, if data source uses browser/server access mode. In this PR we are passing information about access to frontend

More https://docs.google.com/document/d/1CzmOgShzXmtac9Tcq5CT8-4_q3n1i2Kd88nZDEZCLGw and https://github.com/grafana/grafana/pull/31579/files#r594475244
**Which issue(s) this PR fixes**:
