### PR TITLE
QueryEditor: Don't use _.defaults as it mutates the query prop directly

### DIFF
--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -1,4 +1,3 @@
-import { defaults } from 'lodash';
 import React, { PureComponent } from 'react';
 import { InlineField, Select, Alert, Input } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue, dataFrameFromJSON, rangeUtil } from '@grafana/data';
@@ -30,13 +29,6 @@ export class QueryEditor extends PureComponent<Props, State> {
       description: 'Stream real-time measurements from Grafana',
     },
   ];
-
-  constructor(props: Props) {
-    super(props);
-    // TODO this mutates the query. We should not do this.
-    // Remove once we have a mechanism for specifying a default query.
-    defaults(props.query, defaultQuery);
-  }
 
   loadChannelInfo() {
     getBackendSrv()
@@ -251,7 +243,10 @@ export class QueryEditor extends PureComponent<Props, State> {
   }
 
   render() {
-    const { query } = this.props;
+    const query = {
+      ...defaultQuery,
+      ...this.props.query,
+    };
 
     return (
       <>

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -1,5 +1,3 @@
-import { defaults } from 'lodash';
-
 import React, { PureComponent } from 'react';
 import { InlineField, Select, Alert, Input } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue, dataFrameFromJSON, rangeUtil } from '@grafana/data';
@@ -245,7 +243,10 @@ export class QueryEditor extends PureComponent<Props, State> {
   }
 
   render() {
-    const query = defaults(this.props.query, defaultQuery);
+    const query = {
+      ...this.props.query,
+      ...defaultQuery,
+    };
     return (
       <>
         <div className="gf-form">

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -1,3 +1,4 @@
+import { defaults } from 'lodash';
 import React, { PureComponent } from 'react';
 import { InlineField, Select, Alert, Input } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue, dataFrameFromJSON, rangeUtil } from '@grafana/data';
@@ -29,6 +30,13 @@ export class QueryEditor extends PureComponent<Props, State> {
       description: 'Stream real-time measurements from Grafana',
     },
   ];
+
+  constructor(props: Props) {
+    super(props);
+    // TODO this mutates the query. We should not do this.
+    // Remove once we have a mechanism for specifying a default query.
+    defaults(props.query, defaultQuery);
+  }
 
   loadChannelInfo() {
     getBackendSrv()
@@ -63,13 +71,6 @@ export class QueryEditor extends PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { query } = this.props;
-
-    // If there is no query type, set the default
-    if (!query.queryType) {
-      const defaultQueryType = this.queryTypes.find((v) => v.value === defaultQuery.queryType) || this.queryTypes[0];
-      this.onQueryTypeChange(defaultQueryType);
-    }
     this.loadChannelInfo();
   }
 

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -63,6 +63,13 @@ export class QueryEditor extends PureComponent<Props, State> {
   }
 
   componentDidMount() {
+    const { query } = this.props;
+
+    // If there is no query type, set the default
+    if (!query.queryType) {
+      const defaultQueryType = this.queryTypes.find((v) => v.value === defaultQuery.queryType) || this.queryTypes[0];
+      this.onQueryTypeChange(defaultQueryType);
+    }
     this.loadChannelInfo();
   }
 
@@ -243,10 +250,8 @@ export class QueryEditor extends PureComponent<Props, State> {
   }
 
   render() {
-    const query = {
-      ...this.props.query,
-      ...defaultQuery,
-    };
+    const { query } = this.props;
+
     return (
       <>
         <div className="gf-form">


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- when changing datasources from `--Grafana--` to `Influx` (or any other datasource really), the query still contains `queryType: 'randomWalk'`
- this is because `QueryGroup` rerenders before `dsSettings` is set correctly in the state at https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryGroup.tsx#L153. `setState` is asynchronous, no guarantee it will update before the next render, etc etc
- when `QueryGroup` rerenders, it rerenders it's children and eventually rerenders the `--Grafana--` `QueryEditor`
- this applies defaults here: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/grafana/components/QueryEditor.tsx#L248, which looks like it directly mutates the `query` prop. so the very act of rerendering causes `query` to be modified with `queryType: 'randomWalk'`
- instead, let's apply the default on mount in an immutable way

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/37800

**Special notes for your reviewer**:

