### PR TITLE
Tempo: Use echo endpoint when testing Tempo datasource

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -168,8 +168,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     if (response.ok) {
       return { status: 'success', message: 'Data source is working' };
     }
-
-    return { status: 'error', message: 'Data source is not working' };
   }
 
   getQueryDisplayText(query: TempoQuery) {

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -165,7 +165,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     };
     const response = await getBackendSrv().fetch<any>(options).toPromise();
 
-    if (response.ok) {
+    if (response?.ok) {
       return { status: 'success', message: 'Data source is working' };
     }
   }

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1,4 +1,4 @@
-import { lastValueFrom, from, merge, Observable, of, throwError } from 'rxjs';
+import { from, merge, Observable, of, throwError } from 'rxjs';
 import { map, mergeMap, toArray } from 'rxjs/operators';
 import {
   DataQuery,
@@ -158,19 +158,18 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   }
 
   async testDatasource(): Promise<any> {
-    // to test Tempo we send a dummy traceID and verify Tempo answers with 'trace not found'
-    const response = await lastValueFrom(super.query({ targets: [{ query: '0' }] } as any));
+    const options: BackendSrvRequest = {
+      headers: {},
+      method: 'GET',
+      url: `${this.instanceSettings.url}/api/echo`,
+    };
+    const response = await getBackendSrv().fetch<any>(options).toPromise();
 
-    const errorMessage = response.error?.message;
-    if (
-      errorMessage &&
-      errorMessage.startsWith('failed to get trace') &&
-      errorMessage.endsWith('trace not found in Tempo')
-    ) {
+    if (response.ok) {
       return { status: 'success', message: 'Data source is working' };
     }
 
-    return { status: 'error', message: 'Data source is not working' + (errorMessage ? `: ${errorMessage}` : '') };
+    return { status: 'error', message: 'Data source is not working' };
   }
 
   getQueryDisplayText(query: TempoQuery) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses the new echo endpoint when testing the Tempo datasource. The previous test relied on a 404 response which we'd like to remove from the stable API. 

**Which issue(s) this PR fixes**:
Fixes #34919 

**Special notes for your reviewer**:

