### PR TITLE
Plugins Catalog: add signature information to details

### DIFF
--- a/public/app/features/plugins/admin/components/PluginBadges.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginBadges.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { PluginSignatureStatus } from '@grafana/data';
-import { PluginBadges } from './PluginBadges';
+import { PluginListBadges } from './PluginListBadges';
 import { CatalogPlugin } from '../types';
 import { config } from '@grafana/runtime';
 
@@ -35,13 +35,13 @@ describe('PluginBadges', () => {
   });
 
   it('renders a plugin signature badge', () => {
-    render(<PluginBadges plugin={plugin} />);
+    render(<PluginListBadges plugin={plugin} />);
 
     expect(screen.getByText(/signed/i)).toBeVisible();
   });
 
   it('renders an installed badge', () => {
-    render(<PluginBadges plugin={{ ...plugin, isInstalled: true }} />);
+    render(<PluginListBadges plugin={{ ...plugin, isInstalled: true }} />);
 
     expect(screen.getByText(/signed/i)).toBeVisible();
     expect(screen.getByText(/installed/i)).toBeVisible();
@@ -49,14 +49,14 @@ describe('PluginBadges', () => {
 
   it('renders an enterprise badge (when a license is valid)', () => {
     config.licenseInfo.hasValidLicense = true;
-    render(<PluginBadges plugin={{ ...plugin, isEnterprise: true }} />);
+    render(<PluginListBadges plugin={{ ...plugin, isEnterprise: true }} />);
     expect(screen.getByText(/enterprise/i)).toBeVisible();
     expect(screen.queryByRole('button', { name: /learn more/i })).not.toBeInTheDocument();
   });
 
   it('renders an enterprise badge with icon and link (when a license is invalid)', () => {
     config.licenseInfo.hasValidLicense = false;
-    render(<PluginBadges plugin={{ ...plugin, isEnterprise: true }} />);
+    render(<PluginListBadges plugin={{ ...plugin, isEnterprise: true }} />);
     expect(screen.getByText(/enterprise/i)).toBeVisible();
     expect(screen.getByLabelText(/lock icon/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /learn more/i })).toBeInTheDocument();

--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -4,6 +4,7 @@ import { css, cx } from '@emotion/css';
 import { AppPlugin, GrafanaTheme2, GrafanaPlugin, PluginMeta } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
+import { PLUGIN_TAB_LABELS } from '../constants';
 import { VersionList } from '../components/VersionList';
 import { AppConfigCtrlWrapper } from '../../wrappers/AppConfigWrapper';
 import { PluginDashboards } from '../../PluginDashboards';
@@ -18,7 +19,7 @@ type PluginDetailsBodyProps = {
 export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: PluginDetailsBodyProps): JSX.Element | null {
   const styles = useStyles2(getStyles);
 
-  if (tab?.label === 'Overview') {
+  if (tab?.label === PLUGIN_TAB_LABELS.OVERVIEW) {
     return (
       <div
         className={cx(styles.readme, styles.container)}
@@ -27,7 +28,7 @@ export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: Plugi
     );
   }
 
-  if (tab?.label === 'Version history') {
+  if (tab?.label === PLUGIN_TAB_LABELS.VERSIONS) {
     return (
       <div className={styles.container}>
         <VersionList versions={remoteVersions ?? []} />
@@ -35,7 +36,7 @@ export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: Plugi
     );
   }
 
-  if (tab?.label === 'Config' && plugin?.angularConfigCtrl) {
+  if (tab?.label === PLUGIN_TAB_LABELS.CONFIG && plugin?.angularConfigCtrl) {
     return (
       <div className={styles.container}>
         <AppConfigCtrlWrapper app={plugin as AppPlugin} />
@@ -55,7 +56,7 @@ export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: Plugi
     }
   }
 
-  if (tab?.label === 'Dashboards' && plugin) {
+  if (tab?.label === PLUGIN_TAB_LABELS.DASHBOARDS && plugin) {
     return (
       <div className={styles.container}>
         <PluginDashboards plugin={plugin.meta} />

--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -4,7 +4,7 @@ import { css, cx } from '@emotion/css';
 import { AppPlugin, GrafanaTheme2, GrafanaPlugin, PluginMeta } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-import { PLUGIN_TAB_LABELS } from '../constants';
+import { PluginTabLabels } from '../types';
 import { VersionList } from '../components/VersionList';
 import { AppConfigCtrlWrapper } from '../../wrappers/AppConfigWrapper';
 import { PluginDashboards } from '../../PluginDashboards';
@@ -19,7 +19,7 @@ type PluginDetailsBodyProps = {
 export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: PluginDetailsBodyProps): JSX.Element | null {
   const styles = useStyles2(getStyles);
 
-  if (tab?.label === PLUGIN_TAB_LABELS.OVERVIEW) {
+  if (tab?.label === PluginTabLabels.OVERVIEW) {
     return (
       <div
         className={cx(styles.readme, styles.container)}
@@ -28,7 +28,7 @@ export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: Plugi
     );
   }
 
-  if (tab?.label === PLUGIN_TAB_LABELS.VERSIONS) {
+  if (tab?.label === PluginTabLabels.VERSIONS) {
     return (
       <div className={styles.container}>
         <VersionList versions={remoteVersions ?? []} />
@@ -36,7 +36,7 @@ export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: Plugi
     );
   }
 
-  if (tab?.label === PLUGIN_TAB_LABELS.CONFIG && plugin?.angularConfigCtrl) {
+  if (tab?.label === PluginTabLabels.CONFIG && plugin?.angularConfigCtrl) {
     return (
       <div className={styles.container}>
         <AppConfigCtrlWrapper app={plugin as AppPlugin} />
@@ -56,7 +56,7 @@ export function PluginDetailsBody({ tab, plugin, remoteVersions, readme }: Plugi
     }
   }
 
-  if (tab?.label === PLUGIN_TAB_LABELS.DASHBOARDS && plugin) {
+  if (tab?.label === PluginTabLabels.DASHBOARDS && plugin) {
     return (
       <div className={styles.container}>
         <PluginDashboards plugin={plugin.meta} />

--- a/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
@@ -19,7 +19,7 @@ export function PluginDetailsHeader({ pluginId, parentUrl, currentUrl }: Props):
   const { state, dispatch } = usePluginDetails(pluginId!);
   const { plugin, pluginConfig, isInflight, hasUpdate, isInstalled, hasInstalledPanel } = state;
 
-  if (!plugin || !pluginConfig) {
+  if (!plugin) {
     return null;
   }
 
@@ -76,7 +76,7 @@ export function PluginDetailsHeader({ pluginId, parentUrl, currentUrl }: Props):
           {plugin.version && <span>{plugin.version}</span>}
 
           {/* Signature information */}
-          <PluginDetailsHeaderSignature plugin={pluginConfig} />
+          <PluginDetailsHeaderSignature installedPlugin={pluginConfig} />
         </div>
 
         <p>{plugin.description}</p>

--- a/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, Icon } from '@grafana/ui';
+
+import { InstallControls } from './InstallControls';
+import { usePluginDetails } from '../hooks/usePluginDetails';
+import { PluginDetailsHeaderSignature } from './PluginDetailsHeaderSignature';
+import { PluginLogo } from './PluginLogo';
+
+type Props = {
+  parentUrl: string;
+  currentUrl: string;
+  pluginId?: string;
+};
+
+export const PluginDetailsHeader = ({ pluginId, parentUrl, currentUrl }: Props) => {
+  const styles = useStyles2(getStyles);
+  const { state, dispatch } = usePluginDetails(pluginId!);
+  const { plugin, pluginConfig, isInflight, hasUpdate, isInstalled, hasInstalledPanel } = state;
+
+  if (!plugin || !pluginConfig) {
+    return null;
+  }
+
+  return (
+    <div className={styles.headerContainer}>
+      <PluginLogo
+        alt={`${plugin.name} logo`}
+        src={plugin.info.logos.small}
+        className={css`
+          object-fit: contain;
+          width: 100%;
+          height: 68px;
+          max-width: 68px;
+        `}
+      />
+
+      <div className={styles.headerWrapper}>
+        {/* Title & navigation */}
+        <nav className={styles.breadcrumb} aria-label="Breadcrumb">
+          <ol>
+            <li>
+              <a className={styles.textUnderline} href={parentUrl}>
+                Plugins
+              </a>
+            </li>
+            <li>
+              <a href={currentUrl} aria-current="page">
+                {plugin.name}
+              </a>
+            </li>
+          </ol>
+        </nav>
+
+        <div className={styles.headerInformation}>
+          {/* Org name */}
+          <span>{plugin.orgName}</span>
+
+          {/* Links */}
+          {plugin.links.map((link: any) => (
+            <a key={link.name} href={link.url}>
+              {link.name}
+            </a>
+          ))}
+
+          {/* Downloads */}
+          {plugin.downloads > 0 && (
+            <span>
+              <Icon name="cloud-download" />
+              {` ${new Intl.NumberFormat().format(plugin.downloads)}`}{' '}
+            </span>
+          )}
+
+          {/* Latest version */}
+          {plugin.version && <span>{plugin.version}</span>}
+
+          {/* Signature information */}
+          <PluginDetailsHeaderSignature plugin={pluginConfig} />
+        </div>
+
+        <p>{plugin.description}</p>
+
+        <InstallControls
+          plugin={plugin}
+          isInflight={isInflight}
+          hasUpdate={hasUpdate}
+          isInstalled={isInstalled}
+          hasInstalledPanel={hasInstalledPanel}
+          dispatch={dispatch}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    headerContainer: css`
+      display: flex;
+      margin-bottom: ${theme.spacing(3)};
+      margin-top: ${theme.spacing(3)};
+      min-height: 120px;
+    `,
+    headerWrapper: css`
+      margin-left: ${theme.spacing(3)};
+    `,
+    breadcrumb: css`
+      font-size: ${theme.typography.h2.fontSize};
+      li {
+        display: inline;
+        list-style: none;
+        &::after {
+          content: '/';
+          padding: 0 0.25ch;
+        }
+        &:last-child::after {
+          content: '';
+        }
+      }
+    `,
+    headerInformation: css`
+      display: flex;
+      align-items: center;
+      margin-top: ${theme.spacing()};
+      margin-bottom: ${theme.spacing(3)};
+
+      & > * {
+        &::after {
+          content: '|';
+          padding: 0 ${theme.spacing()};
+        }
+        &:last-child::after {
+          content: '';
+          padding-right: 0;
+        }
+      }
+      font-size: ${theme.typography.h4.fontSize};
+    `,
+    headerOrgName: css`
+      font-size: ${theme.typography.h4.fontSize};
+    `,
+    signature: css`
+      margin: ${theme.spacing(3)};
+      margin-bottom: 0;
+    `,
+    textUnderline: css`
+      text-decoration: underline;
+    `,
+  };
+};

--- a/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
@@ -14,7 +14,7 @@ type Props = {
   pluginId?: string;
 };
 
-export const PluginDetailsHeader = ({ pluginId, parentUrl, currentUrl }: Props) => {
+export function PluginDetailsHeader({ pluginId, parentUrl, currentUrl }: Props): React.ReactElement | null {
   const styles = useStyles2(getStyles);
   const { state, dispatch } = usePluginDetails(pluginId!);
   const { plugin, pluginConfig, isInflight, hasUpdate, isInstalled, hasInstalledPanel } = state;
@@ -92,7 +92,7 @@ export const PluginDetailsHeader = ({ pluginId, parentUrl, currentUrl }: Props) 
       </div>
     </div>
   );
-};
+}
 
 export const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/plugins/admin/components/PluginDetailsHeaderSignature.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeaderSignature.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 // Designed to show plugin signature information in the header on the plugin's details page
-export const PluginDetailsHeaderSignature = ({ plugin, className }: Props) => {
+export function PluginDetailsHeaderSignature({ plugin, className }: Props): React.ReactElement | null {
   const isSignatureValid = plugin.meta.signature === PluginSignatureStatus.valid;
 
   return (
@@ -26,4 +26,4 @@ export const PluginDetailsHeaderSignature = ({ plugin, className }: Props) => {
       )}
     </div>
   );
-};
+}

--- a/public/app/features/plugins/admin/components/PluginDetailsHeaderSignature.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeaderSignature.tsx
@@ -4,24 +4,27 @@ import { PluginSignatureBadge } from '@grafana/ui';
 import { PluginSignatureDetailsBadge } from './PluginSignatureDetailsBadge';
 
 type Props = {
-  className?: string;
-  plugin: GrafanaPlugin<PluginMeta<{}>>;
+  installedPlugin?: GrafanaPlugin<PluginMeta<{}>>;
 };
 
 // Designed to show plugin signature information in the header on the plugin's details page
-export function PluginDetailsHeaderSignature({ plugin, className }: Props): React.ReactElement | null {
-  const isSignatureValid = plugin.meta.signature === PluginSignatureStatus.valid;
+export function PluginDetailsHeaderSignature({ installedPlugin }: Props): React.ReactElement | null {
+  if (!installedPlugin) {
+    return null;
+  }
+
+  const isSignatureValid = installedPlugin.meta.signature === PluginSignatureStatus.valid;
 
   return (
     <div>
       <a href="https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/" target="_blank" rel="noreferrer">
-        <PluginSignatureBadge status={plugin.meta.signature} />
+        <PluginSignatureBadge status={installedPlugin.meta.signature} />
       </a>
 
       {isSignatureValid && (
         <PluginSignatureDetailsBadge
-          signatureType={plugin.meta.signatureType}
-          signatureOrg={plugin.meta.signatureOrg}
+          signatureType={installedPlugin.meta.signatureType}
+          signatureOrg={installedPlugin.meta.signatureOrg}
         />
       )}
     </div>

--- a/public/app/features/plugins/admin/components/PluginDetailsHeaderSignature.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeaderSignature.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { GrafanaPlugin, PluginMeta, PluginSignatureStatus } from '@grafana/data';
+import { PluginSignatureBadge } from '@grafana/ui';
+import { PluginSignatureDetailsBadge } from './PluginSignatureDetailsBadge';
+
+type Props = {
+  className?: string;
+  plugin: GrafanaPlugin<PluginMeta<{}>>;
+};
+
+// Designed to show plugin signature information in the header on the plugin's details page
+export const PluginDetailsHeaderSignature = ({ plugin, className }: Props) => {
+  const isSignatureValid = plugin.meta.signature === PluginSignatureStatus.valid;
+
+  return (
+    <div>
+      <a href="https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/" target="_blank" rel="noreferrer">
+        <PluginSignatureBadge status={plugin.meta.signature} />
+      </a>
+
+      {isSignatureValid && (
+        <PluginSignatureDetailsBadge
+          signatureType={plugin.meta.signatureType}
+          signatureOrg={plugin.meta.signatureOrg}
+        />
+      )}
+    </div>
+  );
+};

--- a/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { selectors } from '@grafana/e2e-selectors';
+import { GrafanaPlugin, PluginMeta, PluginSignatureStatus } from '@grafana/data';
+import { Alert } from '@grafana/ui';
+
+type PluginDetailsSignatureProps = {
+  className?: string;
+  plugin: GrafanaPlugin<PluginMeta<{}>>;
+};
+
+// Designed to show signature information inside the active tab on the plugin's details page
+export const PluginDetailsSignature = ({ plugin, className }: PluginDetailsSignatureProps) => {
+  const isSignatureValid = plugin.meta.signature === PluginSignatureStatus.valid;
+  const isCore = plugin.meta.signature === PluginSignatureStatus.internal;
+
+  // The basic information is already available in the header
+  if (isSignatureValid || isCore) {
+    return null;
+  }
+
+  return (
+    <Alert
+      severity="warning"
+      title="Invlaid plugin signature"
+      aria-label={selectors.pages.PluginPage.signatureInfo}
+      className={className}
+    >
+      <p>
+        Grafana Labs checks each plugin to verify that it has a valid digital signature. Plugin signature verification
+        is part of our security measures to ensure plugins are safe and trustworthy. Grafana Labs can’t guarantee the
+        integrity of this unsigned plugin. Ask the plugin author to request it to be signed.
+      </p>
+
+      <a
+        href="https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/"
+        className="external-link"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Read more about plugins signing.
+      </a>
+    </Alert>
+  );
+};

--- a/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
@@ -5,13 +5,20 @@ import { Alert } from '@grafana/ui';
 
 type PluginDetailsSignatureProps = {
   className?: string;
-  plugin: GrafanaPlugin<PluginMeta<{}>>;
+  installedPlugin?: GrafanaPlugin<PluginMeta<{}>>;
 };
 
 // Designed to show signature information inside the active tab on the plugin's details page
-export function PluginDetailsSignature({ plugin, className }: PluginDetailsSignatureProps): React.ReactElement | null {
-  const isSignatureValid = plugin.meta.signature === PluginSignatureStatus.valid;
-  const isCore = plugin.meta.signature === PluginSignatureStatus.internal;
+export function PluginDetailsSignature({
+  className,
+  installedPlugin,
+}: PluginDetailsSignatureProps): React.ReactElement | null {
+  if (!installedPlugin) {
+    return null;
+  }
+
+  const isSignatureValid = installedPlugin.meta.signature === PluginSignatureStatus.valid;
+  const isCore = installedPlugin.meta.signature === PluginSignatureStatus.internal;
 
   // The basic information is already available in the header
   if (isSignatureValid || isCore) {

--- a/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
@@ -21,7 +21,7 @@ export function PluginDetailsSignature({ plugin, className }: PluginDetailsSigna
   return (
     <Alert
       severity="warning"
-      title="Invlaid plugin signature"
+      title="Invalid plugin signature"
       aria-label={selectors.pages.PluginPage.signatureInfo}
       className={className}
     >

--- a/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsSignature.tsx
@@ -9,7 +9,7 @@ type PluginDetailsSignatureProps = {
 };
 
 // Designed to show signature information inside the active tab on the plugin's details page
-export const PluginDetailsSignature = ({ plugin, className }: PluginDetailsSignatureProps) => {
+export function PluginDetailsSignature({ plugin, className }: PluginDetailsSignatureProps): React.ReactElement | null {
   const isSignatureValid = plugin.meta.signature === PluginSignatureStatus.valid;
   const isCore = plugin.meta.signature === PluginSignatureStatus.internal;
 
@@ -41,4 +41,4 @@ export const PluginDetailsSignature = ({ plugin, className }: PluginDetailsSigna
       </a>
     </Alert>
   );
-};
+}

--- a/public/app/features/plugins/admin/components/PluginListBadges.tsx
+++ b/public/app/features/plugins/admin/components/PluginListBadges.tsx
@@ -9,9 +9,9 @@ type PluginBadgeType = {
   plugin: CatalogPlugin;
 };
 
-export function PluginBadges({ plugin }: PluginBadgeType) {
+export function PluginListBadges({ plugin }: PluginBadgeType) {
   if (plugin.isEnterprise) {
-    return <EnterpriseBadge id={plugin.id} />;
+    return <EnterpriseBadge plugin={plugin} />;
   }
   return (
     <HorizontalGroup>
@@ -21,12 +21,12 @@ export function PluginBadges({ plugin }: PluginBadgeType) {
   );
 }
 
-function EnterpriseBadge({ id }: { id: string }) {
+function EnterpriseBadge({ plugin }: { plugin: CatalogPlugin }) {
   const customBadgeStyles = useStyles2(getBadgeColor);
   const onClick = (ev: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     ev.preventDefault();
     window.open(
-      `https://grafana.com/grafana/plugins/${id}?utm_source=grafana_catalog_learn_more`,
+      `https://grafana.com/grafana/plugins/${plugin.id}?utm_source=grafana_catalog_learn_more`,
       '_blank',
       'noopener,noreferrer'
     );
@@ -38,6 +38,7 @@ function EnterpriseBadge({ id }: { id: string }) {
 
   return (
     <HorizontalGroup>
+      <PluginSignatureBadge status={plugin.signature} />
       <Badge icon="lock" aria-label="lock icon" text="Enterprise" color="blue" className={customBadgeStyles} />
       <Button size="sm" fill="text" icon="external-link-alt" onClick={onClick}>
         Learn more

--- a/public/app/features/plugins/admin/components/PluginListCard.tsx
+++ b/public/app/features/plugins/admin/components/PluginListCard.tsx
@@ -4,7 +4,7 @@ import { Icon, useStyles2, CardContainer, VerticalGroup } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { CatalogPlugin } from '../types';
 import { PluginLogo } from './PluginLogo';
-import { PluginBadges } from './PluginBadges';
+import { PluginListBadges } from './PluginListBadges';
 
 const LOGO_SIZE = '48px';
 
@@ -42,7 +42,7 @@ export function PluginListCard({ plugin, pathName }: PluginListCardProps) {
           )}
         </div>
         <p className={styles.orgName}>By {orgName}</p>
-        <PluginBadges plugin={plugin} />
+        <PluginListBadges plugin={plugin} />
       </VerticalGroup>
     </CardContainer>
   );

--- a/public/app/features/plugins/admin/components/PluginSignatureDetailsBadge.tsx
+++ b/public/app/features/plugins/admin/components/PluginSignatureDetailsBadge.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { capitalize } from 'lodash';
+import { GrafanaTheme2, PluginSignatureType } from '@grafana/data';
+import { useStyles2, Icon, Badge, IconName } from '@grafana/ui';
+
+const SIGNATURE_ICONS: Record<string, IconName> = {
+  [PluginSignatureType.grafana]: 'grafana',
+  [PluginSignatureType.commercial]: 'shield',
+  [PluginSignatureType.community]: 'shield',
+  DEFAULT: 'shield-exclamation',
+};
+
+type PluginSignatureDetailsBadgeProps = {
+  signatureType?: PluginSignatureType;
+  signatureOrg?: string;
+};
+
+// Shows more information about a valid signature
+export const PluginSignatureDetailsBadge: React.FC<PluginSignatureDetailsBadgeProps> = ({
+  signatureType = '',
+  signatureOrg = '',
+}) => {
+  const styles = useStyles2(getStyles);
+
+  if (!signatureType && !signatureOrg) {
+    return null;
+  }
+
+  const signatureTypeText = signatureType === PluginSignatureType.grafana ? 'Grafana Labs' : capitalize(signatureType);
+
+  return (
+    <>
+      <DetailsBadge>
+        <strong className={styles.strong}>Level:&nbsp;</strong>
+        <Icon size="xs" name={SIGNATURE_ICONS[signatureType] || SIGNATURE_ICONS.DEFAULT} />
+        &nbsp;
+        {signatureTypeText}
+      </DetailsBadge>
+
+      <DetailsBadge>
+        <strong className={styles.strong}>Signed by:</strong> {signatureOrg}
+      </DetailsBadge>
+    </>
+  );
+};
+
+export const DetailsBadge: React.FC = ({ children }) => {
+  const styles = useStyles2(getStyles);
+
+  return <Badge color="green" className={styles.badge} text={<>{children}</>} />;
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  badge: css`
+    background-color: ${theme.colors.background.canvas};
+    border-color: ${theme.colors.border.strong};
+    color: ${theme.colors.text.secondary};
+    margin-left: ${theme.spacing()};
+  `,
+  strong: css`
+    color: ${theme.colors.text.primary};
+  `,
+  icon: css`
+    margin-right: ${theme.spacing(0.5)};
+  `,
+});

--- a/public/app/features/plugins/admin/components/PluginSignatureDetailsBadge.tsx
+++ b/public/app/features/plugins/admin/components/PluginSignatureDetailsBadge.tsx
@@ -11,16 +11,13 @@ const SIGNATURE_ICONS: Record<string, IconName> = {
   DEFAULT: 'shield-exclamation',
 };
 
-type PluginSignatureDetailsBadgeProps = {
+type Props = {
   signatureType?: PluginSignatureType;
   signatureOrg?: string;
 };
 
 // Shows more information about a valid signature
-export const PluginSignatureDetailsBadge: React.FC<PluginSignatureDetailsBadgeProps> = ({
-  signatureType = '',
-  signatureOrg = '',
-}) => {
+export function PluginSignatureDetailsBadge({ signatureType, signatureOrg = '' }: Props): React.ReactElement | null {
   const styles = useStyles2(getStyles);
 
   if (!signatureType && !signatureOrg) {
@@ -28,12 +25,13 @@ export const PluginSignatureDetailsBadge: React.FC<PluginSignatureDetailsBadgePr
   }
 
   const signatureTypeText = signatureType === PluginSignatureType.grafana ? 'Grafana Labs' : capitalize(signatureType);
+  const signatureIcon = SIGNATURE_ICONS[signatureType || ''] || SIGNATURE_ICONS.DEFAULT;
 
   return (
     <>
       <DetailsBadge>
         <strong className={styles.strong}>Level:&nbsp;</strong>
-        <Icon size="xs" name={SIGNATURE_ICONS[signatureType] || SIGNATURE_ICONS.DEFAULT} />
+        <Icon size="xs" name={signatureIcon} />
         &nbsp;
         {signatureTypeText}
       </DetailsBadge>
@@ -43,7 +41,7 @@ export const PluginSignatureDetailsBadge: React.FC<PluginSignatureDetailsBadgePr
       </DetailsBadge>
     </>
   );
-};
+}
 
 export const DetailsBadge: React.FC = ({ children }) => {
   const styles = useStyles2(getStyles);

--- a/public/app/features/plugins/admin/constants.ts
+++ b/public/app/features/plugins/admin/constants.ts
@@ -1,8 +1,8 @@
 export const API_ROOT = '/api/plugins';
 export const GRAFANA_API_ROOT = '/api/gnet';
-export const PLUGIN_TAB_LABELS = {
-  OVERVIEW: 'Overview',
-  VERSIONS: 'Version history',
-  CONFIG: 'Config',
-  DASHBOARDS: 'Dashboards',
-};
+export enum PLUGIN_TAB_LABELS {
+  OVERVIEW = 'Overview',
+  VERSIONS = 'Version history',
+  CONFIG = 'Config',
+  DASHBOARDS = 'Dashboards',
+}

--- a/public/app/features/plugins/admin/constants.ts
+++ b/public/app/features/plugins/admin/constants.ts
@@ -1,2 +1,8 @@
 export const API_ROOT = '/api/plugins';
 export const GRAFANA_API_ROOT = '/api/gnet';
+export const PLUGIN_TAB_LABELS = {
+  OVERVIEW: 'Overview',
+  VERSIONS: 'Version history',
+  CONFIG: 'Config',
+  DASHBOARDS: 'Dashboards',
+};

--- a/public/app/features/plugins/admin/constants.ts
+++ b/public/app/features/plugins/admin/constants.ts
@@ -1,8 +1,2 @@
 export const API_ROOT = '/api/plugins';
 export const GRAFANA_API_ROOT = '/api/gnet';
-export enum PLUGIN_TAB_LABELS {
-  OVERVIEW = 'Overview',
-  VERSIONS = 'Version history',
-  CONFIG = 'Config',
-  DASHBOARDS = 'Dashboards',
-}

--- a/public/app/features/plugins/admin/hooks/usePluginDetails.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetails.tsx
@@ -4,8 +4,9 @@ import { api } from '../api';
 import { loadPlugin } from '../../PluginPage';
 import { getCatalogPluginDetails, isOrgAdmin } from '../helpers';
 import { ActionTypes, PluginDetailsActions, PluginDetailsState } from '../types';
+import { PLUGIN_TAB_LABELS } from '../constants';
 
-const defaultTabs = [{ label: 'Overview' }, { label: 'Version history' }];
+const defaultTabs = [{ label: PLUGIN_TAB_LABELS.OVERVIEW }, { label: PLUGIN_TAB_LABELS.VERSIONS }];
 
 const initialState = {
   hasInstalledPanel: false,
@@ -129,7 +130,7 @@ export const usePluginDetails = (id: string) => {
       if (pluginConfig.meta.type === PluginType.app) {
         if (pluginConfig.angularConfigCtrl) {
           tabs.push({
-            label: 'Config',
+            label: PLUGIN_TAB_LABELS.CONFIG,
           });
         }
 
@@ -143,7 +144,7 @@ export const usePluginDetails = (id: string) => {
 
         if (pluginConfig.meta.includes?.find((include) => include.type === PluginIncludeType.dashboard)) {
           tabs.push({
-            label: 'Dashboards',
+            label: PLUGIN_TAB_LABELS.DASHBOARDS,
           });
         }
       }

--- a/public/app/features/plugins/admin/hooks/usePluginDetails.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetails.tsx
@@ -6,7 +6,11 @@ import { getCatalogPluginDetails, isOrgAdmin } from '../helpers';
 import { ActionTypes, PluginDetailsActions, PluginDetailsState } from '../types';
 import { PLUGIN_TAB_LABELS } from '../constants';
 
-const defaultTabs = [{ label: PLUGIN_TAB_LABELS.OVERVIEW }, { label: PLUGIN_TAB_LABELS.VERSIONS }];
+type Tab = {
+  label: PLUGIN_TAB_LABELS;
+};
+
+const defaultTabs: Tab[] = [{ label: PLUGIN_TAB_LABELS.OVERVIEW }, { label: PLUGIN_TAB_LABELS.VERSIONS }];
 
 const initialState = {
   hasInstalledPanel: false,
@@ -124,7 +128,7 @@ export const usePluginDetails = (id: string) => {
 
   useEffect(() => {
     const pluginConfig = state.pluginConfig;
-    const tabs: Array<{ label: string }> = [...defaultTabs];
+    const tabs: Tab[] = [...defaultTabs];
 
     if (pluginConfig && userCanConfigurePlugins) {
       if (pluginConfig.meta.type === PluginType.app) {
@@ -134,10 +138,11 @@ export const usePluginDetails = (id: string) => {
           });
         }
 
+        // Configuration pages with custom labels
         if (pluginConfig.configPages) {
           for (const page of pluginConfig.configPages) {
             tabs.push({
-              label: page.title,
+              label: page.title as PLUGIN_TAB_LABELS,
             });
           }
         }

--- a/public/app/features/plugins/admin/hooks/usePluginDetails.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetails.tsx
@@ -3,14 +3,13 @@ import { PluginType, PluginIncludeType, GrafanaPlugin, PluginMeta } from '@grafa
 import { api } from '../api';
 import { loadPlugin } from '../../PluginPage';
 import { getCatalogPluginDetails, isOrgAdmin } from '../helpers';
-import { ActionTypes, CatalogPluginDetails, PluginDetailsActions, PluginDetailsState } from '../types';
-import { PLUGIN_TAB_LABELS } from '../constants';
+import { ActionTypes, CatalogPluginDetails, PluginDetailsActions, PluginDetailsState, PluginTabLabels } from '../types';
 
 type Tab = {
-  label: PLUGIN_TAB_LABELS;
+  label: PluginTabLabels;
 };
 
-const defaultTabs: Tab[] = [{ label: PLUGIN_TAB_LABELS.OVERVIEW }, { label: PLUGIN_TAB_LABELS.VERSIONS }];
+const defaultTabs: Tab[] = [{ label: PluginTabLabels.OVERVIEW }, { label: PluginTabLabels.VERSIONS }];
 
 const initialState = {
   hasInstalledPanel: false,
@@ -153,7 +152,7 @@ export const usePluginDetails = (id: string) => {
       if (pluginConfig.meta.type === PluginType.app) {
         if (pluginConfig.angularConfigCtrl) {
           tabs.push({
-            label: PLUGIN_TAB_LABELS.CONFIG,
+            label: PluginTabLabels.CONFIG,
           });
         }
 
@@ -161,14 +160,14 @@ export const usePluginDetails = (id: string) => {
         if (pluginConfig.configPages) {
           for (const page of pluginConfig.configPages) {
             tabs.push({
-              label: page.title as PLUGIN_TAB_LABELS,
+              label: page.title as PluginTabLabels,
             });
           }
         }
 
         if (pluginConfig.meta.includes?.find((include) => include.type === PluginIncludeType.dashboard)) {
           tabs.push({
-            label: PLUGIN_TAB_LABELS.DASHBOARDS,
+            label: PluginTabLabels.DASHBOARDS,
           });
         }
       }

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -32,7 +32,7 @@ export default function PluginDetails({ match }: PluginDetailsProps): JSX.Elemen
     );
   }
 
-  if (!plugin || !pluginConfig) {
+  if (!plugin) {
     return null;
   }
 
@@ -63,7 +63,7 @@ export default function PluginDetails({ match }: PluginDetailsProps): JSX.Elemen
               </>
             </Alert>
           )}
-          <PluginDetailsSignature plugin={pluginConfig} className={styles.signature} />
+          <PluginDetailsSignature installedPlugin={pluginConfig} className={styles.signature} />
           <PluginDetailsBody tab={tab} plugin={pluginConfig} remoteVersions={plugin.versions} readme={plugin.readme} />
         </TabContent>
       </PluginPage>

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, TabsBar, TabContent, Tab, Icon, Alert } from '@grafana/ui';
+import { useStyles2, TabsBar, TabContent, Tab, Alert } from '@grafana/ui';
 
 import { AppNotificationSeverity } from 'app/types';
-import { InstallControls } from '../components/InstallControls';
+import { PluginDetailsSignature } from '../components/PluginDetailsSignature';
+import { PluginDetailsHeader } from '../components/PluginDetailsHeader';
 import { usePluginDetails } from '../hooks/usePluginDetails';
 import { Page as PluginPage } from '../components/Page';
 import { Loader } from '../components/Loader';
 import { Page } from 'app/core/components/Page/Page';
-import { PluginLogo } from '../components/PluginLogo';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { ActionTypes } from '../types';
 import { PluginDetailsBody } from '../components/PluginDetailsBody';
@@ -19,21 +19,10 @@ type PluginDetailsProps = GrafanaRouteComponentProps<{ pluginId?: string }>;
 export default function PluginDetails({ match }: PluginDetailsProps): JSX.Element | null {
   const { pluginId } = match.params;
   const { state, dispatch } = usePluginDetails(pluginId!);
-  const {
-    loading,
-    error,
-    plugin,
-    pluginConfig,
-    tabs,
-    activeTab,
-    isInflight,
-    hasUpdate,
-    isInstalled,
-    hasInstalledPanel,
-  } = state;
+  const { loading, error, plugin, pluginConfig, tabs, activeTab } = state;
   const tab = tabs[activeTab];
   const styles = useStyles2(getStyles);
-  const breadcrumbHref = match.url.substring(0, match.url.lastIndexOf('/'));
+  const parentUrl = match.url.substring(0, match.url.lastIndexOf('/'));
 
   if (loading) {
     return (
@@ -43,147 +32,54 @@ export default function PluginDetails({ match }: PluginDetailsProps): JSX.Elemen
     );
   }
 
-  if (plugin) {
-    return (
-      <Page>
-        <PluginPage>
-          <div className={styles.headerContainer}>
-            <PluginLogo
-              alt={`${plugin.name} logo`}
-              src={plugin.info.logos.small}
-              className={css`
-                object-fit: contain;
-                width: 100%;
-                height: 68px;
-                max-width: 68px;
-              `}
-            />
-
-            <div className={styles.headerWrapper}>
-              <nav className={styles.breadcrumb} aria-label="Breadcrumb">
-                <ol>
-                  <li>
-                    <a
-                      className={css`
-                        text-decoration: underline;
-                      `}
-                      href={breadcrumbHref}
-                    >
-                      Plugins
-                    </a>
-                  </li>
-                  <li>
-                    <a href={`${match.url}`} aria-current="page">
-                      {plugin.name}
-                    </a>
-                  </li>
-                </ol>
-              </nav>
-              <div className={styles.headerLinks}>
-                <span>{plugin.orgName}</span>
-                {plugin.links.map((link: any) => (
-                  <a key={link.name} href={link.url}>
-                    {link.name}
-                  </a>
-                ))}
-                {plugin.downloads > 0 && (
-                  <span>
-                    <Icon name="cloud-download" />
-                    {` ${new Intl.NumberFormat().format(plugin.downloads)}`}{' '}
-                  </span>
-                )}
-                {plugin.version && <span>{plugin.version}</span>}
-              </div>
-              <p>{plugin.description}</p>
-              <InstallControls
-                plugin={plugin}
-                isInflight={isInflight}
-                hasUpdate={hasUpdate}
-                isInstalled={isInstalled}
-                hasInstalledPanel={hasInstalledPanel}
-                dispatch={dispatch}
-              />
-            </div>
-          </div>
-          <TabsBar>
-            {tabs.map((tab: { label: string }, idx: number) => (
-              <Tab
-                key={tab.label}
-                label={tab.label}
-                active={idx === activeTab}
-                onChangeTab={() => dispatch({ type: ActionTypes.SET_ACTIVE_TAB, payload: idx })}
-              />
-            ))}
-          </TabsBar>
-          <TabContent>
-            {error && (
-              <Alert severity={AppNotificationSeverity.Error} title="Error Loading Plugin">
-                <>
-                  Check the server startup logs for more information. <br />
-                  If this plugin was loaded from git, make sure it was compiled.
-                </>
-              </Alert>
-            )}
-            <PluginDetailsBody
-              tab={tab}
-              plugin={pluginConfig}
-              remoteVersions={plugin.versions}
-              readme={plugin.readme}
-            />
-          </TabContent>
-        </PluginPage>
-      </Page>
-    );
+  if (!plugin || !pluginConfig) {
+    return null;
   }
 
-  return null;
+  return (
+    <Page>
+      <PluginPage>
+        <PluginDetailsHeader currentUrl={match.url} parentUrl={parentUrl} pluginId={pluginId} />
+
+        {/* Tab navigation */}
+        <TabsBar>
+          {tabs.map((tab: { label: string }, idx: number) => (
+            <Tab
+              key={tab.label}
+              label={tab.label}
+              active={idx === activeTab}
+              onChangeTab={() => dispatch({ type: ActionTypes.SET_ACTIVE_TAB, payload: idx })}
+            />
+          ))}
+        </TabsBar>
+
+        {/* Active tab */}
+        <TabContent className={styles.tabContent}>
+          {error && (
+            <Alert severity={AppNotificationSeverity.Error} title="Error Loading Plugin">
+              <>
+                Check the server startup logs for more information. <br />
+                If this plugin was loaded from git, make sure it was compiled.
+              </>
+            </Alert>
+          )}
+          <PluginDetailsSignature plugin={pluginConfig} className={styles.signature} />
+          <PluginDetailsBody tab={tab} plugin={pluginConfig} remoteVersions={plugin.versions} readme={plugin.readme} />
+        </TabContent>
+      </PluginPage>
+    </Page>
+  );
 }
 
 export const getStyles = (theme: GrafanaTheme2) => {
   return {
-    headerContainer: css`
-      display: flex;
-      margin-bottom: ${theme.spacing(3)};
-      margin-top: ${theme.spacing(3)};
-      min-height: 120px;
+    signature: css`
+      margin: ${theme.spacing(3)};
+      margin-bottom: 0;
     `,
-    headerWrapper: css`
-      margin-left: ${theme.spacing(3)};
-    `,
-    breadcrumb: css`
-      font-size: ${theme.typography.h2.fontSize};
-      li {
-        display: inline;
-        list-style: none;
-        &::after {
-          content: '/';
-          padding: 0 0.25ch;
-        }
-        &:last-child::after {
-          content: '';
-        }
-      }
-    `,
-    headerLinks: css`
-      display: flex;
-      align-items: center;
-      margin-top: ${theme.spacing()};
-      margin-bottom: ${theme.spacing(3)};
-
-      & > * {
-        &::after {
-          content: '|';
-          padding: 0 ${theme.spacing()};
-        }
-        &:last-child::after {
-          content: '';
-          padding-right: 0;
-        }
-      }
-      font-size: ${theme.typography.h4.fontSize};
-    `,
-    headerOrgName: css`
-      font-size: ${theme.typography.h4.fontSize};
+    // Needed due to block formatting context
+    tabContent: css`
+      overflow: auto;
     `,
   };
 };

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -229,3 +229,10 @@ export enum PluginStatus {
   UNINSTALL = 'UNINSTALL',
   UPDATE = 'UPDATE',
 }
+
+export enum PluginTabLabels {
+  OVERVIEW = 'Overview',
+  VERSIONS = 'Version history',
+  CONFIG = 'Config',
+  DASHBOARDS = 'Dashboards',
+}


### PR DESCRIPTION
**Which issue(s) this PR fixes**: https://github.com/grafana/grafana/issues/37930

**What this PR does / why we need it**: 
Adds signature information to the plugins details page under the plugins catalog, and also to the Enterprise plugin list items.


https://user-images.githubusercontent.com/9974811/130811185-beee4681-149e-484e-a674-f417e8eb1267.mov

 


Fixes #37930

---

### ⚠️ &nbsp; Notes
Tests are coming.

