### PR TITLE
doc: add missing LoadingState.Streaming

### DIFF
--- a/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-streaming-data-source-plugin.md
@@ -120,6 +120,7 @@ query(options: DataQueryRequest<MyQuery>): Observable<DataQueryResponse> {
         subscriber.next({
           data: [frame],
           key: query.refId,
+          state: LoadingState.Streaming,
         });
       }, 100);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The final query is missing this property and does not work without it. It is in the snippet above, just not in the final query.

