### PR TITLE
Toolkit: return original stack trace for webpack errors

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin/bundle.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin/bundle.ts
@@ -57,17 +57,19 @@ export const bundlePlugin = async ({ watch, production, preserveConsole }: Plugi
     } else {
       compiler.run((err: Error, stats: webpack.Stats) => {
         if (err) {
-          reject(err.message);
-
+          reject(err);
           return;
         }
+
         if (stats.hasErrors()) {
           stats.compilation.errors.forEach((e) => {
             console.log(e.message);
           });
 
           reject('Build failed');
+          return;
         }
+
         console.log('\n', stats.toString({ colors: true }), '\n');
         resolve();
       });

--- a/packages/grafana-toolkit/src/cli/utils/useSpinner.ts
+++ b/packages/grafana-toolkit/src/cli/utils/useSpinner.ts
@@ -11,7 +11,8 @@ export const useSpinner = async (label: string, fn: () => Promise<any>, killProc
 
     if (err.stdout) {
       console.error(err.stdout);
-    } else {
+    } else if (err.message) {
+      // Return stack trace if error object
       console.trace(err); // eslint-disable-line no-console
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when Grafana Toolkit fails with Webpack error, the actual stack trace of the error is being discarded and it becomes almost impossible to find the root cause without running toolkit in debugger.

This PR changes two things:
* If webpack returns unhandled error, then toolkit print original stack trace of the error
* If webpack returns compilation error, then no stack trace printed, since detailed error information is self-explanatory and stack trace is not relevant.

Error output of Webpack before this PR:
```
× Cannot read property 'bind' of undefined
  Trace: Cannot read property 'bind' of undefined
      at D:\Dev\Grafana\Grafana\packages\grafana-toolkit\src\cli\utils\useSpinner.ts:15:15
      at step (D:\Dev\Grafana\Grafana\node_modules\tslib\tslib.js:143:27)
      at Object.throw (D:\Dev\Grafana\Grafana\node_modules\tslib\tslib.js:124:57)
      at rejected (D:\Dev\Grafana\Grafana\node_modules\tslib\tslib.js:115:69)
```

Same error with this PR:
```
× Cannot read property 'bind' of undefined
  Trace: TypeError: Cannot read property 'bind' of undefined
      at D:\Dev\Grafana\Grafana\node_modules\replace-in-file-webpack-plugin\index.js:28:81
      at Array.reduce (<anonymous>)
      at replace (D:\Dev\Grafana\Grafana\node_modules\replace-in-file-webpack-plugin\index.js:26:19)
      at D:\Dev\Grafana\Grafana\node_modules\replace-in-file-webpack-plugin\index.js:54:7
      at Array.forEach (<anonymous>)
      at D:\Dev\Grafana\Grafana\node_modules\replace-in-file-webpack-plugin\index.js:53:12
      at Array.forEach (<anonymous>)
      at done (D:\Dev\Grafana\Grafana\node_modules\replace-in-file-webpack-plugin\index.js:46:16)
      at AsyncSeriesHook.eval [as callAsync] (eval at create (D:\Dev\Grafana\Grafana\node_modules\tapable\lib\HookCodeFactory.js:33:10), <anonymous>:9:1)
      at AsyncSeriesHook.lazyCompileHook (D:\Dev\Grafana\Grafana\node_modules\tapable\lib\Hook.js:154:20)
      at D:\Dev\Grafana\Grafana\node_modules\webpack\lib\Compiler.js:304:22
      at Compiler.emitRecords (D:\Dev\Grafana\Grafana\node_modules\webpack\lib\Compiler.js:499:39)
      at D:\Dev\Grafana\Grafana\node_modules\webpack\lib\Compiler.js:298:10
      at D:\Dev\Grafana\Grafana\node_modules\webpack\lib\Compiler.js:485:14
      at _next0 (eval at create (D:\Dev\Grafana\Grafana\node_modules\tapable\lib\HookCodeFactory.js:33:10), <anonymous>:16:1)
      at eval (eval at create (D:\Dev\Grafana\Grafana\node_modules\tapable\lib\HookCodeFactory.js:33:10), <anonymous>:24:1)
      at D:\Dev\Grafana\Grafana\packages\grafana-toolkit\src\cli\utils\useSpinner.ts:15:15
      at step (D:\Dev\Grafana\Grafana\node_modules\tslib\tslib.js:143:27)
      at Object.throw (D:\Dev\Grafana\Grafana\node_modules\tslib\tslib.js:124:57)
      at rejected (D:\Dev\Grafana\Grafana\node_modules\tslib\tslib.js:115:69)
```

Compilation error with this PR:

```
| Compiling...  ERROR in D:/Dev/Grafana/Plugins/src/QueryEditor.tsx(538,14):
  TS2741: Property 'css' is missing in type '...' but required in type 'Pick<...>'.
× Build failed
```
