### PR TITLE
Docs: Clarify how to enable "Forward OAuth Identity" for data sources

### DIFF
--- a/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
+++ b/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
@@ -285,7 +285,7 @@ func (ds *dataSource) QueryData(ctx context.Context, req *backend.QueryDataReque
 
 If your data source uses the same OAuth provider as Grafana itself, for example using [Generic OAuth Authentication]({{< relref "../../auth/generic-oauth.md" >}}), your data source plugin can reuse the access token for the logged-in Grafana user.
 
-To allow Grafana to pass the access token to the plugin, the user needs to enable **Forward OAuth Identity** on the data source configuration page. This tells Grafana to pass the token to the plugin in a Authorization header. Note that your plugin needs to use the [DataSourceHttpSettings](https://developers.grafana.com/ui/latest/index.html?path=/story/data-source-datasourcehttpsettings--basic) component in the configuration editor to expose the setting for your data source plugin.
+To allow Grafana to pass the access token to the plugin, the `jsonData.oauthPassThru` must be set to `true` on the data source configuration. The [DataSourceHttpSettings](https://developers.grafana.com/ui/latest/index.html?path=/story/data-source-datasourcehttpsettings--basic) provides a toggle for this as **Forward OAuth Identity**. Otherwise, you should build an appropriate toggle to set `jsonData.oauthPassThru` in your own data source configuration page UI.
 
 The Authorization header is available on the `DataQuery` object on the query data request in your backend data source.
 

--- a/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
+++ b/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
@@ -285,7 +285,7 @@ func (ds *dataSource) QueryData(ctx context.Context, req *backend.QueryDataReque
 
 If your data source uses the same OAuth provider as Grafana itself, for example using [Generic OAuth Authentication]({{< relref "../../auth/generic-oauth.md" >}}), your data source plugin can reuse the access token for the logged-in Grafana user.
 
-To allow Grafana to pass the access token to the plugin, the `jsonData.oauthPassThru` must be set to `true` on the data source configuration. The [DataSourceHttpSettings](https://developers.grafana.com/ui/latest/index.html?path=/story/data-source-datasourcehttpsettings--basic) provides a toggle for this as **Forward OAuth Identity**. Otherwise, you should build an appropriate toggle to set `jsonData.oauthPassThru` in your own data source configuration page UI.
+To allow Grafana to pass the access token to the plugin, update the data source configuration and set the` jsonData.oauthPassThru` property to `true`. The [DataSourceHttpSettings](https://developers.grafana.com/ui/latest/index.html?path=/story/data-source-datasourcehttpsettings--basic) provides a toggle, the **Forward OAuth Identity** option, for this. You can also build an appropriate toggle to set `jsonData.oauthPassThru` in your data source configuration page UI.
 
 The Authorization header is available on the `DataQuery` object on the query data request in your backend data source.
 

--- a/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
+++ b/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
@@ -287,7 +287,7 @@ If your data source uses the same OAuth provider as Grafana itself, for example 
 
 To allow Grafana to pass the access token to the plugin, update the data source configuration and set the` jsonData.oauthPassThru` property to `true`. The [DataSourceHttpSettings](https://developers.grafana.com/ui/latest/index.html?path=/story/data-source-datasourcehttpsettings--basic) provides a toggle, the **Forward OAuth Identity** option, for this. You can also build an appropriate toggle to set `jsonData.oauthPassThru` in your data source configuration page UI.
 
-The Authorization header is available on the `DataQuery` object on the query data request in your backend data source.
+When configured, Grafana will pass the user's token to the plugin in an Authorization header, available on the `QueryDataRequest` object on the `QueryData` request in your backend data source.
 
 ```go
 func (ds *dataSource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates documentation to provide clarification on how developers can enable oauth forwarding for their backend data source plugins.
