### PR TITLE
Manually set query type in Tempo explore on component mount (#38408)

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -33,6 +33,14 @@ export class TempoQueryField extends React.PureComponent<Props, State> {
         linkedDatasource,
       });
     }
+
+    // Set initial query type to ensure traceID field appears
+    if (!this.props.query.queryType) {
+      this.props.onChange({
+        ...this.props.query,
+        queryType: DEFAULT_QUERY_TYPE,
+      });
+    }
   }
 
   onChangeLinkedQuery = (value: DataQuery) => {
@@ -60,7 +68,7 @@ export class TempoQueryField extends React.PureComponent<Props, State> {
                 { value: 'search', label: 'Search' },
                 { value: 'traceId', label: 'TraceID' },
               ]}
-              value={query.queryType || DEFAULT_QUERY_TYPE}
+              value={query.queryType}
               onChange={(v) =>
                 onChange({
                   ...query,


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the queryType on QueryField component did mount because it was previously not set, thus no input was rendered.

Also, if native search is not enabled, I put Loki search as the first option and name is Search to keep it as consistent as possible with previous versions.

Backport for #38408 