### PR TITLE
Grafana UI: Fix TS error property `css` is missing in type

### DIFF
--- a/packages/grafana-ui/src/types/emotion-core-stub.d.ts
+++ b/packages/grafana-ui/src/types/emotion-core-stub.d.ts
@@ -1,0 +1,4 @@
+// This stub is required due to Storybook 6.x reliance on @emotion/core
+// which causes conflicts with emotion 11 types resulting in bundled
+// components throwing ts error `Property 'css' is missing in type...`
+export {};

--- a/packages/grafana-ui/tsconfig.build.json
+++ b/packages/grafana-ui/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
+  "compilerOptions": {
+    "paths": {
+      "@emotion/core": ["../../src/types/emotion-core-stub.d.ts"],
+      "@grafana/slate-react": ["slate-react"],
+      "@grafana/ui": ["."]
+    }
+  },
   "exclude": ["**/*.story.tsx", "**/*.test.ts*", "**/*.tmpl.ts", "dist", "node_modules", "src/utils/storybook"],
   "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR creates a stub for `@emotion/core` types to prevent any `@grafana/ui` components with type definitions that extend react types from adding a mandatory `css` prop. From the research I've done the underlying issue is related to Storybook still using emotion 10 which comes with global types that overwrite reacts.

There are a few types in the codebase that currently omit the `css` prop to get around this issue. Will remove them before merging.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35878


**Special notes for your reviewer**:
I tested this by:

1. follow the repro steps outlined in the related issue
1. build the `grafana/ui` lib in this branch
2. replace the  contents of `node_modules/@grafana/ui` in the starter plugin (created in step1 of issue repo steps) with the contents of `grafana/ui/dist` folder created in previous step.
3. Restart IDE / run `yarn build` in starter panel to confirm TS errors are gone.

# Release notice breaking change

The mandatory `css`  property in `grafana/ui` components has been removed. 

Previous versions of `grafana/ui` components were typed incorrectly due to a dependency mismatch between emotion 10 and 11 causing a `css` prop to be added to components that extended react types.
