### PR TITLE
OAuth: role/group (JMESPath) mapping prefer Userinfo as per doco

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -55,6 +55,8 @@ You can also specify the SSL/TLS configuration used by the client.
 
 Set `empty_scopes` to true to use an empty scope during authentication. By default, Grafana uses `user:email` as scope.
 
+### E-mail address
+
 Grafana will attempt to determine the user's e-mail address by querying the OAuth provider as described below in the following order until an e-mail address is found:
 
 1. Check for the presence of an e-mail address via the `email` field encoded in the OAuth `id_token` parameter.
@@ -64,6 +66,8 @@ Grafana will attempt to determine the user's e-mail address by querying the OAut
 1. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
 1. If no e-mail address is found in steps (1-4), then the e-mail address of the user is set to the empty string.
 
+### Roles & Groups
+
 Grafana will also attempt to do role mapping through OAuth as described below.
 
 Check for the presence of a role using the [JMESPath](http://jmespath.org/examples.html) specified via the `role_attribute_path` configuration option. The JSON used for the path lookup is the HTTP response obtained from querying the UserInfo endpoint specified via the `api_url` configuration option. The result after evaluating the `role_attribute_path` JMESPath expression needs to be a valid Grafana role, i.e. `Viewer`, `Editor` or `Admin`.
@@ -72,7 +76,11 @@ Grafana also attempts to map teams through OAuth as described below.
 
 Check for the presence of groups using the [JMESPath](http://jmespath.org/examples.html) specified via the `groups_attribute_path` configuration option. The JSON used for the path lookup is the HTTP response obtained from querying the UserInfo endpoint specified via the `api_url` configuration option. After evaluating the `groups_attribute_path` JMESPath expression, the result should be a string array of groups.
 
+In both cases, the JMESPath is attempted on the ID token as a fallback if it doesn't produce a value from the UserInfo.
+
 See [JMESPath examples](#jmespath-examples) for more information.
+
+### Login
 
 Customize user login using `login_attribute_path` configuration option. Order of operations is as follows:
 

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -326,18 +326,18 @@ func TestUserInfoSearchesForEmailAndRole(t *testing.T) {
 				ExpectedRole:      "",
 			},
 			{
-				Name: "Given a valid id_token, a valid role path, a valid API response, prefer id_token",
+				Name: "Given a valid id_token, a valid role path, a valid API response, prefer API response",
 				OAuth2Extra: map[string]interface{}{
-					// { "role": "Admin", "email": "john.doe@example.com" }
-					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiQWRtaW4iLCJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIn0.9PtHcCaXxZa2HDlASyKIaFGfOKlw2ILQo32xlvhvhRg",
+					// { "role": "FromIDToken", "email": "john.doe@example.com" }
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiRnJvbUlEVG9rZW4iLCJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIn0.yE6HUzUTIisCinGxL9x_jbsG5i9mzyDBHXrg11JTRus",
 				},
 				ResponseBody: map[string]interface{}{
-					"role":  "FromResponse",
+					"role":  "Editor",
 					"email": "from_response@example.com",
 				},
 				RoleAttributePath: "role",
 				ExpectedEmail:     "john.doe@example.com",
-				ExpectedRole:      "Admin",
+				ExpectedRole:      "Editor",
 			},
 			{
 				Name: "Given a valid id_token, an invalid role path, a valid API response, prefer id_token",
@@ -378,6 +378,35 @@ func TestUserInfoSearchesForEmailAndRole(t *testing.T) {
 				RoleAttributePath: "role",
 				ExpectedEmail:     "john.doe@example.com",
 				ExpectedRole:      "FromResponse",
+			},
+			{
+				Name: "Given a valid id_token with only email, a valid advanced JMESPath role path, a valid API response, derive the correct role using API response",
+				OAuth2Extra: map[string]interface{}{
+					// { "email": "john.doe@example.com" }
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIn0.k5GwPcZvGe2BE_jgwN0ntz0nz4KlYhEd0hRRLApkTJ4",
+				},
+				ResponseBody: map[string]interface{}{
+					"info": map[string]interface{}{
+						"roles": []string{"engineering", "SRE"},
+					},
+				},
+				RoleAttributePath: "contains(info.roles[*], 'SRE') && 'Editor'",
+				ExpectedEmail:     "john.doe@example.com",
+				ExpectedRole:      "Editor",
+			},
+			{
+				Name: "Given a valid id_token, a valid advanced JMESPath role path, a valid API response without the JMESpath key, derive the correct from id_token (with warning for API response)",
+				OAuth2Extra: map[string]interface{}{
+					// { "email": "john.doe@example.com",
+					//   "info": { "roles": [ "dev", "engineering" ] }}
+					"id_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwiaW5mbyI6eyJyb2xlcyI6WyJkZXYiLCJlbmdpbmVlcmluZyJdfX0.RmmQfv25eXb4p3wMrJsvXfGQ6EXhGtwRXo6SlCFHRNg",
+				},
+				ResponseBody: map[string]interface{}{
+					"role": "FromResponse",
+				},
+				RoleAttributePath: "contains(info.roles[*], 'dev') && 'Editor'",
+				ExpectedEmail:     "john.doe@example.com",
+				ExpectedRole:      "Editor",
 			},
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the search order for OAuth roles & group mappings to prefer the UserInfo as per the documentation.
Currently, the ID token is preferred which has caused confusion.

Using a valid Keycloak set-up based on the current documentation, was seeing errors along the lines:
```
lvl=eror msg="Failed to extract role" logger=oauth.generic_oauth error="failed to search user info JSON response with provided path: \"contains(groups[*], 'SRE') && 'Admin'\": Invalid type for: <nil>, expected: []jmespath.jpType{\"array\", \"string\"}"
```
After a bit of digging realised this was because Grafana was checking the ID token which didn't have the claim.


**Special notes for your reviewer**:
Added a line to documenation also stating the ID token is used as fallback in line with:
https://github.com/grafana/grafana/pull/20300#issuecomment-561063918