### PR TITLE
Loki: Add pattern parser to syntax

### DIFF
--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -66,6 +66,11 @@ export const PIPE_PARSERS: CompletionItem[] = [
     insertText: 'logfmt',
     documentation: 'Extracting labels from the log line using logfmt parser. Only available in Loki 2.0+.',
   },
+  {
+    label: 'pattern',
+    insertText: 'pattern',
+    documentation: 'Extracting labels from the log line using pattern parser. Only available in Loki 2.3+.',
+  },
 ];
 
 export const PIPE_OPERATORS: CompletionItem[] = [


### PR DESCRIPTION
This PR adds newly introduced Loki pattern parser to syntax, so it is suggested in autocomplete. 

From Loki documentation `Loki supports JSON, logfmt, pattern, regexp and unpack parsers.` https://grafana.com/docs/loki/latest/logql/#pattern