### PR TITLE
Alerting/Docs: Clarify NoData option

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -77,9 +77,9 @@ Toggle **Configure no data and error handling** switch to configure how the rule
 
 | No Data Option | Description                                                                                                 |
 | -------------- | ----------------------------------------------------------------------------------------------------------- |
-| No Data        | Set alert state to `NoData` and rule state to `Normal` (notifications will not be be sent on NoData states) |
-| Alerting       | Set alert rule state to `Alerting`                                                                          |
-| Ok             | Set alert rule state to `Normal`                                                                            |
+| No Data        | Set alert state to `NoData` and rule state to `Normal` (notifications are not sent on NoData states). |
+| Alerting       | Set alert rule state to `Alerting`.                                                                          |
+| Ok             | Set alert rule state to `Normal`.                                                                            |
 
 | Error or timeout option | Description                        |
 | ----------------------- | ---------------------------------- |

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -75,11 +75,11 @@ See or [expressions documentation]({{< relref "../../../panels/expressions.md" >
 
 Toggle **Configure no data and error handling** switch to configure how the rule should handle cases where evaluation results in error or returns no data.
 
-| No Data Option | Description                                            |
-| -------------- | ------------------------------------------------------ |
-| No Data        | Set alert state to `NoData` and rule state to `Normal` |
-| Alerting       | Set alert rule state to `Alerting`                     |
-| Ok             | Set alert rule state to `Normal`                       |
+| No Data Option | Description                                                                                                 |
+| -------------- | ----------------------------------------------------------------------------------------------------------- |
+| No Data        | Set alert state to `NoData` and rule state to `Normal` (notifications will not be be sent on NoData states) |
+| Alerting       | Set alert rule state to `Alerting`                                                                          |
+| Ok             | Set alert rule state to `Normal`                                                                            |
 
 | Error or timeout option | Description                        |
 | ----------------------- | ---------------------------------- |


### PR DESCRIPTION
**What this PR does / why we need it**:
Docs update to clarify that when the NoData option is set to NoData value, not notifications are not sent on NoData events.

**Which issue(s) this PR fixes**:

Fixes for #37665

**Special notes for your reviewer**:

