### PR TITLE
Annotation Panel: Fix annotation with end time not being centered

### DIFF
--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -140,7 +140,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
 
     const params: any = {
       from: this._timeOffset(anno.time, options.navigateBefore, true),
-      to: this._timeOffset(anno.time, options.navigateAfter, false),
+      to: this._timeOffset(anno.timeEnd ? anno.timeEnd : anno.time, options.navigateAfter, false),
     };
 
     if (options.navigateToPanel) {

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -140,7 +140,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
 
     const params: any = {
       from: this._timeOffset(anno.time, options.navigateBefore, true),
-      to: this._timeOffset(anno.timeEnd ? anno.timeEnd : anno.time, options.navigateAfter, false),
+      to: this._timeOffset(anno.timeEnd ?? anno.time, options.navigateAfter, false),
     };
 
     if (options.navigateToPanel) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes time range annotation not being correctly centered when clicking the item in the list. 
The time property was always used even if the timeEnd propety was defined to another date. While this is true for annotation on a single time range, it can't be applied to annotation with the timeEnd property. 

The fix uses the time property if the timeEnd property is not defined.

Before:
![image](https://user-images.githubusercontent.com/1786065/130367015-095699c1-a7a3-40b5-8e8c-e76c1b73a5e1.png)


After:

![image](https://user-images.githubusercontent.com/1786065/130367024-b50dcd0c-e059-4929-b131-f04b6a450941.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38422

**Special notes for your reviewer**:

