### PR TITLE
devenv: influxdb: update telegraf config

### DIFF
--- a/devenv/docker/blocks/influxdb/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb/docker-compose.yaml
@@ -24,12 +24,12 @@
       - influxdb
 
   telegraf:
-    image: telegraf:1.19.1
+    image: telegraf:latest
     links:
       - influxdb
     depends_on:
       - influxdb_cli
     volumes:
       - ./docker/blocks/influxdb/telegraf.conf:/etc/telegraf/telegraf.conf:ro
-      - /var/log:/var/log
+      - /var/log:/var/log/host
       - ../data/log:/var/log/grafana

--- a/devenv/docker/blocks/influxdb/telegraf.conf
+++ b/devenv/docker/blocks/influxdb/telegraf.conf
@@ -44,7 +44,7 @@
 
 [[inputs.logparser]]
   files = [
-    "/var/log/*.log",
+    "/var/log/host/*.log",
     "/var/log/grafana/*.log"
   ]
   [inputs.logparser.grok]

--- a/devenv/docker/blocks/influxdb1/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb1/docker-compose.yaml
@@ -22,11 +22,11 @@
       FD_PORT: 8086
 
   telegraf-influxdb1:
-    image: telegraf:1.19.1
+    image: telegraf:latest
     links:
       - influxdb1
     volumes:
       - ./docker/blocks/influxdb1/telegraf.conf:/etc/telegraf/telegraf.conf:ro
-      - /var/log:/var/log
+      - /var/log:/var/log/host
       - ../data/log:/var/log/grafana
 

--- a/devenv/docker/blocks/influxdb1/telegraf.conf
+++ b/devenv/docker/blocks/influxdb1/telegraf.conf
@@ -52,7 +52,7 @@
 
 [[inputs.logparser]]
   files = [
-    "/var/log/*.log",
+    "/var/log/host/*.log",
     "/var/log/grafana/*.log"
   ]
   [inputs.logparser.grok]


### PR DESCRIPTION
in devenv influxdb configs "telegraf" was updated to "latest" version.

also, the place where we mount the logs from the host-computer was moved from "/var/log" to "/var/log/host", this way, inside the docker-container, "/var/log" is still clean and usable for whatever the container needs. 
(but this is not that important anyway, because on macOS this log-mounting does not really work, new log-changes do not arrive or arrive too late)