### PR TITLE
Slack: Remove duplicated title from Slack notification

### DIFF
--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -299,7 +299,6 @@ func (sn *SlackNotifier) Notify(evalContext *alerting.EvalContext) error {
 	}
 	body := map[string]interface{}{
 		"channel": sn.recipient,
-		"text":    evalContext.GetNotificationTitle(),
 		"attachments": []map[string]interface{}{
 			attachment,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes duplicated title in Slack notifications.

**Which issue(s) this PR fixes**:

Before the fix, a Slack notification looked like:

![image](https://user-images.githubusercontent.com/15115078/129177477-f5a6de36-1fa1-4787-8c35-78c4c404d4f7.png)

After the fix:

![image](https://user-images.githubusercontent.com/15115078/129177544-207f28bc-4b68-4db7-8141-a7f7009b3908.png)

Fixes #24495

**Special notes for your reviewer**:

This fix is for the "old" alerting platform (before Grafana v8). After v8 and when using the new unified alerting, the problem doesn't exist.

