### PR TITLE
Broadcast data source deletion

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -105,7 +105,7 @@ func (hs *HTTPServer) DeleteDataSourceById(c *models.ReqContext) response.Respon
 
 	cmd := &models.DeleteDataSourceCommand{ID: id, OrgID: c.OrgId}
 
-	err = bus.Dispatch(cmd)
+	err = bus.Broadcast(cmd)
 	if err != nil {
 		return response.Error(500, "Failed to delete datasource", err)
 	}
@@ -152,7 +152,7 @@ func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Respo
 
 	cmd := &models.DeleteDataSourceCommand{UID: uid, OrgID: c.OrgId}
 
-	err = bus.Dispatch(cmd)
+	err = bus.Broadcast(cmd)
 	if err != nil {
 		return response.Error(500, "Failed to delete datasource", err)
 	}
@@ -182,7 +182,7 @@ func (hs *HTTPServer) DeleteDataSourceByName(c *models.ReqContext) response.Resp
 	}
 
 	cmd := &models.DeleteDataSourceCommand{Name: name, OrgID: c.OrgId}
-	err := bus.Dispatch(cmd)
+	err := bus.Broadcast(cmd)
 	if err != nil {
 		return response.Error(500, "Failed to delete datasource", err)
 	}

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -144,3 +144,25 @@ func TestEvent_NoRegisteredListener(t *testing.T) {
 	err := bus.Publish(&testQuery{})
 	require.NoError(t, err, "unable to publish event")
 }
+
+func TestBroadcast(t *testing.T) {
+	bus := New()
+
+	var dispatched bool
+	bus.AddHandler(func(query *testQuery) error {
+		dispatched = true
+		return nil
+	})
+
+	var published bool
+	bus.AddEventListener(func(query *testQuery) error {
+		published = true
+		return nil
+	})
+
+	err := bus.Broadcast(&testQuery{})
+	require.NoError(t, err, "failed to dispatch and publish")
+
+	require.True(t, dispatched)
+	require.True(t, published)
+}

--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -85,7 +85,7 @@ func (dc *DatasourceProvisioner) applyChanges(configPath string) error {
 func (dc *DatasourceProvisioner) deleteDatasources(dsToDelete []*deleteDatasourceConfig) error {
 	for _, ds := range dsToDelete {
 		cmd := &models.DeleteDataSourceCommand{OrgID: ds.OrgID, Name: ds.Name}
-		if err := bus.Dispatch(cmd); err != nil {
+		if err := bus.Broadcast(cmd); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
I'm building an extension that needs to respond to data source deletions. To accomplish this, I've added a `Broadcast` method to the event bus that will both `Dispatch` and `Publish` events so any interested component can receive it. 

I've only made data source deletions be broadcast but this could be useful for other operations as well. If we know of any, I'm happy to add them as part of this PR.