### PR TITLE
devenv: influxdb: simplified versioning for old-version influxdb

### DIFF
--- a/devenv/docker/blocks/influxdb1/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb1/docker-compose.yaml
@@ -1,5 +1,5 @@
   influxdb1:
-    image: influxdb:1.8.6
+    image: influxdb:1.8
     container_name: influxdb1
     ports:
       - '2004:2004'


### PR DESCRIPTION
in the devenv-docker-compose for the OLD version of influxdb (1.x), i simplified the version-number to basically "1.8.newest"