### PR TITLE
Alerting: Remove Multiorg alertmanager from the top-level services

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -385,7 +385,7 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		apiRoute.Get("/alert-notifiers", reqEditorRole, routing.Wrap(
-			GetAlertNotifiers(hs.MultiOrgAlertmanager != nil && hs.Cfg.IsNgAlertEnabled())),
+			GetAlertNotifiers(hs.Cfg.IsNgAlertEnabled())),
 		)
 
 		apiRoute.Group("/alert-notifications", func(alertNotifications routing.RouteRegister) {

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -42,7 +42,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/live/pushhttp"
 	"github.com/grafana/grafana/pkg/services/login"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/provisioning"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/rendering"
@@ -104,7 +103,6 @@ type HTTPServer struct {
 	PluginDashboardService *plugindashboards.Service               `inject:""`
 	AlertEngine            *alerting.AlertEngine                   `inject:""`
 	LoadSchemaService      *schemaloader.SchemaLoaderService       `inject:""`
-	MultiOrgAlertmanager   *notifier.MultiOrgAlertmanager          `inject:""`
 	LibraryPanelService    librarypanels.Service                   `inject:""`
 	LibraryElementService  libraryelements.Service                 `inject:""`
 	SocialService          social.Service                          `inject:""`


### PR DESCRIPTION
Removes the registration of the multi-org alertmanager, it is started as a subservice of ngalerting.