### PR TITLE
Zipkin: support running queries with keyboard shortcut

### DIFF
--- a/public/app/plugins/datasource/zipkin/QueryField.test.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.test.tsx
@@ -19,9 +19,6 @@ describe('QueryField', () => {
       />
     );
 
-    /*expect(wrapper.find(ButtonCascader).length).toBe(1);
-    expect(wrapper.find(QueryField).length).toBe(1);
-    expect(wrapper.find(QueryField).prop('query')).toBe('1234');*/
     expect(screen.getByText(/1234/i)).toBeInTheDocument();
     expect(screen.getByText(/Traces/i)).toBeInTheDocument();
   });

--- a/public/app/plugins/datasource/zipkin/QueryField.test.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.test.tsx
@@ -3,14 +3,14 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { ZipkinDatasource } from './datasource';
-import { QueryField, useLoadOptions, useServices } from './QueryField';
+import { ZipkinQueryField, useLoadOptions, useServices } from './QueryField';
 import { ZipkinQuery } from './types';
 
 describe('QueryField', () => {
   it('renders properly', () => {
     const ds = {} as ZipkinDatasource;
     const wrapper = shallow(
-      <QueryField
+      <ZipkinQueryField
         history={[]}
         datasource={ds}
         query={{ query: '1234' } as ZipkinQuery}

--- a/public/app/plugins/datasource/zipkin/QueryField.test.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.test.tsx
@@ -23,6 +23,7 @@ describe('QueryField', () => {
     expect(wrapper.find(QueryField).length).toBe(1);
     expect(wrapper.find(QueryField).prop('query')).toBe('1234');*/
     expect(screen.getByText(/1234/i)).toBeInTheDocument();
+    expect(screen.getByText(/Traces/i)).toBeInTheDocument();
   });
 });
 

--- a/public/app/plugins/datasource/zipkin/QueryField.test.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.test.tsx
@@ -1,6 +1,6 @@
-import { ButtonCascader, CascaderOption, QueryField } from '@grafana/ui';
+import { CascaderOption } from '@grafana/ui';
 import { act, renderHook } from '@testing-library/react-hooks';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ZipkinDatasource } from './datasource';
 import { ZipkinQueryField, useLoadOptions, useServices } from './QueryField';
@@ -9,7 +9,7 @@ import { ZipkinQuery } from './types';
 describe('QueryField', () => {
   it('renders properly', () => {
     const ds = {} as ZipkinDatasource;
-    const wrapper = shallow(
+    render(
       <ZipkinQueryField
         history={[]}
         datasource={ds}
@@ -19,9 +19,10 @@ describe('QueryField', () => {
       />
     );
 
-    expect(wrapper.find(ButtonCascader).length).toBe(1);
+    /*expect(wrapper.find(ButtonCascader).length).toBe(1);
     expect(wrapper.find(QueryField).length).toBe(1);
-    expect(wrapper.find(QueryField).prop('query')).toBe('1234');
+    expect(wrapper.find(QueryField).prop('query')).toBe('1234');*/
+    expect(screen.getByText(/1234/i)).toBeInTheDocument();
   });
 });
 

--- a/public/app/plugins/datasource/zipkin/QueryField.test.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.test.tsx
@@ -52,7 +52,6 @@ describe('useLoadOptions', () => {
           return Promise.resolve(['span1', 'span2']);
         }
 
-        console.log({ url });
         if (url === '/api/v2/traces' && params?.serviceName === 'service1' && params?.spanName === 'span1') {
           return Promise.resolve([[{ name: 'trace1', duration: 10_000, traceId: 'traceId1' }]]);
         }

--- a/public/app/plugins/datasource/zipkin/QueryField.test.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.test.tsx
@@ -1,4 +1,4 @@
-import { ButtonCascader, CascaderOption } from '@grafana/ui';
+import { ButtonCascader, CascaderOption, QueryField } from '@grafana/ui';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { shallow } from 'enzyme';
 import React from 'react';
@@ -20,8 +20,8 @@ describe('QueryField', () => {
     );
 
     expect(wrapper.find(ButtonCascader).length).toBe(1);
-    expect(wrapper.find('input').length).toBe(1);
-    expect(wrapper.find('input').props().value).toBe('1234');
+    expect(wrapper.find(QueryField).length).toBe(1);
+    expect(wrapper.find(QueryField).prop('query')).toBe('1234');
   });
 });
 

--- a/public/app/plugins/datasource/zipkin/QueryField.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import { ExploreQueryFieldProps } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
 import {
   ButtonCascader,
   CascaderOption,
@@ -9,6 +8,7 @@ import {
   InlineFieldRow,
   RadioButtonGroup,
   useTheme2,
+  QueryField,
 } from '@grafana/ui';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -23,7 +23,7 @@ import { ZipkinQuery, ZipkinQueryType, ZipkinSpan } from './types';
 
 type Props = ExploreQueryFieldProps<ZipkinDatasource, ZipkinQuery>;
 
-export const QueryField = ({ query, onChange, onRunQuery, datasource }: Props) => {
+export const ZipkinQueryField = ({ query, onChange, onRunQuery, datasource }: Props) => {
   const serviceOptions = useServices(datasource);
   const theme = useTheme2();
   const { onLoadOptions, allOptions } = useLoadOptions(datasource);
@@ -38,6 +38,11 @@ export const QueryField = ({ query, onChange, onRunQuery, datasource }: Props) =
     },
     [onChange, onRunQuery, query]
   );
+
+  const onChangeQuery = (value: string) => {
+    const nextQuery = { ...query, query: value };
+    onChange(nextQuery);
+  };
 
   let cascaderOptions = useMapToCascaderOptions(serviceOptions, allOptions);
 
@@ -78,21 +83,14 @@ export const QueryField = ({ query, onChange, onRunQuery, datasource }: Props) =
               Traces
             </ButtonCascader>
           </div>
-          <div className="gf-form gf-form--grow flex-shrink-1">
-            <div className="slate-query-field__wrapper">
-              <div className="slate-query-field" aria-label={selectors.components.QueryField.container}>
-                <input
-                  style={{ width: '100%' }}
-                  value={query.query || ''}
-                  onChange={(e) =>
-                    onChange({
-                      ...query,
-                      query: e.currentTarget.value,
-                    })
-                  }
-                />
-              </div>
-            </div>
+          <div className="gf-form gf-form--grow flex-shrink-1 min-width-15">
+            <QueryField
+              query={query.query}
+              onChange={onChangeQuery}
+              onRunQuery={onRunQuery}
+              placeholder={'Insert Trace ID (run with Shift+Enter)'}
+              portalOrigin="zipkin"
+            />
           </div>
         </div>
       )}

--- a/public/app/plugins/datasource/zipkin/module.ts
+++ b/public/app/plugins/datasource/zipkin/module.ts
@@ -1,8 +1,8 @@
 import { DataSourcePlugin } from '@grafana/data';
 import { ZipkinDatasource } from './datasource';
-import { QueryField } from './QueryField';
+import { ZipkinQueryField } from './QueryField';
 import { ConfigEditor } from './ConfigEditor';
 
 export const plugin = new DataSourcePlugin(ZipkinDatasource)
   .setConfigEditor(ConfigEditor)
-  .setExploreQueryField(QueryField);
+  .setExploreQueryField(ZipkinQueryField);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds support for running queries with <kbd>Shift</kbd>+<kbd>Enter</kbd> in Explore when using Zipkin and is a complement to #37958

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # 36694

**Special notes for your reviewer**:
A plugin for running queries with <kbd>Shift</kbd>+<kbd>Enter</kbd> already exists in the QueryField component which is why it's been added to Zipkin

