### PR TITLE
Chore: Remove `pkg-archive` command from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ shellcheck: $(SH_FILES) ## Run checks for shell scripts.
 build-docker-dev: ## Build Docker image for development (fast).
 	@echo "build development container"
 	@echo "\033[92mInfo:\033[0m the frontend code is expected to be built already."
-	$(GO) run build.go -goos linux -pkg-arch amd64 ${OPT} build pkg-archive latest
+	$(GO) run build.go -goos linux -pkg-arch amd64 ${OPT} build latest
 	cp dist/grafana-latest.linux-x64.tar.gz packaging/docker
 	cd packaging/docker && docker build --tag grafana/grafana:dev .
 
@@ -141,7 +141,7 @@ clean: ## Clean up intermediate build artifacts.
 	rm -rf public/build
 
 # This repository's configuration is protected (https://readme.drone.io/signature/).
-# Use this make target to regenerate the configuration YAML files when 
+# Use this make target to regenerate the configuration YAML files when
 # you modify starlark files.
 drone:
 	drone starlark


### PR DESCRIPTION
**What this PR does / why we need it**:

After this PR https://github.com/grafana/grafana/pull/29461, the `pkg-archive` command has been deleted. Needs to also be cleaned up from the Makefile (leftover currently)

**Which issue(s) this PR fixes**:

Fixes #34108

