### PR TITLE
Relative reference error for influxdb gettting started guide

### DIFF
--- a/docs/sources/getting-started/getting-started-influxdb.md
+++ b/docs/sources/getting-started/getting-started-influxdb.md
@@ -107,5 +107,5 @@ There you go! Use Explore and Data Explorer to experiment with your data, and ad
 
 Here are some resources to learn more:
 
-- Grafana documentation: [InfluxDB data source](../datasources/influxdb/_index.md)
+- Grafana documentation: [InfluxDB data source]({{< relref "../datasources/influxdb/_index.md" >}})
 - InfluxDB documentation: [Comparison of Flux vs InfluxQL](https://docs.influxdata.com/influxdb/v1.8/flux/flux-vs-influxql/)


### PR DESCRIPTION
Documentation quick fix for some missing markup in the markdown related to the InfluxDB data source on the influx getting started guide. 