### PR TITLE
XYChart: Allow string fields as x axis values

### DIFF
--- a/public/app/plugins/panel/xychart/dims.ts
+++ b/public/app/plugins/panel/xychart/dims.ts
@@ -20,7 +20,7 @@ export interface XYDimensions {
 }
 
 export function isGraphable(field: Field) {
-  return field.type === FieldType.number;
+  return field.type === FieldType.number || field.type === FieldType.string;
 }
 
 export function getXYDimensions(cfg?: XYDimensionConfig, data?: DataFrame[]): XYDimensions {


### PR DESCRIPTION
Exploring the way to use string fields as x-axis values.

This brings possiblity to have a charts like the one below assuming the x-axis values come as string from the datasource:

![image](https://user-images.githubusercontent.com/2376619/130068452-d92dd41e-0ee1-4156-9cf7-7bc6c77daf47.png)

Test data:
```csv
"month","avg_game_duration"
April 2016,185.9865771812081
May 2016,186.12707182320437
June 2016,183.97175141242943
July 2016,185.4023668639054
August 2016,182.9932885906041
September 2016,184.86666666666665
October 2016,172.28
```

@leeoniya any suggestions about aligning the range so that the first x axis tick is not rendered at the axes intersection? I would expect the graph to be centered rather than left aligned within the canvas. Similar to how gsheets does it when the x axis values are plain text:
![image](https://user-images.githubusercontent.com/2376619/130069084-ee468578-c48b-4ee5-812e-20e2628fa837.png)
