### PR TITLE
Elasticsearch: Fix metric names for alert queries

### DIFF
--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -28,7 +28,7 @@ var newTimeSeriesQuery = func(client es.Client, dataQuery []backend.DataQuery,
 	}
 }
 
-// nolint:staticcheck // plugins.DataQueryResult deprecated
+// nolint:staticcheck
 func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 	tsQueryParser := newTimeSeriesQueryParser()
 	queries, err := tsQueryParser.parse(e.dataQueries)
@@ -63,7 +63,7 @@ func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 	return rp.getTimeSeries()
 }
 
-// nolint:staticcheck // plugins.DataQueryResult deprecated
+// nolint:staticcheck
 func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to string,
 	result backend.QueryDataResponse) error {
 	minInterval, err := e.client.GetMinInterval(q.Interval)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the metric names for alert queries to use the actual metric / metric alias.

**Which issue(s) this PR fixes**:

Fixes #37846

**Special notes for your reviewer**:

Before the fix:
![image](https://user-images.githubusercontent.com/15115078/129343755-34b48bda-55d7-4248-9948-97143a55b5de.png)

After the fix:
![image](https://user-images.githubusercontent.com/15115078/129343599-0fa414b5-6d6a-47c0-b653-dcef8cd70584.png)


