### PR TITLE
Admin: Obfuscate azure_blob Account Key in the admin settings UI

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -474,6 +474,7 @@ func RedactedValue(key, value string) string {
 		"PRIVATE_KEY",
 		"SECRET_KEY",
 		"CERTIFICATE",
+		"ACCOUNT_KEY",
 	} {
 		if strings.Contains(uppercased, pattern) {
 			return RedactedPassword


### PR DESCRIPTION
Azure key should not be shown in Admin Settings UI

**What this PR does / why we need it**: Obfuscate the azure blob account_key in the admin settings area,

**Which issue(s) this PR fixes**: #37970 

Fixes #37970 
