### PR TITLE
Annotations: Fixes so alert annotations are visible in the correct Panel

### DIFF
--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -122,6 +122,7 @@ const alertEventAndAnnotationFields: AnnotationFieldInfo[] = [
   { key: 'prevState' },
   { key: 'newState' },
   { key: 'data' as any },
+  { key: 'panelId' },
 ];
 
 export function getAnnotationsFromData(


### PR DESCRIPTION
**What this PR does / why we need it**:
We missed propagating the `panelId` property all the way through the annotations data pipeline. This PR fixes that and adds tests.

**Which issue(s) this PR fixes**:
Fixes #37612

**Special notes for your reviewer**:

