### PR TITLE
AzureMonitor: Fix crash from infinite render loop

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
@@ -69,10 +69,15 @@ export const useSubscriptions: DataHook = (query, datasource, onChange, setError
   );
 
   useEffect(() => {
-    if (!subscription && defaultSubscription && hasOption(subscriptionOptions, defaultSubscription)) {
-      onChange(setSubscriptionID(query, defaultSubscription));
-    } else if ((!subscription && subscriptionOptions.length) || subscriptionOptions.length === 1) {
-      onChange(setSubscriptionID(query, subscriptionOptions[0].value));
+    // Return early if subscriptions havent loaded, or if the query already has a subscription
+    if (!subscriptionOptions.length || (subscription && hasOption(subscriptionOptions, subscription))) {
+      return;
+    }
+
+    const defaultSub = defaultSubscription || subscriptionOptions[0].value;
+
+    if (!subscription && defaultSub && hasOption(subscriptionOptions, defaultSub)) {
+      onChange(setSubscriptionID(query, defaultSub));
     }
   }, [subscriptionOptions, query, subscription, defaultSubscription, onChange]);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed that in main AzureMonitor will crash from an infinite render loop, caused by some bad logic in a react hook.

I'll need to check if this issue is in 8.1 (or at least the branch) to see if it needs backporting
