### PR TITLE
Graphite: Convert tag values returned as numbers to strings

### DIFF
--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -251,11 +251,11 @@ func (s *Service) toDataFrames(response *http.Response) (frames data.Frames, err
 
 		tags := make(map[string]string)
 		for name, value := range series.Tags {
-			switch value.(type) {
+			switch value := value.(type) {
 			case string:
-				tags[name] = value.(string)
+				tags[name] = value
 			case float64:
-				tags[name] = strconv.FormatFloat(value.(float64), 'f', -1, 64)
+				tags[name] = strconv.FormatFloat(value, 'f', -1, 64)
 			}
 		}
 

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -267,7 +267,7 @@ func (s *Service) toDataFrames(response *http.Response) (frames data.Frames, err
 			s.logger.Debug("Graphite response", "target", series.Target, "datapoints", len(series.DataPoints))
 		}
 	}
-	return
+	return frames, nil
 }
 
 func (s *Service) createRequest(dsInfo *datasourceInfo, data url.Values) (*http.Request, error) {

--- a/pkg/tsdb/graphite/graphite_test.go
+++ b/pkg/tsdb/graphite/graphite_test.go
@@ -52,12 +52,39 @@ func TestFixIntervalFormat(t *testing.T) {
 
 	service := &Service{logger: log.New("tsdb.graphite")}
 
-	t.Run("Converts response to data frames", func(*testing.T) {
+	t.Run("Converts response without tags to data frames", func(*testing.T) {
 		body := `
 		[
 			{
 				"target": "target",
-				"tags": { "fooTag": "fooValue", "barTag": "barValue" },
+				"datapoints": [[50, 1], [null, 2], [100, 3]]
+			}
+		]`
+		a := 50.0
+		b := 100.0
+		expectedFrame := data.NewFrame("target",
+			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
+			data.NewField("value", data.Labels{}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target"}),
+		)
+		expectedFrames := data.Frames{expectedFrame}
+
+		httpResponse := &http.Response{StatusCode: 200, Body: ioutil.NopCloser(strings.NewReader(body))}
+		dataFrames, err := service.toDataFrames(httpResponse)
+
+		require.NoError(t, err)
+		if !reflect.DeepEqual(expectedFrames, dataFrames) {
+			expectedFramesJSON, _ := json.Marshal(expectedFrames)
+			dataFramesJSON, _ := json.Marshal(dataFrames)
+			t.Errorf("Data frames should have been equal but was, expected:\n%s\nactual:\n%s", expectedFramesJSON, dataFramesJSON)
+		}
+	})
+
+	t.Run("Converts response with tags to data frames", func(*testing.T) {
+		body := `
+		[
+			{
+				"target": "target",
+				"tags": { "fooTag": "fooValue", "barTag": "barValue", "int": 100, "float": 3.14 },
 				"datapoints": [[50, 1], [null, 2], [100, 3]]
 			}
 		]`
@@ -68,6 +95,8 @@ func TestFixIntervalFormat(t *testing.T) {
 			data.NewField("value", data.Labels{
 				"fooTag": "fooValue",
 				"barTag": "barValue",
+				"int":    "100",
+				"float":  "3.14",
 			}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target"}),
 		)
 		expectedFrames := data.Frames{expectedFrame}

--- a/pkg/tsdb/graphite/types.go
+++ b/pkg/tsdb/graphite/types.go
@@ -5,5 +5,6 @@ import "github.com/grafana/grafana/pkg/plugins"
 type TargetResponseDTO struct {
 	Target     string                       `json:"target"`
 	DataPoints plugins.DataTimeSeriesPoints `json:"datapoints"`
-	Tags       map[string]string            `json:"tags"`
+	// Graphite <=1.1.7 may return some tags as numbers requiring extra conversion. See https://github.com/grafana/grafana/issues/37614
+	Tags map[string]interface{} `json:"tags"`
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Graphite <= 1.1.7 may return tag values as numbers when some transformation functions are used (e.g. scale()). It was changed in 1.1.8 by https://github.com/graphite-project/graphite-web/commit/7e0dec19b8062d09a08d6c7ce00bb2f028ba42ec. This PR ensures tag values returned as numbers are converted to strings.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37614

**Special notes for your reviewer**:

How to test it?

Spin up a devenv with Graphite 1.1.7. To do this, you can modify graphite1 block https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/graphite1/docker-compose.yaml:

```diff
-image: graphiteapp/graphite-statsd:1.0.2-3
+image: graphiteapp/graphite-statsd:1.1.7-1
```

Create a dashboard and select Graphtie 1.1.7 data source (if you used graphite1 block it'd be `gdev-graphite-1.0`). Create a query: `scale(apps.backend.backend_01.counters.requests.count, 10.5)` (you can switch to text editor and paste it).

Create an alert and test it. In main it should return an error described in #37614. In the branch it should run the test correctly.