### PR TITLE
Alerting/Docs: $labels and $values not available with classic condition

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -106,11 +106,11 @@ Labels are key value pairs that categorize or identify an alert. Labels are used
 
 The following template variables are available when expanding annotations and labels.
 
-| Name    | Description                                                                                                                                                                                                             |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| $labels | The labels from the query or condition. For example, `{{ $labels.instance }}` and `{{ $labels.job }}`.                                                                                                                  |
-| $values | The values of all reduce and math expressions that were evaluated for this alert rule. For example, `{{ $values.A }}`, `{{ $values.A.Labels }}` and `{{ $values.A.Value }}` where `A` is the `refID` of the expression. |
-| $value  | The value string of the alert instance. For example, `[ var='A' labels={instance=foo} value=10 ]`.                                                                                                                      |
+| Name    | Description                                                                                                                                                                                                                                                                         |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| $labels | The labels from the query or condition. For example, `{{ $labels.instance }}` and `{{ $labels.job }}`. This is unavailable when the rule uses a classic condition.                                                                                                                  |
+| $values | The values of all reduce and math expressions that were evaluated for this alert rule. For example, `{{ $values.A }}`, `{{ $values.A.Labels }}` and `{{ $values.A.Value }}` where `A` is the `refID` of the expression. This is unavailable when the rule uses a classic condition. |
+| $value  | The value string of the alert instance. For example, `[ var='A' labels={instance=foo} value=10 ]`.                                                                                                                                                                                  |
 
 ## Preview alerts
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Clarifies that `$values and $labels` are not available with the classic condition.

**Which issue(s) this PR fixes**:

Fixes #37836

**Special notes for your reviewer**:

