### PR TITLE
Logs panel: Scroll to the bottom on page refresh when sorting in ascending order

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentProps } from 'react';
 import { render, screen } from '@testing-library/react';
-import { LoadingState, MutableDataFrame, FieldType } from '@grafana/data';
+import { LoadingState, MutableDataFrame, FieldType, LogsSortOrder } from '@grafana/data';
 import { LogsPanel } from './LogsPanel';
 
 type LogsPanelProps = ComponentProps<typeof LogsPanel>;
@@ -37,6 +37,22 @@ describe('LogsPanel', () => {
       expect(screen.getByText(/common labels:/i)).toBeInTheDocument();
       expect(screen.getByText(/common_app/i)).toBeInTheDocument();
       expect(screen.getByText(/common_job/i)).toBeInTheDocument();
+    });
+    it('shows common labels on top when descending sort order', () => {
+      const { container } = setup({
+        data: { series: seriesWithCommonLabels },
+        options: { showCommonLabels: true, sortOrder: LogsSortOrder.Descending },
+      });
+
+      expect(container.firstChild?.childNodes[0].textContent).toMatch(/^Common labels:common_appcommon_job/);
+    });
+    it('shows common labels on bottom when ascending sort order', () => {
+      const { container } = setup({
+        data: { series: seriesWithCommonLabels },
+        options: { showCommonLabels: true, sortOrder: LogsSortOrder.Ascending },
+      });
+
+      expect(container.firstChild?.childNodes[0].textContent).toMatch(/Common labels:common_appcommon_job$/);
     });
     it('does not show common labels when showCommonLabels is set to false', () => {
       setup({ data: { series: seriesWithCommonLabels }, options: { showCommonLabels: false } });

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -26,7 +26,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
 }) => {
   const style = useStyles2(getStyles(title, sortOrder));
   const [scrollTop, setScrollTop] = useState(0);
-  const labelsContainerRef = useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
+  const logsContainerRef = useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
   const isAscending = sortOrder === LogsSortOrder.Ascending;
 
   // Important to memoize stuff here, as panel rerenders a lot for example when resizing.
@@ -39,8 +39,8 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   }, [data, dedupStrategy]);
 
   useLayoutEffect(() => {
-    if (isAscending && labelsContainerRef.current) {
-      setScrollTop(labelsContainerRef.current.offsetHeight);
+    if (isAscending && logsContainerRef.current) {
+      setScrollTop(logsContainerRef.current.offsetHeight);
     } else {
       setScrollTop(0);
     }
@@ -70,7 +70,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
 
   return (
     <CustomScrollbar autoHide scrollTop={scrollTop}>
-      <div className={style.container} ref={labelsContainerRef}>
+      <div className={style.container} ref={logsContainerRef}>
         {showCommonLabels && !isAscending && renderCommonLabels()}
         <LogRows
           logRows={logRows}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -27,7 +27,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   const isAscending = sortOrder === LogsSortOrder.Ascending;
   const style = useStyles2(getStyles(title, isAscending));
   const [scrollTop, setScrollTop] = useState(0);
-  const logsContainerRef = useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
+  const logsContainerRef = useRef<HTMLDivElement>(null);
 
   // Important to memoize stuff here, as panel rerenders a lot for example when resizing.
   const [logRows, deduplicatedRows, commonLabels] = useMemo(() => {
@@ -44,7 +44,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
     } else {
       setScrollTop(0);
     }
-  }, [isAscending]);
+  }, [isAscending, logRows]);
 
   const getFieldLinks = useCallback(
     (field: Field, rowIndex: number) => {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef, useLayoutEffect, useState } from 'react';
 import { css } from '@emotion/css';
 import { LogRows, CustomScrollbar, LogLabels, useStyles2 } from '@grafana/ui';
-import { PanelProps, Field, Labels, GrafanaTheme2 } from '@grafana/data';
+import { PanelProps, Field, Labels, GrafanaTheme2, LogsSortOrder } from '@grafana/data';
 import { Options } from './types';
 import { dataFrameToLogsModel, dedupLogRows } from 'app/core/logs_model';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
@@ -24,7 +24,10 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   },
   title,
 }) => {
-  const style = useStyles2(getStyles(title));
+  const style = useStyles2(getStyles(title, sortOrder));
+  const [scrollTop, setScrollTop] = useState(0);
+  const labelsContainerRef = useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
+  const isAscending = sortOrder === LogsSortOrder.Ascending;
 
   // Important to memoize stuff here, as panel rerenders a lot for example when resizing.
   const [logRows, deduplicatedRows, commonLabels] = useMemo(() => {
@@ -34,6 +37,14 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
     const deduplicatedRows = dedupLogRows(logRows, dedupStrategy);
     return [logRows, deduplicatedRows, commonLabels];
   }, [data, dedupStrategy]);
+
+  useLayoutEffect(() => {
+    if (isAscending && labelsContainerRef.current) {
+      setScrollTop(labelsContainerRef.current.offsetHeight);
+    } else {
+      setScrollTop(0);
+    }
+  }, [isAscending]);
 
   const getFieldLinks = useCallback(
     (field: Field, rowIndex: number) => {
@@ -50,15 +61,17 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
     );
   }
 
+  const renderCommonLabels = () => (
+    <div className={style.labelContainer}>
+      <span className={style.label}>Common labels:</span>
+      <LogLabels labels={commonLabels ? (commonLabels.value as Labels) : { labels: '(no common labels)' }} />
+    </div>
+  );
+
   return (
-    <CustomScrollbar autoHide>
-      <div className={style.container}>
-        {showCommonLabels && (
-          <div className={style.labelContainer}>
-            <span className={style.label}>Common labels:</span>
-            <LogLabels labels={commonLabels ? (commonLabels.value as Labels) : { labels: '(no common labels)' }} />
-          </div>
-        )}
+    <CustomScrollbar autoHide scrollTop={scrollTop}>
+      <div className={style.container} ref={labelsContainerRef}>
+        {showCommonLabels && !isAscending && renderCommonLabels()}
         <LogRows
           logRows={logRows}
           deduplicatedRows={deduplicatedRows}
@@ -71,20 +84,22 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
           getFieldLinks={getFieldLinks}
           logsSortOrder={sortOrder}
           enableLogDetails={enableLogDetails}
+          previewLimit={isAscending ? logRows.length : undefined}
         />
+        {showCommonLabels && isAscending && renderCommonLabels()}
       </div>
     </CustomScrollbar>
   );
 };
 
-const getStyles = (title: string) => (theme: GrafanaTheme2) => ({
+const getStyles = (title: string, sortOrder: LogsSortOrder) => (theme: GrafanaTheme2) => ({
   container: css`
     margin-bottom: ${theme.spacing(1.5)};
     //We can remove this hot-fix when we fix panel menu with no title overflowing top of all panels
     margin-top: ${theme.spacing(!title ? 2.5 : 0)};
   `,
   labelContainer: css`
-    margin: ${theme.spacing(0, 0, 0.5, 0.5)};
+    margin: ${sortOrder === LogsSortOrder.Descending ? theme.spacing(0, 0, 0.5, 0.5) : theme.spacing(0.5, 0, 0.5, 0)};
     display: flex;
     align-items: center;
   `,

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -24,10 +24,10 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   },
   title,
 }) => {
-  const style = useStyles2(getStyles(title, sortOrder));
+  const isAscending = sortOrder === LogsSortOrder.Ascending;
+  const style = useStyles2(getStyles(title, isAscending));
   const [scrollTop, setScrollTop] = useState(0);
   const logsContainerRef = useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
-  const isAscending = sortOrder === LogsSortOrder.Ascending;
 
   // Important to memoize stuff here, as panel rerenders a lot for example when resizing.
   const [logRows, deduplicatedRows, commonLabels] = useMemo(() => {
@@ -92,14 +92,14 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
   );
 };
 
-const getStyles = (title: string, sortOrder: LogsSortOrder) => (theme: GrafanaTheme2) => ({
+const getStyles = (title: string, isAscending: boolean) => (theme: GrafanaTheme2) => ({
   container: css`
     margin-bottom: ${theme.spacing(1.5)};
     //We can remove this hot-fix when we fix panel menu with no title overflowing top of all panels
     margin-top: ${theme.spacing(!title ? 2.5 : 0)};
   `,
   labelContainer: css`
-    margin: ${sortOrder === LogsSortOrder.Descending ? theme.spacing(0, 0, 0.5, 0.5) : theme.spacing(0.5, 0, 0.5, 0)};
+    margin: ${isAscending ? theme.spacing(0.5, 0, 0.5, 0) : theme.spacing(0, 0, 0.5, 0.5)};
     display: flex;
     align-items: center;
   `,


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, in logs panel + ascending order, user needs to scroll down on every refresh to see new data lines. Default scrolling seems to be top which is ok for descending but it should be bottom for ascending. This PR fixes it and changes default scrolling to bottom when the order is ascending. To make this work best, we need to set preview limit to logRows.length. 
**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/33661
