### PR TITLE
Timeseries: migrate log scale

### DIFF
--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -489,6 +489,10 @@ Object {
           "fill": "dash",
         },
         "lineWidth": 1,
+        "scaleDistribution": Object {
+          "log": 10,
+          "type": "log",
+        },
         "showPoints": "never",
         "spanNulls": true,
       },

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -632,7 +632,7 @@ const stepedColordLine = {
       $$hashKey: 'object:39',
       format: 'short',
       label: null,
-      logBase: 1,
+      logBase: 10,
       max: null,
       min: null,
       show: true,

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -22,6 +22,7 @@ import {
   LineInterpolation,
   LineStyle,
   PointVisibility,
+  ScaleDistribution,
   StackingMode,
   TooltipDisplayMode,
 } from '@grafana/ui';
@@ -466,6 +467,15 @@ function getFieldConfigFromOldAxis(obj: any): FieldConfig<GraphFieldConfig> {
   };
   if (obj.label) {
     graph.axisLabel = obj.label;
+  }
+  if (obj.logBase) {
+    const log = obj.logBase as number;
+    if (log === 2 || log === 10) {
+      graph.scaleDistribution = {
+        type: ScaleDistribution.Log,
+        log,
+      };
+    }
   }
   return omitBy(
     {


### PR DESCRIPTION
This will support migrating a panel that had log scales:

![image](https://user-images.githubusercontent.com/705951/128954534-4a06b9d2-17e6-4f20-af71-bebe41367e3f.png)

to

![image](https://user-images.githubusercontent.com/705951/128954608-346e6f79-7171-48d0-8fc2-e7a233a9272a.png)
