### PR TITLE
Pipeline: Revert a11y changes to fix publish frontend metrics step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -440,7 +440,6 @@ steps:
 - name: test-a11y-frontend
   image: buildkite/puppeteer
   commands:
-  - ./e2e/wait-for-grafana
   - yarn -s test:accessibility --json > pa11y-ci-results.json 1>&2
   environment:
     GRAFANA_MISC_STATS_API_KEY:
@@ -3577,6 +3576,6 @@ get:
 
 ---
 kind: signature
-hmac: ff4f66e40485ce90a3259d04ec562033e5b37013f0902d71a602c1a1572e1f27
+hmac: fc2618815f2265330f70494b9b57bce4e4e45a4301726778f7698ec7fe97504f
 
 ...

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -495,7 +495,6 @@ def test_a11y_frontend_step(edition, port=3001):
         },
         'failure': 'ignore',
         'commands': [
-            './e2e/wait-for-grafana',
             'yarn -s test:accessibility --json > pa11y-ci-results.json 1>&2',
         ],
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Revert changes done on this [PR](https://github.com/grafana/grafana/pull/38445), the docker image does not contain `nc`, and is causing publish frontend metrics to fail. 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

