### PR TITLE
Explore: Download traces as JSON in Explore Inspector

### DIFF
--- a/docs/sources/explore/explore-inspector.md
+++ b/docs/sources/explore/explore-inspector.md
@@ -62,7 +62,7 @@ Grafana generates a TXT file in your default browser download location. You can 
 Based on the data source type, Grafana generates a JSON file for the trace results in one of the supported formats: Jaeger, Zipkin, or OTLP formats.
 
 1. Open the inspector.
-1. Inspect the trace query results as described above.
+1. Inspect the trace query results [as described above](#inspect-raw-query-results).
 1. Click **Download traces**.
 
 ### Inspect query performance

--- a/docs/sources/explore/explore-inspector.md
+++ b/docs/sources/explore/explore-inspector.md
@@ -57,6 +57,14 @@ Grafana generates a TXT file in your default browser download location. You can 
 1. Inspect the log query results as described above.
 1. Click **Download logs**.
 
+### Download trace results
+
+Grafana generates a JSON file for the trace results based on the trace datasource type. Jaeger, Zipkin, and OTLP formats are supported.
+
+1. Open the inspector.
+1. Inspect the trace query results as described above.
+1. Click **Download traces**.
+
 ### Inspect query performance
 
 The Stats tab displays statistics that tell you how long your query takes, how many queries you send, and the number of rows returned. This information can help you troubleshoot your queries, especially if any of the numbers are unexpectedly high or low.

--- a/docs/sources/explore/explore-inspector.md
+++ b/docs/sources/explore/explore-inspector.md
@@ -59,7 +59,7 @@ Grafana generates a TXT file in your default browser download location. You can 
 
 ### Download trace results
 
-Grafana generates a JSON file for the trace results based on the trace datasource type. Jaeger, Zipkin, and OTLP formats are supported.
+Based on the data source type, Grafana generates a JSON file for the trace results in one of the supported formats: Jaeger, Zipkin, or OTLP formats.
 
 1. Open the inspector.
 1. Inspect the trace query results as described above.

--- a/public/app/features/inspector/InspectDataTab.test.tsx
+++ b/public/app/features/inspector/InspectDataTab.test.tsx
@@ -83,5 +83,63 @@ describe('InspectDataTab', () => {
       render(<InspectDataTab {...createProps()} />);
       expect(screen.queryByText(/Download logs/i)).not.toBeInTheDocument();
     });
+    it('should show download traces button if traces data', () => {
+      const dataWithtraces = ([
+        {
+          name: 'Data frame with traces',
+          fields: [
+            { name: 'traceID', values: ['3fa414edcef6ad90', '3fa414edcef6ad90'] },
+            { name: 'spanID', values: ['3fa414edcef6ad90', '0f5c1808567e4403'] },
+            { name: 'parentSpanID', values: [undefined, '3fa414edcef6ad90'] },
+            { name: 'operationName', values: ['HTTP GET - api_traces_traceid', '/tempopb.Querier/FindTraceByID'] },
+            { name: 'serviceName', values: ['tempo-querier', 'tempo-querier'] },
+            {
+              name: 'serviceTags',
+              values: [
+                [
+                  { key: 'cluster', type: 'string', value: 'ops-tools1' },
+                  { key: 'container', type: 'string', value: 'tempo-query' },
+                ],
+                [
+                  { key: 'cluster', type: 'string', value: 'ops-tools1' },
+                  { key: 'container', type: 'string', value: 'tempo-query' },
+                ],
+              ],
+            },
+            { name: 'startTime', values: [1605873894680.409, 1605873894680.587] },
+            { name: 'duration', values: [1049.141, 1.847] },
+            { name: 'logs', values: [[], []] },
+            {
+              name: 'tags',
+              values: [
+                [
+                  { key: 'sampler.type', type: 'string', value: 'probabilistic' },
+                  { key: 'sampler.param', type: 'float64', value: 1 },
+                ],
+                [
+                  { key: 'component', type: 'string', value: 'gRPC' },
+                  { key: 'span.kind', type: 'string', value: 'client' },
+                ],
+              ],
+            },
+            { name: 'warnings', values: [undefined, undefined] },
+            { name: 'stackTraces', values: [undefined, undefined] },
+          ],
+          length: 2,
+          meta: {
+            preferredVisualisationType: 'trace',
+            custom: {
+              traceFormat: 'jaeger',
+            },
+          },
+        },
+      ] as unknown) as DataFrame[];
+      render(<InspectDataTab {...createProps({ data: dataWithtraces })} />);
+      expect(screen.getByText(/Download traces/i)).toBeInTheDocument();
+    });
+    it('should not show download traces button if no traces data', () => {
+      render(<InspectDataTab {...createProps()} />);
+      expect(screen.queryByText(/Download traces/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -25,6 +25,7 @@ import { PanelModel } from 'app/features/dashboard/state';
 import { dataFrameToLogsModel } from 'app/core/logs_model';
 import { transformToJaeger } from 'app/plugins/datasource/jaeger/responseTransform';
 import { transformToZipkin } from 'app/plugins/datasource/zipkin/utils/transforms';
+import { transformToOTLP } from 'app/plugins/datasource/tempo/resultTransformer';
 
 interface Props {
   isLoading: boolean;
@@ -132,6 +133,11 @@ export class InspectDataTab extends PureComponent<Props, State> {
     }
 
     for (const df of data) {
+      // Only export traces
+      if (df.meta?.preferredVisualisationType !== 'trace') {
+        continue;
+      }
+
       switch (df.meta?.custom?.traceFormat) {
         case 'jaeger': {
           let res = transformToJaeger(new MutableDataFrame(df));
@@ -145,6 +151,8 @@ export class InspectDataTab extends PureComponent<Props, State> {
         }
         case 'otlp':
         default: {
+          let res = transformToOTLP(new MutableDataFrame(df));
+          this.saveTraceJson(res, panel);
           break;
         }
       }

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -171,5 +171,8 @@ const emptyTraceDataFrame = new MutableDataFrame({
   ],
   meta: {
     preferredVisualisationType: 'trace',
+    custom: {
+      traceFormat: 'jaeger',
+    },
   },
 });

--- a/public/app/plugins/datasource/jaeger/responseTransform.test.ts
+++ b/public/app/plugins/datasource/jaeger/responseTransform.test.ts
@@ -8,7 +8,7 @@ describe('createTraceFrame', () => {
     expect(dataFrame.fields).toMatchObject(testResponseDataFrameFields);
   });
 
-  fit('transforms to jaeger format from data frame', () => {
+  it('transforms to jaeger format from data frame', () => {
     const dataFrame = createTraceFrame(testResponse);
     const response = transformToJaeger(new MutableDataFrame(dataFrame));
     expect(response).toMatchObject({ data: [testResponse] });

--- a/public/app/plugins/datasource/jaeger/responseTransform.test.ts
+++ b/public/app/plugins/datasource/jaeger/responseTransform.test.ts
@@ -11,6 +11,6 @@ describe('createTraceFrame', () => {
   fit('transforms to jaeger format from data frame', () => {
     const dataFrame = createTraceFrame(testResponse);
     const response = transformToJaeger(new MutableDataFrame(dataFrame));
-    expect(response).toMatchObject(testResponse);
+    expect(response).toMatchObject({ data: [testResponse] });
   });
 });

--- a/public/app/plugins/datasource/jaeger/responseTransform.test.ts
+++ b/public/app/plugins/datasource/jaeger/responseTransform.test.ts
@@ -1,9 +1,16 @@
-import { createTraceFrame } from './responseTransform';
+import { createTraceFrame, transformToJaeger } from './responseTransform';
 import { testResponse, testResponseDataFrameFields } from './testResponse';
+import { MutableDataFrame } from '@grafana/data';
 
 describe('createTraceFrame', () => {
   it('creates data frame from jaeger response', () => {
     const dataFrame = createTraceFrame(testResponse);
     expect(dataFrame.fields).toMatchObject(testResponseDataFrameFields);
+  });
+
+  fit('transforms to jaeger format from data frame', () => {
+    const dataFrame = createTraceFrame(testResponse);
+    const response = transformToJaeger(new MutableDataFrame(dataFrame));
+    expect(response).toMatchObject(testResponse);
   });
 });

--- a/public/app/plugins/datasource/jaeger/types.ts
+++ b/public/app/plugins/datasource/jaeger/types.ts
@@ -64,3 +64,11 @@ export type JaegerQuery = {
 } & DataQuery;
 
 export type JaegerQueryType = 'search' | 'upload';
+
+export type JaegerResponse = {
+  data: TraceResponse[];
+  total: number;
+  limit: number;
+  offset: number;
+  errors?: string[] | null;
+};

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -84,7 +84,10 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
                 .map((field) => field.matcherRegex) || [];
             if (!traceLinkMatcher || traceLinkMatcher.length === 0) {
               return throwError(
-                'No Loki datasource configured for search. Set up Derived Fields for traces in a Loki datasource settings and link it to this Tempo datasource.'
+                () =>
+                  new Error(
+                    'No Loki datasource configured for search. Set up Derived Fields for traces in a Loki datasource settings and link it to this Tempo datasource.'
+                  )
               );
             } else {
               return (linkedDatasource.query(linkedRequest) as Observable<DataQueryResponse>).pipe(

--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -1,5 +1,6 @@
 import { FieldType, MutableDataFrame } from '@grafana/data';
-import { createTableFrame } from './resultTransformer';
+import { createTableFrame, transformToOTLP } from './resultTransformer';
+import { otlpDataFrame, otlpResponse } from './testResponse';
 
 describe('transformTraceList()', () => {
   const lokiDataFrame = new MutableDataFrame({
@@ -33,5 +34,12 @@ describe('transformTraceList()', () => {
     // Second match in new line
     expect(frame.fields[0].values.get(1)).toBe('2020-02-12T15:05:15.265Z');
     expect(frame.fields[1].values.get(1)).toBe('as');
+  });
+});
+
+describe('transformToOTLP()', () => {
+  test('transforms dataframe to OTLP format', () => {
+    const otlp = transformToOTLP(otlpDataFrame);
+    expect(otlp).toMatchObject(otlpResponse);
   });
 });

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -384,7 +384,10 @@ function tagsToAttributes(tags: TraceKeyValuePair[]): opentelemetryProto.common.
           'otel.status_code',
         ].includes(t.key)
     )
-    .reduce((attributes, tag) => [...attributes, { key: tag.key, value: toAttributeValue(tag) }], []);
+    .reduce<opentelemetryProto.common.v1.KeyValue[]>(
+      (attributes, tag) => [...attributes, { key: tag.key, value: toAttributeValue(tag) }],
+      []
+    );
 }
 
 /**

--- a/public/app/plugins/datasource/tempo/testResponse.ts
+++ b/public/app/plugins/datasource/tempo/testResponse.ts
@@ -1848,3 +1848,194 @@ export const bigResponse = new MutableDataFrame({
     },
   ],
 });
+
+export const otlpDataFrame = new MutableDataFrame({
+  meta: {
+    preferredVisualisationType: 'trace',
+    custom: {
+      traceFormat: 'otlp',
+    },
+  },
+  fields: [
+    {
+      name: 'traceID',
+      type: 'string',
+      config: {},
+      values: ['60ba2abb44f13eae'],
+      state: {
+        displayName: 'traceID',
+      },
+    },
+    {
+      name: 'spanID',
+      type: 'string',
+      config: {},
+      values: ['726b5e30102fc0d0'],
+      state: {
+        displayName: 'spanID',
+      },
+    },
+    {
+      name: 'parentSpanID',
+      type: 'string',
+      config: {},
+      values: ['398f0f21a3db99ae'],
+      state: {
+        displayName: 'parentSpanID',
+      },
+    },
+    {
+      name: 'operationName',
+      type: 'string',
+      config: {},
+      values: ['HTTP GET - root'],
+      state: {
+        displayName: 'operationName',
+      },
+    },
+    {
+      name: 'serviceName',
+      type: 'string',
+      config: {},
+      values: ['db'],
+      state: {
+        displayName: 'serviceName',
+      },
+    },
+    {
+      name: 'serviceTags',
+      type: 'other',
+      config: {},
+      values: [
+        [
+          {
+            key: 'service.name',
+            value: 'db',
+          },
+          {
+            key: 'job',
+            value: 'tns/db',
+          },
+          {
+            key: 'opencensus.exporterversion',
+            value: 'Jaeger-Go-2.22.1',
+          },
+          {
+            key: 'host.name',
+            value: '63d16772b4a2',
+          },
+          {
+            key: 'ip',
+            value: '0.0.0.0',
+          },
+          {
+            key: 'client-uuid',
+            value: '39fb01637a579639',
+          },
+        ],
+      ],
+      state: {
+        displayName: 'serviceTags',
+      },
+    },
+    {
+      name: 'startTime',
+      type: 'number',
+      config: {},
+      values: [1627471657255.809],
+      state: {
+        displayName: 'startTime',
+      },
+    },
+    {
+      name: 'duration',
+      type: 'number',
+      config: {},
+      values: [0.459008],
+      state: {
+        displayName: 'duration',
+      },
+    },
+    {
+      name: 'logs',
+      type: 'other',
+      config: {},
+      values: [[]],
+      state: {
+        displayName: 'logs',
+      },
+    },
+    {
+      name: 'tags',
+      type: 'other',
+      config: {},
+      values: [
+        [
+          {
+            key: 'http.status_code',
+            value: 200,
+          },
+          {
+            key: 'http.method',
+            value: 'GET',
+          },
+          {
+            key: 'http.url',
+            value: '/',
+          },
+          {
+            key: 'component',
+            value: 'net/http',
+          },
+          {
+            key: 'span.kind',
+            value: 'client',
+          },
+        ],
+      ],
+      state: {
+        displayName: 'tags',
+      },
+    },
+  ],
+  first: ['60ba2abb44f13eae'],
+  length: 1,
+} as any);
+
+export const otlpResponse = {
+  batches: [
+    {
+      resource: {
+        attributes: [
+          { key: 'service.name', value: { stringValue: 'db' } },
+          { key: 'job', value: { stringValue: 'tns/db' } },
+          { key: 'opencensus.exporterversion', value: { stringValue: 'Jaeger-Go-2.22.1' } },
+          { key: 'host.name', value: { stringValue: '63d16772b4a2' } },
+          { key: 'ip', value: { stringValue: '0.0.0.0' } },
+          { key: 'client-uuid', value: { stringValue: '39fb01637a579639' } },
+        ],
+      },
+      instrumentationLibrarySpans: [
+        {
+          spans: [
+            {
+              traceId: 'AAAAAAAAAABguiq7RPE+rg==',
+              spanId: 'cmteMBAvwNA=',
+              parentSpanId: 'OY8PIaPbma4=',
+              name: 'HTTP GET - root',
+              kind: 'SPAN_KIND_CLIENT',
+              startTimeUnixNano: 1627471657255809000,
+              endTimeUnixNano: 1627471657256268000,
+              attributes: [
+                { key: 'http.status_code', value: { intValue: 200 } },
+                { key: 'http.method', value: { stringValue: 'GET' } },
+                { key: 'http.url', value: { stringValue: '/' } },
+                { key: 'component', value: { stringValue: 'net/http' } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/public/app/plugins/datasource/zipkin/datasource.ts
+++ b/public/app/plugins/datasource/zipkin/datasource.ts
@@ -93,6 +93,9 @@ const emptyDataQueryResponse = {
       ],
       meta: {
         preferredVisualisationType: 'trace',
+        custom: {
+          traceFormat: 'zipkin',
+        },
       },
     }),
   ],

--- a/public/app/plugins/datasource/zipkin/types.ts
+++ b/public/app/plugins/datasource/zipkin/types.ts
@@ -12,6 +12,7 @@ export type ZipkinSpan = {
   annotations?: ZipkinAnnotation[];
   tags?: { [key: string]: string };
   kind?: 'CLIENT' | 'SERVER' | 'PRODUCER' | 'CONSUMER';
+  shared?: boolean;
 };
 
 export type ZipkinEndpoint = {

--- a/public/app/plugins/datasource/zipkin/utils/testData.ts
+++ b/public/app/plugins/datasource/zipkin/utils/testData.ts
@@ -29,7 +29,6 @@ export const zipkinResponse: ZipkinSpan[] = [
     },
     kind: 'CLIENT',
   },
-
   {
     traceId: 'trace_id',
     parentId: 'span 1 id',
@@ -71,9 +70,16 @@ export const traceFrameFields = [
       [
         { key: 'ipv4', value: '1.0.0.1' },
         { key: 'port', value: 42 },
+        { key: 'endpointType', value: 'local' },
       ],
-      [{ key: 'ipv4', value: '1.0.0.1' }],
-      [{ key: 'ipv6', value: '127.0.0.1' }],
+      [
+        { key: 'ipv4', value: '1.0.0.1' },
+        { key: 'endpointType', value: 'local' },
+      ],
+      [
+        { key: 'ipv6', value: '127.0.0.1' },
+        { key: 'endpointType', value: 'remote' },
+      ],
     ],
   },
   { name: 'startTime', values: [0.001, 0.004, 0.006] },

--- a/public/app/plugins/datasource/zipkin/utils/transforms.test.ts
+++ b/public/app/plugins/datasource/zipkin/utils/transforms.test.ts
@@ -11,7 +11,6 @@ describe('transformResponse', () => {
   it('converts dataframe to ZipkinSpan[]', () => {
     const dataFrame = transformResponse(zipkinResponse);
     const response = transformToZipkin(new MutableDataFrame(dataFrame));
-    // TODO - figure out shared, figure out remote vs local endpoint. Otherwise change test and move on
     expect(response).toMatchObject(zipkinResponse);
   });
 });

--- a/public/app/plugins/datasource/zipkin/utils/transforms.test.ts
+++ b/public/app/plugins/datasource/zipkin/utils/transforms.test.ts
@@ -1,10 +1,17 @@
-import { transformResponse } from './transforms';
+import { transformResponse, transformToZipkin } from './transforms';
 import { traceFrameFields, zipkinResponse } from './testData';
+import { MutableDataFrame } from '@grafana/data';
 
 describe('transformResponse', () => {
   it('transforms response', () => {
     const dataFrame = transformResponse(zipkinResponse);
 
     expect(dataFrame.fields).toMatchObject(traceFrameFields);
+  });
+  it('converts dataframe to ZipkinSpan[]', () => {
+    const dataFrame = transformResponse(zipkinResponse);
+    const response = transformToZipkin(new MutableDataFrame(dataFrame));
+    // TODO - figure out shared, figure out remote vs local endpoint. Otherwise change test and move on
+    expect(response).toMatchObject(zipkinResponse);
   });
 });

--- a/public/app/plugins/datasource/zipkin/utils/transforms.ts
+++ b/public/app/plugins/datasource/zipkin/utils/transforms.ts
@@ -159,8 +159,8 @@ export const transformToZipkin = (data: MutableDataFrame): ZipkinSpan[] => {
               return { ...tags, [t.key]: t.value };
             }, {})
         : undefined,
-      kind: span.tags.find((t: TraceKeyValuePair) => t.key === 'kind')?.value ?? undefined,
-      shared: span.tags.find((t: TraceKeyValuePair) => t.key === 'shared')?.value ?? undefined,
+      kind: span.tags.find((t: TraceKeyValuePair) => t.key === 'kind')?.value,
+      shared: span.tags.find((t: TraceKeyValuePair) => t.key === 'shared')?.value,
     });
   }
 
@@ -177,9 +177,9 @@ const getEndpoint = (span: any): { [key: string]: ZipkinEndpoint } | undefined =
     ? {
         [key]: {
           serviceName: span.serviceName,
-          ipv4: span.serviceTags.find((t: TraceKeyValuePair) => t.key === 'ipv4')?.value ?? undefined,
-          ipv6: span.serviceTags.find((t: TraceKeyValuePair) => t.key === 'ipv6')?.value ?? undefined,
-          port: span.serviceTags.find((t: TraceKeyValuePair) => t.key === 'port')?.value ?? undefined,
+          ipv4: span.serviceTags.find((t: TraceKeyValuePair) => t.key === 'ipv4')?.value,
+          ipv6: span.serviceTags.find((t: TraceKeyValuePair) => t.key === 'ipv6')?.value,
+          port: span.serviceTags.find((t: TraceKeyValuePair) => t.key === 'port')?.value,
         },
       }
     : undefined;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to download traces as JSON in their relevant format (Jaeger, Zipkin, or OTLP). 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #27852

**Special notes for your reviewer**:

TODO:
- [x] Jaeger transform and tests
- [x] Zipkin transform and tests
- [x] OTLP transform and tests
- [x] Download file in Inspect Data tab
- [x] Documentation