### PR TITLE
Loki: Fix ad-hoc filter in dashboard when used with parser

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -416,21 +416,11 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
     let expression = query.expr ?? '';
     switch (action.type) {
       case 'ADD_FILTER': {
-        // Temporary fix for log queries that use parser. We don't know which labels are parsed and which are actual labels.
-        // If query has parser, we treat all labels as parsed and use | key="value" syntax (same in ADD_FILTER_OUT)
-        if (queryHasPipeParser(expression) && !isMetricsQuery(expression)) {
-          expression = addParsedLabelToQuery(expression, action.key, action.value, '=');
-        } else {
-          expression = addLabelToQuery(expression, action.key, action.value, undefined, true);
-        }
+        expression = this.addLabelToQuery(expression, action.key, action.value, '=');
         break;
       }
       case 'ADD_FILTER_OUT': {
-        if (queryHasPipeParser(expression) && !isMetricsQuery(expression)) {
-          expression = addParsedLabelToQuery(expression, action.key, action.value, '!=');
-        } else {
-          expression = addLabelToQuery(expression, action.key, action.value, '!=', true);
-        }
+        expression = this.addLabelToQuery(expression, action.key, action.value, '!=');
         break;
       }
       default:
@@ -674,10 +664,19 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
       if (operator === '=~' || operator === '!~') {
         value = lokiRegularEscape(value);
       }
-      return addLabelToQuery(acc, key, value, operator);
+
+      return this.addLabelToQuery(acc, key, value, operator);
     }, expr);
 
     return expr;
+  }
+
+  addLabelToQuery(queryExpr: string, key: string, value: string | number, operator: string) {
+    if (queryHasPipeParser(queryExpr) && !isMetricsQuery(queryExpr)) {
+      // If query has parser, we treat all labels as parsed and use | key="value" syntax
+    } else {
+      return addLabelToQuery(queryExpr, key, value, operator, true);
+    }
   }
 }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -674,6 +674,7 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   addLabelToQuery(queryExpr: string, key: string, value: string | number, operator: string) {
     if (queryHasPipeParser(queryExpr) && !isMetricsQuery(queryExpr)) {
       // If query has parser, we treat all labels as parsed and use | key="value" syntax
+      return addParsedLabelToQuery(queryExpr, key, value, operator);
     } else {
       return addLabelToQuery(queryExpr, key, value, operator, true);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes adhoc filtering in dashboard.  To fix this, we are re-using logic from ad-hoc filtering in Explore logs/Table. I have extracted the logic into new method and re-used it on both places. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/38530

**How to test this**:
1. Create dashboard
2. Create loki logs panel with following query `{job="grafana"} | logfmt | line_format {{.some_field}}`
3. Create loki logs panel with following query `{job="grafana"}`
4. Create loki metrics panel with following query `rate({job="grafana"}[5m]) `
5. Create and add ad-hoc variable filter
6. No queries should error

![image](https://user-images.githubusercontent.com/30407135/130774428-99b1df6f-caac-4935-bc38-c1a6c59d7dc9.png)
![image](https://user-images.githubusercontent.com/30407135/130774693-569de53b-bb62-463b-be0c-796f7dfb1955.png)
![image](https://user-images.githubusercontent.com/30407135/130774751-e70ccce1-3957-4c36-bd63-23db7d55add0.png)



