### PR TITLE
Chore: Add public/lib/monaco to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,4 @@ e2e/tmp
 public/build/
 public/sass/*.generated.scss
 devenv/
-public/lib
+public/lib/monaco

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ e2e/tmp
 public/build/
 public/sass/*.generated.scss
 devenv/
+public/lib


### PR DESCRIPTION
**What this PR does / why we need it**:

Prettifier fails locally, if the frontend has been build before it runs. This happens because there are some autogenerated typescript files under `public/lib/monaco` directory which make the `yarn run prettier:check` fail.

**Special notes for your reviewer**:

Try building frontend and then run `yarn run prettier:check` on main. The following error will appear:

```
> yarn run prettier:check                                                                                                      
yarn run v1.22.10
$ prettier --list-different "**/*.{ts,tsx,scss}"
public/lib/monaco/min/vs/language/kusto/monaco.contribution.d.ts
public/lib/monaco/min/vs/language/kusto/monaco.d.ts
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After ignoring the `public/lib` folder from being checked, everything runs normally.