### PR TITLE
POC/Cue: define simple schema for MySQL

### DIFF
--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -4,7 +4,8 @@ import { getBackendSrv, DataSourceWithBackend, FetchResponse, BackendDataSourceR
 import { DataSourceInstanceSettings, ScopedVars, MetricFindValue, AnnotationEvent } from '@grafana/data';
 import MySQLQueryModel from 'app/plugins/datasource/mysql/mysql_query_model';
 import ResponseParser from './response_parser';
-import { MysqlQueryForInterpolation, MySQLOptions, MySQLQuery } from './types';
+import { MysqlQueryForInterpolation } from './types';
+import { MySQLOptions, MySQLQuery } from './models.gen';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 import { getSearchFilterScopedVar } from '../../../features/variables/utils';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';

--- a/public/app/plugins/datasource/mysql/models.cue
+++ b/public/app/plugins/datasource/mysql/models.cue
@@ -1,0 +1,36 @@
+// Copyright 2021 Grafana Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grafanaschema
+
+Family: {
+    lineages: [
+        [
+            {
+                ResultFormat: "time_series" | "table"
+
+                DataQuery: {
+                    alias?: string
+                    format: ResultFormat | *"table"
+                    rawSql?: string
+                }
+
+                DataSourceJsonData: {
+                    timeInterval?: string
+                }
+            }
+        ]
+    ]
+    migrations: []
+}

--- a/public/app/plugins/datasource/mysql/models.gen.ts
+++ b/public/app/plugins/datasource/mysql/models.gen.ts
@@ -1,0 +1,19 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// NOTE: This file will be auto generated from models.cue
+// It is currenty hand written but will serve as the target for cuetsy
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { DataQuery, DataSourceJsonData } from '@grafana/data';
+
+export const modelVersion = Object.freeze([1, 0]);
+
+export interface MySQLOptions extends DataSourceJsonData {
+  timeInterval: string;
+}
+
+export type ResultFormat = 'time_series' | 'table';
+
+export interface MySQLQuery extends DataQuery {
+  alias?: string;
+  format?: ResultFormat;
+  rawSql?: string;
+}

--- a/public/app/plugins/datasource/mysql/module.ts
+++ b/public/app/plugins/datasource/mysql/module.ts
@@ -5,7 +5,7 @@ import {
   createResetHandler,
   PasswordFieldEnum,
 } from '../../../features/datasources/utils/passwordHandlers';
-import { MySQLQuery } from './types';
+import { MySQLQuery } from './models.gen';
 import { DataSourcePlugin } from '@grafana/data';
 
 class MysqlConfigCtrl {

--- a/public/app/plugins/datasource/mysql/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/mysql/specs/datasource.test.ts
@@ -13,7 +13,7 @@ import { backendSrv } from 'app/core/services/backend_srv'; // will use the vers
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { initialCustomVariableModelState } from '../../../../features/variables/custom/reducer';
 import { FetchResponse, setBackendSrv } from '@grafana/runtime';
-import { MySQLOptions, MySQLQuery } from './../types';
+import { MySQLOptions, MySQLQuery } from './../models.gen';
 
 describe('MySQLDatasource', () => {
   const setupTextContext = (response: any) => {

--- a/public/app/plugins/datasource/mysql/types.ts
+++ b/public/app/plugins/datasource/mysql/types.ts
@@ -1,20 +1,7 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
 export interface MysqlQueryForInterpolation {
   alias?: any;
   format?: any;
   rawSql?: any;
   refId: any;
   hide?: any;
-}
-
-export interface MySQLOptions extends DataSourceJsonData {
-  timeInterval: string;
-}
-
-export type ResultFormat = 'time_series' | 'table';
-
-export interface MySQLQuery extends DataQuery {
-  alias?: string;
-  format?: ResultFormat;
-  rawSql?: any;
 }


### PR DESCRIPTION
We have not yet tackled datasources in cue schema land.... this is an example showing what that *may* look like for MySQL.

Datasources can define three types:

1. DataQuery -- extra properties that live next to the common target properties
2. DataSourceJsonData -- options saved for the datasource instance
3. SecureJSON -- Map<string,any> saved encoded in the database

I am posting this here mainly to start thinking about the structure.  We will need to merge https://github.com/grafana/grafana/pull/33817 before this could possibly be useful