### PR TITLE
Toolkit: rename deprecated tsConfig to tsconfig

### DIFF
--- a/packages/grafana-toolkit/src/config/jest.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/jest.plugin.config.ts
@@ -60,7 +60,7 @@ export const jestConfig = (baseDir: string = process.cwd()) => {
     globals: {
       'ts-jest': {
         isolatedModules: true,
-        tsConfig: path.resolve(baseDir, 'tsconfig.json'),
+        tsconfig: path.resolve(baseDir, 'tsconfig.json'),
       },
     },
     coverageReporters: ['json-summary', 'text', 'lcov'],


### PR DESCRIPTION
**What this PR does / why we need it**:

When running tests with toolkit there is a warning `ts-jest[config] (WARN) The option 'tsConfig' is deprecated and will be removed in ts-jest 27, use 'tsconfig' instead`

