### PR TITLE
Alerting: Fix flake on test receiver tests

### DIFF
--- a/pkg/services/ngalert/notifier/receivers.go
+++ b/pkg/services/ngalert/notifier/receivers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"time"
 
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -126,6 +127,12 @@ func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 		for _, next := range m {
 			v.Receivers = append(v.Receivers, next)
 		}
+
+		// Make sure the return order is deterministic.
+		sort.Slice(v.Receivers, func(i, j int) bool {
+			return v.Receivers[i].Name < v.Receivers[i].Name
+		})
+
 		return v
 	}
 

--- a/pkg/services/ngalert/notifier/receivers.go
+++ b/pkg/services/ngalert/notifier/receivers.go
@@ -130,7 +130,7 @@ func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 
 		// Make sure the return order is deterministic.
 		sort.Slice(v.Receivers, func(i, j int) bool {
-			return v.Receivers[i].Name < v.Receivers[i].Name
+			return v.Receivers[i].Name < v.Receivers[j].Name
 		})
 
 		return v

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -329,6 +330,12 @@ func TestTestReceivers(t *testing.T) {
 		require.Len(t, result.Receivers, 2)
 		require.Len(t, result.Receivers[0].Configs, 1)
 		require.Len(t, result.Receivers[1].Configs, 1)
+
+		// Sort the results to guarantee the order below matches in terms of UIDs.
+		sort.Slice(result.Receivers, func(i, j int) bool {
+			return result.Receivers[i].Name < result.Receivers[j].Name
+		})
+
 		require.Equal(t, apimodels.TestReceiversResult{
 			Receivers: []apimodels.TestReceiverResult{{
 				Name: "receiver-1",

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -11,7 +11,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -330,12 +329,6 @@ func TestTestReceivers(t *testing.T) {
 		require.Len(t, result.Receivers, 2)
 		require.Len(t, result.Receivers[0].Configs, 1)
 		require.Len(t, result.Receivers[1].Configs, 1)
-
-		// Sort the results to guarantee the order below matches in terms of UIDs.
-		sort.Slice(result.Receivers, func(i, j int) bool {
-			return result.Receivers[i].Name < result.Receivers[j].Name
-		})
-
 		require.Equal(t, apimodels.TestReceiversResult{
 			Receivers: []apimodels.TestReceiverResult{{
 				Name: "receiver-1",


### PR DESCRIPTION
Fixes a flake that occurred in #38506 - it seems like we expect the results to be ordered otherwise the UID's won't match.