### PR TITLE
Admin: remove Redux from ServerStats

### DIFF
--- a/public/app/features/admin/ServerStats.test.tsx
+++ b/public/app/features/admin/ServerStats.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { ServerStats, Props } from './ServerStats';
+import { ServerStats } from './ServerStats';
 import { ServerStat } from './state/apis';
 
 const stats: ServerStat = {
@@ -23,21 +23,13 @@ const stats: ServerStat = {
   viewers: 2,
 };
 
-const getServerStats = () => {
-  return Promise.resolve(stats);
-};
+jest.mock('./state/apis', () => ({
+  getServerStats: async () => stats,
+}));
 
-const setup = (propOverrides?: Partial<Props>) => {
-  const props: Props = {
-    getServerStats,
-  };
-  Object.assign(props, propOverrides);
-
-  render(<ServerStats {...props} />);
-};
 describe('ServerStats', () => {
   it('Should render page with stats', async () => {
-    setup();
+    render(<ServerStats />);
     expect(await screen.findByRole('heading', { name: /instance statistics/i })).toBeInTheDocument();
     expect(screen.getByText('Dashboards (starred)')).toBeInTheDocument();
     expect(screen.getByText('Tags')).toBeInTheDocument();

--- a/public/app/features/admin/ServerStats.tsx
+++ b/public/app/features/admin/ServerStats.tsx
@@ -1,20 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { hot } from 'react-hot-loader';
-import { connect } from 'react-redux';
 import { css } from '@emotion/css';
 import { CardContainer, LinkButton, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
-import { AccessControlAction, StoreState } from 'app/types';
-import { getNavModel } from 'app/core/selectors/navModel';
+import { AccessControlAction } from 'app/types';
 import { getServerStats, ServerStat } from './state/apis';
 import { contextSrv } from '../../core/services/context_srv';
 import { Loader } from '../plugins/admin/components/Loader';
 
-export interface Props {
-  getServerStats: () => Promise<ServerStat | null>;
-}
-
-export const ServerStats = ({ getServerStats }: Props) => {
+export const ServerStats = () => {
   const [stats, setStats] = useState<ServerStat | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const styles = useStyles2(getStyles);
@@ -24,7 +17,7 @@ export const ServerStats = ({ getServerStats }: Props) => {
       setStats(stats);
       setIsLoading(false);
     });
-  }, [getServerStats]);
+  }, []);
 
   if (!contextSrv.hasPermission(AccessControlAction.ActionServerStatsRead)) {
     return null;
@@ -131,11 +124,6 @@ const getStyles = (theme: GrafanaTheme2) => {
   };
 };
 
-const mapStateToProps = (state: StoreState) => ({
-  navModel: getNavModel(state.navIndex, 'server-stats'),
-  getServerStats,
-});
-
 type StatCardProps = {
   content: Array<Record<string, number | string>>;
   footer?: JSX.Element;
@@ -184,4 +172,3 @@ const getCardStyles = (theme: GrafanaTheme2) => {
     `,
   };
 };
-export default hot(module)(connect(mapStateToProps)(ServerStats));

--- a/public/app/features/admin/UpgradePage.tsx
+++ b/public/app/features/admin/UpgradePage.tsx
@@ -8,7 +8,7 @@ import Page from '../../core/components/Page/Page';
 import { getNavModel } from '../../core/selectors/navModel';
 import { LicenseChrome } from './LicenseChrome';
 import { StoreState } from '../../types';
-import ServerStats from './ServerStats';
+import { ServerStats } from './ServerStats';
 
 interface Props {
   navModel: NavModel;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
ServerStats is now a part of licensing page and doesn't need connected props from Redux anymore. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

