### PR TITLE
Chore: Update channel to where failed Docker nightly builds are posted 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3527,4 +3527,8 @@ get:
   path: infra/data/ci/drone
   name: machine-user-token
 
+---
+kind: signature
+hmac: 0ab7831c1f9acfcc20fbd011bd0e04f88f85f77d9997ab7a5092592bbcd8ae34
+
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3489,7 +3489,7 @@ steps:
 - name: slack-notify-failure
   image: plugins/slack
   settings:
-    channel: grafana-backend
+    channel: grafana-backend-ops
     template: "Nightly docker image scan job for {{repo.name}} failed: {{build.link}}"
     webhook:
       from_secret: slack_webhook_backend
@@ -3526,9 +3526,5 @@ name: drone_token
 get:
   path: infra/data/ci/drone
   name: machine-user-token
-
----
-kind: signature
-hmac: 4f23649a1678c66fb96af929675bcf569cca3b208d425eace86150d981ee9fbb
 
 ...

--- a/scripts/job.star
+++ b/scripts/job.star
@@ -17,7 +17,7 @@ def cronjobs(edition):
     steps=[
         scan_docker_image_unkown_low_medium_vulnerabilities_step(edition),
         scan_docker_image_high_critical_vulnerabilities_step(edition),
-        slack_job_failed_step('grafana-backend'),
+        slack_job_failed_step('grafana-backend-ops'),
     ]
     return [
         {


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes internal channel names to distinguish team channel with alert channel

