### PR TITLE
prometheus: alerting: handle datasource.timeRange is nil case

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -85,9 +85,18 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 			return nil, errors.New("no http method provided")
 		}
 
-		timeInterval, ok := jsonData["timeInterval"].(string)
-		if !ok {
-			return nil, errors.New("invalid time-interval provided")
+		// timeInterval can be a string or can be missing.
+		// if it is missing, we set it to empty-string
+
+		timeInterval := ""
+
+		timeIntervalJson := jsonData["timeInterval"]
+		if timeIntervalJson != nil {
+			// if it is not nil, it must be a string
+			timeInterval, ok = timeIntervalJson.(string)
+			if !ok {
+				return nil, errors.New("invalid time-interval provided")
+			}
 		}
 
 		mdl := DatasourceInfo{


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/37887

when you create a prometheus data source, and do not enter anything in the "scrape interval" field, then this will appear `nil` in go-code (NOTE: if you enter something, save, then clear the field and save again, it will be `""` empty-string)

this pull requests fixes the go code to handle this case.

how to test:

- create a new prometheus data source, do not enter anything in the "scrape interval" field. save.
- create an alert with this prometheus data source
- it should work