### PR TITLE
Docker: Force use of libcrypto1.1 and libssl1.1 versions to fix CVE-2021-3711

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 WORKDIR $GF_PATHS_HOME
 
 RUN apk add --no-cache ca-certificates bash tzdata && \
-    apk add --no-cache openssl musl-utils
+    apk add --no-cache openssl musl-utils libcrypto1.1>1.1.1l-r0 libssl1.1>1.1.1l-r0
 
 COPY conf ./conf
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 WORKDIR $GF_PATHS_HOME
 
 RUN apk add --no-cache ca-certificates bash tzdata && \
-    apk add --no-cache openssl musl-utils
+    apk add --no-cache openssl musl-utils libcrypto1.1>1.1.1l-r0 libssl1.1>1.1.1l-r0
 
 # Oracle Support for x86_64 only
 RUN if [ `arch` = "x86_64" ]; then \


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://nvd.nist.gov/vuln/detail/CVE-2021-3711 was reported, we need to update the specific dependencies to use non-vulnerable versions.
These can stop specified explicitly, when `alpine` image includes the new `openssl` version. Then, we'll just need to update the `apline` version.