### PR TITLE
DataFrame: add frame type key to DataFrame structure

### DIFF
--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -3,6 +3,7 @@ import { DataTransformerConfig } from './transformations';
 import { ApplyFieldOverrideOptions } from './fieldOverrides';
 import { PanelPluginDataSupport } from '.';
 import { DataTopic } from './query';
+import { DataFrameType } from './dataFrameTypes';
 
 export type KeyValue<T = any> = Record<string, T>;
 
@@ -25,6 +26,8 @@ export type PreferredVisualisationType = 'graph' | 'table' | 'logs' | 'trace' | 
  * @public
  */
 export interface QueryResultMeta {
+  type?: DataFrameType;
+
   /** DatasSource Specific Values */
   custom?: Record<string, any>;
 

--- a/packages/grafana-data/src/types/dataFrameTypes.ts
+++ b/packages/grafana-data/src/types/dataFrameTypes.ts
@@ -1,0 +1,11 @@
+/**
+ * See also:
+ * https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/frame_type.go
+ *
+ * @public
+ */
+export enum DataFrameType {
+  TimeSeriesWide = 'timeseries-wide',
+  TimeSeriesLong = 'timeseries-long',
+  TimeSeriesMany = 'timeseries-many',
+}

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './data';
 export * from './dataFrame';
+export * from './dataFrameTypes';
 export * from './dataLink';
 export * from './dashboard';
 export * from './query';

--- a/public/app/core/components/TransformersUI/prepareTimeSeries/prepareTimeSeries.test.ts
+++ b/public/app/core/components/TransformersUI/prepareTimeSeries/prepareTimeSeries.test.ts
@@ -1,4 +1,12 @@
-import { toDataFrame, ArrayVector, DataFrame, FieldType, toDataFrameDTO, DataFrameDTO } from '@grafana/data';
+import {
+  toDataFrame,
+  ArrayVector,
+  DataFrame,
+  FieldType,
+  toDataFrameDTO,
+  DataFrameDTO,
+  DataFrameType,
+} from '@grafana/data';
 import { prepareTimeSeriesTransformer, PrepareTimeSeriesOptions, timeSeriesFormat } from './prepareTimeSeries';
 
 describe('Prepair time series transformer', () => {
@@ -27,6 +35,9 @@ describe('Prepair time series transformer', () => {
           { name: 'time', type: FieldType.time, values: [10, 9, 8, 7, 6, 5] },
           { name: 'count', type: FieldType.number, values: [1, 2, 3, 4, 5, 6] },
         ],
+        meta: {
+          type: DataFrameType.TimeSeriesMany,
+        },
         length: 6,
       }),
       toEquableDataFrame({
@@ -36,6 +47,9 @@ describe('Prepair time series transformer', () => {
           { name: 'time', type: FieldType.time, values: [10, 9, 8, 7, 6, 5] },
           { name: 'more', type: FieldType.number, values: [2, 3, 4, 5, 6, 7] },
         ],
+        meta: {
+          type: DataFrameType.TimeSeriesMany,
+        },
         length: 6,
       }),
     ]);
@@ -68,6 +82,9 @@ describe('Prepair time series transformer', () => {
           { name: 'count', type: FieldType.number, values: [1, 2, 3, 4, 5, 6] },
         ],
         length: 6,
+        meta: {
+          type: DataFrameType.TimeSeriesMany,
+        },
       }),
       toEquableDataFrame({
         name: 'wide',
@@ -77,6 +94,9 @@ describe('Prepair time series transformer', () => {
           { name: 'more', type: FieldType.number, values: [2, 3, 4, 5, 6, 7] },
         ],
         length: 6,
+        meta: {
+          type: DataFrameType.TimeSeriesMany,
+        },
       }),
     ]);
   });
@@ -116,6 +136,9 @@ describe('Prepair time series transformer', () => {
           { name: 'count', type: FieldType.number, values: [1, 2, 3, 4, 5, 6] },
         ],
         length: 6,
+        meta: {
+          type: DataFrameType.TimeSeriesMany,
+        },
       }),
       toEquableDataFrame({
         name: 'wide',
@@ -125,6 +148,9 @@ describe('Prepair time series transformer', () => {
           { name: 'another', type: FieldType.number, values: [2, 3, 4, 5, 6, 7] },
         ],
         length: 6,
+        meta: {
+          type: DataFrameType.TimeSeriesMany,
+        },
       }),
       toEquableDataFrame({
         name: 'long',
@@ -134,6 +160,9 @@ describe('Prepair time series transformer', () => {
           { name: 'value', type: FieldType.number, values: [2, 3, 4, 5, 6, 7] },
         ],
         length: 6,
+        meta: {
+          type: DataFrameType.TimeSeriesMany,
+        },
       }),
     ]);
   });
@@ -163,7 +192,14 @@ describe('Prepair time series transformer', () => {
     };
 
     expect(toEquableDataFrames(prepareTimeSeriesTransformer.transformer(config)(source))).toEqual(
-      toEquableDataFrames(source)
+      toEquableDataFrames(
+        source.map((frame) => ({
+          ...frame,
+          meta: {
+            type: DataFrameType.TimeSeriesMany,
+          },
+        }))
+      )
     );
   });
 

--- a/public/app/core/components/TransformersUI/prepareTimeSeries/prepareTimeSeries.ts
+++ b/public/app/core/components/TransformersUI/prepareTimeSeries/prepareTimeSeries.ts
@@ -8,6 +8,7 @@ import {
   FieldMatcherID,
 } from '@grafana/data';
 import { map } from 'rxjs/operators';
+import { DataFrameType } from '../../../../../../packages/grafana-data/src/types/dataFrameTypes';
 
 /**
  * There is currently an effort to figure out consistent names
@@ -54,7 +55,10 @@ export function toTimeSeriesMany(data: DataFrame[]): DataFrame[] {
       result.push({
         name: frame.name,
         refId: frame.refId,
-        meta: frame.meta,
+        meta: {
+          ...frame.meta,
+          type: DataFrameType.TimeSeriesMany,
+        },
         fields: [timeField, field],
         length: frame.length,
       });

--- a/public/app/core/components/TransformersUI/prepareTimeSeries/prepareTimeSeries.ts
+++ b/public/app/core/components/TransformersUI/prepareTimeSeries/prepareTimeSeries.ts
@@ -1,6 +1,7 @@
 import {
   SynchronousDataTransformerInfo,
   DataFrame,
+  DataFrameType,
   FieldType,
   DataTransformerID,
   outerJoinDataFrames,
@@ -8,7 +9,6 @@ import {
   FieldMatcherID,
 } from '@grafana/data';
 import { map } from 'rxjs/operators';
-import { DataFrameType } from '../../../../../../packages/grafana-data/src/types/dataFrameTypes';
 
 /**
  * There is currently an effort to figure out consistent names


### PR DESCRIPTION
This exposes the changes in: https://github.com/grafana/grafana-plugin-sdk-go/pull/397 to the frontend structures

When the sdk is updated (not required for this PR) SQL queries will advertise themselves as "wide"


