### PR TITLE
docs: update cloud data sources README links

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/README.md
+++ b/public/app/plugins/datasource/cloud-monitoring/README.md
@@ -1,7 +1,7 @@
 # Google Cloud Monitoring Data Source - Native Plugin (formerly named Stackdriver)
 
-Grafana ships with built-in support for Google Cloud Monitoring. You just have to add it as a data source and you will be ready to build dashboards for your Cloud Monitoring metrics.
+Grafana ships with **built in** support for Google Cloud Monitoring. You just have to add it as a data source and you will be ready to build dashboards for your Cloud Monitoring metrics.
 
 Read more about it here:
 
-[https://grafana.com/docs/grafana/latest/features/datasources/cloudmonitoring/](https://grafana.com/docs/grafana/latest/features/datasources/cloudmonitoring/)
+[https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/](https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/)

--- a/public/app/plugins/datasource/cloud-monitoring/README.md
+++ b/public/app/plugins/datasource/cloud-monitoring/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Monitoring Data Source - Native Plugin (formerly named Stackdriver)
+# Google Cloud Monitoring data source - native plugin (formerly named Stackdriver)
 
 Grafana ships with **built in** support for Google Cloud Monitoring. Simply add it as a data source and you are ready to build dashboards for your Cloud Monitoring metrics.
 

--- a/public/app/plugins/datasource/cloud-monitoring/README.md
+++ b/public/app/plugins/datasource/cloud-monitoring/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Monitoring Data Source - Native Plugin (formerly named Stackdriver)
 
-Grafana ships with **built in** support for Google Cloud Monitoring. You just have to add it as a data source and you will be ready to build dashboards for your Cloud Monitoring metrics.
+Grafana ships with **built in** support for Google Cloud Monitoring. Simply add it as a data source and you are ready to build dashboards for your Cloud Monitoring metrics.
 
 Read more about it here:
 

--- a/public/app/plugins/datasource/cloudwatch/README.md
+++ b/public/app/plugins/datasource/cloudwatch/README.md
@@ -1,4 +1,4 @@
-# CloudWatch Data Source - Native Plugin
+# CloudWatch data source - native plugin
 
 Grafana ships with **built in** support for CloudWatch. You just have to add it as a data source and you will be ready to build dashboards for your CloudWatch metrics.
 

--- a/public/app/plugins/datasource/cloudwatch/README.md
+++ b/public/app/plugins/datasource/cloudwatch/README.md
@@ -1,6 +1,6 @@
 # CloudWatch data source - native plugin
 
-Grafana ships with **built in** support for CloudWatch. You just have to add it as a data source and you will be ready to build dashboards for your CloudWatch metrics.
+Grafana ships with **built in** support for CloudWatch. Simply add it as a data source and are ready to build dashboards for your CloudWatch metrics.
 
 Read more about it here:
 

--- a/public/app/plugins/datasource/cloudwatch/README.md
+++ b/public/app/plugins/datasource/cloudwatch/README.md
@@ -1,7 +1,7 @@
-# CloudWatch Data Source -  Native Plugin
+# CloudWatch Data Source - Native Plugin
 
 Grafana ships with **built in** support for CloudWatch. You just have to add it as a data source and you will be ready to build dashboards for your CloudWatch metrics.
 
 Read more about it here:
 
-[https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/](https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/)
+[https://grafana.com/docs/grafana/latest/datasources/cloudwatch/](https://grafana.com/docs/grafana/latest/datasources/cloudwatch/)

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/README.md
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/README.md
@@ -1,0 +1,7 @@
+# Azure Monitor Data Source - Native Plugin
+
+Grafana ships with **built in** support for Azure Monitor. You just have to add it as a data source and you will be ready to build dashboards for your Azure Monitor metrics.
+
+Read more about it here:
+
+[https://grafana.com/docs/grafana/latest/datasources/azuremonitor/](https://grafana.com/docs/grafana/latest/datasources/azuremonitor/)

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/README.md
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/README.md
@@ -1,4 +1,4 @@
-# Azure Monitor Data Source - Native Plugin
+# Azure Monitor data source - native plugin
 
 Grafana ships with **built in** support for Azure Monitor. You just have to add it as a data source and you will be ready to build dashboards for your Azure Monitor metrics.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The documentation for the plugins are outdated.

- The Cloud Monitoring link redirected to `7.5` of the documentation: https://grafana.com/docs/grafana/latest/features/datasources/cloudmonitoring/
- The CloudWatch link gave a 404 error
- There was no README for Azure Monitor

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

TIA 🙏