### PR TITLE
Tooltip: bring back optimized hoverpoint code

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -29,15 +29,6 @@ interface TooltipPluginProps {
   renderTooltip?: (alignedFrame: DataFrame, seriesIdx: number | null, datapointIdx: number | null) => React.ReactNode;
 }
 
-const eqArrays = (a: any[], b: any[]) => {
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) {
-      return false;
-    }
-  }
-  return true;
-};
-
 const TOOLTIP_OFFSET = 10;
 
 /**
@@ -123,16 +114,13 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
         })(u);
       });
     } else {
-      let prevIdx: number | null = null;
-      let prevIdxs: Array<number | null> | null = null;
+      config.addHook('setLegend', (u) => {
+        setFocusedPointIdx(u.legend.idx!);
+        setFocusedPointIdxs(u.legend.idxs!.slice());
+      });
 
       // default series/datapoint idx retireval
       config.addHook('setCursor', (u) => {
-        if (u.cursor.idx !== prevIdx || prevIdxs == null || !eqArrays(prevIdxs, u.cursor.idxs!)) {
-          setFocusedPointIdx((prevIdx = u.cursor.idx!));
-          setFocusedPointIdxs((prevIdxs = u.cursor.idxs!.slice()));
-        }
-
         const bbox = plotCtx.getCanvasBoundingBox();
         if (!bbox) {
           return;


### PR DESCRIPTION
This reverts a work-around [1] which was required prior to uPlot 1.6.15 (the original hook code expected `setLegend` to fire as it now does).

[1] https://github.com/grafana/grafana/pull/37615