### PR TITLE
InfluxDB: InfluxQL: update provisioning example

### DIFF
--- a/docs/sources/datasources/influxdb/provision-influxdb.md
+++ b/docs/sources/datasources/influxdb/provision-influxdb.md
@@ -21,10 +21,11 @@ datasources:
     access: proxy
     database: site
     user: grafana
-    password: grafana
     url: http://localhost:8086
     jsonData:
       httpMode: GET
+    secureJsonData:
+      password: grafana
 ```
 
 ## InfluxDB 2.x for Flux example


### PR DESCRIPTION
the code-example showing provisioning for InfluxDB uses the old, deprecated method to specify the password. this pull request fixes this.

relates to the issue https://github.com/grafana/grafana/issues/37626#issuecomment-895302167