### PR TITLE
live: add ha with redis to what's new

### DIFF
--- a/docs/sources/live/live-ha-setup.md
+++ b/docs/sources/live/live-ha-setup.md
@@ -29,6 +29,8 @@ ha_engine = redis
 ha_engine_address = 127.0.0.1:6379
 ```
 
+See a description of [ha_engine]({{< relref "../administration/configuration.md#ha_engine" >}}) and [ha_engine_address]({{< relref "../administration/configuration.md#ha_engine_address" >}}) options.
+
 After running:
 
 - All built-in real-time notifications like dashboard changes are delivered to all Grafana server instances and broadcasted to all subscribers.

--- a/docs/sources/live/live-ha-setup.md
+++ b/docs/sources/live/live-ha-setup.md
@@ -29,7 +29,7 @@ ha_engine = redis
 ha_engine_address = 127.0.0.1:6379
 ```
 
-See a description of [ha_engine]({{< relref "../administration/configuration.md#ha_engine" >}}) and [ha_engine_address]({{< relref "../administration/configuration.md#ha_engine_address" >}}) options.
+For additional information, refer to the [ha_engine]({{< relref "../administration/configuration.md#ha_engine" >}}) and [ha_engine_address]({{< relref "../administration/configuration.md#ha_engine_address" >}}) options.
 
 After running:
 

--- a/docs/sources/whatsnew/whats-new-in-v8-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-1.md
@@ -129,7 +129,7 @@ We’d love as much feedback as possible about this change, because we are consi
 
 ### High availability setup support for Grafana Live
 
-We have added an experimental HA setup support for Grafana Live with Redis. This resolves several limitations of Grafana Live when clients were connected to different Grafana instances and instances had no shared state. For additional information, refer to [Configure Grafana Live HA setup]({{< relref "../live/live-ha-setup.md" >}}).
+We have added an experimental HA setup support for Grafana Live with Redis. This resolves the limitation when clients were connected to different Grafana instances and those instances had no shared state. For additional information, refer to [Configure Grafana Live HA setup]({{< relref "../live/live-ha-setup.md" >}}).
 
 ## Enterprise features
 

--- a/docs/sources/whatsnew/whats-new-in-v8-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-1.md
@@ -127,6 +127,10 @@ Tests are most likely to be affected. There are some tips for fixing these in th
 
 We’d love as much feedback as possible about this change, because we are considering making this the default behavior in a future release of Grafana.
 
+### High availability setup support for Grafana Live
+
+We have added an experimental HA setup support for Grafana Live with Redis. This resolves several limitations of Grafana Live when clients were connected to different Grafana instances and instances had no shared state. For additional information, refer to [Configure Grafana Live HA setup]({{< relref "../live/live-ha-setup.md" >}}).
+
 ## Enterprise features
 
 These features are included in the Grafana Enterprise edition.


### PR DESCRIPTION
**What this PR does / why we need it**:

Mentioning Live HA with Redis in What's new docs