### PR TITLE
[v8.0.x] Docs: Fix error in provisioning docs for discord notifier

### DIFF
--- a/docs/sources/administration/provisioning.md
+++ b/docs/sources/administration/provisioning.md
@@ -439,11 +439,11 @@ The following sections detail the supported settings and secure settings for eac
 
 #### Alert notification `discord`
 
-| Name           | Secure setting |
-| -------------- | -------------- |
-| url            | yes            |
-| avatar_url     |                |
-| message        |                |
+| Name       | Secure setting |
+| ---------- | -------------- |
+| url        | yes            |
+| avatar_url |                |
+| content    |                |
 
 #### Alert notification `slack`
 


### PR DESCRIPTION
Backport b231afd from #38579