### PR TITLE
Alerting: Various fixes for tests

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -19,7 +19,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs(t *testing.T) {
 		orgs: []int64{1, 2, 3},
 	}
 	SyncOrgsPollInterval = 10 * time.Minute // Don't poll in unit tests.
-	mam := NewMultiOrgAlertmanager(&setting.Cfg{}, configStore, orgStore)
+	mam := NewMultiOrgAlertmanager(&setting.Cfg{DataPath: t.TempDir()}, configStore, orgStore)
 	ctx := context.Background()
 
 	// Ensure that one Alertmanager is created per org.
@@ -50,7 +50,7 @@ func TestMultiOrgAlertmanager_AlertmanagerFor(t *testing.T) {
 	}
 
 	SyncOrgsPollInterval = 10 * time.Minute // Don't poll in unit tests.
-	mam := NewMultiOrgAlertmanager(&setting.Cfg{}, configStore, orgStore)
+	mam := NewMultiOrgAlertmanager(&setting.Cfg{DataPath: t.TempDir()}, configStore, orgStore)
 	ctx := context.Background()
 
 	// Ensure that one Alertmanagers is created per org.

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -151,7 +151,7 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	// Eventually, our Alertmanager should have received at least two alerts.
 	require.Eventually(t, func() bool {
 		return fakeAM.AlertsCount() == 2 && fakeAM.AlertNamesCompare([]string{alertRuleOrgOne.Title, alertRuleOrgTwo.Title})
-	}, 20*time.Second, 200*time.Millisecond)
+	}, 30*time.Second, 200*time.Millisecond)
 
 	// 2. Next, let's modify the configuration of an organization by adding an extra alertmanager.
 	fakeAM2 := NewFakeExternalAlertmanager(t)


### PR DESCRIPTION
1. Ensures Alertmanager files are persisted to temporary directories
2. Gives a bit more time for alerts to arrive as part of the scheduler tests