### PR TITLE
Chore: Update to golang:1.16.1-alpine3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.16.1-alpine3.13 as go-builder
+FROM golang:1.16.1-alpine3.14 as go-builder
 
 RUN apk add --no-cache gcc g++
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update golang alpine image to 3.14

