### PR TITLE
Jaeger: fix bug where query is executed twice

### DIFF
--- a/e2e/suite1/specs/trace-view-scrolling.spec.ts
+++ b/e2e/suite1/specs/trace-view-scrolling.spec.ts
@@ -21,7 +21,9 @@ describe('Trace view', () => {
 
     e2e.components.QueryField.container().should('be.visible').type('long-trace');
 
-    e2e.components.RefreshPicker.runButton().should('be.visible').focus();
+    e2e().wait(500);
+
+    e2e.components.RefreshPicker.runButton().should('be.visible').click();
 
     e2e().wait('@longTrace');
 

--- a/public/app/plugins/datasource/jaeger/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/jaeger/components/QueryEditor.tsx
@@ -40,6 +40,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
                 query={query.query}
                 onChange={onChangeQuery}
                 onRunQuery={onRunQuery}
+                onBlur={() => {}}
                 placeholder={'Enter a Trace ID (run with Shift+Enter)'}
                 portalOrigin="jaeger"
               />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes the bug where the query is run twice when pressing the Run Query button which was introduced in #37958

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38541

**Special notes for your reviewer:**
The bug is caused by the query being run onBlur so an empty callback function was added to prevent this
