### PR TITLE
Access Control: Make the evaluator prefix match only

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -2,6 +2,7 @@ package accesscontrol
 
 import (
 	"context"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
 )
@@ -52,4 +53,16 @@ func BuildPermissionsMap(permissions []*Permission) map[string]bool {
 	}
 
 	return permissionsMap
+}
+
+func ValidateScope(scope string) bool {
+	prefix := scope[:len(scope)-1]
+	// verify that last char is either ':' or '/'
+	if len(prefix) > 0 {
+		lastChar := prefix[len(prefix)-1]
+		if lastChar != ':' && lastChar != '/' {
+			return false
+		}
+	}
+	return !strings.ContainsAny(prefix, "*?")
 }

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -56,9 +56,9 @@ func BuildPermissionsMap(permissions []*Permission) map[string]bool {
 }
 
 func ValidateScope(scope string) bool {
-	prefix := scope[:len(scope)-1]
-	// verify that last char is either ':' or '/'
-	if len(prefix) > 0 {
+	prefix, last := scope[:len(scope)-1], scope[len(scope)-1]
+	// verify that last char is either ':' or '/' if last character of scope is '*'
+	if len(prefix) > 0 && last == '*' {
 		lastChar := prefix[len(prefix)-1]
 		if lastChar != ':' && lastChar != '/' {
 			return false

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+var logger = log.New("accesscontrol.evaluator")
 
 // Evaluate evaluates access to the given resource, using provided AccessControl instance.
 // Scopes are evaluated with an `OR` relationship.

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -44,7 +44,7 @@ func evaluateScope(dbScopes map[string]struct{}, targetScopes ...string) (bool, 
 		var match bool
 		for dbScope := range dbScopes {
 
-			prefix := dbScope[0 : len(dbScope)-1]
+			prefix := dbScope[:len(dbScope)-1]
 			if strings.ContainsAny(prefix, "*?") {
 				msg := fmt.Sprintf("Invalid scope: %v should not contain meta-characters like * or ?, except in the last position", dbScope)
 				logger.Error(msg, "scope", dbScope)

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -48,7 +48,7 @@ func evaluateScope(dbScopes map[string]struct{}, targetScopes ...string) (bool, 
 		for dbScope := range dbScopes {
 
 			prefix := dbScope[:len(dbScope)-1]
-			if !ValidateScope(prefix) {
+			if ValidateScope(prefix) {
 				msg := "Invalid scope"
 				reason := fmt.Sprintf("%v should not contain meta-characters like * or ?, except in the last position", dbScope)
 				logger.Error(msg, "reason", reason, "scope", dbScope)

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -51,7 +51,7 @@ func evaluateScope(dbScopes map[string]struct{}, targetScopes ...string) (bool, 
 			} else {
 				prefix := dbScope[:len(dbScope)-1]
 				lastChar := dbScope[len(dbScope)-1]
-				if !ValidateScope(prefix) {
+				if !ValidateScope(dbScope) {
 					msg := "Invalid scope"
 					reason := fmt.Sprintf("%v should not contain meta-characters like * or ?, except in the last position", dbScope)
 					logger.Error(msg, "reason", reason, "scope", dbScope)

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -60,7 +60,7 @@ func evaluateScope(dbScopes map[string]struct{}, targetScopes ...string) (bool, 
 
 				msg := "Access control"
 				reason := fmt.Sprintf("matched request scope %v against resource scope %v", dbScope, s)
-				if lastChar == "*"[0] { //Prefix match
+				if lastChar == '*' { //Prefix match
 					match := strings.HasPrefix(s, prefix)
 					if match {
 						logger.Debug(msg, "reason", reason, "request scope", dbScope, "resource scope", s)

--- a/pkg/services/accesscontrol/evaluator/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator.go
@@ -35,7 +35,7 @@ func Evaluate(ctx context.Context, ac accesscontrol.AccessControl, user *models.
 
 func ValidateScope(scope string) bool {
 	prefix := scope[:len(scope)-1]
-	return strings.ContainsAny(prefix, "*?")
+	return !strings.ContainsAny(prefix, "*?")
 }
 
 func evaluateScope(dbScopes map[string]struct{}, targetScopes ...string) (bool, error) {
@@ -48,7 +48,7 @@ func evaluateScope(dbScopes map[string]struct{}, targetScopes ...string) (bool, 
 		for dbScope := range dbScopes {
 
 			prefix := dbScope[:len(dbScope)-1]
-			if ValidateScope(prefix) {
+			if !ValidateScope(prefix) {
 				msg := "Invalid scope"
 				reason := fmt.Sprintf("%v should not contain meta-characters like * or ?, except in the last position", dbScope)
 				logger.Error(msg, "reason", reason, "scope", dbScope)

--- a/pkg/services/accesscontrol/evaluator/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator_test.go
@@ -97,7 +97,7 @@ func TestEvaluatePermissions(t *testing.T) {
 				"users:*":              {},
 				"permissions:delegate": {},
 			},
-			NeedAnyScope: []string{"teams1", "permissions:delegate"},
+			NeedAnyScope: []string{"teams1", "permissions:nodelegate"},
 			Valid:        false,
 		},
 	}

--- a/pkg/services/accesscontrol/evaluator/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator_test.go
@@ -93,7 +93,6 @@ func TestEvaluatePermissions(t *testing.T) {
 			Name: "No match found",
 			HasScopes: map[string]struct{}{
 				"teams:*":              {},
-				"permissions:*":        {},
 				"users:*":              {},
 				"permissions:delegate": {},
 			},

--- a/pkg/services/accesscontrol/evaluator/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator/evaluator_test.go
@@ -14,7 +14,11 @@ func TestExtractPermission(t *testing.T) {
 	userPermissions := []*accesscontrol.Permission{
 		{
 			Action: "permissions:create",
-			Scope:  "teams:*/permissions:*",
+			Scope:  "teams:*",
+		},
+		{
+			Action: "permissions:create",
+			Scope:  "permissions:*",
 		},
 		{
 			Action: "permissions:remove",
@@ -22,7 +26,8 @@ func TestExtractPermission(t *testing.T) {
 		},
 	}
 	expectedScopes := map[string]struct{}{
-		"teams:*/permissions:*": {},
+		"permissions:*": {},
+		"teams:*":       {},
 	}
 	ok, scopes := extractScopes(userPermissions, targetPermission)
 	assert.True(t, ok)
@@ -45,9 +50,10 @@ func TestEvaluatePermissions(t *testing.T) {
 		{
 			Name: "No expected scope always returns true",
 			HasScopes: map[string]struct{}{
-				"teams:*/permissions:*": {},
-				"users:*":               {},
-				"permissions:delegate":  {},
+				"teams:*":              {},
+				"permissions:*":        {},
+				"users:*":              {},
+				"permissions:delegate": {},
 			},
 			NeedAnyScope: []string{},
 			Valid:        true,
@@ -55,27 +61,30 @@ func TestEvaluatePermissions(t *testing.T) {
 		{
 			Name: "Single scope from  list",
 			HasScopes: map[string]struct{}{
-				"teams:1/permissions:delegate": {},
+				"teams:1":              {},
+				"permissions:delegate": {},
 			},
-			NeedAnyScope: []string{"teams:1/permissions:delegate"},
+			NeedAnyScope: []string{"teams:1", "permissions:delegate"},
 			Valid:        true,
 		},
 		{
 			Name: "Single scope from glob list",
 			HasScopes: map[string]struct{}{
-				"teams:*/permissions:*": {},
-				"users:*":               {},
-				"permissions:delegate":  {},
+				"teams:*":              {},
+				"permissions:*":        {},
+				"users:*":              {},
+				"permissions:delegate": {},
 			},
-			NeedAnyScope: []string{"teams:1/permissions:delegate"},
+			NeedAnyScope: []string{"teams:1", "permissions:delegate"},
 			Valid:        true,
 		},
 		{
 			Name: "Either of two scopes from glob list",
 			HasScopes: map[string]struct{}{
-				"teams:*/permissions:*": {},
-				"users:*":               {},
-				"permissions:delegate":  {},
+				"teams:*":              {},
+				"permissions:*":        {},
+				"users:*":              {},
+				"permissions:delegate": {},
 			},
 			NeedAnyScope: []string{"global:admin", "permissions:delegate"},
 			Valid:        true,
@@ -83,11 +92,12 @@ func TestEvaluatePermissions(t *testing.T) {
 		{
 			Name: "No match found",
 			HasScopes: map[string]struct{}{
-				"teams:*/permissions:*": {},
-				"users:*":               {},
-				"permissions:delegate":  {},
+				"teams:*":              {},
+				"permissions:*":        {},
+				"users:*":              {},
+				"permissions:delegate": {},
 			},
-			NeedAnyScope: []string{"teams1/permissions:delegate"},
+			NeedAnyScope: []string{"teams1", "permissions:delegate"},
 			Valid:        false,
 		},
 	}

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -102,7 +102,7 @@ const (
 	ScopeUsersAll = "users:*"
 
 	// Settings scope
-	ScopeSettingsAll = "settings:**"
+	ScopeSettingsAll = "settings:*"
 )
 
 const RoleGrafanaAdmin = "Grafana Admin"

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -57,7 +57,7 @@ var (
 	}
 
 	settingsAdminReadRole = RoleDTO{
-		Version: 1,
+		Version: 2,
 		Name:    settingsAdminRead,
 		Permissions: []Permission{
 			{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The evaluator currently can sometimes treat a meta-character as a normal character, resulting in unwanted matches.  As suggested in https://docs.google.com/document/d/1KTDZj2fr7DwiKIUgvsXxlP5FofEMV5RjUGBrfzWQ1pY/edit# , allowing only prefix matches is preferable, so this patch only allows matching by prefix.

Also adds some debug messages for users who need to debug their access control permissions.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/1651

**Special notes for your reviewer**:

