### PR TITLE
AzureMonitor: Show error message when subscriptions request fails in ConfigEditor

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -152,11 +152,12 @@ export interface BackendSrv {
   request(options: BackendSrvRequest): Promise<any>;
 
   /**
-   * @deprecated Use the fetch function instead
    * Special function used to communicate with datasources that will emit core
    * events that the Grafana QueryInspector and QueryEditor is listening for to be able
    * to display datasource query information. Can be skipped by adding `option.silent`
    * when initializing the request.
+   *
+   * @deprecated Use the fetch function instead
    */
   datasourceRequest<T = any>(options: BackendSrvRequest): Promise<FetchResponse<T>>;
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/AzureCredentialsForm.tsx
@@ -252,7 +252,7 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
           <div className="gf-form-inline">
             <div className="gf-form">
               <InlineFormLabel className="width-12">Default Subscription</InlineFormLabel>
-              <div className="width-25">
+              <div className="width-30">
                 <Select
                   menuShouldPortal
                   value={

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/__snapshots__/AzureCredentialsForm.test.tsx.snap
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/__snapshots__/AzureCredentialsForm.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`Render should disable azure monitor secret input 1`] = `
         Default Subscription
       </FormLabel>
       <div
-        className="width-25"
+        className="width-30"
       >
         <Select
           allowCustomValue={false}
@@ -365,7 +365,7 @@ exports[`Render should enable azure monitor load subscriptions button 1`] = `
         Default Subscription
       </FormLabel>
       <div
-        className="width-25"
+        className="width-30"
       >
         <Select
           allowCustomValue={false}
@@ -570,7 +570,7 @@ exports[`Render should render component 1`] = `
         Default Subscription
       </FormLabel>
       <div
-        className="width-25"
+        className="width-30"
       >
         <Select
           allowCustomValue={false}


### PR DESCRIPTION
**What this PR does / why we need it**:

Shows error message if the request to get subscriptions fail.

**Which issue(s) this PR fixes**:

Fixes #34426

**Special notes for your reviewer**:

