### PR TITLE
Variables: Fix issue with empty drop downs on navigation

### DIFF
--- a/public/app/features/variables/guard.ts
+++ b/public/app/features/variables/guard.ts
@@ -44,13 +44,21 @@ export const isMulti = (model: VariableModel): model is VariableWithMultiSupport
 };
 
 export const hasOptions = (model: VariableModel): model is VariableWithOptions => {
+  return hasObjectProperty(model, 'options');
+};
+
+export const hasCurrent = (model: VariableModel): model is VariableWithOptions => {
+  return hasObjectProperty(model, 'current');
+};
+
+function hasObjectProperty(model: VariableModel, property: string): model is VariableWithOptions {
   if (!model) {
     return false;
   }
 
-  const withOptions = model as VariableWithOptions;
-  return withOptions.hasOwnProperty('options') && typeof withOptions.options === 'object';
-};
+  const withProperty = model as Record<string, any>;
+  return withProperty.hasOwnProperty(property) && typeof withProperty[property] === 'object';
+}
 
 interface DataSourceWithLegacyVariableSupport<
   TQuery extends DataQuery = DataQuery,

--- a/public/app/features/variables/state/sharedReducer.test.ts
+++ b/public/app/features/variables/state/sharedReducer.test.ts
@@ -20,9 +20,9 @@ import { ConstantVariableModel, QueryVariableModel, VariableHide, VariableOption
 import {
   ALL_VARIABLE_TEXT,
   ALL_VARIABLE_VALUE,
+  initialVariablesState,
   toVariablePayload,
   VariableIdentifier,
-  initialVariablesState,
   VariablesState,
 } from './types';
 import { variableAdapters } from '../adapters';
@@ -338,58 +338,6 @@ describe('sharedReducer', () => {
               { selected: true, text: 'B', value: 'B' },
             ],
             current: { selected: true, text: 'A + B', value: ['A', 'B'] },
-          } as unknown) as QueryVariableModel,
-        });
-    });
-  });
-
-  describe('when setCurrentVariableValue is dispatched and current.value has no value', () => {
-    it('then the first available option should be selected', () => {
-      const adapter = createQueryVariableAdapter();
-      const { initialState } = getVariableTestContext(adapter, {
-        options: [
-          { text: 'A', value: 'A', selected: false },
-          { text: 'B', value: 'B', selected: false },
-          { text: 'C', value: 'C', selected: false },
-        ],
-      });
-      const current = { text: '', value: '', selected: false };
-      const payload = toVariablePayload({ id: '0', type: 'query' }, { option: current });
-      reducerTester<VariablesState>()
-        .givenReducer(sharedReducer, cloneDeep(initialState))
-        .whenActionIsDispatched(setCurrentVariableValue(payload))
-        .thenStateShouldEqual({
-          ...initialState,
-          '0': ({
-            ...initialState[0],
-            options: [
-              { selected: true, text: 'A', value: 'A' },
-              { selected: false, text: 'B', value: 'B' },
-              { selected: false, text: 'C', value: 'C' },
-            ],
-            current: { selected: true, text: 'A', value: 'A' },
-          } as unknown) as QueryVariableModel,
-        });
-    });
-  });
-
-  describe('when setCurrentVariableValue is dispatched and current.value has no value and there are no options', () => {
-    it('then no option should be selected', () => {
-      const adapter = createQueryVariableAdapter();
-      const { initialState } = getVariableTestContext(adapter, {
-        options: [],
-      });
-      const current = { text: '', value: '', selected: false };
-      const payload = toVariablePayload({ id: '0', type: 'query' }, { option: current });
-      reducerTester<VariablesState>()
-        .givenReducer(sharedReducer, cloneDeep(initialState))
-        .whenActionIsDispatched(setCurrentVariableValue(payload))
-        .thenStateShouldEqual({
-          ...initialState,
-          '0': ({
-            ...initialState[0],
-            options: [],
-            current: { selected: false, text: '', value: '' },
           } as unknown) as QueryVariableModel,
         });
     });

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -121,15 +121,6 @@ const sharedReducerSlice = createSlice({
       const { option } = action.payload.data;
       const current = { ...option, text: ensureStringValues(option?.text), value: ensureStringValues(option?.value) };
 
-      // If no value is set, default to the first avilable
-      if (!current.value && instanceState.options.length) {
-        instanceState.options.forEach((option, index) => {
-          option.selected = !Boolean(index);
-        });
-        instanceState.current = instanceState.options[0];
-        return;
-      }
-
       instanceState.current = current;
       instanceState.options = instanceState.options.map((option) => {
         option.value = ensureStringValues(option.value);

--- a/public/app/features/variables/state/templateVarsChangedInUrl.test.ts
+++ b/public/app/features/variables/state/templateVarsChangedInUrl.test.ts
@@ -1,0 +1,121 @@
+import { variableAdapters } from '../adapters';
+import { customBuilder } from '../shared/testing/builders';
+import { DashboardState, StoreState } from '../../../types';
+import { initialState } from '../../dashboard/state/reducers';
+import { TemplatingState } from './reducers';
+import { ExtendedUrlQueryMap } from '../utils';
+import { templateVarsChangedInUrl } from './actions';
+import { createCustomVariableAdapter } from '../custom/adapter';
+import { VariablesState } from './types';
+import { DashboardModel } from '../../dashboard/state';
+
+variableAdapters.setInit(() => [createCustomVariableAdapter()]);
+
+async function getTestContext(urlQueryMap: ExtendedUrlQueryMap = {}) {
+  jest.clearAllMocks();
+
+  const custom = customBuilder().withId('custom').withCurrent(['A', 'C']).withOptions('A', 'B', 'C').build();
+  const setValueFromUrlMock = jest.fn();
+  variableAdapters.get('custom').setValueFromUrl = setValueFromUrlMock;
+
+  const templateVariableValueUpdatedMock = jest.fn();
+  const startRefreshMock = jest.fn();
+  const dashboardModel: Partial<DashboardModel> = {
+    templateVariableValueUpdated: templateVariableValueUpdatedMock,
+    startRefresh: startRefreshMock,
+    templating: { list: [custom] },
+  };
+  const dashboard: DashboardState = {
+    ...initialState,
+    getModel: () => (dashboardModel as unknown) as DashboardModel,
+  };
+
+  const variables: VariablesState = { custom };
+  const templating = ({ variables } as unknown) as TemplatingState;
+  const state: Partial<StoreState> = {
+    dashboard,
+    templating,
+  };
+  const getState = () => (state as unknown) as StoreState;
+
+  const dispatch = jest.fn();
+  const thunk = templateVarsChangedInUrl(urlQueryMap);
+
+  await thunk(dispatch, getState, undefined);
+
+  return { setValueFromUrlMock, templateVariableValueUpdatedMock, startRefreshMock, custom };
+}
+
+describe('templateVarsChangedInUrl', () => {
+  describe('when called with no variables in url query map', () => {
+    it('then no value should change and dashboard should not be refreshed', async () => {
+      const { setValueFromUrlMock, templateVariableValueUpdatedMock, startRefreshMock } = await getTestContext();
+
+      expect(setValueFromUrlMock).not.toHaveBeenCalled();
+      expect(templateVariableValueUpdatedMock).not.toHaveBeenCalled();
+      expect(startRefreshMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when called with no variables in url query map matching variables in state', () => {
+    it('then no value should change and dashboard should not be refreshed', async () => {
+      const { setValueFromUrlMock, templateVariableValueUpdatedMock, startRefreshMock } = await getTestContext({
+        'var-query': { value: 'A' },
+      });
+
+      expect(setValueFromUrlMock).not.toHaveBeenCalled();
+      expect(templateVariableValueUpdatedMock).not.toHaveBeenCalled();
+      expect(startRefreshMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when called with variables in url query map matching variables in state', () => {
+    describe('and the values in url query map are the same as current in state', () => {
+      it('then no value should change and dashboard should not be refreshed', async () => {
+        const { setValueFromUrlMock, templateVariableValueUpdatedMock, startRefreshMock } = await getTestContext({
+          'var-custom': { value: ['A', 'C'] },
+        });
+
+        expect(setValueFromUrlMock).not.toHaveBeenCalled();
+        expect(templateVariableValueUpdatedMock).not.toHaveBeenCalled();
+        expect(startRefreshMock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('and the values in url query map are the not the same as current in state', () => {
+      it('then the value should change to the value in url query map and dashboard should be refreshed', async () => {
+        const {
+          setValueFromUrlMock,
+          templateVariableValueUpdatedMock,
+          startRefreshMock,
+          custom,
+        } = await getTestContext({
+          'var-custom': { value: 'B' },
+        });
+
+        expect(setValueFromUrlMock).toHaveBeenCalledTimes(1);
+        expect(setValueFromUrlMock).toHaveBeenCalledWith(custom, 'B');
+        expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(1);
+        expect(startRefreshMock).toHaveBeenCalledTimes(1);
+      });
+
+      describe('but the values in url query map were removed', () => {
+        it('then the value should change to the value in dashboard json and dashboard should be refreshed', async () => {
+          const {
+            setValueFromUrlMock,
+            templateVariableValueUpdatedMock,
+            startRefreshMock,
+            custom,
+          } = await getTestContext({
+            'var-custom': { value: '', removed: true },
+          });
+
+          expect(setValueFromUrlMock).toHaveBeenCalledTimes(1);
+          expect(setValueFromUrlMock).toHaveBeenCalledWith(custom, ['A', 'C']);
+          expect(templateVariableValueUpdatedMock).toHaveBeenCalledTimes(1);
+          expect(startRefreshMock).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
+});

--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -99,8 +99,8 @@ describe('findTemplateVarChanges', () => {
       aaa: 'ignore me',
     };
 
-    expect(findTemplateVarChanges(b, a)).toEqual({ 'var-xyz': 'hello' });
-    expect(findTemplateVarChanges(a, b)).toEqual({ 'var-xyz': '' });
+    expect(findTemplateVarChanges(b, a)).toEqual({ 'var-xyz': { value: 'hello' } });
+    expect(findTemplateVarChanges(a, b)).toEqual({ 'var-xyz': { value: '', removed: true } });
   });
 
   it('then should ignore equal values', () => {
@@ -161,7 +161,7 @@ describe('findTemplateVarChanges', () => {
       'var-test': 'asd',
     };
 
-    expect(findTemplateVarChanges(a, b)!['var-test']).toEqual(['test']);
+    expect(findTemplateVarChanges(a, b)!['var-test']).toEqual({ value: ['test'] });
   });
 });
 

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -1,5 +1,5 @@
 import { isArray, isEqual } from 'lodash';
-import { ScopedVars, UrlQueryMap, VariableType } from '@grafana/data';
+import { ScopedVars, UrlQueryMap, UrlQueryValue, VariableType } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from './state/types';
@@ -185,9 +185,16 @@ function getUrlValueForComparison(value: any): any {
   return value;
 }
 
-export function findTemplateVarChanges(query: UrlQueryMap, old: UrlQueryMap): UrlQueryMap | undefined {
+export interface UrlQueryType {
+  value: UrlQueryValue;
+  removed?: boolean;
+}
+
+export interface ExtendedUrlQueryMap extends Record<string, UrlQueryType> {}
+
+export function findTemplateVarChanges(query: UrlQueryMap, old: UrlQueryMap): ExtendedUrlQueryMap | undefined {
   let count = 0;
-  const changes: UrlQueryMap = {};
+  const changes: ExtendedUrlQueryMap = {};
 
   for (const key in query) {
     if (!key.startsWith('var-')) {
@@ -198,7 +205,7 @@ export function findTemplateVarChanges(query: UrlQueryMap, old: UrlQueryMap): Ur
     let newValue = getUrlValueForComparison(query[key]);
 
     if (!isEqual(newValue, oldValue)) {
-      changes[key] = query[key];
+      changes[key] = { value: query[key] };
       count++;
     }
   }
@@ -216,7 +223,7 @@ export function findTemplateVarChanges(query: UrlQueryMap, old: UrlQueryMap): Ur
     }
 
     if (!query.hasOwnProperty(key)) {
-      changes[key] = ''; // removed
+      changes[key] = { value: '', removed: true }; // removed
       count++;
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Before we migrated to React router we did a full page refresh whenever we clicked on a panel link to the same dashboard. That meant that we would follow the "usual" path of loading variables. Now with the React router in place we don't do a full page refresh we have introduced an alternative path through the variable system to change variables on the same page.

This PR introduces a `removed` prop to the each query result of `findTemplateVarChanges` function so we can distinguish between:

-  a variable being removed from the url 
- setting the variable value to `''`

This PR also removes all the previous code from #36521

**Which issue(s) this PR fixes**:
Fixes #35471
Fixes #33525

**Special notes for your reviewer**:
I used this dashboard.json while testing

```json

{
  "__inputs": [
    {
      "name": "DS_GDEV-TESTDATA",
      "label": "gdev-testdata",
      "description": "",
      "type": "datasource",
      "pluginId": "testdata",
      "pluginName": "TestData DB"
    }
  ],
  "__requires": [
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "8.1.0-pre"
    },
    {
      "type": "panel",
      "id": "stat",
      "name": "Stat",
      "version": ""
    },
    {
      "type": "datasource",
      "id": "testdata",
      "name": "TestData DB",
      "version": "1.0.0"
    },
    {
      "type": "panel",
      "id": "text",
      "name": "Text",
      "version": ""
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "gnetId": null,
  "graphTooltip": 0,
  "id": null,
  "iteration": 1628657306144,
  "links": [],
  "panels": [
    {
      "datasource": "${DS_GDEV-TESTDATA}",
      "description": "",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "links": [],
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "links": [
        {
          "title": "Reset",
          "url": "http://localhost:3000/d/${__dashboard.uid}"
        },
        {
          "title": "Reset with title",
          "url": "http://localhost:3000/d/${__dashboard.uid}/variables-and-links?orgId=1"
        },
        {
          "title": "Set prod",
          "url": "http://localhost:3000/d/${__dashboard.uid}?var-query0="
        }
      ],
      "options": {
        "colorMode": "value",
        "graphMode": "area",
        "justifyMode": "auto",
        "orientation": "auto",
        "reduceOptions": {
          "calcs": [
            "lastNotNull"
          ],
          "fields": "",
          "values": false
        },
        "text": {},
        "textMode": "auto"
      },
      "pluginVersion": "8.1.0-pre",
      "title": "Panel Title",
      "type": "stat"
    },
    {
      "datasource": null,
      "description": "",
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 12,
        "y": 0
      },
      "id": 4,
      "options": {
        "content": "dashboard uid: `${__dashboard.uid}`\n\nquery0: `$query0`\n\nquery1: `$query1`",
        "mode": "markdown"
      },
      "pluginVersion": "8.1.0-pre",
      "title": "Panel Title",
      "type": "text"
    }
  ],
  "refresh": "",
  "schemaVersion": 30,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": [
      {
        "allValue": null,
        "current": {
          "selected": false,
          "text": [
            "test"
          ],
          "value": [
            "test"
          ]
        },
        "description": null,
        "error": null,
        "hide": 0,
        "includeAll": true,
        "label": null,
        "multi": true,
        "name": "query0",
        "options": [
          {
            "selected": false,
            "text": "All",
            "value": "$__all"
          },
          {
            "selected": true,
            "text": "test",
            "value": "test"
          },
          {
            "selected": false,
            "text": "stage",
            "value": "stage"
          },
          {
            "selected": false,
            "text": "prod",
            "value": "prod"
          }
        ],
        "query": "test,stage,prod",
        "queryValue": "",
        "skipUrlSync": false,
        "type": "custom"
      },
      {
        "allValue": null,
        "current": {},
        "datasource": "${DS_GDEV-TESTDATA}",
        "definition": "*",
        "description": null,
        "error": null,
        "hide": 0,
        "includeAll": true,
        "label": null,
        "multi": true,
        "name": "query1",
        "options": [],
        "query": {
          "query": "*",
          "refId": "StandardVariableQuery"
        },
        "refresh": 1,
        "regex": "",
        "skipUrlSync": false,
        "sort": 0,
        "tagValuesQuery": "",
        "tagsQuery": "",
        "type": "query",
        "useTags": false
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "Variables and links",
  "uid": "cGgI4lGnz",
  "version": 9
}

```
