### PR TITLE
Docs: clarify state of Unified Alerting

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -7,7 +7,7 @@ weight = 110
 
 Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
 
-Grafana 8.0 (beta) has new and improved alerts. The new alerting system is an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
+Grafana 8.0 has new and improved alerts. The new alerting system is an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
 
 > **Note:** Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing Grafana 8 alerts.
 

--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -7,7 +7,7 @@ weight = 110
 
 Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
 
-Grafana 8.0 (beta) has new and improved alerts. This new alerting system are an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
+Grafana 8.0 (beta) has new and improved alerts. The new alerting system is an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
 
 > **Note:** Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing Grafana 8 alerts.
 

--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -7,7 +7,9 @@ weight = 110
 
 Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
 
-Grafana 8.0 has new and improved alerts. The new alerting system are an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
+Grafana 8.0 (beta) has new and improved alerts. This new alerting system are an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
+
+> **Note:** Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing Grafana 8 alerts.
 
 Alerts have four main components:
 

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -6,9 +6,9 @@ weight = 113
 
 # Overview of Grafana 8 alerts
 
-> **Note:** This information is for the new, Grafana 8 Alerts. This is an [opt-in]({{< relref"./opt-in.md" >}}) feature released in Grafana 8.0 and is not production ready yet. Grafana still supports [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}) out of the box. If you find bugs while testing this feature, please create issues in the Grafana GitHub repository.
-
 Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
+
+> **Note:** Trafana 8 alerts(beta) is an [opt-in]({{< relref"./opt-in.md" >}}) feature. Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing this feature.
 
 Alerts have four main components:
 

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -8,9 +8,9 @@ weight = 113
 
 Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
 
-> **Note:** Trafana 8 alerts(beta) is an [opt-in]({{< relref"./opt-in.md" >}}) feature. Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing this feature.
+> **Note:** Grafana 8 alerts (beta) is an [opt-in]({{< relref"./opt-in.md" >}}) feature. Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing this new feature.
 
-Alerts have four main components:
+Grafana 8 alerts have four main components:
 
 - Alerting rule - One or more query and/or expression, a condition, the frequency of evaluation, and the (optional) duration that a condition must be met before creating an alert.
 - Contact point - A channel for sending notifications when the conditions of an alerting rule are met.

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -6,9 +6,9 @@ weight = 113
 
 # Overview of Grafana 8 alerts
 
-Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
+> **Note:** This information is for the new, Grafana 8 Alerts. This is an [opt-in]({{< relref"./opt-in.md" >}}) feature released in Grafana 8.0. Grafana still supports [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}) out of the box. If you find bugs while testing this feature, please create issues in the Grafana GitHub repository.
 
-> **Note:** This information is for the new, Grafana 8 Alerts. This is an [opt-in]({{< relref"./opt-in.md" >}}) feature released in Grafana 8.0. Grafana still supports [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}) out of the box
+Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
 
 Alerts have four main components:
 

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -6,7 +6,7 @@ weight = 113
 
 # Overview of Grafana 8 alerts
 
-> **Note:** This information is for the new, Grafana 8 Alerts. This is an [opt-in]({{< relref"./opt-in.md" >}}) feature released in Grafana 8.0. Grafana still supports [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}) out of the box. If you find bugs while testing this feature, please create issues in the Grafana GitHub repository.
+> **Note:** This information is for the new, Grafana 8 Alerts. This is an [opt-in]({{< relref"./opt-in.md" >}}) feature released in Grafana 8.0 and is not production ready yet. Grafana still supports [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}) out of the box. If you find bugs while testing this feature, please create issues in the Grafana GitHub repository.
 
 Alerts allow you to know about problems in your systems moments after they occur. Robust and actionable alerts help you identify and resolve issues quickly, minimizing disruption to your services.
 


### PR DESCRIPTION
Following feedback in https://github.com/grafana/grafana/issues/38055#issuecomment-906163119, this PR clarifies the fact that unified alerting is currently an opt-in feature that still contains a few bugs.