### PR TITLE
Remove debug log from gzipper

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -58,7 +58,6 @@ func Gziper() func(http.Handler) http.Handler {
 
 			for _, pathMatcher := range gzipIgnoredPaths {
 				if pathMatcher(requestPath) {
-					fmt.Println("skip path", requestPath)
 					next.ServeHTTP(rw, req)
 					return
 				}


### PR DESCRIPTION
Remove a debug log, carelessly forgotten in the previous macaron PR.