### PR TITLE
feat: added support set unix socket file mode and group

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -63,6 +63,15 @@ enable_gzip = false
 cert_file =
 cert_key =
 
+# Unix socket gid
+# Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
+# It is recommended to set the gid as http server user gid
+# Not set when the value is -1
+socket_gid = -1
+
+# Unix socket mode
+socket_mode = 0660
+
 # Unix socket path
 socket = /tmp/grafana.sock
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -64,6 +64,15 @@
 ;cert_file =
 ;cert_key =
 
+# Unix socket gid
+# Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
+# It is recommended to set the gid as http server user gid
+# Not set when the value is -1
+;socket_gid =
+
+# Unix socket mode
+;socket_mode =
+
 # Unix socket path
 ;socket =
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -253,9 +253,20 @@ Path to the certificate file (if `protocol` is set to `https` or `h2`).
 
 Path to the certificate key file (if `protocol` is set to `https` or `h2`).
 
+### socket_gid
+
+GID where the socket should be set when `protocol=socket`.
+Make sure that the target group is in the group of Grafana process and that Grafana process is the file owner before you change this setting.
+It is recommended to set the gid as http server user gid
+Not set when the value is -1
+
+### socket_mode
+
+Mode where the socket should be set when `protocol=socket`. Make sure that Grafana process is the file owner before you change this setting.
+
 ### socket
 
-Path where the socket should be created when `protocol=socket`. Make sure that Grafana has appropriate permissions before you change this setting.
+Path where the socket should be created when `protocol=socket`. Make sure Grafana has read and write permissions for that path before you change this setting.
 
 ### cdn_url
 

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -215,8 +215,14 @@ func (hs *HTTPServer) getListener() (net.Listener, error) {
 
 		// Make socket writable by group
 		// nolint:gosec
-		if err := os.Chmod(hs.Cfg.SocketPath, 0660); err != nil {
-			return nil, errutil.Wrapf(err, "failed to change socket permissions")
+		if err := os.Chmod(hs.Cfg.SocketPath, os.FileMode(hs.Cfg.SocketMode)); err != nil {
+			return nil, errutil.Wrapf(err, "failed to change socket mode %d", hs.Cfg.SocketMode)
+		}
+
+		// golang.org/pkg/os does not have chgrp
+		// Changing the gid of a file without privileges requires that the target group is in the group of the process and that the process is the file owner
+		if err := os.Chown(hs.Cfg.SocketPath, -1, hs.Cfg.SocketGid); err != nil {
+			return nil, errutil.Wrapf(err, "failed to change socket group id %d", hs.Cfg.SocketGid)
 		}
 
 		return listener, nil

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -196,6 +196,8 @@ type Cfg struct {
 	ServeFromSubPath bool
 	StaticRootPath   string
 	Protocol         Scheme
+	SocketGid        int
+	SocketMode       int
 	SocketPath       string
 	RouterLogging    bool
 	Domain           string
@@ -1423,6 +1425,14 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	}
 	if protocolStr == "socket" {
 		cfg.Protocol = SocketScheme
+		cfg.SocketGid, err = server.Key("socket_gid").Int()
+		if err != nil {
+			log.Fatalf(4, err.Error())
+		}
+		cfg.SocketMode, err = server.Key("socket_mode").Int()
+		if err != nil {
+			log.Fatalf(4, err.Error())
+		}
 		cfg.SocketPath = server.Key("socket").String()
 	}
 
@@ -1430,6 +1440,8 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	cfg.HTTPAddr = valueAsString(server, "http_addr", DefaultHTTPAddr)
 	cfg.HTTPPort = valueAsString(server, "http_port", "3000")
 	cfg.RouterLogging = server.Key("router_logging").MustBool(false)
+	cfg.SocketGid = server.Key("socket_gid").MustInt(-1)
+	cfg.SocketMode = server.Key("socket_mode").MustInt(0660)
 
 	cfg.EnableGzip = server.Key("enable_gzip").MustBool(false)
 	cfg.EnforceDomain = server.Key("enforce_domain").MustBool(false)


### PR DESCRIPTION
**What this PR does / why we need it**:

To customize the attributes of the socket file when it is listened by grafana, like file mode 0666.

**Which issue(s) this PR fixes**:

Fixes #27145

**Special notes for your reviewer**:

