### PR TITLE
[WIP] Folders: Prevent dashboards from being saved to General folder when limit is exceeded

### DIFF
--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -320,6 +320,7 @@ func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSear
 
 	var res []DashboardSearchProjection
 	sb := &searchstore.Builder{Dialect: dialect, Filters: filters}
+	var limitOffset string
 
 	limit := query.Limit
 	if limit < 1 {
@@ -327,11 +328,12 @@ func findDashboards(query *search.FindPersistedDashboardsQuery) ([]DashboardSear
 	}
 
 	page := query.Page
-	if page < 1 {
+	if page < 1 && query.Type != "dash-folder" {
 		page = 1
+		limitOffset = sb.Dialect.LimitOffset(limit, (page-1)*limit)
 	}
 
-	sql, params := sb.ToSQL(limit, page)
+	sql, params := sb.ToSQL(limitOffset)
 	err := x.SQL(sql, params...).Find(&res)
 	if err != nil {
 		return nil, err

--- a/pkg/services/sqlstore/searchstore/builder.go
+++ b/pkg/services/sqlstore/searchstore/builder.go
@@ -21,7 +21,7 @@ type Builder struct {
 }
 
 // ToSQL builds the SQL query and returns it as a string, together with the SQL parameters.
-func (b *Builder) ToSQL(limit, page int64) (string, []interface{}) {
+func (b *Builder) ToSQL(limitOffset string) (string, []interface{}) {
 	b.params = make([]interface{}, 0)
 	b.sql = bytes.Buffer{}
 
@@ -30,7 +30,7 @@ func (b *Builder) ToSQL(limit, page int64) (string, []interface{}) {
 	b.sql.WriteString("( ")
 	orderQuery := b.applyFilters()
 
-	b.sql.WriteString(b.Dialect.LimitOffset(limit, (page-1)*limit) + `) AS ids
+	b.sql.WriteString(limitOffset + `) AS ids
 		INNER JOIN dashboard ON ids.id = dashboard.id`)
 	b.sql.WriteString("\n")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When the dashboards/dashboards folder limit has been met, when going to dashboard settings and trying to save a dashboard, it only allows users to save it to `General` folder. This PR fixes this issue, by iterating all `dash-folders` without a limit. 

**Which issue(s) this PR fixes**:

Fixes #37348

**Special notes for your reviewer**:

Other changes regarding `limit` may be needed as well, such as parse it as a config variable instead of query parameter. TBD.