### PR TITLE
Attempt to fix Windows MSI license

### DIFF
--- a/scripts/build/ci-msi-build/msigenerator/resources/license/LICENSE.rtf
+++ b/scripts/build/ci-msi-build/msigenerator/resources/license/LICENSE.rtf
@@ -1,206 +1,667 @@
 {\rtf1\ansi\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Courier New;}}
-{\*\generator Riched20 6.3.9600}\viewkind4\uc1 
-\pard\f0\fs22\lang1033\par
-                                 Apache License\par
-                           Version 2.0, January 2004\par
-                        http://www.apache.org/licenses/\par
+{\colortbl ;\red0\green0\blue255;}
+{\*\generator Riched20 10.0.19041}\viewkind4\uc1 
+\pard\f0\fs22\lang1033                     GNU AFFERO GENERAL PUBLIC LICENSE\par
+                       Version 3, 19 November 2007\par
 \par
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\par
+ Copyright (C) 2007 Free Software Foundation, Inc. <{{\field{\*\fldinst{HYPERLINK "https://fsf.org/"}}{\fldrslt{https://fsf.org/\ul0\cf0}}}}\f0\fs22 >\par
+ Everyone is permitted to copy and distribute verbatim copies\par
+ of this license document, but changing it is not allowed.\par
 \par
-   1. Definitions.\par
+                            Preamble\par
 \par
-      "License" shall mean the terms and conditions for use, reproduction,\par
-      and distribution as defined by Sections 1 through 9 of this document.\par
+  The GNU Affero General Public License is a free, copyleft license for\par
+software and other kinds of works, specifically designed to ensure\par
+cooperation with the community in the case of network server software.\par
 \par
-      "Licensor" shall mean the copyright owner or entity authorized by\par
-      the copyright owner that is granting the License.\par
+  The licenses for most software and other practical works are designed\par
+to take away your freedom to share and change the works.  By contrast,\par
+our General Public Licenses are intended to guarantee your freedom to\par
+share and change all versions of a program--to make sure it remains free\par
+software for all its users.\par
 \par
-      "Legal Entity" shall mean the union of the acting entity and all\par
-      other entities that control, are controlled by, or are under common\par
-      control with that entity. For the purposes of this definition,\par
-      "control" means (i) the power, direct or indirect, to cause the\par
-      direction or management of such entity, whether by contract or\par
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the\par
-      outstanding shares, or (iii) beneficial ownership of such entity.\par
+  When we speak of free software, we are referring to freedom, not\par
+price.  Our General Public Licenses are designed to make sure that you\par
+have the freedom to distribute copies of free software (and charge for\par
+them if you wish), that you receive source code or can get it if you\par
+want it, that you can change the software or use pieces of it in new\par
+free programs, and that you know you can do these things.\par
 \par
-      "You" (or "Your") shall mean an individual or Legal Entity\par
-      exercising permissions granted by this License.\par
+  Developers that use our General Public Licenses protect your rights\par
+with two steps: (1) assert copyright on the software, and (2) offer\par
+you this License which gives you legal permission to copy, distribute\par
+and/or modify the software.\par
 \par
-      "Source" form shall mean the preferred form for making modifications,\par
-      including but not limited to software source code, documentation\par
-      source, and configuration files.\par
+  A secondary benefit of defending all users' freedom is that\par
+improvements made in alternate versions of the program, if they\par
+receive widespread use, become available for other developers to\par
+incorporate.  Many developers of free software are heartened and\par
+encouraged by the resulting cooperation.  However, in the case of\par
+software used on network servers, this result may fail to come about.\par
+The GNU General Public License permits making a modified version and\par
+letting the public access it on a server without ever releasing its\par
+source code to the public.\par
 \par
-      "Object" form shall mean any form resulting from mechanical\par
-      transformation or translation of a Source form, including but\par
-      not limited to compiled object code, generated documentation,\par
-      and conversions to other media types.\par
+  The GNU Affero General Public License is designed specifically to\par
+ensure that, in such cases, the modified source code becomes available\par
+to the community.  It requires the operator of a network server to\par
+provide the source code of the modified version running there to the\par
+users of that server.  Therefore, public use of a modified version, on\par
+a publicly accessible server, gives the public access to the source\par
+code of the modified version.\par
 \par
-      "Work" shall mean the work of authorship, whether in Source or\par
-      Object form, made available under the License, as indicated by a\par
-      copyright notice that is included in or attached to the work\par
-      (an example is provided in the Appendix below).\par
+  An older license, called the Affero General Public License and\par
+published by Affero, was designed to accomplish similar goals.  This is\par
+a different license, not a version of the Affero GPL, but Affero has\par
+released a new version of the Affero GPL which permits relicensing under\par
+this license.\par
 \par
-      "Derivative Works" shall mean any work, whether in Source or Object\par
-      form, that is based on (or derived from) the Work and for which the\par
-      editorial revisions, annotations, elaborations, or other modifications\par
-      represent, as a whole, an original work of authorship. For the purposes\par
-      of this License, Derivative Works shall not include works that remain\par
-      separable from, or merely link (or bind by name) to the interfaces of,\par
-      the Work and Derivative Works thereof.\par
+  The precise terms and conditions for copying, distribution and\par
+modification follow.\par
 \par
-      "Contribution" shall mean any work of authorship, including\par
-      the original version of the Work and any modifications or additions\par
-      to that Work or Derivative Works thereof, that is intentionally\par
-      submitted to Licensor for inclusion in the Work by the copyright owner\par
-      or by an individual or Legal Entity authorized to submit on behalf of\par
-      the copyright owner. For the purposes of this definition, "submitted"\par
-      means any form of electronic, verbal, or written communication sent\par
-      to the Licensor or its representatives, including but not limited to\par
-      communication on electronic mailing lists, source code control systems,\par
-      and issue tracking systems that are managed by, or on behalf of, the\par
-      Licensor for the purpose of discussing and improving the Work, but\par
-      excluding communication that is conspicuously marked or otherwise\par
-      designated in writing by the copyright owner as "Not a Contribution."\par
+                       TERMS AND CONDITIONS\par
 \par
-      "Contributor" shall mean Licensor and any individual or Legal Entity\par
-      on behalf of whom a Contribution has been received by Licensor and\par
-      subsequently incorporated within the Work.\par
+  0. Definitions.\par
 \par
-   2. Grant of Copyright License. Subject to the terms and conditions of\par
-      this License, each Contributor hereby grants to You a perpetual,\par
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\par
-      copyright license to reproduce, prepare Derivative Works of,\par
-      publicly display, publicly perform, sublicense, and distribute the\par
-      Work and such Derivative Works in Source or Object form.\par
+  "This License" refers to version 3 of the GNU Affero General Public License.\par
 \par
-   3. Grant of Patent License. Subject to the terms and conditions of\par
-      this License, each Contributor hereby grants to You a perpetual,\par
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\par
-      (except as stated in this section) patent license to make, have made,\par
-      use, offer to sell, sell, import, and otherwise transfer the Work,\par
-      where such license applies only to those patent claims licensable\par
-      by such Contributor that are necessarily infringed by their\par
-      Contribution(s) alone or by combination of their Contribution(s)\par
-      with the Work to which such Contribution(s) was submitted. If You\par
-      institute patent litigation against any entity (including a\par
-      cross-claim or counterclaim in a lawsuit) alleging that the Work\par
-      or a Contribution incorporated within the Work constitutes direct\par
-      or contributory patent infringement, then any patent licenses\par
-      granted to You under this License for that Work shall terminate\par
-      as of the date such litigation is filed.\par
+  "Copyright" also means copyright-like laws that apply to other kinds of\par
+works, such as semiconductor masks.\par
 \par
-   4. Redistribution. You may reproduce and distribute copies of the\par
-      Work or Derivative Works thereof in any medium, with or without\par
-      modifications, and in Source or Object form, provided that You\par
-      meet the following conditions:\par
+  "The Program" refers to any copyrightable work licensed under this\par
+License.  Each licensee is addressed as "you".  "Licensees" and\par
+"recipients" may be individuals or organizations.\par
 \par
-      (a) You must give any other recipients of the Work or\par
-          Derivative Works a copy of this License; and\par
+  To "modify" a work means to copy from or adapt all or part of the work\par
+in a fashion requiring copyright permission, other than the making of an\par
+exact copy.  The resulting work is called a "modified version" of the\par
+earlier work or a work "based on" the earlier work.\par
 \par
-      (b) You must cause any modified files to carry prominent notices\par
-          stating that You changed the files; and\par
+  A "covered work" means either the unmodified Program or a work based\par
+on the Program.\par
 \par
-      (c) You must retain, in the Source form of any Derivative Works\par
-          that You distribute, all copyright, patent, trademark, and\par
-          attribution notices from the Source form of the Work,\par
-          excluding those notices that do not pertain to any part of\par
-          the Derivative Works; and\par
+  To "propagate" a work means to do anything with it that, without\par
+permission, would make you directly or secondarily liable for\par
+infringement under applicable copyright law, except executing it on a\par
+computer or modifying a private copy.  Propagation includes copying,\par
+distribution (with or without modification), making available to the\par
+public, and in some countries other activities as well.\par
 \par
-      (d) If the Work includes a "NOTICE" text file as part of its\par
-          distribution, then any Derivative Works that You distribute must\par
-          include a readable copy of the attribution notices contained\par
-          within such NOTICE file, excluding those notices that do not\par
-          pertain to any part of the Derivative Works, in at least one\par
-          of the following places: within a NOTICE text file distributed\par
-          as part of the Derivative Works; within the Source form or\par
-          documentation, if provided along with the Derivative Works; or,\par
-          within a display generated by the Derivative Works, if and\par
-          wherever such third-party notices normally appear. The contents\par
-          of the NOTICE file are for informational purposes only and\par
-          do not modify the License. You may add Your own attribution\par
-          notices within Derivative Works that You distribute, alongside\par
-          or as an addendum to the NOTICE text from the Work, provided\par
-          that such additional attribution notices cannot be construed\par
-          as modifying the License.\par
+  To "convey" a work means any kind of propagation that enables other\par
+parties to make or receive copies.  Mere interaction with a user through\par
+a computer network, with no transfer of a copy, is not conveying.\par
 \par
-      You may add Your own copyright statement to Your modifications and\par
-      may provide additional or different license terms and conditions\par
-      for use, reproduction, or distribution of Your modifications, or\par
-      for any such Derivative Works as a whole, provided Your use,\par
-      reproduction, and distribution of the Work otherwise complies with\par
-      the conditions stated in this License.\par
+  An interactive user interface displays "Appropriate Legal Notices"\par
+to the extent that it includes a convenient and prominently visible\par
+feature that (1) displays an appropriate copyright notice, and (2)\par
+tells the user that there is no warranty for the work (except to the\par
+extent that warranties are provided), that licensees may convey the\par
+work under this License, and how to view a copy of this License.  If\par
+the interface presents a list of user commands or options, such as a\par
+menu, a prominent item in the list meets this criterion.\par
 \par
-   5. Submission of Contributions. Unless You explicitly state otherwise,\par
-      any Contribution intentionally submitted for inclusion in the Work\par
-      by You to the Licensor shall be under the terms and conditions of\par
-      this License, without any additional terms or conditions.\par
-      Notwithstanding the above, nothing herein shall supersede or modify\par
-      the terms of any separate license agreement you may have executed\par
-      with Licensor regarding such Contributions.\par
+  1. Source Code.\par
 \par
-   6. Trademarks. This License does not grant permission to use the trade\par
-      names, trademarks, service marks, or product names of the Licensor,\par
-      except as required for reasonable and customary use in describing the\par
-      origin of the Work and reproducing the content of the NOTICE file.\par
+  The "source code" for a work means the preferred form of the work\par
+for making modifications to it.  "Object code" means any non-source\par
+form of a work.\par
 \par
-   7. Disclaimer of Warranty. Unless required by applicable law or\par
-      agreed to in writing, Licensor provides the Work (and each\par
-      Contributor provides its Contributions) on an "AS IS" BASIS,\par
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\par
-      implied, including, without limitation, any warranties or conditions\par
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\par
-      PARTICULAR PURPOSE. You are solely responsible for determining the\par
-      appropriateness of using or redistributing the Work and assume any\par
-      risks associated with Your exercise of permissions under this License.\par
+  A "Standard Interface" means an interface that either is an official\par
+standard defined by a recognized standards body, or, in the case of\par
+interfaces specified for a particular programming language, one that\par
+is widely used among developers working in that language.\par
 \par
-   8. Limitation of Liability. In no event and under no legal theory,\par
-      whether in tort (including negligence), contract, or otherwise,\par
-      unless required by applicable law (such as deliberate and grossly\par
-      negligent acts) or agreed to in writing, shall any Contributor be\par
-      liable to You for damages, including any direct, indirect, special,\par
-      incidental, or consequential damages of any character arising as a\par
-      result of this License or out of the use or inability to use the\par
-      Work (including but not limited to damages for loss of goodwill,\par
-      work stoppage, computer failure or malfunction, or any and all\par
-      other commercial damages or losses), even if such Contributor\par
-      has been advised of the possibility of such damages.\par
+  The "System Libraries" of an executable work include anything, other\par
+than the work as a whole, that (a) is included in the normal form of\par
+packaging a Major Component, but which is not part of that Major\par
+Component, and (b) serves only to enable use of the work with that\par
+Major Component, or to implement a Standard Interface for which an\par
+implementation is available to the public in source code form.  A\par
+"Major Component", in this context, means a major essential component\par
+(kernel, window system, and so on) of the specific operating system\par
+(if any) on which the executable work runs, or a compiler used to\par
+produce the work, or an object code interpreter used to run it.\par
 \par
-   9. Accepting Warranty or Additional Liability. While redistributing\par
-      the Work or Derivative Works thereof, You may choose to offer,\par
-      and charge a fee for, acceptance of support, warranty, indemnity,\par
-      or other liability obligations and/or rights consistent with this\par
-      License. However, in accepting such obligations, You may act only\par
-      on Your own behalf and on Your sole responsibility, not on behalf\par
-      of any other Contributor, and only if You agree to indemnify,\par
-      defend, and hold each Contributor harmless for any liability\par
-      incurred by, or claims asserted against, such Contributor by reason\par
-      of your accepting any such warranty or additional liability.\par
+  The "Corresponding Source" for a work in object code form means all\par
+the source code needed to generate, install, and (for an executable\par
+work) run the object code and to modify the work, including scripts to\par
+control those activities.  However, it does not include the work's\par
+System Libraries, or general-purpose tools or generally available free\par
+programs which are used unmodified in performing those activities but\par
+which are not part of the work.  For example, Corresponding Source\par
+includes interface definition files associated with source files for\par
+the work, and the source code for shared libraries and dynamically\par
+linked subprograms that the work is specifically designed to require,\par
+such as by intimate data communication or control flow between those\par
+subprograms and other parts of the work.\par
 \par
-   END OF TERMS AND CONDITIONS\par
+  The Corresponding Source need not include anything that users\par
+can regenerate automatically from other parts of the Corresponding\par
+Source.\par
 \par
-   APPENDIX: How to apply the Apache License to your work.\par
+  The Corresponding Source for a work in source code form is that\par
+same work.\par
 \par
-      To apply the Apache License to your work, attach the following\par
-      boilerplate notice, with the fields enclosed by brackets "[]"\par
-      replaced with your own identifying information. (Don't include\par
-      the brackets!)  The text should be enclosed in the appropriate\par
-      comment syntax for the file format. We also recommend that a\par
-      file or class name and description of purpose be included on the\par
-      same "printed page" as the copyright notice for easier\par
-      identification within third-party archives.\par
+  2. Basic Permissions.\par
 \par
-   Copyright [yyyy] [name of copyright owner]\par
+  All rights granted under this License are granted for the term of\par
+copyright on the Program, and are irrevocable provided the stated\par
+conditions are met.  This License explicitly affirms your unlimited\par
+permission to run the unmodified Program.  The output from running a\par
+covered work is covered by this License only if the output, given its\par
+content, constitutes a covered work.  This License acknowledges your\par
+rights of fair use or other equivalent, as provided by copyright law.\par
 \par
-   Licensed under the Apache License, Version 2.0 (the "License");\par
-   you may not use this file except in compliance with the License.\par
-   You may obtain a copy of the License at\par
+  You may make, run and propagate covered works that you do not\par
+convey, without conditions so long as your license otherwise remains\par
+in force.  You may convey covered works to others for the sole purpose\par
+of having them make modifications exclusively for you, or provide you\par
+with facilities for running those works, provided that you comply with\par
+the terms of this License in conveying all material for which you do\par
+not control copyright.  Those thus making or running the covered works\par
+for you must do so exclusively on your behalf, under your direction\par
+and control, on terms that prohibit them from making any copies of\par
+your copyrighted material outside their relationship with you.\par
 \par
-       http://www.apache.org/licenses/LICENSE-2.0\par
+  Conveying under any other circumstances is permitted solely under\par
+the conditions stated below.  Sublicensing is not allowed; section 10\par
+makes it unnecessary.\par
 \par
-   Unless required by applicable law or agreed to in writing, software\par
-   distributed under the License is distributed on an "AS IS" BASIS,\par
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\par
-   See the License for the specific language governing permissions and\par
-   limitations under the License.\par
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.\par
+\par
+  No covered work shall be deemed part of an effective technological\par
+measure under any applicable law fulfilling obligations under article\par
+11 of the WIPO copyright treaty adopted on 20 December 1996, or\par
+similar laws prohibiting or restricting circumvention of such\par
+measures.\par
+\par
+  When you convey a covered work, you waive any legal power to forbid\par
+circumvention of technological measures to the extent such circumvention\par
+is effected by exercising rights under this License with respect to\par
+the covered work, and you disclaim any intention to limit operation or\par
+modification of the work as a means of enforcing, against the work's\par
+users, your or third parties' legal rights to forbid circumvention of\par
+technological measures.\par
+\par
+  4. Conveying Verbatim Copies.\par
+\par
+  You may convey verbatim copies of the Program's source code as you\par
+receive it, in any medium, provided that you conspicuously and\par
+appropriately publish on each copy an appropriate copyright notice;\par
+keep intact all notices stating that this License and any\par
+non-permissive terms added in accord with section 7 apply to the code;\par
+keep intact all notices of the absence of any warranty; and give all\par
+recipients a copy of this License along with the Program.\par
+\par
+  You may charge any price or no price for each copy that you convey,\par
+and you may offer support or warranty protection for a fee.\par
+\par
+  5. Conveying Modified Source Versions.\par
+\par
+  You may convey a work based on the Program, or the modifications to\par
+produce it from the Program, in the form of source code under the\par
+terms of section 4, provided that you also meet all of these conditions:\par
+\par
+    a) The work must carry prominent notices stating that you modified\par
+    it, and giving a relevant date.\par
+\par
+    b) The work must carry prominent notices stating that it is\par
+    released under this License and any conditions added under section\par
+    7.  This requirement modifies the requirement in section 4 to\par
+    "keep intact all notices".\par
+\par
+    c) You must license the entire work, as a whole, under this\par
+    License to anyone who comes into possession of a copy.  This\par
+    License will therefore apply, along with any applicable section 7\par
+    additional terms, to the whole of the work, and all its parts,\par
+    regardless of how they are packaged.  This License gives no\par
+    permission to license the work in any other way, but it does not\par
+    invalidate such permission if you have separately received it.\par
+\par
+    d) If the work has interactive user interfaces, each must display\par
+    Appropriate Legal Notices; however, if the Program has interactive\par
+    interfaces that do not display Appropriate Legal Notices, your\par
+    work need not make them do so.\par
+\par
+  A compilation of a covered work with other separate and independent\par
+works, which are not by their nature extensions of the covered work,\par
+and which are not combined with it such as to form a larger program,\par
+in or on a volume of a storage or distribution medium, is called an\par
+"aggregate" if the compilation and its resulting copyright are not\par
+used to limit the access or legal rights of the compilation's users\par
+beyond what the individual works permit.  Inclusion of a covered work\par
+in an aggregate does not cause this License to apply to the other\par
+parts of the aggregate.\par
+\par
+  6. Conveying Non-Source Forms.\par
+\par
+  You may convey a covered work in object code form under the terms\par
+of sections 4 and 5, provided that you also convey the\par
+machine-readable Corresponding Source under the terms of this License,\par
+in one of these ways:\par
+\par
+    a) Convey the object code in, or embodied in, a physical product\par
+    (including a physical distribution medium), accompanied by the\par
+    Corresponding Source fixed on a durable physical medium\par
+    customarily used for software interchange.\par
+\par
+    b) Convey the object code in, or embodied in, a physical product\par
+    (including a physical distribution medium), accompanied by a\par
+    written offer, valid for at least three years and valid for as\par
+    long as you offer spare parts or customer support for that product\par
+    model, to give anyone who possesses the object code either (1) a\par
+    copy of the Corresponding Source for all the software in the\par
+    product that is covered by this License, on a durable physical\par
+    medium customarily used for software interchange, for a price no\par
+    more than your reasonable cost of physically performing this\par
+    conveying of source, or (2) access to copy the\par
+    Corresponding Source from a network server at no charge.\par
+\par
+    c) Convey individual copies of the object code with a copy of the\par
+    written offer to provide the Corresponding Source.  This\par
+    alternative is allowed only occasionally and noncommercially, and\par
+    only if you received the object code with such an offer, in accord\par
+    with subsection 6b.\par
+\par
+    d) Convey the object code by offering access from a designated\par
+    place (gratis or for a charge), and offer equivalent access to the\par
+    Corresponding Source in the same way through the same place at no\par
+    further charge.  You need not require recipients to copy the\par
+    Corresponding Source along with the object code.  If the place to\par
+    copy the object code is a network server, the Corresponding Source\par
+    may be on a different server (operated by you or a third party)\par
+    that supports equivalent copying facilities, provided you maintain\par
+    clear directions next to the object code saying where to find the\par
+    Corresponding Source.  Regardless of what server hosts the\par
+    Corresponding Source, you remain obligated to ensure that it is\par
+    available for as long as needed to satisfy these requirements.\par
+\par
+    e) Convey the object code using peer-to-peer transmission, provided\par
+    you inform other peers where the object code and Corresponding\par
+    Source of the work are being offered to the general public at no\par
+    charge under subsection 6d.\par
+\par
+  A separable portion of the object code, whose source code is excluded\par
+from the Corresponding Source as a System Library, need not be\par
+included in conveying the object code work.\par
+\par
+  A "User Product" is either (1) a "consumer product", which means any\par
+tangible personal property which is normally used for personal, family,\par
+or household purposes, or (2) anything designed or sold for incorporation\par
+into a dwelling.  In determining whether a product is a consumer product,\par
+doubtful cases shall be resolved in favor of coverage.  For a particular\par
+product received by a particular user, "normally used" refers to a\par
+typical or common use of that class of product, regardless of the status\par
+of the particular user or of the way in which the particular user\par
+actually uses, or expects or is expected to use, the product.  A product\par
+is a consumer product regardless of whether the product has substantial\par
+commercial, industrial or non-consumer uses, unless such uses represent\par
+the only significant mode of use of the product.\par
+\par
+  "Installation Information" for a User Product means any methods,\par
+procedures, authorization keys, or other information required to install\par
+and execute modified versions of a covered work in that User Product from\par
+a modified version of its Corresponding Source.  The information must\par
+suffice to ensure that the continued functioning of the modified object\par
+code is in no case prevented or interfered with solely because\par
+modification has been made.\par
+\par
+  If you convey an object code work under this section in, or with, or\par
+specifically for use in, a User Product, and the conveying occurs as\par
+part of a transaction in which the right of possession and use of the\par
+User Product is transferred to the recipient in perpetuity or for a\par
+fixed term (regardless of how the transaction is characterized), the\par
+Corresponding Source conveyed under this section must be accompanied\par
+by the Installation Information.  But this requirement does not apply\par
+if neither you nor any third party retains the ability to install\par
+modified object code on the User Product (for example, the work has\par
+been installed in ROM).\par
+\par
+  The requirement to provide Installation Information does not include a\par
+requirement to continue to provide support service, warranty, or updates\par
+for a work that has been modified or installed by the recipient, or for\par
+the User Product in which it has been modified or installed.  Access to a\par
+network may be denied when the modification itself materially and\par
+adversely affects the operation of the network or violates the rules and\par
+protocols for communication across the network.\par
+\par
+  Corresponding Source conveyed, and Installation Information provided,\par
+in accord with this section must be in a format that is publicly\par
+documented (and with an implementation available to the public in\par
+source code form), and must require no special password or key for\par
+unpacking, reading or copying.\par
+\par
+  7. Additional Terms.\par
+\par
+  "Additional permissions" are terms that supplement the terms of this\par
+License by making exceptions from one or more of its conditions.\par
+Additional permissions that are applicable to the entire Program shall\par
+be treated as though they were included in this License, to the extent\par
+that they are valid under applicable law.  If additional permissions\par
+apply only to part of the Program, that part may be used separately\par
+under those permissions, but the entire Program remains governed by\par
+this License without regard to the additional permissions.\par
+\par
+  When you convey a copy of a covered work, you may at your option\par
+remove any additional permissions from that copy, or from any part of\par
+it.  (Additional permissions may be written to require their own\par
+removal in certain cases when you modify the work.)  You may place\par
+additional permissions on material, added by you to a covered work,\par
+for which you have or can give appropriate copyright permission.\par
+\par
+  Notwithstanding any other provision of this License, for material you\par
+add to a covered work, you may (if authorized by the copyright holders of\par
+that material) supplement the terms of this License with terms:\par
+\par
+    a) Disclaiming warranty or limiting liability differently from the\par
+    terms of sections 15 and 16 of this License; or\par
+\par
+    b) Requiring preservation of specified reasonable legal notices or\par
+    author attributions in that material or in the Appropriate Legal\par
+    Notices displayed by works containing it; or\par
+\par
+    c) Prohibiting misrepresentation of the origin of that material, or\par
+    requiring that modified versions of such material be marked in\par
+    reasonable ways as different from the original version; or\par
+\par
+    d) Limiting the use for publicity purposes of names of licensors or\par
+    authors of the material; or\par
+\par
+    e) Declining to grant rights under trademark law for use of some\par
+    trade names, trademarks, or service marks; or\par
+\par
+    f) Requiring indemnification of licensors and authors of that\par
+    material by anyone who conveys the material (or modified versions of\par
+    it) with contractual assumptions of liability to the recipient, for\par
+    any liability that these contractual assumptions directly impose on\par
+    those licensors and authors.\par
+\par
+  All other non-permissive additional terms are considered "further\par
+restrictions" within the meaning of section 10.  If the Program as you\par
+received it, or any part of it, contains a notice stating that it is\par
+governed by this License along with a term that is a further\par
+restriction, you may remove that term.  If a license document contains\par
+a further restriction but permits relicensing or conveying under this\par
+License, you may add to a covered work material governed by the terms\par
+of that license document, provided that the further restriction does\par
+not survive such relicensing or conveying.\par
+\par
+  If you add terms to a covered work in accord with this section, you\par
+must place, in the relevant source files, a statement of the\par
+additional terms that apply to those files, or a notice indicating\par
+where to find the applicable terms.\par
+\par
+  Additional terms, permissive or non-permissive, may be stated in the\par
+form of a separately written license, or stated as exceptions;\par
+the above requirements apply either way.\par
+\par
+  8. Termination.\par
+\par
+  You may not propagate or modify a covered work except as expressly\par
+provided under this License.  Any attempt otherwise to propagate or\par
+modify it is void, and will automatically terminate your rights under\par
+this License (including any patent licenses granted under the third\par
+paragraph of section 11).\par
+\par
+  However, if you cease all violation of this License, then your\par
+license from a particular copyright holder is reinstated (a)\par
+provisionally, unless and until the copyright holder explicitly and\par
+finally terminates your license, and (b) permanently, if the copyright\par
+holder fails to notify you of the violation by some reasonable means\par
+prior to 60 days after the cessation.\par
+\par
+  Moreover, your license from a particular copyright holder is\par
+reinstated permanently if the copyright holder notifies you of the\par
+violation by some reasonable means, this is the first time you have\par
+received notice of violation of this License (for any work) from that\par
+copyright holder, and you cure the violation prior to 30 days after\par
+your receipt of the notice.\par
+\par
+  Termination of your rights under this section does not terminate the\par
+licenses of parties who have received copies or rights from you under\par
+this License.  If your rights have been terminated and not permanently\par
+reinstated, you do not qualify to receive new licenses for the same\par
+material under section 10.\par
+\par
+  9. Acceptance Not Required for Having Copies.\par
+\par
+  You are not required to accept this License in order to receive or\par
+run a copy of the Program.  Ancillary propagation of a covered work\par
+occurring solely as a consequence of using peer-to-peer transmission\par
+to receive a copy likewise does not require acceptance.  However,\par
+nothing other than this License grants you permission to propagate or\par
+modify any covered work.  These actions infringe copyright if you do\par
+not accept this License.  Therefore, by modifying or propagating a\par
+covered work, you indicate your acceptance of this License to do so.\par
+\par
+  10. Automatic Licensing of Downstream Recipients.\par
+\par
+  Each time you convey a covered work, the recipient automatically\par
+receives a license from the original licensors, to run, modify and\par
+propagate that work, subject to this License.  You are not responsible\par
+for enforcing compliance by third parties with this License.\par
+\par
+  An "entity transaction" is a transaction transferring control of an\par
+organization, or substantially all assets of one, or subdividing an\par
+organization, or merging organizations.  If propagation of a covered\par
+work results from an entity transaction, each party to that\par
+transaction who receives a copy of the work also receives whatever\par
+licenses to the work the party's predecessor in interest had or could\par
+give under the previous paragraph, plus a right to possession of the\par
+Corresponding Source of the work from the predecessor in interest, if\par
+the predecessor has it or can get it with reasonable efforts.\par
+\par
+  You may not impose any further restrictions on the exercise of the\par
+rights granted or affirmed under this License.  For example, you may\par
+not impose a license fee, royalty, or other charge for exercise of\par
+rights granted under this License, and you may not initiate litigation\par
+(including a cross-claim or counterclaim in a lawsuit) alleging that\par
+any patent claim is infringed by making, using, selling, offering for\par
+sale, or importing the Program or any portion of it.\par
+\par
+  11. Patents.\par
+\par
+  A "contributor" is a copyright holder who authorizes use under this\par
+License of the Program or a work on which the Program is based.  The\par
+work thus licensed is called the contributor's "contributor version".\par
+\par
+  A contributor's "essential patent claims" are all patent claims\par
+owned or controlled by the contributor, whether already acquired or\par
+hereafter acquired, that would be infringed by some manner, permitted\par
+by this License, of making, using, or selling its contributor version,\par
+but do not include claims that would be infringed only as a\par
+consequence of further modification of the contributor version.  For\par
+purposes of this definition, "control" includes the right to grant\par
+patent sublicenses in a manner consistent with the requirements of\par
+this License.\par
+\par
+  Each contributor grants you a non-exclusive, worldwide, royalty-free\par
+patent license under the contributor's essential patent claims, to\par
+make, use, sell, offer for sale, import and otherwise run, modify and\par
+propagate the contents of its contributor version.\par
+\par
+  In the following three paragraphs, a "patent license" is any express\par
+agreement or commitment, however denominated, not to enforce a patent\par
+(such as an express permission to practice a patent or covenant not to\par
+sue for patent infringement).  To "grant" such a patent license to a\par
+party means to make such an agreement or commitment not to enforce a\par
+patent against the party.\par
+\par
+  If you convey a covered work, knowingly relying on a patent license,\par
+and the Corresponding Source of the work is not available for anyone\par
+to copy, free of charge and under the terms of this License, through a\par
+publicly available network server or other readily accessible means,\par
+then you must either (1) cause the Corresponding Source to be so\par
+available, or (2) arrange to deprive yourself of the benefit of the\par
+patent license for this particular work, or (3) arrange, in a manner\par
+consistent with the requirements of this License, to extend the patent\par
+license to downstream recipients.  "Knowingly relying" means you have\par
+actual knowledge that, but for the patent license, your conveying the\par
+covered work in a country, or your recipient's use of the covered work\par
+in a country, would infringe one or more identifiable patents in that\par
+country that you have reason to believe are valid.\par
+\par
+  If, pursuant to or in connection with a single transaction or\par
+arrangement, you convey, or propagate by procuring conveyance of, a\par
+covered work, and grant a patent license to some of the parties\par
+receiving the covered work authorizing them to use, propagate, modify\par
+or convey a specific copy of the covered work, then the patent license\par
+you grant is automatically extended to all recipients of the covered\par
+work and works based on it.\par
+\par
+  A patent license is "discriminatory" if it does not include within\par
+the scope of its coverage, prohibits the exercise of, or is\par
+conditioned on the non-exercise of one or more of the rights that are\par
+specifically granted under this License.  You may not convey a covered\par
+work if you are a party to an arrangement with a third party that is\par
+in the business of distributing software, under which you make payment\par
+to the third party based on the extent of your activity of conveying\par
+the work, and under which the third party grants, to any of the\par
+parties who would receive the covered work from you, a discriminatory\par
+patent license (a) in connection with copies of the covered work\par
+conveyed by you (or copies made from those copies), or (b) primarily\par
+for and in connection with specific products or compilations that\par
+contain the covered work, unless you entered into that arrangement,\par
+or that patent license was granted, prior to 28 March 2007.\par
+\par
+  Nothing in this License shall be construed as excluding or limiting\par
+any implied license or other defenses to infringement that may\par
+otherwise be available to you under applicable patent law.\par
+\par
+  12. No Surrender of Others' Freedom.\par
+\par
+  If conditions are imposed on you (whether by court order, agreement or\par
+otherwise) that contradict the conditions of this License, they do not\par
+excuse you from the conditions of this License.  If you cannot convey a\par
+covered work so as to satisfy simultaneously your obligations under this\par
+License and any other pertinent obligations, then as a consequence you may\par
+not convey it at all.  For example, if you agree to terms that obligate you\par
+to collect a royalty for further conveying from those to whom you convey\par
+the Program, the only way you could satisfy both those terms and this\par
+License would be to refrain entirely from conveying the Program.\par
+\par
+  13. Remote Network Interaction; Use with the GNU General Public License.\par
+\par
+  Notwithstanding any other provision of this License, if you modify the\par
+Program, your modified version must prominently offer all users\par
+interacting with it remotely through a computer network (if your version\par
+supports such interaction) an opportunity to receive the Corresponding\par
+Source of your version by providing access to the Corresponding Source\par
+from a network server at no charge, through some standard or customary\par
+means of facilitating copying of software.  This Corresponding Source\par
+shall include the Corresponding Source for any work covered by version 3\par
+of the GNU General Public License that is incorporated pursuant to the\par
+following paragraph.\par
+\par
+  Notwithstanding any other provision of this License, you have\par
+permission to link or combine any covered work with a work licensed\par
+under version 3 of the GNU General Public License into a single\par
+combined work, and to convey the resulting work.  The terms of this\par
+License will continue to apply to the part which is the covered work,\par
+but the work with which it is combined will remain governed by version\par
+3 of the GNU General Public License.\par
+\par
+  14. Revised Versions of this License.\par
+\par
+  The Free Software Foundation may publish revised and/or new versions of\par
+the GNU Affero General Public License from time to time.  Such new versions\par
+will be similar in spirit to the present version, but may differ in detail to\par
+address new problems or concerns.\par
+\par
+  Each version is given a distinguishing version number.  If the\par
+Program specifies that a certain numbered version of the GNU Affero General\par
+Public License "or any later version" applies to it, you have the\par
+option of following the terms and conditions either of that numbered\par
+version or of any later version published by the Free Software\par
+Foundation.  If the Program does not specify a version number of the\par
+GNU Affero General Public License, you may choose any version ever published\par
+by the Free Software Foundation.\par
+\par
+  If the Program specifies that a proxy can decide which future\par
+versions of the GNU Affero General Public License can be used, that proxy's\par
+public statement of acceptance of a version permanently authorizes you\par
+to choose that version for the Program.\par
+\par
+  Later license versions may give you additional or different\par
+permissions.  However, no additional obligations are imposed on any\par
+author or copyright holder as a result of your choosing to follow a\par
+later version.\par
+\par
+  15. Disclaimer of Warranty.\par
+\par
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY\par
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT\par
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY\par
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,\par
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\par
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM\par
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF\par
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\par
+\par
+  16. Limitation of Liability.\par
+\par
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING\par
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS\par
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY\par
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE\par
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF\par
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD\par
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),\par
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF\par
+SUCH DAMAGES.\par
+\par
+  17. Interpretation of Sections 15 and 16.\par
+\par
+  If the disclaimer of warranty and limitation of liability provided\par
+above cannot be given local legal effect according to their terms,\par
+reviewing courts shall apply local law that most closely approximates\par
+an absolute waiver of all civil liability in connection with the\par
+Program, unless a warranty or assumption of liability accompanies a\par
+copy of the Program in return for a fee.\par
+\par
+                     END OF TERMS AND CONDITIONS\par
+\par
+            How to Apply These Terms to Your New Programs\par
+\par
+  If you develop a new program, and you want it to be of the greatest\par
+possible use to the public, the best way to achieve this is to make it\par
+free software which everyone can redistribute and change under these terms.\par
+\par
+  To do so, attach the following notices to the program.  It is safest\par
+to attach them to the start of each source file to most effectively\par
+state the exclusion of warranty; and each file should have at least\par
+the "copyright" line and a pointer to where the full notice is found.\par
+\par
+    <one line to give the program's name and a brief idea of what it does.>\par
+    Copyright (C) <year>  <name of author>\par
+\par
+    This program is free software: you can redistribute it and/or modify\par
+    it under the terms of the GNU Affero General Public License as published by\par
+    the Free Software Foundation, either version 3 of the License, or\par
+    (at your option) any later version.\par
+\par
+    This program is distributed in the hope that it will be useful,\par
+    but WITHOUT ANY WARRANTY; without even the implied warranty of\par
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\par
+    GNU Affero General Public License for more details.\par
+\par
+    You should have received a copy of the GNU Affero General Public License\par
+    along with this program.  If not, see <{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f0\fs22 >.\par
+\par
+Also add information on how to contact you by electronic and paper mail.\par
+\par
+  If your software can interact with users remotely through a computer\par
+network, you should also make sure that it provides a way for users to\par
+get its source.  For example, if your program is a web application, its\par
+interface could display a "Source" link that leads users to an archive\par
+of the code.  There are many ways you could offer source, and different\par
+solutions will be better for different programs; see section 13 for the\par
+specific requirements.\par
+\par
+  You should also get your employer (if you work as a programmer) or school,\par
+if any, to sign a "copyright disclaimer" for the program, if necessary.\par
+For more information on this, and how to apply and follow the GNU AGPL, see\par
+<{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f0\fs22 >.\par
+\par
 }
  


### PR DESCRIPTION
As noted in #38093, the Windows installer incorrectly references the Apache License. I note that the md file in the `scripts/build/ci-msi-build/msigenerator/resources/license` directory has been corrected, but the `rtf` file hasn't.

My assumption is that the MSI build in fact uses the RTF file instead. We do need to test this assumption before merging this PR.

Fixes #38093