### PR TITLE
Loki: Small UX updates

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -36,7 +36,7 @@ const LOGQL_EXAMPLES = [
 export default class LokiCheatSheet extends PureComponent<QueryEditorHelpProps<LokiQuery>, { userExamples: string[] }> {
   declare userLabelTimer: NodeJS.Timeout;
   state = {
-    userExamples: DEFAULT_EXAMPLES,
+    userExamples: [],
   };
 
   componentDidMount() {
@@ -81,23 +81,28 @@ export default class LokiCheatSheet extends PureComponent<QueryEditorHelpProps<L
 
   render() {
     const { userExamples } = this.state;
+    const hasUserExamples = userExamples.length > 0;
 
     return (
       <div>
         <h2>Loki Cheat Sheet</h2>
         <div className="cheat-sheet-item">
           <div className="cheat-sheet-item__title">See your logs</div>
-          <div className="cheat-sheet-item__label">Start by selecting a log stream from the Log labels selector.</div>
           <div className="cheat-sheet-item__label">
-            Alternatively, you can write a stream selector into the query field:
+            Start by selecting a log stream from the Log browser, or alternatively you can write a stream selector into
+            the query field.
           </div>
-          {this.renderExpression('{job="default/prometheus"}')}
-          {userExamples !== DEFAULT_EXAMPLES && userExamples.length > 0 ? (
+          {hasUserExamples ? (
             <div>
               <div className="cheat-sheet-item__label">Here are some example streams from your logs:</div>
               {userExamples.map((example) => this.renderExpression(example))}
             </div>
-          ) : null}
+          ) : (
+            <div>
+              <div className="cheat-sheet-item__label">Here is an example of a log stream:</div>
+              {this.renderExpression(DEFAULT_EXAMPLES[0])}
+            </div>
+          )}
         </div>
         <div className="cheat-sheet-item">
           <div className="cheat-sheet-item__title">Combine stream selectors</div>

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -424,7 +424,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
 
     const res = await this.request(url, timeRange);
     if (Array.isArray(res)) {
-      this.labelKeys = res.slice().sort();
+      const labels = res
+        .slice()
+        .sort()
+        .filter((label) => label !== '__name__');
+      this.labelKeys = labels;
     }
 
     return [];


### PR DESCRIPTION
**What this PR does / why we need it**:

Small UX updates for Loki:
1. Removing of `__name__` label as in Loki, this label is not usable. Value for that label is hardcoded to logs in Loki code. It comes from Cortex code which indexes logs with metric name in it. (Removing of it was approved in #loki channel https://raintank-corp.slack.com/archives/C9T1FLN9K/p1628508136189800)
2. In cheatsheet, if we receive userExamples, show only those. Currently, we show example log stream and under it we have usable log stream examples. Users tend to click on first option and if our first option is invalid log stream, this can be blocker for smooth start. 

+fyi @idafurjes 🙂
