### PR TITLE
Docs: Fix error in provisioning docs for discord notifier

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -448,7 +448,7 @@ The following sections detail the supported settings and secure settings for eac
 | ---------- | -------------- |
 | url        | yes            |
 | avatar_url |                |
-| message    |                |
+| content    |                |
 
 #### Alert notification `slack`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an error in provisioning docs for discord notifier referencing the wrong name of the "message content" setting.

**Which issue(s) this PR fixes**:
Fixes #38494 

**Special notes for your reviewer**:

