### PR TITLE
Matchers: add Is/Is not undefined matchers

### DIFF
--- a/docs/sources/panels/transformations/types-options.md
+++ b/docs/sources/panels/transformations/types-options.md
@@ -372,6 +372,8 @@ The available conditions for all fields are:
 - **Regex:** Match a regex expression
 - **Is Null:** Match if the value is null
 - **Is Not Null:** Match if the value is not null
+- **Is Undefined:** Match if the value is undefined
+- **Is Not Undefined:** Match if the value is not undefined
 - **Equal:** Match if the value is equal to the specified value
 - **Different:** match if the value is different than the specified value
 

--- a/packages/grafana-data/src/transformations/matchers.ts
+++ b/packages/grafana-data/src/transformations/matchers.ts
@@ -19,6 +19,7 @@ import { getEqualValueMatchers } from './matchers/valueMatchers/equalMatchers';
 import { getRangeValueMatchers } from './matchers/valueMatchers/rangeMatchers';
 import { getSimpleFieldMatchers } from './matchers/simpleFieldMatcher';
 import { getRegexValueMatcher } from './matchers/valueMatchers/regexMatchers';
+import { getUndefinedValueMatchers } from './matchers/valueMatchers/undefinedMatchers';
 
 /**
  * Registry that contains all of the built in field matchers.
@@ -52,6 +53,7 @@ export const frameMatchers = new Registry<FrameMatcherInfo>(() => {
 export const valueMatchers = new Registry<ValueMatcherInfo>(() => {
   return [
     ...getNullValueMatchers(),
+    ...getUndefinedValueMatchers(),
     ...getNumericValueMatchers(),
     ...getEqualValueMatchers(),
     ...getRangeValueMatchers(),

--- a/packages/grafana-data/src/transformations/matchers/ids.ts
+++ b/packages/grafana-data/src/transformations/matchers/ids.ts
@@ -45,6 +45,8 @@ export enum ValueMatcherID {
   regex = 'regex',
   isNull = 'isNull',
   isNotNull = 'isNotNull',
+  isUndefined = 'isUndefined',
+  isNotUndefined = 'isNotUndefined',
   greater = 'greater',
   greaterOrEqual = 'greaterOrEqual',
   lower = 'lower',

--- a/packages/grafana-data/src/transformations/matchers/valueMatchers/undefinedMatchers.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/valueMatchers/undefinedMatchers.test.ts
@@ -1,0 +1,76 @@
+import { toDataFrame } from '../../../dataframe';
+import { DataFrame } from '../../../types';
+import { getValueMatcher } from '../../matchers';
+import { ValueMatcherID } from '../ids';
+
+describe('value undefined matcher', () => {
+  const data: DataFrame[] = [
+    toDataFrame({
+      fields: [
+        {
+          name: 'temp',
+          values: [7, null, undefined],
+        },
+      ],
+    }),
+  ];
+
+  const matcher = getValueMatcher({
+    id: ValueMatcherID.isUndefined,
+    options: {},
+  });
+
+  it('should match undefined values', () => {
+    const frame = data[0];
+    const field = frame.fields[0];
+    const valueIndex = 2;
+
+    expect(matcher(valueIndex, field, frame, data)).toBeTruthy();
+  });
+
+  it('should not match non-undefined values', () => {
+    const frame = data[0];
+    const field = frame.fields[0];
+    const valueIndexes = [0, 1];
+
+    for (const valueIndex of valueIndexes) {
+      expect(matcher(valueIndex, field, frame, data)).toBeFalsy();
+    }
+  });
+});
+
+describe('value not undefined matcher', () => {
+  const data: DataFrame[] = [
+    toDataFrame({
+      fields: [
+        {
+          name: 'temp',
+          values: [7, null, undefined],
+        },
+      ],
+    }),
+  ];
+
+  const matcher = getValueMatcher({
+    id: ValueMatcherID.isNotUndefined,
+    options: {},
+  });
+
+  it('should match non-undefined values', () => {
+    const frame = data[0];
+    const field = frame.fields[0];
+    const valueIndexes = [0, 1];
+
+    for (const valueIndex of valueIndexes) {
+      expect(matcher(valueIndex, field, frame, data)).toBeTruthy();
+    }
+  });
+
+  it('should not match undefined values', () => {
+    const frame = data[0];
+    const field = frame.fields[0];
+    const valueIndex = 2;
+
+    expect(matcher(valueIndex, field, frame, data)).toBeFalsy();
+  });
+});

--- a/packages/grafana-data/src/transformations/matchers/valueMatchers/undefinedMatchers.ts
+++ b/packages/grafana-data/src/transformations/matchers/valueMatchers/undefinedMatchers.ts
@@ -1,0 +1,39 @@
+import { Field, ValueMatcherInfo } from '../../../types';
+import { ValueMatcherID } from '../ids';
+import { ValueMatcherOptions } from './types';
+
+const isUndefinedMatcher: ValueMatcherInfo<ValueMatcherOptions> = {
+  id: ValueMatcherID.isUndefined,
+  name: 'Is undefined',
+  description: 'Match where value for given field is undefined.',
+  get: () => {
+    return (valueIndex: number, field: Field) => {
+      const value = field.values.get(valueIndex);
+      return value === undefined;
+    };
+  },
+  getOptionsDisplayText: () => {
+    return `Matches all rows where field is undefined.`;
+  },
+  isApplicable: () => true,
+  getDefaultOptions: () => ({}),
+};
+
+const isNotUndefinedMatcher: ValueMatcherInfo<ValueMatcherOptions> = {
+  id: ValueMatcherID.isNotUndefined,
+  name: 'Is not undefined',
+  description: 'Match where value for given field is not undefined.',
+  get: () => {
+    return (valueIndex: number, field: Field) => {
+      const value = field.values.get(valueIndex);
+      return value !== undefined;
+    };
+  },
+  getOptionsDisplayText: () => {
+    return `Matches all rows where field is not undefined.`;
+  },
+  isApplicable: () => true,
+  getDefaultOptions: () => ({}),
+};
+
+export const getUndefinedValueMatchers = (): ValueMatcherInfo[] => [isUndefinedMatcher, isNotUndefinedMatcher];

--- a/public/app/core/components/TransformersUI/FilterByValueTransformer/ValueMatchers/NoopMatcherEditor.tsx
+++ b/public/app/core/components/TransformersUI/FilterByValueTransformer/ValueMatchers/NoopMatcherEditor.tsx
@@ -18,5 +18,15 @@ export const getNoopValueMatchersUI = (): Array<ValueMatcherUIRegistryItem<any>>
       id: ValueMatcherID.isNotNull,
       component: NoopMatcherEditor,
     },
+    {
+      name: 'Is undefined',
+      id: ValueMatcherID.isUndefined,
+      component: NoopMatcherEditor,
+    },
+    {
+      name: 'Is not undefined',
+      id: ValueMatcherID.isNotUndefined,
+      component: NoopMatcherEditor,
+    },
   ];
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The "Filter data by values" transformation has "Is null" and "Is not null" matchers, but at least after #30808 there can also be `undefined` values in fields, so it seems like there should be some way to filter those, so this adds "Is undefined" and "Is not undefined" matchers which do that.

This is especially useful when using the "Merge" or "Labels to fields" transformations to combined mixed data sources when either data source may not have matching values for certain fields needed for calculations, etc.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37664

**Special notes for your reviewer**:

