### PR TITLE
Plugins: Fix plugin signature status

### DIFF
--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -124,7 +124,7 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin): 
     popularity: remote?.popularity || 0,
     publishedAt: remote?.createdAt || '',
     type: remote?.typeCode || local?.type,
-    signature: local?.signature || hasRemoteSignature ? PluginSignatureStatus.valid : PluginSignatureStatus.missing,
+    signature: local?.signature || (hasRemoteSignature ? PluginSignatureStatus.valid : PluginSignatureStatus.missing),
     updatedAt: remote?.updatedAt || local?.info.updated || '',
     version,
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently the signature status of plugins is incorrect if there is a local plugin and a remote plugin  with different signatures (for example Azure Monitor which is signed on remote but now a core plugin). This PR fixes this by making sure to evaluate the local signature first.

| Before | After |
| --- | --- |
| <img width="733" alt="Screenshot 2021-08-05 at 11 58 29" src="https://user-images.githubusercontent.com/73201/128332779-39b3d117-b458-4f1d-af68-01f821e964ea.png"> | <img width="733" alt="Screenshot 2021-08-05 at 11 57 47" src="https://user-images.githubusercontent.com/73201/128332777-4f9e5f08-6944-4868-b5f0-fdba9cd64854.png"> |

Related: #36229

**Special notes for your reviewer**:

Due to release I'll add the backport label and milestone later.