### PR TITLE
Docs: Updated note in Share a panel topic

### DIFF
--- a/docs/sources/sharing/share-panel.md
+++ b/docs/sources/sharing/share-panel.md
@@ -62,7 +62,7 @@ If you created a snapshot by mistake, click **delete snapshot** to remove the sn
 
 You can embed a panel using an iframe on another web site. A viewer must be signed into Grafana to view the graph.
 
-**> Note:** As of Grafana 8.0, anonymous access permission is no available for Grafana Cloud.
+**> Note:** As of Grafana 8.0, anonymous access permission is no longer available for Grafana Cloud.
 
 ![Panel share embed](/static/img/docs/sharing/share-panel-embedded-link-8-0.png)
 


### PR DESCRIPTION
The issue was raised in slack: https://raintank-corp.slack.com/archives/C5PG2JK8W/p1628520532018200?thread_ts=1628520497.017700&cid=C5PG2JK8W

The note now reads: As of Grafana 8.0, anonymous access permission is no longer available for Grafana Cloud.