### PR TITLE
CloudWatch Logs: Fix crash when no region is selected

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -119,7 +119,15 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
         label: logGroup,
       }));
     } catch (err) {
-      dispatch(notifyApp(createErrorNotification(err)));
+      let errMessage = 'unknown error';
+      if (typeof err !== 'string') {
+        try {
+          errMessage = JSON.stringify(err);
+        } catch (e) {}
+      } else {
+        errMessage = err;
+      }
+      dispatch(notifyApp(createErrorNotification(errMessage)));
       return [];
     }
   };

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -660,6 +660,9 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
       catchError((err) => {
         if (err.data?.error) {
           throw err.data.error;
+        } else if (err.data?.message) {
+          // In PROD we do not supply .error
+          throw err.data.message;
         }
 
         throw err;


### PR DESCRIPTION
Reported by @jongyllen this only happens on prod (can be seen on play.grafana.com). Here we conditionally add error property in response https://github.com/grafana/grafana/blob/93d0f7163fce059cd774bf50d3b6994003402e86/pkg/api/response/response.go#L193
due to that the error handling on frontend expected string but on prod it got object which then crashed during rendering.