### PR TITLE
Chore: Add CODEOWNERS for CI related code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,10 @@
 go.mod @grafana/backend-platform
 go.sum @grafana/backend-platform
 
+# Continuous Integration
+.drone.yml @malcolmholmes @dsotirakis @zserge
+/scripts/*.star @malcolmholmes @dsotirakis @zserge
+
 # Cloud Datasources backend code
 /pkg/tsdb/cloudwatch @grafana/cloud-datasources @grafana/observability-squad
 /pkg/tsdb/azuremonitor @grafana/cloud-datasources


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds @malcolmholmes @dsotirakis and @zserge as CODEOWNERS for CI related code