### PR TITLE
Adapt dashboard schema to validate on some devenv dashboards

### DIFF
--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -120,6 +120,9 @@ Family: scuemata.#Family & {
                     // The panel plugin type id. 
                     type: !=""
 
+                    // TODO docs
+                    id?: number
+
                     // Internal - the exact major and minor versions of the panel plugin
                     // schema. Hidden and therefore not a part of the data model, but
                     // expected to be filled with panel plugin schema versions so that it's
@@ -153,6 +156,7 @@ Family: scuemata.#Family & {
                     }
                     // Panel links.
                     // links?: [..._panelLink]
+
                     // Name of template variable to repeat for.
                     repeat?: string
                     // Direction to repeat in if 'repeat' is set.

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -177,7 +177,7 @@ Family: scuemata.#Family & {
 
                     // TODO docs
                     // TODO tighter constraint
-                    interval: string
+                    interval?: string
 
                     // The values depend on panel type
                     options: {...}

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -69,7 +69,7 @@ Family: scuemata.#Family & {
                 refresh?: string
                 // Version of the JSON schema, incremented each time a Grafana update brings
                 // changes to said schema.
-                schemaVersion: number | *25
+                schemaVersion: number | *30
                 // Version of the dashboard, incremented each time the dashboard is updated.
                 version?: number
                 panels?: [...#Panel]

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -165,7 +165,8 @@ Family: scuemata.#Family & {
                     // FIXME this is temporarily specified as a closed list so
                     // that validation will pass when no links are present, but
                     // to force a failure as soon as it's checked against there
-                    // being anything in the list
+                    // being anything in the list so it can be fixed in
+                    // accordance with that object
                     links?: []
 
                     // Name of template variable to repeat for.
@@ -188,6 +189,14 @@ Family: scuemata.#Family & {
                     // TODO docs
                     // TODO tighter constraint
                     interval?: string
+
+                    // TODO docs
+                    // TODO tighter constraint
+                    timeFrom?: string
+
+                    // TODO docs
+                    // TODO tighter constraint
+                    timeShift?: string
 
                     // The values depend on panel type
                     options: {...}

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -22,7 +22,7 @@ Family: scuemata.#Family & {
                 // Theme of dashboard.
                 style: *"light" | "dark"
                 // Timezone of dashboard,
-                timezone?: *"browser" | "utc"
+                timezone?: *"browser" | "utc" | ""
                 // Whether a dashboard is editable or not.
                 editable: bool | *true
                 // 0 for no shared crosshair or tooltip (default).

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -66,7 +66,7 @@ Family: scuemata.#Family & {
                     showIn:   number | *0
                 }]
                 // Auto-refresh interval.
-                refresh?: string
+                refresh?: string | false
                 // Version of the JSON schema, incremented each time a Grafana update brings
                 // changes to said schema.
                 schemaVersion: number | *30

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -74,13 +74,13 @@ Family: scuemata.#Family & {
                 version?: number
                 panels?: [...#Panel]
 
-                // TODO
+                // TODO docs
                 #FieldColorModeId: "thresholds" | "palette-classic" | "palette-saturated" | "continuous-GrYlRd" | "fixed" @cuetsy(targetType="enum")
 
-                // TODO
+                // TODO docs
                 #FieldColorSeriesByMode: "min" | "max" | "last" @cuetsy(targetType="type")
 
-                // TODO
+                // TODO docs
                 #FieldColor: {
                     // The main color scheme mode
                     mode: #FieldColorModeId | string
@@ -88,6 +88,27 @@ Family: scuemata.#Family & {
                     fixedColor?: string
                     // Some visualizations need to know how to assign a series color from by value color schemes
                     seriesBy?: #FieldColorSeriesByMode
+                } @cuetsy(targetType="interface")
+
+                // TODO docs
+                #Threshold: {
+                    // TODO docs
+                    value: number
+                    // TODO docs
+                    color: string
+                    // TODO docs
+                    // TODO are the values here enumerable into a disjunction?
+                    // Some seem to be listed in typescript comment
+                    state?: string
+                } @cuetsy(targetType="interface")
+
+                #ThresholdsMode: "absolute" | "percentage" @cuetsy(targetType="enum")
+
+                #ThresholdsConfig: {
+                    mode: #ThresholdsMode
+
+                    // Must be sorted by 'value', first value is always -Infinity
+                    steps: [...#Threshold]
                 } @cuetsy(targetType="interface")
 
                 // Dashboard panels. Panels are canonically defined inline
@@ -185,14 +206,14 @@ Family: scuemata.#Family & {
                             //   // Convert input values into a display string
                             //   mappings?: ValueMapping[];
 
-                            //   // Map numeric values to states
-                            //   thresholds?: ThresholdsConfig;
+                            // Map numeric values to states
+                            thresholds?: #ThresholdsConfig
 
                             //   // Map values to a display color
                             color?: #FieldColor
 
                             //   // Used when reducing field values
-                            //   nullValueMode?: NullValueMode;
+                            //   nullValueMode?: NullValueMode
 
                             //   // The behavior when clicking on a result
                             links?: [...]

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -124,6 +124,12 @@ Family: scuemata.#Family & {
                     // TODO docs
                     id?: number
 
+                    // FIXME this almost certainly has to be changed in favor of scuemata versions
+                    pluginVersion?: string
+
+                    // TODO docs
+                    tags?: [...string]
+
                     // Internal - the exact major and minor versions of the panel plugin
                     // schema. Hidden and therefore not a part of the data model, but
                     // expected to be filled with panel plugin schema versions so that it's
@@ -156,7 +162,11 @@ Family: scuemata.#Family & {
                         static?: bool
                     }
                     // Panel links.
-                    // links?: [..._panelLink]
+                    // FIXME this is temporarily specified as a closed list so
+                    // that validation will pass when no links are present, but
+                    // to force a failure as soon as it's checked against there
+                    // being anything in the list
+                    links?: []
 
                     // Name of template variable to repeat for.
                     repeat?: string

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -93,7 +93,8 @@ Family: scuemata.#Family & {
                 // TODO docs
                 #Threshold: {
                     // TODO docs
-                    value: number
+                    // FIXME the corresponding typescript field is required/non-optional, but some dashboard json apparently omits this field
+                    value?: number
                     // TODO docs
                     color: string
                     // TODO docs

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -214,8 +214,16 @@ Family: scuemata.#Family & {
                             min?: number
                             max?: number
 
-                            //   // Convert input values into a display string
-                            //   mappings?: ValueMapping[];
+                            // Convert input values into a display string
+                            //
+                            // TODO this one corresponds to a complex type with
+                            // generics on the typescript side. Ouch. Will
+                            // either need special care, or we'll just need to
+                            // accept a very loosely specified schema. It's very
+                            // unlikely we'll be able to translate cue to
+                            // typescript generics in the general case, though
+                            // this particular one *may* be able to work.
+                            mappings?: [...{...}]
 
                             // Map numeric values to states
                             thresholds?: #ThresholdsConfig

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -200,10 +200,17 @@ Family: scuemata.#Family & {
                             // Alternative to empty string
                             noValue?: string
 
+                            // TODO conundrum: marking this struct as open would
+                            // - i think - preclude closed validation of
+                            // plugin-defined config bits. But, marking it
+                            // closed makes it impossible to use just this
+                            // schema (the "base" variant) to validate the base
+                            // components of a dashboard.
+                            //
                             // Can always exist. Valid fields within this are
                             // defined by the panel plugin - that's the
                             // PanelFieldConfig that comes from the plugin.
-                            custom?: {}
+                            custom?: {...}
                         }
                         overrides: [...{
                             matcher: {

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -69,6 +69,7 @@ Family: scuemata.#Family & {
                 refresh?: string | false
                 // Version of the JSON schema, incremented each time a Grafana update brings
                 // changes to said schema.
+                // FIXME this is the old schema numbering system, and will be replaced by scuemata
                 schemaVersion: number | *30
                 // Version of the dashboard, incremented each time the dashboard is updated.
                 version?: number
@@ -93,7 +94,7 @@ Family: scuemata.#Family & {
                 // TODO docs
                 #Threshold: {
                     // TODO docs
-                    // FIXME the corresponding typescript field is required/non-optional, but some dashboard json apparently omits this field
+                    // FIXME the corresponding typescript field is required/non-optional, but nulls currently appear here when serializing -Infinity to JSON
                     value?: number
                     // TODO docs
                     color: string
@@ -111,6 +112,15 @@ Family: scuemata.#Family & {
                     // Must be sorted by 'value', first value is always -Infinity
                     steps: [...#Threshold]
                 } @cuetsy(targetType="interface")
+
+                // Schema for panel targets is specified by datasource
+                // plugins. We use a placeholder definition, which the Go
+                // schema loader either left open/as-is with the Base
+                // variant of the Dashboard and Panel families, or filled
+                // with types derived from plugins in the Instance variant.
+                // When working directly from CUE, importers can extend this
+                // type directly to achieve the same effect.
+                #Target: {...}
 
                 // Dashboard panels. Panels are canonically defined inline
                 // because they share a version timeline with the dashboard
@@ -139,6 +149,9 @@ Family: scuemata.#Family & {
                     // The major and minor versions of the panel plugin for this schema.
                     // TODO 2-tuple list instead of struct?
                     panelSchema?: { maj: number, min: number }
+
+                    // TODO docs
+                    targets?: [...#Target]
 
                     // Panel title.
                     title?: string
@@ -174,14 +187,6 @@ Family: scuemata.#Family & {
                     // Direction to repeat in if 'repeat' is set.
                     // "h" for horizontal, "v" for vertical.
                     repeatDirection: *"h" | "v"
-                    // Schema for panel targets is specified by datasource
-                    // plugins. We use a placeholder definition, which the Go
-                    // schema loader either left open/as-is with the Base
-                    // variant of the Dashboard and Panel families, or filled
-                    // with types derived from plugins in the Instance variant.
-                    // When working directly from CUE, importers can extend this
-                    // type directly to achieve the same effect.
-                    targets?: [...{...}]
 
                     // TODO docs
                     maxDataPoints?: number

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -171,6 +171,13 @@ Family: scuemata.#Family & {
                     // type directly to achieve the same effect.
                     targets?: [...{...}]
 
+                    // TODO docs
+                    maxDataPoints?: number
+
+                    // TODO docs
+                    // TODO tighter constraint
+                    interval: string
+
                     // The values depend on panel type
                     options: {...}
                     fieldConfig: {

--- a/cue/data/gen.cue
+++ b/cue/data/gen.cue
@@ -74,6 +74,22 @@ Family: scuemata.#Family & {
                 version?: number
                 panels?: [...#Panel]
 
+                // TODO
+                #FieldColorModeId: "thresholds" | "palette-classic" | "palette-saturated" | "continuous-GrYlRd" | "fixed" @cuetsy(targetType="enum")
+
+                // TODO
+                #FieldColorSeriesByMode: "min" | "max" | "last" @cuetsy(targetType="type")
+
+                // TODO
+                #FieldColor: {
+                    // The main color scheme mode
+                    mode: #FieldColorModeId | string
+                    // Stores the fixed color value if mode is fixed
+                    fixedColor?: string
+                    // Some visualizations need to know how to assign a series color from by value color schemes
+                    seriesBy?: #FieldColorSeriesByMode
+                } @cuetsy(targetType="interface")
+
                 // Dashboard panels. Panels are canonically defined inline
                 // because they share a version timeline with the dashboard
                 // schema; they do not vary independently. We create a separate,
@@ -173,7 +189,7 @@ Family: scuemata.#Family & {
                             //   thresholds?: ThresholdsConfig;
 
                             //   // Map values to a display color
-                            //   color?: FieldColor;
+                            color?: #FieldColor
 
                             //   // Used when reducing field values
                             //   nullValueMode?: NullValueMode;

--- a/cue/ui/gen.cue
+++ b/cue/ui/gen.cue
@@ -33,7 +33,7 @@ ScaleDistribution:    "linear" | "log"                                        @c
 GraphGradientMode:    "none" | "opacity" | "hue" | "scheme"                   @cuetsy(targetType="enum")
 LineStyle: {
 	fill?: "solid" | "dash" | "dot" | "square"
-	dash?: [number]
+	dash?: [...number]
 } @cuetsy(targetType="interface")
 LineConfig: {
 	lineColor?:         string
@@ -68,7 +68,7 @@ AxisConfig: {
 HideSeriesConfig: {
 	tooltip: bool
 	legend:  bool
-	graph:   bool
+	viz:   bool
 } @cuetsy(targetType="interface")
 LegendPlacement:   "bottom" | "right"          @cuetsy(targetType="type")
 LegendDisplayMode: "list" | "table" | "hidden" @cuetsy(targetType="enum")
@@ -86,7 +86,7 @@ GraphFieldConfig: LineConfig & FillConfig & PointsConfig & AxisConfig & {
 VizLegendOptions: {
 	displayMode: LegendDisplayMode
 	placement:   LegendPlacement
-	calcs: [string]
+	calcs: [...string]
 } @cuetsy(targetType="interface")
 VizTooltipOptions: {
 	mode: TooltipDisplayMode

--- a/devenv/dev-dashboards/home.json
+++ b/devenv/dev-dashboards/home.json
@@ -19,12 +19,10 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
   "graphTooltip": 0,
   "links": [],
   "panels": [
     {
-      "datasource": null,
       "gridPos": {
         "h": 26,
         "w": 6,
@@ -34,7 +32,6 @@
       "id": 7,
       "links": [],
       "options": {
-        "folderId": null,
         "maxItems": 100,
         "query": "",
         "showHeadings": true,
@@ -45,13 +42,10 @@
       },
       "pluginVersion": "8.1.0-pre",
       "tags": [],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Starred",
       "type": "dashlist"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 13,
         "w": 6,
@@ -75,13 +69,10 @@
       "tags": [
         "panel-tests"
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "tag: panel-tests",
       "type": "dashlist"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 13,
         "w": 6,
@@ -91,7 +82,6 @@
       "id": 3,
       "links": [],
       "options": {
-        "folderId": null,
         "maxItems": 1000,
         "query": "",
         "showHeadings": false,
@@ -108,13 +98,10 @@
         "gdev",
         "demo"
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "tag: dashboard-demo",
       "type": "dashlist"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 26,
         "w": 6,
@@ -124,7 +111,6 @@
       "id": 5,
       "links": [],
       "options": {
-        "folderId": null,
         "maxItems": 1000,
         "query": "",
         "showHeadings": false,
@@ -141,13 +127,10 @@
         "gdev",
         "datasource-test"
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Data source tests",
       "type": "dashlist"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 13,
         "w": 6,
@@ -173,13 +156,10 @@
         "templating",
         "gdev"
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "tag: templating ",
       "type": "dashlist"
     },
     {
-      "datasource": null,
       "gridPos": {
         "h": 13,
         "w": 6,
@@ -205,8 +185,6 @@
         "gdev",
         "demo"
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "tag: transforms",
       "type": "dashlist"
     }

--- a/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
@@ -13,7 +13,6 @@
       ]
     },
     "editable": true,
-    "gnetId": null,
     "graphTooltip": 0,    
     "links": [],
     "panels": [
@@ -59,8 +58,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "green",
-                  "value": null
+                  "color": "green"
                 },
                 {
                   "color": "orange",
@@ -104,7 +102,6 @@
         "type": "timeseries"
       },
       {
-        "datasource": null,
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -145,8 +142,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "green",
-                  "value": null
+                  "color": "green"
                 },
                 {
                   "color": "orange",
@@ -192,7 +188,6 @@
             "startValue": 1
           }
         ],
-        "timeFrom": null,
         "title": "Color bars by discrete thresholds",
         "type": "timeseries"
       },
@@ -238,8 +233,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "blue",
-                  "value": null
+                  "color": "blue"
                 },
                 {
                   "color": "green",
@@ -328,8 +322,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "blue",
-                  "value": null
+                  "color": "blue"
                 },
                 {
                   "color": "green",
@@ -418,8 +411,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "blue",
-                  "value": null
+                  "color": "blue"
                 },
                 {
                   "color": "green",
@@ -467,7 +459,6 @@
         "type": "timeseries"
       },
       {
-        "datasource": null,
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -508,8 +499,7 @@
               "mode": "absolute",
               "steps": [
                 {
-                  "color": "blue",
-                  "value": null
+                  "color": "blue"
                 },
                 {
                   "color": "green",

--- a/packages/grafana-ui/src/components/uPlot/models.cue
+++ b/packages/grafana-ui/src/components/uPlot/models.cue
@@ -50,9 +50,12 @@ AxisConfig: {
 HideSeriesConfig: {
   tooltip: bool
   legend: bool
-  graph: bool
+  viz: bool
 } @cuetsy(targetType="interface")
 
+// TODO This is the same composition as what's used in the timeseries panel's
+// PanelFieldConfig. If that's the only place it's used, it probably shouldn't
+// be assembled here, too
 GraphFieldConfig: LineConfig & FillConfig & PointsConfig & AxisConfig & {
   drawStyle?: DrawStyle
   gradientMode?: GraphGradientMode

--- a/public/app/plugins/panel/timeseries/models.cue
+++ b/public/app/plugins/panel/timeseries/models.cue
@@ -1,0 +1,42 @@
+// Copyright 2021 Grafana Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grafanaschema
+
+import (
+    ui "github.com/grafana/grafana/cue/ui:grafanaschema"
+)
+
+Family: {
+    lineages: [
+        [
+            {
+                PanelOptions: {
+                    legend: ui.VizLegendOptions
+                    tooltip: ui.VizTooltipOptions
+                }
+                PanelFieldConfig: {
+                    ui.LineConfig
+                    ui.FillConfig
+                    ui.PointsConfig
+                    ui.AxisConfig
+                    drawStyle?:    ui.DrawStyle
+                    gradientMode?: ui.GraphGradientMode
+                    hideFrom?:     ui.HideSeriesConfig
+                }
+            }
+        ]
+    ]
+    migrations: []
+}


### PR DESCRIPTION
Part of #36844

This updates the dashboard schema (`cue/data/gen.cue`) such that `devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json` passes validation. It also creates the `models.cue` for the `timeseries` panel plugin.

Some notes about things that arose while i was doing this one:

* We're just ignoring everything under `packages/` for the moment, but this introduced a _lot_ of types into the dashboard schema that i believe the intent is to have be in standalone files, and exported to Typescript (because i derived those types from Typescript definitions)
  * Pursuant to the above, i'm not actually sure that using definitions (e.g. `#Threshold`) like this within scuemata - where we need to be able to do the backwards compat subsumption checks with subsequent versions of schema - is a good idea. But i'm kicking that can down the road to the next iteration of scuemata work; we do it this way for now just to make it through this round.
* Do we really want to allow empty string for `timezone`? If empty string is treated as equivalent to either `browser` or `utc`, then one of those must be the default in the schema, and `""` should not be allowed. This is the same reason we disallow nulls - having multiple values that mean the same thing creates ambiguity and confusion.
* There's a conundrum around the openness of the struct for the `custom` field, see the note in code. (Also applies to `options`, though the note isn't there.)
* The errors when a validation problem occurs in a plugin-owned part of the JSON are really quite confusing:

```
Family.lineages.0.0.panels.1: 6 errors in empty disjunction:
Family.lineages.0.0.panels.1.options.legend.calcs: incompatible list lengths (0 and 1)
Family.lineages.0.0.panels.1.type: conflicting values "dashlist" and "timeseries":
    /cue/data/gen.cue:75:30
    dashlist-glue-panelComposition:3:9
    dashlist-glue-panelComposition:11:9
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:1:1
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:192:17
    glue-panelDisjunction:3:34
    glue-unifyPanelDashboard:4:11
Family.lineages.0.0.panels.1.type: conflicting values "histogram" and "timeseries":
    /cue/data/gen.cue:75:30
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:1:1
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:192:17
    glue-panelDisjunction:3:34
    glue-unifyPanelDashboard:4:11
    histogram-glue-panelComposition:3:9
    histogram-glue-panelComposition:11:9
Family.lineages.0.0.panels.1.type: conflicting values "news" and "timeseries":
    /cue/data/gen.cue:75:30
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:1:1
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:192:17
    glue-panelDisjunction:3:34
    glue-unifyPanelDashboard:4:11
    news-glue-panelComposition:3:9
    news-glue-panelComposition:11:9
Family.lineages.0.0.panels.1.type: conflicting values "table" and "timeseries":
    /cue/data/gen.cue:75:30
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:1:1
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:192:17
    glue-panelDisjunction:3:34
    glue-unifyPanelDashboard:4:11
    table-glue-panelComposition:3:9
    table-glue-panelComposition:11:9
Family.lineages.0.0.panels.1.type: conflicting values "text" and "timeseries":
    /cue/data/gen.cue:75:30
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:1:1
    devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json:192:17
    glue-panelDisjunction:3:34
    glue-unifyPanelDashboard:4:11
    text-glue-panelComposition:3:9
    text-glue-panelComposition:11:9
```

Of the 41 lines of text there, only line 2 tells us the actual problem (`options.legend.calcs` has a mismatched list length, violating the schema declared by `timeseries`. ([This](https://github.com/grafana/grafana/pull/37594/files#diff-279feda2afcd43dcb2ae29a39aa2ab9fbf36fae988f968b89030b88e0b90235cR89) was the problem - the list needed to be open, not closed.) Everything else is just saying, "this isn't a panel of type X". 

Will make separate issues for these items.