### PR TITLE
Datasource: Change HTTP status code for failed datasource health check to 400

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -477,7 +477,7 @@ func (hs *HTTPServer) CheckDatasourceHealth(c *models.ReqContext) response.Respo
 	}
 
 	if resp.Status != backend.HealthStatusOk {
-		return response.JSON(503, payload)
+		return response.JSON(400, payload)
 	}
 
 	return response.JSON(200, payload)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the http status code returned when the datasource fails a health check. Since the datasources settings are configured by the user, the health check error most likely is a client-side error on the setup.

**Which issue(s) this PR fixes**:

N/A - Fixes an issue found internally with the interaction between catching errors through nginx

**Special notes for your reviewer**:
