### PR TITLE
Wire: fix database migrations for tests

### DIFF
--- a/pkg/server/test_env.go
+++ b/pkg/server/test_env.go
@@ -1,0 +1,12 @@
+package server
+
+import "github.com/grafana/grafana/pkg/services/sqlstore"
+
+func ProvideTestEnv(server *Server, store *sqlstore.SQLStore) (*TestEnv, error) {
+	return &TestEnv{server, store}, nil
+}
+
+type TestEnv struct {
+	Server   *Server
+	SQLStore *sqlstore.SQLStore
+}

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -137,6 +137,8 @@ var wireSet = wire.NewSet(
 
 var wireTestSet = wire.NewSet(
 	wireBasicSet,
+	ProvideTestEnv,
+	sqlstore.ProvideServiceForTests,
 	ngmetrics.ProvideServiceForTest,
 )
 
@@ -145,7 +147,7 @@ func Initialize(cla setting.CommandLineArgs, opts Options, apiOpts api.ServerOpt
 	return &Server{}, nil
 }
 
-func InitializeForTest(cla setting.CommandLineArgs, opts Options, apiOpts api.ServerOptions, sqlStore *sqlstore.SQLStore) (*Server, error) {
+func InitializeForTest(cla setting.CommandLineArgs, opts Options, apiOpts api.ServerOptions) (*TestEnv, error) {
 	wire.Build(wireExtsTestSet)
-	return &Server{}, nil
+	return &TestEnv{Server: &Server{}, SQLStore: &sqlstore.SQLStore{}}, nil
 }

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -73,6 +73,10 @@ func ProvideService(cfg *setting.Cfg, cacheService *localcache.CacheService, bus
 	return s, nil
 }
 
+func ProvideServiceForTests(migrations registry.DatabaseMigrator) (*SQLStore, error) {
+	return initTestDB(migrations, InitTestDBOpt{EnsureDefaultOrgAndUser: true})
+}
+
 func newSQLStore(cfg *setting.Cfg, cacheService *localcache.CacheService, bus bus.Bus, engine *xorm.Engine,
 	migrations registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQLStore, error) {
 	ss := &SQLStore{
@@ -433,16 +437,25 @@ type InitTestDBOpt struct {
 
 // InitTestDBWithMigration initializes the test DB given custom migrations.
 func InitTestDBWithMigration(t ITestDB, migration registry.DatabaseMigrator, opts ...InitTestDBOpt) *SQLStore {
-	return initTestDB(t, migration, opts...)
+	t.Helper()
+	store, err := initTestDB(migration, opts...)
+	if err != nil {
+		t.Fatalf("failed to initialize sql store: %v", err)
+	}
+	return store
 }
 
 // InitTestDB initializes the test DB.
 func InitTestDB(t ITestDB, opts ...InitTestDBOpt) *SQLStore {
-	return initTestDB(t, &migrations.OSSMigrations{}, opts...)
+	t.Helper()
+	store, err := initTestDB(&migrations.OSSMigrations{}, opts...)
+	if err != nil {
+		t.Fatalf("failed to initialize sql store: %v", err)
+	}
+	return store
 }
 
-func initTestDB(t ITestDB, migration registry.DatabaseMigrator, opts ...InitTestDBOpt) *SQLStore {
-	t.Helper()
+func initTestDB(migration registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQLStore, error) {
 	testSQLStoreMutex.Lock()
 	defer testSQLStoreMutex.Unlock()
 	if testSQLStore == nil {
@@ -454,7 +467,6 @@ func initTestDB(t ITestDB, migration registry.DatabaseMigrator, opts ...InitTest
 
 		// environment variable present for test db?
 		if db, present := os.LookupEnv("GRAFANA_TEST_DB"); present {
-			t.Logf("Using database type %q", db)
 			dbType = db
 		}
 
@@ -462,41 +474,39 @@ func initTestDB(t ITestDB, migration registry.DatabaseMigrator, opts ...InitTest
 		cfg := setting.NewCfg()
 		sec, err := cfg.Raw.NewSection("database")
 		if err != nil {
-			t.Fatalf("Failed to create section: %s", err)
+			return nil, err
 		}
 		if _, err := sec.NewKey("type", dbType); err != nil {
-			t.Fatalf("Failed to create key: %s", err)
+			return nil, err
 		}
 
 		switch dbType {
 		case "mysql":
 			if _, err := sec.NewKey("connection_string", sqlutil.MySQLTestDB().ConnStr); err != nil {
-				t.Fatalf("Failed to create key: %s", err)
+				return nil, err
 			}
 		case "postgres":
 			if _, err := sec.NewKey("connection_string", sqlutil.PostgresTestDB().ConnStr); err != nil {
-				t.Fatalf("Failed to create key: %s", err)
+				return nil, err
 			}
 		default:
 			if _, err := sec.NewKey("connection_string", sqlutil.SQLite3TestDB().ConnStr); err != nil {
-				t.Fatalf("Failed to create key: %s", err)
+				return nil, err
 			}
 		}
 
 		// useful if you already have a database that you want to use for tests.
 		// cannot just set it on testSQLStore as it overrides the config in Init
 		if _, present := os.LookupEnv("SKIP_MIGRATIONS"); present {
-			t.Log("Skipping database migrations")
 			if _, err := sec.NewKey("skip_migrations", "true"); err != nil {
-				t.Fatalf("Failed to create key: %s", err)
+				return nil, err
 			}
 		}
 
 		// need to get engine to clean db before we init
-		t.Logf("Creating database connection: %q", sec.Key("connection_string"))
 		engine, err := xorm.NewEngine(dbType, sec.Key("connection_string").String())
 		if err != nil {
-			t.Fatalf("Failed to init test database: %v", err)
+			return nil, err
 		}
 
 		engine.DatabaseTZ = time.UTC
@@ -504,46 +514,42 @@ func initTestDB(t ITestDB, migration registry.DatabaseMigrator, opts ...InitTest
 
 		testSQLStore, err = newSQLStore(cfg, localcache.New(5*time.Minute, 10*time.Minute), bus.GetBus(), engine, migration, opts...)
 		if err != nil {
-			t.Fatalf("Failed to init test database: %s", err)
+			return nil, err
 		}
 
 		if err := testSQLStore.Migrate(); err != nil {
-			t.Fatalf("Database migration failed: %s", err)
+			return nil, err
 		}
 
-		t.Log("Truncating DB tables")
 		if err := dialect.TruncateDBTables(); err != nil {
-			t.Fatalf("Failed to truncate test db: %s", err)
+			return nil, err
 		}
 
 		if err := testSQLStore.Reset(); err != nil {
-			t.Fatalf("Database reset failed: %s", err)
+			return nil, err
 		}
 
 		// Make sure the changes are synced, so they get shared with eventual other DB connections
 		// XXX: Why is this only relevant when not skipping migrations?
 		if !testSQLStore.dbCfg.SkipMigrations {
 			if err := testSQLStore.Sync(); err != nil {
-				t.Fatalf("Database sync failed: %s", err)
+				return nil, err
 			}
 		}
 
-		t.Log("Successfully initialized test database")
 		// temp global var until we get rid of global vars
 		dialect = testSQLStore.Dialect
-
-		return testSQLStore
+		return testSQLStore, nil
 	}
 
-	t.Log("Truncating DB tables")
 	if err := dialect.TruncateDBTables(); err != nil {
-		t.Fatalf("Failed to truncate test db: %s", err)
+		return nil, err
 	}
 	if err := testSQLStore.Reset(); err != nil {
-		t.Fatalf("Failed to reset SQLStore: %s", err)
+		return nil, err
 	}
 
-	return testSQLStore
+	return testSQLStore, nil
 }
 
 func IsTestDbMySQL() bool {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -440,7 +440,7 @@ func InitTestDBWithMigration(t ITestDB, migration registry.DatabaseMigrator, opt
 	t.Helper()
 	store, err := initTestDB(migration, opts...)
 	if err != nil {
-		t.Fatalf("failed to initialize sql store: %v", err)
+		t.Fatalf("failed to initialize sql store: %s", err)
 	}
 	return store
 }
@@ -450,7 +450,7 @@ func InitTestDB(t ITestDB, opts ...InitTestDBOpt) *SQLStore {
 	t.Helper()
 	store, err := initTestDB(&migrations.OSSMigrations{}, opts...)
 	if err != nil {
-		t.Fatalf("failed to initialize sql store: %v", err)
+		t.Fatalf("failed to initialize sql store: %s", err)
 	}
 	return store
 }

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -19,8 +19,7 @@ func TestAlertmanagerConfigurationIsTransactional(t *testing.T) {
 		AnonymousUserRole:    models.ROLE_EDITOR,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
+	grafanaListedAddr, _ := testinfra.StartGrafana(t, dir, path)
 	alertConfigURL := fmt.Sprintf("http://%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
 
 	// On a blank start with no configuration, it saves and delivers the default configuration.
@@ -74,8 +73,7 @@ func TestAlertmanagerConfigurationPersistSecrets(t *testing.T) {
 		AnonymousUserRole:    models.ROLE_EDITOR,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
+	grafanaListedAddr, _ := testinfra.StartGrafana(t, dir, path)
 	alertConfigURL := fmt.Sprintf("http://%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)
 	generatedUID := ""
 

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -33,10 +33,9 @@ func TestAMConfigAccess(t *testing.T) {
 		DisableAnonymous:     true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create a users to make authenticated requests
 	require.NoError(t, createUser(t, store, models.ROLE_VIEWER, "viewer", "viewer"))
@@ -380,10 +379,9 @@ func TestAlertAndGroupsQuery(t *testing.T) {
 		DisableAnonymous:     true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// unauthenticated request to get the alerts should fail
 	{
@@ -544,10 +542,9 @@ func TestRulerAccess(t *testing.T) {
 		ViewersCanEdit:       true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create the namespace we'll save our alerts to.
 	_, err := createFolder(t, store, 0, "default")
@@ -659,10 +656,9 @@ func TestDeleteFolderWithRules(t *testing.T) {
 		ViewersCanEdit:       true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create the namespace we'll save our alerts to.
 	namespaceUID, err := createFolder(t, store, 0, "default")
@@ -810,10 +806,9 @@ func TestAlertRuleCRUD(t *testing.T) {
 		DisableAnonymous:     true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	err := createUser(t, store, models.ROLE_EDITOR, "grafana", "password")
 
@@ -1754,8 +1749,8 @@ func TestAlertmanagerStatus(t *testing.T) {
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		EnableFeatureToggles: []string{"ngalert"},
 	})
-	store := testinfra.SetUpDatabase(t, dir)
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
+
+	grafanaListedAddr, _ := testinfra.StartGrafana(t, dir, path)
 
 	// Get the Alertmanager current status.
 	{
@@ -1817,10 +1812,9 @@ func TestQuota(t *testing.T) {
 		DisableAnonymous:     true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create the namespace we'll save our alerts to.
 	_, err := createFolder(t, store, 0, "default")
@@ -1916,10 +1910,9 @@ func TestEval(t *testing.T) {
 		DisableAnonymous:     true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	require.NoError(t, createUser(t, store, models.ROLE_EDITOR, "grafana", "password"))
 

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -19,9 +19,8 @@ func TestAvailableChannels(t *testing.T) {
 		DisableAnonymous:     true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create a user to make authenticated requests
 	require.NoError(t, createUser(t, store, models.ROLE_EDITOR, "grafana", "password"))

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -36,9 +36,8 @@ func TestNotificationChannels(t *testing.T) {
 		DisableAnonymous:     true,
 	})
 
-	s := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, s := testinfra.StartGrafana(t, dir, path)
 	s.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, s)
 
 	mockChannel := newMockNotificationChannel(t, grafanaListedAddr)
 	amConfig := getAlertmanagerConfig(mockChannel.server.Addr)

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -24,10 +24,10 @@ func TestPrometheusRules(t *testing.T) {
 		EnableFeatureToggles: []string{"ngalert"},
 		DisableAnonymous:     true,
 	})
-	store := testinfra.SetUpDatabase(t, dir)
+
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create the namespace under default organisation (orgID = 1) where we'll save our alerts to.
 	_, err := createFolder(t, store, 0, "default")
@@ -264,10 +264,10 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 		EnableFeatureToggles: []string{"ngalert"},
 		DisableAnonymous:     true,
 	})
-	store := testinfra.SetUpDatabase(t, dir)
+
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create a user to make authenticated requests
 	require.NoError(t, createUser(t, store, models.ROLE_EDITOR, "grafana", "password"))

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -25,10 +25,10 @@ func TestAlertRulePermissions(t *testing.T) {
 		EnableFeatureToggles: []string{"ngalert"},
 		DisableAnonymous:     true,
 	})
-	store := testinfra.SetUpDatabase(t, dir)
+
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create a user to make authenticated requests
 	require.NoError(t, createUser(t, store, models.ROLE_EDITOR, "grafana", "password"))
@@ -308,10 +308,9 @@ func TestAlertRuleConflictingTitle(t *testing.T) {
 		ViewersCanEdit:       true,
 	})
 
-	store := testinfra.SetUpDatabase(t, dir)
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
 	// override bus to get the GetSignedInUserQuery handler
 	store.Bus = bus.GetBus()
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, path, store)
 
 	// Create the namespace we'll save our alerts to.
 	_, err := createFolder(t, store, 0, "folder1")

--- a/pkg/tests/api/metrics/api_metrics_test.go
+++ b/pkg/tests/api/metrics/api_metrics_test.go
@@ -30,8 +30,8 @@ import (
 
 func TestQueryCloudWatchMetrics(t *testing.T) {
 	grafDir, cfgPath := testinfra.CreateGrafDir(t)
-	sqlStore := setUpDatabase(t, grafDir)
-	addr := testinfra.StartGrafana(t, grafDir, cfgPath, sqlStore)
+	addr, sqlStore := testinfra.StartGrafana(t, grafDir, cfgPath)
+	setUpDatabase(t, sqlStore)
 
 	origNewCWClient := cloudwatch.NewCWClient
 	t.Cleanup(func() {
@@ -94,8 +94,8 @@ func TestQueryCloudWatchMetrics(t *testing.T) {
 
 func TestQueryCloudWatchLogs(t *testing.T) {
 	grafDir, cfgPath := testinfra.CreateGrafDir(t)
-	sqlStore := setUpDatabase(t, grafDir)
-	addr := testinfra.StartGrafana(t, grafDir, cfgPath, sqlStore)
+	addr, store := testinfra.StartGrafana(t, grafDir, cfgPath)
+	setUpDatabase(t, store)
 
 	origNewCWLogsClient := cloudwatch.NewCWLogsClient
 	t.Cleanup(func() {
@@ -173,11 +173,10 @@ func makeCWRequest(t *testing.T, req dtos.MetricRequest, addr string) backend.Qu
 	return tr
 }
 
-func setUpDatabase(t *testing.T, grafDir string) *sqlstore.SQLStore {
+func setUpDatabase(t *testing.T, store *sqlstore.SQLStore) {
 	t.Helper()
 
-	sqlStore := testinfra.SetUpDatabase(t, grafDir)
-	err := sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		_, err := sess.Insert(&models.DataSource{
 			Id: 1,
 			// This will be the ID of the main org
@@ -192,8 +191,7 @@ func setUpDatabase(t *testing.T, grafDir string) *sqlstore.SQLStore {
 	require.NoError(t, err)
 
 	// Make sure changes are synced with other goroutines
-	err = sqlStore.Sync()
+	err = store.Sync()
 	require.NoError(t, err)
 
-	return sqlStore
 }

--- a/pkg/tests/api/plugins/api_install_test.go
+++ b/pkg/tests/api/plugins/api_install_test.go
@@ -29,9 +29,9 @@ func TestPluginInstallAccess(t *testing.T) {
 	dir, cfgPath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		PluginAdminEnabled: true,
 	})
-	store := testinfra.SetUpDatabase(t, dir)
+
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, cfgPath)
 	store.Bus = bus.GetBus() // in order to allow successful user auth
-	grafanaListedAddr := testinfra.StartGrafana(t, dir, cfgPath, store)
 
 	createUser(t, store, usernameNonAdmin, defaultPassword, false)
 	createUser(t, store, usernameAdmin, defaultPassword, true)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -24,7 +24,7 @@ import (
 
 // StartGrafana starts a Grafana server.
 // The server address is returned.
-func StartGrafana(t *testing.T, grafDir, cfgPath string, sqlStore *sqlstore.SQLStore) string {
+func StartGrafana(t *testing.T, grafDir, cfgPath string) (string, *sqlstore.SQLStore) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -33,17 +33,19 @@ func StartGrafana(t *testing.T, grafDir, cfgPath string, sqlStore *sqlstore.SQLS
 	cmdLineArgs := setting.CommandLineArgs{Config: cfgPath, HomePath: grafDir}
 	serverOpts := server.Options{Listener: listener, HomePath: grafDir}
 	apiServerOpts := api.ServerOptions{Listener: listener}
-	srv, err := server.InitializeForTest(cmdLineArgs, serverOpts, apiServerOpts, sqlStore)
+
+	env, err := server.InitializeForTest(cmdLineArgs, serverOpts, apiServerOpts)
 	require.NoError(t, err)
+	require.NoError(t, env.SQLStore.Sync())
 
 	go func() {
 		// When the server runs, it will also build and initialize the service graph
-		if err := srv.Run(); err != nil {
+		if err := env.Server.Run(); err != nil {
 			t.Log("Server exited uncleanly", "error", err)
 		}
 	}()
 	t.Cleanup(func() {
-		if err := srv.Shutdown(ctx, "test cleanup"); err != nil {
+		if err := env.Server.Shutdown(ctx, "test cleanup"); err != nil {
 			t.Error("Timed out waiting on server to shut down")
 		}
 	})
@@ -61,7 +63,7 @@ func StartGrafana(t *testing.T, grafDir, cfgPath string, sqlStore *sqlstore.SQLS
 
 	t.Logf("Grafana is listening on %s", addr)
 
-	return addr
+	return addr, env.SQLStore
 }
 
 // SetUpDatabase sets up the Grafana database.

--- a/pkg/tests/web/index_view_test.go
+++ b/pkg/tests/web/index_view_test.go
@@ -18,8 +18,7 @@ func TestIndexView(t *testing.T) {
 		grafDir, cfgPath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			EnableCSP: true,
 		})
-		sqlStore := testinfra.SetUpDatabase(t, grafDir)
-		addr := testinfra.StartGrafana(t, grafDir, cfgPath, sqlStore)
+		addr, _ := testinfra.StartGrafana(t, grafDir, cfgPath)
 
 		// nolint:bodyclose
 		resp, html := makeRequest(t, addr)
@@ -29,8 +28,7 @@ func TestIndexView(t *testing.T) {
 
 	t.Run("CSP disabled", func(t *testing.T) {
 		grafDir, cfgPath := testinfra.CreateGrafDir(t)
-		sqlStore := testinfra.SetUpDatabase(t, grafDir)
-		addr := testinfra.StartGrafana(t, grafDir, cfgPath, sqlStore)
+		addr, _ := testinfra.StartGrafana(t, grafDir, cfgPath)
 
 		// nolint:bodyclose
 		resp, html := makeRequest(t, addr)


### PR DESCRIPTION
**What this PR does / why we need it**:
To solve migrations issues in tests for both enterprise and oss
