### PR TITLE
Manually set query type in Tempo explore on component mount

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -64,10 +64,12 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
     });
 
     // Set initial query type to ensure traceID field appears
-    this.props.onChange({
-      ...this.props.query,
-      queryType: DEFAULT_QUERY_TYPE,
-    });
+    if (!this.props.query.queryType) {
+      this.props.onChange({
+        ...this.props.query,
+        queryType: DEFAULT_QUERY_TYPE,
+      });
+    }
   }
 
   onChangeLinkedQuery = (value: LokiQuery) => {
@@ -118,7 +120,7 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
           <InlineField label="Query type">
             <RadioButtonGroup<TempoQueryType>
               options={queryTypeOptions}
-              value={query.queryType || DEFAULT_QUERY_TYPE}
+              value={query.queryType}
               onChange={(v) =>
                 onChange({
                   ...query,

--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -62,6 +62,12 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
       serviceMapDatasourceUid: serviceMapDsUid,
       serviceMapDatasource: serviceMapDs as PrometheusDatasource,
     });
+
+    // Set initial query type to ensure traceID field appears
+    this.props.onChange({
+      ...this.props.query,
+      queryType: DEFAULT_QUERY_TYPE,
+    });
   }
 
   onChangeLinkedQuery = (value: LokiQuery) => {
@@ -97,7 +103,13 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
     }
 
     if (logsDatasourceUid) {
-      queryTypeOptions.push({ value: 'search', label: 'Loki Search' });
+      if (!config.featureToggles.tempoSearch) {
+        // Place at beginning as Search if no native search
+        queryTypeOptions.unshift({ value: 'search', label: 'Search' });
+      } else {
+        // Place at end as Loki Search if native search is enabled
+        queryTypeOptions.push({ value: 'search', label: 'Loki Search' });
+      }
     }
 
     return (


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the queryType on QueryField component did mount because it was previously not set, thus no input was rendered.

Also, if native search is not enabled, I put Loki search as the first option and name is Search to keep it as consistent as possible with previous versions. 

**Which issue(s) this PR fixes**:
Fixes #38407

**Special notes for your reviewer**:
This feels a bit hacky. Is there a way to define the default query when defining the datasource? Maybe I need to add a default to the TempoQuery type?