### PR TITLE
GraphNG: optimize measureText(), drop estimation for y-axis auto-sizing

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -143,8 +143,8 @@ function calculateAxisSize(self: uPlot, values: string[], axisIdx: number) {
   if (axis.side === 2) {
     axisSize += axis!.gap! + fontSize;
   } else if (values?.length) {
-    let longestValue = values.reduce((acc, value) => (value.length > acc.length ? value : acc), '');
-    axisSize += axis!.gap! + axis!.labelGap! + measureText('0'.repeat(longestValue.length), fontSize).width;
+    let maxTextWidth = values.reduce((acc, value) => Math.max(acc, measureText(value, fontSize).width), 0);
+    axisSize += axis!.gap! + axis!.labelGap! + maxTextWidth;
   }
 
   return Math.ceil(axisSize);


### PR DESCRIPTION
Fixes #37740

- switch from Object to Map() for text metrics cache
- set a cache size limit to fix unbounded cache growth
- create the global context2d eagerly, make the functions cheap
- remove guards around context creation (we likely would never have reached there anyways since canvas is used in a lot of places prior to any measureText() calls, and many other things would break if that failed...which i've never seen happen on contexts of tiny sizes that cannot exceed gpu texture limits - here the size is 0x0).
- reduce `context.font` mutation, it ain't cheap even if setting to same value.
- remove text size estimation [via text with most chars] from y-axis width autosizing. for streaming cases, our recommendation is to disable dynamic axis ranging anyhow, which would keep the labels stable across data updates and always hit the cache.