### PR TITLE
AzureMonitor: Fix issue when using both Managed Identity and App Registration auth methods

### DIFF
--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
@@ -140,6 +140,12 @@ func (c *managedIdentityTokenRetriever) Init() error {
 }
 
 func (c *managedIdentityTokenRetriever) GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error) {
+	// Workaround for a bug in Azure SDK which mutates the passed array of scopes
+	// See details https://github.com/Azure/azure-sdk-for-go/issues/15308
+	arr := make([]string, len(scopes))
+	copy(arr, scopes)
+	scopes = arr
+
 	accessToken, err := c.credential.GetToken(ctx, azcore.TokenRequestOptions{Scopes: scopes})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to a bug in Azure SDK ([#15308](https://github.com/Azure/azure-sdk-for-go/issues/15308)), users who use _both_ Managed Identity _and_ App Registration authentication for Azure Monitor datasources in the same instance of Grafana, experience problems with App Registration authentication.

The bug causes unwanted conflict between the two authentication methods.

**Who is affected**
* Users who use both Managed Identity and App Registration authentication methods in the same instance of Grafana.

**Who is not affected**
* Users who use only one of the authentication methods.

**Special notes for your reviewer**:

This PR is a workaround which creates a copy of the original `scopes` array before passing it to Azure SDK's `ManagedIdentityCredential.GetToken(...)`. It's needed until the upstream bug in the Azure SDK fixed.
