### PR TITLE
Chore: Use most appropriate func for registering core plugins

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -79,7 +79,7 @@ func (s *CloudWatchService) Init() error {
 		QueryDataHandler: newExecutor(s.LogsService, im, s.Cfg, awsds.NewSessionCache()),
 	})
 
-	if err := s.BackendPluginManager.RegisterAndStart(context.Background(), "cloudwatch", factory); err != nil {
+	if err := s.BackendPluginManager.Register("cloudwatch", factory); err != nil {
 		plog.Error("Failed to register plugin", "error", err)
 	}
 	return nil

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -83,7 +83,7 @@ func (s *Service) Init() error {
 		QueryDataHandler: s,
 	})
 
-	if err := s.BackendPluginManager.RegisterAndStart(context.Background(), "graphite", factory); err != nil {
+	if err := s.BackendPluginManager.Register("graphite", factory); err != nil {
 		s.logger.Error("Failed to register plugin", "error", err)
 	}
 	return nil

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -58,7 +58,7 @@ func (s *Service) Init() error {
 		QueryDataHandler: s,
 	})
 
-	if err := s.BackendPluginManager.RegisterAndStart(context.Background(), "influxdb", factory); err != nil {
+	if err := s.BackendPluginManager.Register("influxdb", factory); err != nil {
 		glog.Error("Failed to register plugin", "error", err)
 	}
 

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -74,7 +74,7 @@ func (s *Service) Init() error {
 		QueryDataHandler: s,
 	})
 
-	if err := s.BackendPluginManager.RegisterAndStart(context.Background(), "loki", factory); err != nil {
+	if err := s.BackendPluginManager.Register("loki", factory); err != nil {
 		plog.Error("Failed to register plugin", "error", err)
 	}
 

--- a/pkg/tsdb/tempo/tempo.go
+++ b/pkg/tsdb/tempo/tempo.go
@@ -55,7 +55,7 @@ func (s *Service) Init() error {
 		QueryDataHandler: s,
 	})
 
-	if err := s.BackendPluginManager.RegisterAndStart(context.Background(), "tempo", factory); err != nil {
+	if err := s.BackendPluginManager.Register("tempo", factory); err != nil {
 		tlog.Error("Failed to register plugin", "error", err)
 	}
 

--- a/pkg/tsdb/testdatasource/testdata.go
+++ b/pkg/tsdb/testdatasource/testdata.go
@@ -1,7 +1,6 @@
 package testdatasource
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -38,7 +37,7 @@ func (p *testDataPlugin) Init() error {
 		CallResourceHandler: httpadapter.New(resourceMux),
 		StreamHandler:       newTestStreamHandler(p.logger),
 	})
-	err := p.BackendPluginManager.RegisterAndStart(context.Background(), "testdata", factory)
+	err := p.BackendPluginManager.Register("testdata", factory)
 	if err != nil {
 		p.logger.Error("Failed to register plugin", "error", err)
 	}


### PR DESCRIPTION
No functionality difference - but core plugins are never actually "started", they're just registered.

This API will be refactored in an upcoming PR