### PR TITLE
Allow Dispatch to have many handlers

### DIFF
--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -55,7 +55,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 	t.Run("When a server admin attempts to logout himself from all devices", func(t *testing.T) {
 		adminLogoutUserScenario(t, "Should not be allowed when calling POST on",
 			"/api/admin/users/1/logout", "/api/admin/users/:id/logout", func(sc *scenarioContext) {
-				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 					cmd.Result = &models.User{Id: testUserID}
 					return nil
 				})
@@ -70,7 +70,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 			"/api/admin/users/:id/logout", func(sc *scenarioContext) {
 				userID := int64(0)
 
-				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 					userID = cmd.Id
 					return models.ErrUserNotFound
 				})
@@ -86,7 +86,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 		adminRevokeUserAuthTokenScenario(t, "Should return not found when calling POST on",
 			"/api/admin/users/200/revoke-auth-token", "/api/admin/users/:id/revoke-auth-token", cmd, func(sc *scenarioContext) {
 				var userID int64
-				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 					userID = cmd.Id
 					return models.ErrUserNotFound
 				})
@@ -101,7 +101,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 		adminGetUserAuthTokensScenario(t, "Should return not found when calling GET on",
 			"/api/admin/users/200/auth-tokens", "/api/admin/users/:id/auth-tokens", func(sc *scenarioContext) {
 				var userID int64
-				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 					userID = cmd.Id
 					return models.ErrUserNotFound
 				})
@@ -117,11 +117,11 @@ func TestAdminAPIEndpoint(t *testing.T) {
 			"/api/admin/users/42/enable", "/api/admin/users/:id/enable", func(sc *scenarioContext) {
 				var userID int64
 				isDisabled := false
-				bus.AddHandler("test", func(cmd *models.GetAuthInfoQuery) error {
+				bus.SetHandler(func(cmd *models.GetAuthInfoQuery) error {
 					return models.ErrUserNotFound
 				})
 
-				bus.AddHandler("test", func(cmd *models.DisableUserCommand) error {
+				bus.SetHandler(func(cmd *models.DisableUserCommand) error {
 					userID = cmd.UserId
 					isDisabled = cmd.IsDisabled
 					return models.ErrUserNotFound
@@ -143,11 +143,11 @@ func TestAdminAPIEndpoint(t *testing.T) {
 			"/api/admin/users/42/disable", "/api/admin/users/:id/disable", func(sc *scenarioContext) {
 				var userID int64
 				isDisabled := false
-				bus.AddHandler("test", func(cmd *models.GetAuthInfoQuery) error {
+				bus.SetHandler(func(cmd *models.GetAuthInfoQuery) error {
 					return models.ErrUserNotFound
 				})
 
-				bus.AddHandler("test", func(cmd *models.DisableUserCommand) error {
+				bus.SetHandler(func(cmd *models.DisableUserCommand) error {
 					userID = cmd.UserId
 					isDisabled = cmd.IsDisabled
 					return models.ErrUserNotFound
@@ -170,7 +170,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 		adminDisableUserScenario(t, "Should return Could not disable external user error", "disable",
 			"/api/admin/users/42/disable", "/api/admin/users/:id/disable", func(sc *scenarioContext) {
 				var userID int64
-				bus.AddHandler("test", func(cmd *models.GetAuthInfoQuery) error {
+				bus.SetHandler(func(cmd *models.GetAuthInfoQuery) error {
 					userID = cmd.UserId
 					return nil
 				})
@@ -188,7 +188,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 		adminDisableUserScenario(t, "Should return Could not enable external user error", "enable",
 			"/api/admin/users/42/enable", "/api/admin/users/:id/enable", func(sc *scenarioContext) {
 				var userID int64
-				bus.AddHandler("test", func(cmd *models.GetAuthInfoQuery) error {
+				bus.SetHandler(func(cmd *models.GetAuthInfoQuery) error {
 					userID = cmd.UserId
 					return nil
 				})
@@ -208,7 +208,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 		adminDeleteUserScenario(t, "Should return user not found error", "/api/admin/users/42",
 			"/api/admin/users/:id", func(sc *scenarioContext) {
 				var userID int64
-				bus.AddHandler("test", func(cmd *models.DeleteUserCommand) error {
+				bus.SetHandler(func(cmd *models.DeleteUserCommand) error {
 					userID = cmd.UserId
 					return models.ErrUserNotFound
 				})

--- a/pkg/api/alerting_test.go
+++ b/pkg/api/alerting_test.go
@@ -25,7 +25,7 @@ func TestAlertingAPIEndpoint(t *testing.T) {
 	editorRole := models.ROLE_EDITOR
 
 	setUp := func(confs ...setUpConf) {
-		bus.AddHandler("test", func(query *models.GetAlertByIdQuery) error {
+		bus.SetHandler(func(query *models.GetAlertByIdQuery) error {
 			query.Result = singleAlert
 			return nil
 		})
@@ -36,12 +36,12 @@ func TestAlertingAPIEndpoint(t *testing.T) {
 				aclMockResp = c.aclMockResp
 			}
 		}
-		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *models.GetTeamsByUserQuery) error {
+		bus.SetHandler(func(query *models.GetTeamsByUserQuery) error {
 			query.Result = []*models.TeamDTO{}
 			return nil
 		})
@@ -85,13 +85,13 @@ func TestAlertingAPIEndpoint(t *testing.T) {
 			setUp()
 
 			var searchQuery *search.Query
-			bus.AddHandler("test", func(query *search.Query) error {
+			bus.SetHandler(func(query *search.Query) error {
 				searchQuery = query
 				return nil
 			})
 
 			var getAlertsQuery *models.GetAlertsQuery
-			bus.AddHandler("test", func(query *models.GetAlertsQuery) error {
+			bus.SetHandler(func(query *models.GetAlertsQuery) error {
 				getAlertsQuery = query
 				return nil
 			})
@@ -109,7 +109,7 @@ func TestAlertingAPIEndpoint(t *testing.T) {
 			setUp()
 
 			var searchQuery *search.Query
-			bus.AddHandler("test", func(query *search.Query) error {
+			bus.SetHandler(func(query *search.Query) error {
 				searchQuery = query
 				query.Result = search.HitList{
 					&search.Hit{ID: 1},
@@ -119,7 +119,7 @@ func TestAlertingAPIEndpoint(t *testing.T) {
 			})
 
 			var getAlertsQuery *models.GetAlertsQuery
-			bus.AddHandler("test", func(query *models.GetAlertsQuery) error {
+			bus.SetHandler(func(query *models.GetAlertsQuery) error {
 				getAlertsQuery = query
 				return nil
 			})
@@ -152,7 +152,7 @@ func TestAlertingAPIEndpoint(t *testing.T) {
 }
 
 func callPauseAlert(sc *scenarioContext) {
-	bus.AddHandler("test", func(cmd *models.PauseAlertCommand) error {
+	bus.SetHandler(func(cmd *models.PauseAlertCommand) error {
 		return nil
 	})
 

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -133,12 +133,12 @@ func TestAnnotationsAPIEndpoint(t *testing.T) {
 		}
 
 		setUp := func() {
-			bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = aclMockResp
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetTeamsByUserQuery) error {
+			bus.SetHandler(func(query *models.GetTeamsByUserQuery) error {
 				query.Result = []*models.TeamDTO{}
 				return nil
 			})

--- a/pkg/api/dashboard_permission_test.go
+++ b/pkg/api/dashboard_permission_test.go
@@ -24,7 +24,7 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 
 		t.Run("Given dashboard not exists", func(t *testing.T) {
 			setUp := func() {
-				bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+				bus.SetHandler(func(query *models.GetDashboardQuery) error {
 					return models.ErrDashboardNotFound
 				})
 			}
@@ -66,7 +66,7 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 			getDashboardQueryResult := models.NewDashboard("Dash")
 
 			setUp := func() {
-				bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 					query.Result = getDashboardQueryResult
 					return nil
 				})
@@ -118,7 +118,7 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 
 			setUp := func() {
 				getDashboardQueryResult := models.NewDashboard("Dash")
-				bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 					query.Result = getDashboardQueryResult
 					return nil
 				})
@@ -171,7 +171,7 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 
 			setUp := func() {
 				getDashboardQueryResult := models.NewDashboard("Dash")
-				bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 					query.Result = getDashboardQueryResult
 					return nil
 				})
@@ -242,7 +242,7 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 
 			setUp := func() {
 				getDashboardQueryResult := models.NewDashboard("Dash")
-				bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 					query.Result = getDashboardQueryResult
 					return nil
 				})
@@ -293,7 +293,7 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 
 			setUp := func() {
 				getDashboardQueryResult := models.NewDashboard("Dash")
-				bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 					query.Result = getDashboardQueryResult
 					return nil
 				})

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -47,22 +47,22 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 			External:  true,
 		}
 
-		bus.AddHandler("test", func(query *models.GetDashboardSnapshotQuery) error {
+		bus.SetHandler(func(query *models.GetDashboardSnapshotQuery) error {
 			query.Result = mockSnapshotResult
 			return nil
 		})
 
-		bus.AddHandler("test", func(cmd *models.DeleteDashboardSnapshotCommand) error {
+		bus.SetHandler(func(cmd *models.DeleteDashboardSnapshotCommand) error {
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})
 
 		teamResp := []*models.TeamDTO{}
-		bus.AddHandler("test", func(query *models.GetTeamsByUserQuery) error {
+		bus.SetHandler(func(query *models.GetTeamsByUserQuery) error {
 			query.Result = teamResp
 			return nil
 		})
@@ -278,7 +278,7 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 
 				setUpSnapshotTest(t)
 
-				bus.AddHandler("test", func(query *models.GetDashboardSnapshotQuery) error {
+				bus.SetHandler(func(query *models.GetDashboardSnapshotQuery) error {
 					query.Result = mockSnapshotResult
 					return nil
 				})

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -40,7 +40,7 @@ func TestGetHomeDashboard(t *testing.T) {
 		Cfg: cfg, Bus: bus.New(),
 		PluginManager: &fakePluginManager{},
 	}
-	hs.Bus.AddHandlerCtx(func(_ context.Context, query *models.GetPreferencesWithDefaultsQuery) error {
+	hs.Bus.SetHandlerCtx(func(_ context.Context, query *models.GetPreferencesWithDefaultsQuery) error {
 		query.Result = &models.Preferences{
 			HomeDashboardId: 0,
 		}
@@ -108,7 +108,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			fakeDash.FolderId = 1
 			fakeDash.HasAcl = false
 
-			bus.AddHandler("test", func(query *models.GetDashboardsBySlugQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardsBySlugQuery) error {
 				dashboards := []*models.Dashboard{fakeDash}
 				query.Result = dashboards
 				return nil
@@ -116,7 +116,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 			state := &testState{}
 
-			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 				query.Result = fakeDash
 				state.dashQueries = append(state.dashQueries, query)
 				return nil
@@ -130,12 +130,12 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 			}
 
-			bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = aclMockResp
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetTeamsByUserQuery) error {
+			bus.SetHandler(func(query *models.GetTeamsByUserQuery) error {
 				query.Result = []*models.TeamDTO{}
 				return nil
 			})
@@ -262,7 +262,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			})
 			setting.ViewersCanEdit = false
 
-			bus.AddHandler("test", func(query *models.GetDashboardsBySlugQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardsBySlugQuery) error {
 				dashboards := []*models.Dashboard{fakeDash}
 				query.Result = dashboards
 				return nil
@@ -276,18 +276,18 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				},
 			}
 
-			bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = aclMockResp
 				return nil
 			})
 
-			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 				query.Result = fakeDash
 				state.dashQueries = append(state.dashQueries, query)
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetTeamsByUserQuery) error {
+			bus.SetHandler(func(query *models.GetTeamsByUserQuery) error {
 				query.Result = []*models.TeamDTO{}
 				return nil
 			})
@@ -391,7 +391,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 			setUpInner := func() *testState {
 				state := setUp()
-				bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -443,7 +443,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 					{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
 				}
 
-				bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -487,7 +487,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				mockResult := []*models.DashboardAclInfoDTO{
 					{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_ADMIN},
 				}
-				bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -537,7 +537,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				mockResult := []*models.DashboardAclInfoDTO{
 					{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
 				}
-				bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -588,7 +588,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		dashTwo.FolderId = 3
 		dashTwo.HasAcl = false
 
-		bus.AddHandler("test", func(query *models.GetDashboardsBySlugQuery) error {
+		bus.SetHandler(func(query *models.GetDashboardsBySlugQuery) error {
 			dashboards := []*models.Dashboard{dashOne, dashTwo}
 			query.Result = dashboards
 			return nil
@@ -778,12 +778,12 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 	t.Run("Given two dashboards being compared", func(t *testing.T) {
 		setUp := func() {
 			mockResult := []*models.DashboardAclInfoDTO{}
-			bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = mockResult
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetDashboardVersionQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardVersionQuery) error {
 				query.Result = &models.DashboardVersion{
 					Data: simplejson.NewFromAny(map[string]interface{}{
 						"title": fmt.Sprintf("Dash%d", query.DashboardId),
@@ -836,12 +836,12 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			fakeDash.FolderId = folderID
 			fakeDash.HasAcl = false
 
-			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 				query.Result = fakeDash
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetDashboardVersionQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardVersionQuery) error {
 				query.Result = &models.DashboardVersion{
 					DashboardId: 2,
 					Version:     1,
@@ -884,12 +884,12 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 			fakeDash.Id = 2
 			fakeDash.HasAcl = false
 
-			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 				query.Result = fakeDash
 				return nil
 			})
 
-			bus.AddHandler("test", func(query *models.GetDashboardVersionQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardVersionQuery) error {
 				query.Result = &models.DashboardVersion{
 					DashboardId: 2,
 					Version:     1,
@@ -928,11 +928,11 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 	t.Run("Given provisioned dashboard", func(t *testing.T) {
 		setUp := func() {
-			bus.AddHandler("test", func(query *models.GetDashboardsBySlugQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardsBySlugQuery) error {
 				query.Result = []*models.Dashboard{{}}
 				return nil
 			})
-			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, query *models.GetDashboardQuery) error {
 				dataValue, err := simplejson.NewJson([]byte(`{"id": 1, "editable": true, "style": "dark"}`))
 				require.NoError(t, err)
 				query.Result = &models.Dashboard{Id: 1, Data: dataValue}
@@ -947,7 +947,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				return &models.DashboardProvisioning{ExternalId: "/tmp/grafana/dashboards/test/dashboard1.json"}, nil
 			}
 
-			bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = []*models.DashboardAclInfoDTO{
 					{OrgId: testOrgID, DashboardId: 1, UserId: testUserID, Permission: models.PERMISSION_EDIT},
 				}
@@ -1049,7 +1049,7 @@ func callGetDashboard(sc *scenarioContext, hs *HTTPServer) {
 }
 
 func callGetDashboardVersion(sc *scenarioContext) {
-	bus.AddHandler("test", func(query *models.GetDashboardVersionQuery) error {
+	bus.SetHandler(func(query *models.GetDashboardVersionQuery) error {
 		query.Result = &models.DashboardVersion{}
 		return nil
 	})
@@ -1059,7 +1059,7 @@ func callGetDashboardVersion(sc *scenarioContext) {
 }
 
 func callGetDashboardVersions(sc *scenarioContext) {
-	bus.AddHandler("test", func(query *models.GetDashboardVersionsQuery) error {
+	bus.SetHandler(func(query *models.GetDashboardVersionsQuery) error {
 		query.Result = []*models.DashboardVersionDTO{}
 		return nil
 	})
@@ -1069,7 +1069,7 @@ func callGetDashboardVersions(sc *scenarioContext) {
 }
 
 func callDeleteDashboardBySlug(sc *scenarioContext, hs *HTTPServer) {
-	bus.AddHandler("test", func(cmd *models.DeleteDashboardCommand) error {
+	bus.SetHandler(func(cmd *models.DeleteDashboardCommand) error {
 		return nil
 	})
 
@@ -1078,7 +1078,7 @@ func callDeleteDashboardBySlug(sc *scenarioContext, hs *HTTPServer) {
 }
 
 func callDeleteDashboardByUID(sc *scenarioContext, hs *HTTPServer) {
-	bus.AddHandler("test", func(cmd *models.DeleteDashboardCommand) error {
+	bus.SetHandler(func(cmd *models.DeleteDashboardCommand) error {
 		return nil
 	})
 

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -23,7 +23,7 @@ const (
 func TestDataSourcesProxy_userLoggedIn(t *testing.T) {
 	loggedInUserScenario(t, "When calling GET on", "/api/datasources/", func(sc *scenarioContext) {
 		// Stubs the database query
-		bus.AddHandler("test", func(query *models.GetDataSourcesQuery) error {
+		bus.SetHandler(func(query *models.GetDataSourcesQuery) error {
 			assert.Equal(t, testOrgID, query.OrgId)
 			query.Result = []*models.DataSource{
 				{Name: "mmm"},
@@ -93,7 +93,7 @@ func TestAddDataSource_URLWithoutProtocol(t *testing.T) {
 	const url = "localhost:5432"
 
 	// Stub handler
-	bus.AddHandler("sql", func(cmd *models.AddDataSourceCommand) error {
+	bus.SetHandler(func(cmd *models.AddDataSourceCommand) error {
 		assert.Equal(t, name, cmd.Name)
 		assert.Equal(t, url, cmd.Url)
 
@@ -141,7 +141,7 @@ func TestUpdateDataSource_URLWithoutProtocol(t *testing.T) {
 	const url = "localhost:5432"
 
 	// Stub handler
-	bus.AddHandler("sql", func(cmd *models.AddDataSourceCommand) error {
+	bus.SetHandler(func(cmd *models.AddDataSourceCommand) error {
 		assert.Equal(t, name, cmd.Name)
 		assert.Equal(t, url, cmd.Url)
 

--- a/pkg/api/health_test.go
+++ b/pkg/api/health_test.go
@@ -21,7 +21,7 @@ func TestHealthAPI_Version(t *testing.T) {
 		cfg.BuildCommit = "59906ab1bf"
 	})
 
-	bus.AddHandler("test", func(query *models.GetDBHealthQuery) error {
+	bus.SetHandler(func(query *models.GetDBHealthQuery) error {
 		return nil
 	})
 
@@ -44,7 +44,7 @@ func TestHealthAPI_AnonymousHideVersion(t *testing.T) {
 	m, hs := setupHealthAPITestEnvironment(t)
 	hs.Cfg.AnonymousHideVersion = true
 
-	bus.AddHandler("test", func(query *models.GetDBHealthQuery) error {
+	bus.SetHandler(func(query *models.GetDBHealthQuery) error {
 		return nil
 	})
 
@@ -67,7 +67,7 @@ func TestHealthAPI_DatabaseHealthy(t *testing.T) {
 	m, hs := setupHealthAPITestEnvironment(t)
 	hs.Cfg.AnonymousHideVersion = true
 
-	bus.AddHandler("test", func(query *models.GetDBHealthQuery) error {
+	bus.SetHandler(func(query *models.GetDBHealthQuery) error {
 		return nil
 	})
 
@@ -98,7 +98,7 @@ func TestHealthAPI_DatabaseUnhealthy(t *testing.T) {
 	m, hs := setupHealthAPITestEnvironment(t)
 	hs.Cfg.AnonymousHideVersion = true
 
-	bus.AddHandler("test", func(query *models.GetDBHealthQuery) error {
+	bus.SetHandler(func(query *models.GetDBHealthQuery) error {
 		return errors.New("bad")
 	})
 
@@ -130,7 +130,7 @@ func TestHealthAPI_DatabaseHealthCached(t *testing.T) {
 	hs.Cfg.AnonymousHideVersion = true
 
 	// Database is healthy.
-	bus.AddHandler("test", func(query *models.GetDBHealthQuery) error {
+	bus.SetHandler(func(query *models.GetDBHealthQuery) error {
 		return nil
 	})
 

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -132,7 +132,7 @@ func TestGetUserFromLDAPAPIEndpoint_OrgNotfound(t *testing.T) {
 		{Id: 1, Name: "Main Org."},
 	}
 
-	bus.AddHandler("test", func(query *models.SearchOrgsQuery) error {
+	bus.SetHandler(func(query *models.SearchOrgsQuery) error {
 		query.Result = mockOrgSearchResult
 		return nil
 	})
@@ -194,7 +194,7 @@ func TestGetUserFromLDAPAPIEndpoint(t *testing.T) {
 		{Id: 1, Name: "Main Org."},
 	}
 
-	bus.AddHandler("test", func(query *models.SearchOrgsQuery) error {
+	bus.SetHandler(func(query *models.SearchOrgsQuery) error {
 		query.Result = mockOrgSearchResult
 		return nil
 	})
@@ -269,12 +269,12 @@ func TestGetUserFromLDAPAPIEndpoint_WithTeamHandler(t *testing.T) {
 		{Id: 1, Name: "Main Org."},
 	}
 
-	bus.AddHandler("test", func(query *models.SearchOrgsQuery) error {
+	bus.SetHandler(func(query *models.SearchOrgsQuery) error {
 		query.Result = mockOrgSearchResult
 		return nil
 	})
 
-	bus.AddHandler("test", func(cmd *models.GetTeamsForLDAPGroupCommand) error {
+	bus.SetHandler(func(cmd *models.GetTeamsForLDAPGroupCommand) error {
 		cmd.Result = []models.TeamOrgGroupDTO{}
 		return nil
 	})
@@ -430,19 +430,19 @@ func TestPostSyncUserWithLDAPAPIEndpoint_Success(t *testing.T) {
 			Login: "ldap-daniel",
 		}
 
-		bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+		bus.SetHandler(func(cmd *models.UpsertUserCommand) error {
 			require.Equal(t, "ldap-daniel", cmd.ExternalUser.Login)
 			return nil
 		})
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, q *models.GetUserByIdQuery) error {
 			require.Equal(t, q.Id, int64(34))
 
 			q.Result = &models.User{Login: "ldap-daniel", Id: 34}
 			return nil
 		})
 
-		bus.AddHandler("test", func(q *models.GetAuthInfoQuery) error {
+		bus.SetHandler(func(q *models.GetAuthInfoQuery) error {
 			require.Equal(t, q.UserId, int64(34))
 			require.Equal(t, q.AuthModule, models.AuthModuleLDAP)
 
@@ -471,7 +471,7 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenUserNotFound(t *testing.T) {
 			return &LDAPMock{}
 		}
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, q *models.GetUserByIdQuery) error {
 			require.Equal(t, q.Id, int64(34))
 
 			return models.ErrUserNotFound
@@ -503,14 +503,14 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenGrafanaAdmin(t *testing.T) {
 
 		sc.cfg.AdminUser = "ldap-daniel"
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, q *models.GetUserByIdQuery) error {
 			require.Equal(t, q.Id, int64(34))
 
 			q.Result = &models.User{Login: "ldap-daniel", Id: 34}
 			return nil
 		})
 
-		bus.AddHandler("test", func(q *models.GetAuthInfoQuery) error {
+		bus.SetHandler(func(q *models.GetAuthInfoQuery) error {
 			require.Equal(t, q.UserId, int64(34))
 			require.Equal(t, q.AuthModule, models.AuthModuleLDAP)
 
@@ -542,26 +542,26 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenUserNotInLDAP(t *testing.T) {
 
 		userSearchResult = nil
 
-		bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+		bus.SetHandler(func(cmd *models.UpsertUserCommand) error {
 			require.Equal(t, "ldap-daniel", cmd.ExternalUser.Login)
 			return nil
 		})
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, q *models.GetUserByIdQuery) error {
 			require.Equal(t, q.Id, int64(34))
 
 			q.Result = &models.User{Login: "ldap-daniel", Id: 34}
 			return nil
 		})
 
-		bus.AddHandler("test", func(q *models.GetExternalUserInfoByLoginQuery) error {
+		bus.SetHandler(func(q *models.GetExternalUserInfoByLoginQuery) error {
 			assert.Equal(t, "ldap-daniel", q.LoginOrEmail)
 			q.Result = &models.ExternalUserInfo{IsDisabled: true, UserId: 34}
 
 			return nil
 		})
 
-		bus.AddHandler("test", func(cmd *models.DisableUserCommand) error {
+		bus.SetHandler(func(cmd *models.DisableUserCommand) error {
 			assert.Equal(t, 34, cmd.UserId)
 			return nil
 		})
@@ -688,16 +688,16 @@ func TestLDAP_AccessControl(t *testing.T) {
 				return &LDAPMock{}
 			}
 
-			bus.AddHandlerCtx("test", func(ctx context.Context, q *models.GetUserByIdQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, q *models.GetUserByIdQuery) error {
 				q.Result = &models.User{}
 				return nil
 			})
 
-			bus.AddHandler("test", func(q *models.GetAuthInfoQuery) error {
+			bus.SetHandler(func(q *models.GetAuthInfoQuery) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+			bus.SetHandler(func(cmd *models.UpsertUserCommand) error {
 				return nil
 			})
 

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -341,7 +341,7 @@ func TestLoginPostRedirect(t *testing.T) {
 		return hs.LoginPost(c, cmd)
 	})
 
-	bus.AddHandler("grafana-auth", func(query *models.LoginUserQuery) error {
+	bus.SetHandler(func(query *models.LoginUserQuery) error {
 		query.User = &models.User{
 			Id:    42,
 			Email: "",
@@ -676,7 +676,7 @@ func TestLoginPostRunLokingHook(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.desc, func(t *testing.T) {
-			bus.AddHandler("grafana-auth", func(query *models.LoginUserQuery) error {
+			bus.SetHandler(func(query *models.LoginUserQuery) error {
 				query.User = c.authUser
 				query.AuthModule = c.authModule
 				return c.authErr

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setUpGetOrgUsersHandler() {
-	bus.AddHandler("test", func(query *models.GetOrgUsersQuery) error {
+	bus.SetHandler(func(query *models.GetOrgUsersQuery) error {
 		query.Result = []*models.OrgUserDTO{
 			{Email: "testUser@grafana.com", Login: testUserLogin},
 			{Email: "user1@grafana.com", Login: "user1"},
@@ -97,11 +97,11 @@ func TestOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
 	loggedInUserScenario(t, "When calling GET as an editor with no team / folder permissions on",
 		"api/org/users/lookup", func(sc *scenarioContext) {
 			setUpGetOrgUsersHandler()
-			bus.AddHandler("test", func(query *models.HasAdminPermissionInFoldersQuery) error {
+			bus.SetHandler(func(query *models.HasAdminPermissionInFoldersQuery) error {
 				query.Result = false
 				return nil
 			})
-			bus.AddHandler("test", func(query *models.IsAdminOfTeamsQuery) error {
+			bus.SetHandler(func(query *models.IsAdminOfTeamsQuery) error {
 				query.Result = false
 				return nil
 			})

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -424,7 +424,7 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 	})
 
 	t.Run("When proxying a datasource that has OAuth token pass-through enabled", func(t *testing.T) {
-		bus.AddHandler("test", func(query *models.GetAuthInfoQuery) error {
+		bus.SetHandler(func(query *models.GetAuthInfoQuery) error {
 			query.Result = &models.UserAuth{
 				Id:                1,
 				UserId:            1,

--- a/pkg/api/pluginproxy/pluginproxy_test.go
+++ b/pkg/api/pluginproxy/pluginproxy_test.go
@@ -25,7 +25,7 @@ func TestPluginProxy(t *testing.T) {
 
 		setting.SecretKey = "password"
 
-		bus.AddHandler("test", func(query *models.GetPluginSettingByIdQuery) error {
+		bus.SetHandler(func(query *models.GetPluginSettingByIdQuery) error {
 			key, err := util.Encrypt([]byte("123"), "password")
 			if err != nil {
 				return err
@@ -104,7 +104,7 @@ func TestPluginProxy(t *testing.T) {
 			Method: "GET",
 		}
 
-		bus.AddHandler("test", func(query *models.GetPluginSettingByIdQuery) error {
+		bus.SetHandler(func(query *models.GetPluginSettingByIdQuery) error {
 			query.Result = &models.PluginSetting{
 				JsonData: map[string]interface{}{
 					"dynamicUrl": "https://dynamic.grafana.com",
@@ -133,7 +133,7 @@ func TestPluginProxy(t *testing.T) {
 			Method: "GET",
 		}
 
-		bus.AddHandler("test", func(query *models.GetPluginSettingByIdQuery) error {
+		bus.SetHandler(func(query *models.GetPluginSettingByIdQuery) error {
 			query.Result = &models.PluginSetting{}
 			return nil
 		})
@@ -158,7 +158,7 @@ func TestPluginProxy(t *testing.T) {
 			Body: []byte(`{ "url": "{{.JsonData.dynamicUrl}}", "secret": "{{.SecureJsonData.key}}"	}`),
 		}
 
-		bus.AddHandler("test", func(query *models.GetPluginSettingByIdQuery) error {
+		bus.SetHandler(func(query *models.GetPluginSettingByIdQuery) error {
 			query.Result = &models.PluginSetting{
 				JsonData: map[string]interface{}{
 					"dynamicUrl": "https://dynamic.grafana.com",

--- a/pkg/api/team_members_test.go
+++ b/pkg/api/team_members_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func setUpGetTeamMembersHandler() {
-	bus.AddHandler("test", func(query *models.GetTeamMembersQuery) error {
+	bus.SetHandler(func(query *models.GetTeamMembersQuery) error {
 		query.Result = []*models.TeamMemberDTO{
 			{Email: "testUser@grafana.com", Login: testUserLogin},
 			{Email: "user1@grafana.com", Login: "user1"},

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -46,7 +46,7 @@ func TestTeamAPIEndpoint(t *testing.T) {
 		loggedInUserScenario(t, "When calling GET on", "/api/teams/search", func(sc *scenarioContext) {
 			var sentLimit int
 			var sendPage int
-			bus.AddHandler("test", func(query *models.SearchTeamsQuery) error {
+			bus.SetHandler(func(query *models.SearchTeamsQuery) error {
 				query.Result = mockResult
 
 				sentLimit = query.Limit
@@ -71,7 +71,7 @@ func TestTeamAPIEndpoint(t *testing.T) {
 		loggedInUserScenario(t, "When calling GET on", "/api/teams/search", func(sc *scenarioContext) {
 			var sentLimit int
 			var sendPage int
-			bus.AddHandler("test", func(query *models.SearchTeamsQuery) error {
+			bus.SetHandler(func(query *models.SearchTeamsQuery) error {
 				query.Result = mockResult
 
 				sentLimit = query.Limit

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -25,7 +25,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 
 	loggedInUserScenario(t, "When calling GET on", "api/users/:id", func(sc *scenarioContext) {
 		fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
-		bus.AddHandler("test", func(query *models.GetUserProfileQuery) error {
+		bus.SetHandler(func(query *models.GetUserProfileQuery) error {
 			query.Result = models.UserProfileDTO{
 				Id:             int64(1),
 				Email:          "daniel@grafana.com",
@@ -41,7 +41,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *models.GetAuthInfoQuery) error {
+		bus.SetHandler(func(query *models.GetAuthInfoQuery) error {
 			query.Result = &models.UserAuth{
 				AuthModule: models.AuthModuleLDAP,
 			}
@@ -78,7 +78,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 
 	loggedInUserScenario(t, "When calling GET on", "/api/users/lookup", func(sc *scenarioContext) {
 		fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
-		bus.AddHandler("test", func(query *models.GetUserByLoginQuery) error {
+		bus.SetHandler(func(query *models.GetUserByLoginQuery) error {
 			require.Equal(t, "danlee", query.LoginOrEmail)
 
 			query.Result = &models.User{
@@ -125,7 +125,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	loggedInUserScenario(t, "When calling GET on", "/api/users", func(sc *scenarioContext) {
 		var sentLimit int
 		var sendPage int
-		bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+		bus.SetHandler(func(query *models.SearchUsersQuery) error {
 			query.Result = mockResult
 
 			sentLimit = query.Limit
@@ -148,7 +148,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	loggedInUserScenario(t, "When calling GET with page and limit querystring parameters on", "/api/users", func(sc *scenarioContext) {
 		var sentLimit int
 		var sendPage int
-		bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+		bus.SetHandler(func(query *models.SearchUsersQuery) error {
 			query.Result = mockResult
 
 			sentLimit = query.Limit
@@ -167,7 +167,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	loggedInUserScenario(t, "When calling GET on", "/api/users/search", func(sc *scenarioContext) {
 		var sentLimit int
 		var sendPage int
-		bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+		bus.SetHandler(func(query *models.SearchUsersQuery) error {
 			query.Result = mockResult
 
 			sentLimit = query.Limit
@@ -192,7 +192,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 	loggedInUserScenario(t, "When calling GET with page and perpage querystring parameters on", "/api/users/search", func(sc *scenarioContext) {
 		var sentLimit int
 		var sendPage int
-		bus.AddHandler("test", func(query *models.SearchUsersQuery) error {
+		bus.SetHandler(func(query *models.SearchUsersQuery) error {
 			query.Result = mockResult
 
 			sentLimit = query.Limit

--- a/pkg/api/user_token_test.go
+++ b/pkg/api/user_token_test.go
@@ -21,7 +21,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 		revokeUserAuthTokenScenario(t, "Should return not found when calling POST on", "/api/user/revoke-auth-token",
 			"/api/user/revoke-auth-token", cmd, 200, func(sc *scenarioContext) {
 				var userID int64
-				bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 					userID = cmd.Id
 					return models.ErrUserNotFound
 				})
@@ -35,7 +35,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 	t.Run("When current user gets auth tokens for a non-existing user", func(t *testing.T) {
 		getUserAuthTokensScenario(t, "Should return not found when calling GET on", "/api/user/auth-tokens", "/api/user/auth-tokens", 200, func(sc *scenarioContext) {
 			var userID int64
-			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 				userID = cmd.Id
 				return models.ErrUserNotFound
 			})
@@ -49,7 +49,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 	t.Run("When logging out an existing user from all devices", func(t *testing.T) {
 		logoutUserFromAllDevicesInternalScenario(t, "Should be successful", 1, func(sc *scenarioContext) {
 			const userID int64 = 200
-			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 				cmd.Result = &models.User{Id: userID}
 				return nil
 			})
@@ -61,7 +61,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 
 	t.Run("When logout a non-existing user from all devices", func(t *testing.T) {
 		logoutUserFromAllDevicesInternalScenario(t, "Should return not found", testUserID, func(sc *scenarioContext) {
-			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 				return models.ErrUserNotFound
 			})
 
@@ -75,7 +75,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 		token := &models.UserToken{Id: 1}
 
 		revokeUserAuthTokenInternalScenario(t, "Should be successful", cmd, 200, token, func(sc *scenarioContext) {
-			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 				cmd.Result = &models.User{Id: 200}
 				return nil
 			})
@@ -93,7 +93,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 		token := &models.UserToken{Id: 2}
 
 		revokeUserAuthTokenInternalScenario(t, "Should not be successful", cmd, testUserID, token, func(sc *scenarioContext) {
-			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 				cmd.Result = &models.User{Id: testUserID}
 				return nil
 			})
@@ -110,7 +110,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 		currentToken := &models.UserToken{Id: 1}
 
 		getUserAuthTokensInternalScenario(t, "Should be successful", currentToken, func(sc *scenarioContext) {
-			bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 				cmd.Result = &models.User{Id: testUserID}
 				return nil
 			})

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -185,21 +185,19 @@ func (b *InProcBus) Publish(msg Msg) error {
 func (b *InProcBus) AddHandler(handler HandlerFunc) {
 	handlerType := reflect.TypeOf(handler)
 	queryTypeName := handlerType.In(0).Elem().Name()
-	_, exists := b.handlers[queryTypeName]
-	if !exists {
-		b.handlers[queryTypeName] = make([]HandlerFunc, 0)
-	}
 	b.handlers[queryTypeName] = append(b.handlers[queryTypeName], handler)
 }
 
 func (b *InProcBus) AddHandlerCtx(handler HandlerFunc) {
 	handlerType := reflect.TypeOf(handler)
 	queryTypeName := handlerType.In(1).Elem().Name()
-	_, exists := b.handlersWithCtx[queryTypeName]
-	if !exists {
-		b.handlersWithCtx[queryTypeName] = make([]HandlerFunc, 0)
-	}
 	b.handlersWithCtx[queryTypeName] = append(b.handlersWithCtx[queryTypeName], handler)
+}
+
+func (b *InProcBus) SetHandlerCtx(handler HandlerFunc) {
+	handlerType := reflect.TypeOf(handler)
+	queryTypeName := handlerType.In(1).Elem().Name()
+	b.handlersWithCtx[queryTypeName] = []HandlerFunc{handler}
 }
 
 // GetHandlersCtx returns the handler functions for the given struct name.
@@ -249,6 +247,10 @@ func Publish(msg Msg) error {
 
 func GetHandlersCtx(name string) []HandlerFunc {
 	return globalBus.(*InProcBus).GetHandlersCtx(name)
+}
+
+func SetHandlerCtx(handler HandlerFunc) {
+	globalBus.(*InProcBus).SetHandlerCtx(handler)
 }
 
 func ClearBusHandlers() {

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -16,17 +16,23 @@ type testQuery struct {
 func TestDispatch(t *testing.T) {
 	bus := New()
 
-	var invoked bool
-
+	var firstInvoked bool
 	bus.AddHandler(func(query *testQuery) error {
-		invoked = true
+		firstInvoked = true
+		return nil
+	})
+
+	var secondInvoked bool
+	bus.AddHandler(func(query *testQuery) error {
+		secondInvoked = true
 		return nil
 	})
 
 	err := bus.Dispatch(&testQuery{})
 	require.NoError(t, err)
 
-	require.True(t, invoked, "expected handler to be called")
+	require.True(t, firstInvoked, "expected handler to be called")
+	require.True(t, secondInvoked, "expected handler to be called")
 }
 
 func TestDispatch_NoRegisteredHandler(t *testing.T) {

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -36,7 +36,7 @@ func TestService(t *testing.T) {
 	s.DataService.RegisterQueryHandler("test", func(*models.DataSource) (plugins.DataPlugin, error) {
 		return me, nil
 	})
-	bus.AddHandler("test", func(query *models.GetDataSourceQuery) error {
+	bus.SetHandler(func(query *models.GetDataSourceQuery) error {
 		query.Result = &models.DataSource{Id: 1, OrgId: 1, Type: "test"}
 		return nil
 	})

--- a/pkg/expr/translate/translate_test.go
+++ b/pkg/expr/translate/translate_test.go
@@ -132,7 +132,7 @@ func alertRuleByRefId(cond *ngmodels.Condition, refID string) (ngmodels.AlertQue
 }
 
 func registerGetDsInfoHandler() {
-	bus.AddHandler("test", func(query *models.GetDataSourceQuery) error {
+	bus.SetHandler(func(query *models.GetDataSourceQuery) error {
 		switch {
 		case query.Id == 2:
 			query.Result = &models.DataSource{Id: 2, OrgId: 1, Uid: "000000002"}

--- a/pkg/login/brute_force_login_protection_test.go
+++ b/pkg/login/brute_force_login_protection_test.go
@@ -72,7 +72,7 @@ func TestSaveInvalidLoginAttempt(t *testing.T) {
 		t.Cleanup(func() { bus.ClearBusHandlers() })
 
 		createLoginAttemptCmd := &models.CreateLoginAttemptCommand{}
-		bus.AddHandler("test", func(cmd *models.CreateLoginAttemptCommand) error {
+		bus.SetHandler(func(cmd *models.CreateLoginAttemptCommand) error {
 			createLoginAttemptCmd = cmd
 			return nil
 		})
@@ -94,7 +94,7 @@ func TestSaveInvalidLoginAttempt(t *testing.T) {
 		t.Cleanup(func() { bus.ClearBusHandlers() })
 
 		var createLoginAttemptCmd *models.CreateLoginAttemptCommand
-		bus.AddHandler("test", func(cmd *models.CreateLoginAttemptCommand) error {
+		bus.SetHandler(func(cmd *models.CreateLoginAttemptCommand) error {
 			createLoginAttemptCmd = cmd
 			return nil
 		})
@@ -127,7 +127,7 @@ func cfgWithBruteForceLoginProtectionEnabled(t *testing.T) *setting.Cfg {
 
 func withLoginAttempts(t *testing.T, loginAttempts int64) {
 	t.Helper()
-	bus.AddHandler("test", func(query *models.GetUserLoginAttemptCountQuery) error {
+	bus.SetHandler(func(query *models.GetUserLoginAttemptCountQuery) error {
 		query.Result = loginAttempts
 		return nil
 	})

--- a/pkg/login/grafana_login_test.go
+++ b/pkg/login/grafana_login_test.go
@@ -94,7 +94,7 @@ func mockPasswordValidation(valid bool, sc *grafanaLoginScenarioContext) {
 }
 
 func (sc *grafanaLoginScenarioContext) getUserByLoginQueryReturns(user *models.User) {
-	bus.AddHandler("test", func(query *models.GetUserByLoginQuery) error {
+	bus.SetHandler(func(query *models.GetUserByLoginQuery) error {
 		if user == nil {
 			return models.ErrUserNotFound
 		}

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -40,7 +40,7 @@ func TestMiddlewareAuth(t *testing.T) {
 
 		middlewareScenario(t, "ReqSignIn true and NoAnonynmous true", func(
 			t *testing.T, sc *scenarioContext) {
-			bus.AddHandler("test", func(query *models.GetOrgByNameQuery) error {
+			bus.SetHandler(func(query *models.GetOrgByNameQuery) error {
 				query.Result = &models.Org{Id: orgID, Name: "test"}
 				return nil
 			})
@@ -53,7 +53,7 @@ func TestMiddlewareAuth(t *testing.T) {
 
 		middlewareScenario(t, "ReqSignIn true and request with forceLogin in query string", func(
 			t *testing.T, sc *scenarioContext) {
-			bus.AddHandler("test", func(query *models.GetOrgByNameQuery) error {
+			bus.SetHandler(func(query *models.GetOrgByNameQuery) error {
 				query.Result = &models.Org{Id: orgID, Name: "test"}
 				return nil
 			})
@@ -82,7 +82,7 @@ func TestMiddlewareAuth(t *testing.T) {
 
 		middlewareScenario(t, "ReqSignIn true and request with different org provided in query string", func(
 			t *testing.T, sc *scenarioContext) {
-			bus.AddHandler("test", func(query *models.GetOrgByNameQuery) error {
+			bus.SetHandler(func(query *models.GetOrgByNameQuery) error {
 				query.Result = &models.Org{Id: orgID, Name: "test"}
 				return nil
 			})

--- a/pkg/middleware/middleware_basic_auth_test.go
+++ b/pkg/middleware/middleware_basic_auth_test.go
@@ -28,7 +28,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 		keyhash, err := util.EncodePassword("v5nAwpMafFP6znaS4urhdWDLS5511M42", "asd")
 		require.NoError(t, err)
 
-		bus.AddHandler("test", func(query *models.GetApiKeyByNameQuery) error {
+		bus.SetHandler(func(query *models.GetApiKeyByNameQuery) error {
 			query.Result = &models.ApiKey{OrgId: orgID, Role: models.ROLE_EDITOR, Key: keyhash}
 			return nil
 		})
@@ -47,7 +47,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 		const salt = "Salt"
 		const orgID int64 = 2
 
-		bus.AddHandler("grafana-auth", func(query *models.LoginUserQuery) error {
+		bus.SetHandler(func(query *models.LoginUserQuery) error {
 			t.Log("Handling LoginUserQuery")
 			encoded, err := util.EncodePassword(password, salt)
 			if err != nil {
@@ -60,7 +60,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 			return nil
 		})
 
-		bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			t.Log("Handling GetSignedInUserQuery")
 			query.Result = &models.SignedInUser{OrgId: orgID, UserId: id}
 			return nil
@@ -80,7 +80,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 
 		login.Init()
 
-		bus.AddHandler("user-query", func(query *models.GetUserByLoginQuery) error {
+		bus.SetHandler(func(query *models.GetUserByLoginQuery) error {
 			encoded, err := util.EncodePassword(password, salt)
 			if err != nil {
 				return err
@@ -93,7 +93,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 			return nil
 		})
 
-		bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{UserId: query.UserId}
 			return nil
 		})
@@ -119,7 +119,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 	}, configure)
 
 	middlewareScenario(t, "Should return error if user & password do not match", func(t *testing.T, sc *scenarioContext) {
-		bus.AddHandler("user-query", func(loginUserQuery *models.GetUserByLoginQuery) error {
+		bus.SetHandler(func(loginUserQuery *models.GetUserByLoginQuery) error {
 			return nil
 		})
 

--- a/pkg/middleware/middleware_jwt_auth_test.go
+++ b/pkg/middleware/middleware_jwt_auth_test.go
@@ -40,7 +40,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 				"foo-username": myUsername,
 			}, nil
 		}
-		bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{
 				UserId: id,
 				OrgId:  orgID,
@@ -67,7 +67,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 				"foo-email": myEmail,
 			}, nil
 		}
-		bus.AddHandlerCtx("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{
 				UserId: id,
 				OrgId:  orgID,

--- a/pkg/middleware/org_redirect_test.go
+++ b/pkg/middleware/org_redirect_test.go
@@ -13,11 +13,11 @@ import (
 func TestOrgRedirectMiddleware(t *testing.T) {
 	middlewareScenario(t, "when setting a correct org for the user", func(t *testing.T, sc *scenarioContext) {
 		sc.withTokenSessionCookie("token")
-		bus.AddHandler("test", func(query *models.SetUsingOrgCommand) error {
+		bus.SetHandler(func(query *models.SetUsingOrgCommand) error {
 			return nil
 		})
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{OrgId: 1, UserId: 12}
 			return nil
 		})
@@ -37,11 +37,11 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 
 	middlewareScenario(t, "when setting an invalid org for user", func(t *testing.T, sc *scenarioContext) {
 		sc.withTokenSessionCookie("token")
-		bus.AddHandler("test", func(query *models.SetUsingOrgCommand) error {
+		bus.SetHandler(func(query *models.SetUsingOrgCommand) error {
 			return fmt.Errorf("")
 		})
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{OrgId: 1, UserId: 12}
 			return nil
 		})

--- a/pkg/middleware/quota_test.go
+++ b/pkg/middleware/quota_test.go
@@ -16,7 +16,7 @@ import (
 func TestMiddlewareQuota(t *testing.T) {
 	t.Run("With user not logged in", func(t *testing.T) {
 		middlewareScenario(t, "and global quota not reached", func(t *testing.T, sc *scenarioContext) {
-			bus.AddHandler("globalQuota", func(query *models.GetGlobalQuotaByTargetQuery) error {
+			bus.SetHandler(func(query *models.GetGlobalQuotaByTargetQuery) error {
 				query.Result = &models.GlobalQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -33,7 +33,7 @@ func TestMiddlewareQuota(t *testing.T) {
 		}, configure)
 
 		middlewareScenario(t, "and global quota reached", func(t *testing.T, sc *scenarioContext) {
-			bus.AddHandler("globalQuota", func(query *models.GetGlobalQuotaByTargetQuery) error {
+			bus.SetHandler(func(query *models.GetGlobalQuotaByTargetQuery) error {
 				query.Result = &models.GlobalQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -53,7 +53,7 @@ func TestMiddlewareQuota(t *testing.T) {
 		})
 
 		middlewareScenario(t, "and global session quota not reached", func(t *testing.T, sc *scenarioContext) {
-			bus.AddHandler("globalQuota", func(query *models.GetGlobalQuotaByTargetQuery) error {
+			bus.SetHandler(func(query *models.GetGlobalQuotaByTargetQuery) error {
 				query.Result = &models.GlobalQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -89,7 +89,7 @@ func TestMiddlewareQuota(t *testing.T) {
 
 		setUp := func(sc *scenarioContext) {
 			sc.withTokenSessionCookie("token")
-			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+			bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 				query.Result = &models.SignedInUser{OrgId: 2, UserId: 12}
 				return nil
 			})
@@ -101,7 +101,7 @@ func TestMiddlewareQuota(t *testing.T) {
 				}, nil
 			}
 
-			bus.AddHandler("globalQuota", func(query *models.GetGlobalQuotaByTargetQuery) error {
+			bus.SetHandler(func(query *models.GetGlobalQuotaByTargetQuery) error {
 				query.Result = &models.GlobalQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -110,7 +110,7 @@ func TestMiddlewareQuota(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("userQuota", func(query *models.GetUserQuotaByTargetQuery) error {
+			bus.SetHandler(func(query *models.GetUserQuotaByTargetQuery) error {
 				query.Result = &models.UserQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,
@@ -119,7 +119,7 @@ func TestMiddlewareQuota(t *testing.T) {
 				return nil
 			})
 
-			bus.AddHandler("orgQuota", func(query *models.GetOrgQuotaByTargetQuery) error {
+			bus.SetHandler(func(query *models.GetOrgQuotaByTargetQuery) error {
 				query.Result = &models.OrgQuotaDTO{
 					Target: query.Target,
 					Limit:  query.Default,

--- a/pkg/plugins/manager/dashboards_test.go
+++ b/pkg/plugins/manager/dashboards_test.go
@@ -23,7 +23,7 @@ func TestGetPluginDashboards(t *testing.T) {
 	err := pm.Init()
 	require.NoError(t, err)
 
-	bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+	bus.SetHandler(func(query *models.GetDashboardQuery) error {
 		if query.Slug == "nginx-connections" {
 			dash := models.NewDashboard("Nginx Connections")
 			dash.Data.Set("revision", "1.1")
@@ -34,7 +34,7 @@ func TestGetPluginDashboards(t *testing.T) {
 		return models.ErrDashboardNotFound
 	})
 
-	bus.AddHandler("test", func(query *models.GetDashboardsByPluginIdQuery) error {
+	bus.SetHandler(func(query *models.GetDashboardsByPluginIdQuery) error {
 		var data = simplejson.New()
 		data.Set("title", "Nginx Connections")
 		data.Set("revision", 22)

--- a/pkg/services/alerting/alerting_usage_test.go
+++ b/pkg/services/alerting/alerting_usage_test.go
@@ -17,7 +17,7 @@ func TestAlertingUsageStats(t *testing.T) {
 		Bus: bus.New(),
 	}
 
-	ae.Bus.AddHandler(func(query *models.GetAllAlertsQuery) error {
+	ae.Bus.SetHandler(func(query *models.GetAllAlertsQuery) error {
 		var createFake = func(file string) *simplejson.Json {
 			// Ignore gosec warning G304 since it's a test
 			// nolint:gosec
@@ -38,7 +38,7 @@ func TestAlertingUsageStats(t *testing.T) {
 		return nil
 	})
 
-	ae.Bus.AddHandler(func(query *models.GetDataSourceQuery) error {
+	ae.Bus.SetHandler(func(query *models.GetDataSourceQuery) error {
 		ds := map[int64]*models.DataSource{
 			1: {Type: "influxdb"},
 			2: {Type: "graphite"},

--- a/pkg/services/alerting/conditions/query_test.go
+++ b/pkg/services/alerting/conditions/query_test.go
@@ -241,7 +241,7 @@ func (rh fakeReqHandler) HandleRequest(context.Context, *models.DataSource, plug
 
 func queryConditionScenario(desc string, fn queryConditionScenarioFunc) {
 	Convey(desc, func() {
-		bus.AddHandler("test", func(query *models.GetDataSourceQuery) error {
+		bus.SetHandler(func(query *models.GetDataSourceQuery) error {
 			query.Result = &models.DataSource{Id: 1, Type: "graphite"}
 			return nil
 		})

--- a/pkg/services/alerting/extractor_test.go
+++ b/pkg/services/alerting/extractor_test.go
@@ -23,12 +23,12 @@ func TestAlertRuleExtraction(t *testing.T) {
 	influxDBDs := &models.DataSource{Id: 16, OrgId: 1, Name: "InfluxDB"}
 	prom := &models.DataSource{Id: 17, OrgId: 1, Name: "Prometheus"}
 
-	bus.AddHandler("test", func(query *models.GetDefaultDataSourceQuery) error {
+	bus.SetHandler(func(query *models.GetDefaultDataSourceQuery) error {
 		query.Result = defaultDs
 		return nil
 	})
 
-	bus.AddHandler("test", func(query *models.GetDataSourceQuery) error {
+	bus.SetHandler(func(query *models.GetDataSourceQuery) error {
 		if query.Name == defaultDs.Name {
 			query.Result = defaultDs
 		}

--- a/pkg/services/alerting/notifier_test.go
+++ b/pkg/services/alerting/notifier_test.go
@@ -177,7 +177,7 @@ func notificationServiceScenario(t *testing.T, name string, evalCtx *EvalContext
 
 		evalCtx.dashboardRef = &models.DashboardRef{Uid: "db-uid"}
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetAlertNotificationsWithUidToSendQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetAlertNotificationsWithUidToSendQuery) error {
 			query.Result = []*models.AlertNotification{
 				{
 					Id:   1,
@@ -190,7 +190,7 @@ func notificationServiceScenario(t *testing.T, name string, evalCtx *EvalContext
 			return nil
 		})
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetOrCreateNotificationStateQuery) error {
+		bus.SetHandlerCtx(func(ctx context.Context, query *models.GetOrCreateNotificationStateQuery) error {
 			query.Result = &models.AlertNotificationState{
 				AlertId:                      evalCtx.Rule.ID,
 				AlertRuleStateUpdatedVersion: 1,
@@ -201,11 +201,11 @@ func notificationServiceScenario(t *testing.T, name string, evalCtx *EvalContext
 			return nil
 		})
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.SetAlertNotificationStateToPendingCommand) error {
+		bus.SetHandlerCtx(func(ctx context.Context, cmd *models.SetAlertNotificationStateToPendingCommand) error {
 			return nil
 		})
 
-		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.SetAlertNotificationStateToCompleteCommand) error {
+		bus.SetHandlerCtx(func(ctx context.Context, cmd *models.SetAlertNotificationStateToCompleteCommand) error {
 			return nil
 		})
 

--- a/pkg/services/alerting/notifiers/opsgenie_test.go
+++ b/pkg/services/alerting/notifiers/opsgenie_test.go
@@ -105,7 +105,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 
 				tags := make([]string, 0)
 				details := make(map[string]interface{})
-				bus.AddHandlerCtx("alerting", func(ctx context.Context, cmd *models.SendWebhookSync) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.SendWebhookSync) error {
 					bodyJSON, err := simplejson.NewJson([]byte(cmd.Body))
 					if err == nil {
 						tags = bodyJSON.Get("tags").MustStringArray([]string{})
@@ -155,7 +155,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 
 				tags := make([]string, 0)
 				details := make(map[string]interface{})
-				bus.AddHandlerCtx("alerting", func(ctx context.Context, cmd *models.SendWebhookSync) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.SendWebhookSync) error {
 					bodyJSON, err := simplejson.NewJson([]byte(cmd.Body))
 					if err == nil {
 						tags = bodyJSON.Get("tags").MustStringArray([]string{})
@@ -205,7 +205,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 
 				tags := make([]string, 0)
 				details := make(map[string]interface{})
-				bus.AddHandlerCtx("alerting", func(ctx context.Context, cmd *models.SendWebhookSync) error {
+				bus.SetHandlerCtx(func(ctx context.Context, cmd *models.SendWebhookSync) error {
 					bodyJSON, err := simplejson.NewJson([]byte(cmd.Body))
 					if err == nil {
 						tags = bodyJSON.Get("tags").MustStringArray([]string{})

--- a/pkg/services/alerting/test_notification.go
+++ b/pkg/services/alerting/test_notification.go
@@ -32,7 +32,7 @@ var (
 )
 
 func init() {
-	bus.AddHandlerCtx("alerting", handleNotificationTestCommand)
+	bus.SetHandlerCtx(handleNotificationTestCommand)
 }
 
 func handleNotificationTestCommand(ctx context.Context, cmd *NotificationTestCommand) error {

--- a/pkg/services/contexthandler/authproxy/authproxy_test.go
+++ b/pkg/services/contexthandler/authproxy/authproxy_test.go
@@ -134,7 +134,7 @@ func TestMiddlewareContext_ldap(t *testing.T) {
 	t.Run("Logs in via LDAP", func(t *testing.T) {
 		const id int64 = 42
 
-		bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+		bus.SetHandler(func(cmd *models.UpsertUserCommand) error {
 			cmd.Result = &models.User{
 				Id: id,
 			}

--- a/pkg/services/dashboards/dashboard_service_test.go
+++ b/pkg/services/dashboards/dashboard_service_test.go
@@ -284,7 +284,7 @@ func setupDeleteHandlers(t *testing.T, fakeStore *fakeDashboardStore, provisione
 	}
 
 	result := &Result{}
-	bus.AddHandler("test", func(cmd *models.DeleteDashboardCommand) error {
+	bus.SetHandler(func(cmd *models.DeleteDashboardCommand) error {
 		So(cmd.Id, ShouldEqual, 1)
 		So(cmd.OrgId, ShouldEqual, 1)
 		result.deleteWasCalled = true

--- a/pkg/services/dashboards/folder_service_test.go
+++ b/pkg/services/dashboards/folder_service_test.go
@@ -24,7 +24,7 @@ func TestFolderService(t *testing.T) {
 			origNewGuardian := guardian.New
 			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{})
 
-			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardQuery) error {
 				query.Result = models.NewDashboardFolder("Folder")
 				return nil
 			})
@@ -84,7 +84,7 @@ func TestFolderService(t *testing.T) {
 			dash := models.NewDashboardFolder("Folder")
 			dash.Id = 1
 
-			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardQuery) error {
 				query.Result = dash
 				return nil
 			})
@@ -98,12 +98,12 @@ func TestFolderService(t *testing.T) {
 				return nil
 			}
 
-			bus.AddHandler("test", func(cmd *models.SaveDashboardCommand) error {
+			bus.SetHandler(func(cmd *models.SaveDashboardCommand) error {
 				cmd.Result = dash
 				return nil
 			})
 
-			bus.AddHandler("test", func(cmd *models.DeleteDashboardCommand) error {
+			bus.SetHandler(func(cmd *models.DeleteDashboardCommand) error {
 				return nil
 			})
 
@@ -138,7 +138,7 @@ func TestFolderService(t *testing.T) {
 			dashFolder.Id = 1
 			dashFolder.Uid = "uid-abc"
 
-			bus.AddHandler("test", func(query *models.GetDashboardQuery) error {
+			bus.SetHandler(func(query *models.GetDashboardQuery) error {
 				query.Result = dashFolder
 				return nil
 			})

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -683,7 +683,7 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 	Convey("Get hidden ACL tests", t, func() {
 		bus.ClearBusHandlers()
 
-		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = []*models.DashboardAclInfoDTO{
 				{Inherited: false, UserId: 1, UserLogin: "user1", Permission: models.PERMISSION_EDIT},
 				{Inherited: false, UserId: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
@@ -731,7 +731,7 @@ func TestGuardianGetAclWithoutDuplicates(t *testing.T) {
 	t.Run("Get hidden ACL tests", func(t *testing.T) {
 		t.Cleanup(bus.ClearBusHandlers)
 
-		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = []*models.DashboardAclInfoDTO{
 				{Inherited: true, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_EDIT},
 				{Inherited: false, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_VIEW},

--- a/pkg/services/guardian/guardian_util_test.go
+++ b/pkg/services/guardian/guardian_util_test.go
@@ -74,7 +74,7 @@ func permissionScenario(desc string, dashboardID int64, sc *scenarioContext,
 	sc.t.Run(desc, func(t *testing.T) {
 		bus.ClearBusHandlers()
 
-		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler(func(query *models.GetDashboardAclInfoListQuery) error {
 			if query.OrgID != sc.givenUser.OrgId {
 				sc.reportFailure("Invalid organization id for GetDashboardAclInfoListQuery", sc.givenUser.OrgId, query.OrgID)
 			}
@@ -94,7 +94,7 @@ func permissionScenario(desc string, dashboardID int64, sc *scenarioContext,
 			}
 		}
 
-		bus.AddHandler("test", func(query *models.GetTeamsByUserQuery) error {
+		bus.SetHandler(func(query *models.GetTeamsByUserQuery) error {
 			if query.OrgId != sc.givenUser.OrgId {
 				sc.reportFailure("Invalid organization id for GetTeamsByUserQuery", sc.givenUser.OrgId, query.OrgId)
 			}

--- a/pkg/services/login/loginservice/loginservice_test.go
+++ b/pkg/services/login/loginservice/loginservice_test.go
@@ -19,20 +19,20 @@ func Test_syncOrgRoles_doesNotBreakWhenTryingToRemoveLastOrgAdmin(t *testing.T) 
 
 	bus.ClearBusHandlers()
 	defer bus.ClearBusHandlers()
-	bus.AddHandler("test", func(q *models.GetUserOrgListQuery) error {
+	bus.SetHandler(func(q *models.GetUserOrgListQuery) error {
 		q.Result = createUserOrgDTO()
 
 		return nil
 	})
 
-	bus.AddHandler("test", func(cmd *models.RemoveOrgUserCommand) error {
+	bus.SetHandler(func(cmd *models.RemoveOrgUserCommand) error {
 		testData := remResp[0]
 		remResp = remResp[1:]
 
 		require.Equal(t, testData.orgId, cmd.OrgId)
 		return testData.response
 	})
-	bus.AddHandler("test", func(cmd *models.SetUsingOrgCommand) error {
+	bus.SetHandler(func(cmd *models.SetUsingOrgCommand) error {
 		return nil
 	})
 
@@ -54,20 +54,20 @@ func Test_syncOrgRoles_whenTryingToRemoveLastOrgLogsError(t *testing.T) {
 
 	bus.ClearBusHandlers()
 	defer bus.ClearBusHandlers()
-	bus.AddHandler("test", func(q *models.GetUserOrgListQuery) error {
+	bus.SetHandler(func(q *models.GetUserOrgListQuery) error {
 		q.Result = createUserOrgDTO()
 
 		return nil
 	})
 
-	bus.AddHandler("test", func(cmd *models.RemoveOrgUserCommand) error {
+	bus.SetHandler(func(cmd *models.RemoveOrgUserCommand) error {
 		testData := remResp[0]
 		remResp = remResp[1:]
 
 		require.Equal(t, testData.orgId, cmd.OrgId)
 		return testData.response
 	})
-	bus.AddHandler("test", func(cmd *models.SetUsingOrgCommand) error {
+	bus.SetHandler(func(cmd *models.SetUsingOrgCommand) error {
 		return nil
 	})
 

--- a/pkg/services/ngalert/notifier/channels/dingding_test.go
+++ b/pkg/services/ngalert/notifier/channels/dingding_test.go
@@ -107,7 +107,7 @@ func TestDingdingNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/discord_test.go
+++ b/pkg/services/ngalert/notifier/channels/discord_test.go
@@ -121,7 +121,7 @@ func TestDiscordNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -53,7 +53,7 @@ func TestEmailNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := map[string]interface{}{}
-		bus.AddHandlerCtx("test", func(ctx context.Context, cmd *models.SendEmailCommandSync) error {
+		bus.SetHandlerCtx(func(ctx context.Context, cmd *models.SendEmailCommandSync) error {
 			expected["subject"] = cmd.SendEmailCommand.Subject
 			expected["to"] = cmd.SendEmailCommand.To
 			expected["single_email"] = cmd.SendEmailCommand.SingleEmail

--- a/pkg/services/ngalert/notifier/channels/googlechat_test.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat_test.go
@@ -172,7 +172,7 @@ func TestGoogleChatNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/kafka_test.go
+++ b/pkg/services/ngalert/notifier/channels/kafka_test.go
@@ -127,7 +127,7 @@ func TestKafkaNotifier(t *testing.T) {
 
 			body := ""
 			actUrl := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				actUrl = webhook.Url
 				return nil

--- a/pkg/services/ngalert/notifier/channels/line_test.go
+++ b/pkg/services/ngalert/notifier/channels/line_test.go
@@ -98,7 +98,7 @@ func TestLineNotifier(t *testing.T) {
 
 			body := ""
 			var headers map[string]string
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				headers = webhook.HttpHeader
 				return nil

--- a/pkg/services/ngalert/notifier/channels/opsgenie_test.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie_test.go
@@ -177,7 +177,7 @@ func TestOpsgenieNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := "<not-sent>"
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/pagerduty_test.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty_test.go
@@ -143,7 +143,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/pushover_test.go
+++ b/pkg/services/ngalert/notifier/channels/pushover_test.go
@@ -150,7 +150,7 @@ func TestPushoverNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/sensugo_test.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo_test.go
@@ -148,7 +148,7 @@ func TestSensuGoNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/teams_test.go
+++ b/pkg/services/ngalert/notifier/channels/teams_test.go
@@ -132,7 +132,7 @@ func TestTeamsNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/threema_test.go
+++ b/pkg/services/ngalert/notifier/channels/threema_test.go
@@ -115,7 +115,7 @@ func TestThreemaNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/victorops_test.go
+++ b/pkg/services/ngalert/notifier/channels/victorops_test.go
@@ -102,7 +102,7 @@ func TestVictoropsNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			body := ""
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				body = webhook.Body
 				return nil
 			})

--- a/pkg/services/ngalert/notifier/channels/webhook_test.go
+++ b/pkg/services/ngalert/notifier/channels/webhook_test.go
@@ -192,7 +192,7 @@ func TestWebhookNotifier(t *testing.T) {
 			require.NoError(t, err)
 
 			var payload *models.SendWebhookSync
-			bus.AddHandlerCtx("test", func(ctx context.Context, webhook *models.SendWebhookSync) error {
+			bus.SetHandlerCtx(func(ctx context.Context, webhook *models.SendWebhookSync) error {
 				payload = webhook
 				return nil
 			})

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -96,7 +96,7 @@ func TestDashboardFileReader(t *testing.T) {
 		})
 		fakeService = mockDashboardProvisioningService()
 
-		bus.AddHandler("test", mockGetDashboardQuery)
+		bus.SetHandler(mockGetDashboardQuery)
 		logger := log.New("test.logger")
 
 		Convey("Reading dashboards from disk", func() {

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -19,7 +19,7 @@ func TestDuplicatesValidator(t *testing.T) {
 	bus.ClearBusHandlers()
 	fakeService = mockDashboardProvisioningService()
 
-	bus.AddHandler("test", mockGetDashboardQuery)
+	bus.SetHandler(mockGetDashboardQuery)
 	cfg := &config{
 		Name:    "Default",
 		Type:    "file",

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -31,11 +31,11 @@ func TestDatasourceAsConfig(t *testing.T) {
 	Convey("Testing datasource as configuration", t, func() {
 		fakeRepo = &fakeRepository{}
 		bus.ClearBusHandlers()
-		bus.AddHandler("test", mockDelete)
-		bus.AddHandler("test", mockInsert)
-		bus.AddHandler("test", mockUpdate)
-		bus.AddHandler("test", mockGet)
-		bus.AddHandler("test", mockGetOrg)
+		bus.SetHandler(mockDelete)
+		bus.SetHandler(mockInsert)
+		bus.SetHandler(mockUpdate)
+		bus.SetHandler(mockGet)
+		bus.SetHandler(mockGetOrg)
 
 		Convey("apply default values when missing", func() {
 			dc := newDatasourceProvisioner(logger)

--- a/pkg/services/provisioning/plugins/plugin_provisioner_test.go
+++ b/pkg/services/provisioning/plugins/plugin_provisioner_test.go
@@ -20,7 +20,7 @@ func TestPluginProvisioner(t *testing.T) {
 	})
 
 	t.Run("Should apply configurations", func(t *testing.T) {
-		bus.AddHandler("test", func(query *models.GetOrgByNameQuery) error {
+		bus.SetHandler(func(query *models.GetOrgByNameQuery) error {
 			if query.Name == "Org 4" {
 				query.Result = &models.Org{Id: 4}
 			}
@@ -28,7 +28,7 @@ func TestPluginProvisioner(t *testing.T) {
 			return nil
 		})
 
-		bus.AddHandler("test", func(query *models.GetPluginSettingByIdQuery) error {
+		bus.SetHandler(func(query *models.GetPluginSettingByIdQuery) error {
 			if query.PluginId == "test-plugin" && query.OrgId == 2 {
 				query.Result = &models.PluginSetting{
 					PluginVersion: "2.0.1",
@@ -41,7 +41,7 @@ func TestPluginProvisioner(t *testing.T) {
 
 		sentCommands := []*models.UpdatePluginSettingCmd{}
 
-		bus.AddHandler("test", func(cmd *models.UpdatePluginSettingCmd) error {
+		bus.SetHandler(func(cmd *models.UpdatePluginSettingCmd) error {
 			sentCommands = append(sentCommands, cmd)
 			return nil
 		})

--- a/pkg/services/search/service_test.go
+++ b/pkg/services/search/service_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSearch_SortedResults(t *testing.T) {
-	bus.AddHandler("test", func(query *FindPersistedDashboardsQuery) error {
+	bus.SetHandler(func(query *FindPersistedDashboardsQuery) error {
 		query.Result = HitList{
 			&Hit{ID: 16, Title: "CCAA", Type: "dash-db", Tags: []string{"BB", "AA"}},
 			&Hit{ID: 10, Title: "AABB", Type: "dash-db", Tags: []string{"CC", "AA"}},
@@ -22,12 +22,12 @@ func TestSearch_SortedResults(t *testing.T) {
 		return nil
 	})
 
-	bus.AddHandler("test", func(query *models.GetUserStarsQuery) error {
+	bus.SetHandler(func(query *models.GetUserStarsQuery) error {
 		query.Result = map[int64]bool{10: true, 12: true}
 		return nil
 	})
 
-	bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+	bus.SetHandlerCtx(func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 		query.Result = &models.SignedInUser{IsGrafanaAdmin: true}
 		return nil
 	})

--- a/pkg/services/teamguardian/teams_test.go
+++ b/pkg/services/teamguardian/teams_test.go
@@ -29,7 +29,7 @@ func TestUpdateTeam(t *testing.T) {
 
 		Convey("Given an editor and a team he isn't a member of", func() {
 			Convey("Should not be able to update the team", func() {
-				bus.AddHandler("test", func(cmd *models.GetTeamMembersQuery) error {
+				bus.SetHandler(func(cmd *models.GetTeamMembersQuery) error {
 					cmd.Result = []*models.TeamMemberDTO{}
 					return nil
 				})
@@ -41,7 +41,7 @@ func TestUpdateTeam(t *testing.T) {
 
 		Convey("Given an editor and a team he is an admin in", func() {
 			Convey("Should be able to update the team", func() {
-				bus.AddHandler("test", func(cmd *models.GetTeamMembersQuery) error {
+				bus.SetHandler(func(cmd *models.GetTeamMembersQuery) error {
 					cmd.Result = []*models.TeamMemberDTO{{
 						OrgId:      testTeam.OrgId,
 						TeamId:     testTeam.Id,
@@ -63,7 +63,7 @@ func TestUpdateTeam(t *testing.T) {
 			}
 
 			Convey("Shouldn't be able to update the team", func() {
-				bus.AddHandler("test", func(cmd *models.GetTeamMembersQuery) error {
+				bus.SetHandler(func(cmd *models.GetTeamMembersQuery) error {
 					cmd.Result = []*models.TeamMemberDTO{{
 						OrgId:      testTeamOtherOrg.OrgId,
 						TeamId:     testTeamOtherOrg.Id,

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -371,14 +371,14 @@ func TestNotificationChannels(t *testing.T) {
 		channels.TelegramAPIURL, channels.PushoverEndpoint, channels.GetBoundary,
 		channels.LineNotifyURL, channels.ThreemaGwBaseURL
 	originalTemplate := channels.DefaultTemplateString
-	originalEmailBus := bus.GetHandlersCtx("SendEmailCommandSync")[0]
+
 	t.Cleanup(func() {
 		channels.SlackAPIEndpoint, channels.PagerdutyEventAPIURL,
 			channels.TelegramAPIURL, channels.PushoverEndpoint, channels.GetBoundary,
 			channels.LineNotifyURL, channels.ThreemaGwBaseURL = os, opa, ot, opu, ogb, ol, oth
 		channels.DefaultTemplateString = originalTemplate
-		bus.AddHandlerCtx("", originalEmailBus)
 	})
+
 	channels.DefaultTemplateString = channels.TemplateForTestsString
 	channels.SlackAPIEndpoint = fmt.Sprintf("http://%s/slack_recvX/slack_testX", mockChannel.server.Addr)
 	channels.PagerdutyEventAPIURL = fmt.Sprintf("http://%s/pagerduty_recvX/pagerduty_testX", mockChannel.server.Addr)
@@ -387,7 +387,9 @@ func TestNotificationChannels(t *testing.T) {
 	channels.LineNotifyURL = fmt.Sprintf("http://%s/line_recv/line_test", mockChannel.server.Addr)
 	channels.ThreemaGwBaseURL = fmt.Sprintf("http://%s/threema_recv/threema_test", mockChannel.server.Addr)
 	channels.GetBoundary = func() string { return "abcd" }
-	bus.AddHandlerCtx("", mockEmail.sendEmailCommandHandlerSync)
+
+	bus.SetHandlerCtx(mockEmail.sendEmailCommandHandlerSync)
+	bus.SetHandlerCtx(bus.GetHandlersCtx("SendWebhookSync")[0]) //ensure that there's only one handler for the webhooks
 
 	// Create a user to make authenticated requests
 	createUser(t, s, models.CreateUserCommand{

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -371,7 +371,7 @@ func TestNotificationChannels(t *testing.T) {
 		channels.TelegramAPIURL, channels.PushoverEndpoint, channels.GetBoundary,
 		channels.LineNotifyURL, channels.ThreemaGwBaseURL
 	originalTemplate := channels.DefaultTemplateString
-	originalEmailBus := bus.GetHandlerCtx("SendEmailCommandSync")
+	originalEmailBus := bus.GetHandlersCtx("SendEmailCommandSync")[0]
 	t.Cleanup(func() {
 		channels.SlackAPIEndpoint, channels.PagerdutyEventAPIURL,
 			channels.TelegramAPIURL, channels.PushoverEndpoint, channels.GetBoundary,

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -74,11 +74,11 @@ func TestTestReceivers(t *testing.T) {
 			Password:       "password",
 		})
 
-		oldEmailBus := bus.GetHandlerCtx("SendEmailCommandSync")
+		oldEmailBus := bus.GetHandlersCtx("SendEmailCommandSync")[0]
 		mockEmails := &mockEmailHandler{}
-		bus.AddHandlerCtx("", mockEmails.sendEmailCommandHandlerSync)
+		bus.SetHandlerCtx(mockEmails.sendEmailCommandHandlerSync)
 		t.Cleanup(func() {
-			bus.AddHandlerCtx("", oldEmailBus)
+			bus.SetHandlerCtx(oldEmailBus)
 		})
 
 		testReceiversURL := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/receivers/test", grafanaListedAddr)
@@ -140,11 +140,11 @@ func TestTestReceivers(t *testing.T) {
 			Password:       "password",
 		})
 
-		oldEmailBus := bus.GetHandlerCtx("SendEmailCommandSync")
+		oldEmailBus := bus.GetHandlersCtx("SendEmailCommandSync")[0]
 		mockEmails := &mockEmailHandler{}
-		bus.AddHandlerCtx("", mockEmails.sendEmailCommandHandlerSync)
+		bus.SetHandlerCtx(mockEmails.sendEmailCommandHandlerSync)
 		t.Cleanup(func() {
-			bus.AddHandlerCtx("", oldEmailBus)
+			bus.SetHandlerCtx(oldEmailBus)
 		})
 
 		testReceiversURL := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/receivers/test", grafanaListedAddr)
@@ -202,13 +202,13 @@ func TestTestReceivers(t *testing.T) {
 			Password:       "password",
 		})
 
-		oldEmailBus := bus.GetHandlerCtx("SendEmailCommandSync")
+		oldEmailBus := bus.GetHandlersCtx("SendEmailCommandSync")[0]
 		mockEmails := &mockEmailHandlerWithTimeout{
 			timeout: 5 * time.Second,
 		}
-		bus.AddHandlerCtx("", mockEmails.sendEmailCommandHandlerSync)
+		bus.SetHandlerCtx(mockEmails.sendEmailCommandHandlerSync)
 		t.Cleanup(func() {
-			bus.AddHandlerCtx("", oldEmailBus)
+			bus.SetHandlerCtx(oldEmailBus)
 		})
 
 		testReceiversURL := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/receivers/test", grafanaListedAddr)
@@ -273,13 +273,13 @@ func TestTestReceivers(t *testing.T) {
 			Password:       "password",
 		})
 
-		oldEmailBus := bus.GetHandlerCtx("SendEmailCommandSync")
+		oldEmailBus := bus.GetHandlersCtx("SendEmailCommandSync")[0]
 		mockEmails := &mockEmailHandlerWithTimeout{
 			timeout: 5 * time.Second,
 		}
-		bus.AddHandlerCtx("", mockEmails.sendEmailCommandHandlerSync)
+		bus.SetHandlerCtx(mockEmails.sendEmailCommandHandlerSync)
 		t.Cleanup(func() {
-			bus.AddHandlerCtx("", oldEmailBus)
+			bus.SetHandlerCtx(oldEmailBus)
 		})
 
 		testReceiversURL := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/receivers/test", grafanaListedAddr)


### PR DESCRIPTION
I'm building an extension that needs to respond to data source deletions. To accomplish this, I've added the ability to add more than one handler to dispatch events.

This also fixes the case where a developer can subscribe to an event type with `AddHandler` and override the previously intended behavior. For example, I was able to add a handler for data source deletion events, but data sources were no longer deleted as a result.



