### PR TITLE
Live: allow connections with request host matching origin host

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -395,7 +395,7 @@ func getCheckOriginFunc(appURL *url.URL, originPatterns []string, originGlobs []
 			return false
 		}
 		if !ok {
-			logger.Warn("Request Origin is not authorized", "origin", origin, "appUrl", appURL.String(), "allowedOrigins", strings.Join(originPatterns, ","))
+			logger.Warn("Request Origin is not authorized", "origin", origin, "host", r.Host, "appUrl", appURL.String(), "allowedOrigins", strings.Join(originPatterns, ","))
 			return false
 		}
 		return true

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -381,7 +381,15 @@ func getCheckOriginFunc(appURL *url.URL, originPatterns []string, originGlobs []
 			// fast path for *.
 			return true
 		}
-		ok, err := checkAllowedOrigin(strings.ToLower(origin), appURL, originGlobs)
+		originURL, err := url.Parse(strings.ToLower(origin))
+		if err != nil {
+			logger.Warn("Failed to parse request origin", "error", err, "origin", origin)
+			return false
+		}
+		if strings.EqualFold(originURL.Host, r.Host) {
+			return true
+		}
+		ok, err := checkAllowedOrigin(origin, originURL, appURL, originGlobs)
 		if err != nil {
 			logger.Warn("Error parsing request origin", "error", err, "origin", origin)
 			return false
@@ -394,12 +402,7 @@ func getCheckOriginFunc(appURL *url.URL, originPatterns []string, originGlobs []
 	}
 }
 
-func checkAllowedOrigin(origin string, appURL *url.URL, originGlobs []glob.Glob) (bool, error) {
-	originURL, err := url.Parse(origin)
-	if err != nil {
-		logger.Warn("Failed to parse request origin", "error", err, "origin", origin)
-		return false, err
-	}
+func checkAllowedOrigin(origin string, originURL *url.URL, appURL *url.URL, originGlobs []glob.Glob) (bool, error) {
 	// Try to match over configured [server] root_url first.
 	if originURL.Port() == "" {
 		if strings.EqualFold(originURL.Scheme, appURL.Scheme) && strings.EqualFold(originURL.Host, appURL.Hostname()) {

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -62,6 +62,7 @@ func TestCheckOrigin(t *testing.T) {
 		appURL         string
 		allowedOrigins []string
 		success        bool
+		host           string
 	}{
 		{
 			name:    "empty_origin",
@@ -126,6 +127,13 @@ func TestCheckOrigin(t *testing.T) {
 			allowedOrigins: []string{"*"},
 			success:        true,
 		},
+		{
+			name:    "request_host_matches_origin_host",
+			origin:  "http://example.com",
+			appURL:  "https://example.com",
+			success: true,
+			host:    "example.com",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -141,6 +149,7 @@ func TestCheckOrigin(t *testing.T) {
 			checkOrigin := getCheckOriginFunc(appURL, tc.allowedOrigins, originGlobs)
 
 			r := httptest.NewRequest("GET", tc.appURL, nil)
+			r.Host = tc.host
 			r.Header.Set("Origin", tc.origin)
 			require.Equal(t, tc.success, checkOrigin(r),
 				"origin %s, appURL: %s", tc.origin, tc.appURL,


### PR DESCRIPTION
In Grafana 8.0 we looked at request.Host to match request Origin host to allow WebSocket connections. This did not work for some cases and required additional setup on load balancer level, so we changed the behavior in Grafana v8.0.4 to match with 
 `root_url` (this works, but again - not automatically and requires configuration changes in some cases, also some users experience problems migrating from v8.0.3 to later Grafana versions).

I think that instead of changing the behaviour we had to make it additional. This pull request combines both approaches.