### PR TITLE
[WIP] Enterprise Default: Make enterprise default docker image

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -20,12 +20,12 @@ You can install Grafana using our official APT repository, by downloading a `.de
 
 If you install from the APT repository, then Grafana is automatically updated every time you run `apt-get update`.
 
-| Grafana Version           | Package            | Repository                                                |
-| ------------------------- | ------------------ | --------------------------------------------------------- |
-| Grafana OSS               | grafana            | `https://packages.grafana.com/oss/deb stable main`        |
-| Grafana OSS (Beta)        | grafana            | `https://packages.grafana.com/oss/deb beta main`          |
-| Grafana Enterprise        | grafana-enterprise | `https://packages.grafana.com/enterprise/deb stable main` |
-| Grafana Enterprise (Beta) | grafana-enterprise | `https://packages.grafana.com/enterprise/deb beta main`   |
+| Grafana Version           | Package            | Repository                                             |
+| ------------------------- | ------------------ | ------------------------------------------------------ |
+| Grafana OSS               | grafana            | `https://packages.grafana.com/oss/deb stable main`     |
+| Grafana OSS (Beta)        | grafana            | `https://packages.grafana.com/oss/deb beta main`       |
+| Grafana Enterprise        | grafana-enterprise | `https://packages.grafana.com/grafana/deb stable main` |
+| Grafana Enterprise (Beta) | grafana-enterprise | `https://packages.grafana.com/grafana/deb beta main`   |
 
 > We recommend all users install the Enterprise Edition of Grafana, which can be seamlessly upgraded with a Grafana Enterprise [subscription](https://grafana.com/products/enterprise/?utm_source=grafana-install-page).
 
@@ -40,13 +40,13 @@ wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 Add this repository for stable releases:
 
 ```bash
-echo "deb https://packages.grafana.com/enterprise/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+echo "deb https://packages.grafana.com/grafana/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 ```
 
 Add this repository if you want beta releases:
 
 ```bash
-echo "deb https://packages.grafana.com/enterprise/deb beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+echo "deb https://packages.grafana.com/grafana/deb beta main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 ```
 
 After you add the repository:

--- a/docs/sources/installation/rpm.md
+++ b/docs/sources/installation/rpm.md
@@ -20,12 +20,12 @@ You can install Grafana from a YUM repository, manually using YUM, manually usin
 
 If you install from the YUM repository, then Grafana is automatically updated every time you run `sudo yum update`.
 
-| Grafana Version           | Package            | Repository                                         |
-| ------------------------- | ------------------ | -------------------------------------------------- |
-| Grafana OSS               | grafana            | `https://packages.grafana.com/oss/rpm`             |
-| Grafana OSS (Beta)        | grafana            | `https://packages.grafana.com/oss/rpm-beta`        |
-| Grafana Enterprise        | grafana-enterprise | `https://packages.grafana.com/enterprise/rpm`      |
-| Grafana Enterprise (Beta) | grafana-enterprise | `https://packages.grafana.com/enterprise/rpm-beta` |
+| Grafana Version           | Package            | Repository                                      |
+| ------------------------- | ------------------ | ----------------------------------------------- |
+| Grafana OSS               | grafana            | `https://packages.grafana.com/oss/rpm`          |
+| Grafana OSS (Beta)        | grafana            | `https://packages.grafana.com/oss/rpm-beta`     |
+| Grafana Enterprise        | grafana-enterprise | `https://packages.grafana.com/grafana/rpm`      |
+| Grafana Enterprise (Beta) | grafana-enterprise | `https://packages.grafana.com/grafana/rpm-beta` |
 
 Add a new file to your YUM repo using the method of your choice. The command below uses `nano`.
 
@@ -42,7 +42,7 @@ For Enterprise releases:
 ```bash
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/enterprise/rpm
+baseurl=https://packages.grafana.com/grafana/rpm
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1

--- a/scripts/build/ci-msi-build/msigenerator/generator/build.py
+++ b/scripts/build/ci-msi-build/msigenerator/generator/build.py
@@ -21,7 +21,7 @@
 # https://s3-us-west-2.amazonaws.com/grafana-releases/release/
 #   grafana-{}.windows-amd64.zip
 #
-# https://dl.grafana.com/enterprise/release/
+# https://dl.grafana.com/grafana/release/
 #   grafana-enterprise-{}.windows-amd64.zip
 #
 import os

--- a/scripts/build/release_publisher/main.go
+++ b/scripts/build/release_publisher/main.go
@@ -42,10 +42,10 @@ func main() {
 	buildArtifacts := completeBuildArtifactConfigurations
 
 	if enterprise {
-		product = "grafana-enterprise"
-		baseURL = createBaseURL(archiveProviderRoot, "enterprise", product, nightly)
-	} else {
 		product = "grafana"
+		baseURL = createBaseURL(archiveProviderRoot, "grafana", product, nightly)
+	} else {
+		product = "grafana-oss"
 		baseURL = createBaseURL(archiveProviderRoot, "oss", product, nightly)
 	}
 

--- a/scripts/verify-repo-update/deb-ee-beta.list
+++ b/scripts/verify-repo-update/deb-ee-beta.list
@@ -1,1 +1,1 @@
-deb https://packages.grafana.com/enterprise/deb beta main
+deb https://packages.grafana.com/grafana/deb beta main

--- a/scripts/verify-repo-update/deb-ee-stable.list
+++ b/scripts/verify-repo-update/deb-ee-stable.list
@@ -1,1 +1,1 @@
-deb https://packages.grafana.com/enterprise/deb stable main
+deb https://packages.grafana.com/grafana/deb stable main

--- a/scripts/verify-repo-update/rpm-ee-beta.list
+++ b/scripts/verify-repo-update/rpm-ee-beta.list
@@ -1,6 +1,6 @@
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/enterprise/rpm-beta
+baseurl=https://packages.grafana.com/grafana/rpm-beta
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1

--- a/scripts/verify-repo-update/rpm-ee-stable.list
+++ b/scripts/verify-repo-update/rpm-ee-stable.list
@@ -1,6 +1,6 @@
 [grafana]
 name=grafana
-baseurl=https://packages.grafana.com/enterprise/rpm
+baseurl=https://packages.grafana.com/grafana/rpm
 repo_gpgcheck=1
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is about making the enterprise the default download version that appears on the Grafana website. This is a design/architectural decision that's going to affect both `enterprise` and `oss` users and considered as breaking change.