### PR TITLE
Devenv: Fix prometheus block permissions error

### DIFF
--- a/devenv/docker/blocks/prometheus/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus/docker-compose.yaml
@@ -4,6 +4,7 @@
       - "9090:9090"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    user: "root:root"
 
   node_exporter:
     image: prom/node-exporter


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
On my mac, `make devenv sources=prometheus` fails starting the prometheus container with:
```
prometheus_1              | level=error ts=2021-08-12T08:25:25.597Z caller=main.go:350 msg="Error loading config (--config.file=/etc/prometheus/prometheus.yml)" err="open /etc/prometheus/prometheus.yml: permission denied"
```
@ivanahuckova has pointed me to [this discussion](https://stackoverflow.com/questions/54232891/docker-compose-directory-permission-errors-on-bind-mount) and our conclusion was that this is due to the fact that the user [is set to nobody](https://github.com/prometheus/prometheus/blob/b7e9f2481bdd992f8567a5920bdbd14a4a5bc7af/Dockerfile#L21).
This fix explicitly sets the user and this resolves the problem for me.
