### PR TITLE
Alerting: Sending separate requests for each alert for OpsGenie

### DIFF
--- a/pkg/services/ngalert/notifier/channels/opsgenie_test.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie_test.go
@@ -16,6 +16,12 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 )
 
+type AlertForTest struct {
+	request  types.Alert
+	response string
+	err      error
+}
+
 func TestOpsgenieNotifier(t *testing.T) {
 	tmpl := templateForTests(t)
 
@@ -26,32 +32,33 @@ func TestOpsgenieNotifier(t *testing.T) {
 	cases := []struct {
 		name         string
 		settings     string
-		alerts       []*types.Alert
-		expMsg       string
+		alerts       []AlertForTest
 		expInitError string
-		expMsgError  error
 	}{
 		{
 			name:     "Default config with one alert",
 			settings: `{"apiKey": "abcdefgh0123456789"}`,
-			alerts: []*types.Alert{
+			alerts: []AlertForTest{
 				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+					request: types.Alert{
+						Alert: model.Alert{
+							Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+							Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh"},
+						},
 					},
+					response: `{
+						"alias": "024d7322cb7c3e6b385f64344116c6643dcb6f7b0c7c6f30d13a7e8bdd7b8f85",
+						"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
+						"details": {
+							"url": "http://localhost/alerting/list"
+						},
+						"message": "[FIRING:1]  (val1)",
+						"source": "Grafana",
+						"tags": ["alertname:alert1", "lbl1:val1"]
+					}`,
+					err: nil,
 				},
 			},
-			expMsg: `{
-				"alias": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
-				"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
-				"details": {
-					"url": "http://localhost/alerting/list"
-				},
-				"message": "[FIRING:1]  (val1)",
-				"source": "Grafana",
-				"tags": ["alertname:alert1", "lbl1:val1"]
-			}`,
 		},
 		{
 			name: "Default config with one alert and send tags as tags",
@@ -59,24 +66,26 @@ func TestOpsgenieNotifier(t *testing.T) {
 				"apiKey": "abcdefgh0123456789",
 				"sendTagsAs": "tags"
 			}`,
-			alerts: []*types.Alert{
+			alerts: []AlertForTest{
 				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+					request: types.Alert{
+						Alert: model.Alert{
+							Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+							Annotations: model.LabelSet{"ann1": "annv1"},
+						},
 					},
+					response: `{
+						"alias": "024d7322cb7c3e6b385f64344116c6643dcb6f7b0c7c6f30d13a7e8bdd7b8f85",
+						"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n",
+						"details": {
+							"url": "http://localhost/alerting/list"
+						},
+						"message": "[FIRING:1]  (val1)",
+						"source": "Grafana",
+						"tags": ["alertname:alert1", "lbl1:val1"]
+					}`,
 				},
 			},
-			expMsg: `{
-				"alias": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
-				"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n",
-				"details": {
-					"url": "http://localhost/alerting/list"
-				},
-				"message": "[FIRING:1]  (val1)",
-				"source": "Grafana",
-				"tags": ["alertname:alert1", "lbl1:val1"]
-			}`,
 		},
 		{
 			name: "Default config with one alert and send tags as details",
@@ -84,26 +93,28 @@ func TestOpsgenieNotifier(t *testing.T) {
 				"apiKey": "abcdefgh0123456789",
 				"sendTagsAs": "details"
 			}`,
-			alerts: []*types.Alert{
+			alerts: []AlertForTest{
 				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+					request: types.Alert{
+						Alert: model.Alert{
+							Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+							Annotations: model.LabelSet{"ann1": "annv1"},
+						},
 					},
+					response: `{
+						"alias": "024d7322cb7c3e6b385f64344116c6643dcb6f7b0c7c6f30d13a7e8bdd7b8f85",
+						"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n",
+						"details": {
+							"alertname": "alert1",
+							"lbl1": "val1",
+							"url": "http://localhost/alerting/list"
+						},
+						"message": "[FIRING:1]  (val1)",
+						"source": "Grafana",
+						"tags": []
+					}`,
 				},
 			},
-			expMsg: `{
-				"alias": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
-				"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n",
-				"details": {
-					"alertname": "alert1",
-					"lbl1": "val1",
-					"url": "http://localhost/alerting/list"
-				},
-				"message": "[FIRING:1]  (val1)",
-				"source": "Grafana",
-				"tags": []
-			}`,
 		},
 		{
 			name: "Custom config with multiple alerts and send tags as both details and tag",
@@ -111,41 +122,60 @@ func TestOpsgenieNotifier(t *testing.T) {
 				"apiKey": "abcdefgh0123456789",
 				"sendTagsAs": "both"
 			}`,
-			alerts: []*types.Alert{
+			alerts: []AlertForTest{
 				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+					request: types.Alert{
+						Alert: model.Alert{
+							Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+							Annotations: model.LabelSet{"ann1": "annv1"},
+						},
 					},
-				}, {
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
+					response: `{
+						"alias": "024d7322cb7c3e6b385f64344116c6643dcb6f7b0c7c6f30d13a7e8bdd7b8f85",
+						"description": "[FIRING:1]  (val1)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n",
+						"details": {
+							"alertname": "alert1",
+							"url": "http://localhost/alerting/list",
+							"lbl1": "val1"
+						},
+						"message": "[FIRING:1]  (val1)",
+						"source": "Grafana",
+						"tags": ["alertname:alert1", "lbl1:val1"]
+					}`,
+				},
+				{
+					request: types.Alert{
+						Alert: model.Alert{
+							Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+							Annotations: model.LabelSet{"ann1": "annv1"},
+						},
 					},
+					response: `{
+						"alias": "d463d365cd6017b8690203ceb675000ed671756718f4e48bf42a647300a56b63",
+						"description": "[FIRING:1]  (val2)\nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n",
+						"details": {
+							"alertname": "alert1",
+							"url": "http://localhost/alerting/list",
+							"lbl1": "val2"
+						},
+						"message": "[FIRING:1]  (val2)",
+						"source": "Grafana",
+						"tags": ["alertname:alert1", "lbl1:val2"]
+					}`,
 				},
 			},
-			expMsg: `{
-				"alias": "6e3538104c14b583da237e9693b76debbc17f0f8058ef20492e5853096cf8733",
-				"description": "[FIRING:2]  \nhttp://localhost/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n",
-				"details": {
-					"alertname": "alert1",
-					"url": "http://localhost/alerting/list"
-				},
-				"message": "[FIRING:2]  ",
-				"source": "Grafana",
-				"tags": ["alertname:alert1"]
-			}`,
-			expMsgError: nil,
 		},
 		{
 			name:     "Resolved is not sent when auto close is false",
 			settings: `{"apiKey": "abcdefgh0123456789", "autoClose": false}`,
-			alerts: []*types.Alert{
+			alerts: []AlertForTest{
 				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1"},
-						EndsAt:      time.Now().Add(-1 * time.Minute),
+					request: types.Alert{
+						Alert: model.Alert{
+							Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+							Annotations: model.LabelSet{"ann1": "annv1"},
+							EndsAt:      time.Now().Add(-1 * time.Minute),
+						},
 					},
 				},
 			},
@@ -176,29 +206,43 @@ func TestOpsgenieNotifier(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			body := "<not-sent>"
+			bodies := []string{}
 			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
-				body = webhook.Body
+				bodies = append(bodies, webhook.Body)
 				return nil
 			})
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			ok, err := pn.Notify(ctx, c.alerts...)
-			if c.expMsgError != nil {
-				require.False(t, ok)
-				require.Error(t, err)
-				require.Equal(t, c.expMsgError.Error(), err.Error())
-				return
-			}
-			require.True(t, ok)
-			require.NoError(t, err)
 
-			if c.expMsg == "" {
-				// No notification was expected.
-				require.Equal(t, "<not-sent>", body)
-			} else {
-				require.JSONEq(t, c.expMsg, body)
+			alerts := []*types.Alert{}
+			for _, alert := range c.alerts {
+				copiedAlert := alert.request
+				alerts = append(alerts, &copiedAlert)
+			}
+
+			_, errs := pn.NotifyMultiple(ctx, alerts)
+
+			expectedBodies := []string{}
+			for _, alert := range c.alerts {
+				if alert.response != "" {
+					expectedBodies = append(expectedBodies, alert.response)
+				}
+			}
+
+			// Checking bodies
+			for index, value := range bodies {
+				require.JSONEq(t, expectedBodies[index], value)
+			}
+
+			// Checking errors
+			for index, alert := range c.alerts {
+				if alert.err != nil {
+					require.Error(t, err)
+					require.Equal(t, err.Error(), errs[index].Error())
+					return
+				}
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1692,7 +1692,7 @@ var expNonEmailNotifications = map[string][]string{
 	},
 	"opsgenie_recv/opsgenie_test": {
 		`{
-		  "alias": "47e92f0f6ef9fe99f3954e0d6155f8d09c4b9a038d8c3105e82c0cee4c62956e",
+		  "alias": "56ab9af043c62fa3c2e98c4e4e316fdac3410be4fc03ab98178c1d0ebd15d0e7",
 		  "description": "[FIRING:1] OpsGenieAlert \nhttp://localhost:3000/alerting/list\n\n**Firing**\n\nLabels:\n - alertname = OpsGenieAlert\nAnnotations:\nSource: http://localhost:3000/alerting/UID_OpsGenieAlert/edit\nSilence: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matchers=alertname%3DOpsGenieAlert\n",
 		  "details": {
 			"url": "http://localhost:3000/alerting/list"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Instead of sending 1 requests for all alerts for OpsGenie, it now sends a separate request per alert, that way OpsGenie would send a notification for each new triggered alert and won't swallow it if there's 1 alert firing and the second one is triggered.

**Which issue(s) this PR fixes**: https://github.com/grafana/grafana/issues/37618, see details here.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37618 

**Special notes for your reviewer**:

I am a first time contributor and I think some things may be improved here and I'm not sure how, check out my comments to this PR.