### PR TITLE
Postgres UUID group issue

### DIFF
--- a/public/app/plugins/datasource/postgres/meta_query.ts
+++ b/public/app/plugins/datasource/postgres/meta_query.ts
@@ -132,7 +132,7 @@ table_schema IN (
         break;
       }
       case 'group': {
-        query += " AND data_type IN ('text','character','character varying')";
+        query += " AND data_type IN ('text','character','character varying','uuid')";
         break;
       }
     }

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -661,12 +661,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
   }
 
   addGroupAction() {
-    switch (this.groupAdd.value) {
-      default: {
-        this.addGroup(this.groupAdd.type, this.groupAdd.value);
-      }
-    }
-
+    this.addGroup(this.groupAdd.type, this.groupAdd.value);
     this.resetPlusButton(this.groupAdd);
     this.updateRawSqlAndRefresh();
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds UUID as a column type that can be grouped by.
Also minor clean up in add group by function.

**Which issue(s) this PR fixes**:
Fixes #22670

