### PR TITLE
Alerting: Ensure model.Settings and models.SecureSettings are not nil in all notification channels 

### DIFF
--- a/pkg/services/ngalert/notifier/channels/alertmanager.go
+++ b/pkg/services/ngalert/notifier/channels/alertmanager.go
@@ -22,7 +22,9 @@ func NewAlertmanagerNotifier(model *NotificationChannelConfig, _ *template.Templ
 	if model.Settings == nil {
 		return nil, receiverInitError{Reason: "no settings supplied"}
 	}
-
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 	urlStr := model.Settings.Get("url").MustString()
 	if urlStr == "" {
 		return nil, receiverInitError{Reason: "could not find url property in settings", Cfg: *model}

--- a/pkg/services/ngalert/notifier/channels/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/channels/alertmanager_test.go
@@ -49,11 +49,13 @@ func TestNewAlertmanagerNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     c.receiverName,
-				Type:     "alertmanager",
-				Settings: settingsJSON,
+				Name:           c.receiverName,
+				Type:           "alertmanager",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
@@ -130,11 +132,13 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     c.receiverName,
-				Type:     "alertmanager",
-				Settings: settingsJSON,
+				Name:           c.receiverName,
+				Type:           "alertmanager",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/dingding.go
+++ b/pkg/services/ngalert/notifier/channels/dingding.go
@@ -19,7 +19,7 @@ const defaultDingdingMsgType = "link"
 // NewDingDingNotifier is the constructor for the Dingding notifier
 func NewDingDingNotifier(model *NotificationChannelConfig, t *template.Template) (*DingDingNotifier, error) {
 	if model.Settings == nil {
-		return nil, receiverInitError{Reason: "no settings supplied", Cfg: *model}
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
 
 	url := model.Settings.Get("url").MustString()

--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -28,7 +28,7 @@ type DiscordNotifier struct {
 
 func NewDiscordNotifier(model *NotificationChannelConfig, t *template.Template) (*DiscordNotifier, error) {
 	if model.Settings == nil {
-		return nil, receiverInitError{Reason: "no settings supplied", Cfg: *model}
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
 
 	avatarURL := model.Settings.Get("avatar_url").MustString()

--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -29,7 +29,7 @@ type EmailNotifier struct {
 // for the EmailNotifier.
 func NewEmailNotifier(model *NotificationChannelConfig, t *template.Template) (*EmailNotifier, error) {
 	if model.Settings == nil {
-		return nil, receiverInitError{Reason: "no settings supplied", Cfg: *model}
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
 
 	addressesString := model.Settings.Get("addresses").MustString()

--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -25,6 +25,10 @@ type GoogleChatNotifier struct {
 }
 
 func NewGoogleChatNotifier(model *NotificationChannelConfig, t *template.Template) (*GoogleChatNotifier, error) {
+	if model.Settings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
+	}
+
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
 		return nil, receiverInitError{Cfg: *model, Reason: "could not find url property in settings"}

--- a/pkg/services/ngalert/notifier/channels/kafka.go
+++ b/pkg/services/ngalert/notifier/channels/kafka.go
@@ -27,6 +27,10 @@ type KafkaNotifier struct {
 
 // NewKafkaNotifier is the constructor function for the Kafka notifier.
 func NewKafkaNotifier(model *NotificationChannelConfig, t *template.Template) (*KafkaNotifier, error) {
+	if model.Settings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
+	}
+
 	endpoint := model.Settings.Get("kafkaRestProxy").MustString()
 	if endpoint == "" {
 		return nil, receiverInitError{Cfg: *model, Reason: "could not find kafka rest proxy endpoint property in settings"}

--- a/pkg/services/ngalert/notifier/channels/line.go
+++ b/pkg/services/ngalert/notifier/channels/line.go
@@ -19,6 +19,13 @@ var (
 
 // NewLineNotifier is the constructor for the LINE notifier
 func NewLineNotifier(model *NotificationChannelConfig, t *template.Template, fn GetDecryptedValueFn) (*LineNotifier, error) {
+	if model.Settings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
+	}
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
+
 	token := fn(context.Background(), model.SecureSettings, "token", model.Settings.Get("token").MustString())
 	if token == "" {
 		return nil, receiverInitError{Cfg: *model, Reason: "could not find token in settings"}

--- a/pkg/services/ngalert/notifier/channels/line_test.go
+++ b/pkg/services/ngalert/notifier/channels/line_test.go
@@ -83,11 +83,13 @@ func TestLineNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "line_testing",
-				Type:     "line",
-				Settings: settingsJSON,
+				Name:           "line_testing",
+				Type:           "line",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie.go
@@ -42,6 +42,12 @@ type OpsgenieNotifier struct {
 
 // NewOpsgenieNotifier is the constructor for the Opsgenie notifier
 func NewOpsgenieNotifier(model *NotificationChannelConfig, t *template.Template, fn GetDecryptedValueFn) (*OpsgenieNotifier, error) {
+	if model.Settings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
+	}
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 	autoClose := model.Settings.Get("autoClose").MustBool(true)
 	overridePriority := model.Settings.Get("overridePriority").MustBool(true)
 	apiKey := fn(context.Background(), model.SecureSettings, "apiKey", model.Settings.Get("apiKey").MustString())

--- a/pkg/services/ngalert/notifier/channels/opsgenie_test.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie_test.go
@@ -163,11 +163,13 @@ func TestOpsgenieNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "opsgenie_testing",
-				Type:     "opsgenie",
-				Settings: settingsJSON,
+				Name:           "opsgenie_testing",
+				Type:           "opsgenie",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -44,6 +44,9 @@ func NewPagerdutyNotifier(model *NotificationChannelConfig, t *template.Template
 	if model.Settings == nil {
 		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 
 	key := fn(context.Background(), model.SecureSettings, "integrationKey", model.Settings.Get("integrationKey").MustString())
 	if key == "" {

--- a/pkg/services/ngalert/notifier/channels/pagerduty_test.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty_test.go
@@ -129,11 +129,13 @@ func TestPagerdutyNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "pageduty_testing",
-				Type:     "pagerduty",
-				Settings: settingsJSON,
+				Name:           "pageduty_testing",
+				Type:           "pagerduty",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/pushover.go
+++ b/pkg/services/ngalert/notifier/channels/pushover.go
@@ -43,6 +43,9 @@ func NewPushoverNotifier(model *NotificationChannelConfig, t *template.Template,
 	if model.Settings == nil {
 		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 
 	userKey := fn(context.Background(), model.SecureSettings, "userKey", model.Settings.Get("userKey").MustString())
 	APIToken := fn(context.Background(), model.SecureSettings, "apiToken", model.Settings.Get("apiToken").MustString())

--- a/pkg/services/ngalert/notifier/channels/pushover_test.go
+++ b/pkg/services/ngalert/notifier/channels/pushover_test.go
@@ -137,11 +137,13 @@ func TestPushoverNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "pushover_testing",
-				Type:     "pushover",
-				Settings: settingsJSON,
+				Name:           "pushover_testing",
+				Type:           "pushover",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/sensugo.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo.go
@@ -34,7 +34,9 @@ func NewSensuGoNotifier(model *NotificationChannelConfig, t *template.Template, 
 	if model.Settings == nil {
 		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
-
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
 		return nil, receiverInitError{Cfg: *model, Reason: "could not find URL property in settings"}

--- a/pkg/services/ngalert/notifier/channels/sensugo_test.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo_test.go
@@ -134,11 +134,13 @@ func TestSensuGoNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "Sensu Go",
-				Type:     "sensugo",
-				Settings: settingsJSON,
+				Name:           "Sensu Go",
+				Type:           "sensugo",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -48,6 +48,9 @@ func NewSlackNotifier(model *NotificationChannelConfig, t *template.Template, fn
 	if model.Settings == nil {
 		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 
 	slackURL := fn(context.Background(), model.SecureSettings, "url", model.Settings.Get("url").MustString())
 	if slackURL == "" {

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -165,11 +165,13 @@ func TestSlackNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "slack_testing",
-				Type:     "slack",
-				Settings: settingsJSON,
+				Name:           "slack_testing",
+				Type:           "slack",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -33,6 +33,9 @@ func NewTelegramNotifier(model *NotificationChannelConfig, t *template.Template,
 	if model.Settings == nil {
 		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 
 	botToken := fn(context.Background(), model.SecureSettings, "bottoken", model.Settings.Get("bottoken").MustString())
 	chatID := model.Settings.Get("chatid").MustString()

--- a/pkg/services/ngalert/notifier/channels/telegram_test.go
+++ b/pkg/services/ngalert/notifier/channels/telegram_test.go
@@ -89,11 +89,13 @@ func TestTelegramNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "telegram_testing",
-				Type:     "telegram",
-				Settings: settingsJSON,
+				Name:           "telegram_testing",
+				Type:           "telegram",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/threema.go
+++ b/pkg/services/ngalert/notifier/channels/threema.go
@@ -35,7 +35,9 @@ func NewThreemaNotifier(model *NotificationChannelConfig, t *template.Template, 
 	if model.Settings == nil {
 		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
 	}
-
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
+	}
 	gatewayID := model.Settings.Get("gateway_id").MustString()
 	recipientID := model.Settings.Get("recipient_id").MustString()
 	apiSecret := fn(context.Background(), model.SecureSettings, "api_secret", model.Settings.Get("api_secret").MustString())

--- a/pkg/services/ngalert/notifier/channels/threema_test.go
+++ b/pkg/services/ngalert/notifier/channels/threema_test.go
@@ -101,11 +101,13 @@ func TestThreemaNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "threema_testing",
-				Type:     "threema",
-				Settings: settingsJSON,
+				Name:           "threema_testing",
+				Type:           "threema",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())

--- a/pkg/services/ngalert/notifier/channels/victorops.go
+++ b/pkg/services/ngalert/notifier/channels/victorops.go
@@ -28,6 +28,10 @@ const (
 // NewVictoropsNotifier creates an instance of VictoropsNotifier that
 // handles posting notifications to Victorops REST API
 func NewVictoropsNotifier(model *NotificationChannelConfig, t *template.Template) (*VictoropsNotifier, error) {
+	if model.Settings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
+	}
+
 	url := model.Settings.Get("url").MustString()
 	if url == "" {
 		return nil, receiverInitError{Cfg: *model, Reason: "could not find victorops url property in settings"}

--- a/pkg/services/ngalert/notifier/channels/webhook.go
+++ b/pkg/services/ngalert/notifier/channels/webhook.go
@@ -31,7 +31,10 @@ type WebhookNotifier struct {
 // the WebHook notifier.
 func NewWebHookNotifier(model *NotificationChannelConfig, t *template.Template, fn GetDecryptedValueFn) (*WebhookNotifier, error) {
 	if model.Settings == nil {
-		return nil, receiverInitError{Cfg: *model, Reason: "could not find settings property"}
+		return nil, receiverInitError{Cfg: *model, Reason: "no settings supplied"}
+	}
+	if model.SecureSettings == nil {
+		return nil, receiverInitError{Cfg: *model, Reason: "no secure settings supplied"}
 	}
 	url := model.Settings.Get("url").MustString()
 	if url == "" {

--- a/pkg/services/ngalert/notifier/channels/webhook_test.go
+++ b/pkg/services/ngalert/notifier/channels/webhook_test.go
@@ -182,12 +182,14 @@ func TestWebhookNotifier(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			settingsJSON, err := simplejson.NewJson([]byte(c.settings))
 			require.NoError(t, err)
+			secureSettings := make(map[string][]byte)
 
 			m := &NotificationChannelConfig{
-				Name:     "webhook_testing",
-				Type:     "webhook",
-				Settings: settingsJSON,
-				OrgID:    orgID,
+				OrgID:          orgID,
+				Name:           "webhook_testing",
+				Type:           "webhook",
+				Settings:       settingsJSON,
+				SecureSettings: secureSettings,
 			}
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request checks that `models.Settings` is non-nil in all notification channels in ngalert.