### PR TITLE
Explore: Add span duration to left panel in trace viewer

### DIFF
--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBarRow.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanBarRow.tsx
@@ -438,6 +438,7 @@ export class UnthemedSpanBarRow extends React.PureComponent<SpanBarRowProps> {
                 )}
               </span>
               <small className={styles.endpointName}>{rpc ? rpc.operationName : operationName}</small>
+              <small className={styles.endpointName}> | {label}</small>
             </a>
             {createSpanLink &&
               (() => {


### PR DESCRIPTION
**What this PR does / why we need it**:
In some situations, the span duration is hidden from view. After discussing in a UX feedback session, we've decided to add the span duration to the left panel in the trace viewer so that it can be easily seen. We have kept the duration next to the span to make it easy to view the duration for spans that are far away from the left panel (long in long traces). 

![image](https://user-images.githubusercontent.com/12838032/129066876-63129027-ed46-4330-9609-672c0d1d7965.png)

**Which issue(s) this PR fixes**:
Fixes #36845

**Special notes for your reviewer**:

