### PR TITLE
AccessControl: add one-dimensional permissions to datasources in the frontend

### DIFF
--- a/public/app/core/components/EmptyListCTA/EmptyListCTA.tsx
+++ b/public/app/core/components/EmptyListCTA/EmptyListCTA.tsx
@@ -8,6 +8,7 @@ export interface Props {
   buttonIcon: IconName;
   buttonLink?: string;
   buttonTitle: string;
+  buttonDisabled?: boolean;
   onClick?: (event: MouseEvent) => void;
   proTip?: string;
   proTipLink?: string;
@@ -31,6 +32,7 @@ const EmptyListCTA: React.FunctionComponent<Props> = ({
   buttonIcon,
   buttonLink,
   buttonTitle,
+  buttonDisabled,
   onClick,
   proTip,
   proTipLink,
@@ -79,6 +81,7 @@ const EmptyListCTA: React.FunctionComponent<Props> = ({
       icon={buttonIcon}
       className={ctaElementClassName}
       aria-label={selectors.components.CallToActionCard.button(buttonTitle)}
+      disabled={buttonDisabled}
     >
       {buttonTitle}
     </LinkButton>

--- a/public/app/core/components/PageActionBar/PageActionBar.tsx
+++ b/public/app/core/components/PageActionBar/PageActionBar.tsx
@@ -5,7 +5,7 @@ import { LinkButton } from '@grafana/ui';
 export interface Props {
   searchQuery: string;
   setSearchQuery: (value: string) => void;
-  linkButton?: { href: string; title: string };
+  linkButton?: { href: string; title: string; disabled?: boolean };
   target?: string;
   placeholder?: string;
 }
@@ -13,7 +13,7 @@ export interface Props {
 export default class PageActionBar extends PureComponent<Props> {
   render() {
     const { searchQuery, linkButton, setSearchQuery, target, placeholder = 'Search by name or type' } = this.props;
-    const linkProps = { href: linkButton?.href };
+    const linkProps = { href: linkButton?.href, disabled: linkButton?.disabled };
 
     if (target) {
       (linkProps as any).target = target;

--- a/public/app/features/datasources/DataSourcesListPage.test.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.test.tsx
@@ -6,6 +6,14 @@ import { DataSourcesListPage, Props } from './DataSourcesListPage';
 import { getMockDataSources } from './__mocks__/dataSourcesMocks';
 import { setDataSourcesLayoutMode, setDataSourcesSearchQuery } from './state/reducers';
 
+jest.mock('app/core/core', () => {
+  return {
+    contextSrv: {
+      hasPermission: () => true,
+    },
+  };
+});
+
 const setup = (propOverrides?: object) => {
   const props: Props = {
     dataSources: [] as DataSourceSettings[],

--- a/public/app/features/datasources/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.tsx
@@ -2,6 +2,8 @@
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { hot } from 'react-hot-loader';
+// Services & Utils
+import { contextSrv } from 'app/core/core';
 // Components
 import Page from 'app/core/components/Page/Page';
 import PageActionBar from 'app/core/components/PageActionBar/PageActionBar';
@@ -10,6 +12,7 @@ import DataSourcesList from './DataSourcesList';
 // Types
 import { IconName } from '@grafana/ui';
 import { StoreState } from 'app/types';
+import { AccessControlAction } from 'app/types/';
 // Actions
 import { loadDataSources } from './state/actions';
 import { getNavModel } from 'app/core/selectors/navModel';
@@ -70,9 +73,11 @@ export class DataSourcesListPage extends PureComponent<Props> {
       hasFetched,
     } = this.props;
 
+    const canCreateDataSource = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
     const linkButton = {
       href: 'datasources/new',
       title: 'Add data source',
+      disabled: !canCreateDataSource,
     };
 
     return (

--- a/public/app/features/datasources/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.tsx
@@ -11,8 +11,7 @@ import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import DataSourcesList from './DataSourcesList';
 // Types
 import { IconName } from '@grafana/ui';
-import { StoreState } from 'app/types';
-import { AccessControlAction } from 'app/types/';
+import { StoreState, AccessControlAction } from 'app/types';
 // Actions
 import { loadDataSources } from './state/actions';
 import { getNavModel } from 'app/core/selectors/navModel';

--- a/public/app/features/datasources/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.tsx
@@ -79,11 +79,16 @@ export class DataSourcesListPage extends PureComponent<Props> {
       disabled: !canCreateDataSource,
     };
 
+    const emptyList = {
+      ...emptyListModel,
+      buttonDisabled: !canCreateDataSource,
+    };
+
     return (
       <Page navModel={navModel}>
         <Page.Contents isLoading={!hasFetched}>
           <>
-            {hasFetched && dataSourcesCount === 0 && <EmptyListCTA {...emptyListModel} />}
+            {hasFetched && dataSourcesCount === 0 && <EmptyListCTA {...emptyList} />}
             {hasFetched &&
               dataSourcesCount > 0 && [
                 <PageActionBar

--- a/public/app/features/datasources/__snapshots__/DataSourcesListPage.test.tsx.snap
+++ b/public/app/features/datasources/__snapshots__/DataSourcesListPage.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Render should render action bar and datasources 1`] = `
       key="action-bar"
       linkButton={
         Object {
+          "disabled": false,
           "href": "datasources/new",
           "title": "Add data source",
         }

--- a/public/app/features/datasources/settings/ButtonRow.test.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.test.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import ButtonRow, { Props } from './ButtonRow';
 
+jest.mock('app/core/core', () => {
+  return {
+    contextSrv: {
+      hasPermission: () => true,
+    },
+  };
+});
+
 const setup = (propOverrides?: object) => {
   const props: Props = {
     isReadOnly: true,

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -18,7 +18,7 @@ export interface Props {
 const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreUrl }) => {
   const canEditDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
   const canDeleteDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesDelete);
-  const canExploreDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
+  const canExploreDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
 
   return (
     <div className="gf-form-button-row">

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -17,7 +17,7 @@ export interface Props {
 
 const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreUrl }) => {
   const canEditDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
-  const canDeleteDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesDelete);
+  const canDeleteDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesDelete);
 
   return (
     <div className="gf-form-button-row">
@@ -31,7 +31,7 @@ const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreU
         <Button
           type="button"
           variant="destructive"
-          disabled={isReadOnly}
+          disabled={!canDeleteDataSources}
           onClick={onDelete}
           aria-label={selectors.pages.DataSource.delete}
         >
@@ -42,7 +42,7 @@ const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreU
         <Button
           type="submit"
           variant="primary"
-          disabled={isReadOnly}
+          disabled={!canEditDataSources}
           onClick={(event) => onSubmit(event)}
           aria-label={selectors.pages.DataSource.saveAndTest}
         >

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -4,6 +4,9 @@ import { selectors } from '@grafana/e2e-selectors';
 import config from 'app/core/config';
 import { Button, LinkButton } from '@grafana/ui';
 
+import { AccessControlAction } from 'app/types/';
+import { contextSrv } from 'app/core/core';
+
 export interface Props {
   exploreUrl: string;
   isReadOnly: boolean;
@@ -13,6 +16,9 @@ export interface Props {
 }
 
 const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreUrl }) => {
+  const canEditDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
+  const canDeleteDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesDelete);
+
   return (
     <div className="gf-form-button-row">
       <LinkButton variant="secondary" fill="solid" href={`${config.appSubUrl}/datasources`}>
@@ -21,16 +27,18 @@ const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreU
       <LinkButton variant="secondary" fill="solid" href={exploreUrl}>
         Explore
       </LinkButton>
-      <Button
-        type="button"
-        variant="destructive"
-        disabled={isReadOnly}
-        onClick={onDelete}
-        aria-label={selectors.pages.DataSource.delete}
-      >
-        Delete
-      </Button>
-      {!isReadOnly && (
+      {canDeleteDataSources && (
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={isReadOnly}
+          onClick={onDelete}
+          aria-label={selectors.pages.DataSource.delete}
+        >
+          Delete
+        </Button>
+      )}
+      {canEditDataSources && (
         <Button
           type="submit"
           variant="primary"
@@ -41,7 +49,7 @@ const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreU
           Save &amp; test
         </Button>
       )}
-      {isReadOnly && (
+      {!canEditDataSources && (
         <Button type="submit" variant="primary" onClick={onTest}>
           Test
         </Button>

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -18,13 +18,14 @@ export interface Props {
 const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreUrl }) => {
   const canEditDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
   const canDeleteDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesDelete);
+  const canExploreDataSources = !isReadOnly && contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
 
   return (
     <div className="gf-form-button-row">
       <LinkButton variant="secondary" fill="solid" href={`${config.appSubUrl}/datasources`}>
         Back
       </LinkButton>
-      <LinkButton variant="secondary" fill="solid" href={exploreUrl}>
+      <LinkButton variant="secondary" fill="solid" href={exploreUrl} disabled={!canExploreDataSources}>
         Explore
       </LinkButton>
       <Button

--- a/public/app/features/datasources/settings/ButtonRow.tsx
+++ b/public/app/features/datasources/settings/ButtonRow.tsx
@@ -27,17 +27,15 @@ const ButtonRow: FC<Props> = ({ isReadOnly, onDelete, onSubmit, onTest, exploreU
       <LinkButton variant="secondary" fill="solid" href={exploreUrl}>
         Explore
       </LinkButton>
-      {canDeleteDataSources && (
-        <Button
-          type="button"
-          variant="destructive"
-          disabled={!canDeleteDataSources}
-          onClick={onDelete}
-          aria-label={selectors.pages.DataSource.delete}
-        >
-          Delete
-        </Button>
-      )}
+      <Button
+        type="button"
+        variant="destructive"
+        disabled={!canDeleteDataSources}
+        onClick={onDelete}
+        aria-label={selectors.pages.DataSource.delete}
+      >
+        Delete
+      </Button>
       {canEditDataSources && (
         <Button
           type="submit"

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
@@ -9,6 +9,14 @@ import { screen, render } from '@testing-library/react';
 import { selectors } from '@grafana/e2e-selectors';
 import { PluginState } from '@grafana/data';
 
+jest.mock('app/core/core', () => {
+  return {
+    contextSrv: {
+      hasPermission: () => true,
+    },
+  };
+});
+
 const getMockNode = () => ({
   text: 'text',
   subTitle: 'subtitle',

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -137,7 +137,7 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
     return (
       <Alert aria-label={selectors.pages.DataSource.readOnly} severity="info" title="Provisioned data source">
         This data source was added by config and cannot be modified using the UI. Please contact your server admin to
-        update this data source. Toto is the best.
+        update this data source.
       </Alert>
     );
   }

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -7,6 +7,8 @@ import BasicSettings from './BasicSettings';
 import ButtonRow from './ButtonRow';
 // Services & Utils
 import appEvents from 'app/core/app_events';
+import { contextSrv } from 'app/core/core';
+
 // Actions & selectors
 import { getDataSource, getDataSourceMeta } from '../state/selectors';
 import {
@@ -19,7 +21,7 @@ import {
 import { getNavModel } from 'app/core/selectors/navModel';
 
 // Types
-import { StoreState } from 'app/types/';
+import { StoreState, AccessControlAction } from 'app/types/';
 import { DataSourceSettings, urlUtil } from '@grafana/data';
 import { Alert, Button, LinkButton } from '@grafana/ui';
 import { getDataSourceLoadingNav, buildNavModel, getDataSourceNav } from '../state/navModel';
@@ -135,7 +137,15 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
     return (
       <Alert aria-label={selectors.pages.DataSource.readOnly} severity="info" title="Provisioned data source">
         This data source was added by config and cannot be modified using the UI. Please contact your server admin to
-        update this data source.
+        update this data source. Toto is the best.
+      </Alert>
+    );
+  }
+
+  renderMissingEditRightsMessage() {
+    return (
+      <Alert aria-label={selectors.pages.DataSource.readOnly} severity="info" title="Missing rights">
+        You are not allowed to modify this data source. Please contact your server admin to update this data source.
       </Alert>
     );
   }
@@ -228,9 +238,11 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
 
   renderSettings() {
     const { dataSourceMeta, setDataSourceName, setIsDefault, dataSource, plugin, testingStatus } = this.props;
+    const canEditDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
 
     return (
       <form onSubmit={this.onSubmit}>
+        {!canEditDataSources && this.renderMissingEditRightsMessage()}
         {this.isReadOnly() && this.renderIsReadOnlyMessage()}
         {dataSourceMeta.state && (
           <div className="gf-form">

--- a/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.tsx
@@ -144,7 +144,7 @@ export class DataSourceSettingsPage extends PureComponent<Props> {
 
   renderMissingEditRightsMessage() {
     return (
-      <Alert aria-label={selectors.pages.DataSource.readOnly} severity="info" title="Missing rights">
+      <Alert severity="info" title="Missing rights">
         You are not allowed to modify this data source. Please contact your server admin to update this data source.
       </Alert>
     );

--- a/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
+++ b/public/app/features/datasources/settings/__snapshots__/ButtonRow.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Render should render component 1`] = `
     Back
   </LinkButton>
   <LinkButton
+    disabled={false}
     fill="solid"
     href="/explore"
     variant="secondary"
@@ -49,6 +50,7 @@ exports[`Render should render with buttons enabled 1`] = `
     Back
   </LinkButton>
   <LinkButton
+    disabled={false}
     fill="solid"
     href="/explore"
     variant="secondary"

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -199,6 +199,7 @@ export function addDataSource(plugin: DataSourcePluginMeta): ThunkResult<void> {
     }
 
     const result = await getBackendSrv().post('/api/datasources', newInstance);
+    await updateFrontendSettings();
     locationService.push(`/datasources/edit/${result.datasource.uid}`);
   };
 }

--- a/public/app/features/explore/NoDataSourceCallToAction.tsx
+++ b/public/app/features/explore/NoDataSourceCallToAction.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { LinkButton, CallToActionCard, Icon, useTheme2 } from '@grafana/ui';
 
-// Services & Utils
 import { contextSrv } from 'app/core/core';
-// Types
 import { AccessControlAction } from 'app/types';
 
 export const NoDataSourceCallToAction = () => {

--- a/public/app/features/explore/NoDataSourceCallToAction.tsx
+++ b/public/app/features/explore/NoDataSourceCallToAction.tsx
@@ -2,8 +2,15 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { LinkButton, CallToActionCard, Icon, useTheme2 } from '@grafana/ui';
 
+// Services & Utils
+import { contextSrv } from 'app/core/core';
+// Types
+import { AccessControlAction } from 'app/types';
+
 export const NoDataSourceCallToAction = () => {
   const theme = useTheme2();
+
+  const canCreateDataSource = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
 
   const message =
     'Explore requires at least one data source. Once you have added a data source, you can query it here.';
@@ -23,7 +30,7 @@ export const NoDataSourceCallToAction = () => {
   );
 
   const ctaElement = (
-    <LinkButton size="lg" href="datasources/new" icon="database">
+    <LinkButton size="lg" href="datasources/new" icon="database" disabled={!canCreateDataSource}>
       Add data source
     </LinkButton>
   );

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -30,6 +30,14 @@ import { Echo } from 'app/core/services/echo/Echo';
 
 type Mock = jest.Mock;
 
+jest.mock('app/core/core', () => {
+  return {
+    contextSrv: {
+      hasPermission: () => true,
+    },
+  };
+});
+
 jest.mock('react-virtualized-auto-sizer', () => {
   return {
     __esModule: true,

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -39,7 +39,6 @@ export enum AccessControlAction {
   DataSourcesCreate = 'datasources:create',
   DataSourcesWrite = 'datasources:write',
   DataSourcesDelete = 'datasources:delete',
-  DataSourcesIDRead = 'datasources:id:read',
 
   ActionServerStatsRead = 'server.stats:read',
 }

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -33,7 +33,13 @@ export enum AccessControlAction {
   LDAPUsersRead = 'ldap.user:read',
   LDAPUsersSync = 'ldap.user:sync',
   LDAPStatusRead = 'ldap.status:read',
+
   DataSourcesExplore = 'datasources:explore',
+  DataSourcesRead = 'datasources:read',
+  DataSourcesCreate = 'datasources:create',
+  DataSourcesWrite = 'datasources:write',
+  DataSourcesDelete = 'datasources:delete',
+  DataSourcesIDRead = 'datasources:id:read',
 
   ActionServerStatsRead = 'server.stats:read',
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR is needed to bring accesscontrol to datasources related endpoints.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partially fixes https://github.com/grafana/grafana-enterprise/issues/1548

**Special notes for your reviewer**:
This is the frontend part only. PR https://github.com/grafana/grafana/pull/38070 is open for backend. The aim is to simplify reading.

#    Provisioning file
Here is the provisioning file used to add permissions to a viewer. You can add roles one by one, by commenting them all first and un-comment them one at a time.
```yaml
---
apiVersion: 1

deleteRoles:
  # - name: "custom:datasources:viewer"
  #   global: true
  #   force: true
  # - name: "custom:datasources:creator"
  #   global: true
  #   force: true
  # - name: "custom:datasources:remover"
  #   global: true
  #   force: true
  # - name: "custom:datasources:editor"
  #   global: true
  #   force: true
  # - name: "custom:datasources:explorer"
  #   global: true
  #   force: true

roles:
  - name: "custom:datasources:viewer"
    description: "Role to allow users to see datasources"
    version: 1
    global: true
    permissions:
      - action: "datasources:read"
        scope: "datasources:*" # to match datasources scopes: "datasources:id:.*", "datasources:uid:.*", "datasources:name:.*"
      - action: "datasources:id:read"
        scope: "datasources:*" # to match datasources scope: "datasources:name:.*"
    builtInRoles:
      - name: "Viewer"
    global: true

  - name: "custom:datasources:creator"
    description: "Role to allow users to create datasources"
    version: 1
    global: true
    permissions:
      - action: "datasources:create"
    builtInRoles:
      - name: "Viewer"
        global: true

  - name: "custom:datasources:remover"
    description: "Role to allow users to remove datasources"
    version: 1
    global: true
    permissions:
      - action: "datasources:delete"
        scope: "datasources:*"
    builtInRoles:
      - name: "Viewer"
        global: true

  - name: "custom:datasources:editor"
    description: "Role to allow users to modify datasources"
    version: 1
    global: true
    permissions:
      - action: "datasources:write"
        scope: "datasources:*"
    builtInRoles:
      - name: "Viewer"
        global: true

  - name: "custom:datasources:explorer"
    description: "Role to allow users to modify datasources"
    version: 1
    global: true
    permissions:
      - action: "datasources:explore"
        scope: "datasources:*"
    builtInRoles:
      - name: "Viewer"
        global: true
```

Reloading can be done using a curl command as an admin:
```bash
curl --basic -u 'admin:**********' -X POST http://localhost:3000/api/admin/provisioning/access-control/reload
```

Here is a couple of snapshots I took testing them one by one:
#    Viewer
If you have viewing only rights, then the datasources menu comes in the navbar (done on backend) and the `Add Data Source` button is disabled:
![000_viewer](https://user-images.githubusercontent.com/5232696/130918224-f835d27b-fff8-4ee4-95a8-c6794fad57ea.png)
**Without datasources**
![001_viewer](https://user-images.githubusercontent.com/5232696/130918229-aeb83963-ec5d-4f2d-ae62-e59d35fbb758.png)
**With datasources**

**If you navigate to the new page manually you get an error message:**
![002_viewer](https://user-images.githubusercontent.com/5232696/130918290-0bedc8ec-0636-4a28-bcc6-35b7746af252.png)

#    Creator
If you have creator rights on top, you can now create a new datasource, but it will only be a default one, you cannot edit the defaults:
![003_creator_0](https://user-images.githubusercontent.com/5232696/130918510-c447dd2a-81ec-4873-a012-54d3f5eb5a27.png) 
**Without datasources**

![003_creator_1](https://user-images.githubusercontent.com/5232696/130918521-ea8fed94-5cb6-41e6-a137-bf16976df18f.png)
**With datasources**

![004_creator](https://user-images.githubusercontent.com/5232696/130918534-33424715-24b7-4d56-93fd-cb1568a29666.png)
In the edit view, a popup notifies you that you are being restricted. Also notice that `Explore` and `Delete` buttons are disabled and that the `Save and Test` button is not displayed in favor of the `Test` button:
![005_creator](https://user-images.githubusercontent.com/5232696/130918547-527fb1fd-1f99-4042-9e73-3f9a26ab1dbf.png)

#    Editor
If you have editor rights on top of these, you now have access to the `Save and Test` button:
![006_editor](https://user-images.githubusercontent.com/5232696/130918804-48ae3e28-13bb-44ce-8eed-807a27f7e18a.png)

#    Deleter
If you have delete rights on top of these, the `Delete` button is now available:
![007_deletor](https://user-images.githubusercontent.com/5232696/130918944-4c075ef6-c26f-4636-8462-39ef0ac3702e.png)

#    Explorer
If you have explore rights on top of these, the  `Explore` button is now available:
![008_explorer](https://user-images.githubusercontent.com/5232696/130919034-507f0ffa-e702-46ff-a670-5c9d941263fc.png)
