### PR TITLE
POC: use live channels for system notifications

### DIFF
--- a/pkg/models/notice.go
+++ b/pkg/models/notice.go
@@ -1,0 +1,25 @@
+package models
+
+type LiveNotice struct {
+	Timestamp int64  `json:"time,omitempty"` // UI can dismiss notice by timestam as id
+	Kind      string `json:"kind,omitempty"` // key that defines full behavior
+	Title     string `json:"title,omitempty"`
+	Body      string `json:"body,omitempty"`
+	Severity  string `json:"severity,omitempty"`
+}
+
+type LiveNoticeAction string
+
+const (
+	LiveNoticeClear       LiveNoticeAction = "clear"
+	LiveNoticeAdd         LiveNoticeAction = "add"
+	LiveNoticeRemove      LiveNoticeAction = "remove"
+	LiveNoticeIncludeKind LiveNoticeAction = "includeKind"
+	LiveNoticeExcludeKind LiveNoticeAction = "excludeKind"
+)
+
+// Will be sent over a notice channel
+type LiveNoticeRequest struct {
+	Action LiveNoticeAction `json:"action"`
+	Notice *LiveNotice      `json:"notice,omitempty"`
+}

--- a/pkg/services/live/features/notice.go
+++ b/pkg/services/live/features/notice.go
@@ -1,0 +1,190 @@
+package features
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana/pkg/models"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+type LiveNotices struct {
+	Notices []models.LiveNotice `json:"notice,omitempty"`
+}
+
+// Process given the current value, return what the next state should look like
+func (n *LiveNotices) Process(req models.LiveNoticeRequest) (bool, error) {
+	if req.Action == models.LiveNoticeClear {
+		changed := len(n.Notices) > 0
+		n.Notices = nil
+		return changed, nil
+	}
+	if req.Notice == nil {
+		return false, fmt.Errorf("missing notice")
+	}
+
+	switch req.Action {
+	case models.LiveNoticeAdd:
+		notice := req.Notice
+		if notice.Timestamp < 1 {
+			notice.Timestamp = time.Now().UnixNano() / int64(time.Millisecond)
+		}
+		if !(notice.Kind == "" && notice.Title != "") {
+			return false, fmt.Errorf("notice must have a kind or title")
+		}
+		n.Notices = append(n.Notices, *notice)
+		return true, nil
+
+	case models.LiveNoticeRemove:
+		return false, fmt.Errorf("TODO, match and remove")
+
+	case models.LiveNoticeIncludeKind:
+		if req.Notice.Kind == "" {
+			return false, fmt.Errorf("missing kind")
+		}
+		if n.Notices != nil {
+			for _, c := range n.Notices {
+				if c.Kind == req.Notice.Kind {
+					return false, nil // already have it
+				}
+			}
+		}
+		n.Notices = append(n.Notices, models.LiveNotice{
+			Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+			Kind:      req.Notice.Kind,
+		})
+		return true, nil
+
+	case models.LiveNoticeExcludeKind:
+		if req.Notice.Kind == "" {
+			return false, fmt.Errorf("missing kind")
+		}
+		changed := false
+		if n.Notices != nil {
+			clean := make([]models.LiveNotice, 0, len(n.Notices))
+			for _, c := range n.Notices {
+				if c.Kind != req.Notice.Kind {
+					clean = append(clean, c)
+				} else {
+					changed = true
+				}
+			}
+			if changed {
+				n.Notices = clean
+			}
+		}
+		return changed, nil
+	}
+
+	return false, fmt.Errorf("unsupported action")
+}
+
+// NoticeRunner will simply broadcast all events to `grafana/notice/system/${role}` channels
+// This assumes that data is a JSON object
+type NoticeRunner struct {
+	liveMessageStore LiveMessageStore
+	publisher        models.ChannelPublisher
+}
+
+func NewNoticeRunner(liveMessageStore LiveMessageStore, publisher models.ChannelPublisher) *NoticeRunner {
+	return &NoticeRunner{liveMessageStore: liveMessageStore, publisher: publisher}
+}
+
+// AddNotice will append a notice
+func (b *NoticeRunner) Process(orgId int64, role models.RoleType, req models.LiveNoticeRequest) error {
+	query := &models.GetLiveMessageQuery{
+		OrgId:   orgId,
+		Channel: fmt.Sprintf("grafana/notice/system/%s", role),
+	}
+	current := LiveNotices{}
+	msg, ok, err := b.liveMessageStore.GetLiveMessage(query)
+	if err != nil {
+		return err
+	}
+	if ok && msg.Data != nil {
+		err = json.Unmarshal(msg.Data, &current)
+		if err != nil {
+			return nil
+		}
+	}
+	changed, err := current.Process(req)
+	if err != nil {
+		return nil
+	}
+	if changed {
+		data, err := json.Marshal(current)
+		if err != nil {
+			return err
+		}
+		save := &models.SaveLiveMessageQuery{
+			OrgId:   query.OrgId,
+			Channel: query.Channel,
+			Data:    data,
+		}
+		if err := b.liveMessageStore.SaveLiveMessage(save); err != nil {
+			return err
+		}
+
+		// broadcast to this path
+		logger.Info("SEND message", "channel", save.Channel, "date", string(save.Data))
+		err = b.publisher(save.OrgId, save.Channel, save.Data)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetHandlerForPath called on init
+func (b *NoticeRunner) GetHandlerForPath(_ string) (models.ChannelHandler, error) {
+	return b, nil // all dashboards share the same handler
+}
+
+// OnSubscribe will let anyone connect to the path
+func (b *NoticeRunner) OnSubscribe(_ context.Context, u *models.SignedInUser, e models.SubscribeEvent) (models.SubscribeReply, backend.SubscribeStreamStatus, error) {
+	// TODO, validate user roles
+	reply := models.SubscribeReply{
+		Presence:  false,
+		JoinLeave: false,
+	}
+	query := &models.GetLiveMessageQuery{
+		OrgId:   u.OrgId,
+		Channel: e.Channel,
+	}
+	msg, ok, err := b.liveMessageStore.GetLiveMessage(query)
+	if err != nil {
+		return models.SubscribeReply{}, 0, err
+	}
+	if ok {
+		reply.Data = msg.Data
+	}
+	return reply, backend.SubscribeStreamStatusOK, nil
+}
+
+// OnPublish is called when posting a message manually....
+func (b *NoticeRunner) OnPublish(_ context.Context, u *models.SignedInUser, e models.PublishEvent) (models.PublishReply, backend.PublishStreamStatus, error) {
+	logger.Debug("got", "channel", e.Channel, "path", e.Path, "has role")
+
+	query := &models.GetLiveMessageQuery{
+		OrgId:   u.OrgId,
+		Channel: e.Channel,
+	}
+	msg, ok, err := b.liveMessageStore.GetLiveMessage(query)
+	if err != nil {
+		return models.PublishReply{}, 0, err
+	}
+	logger.Debug("LAST", "msg", msg, "ok", ok)
+
+	save := &models.SaveLiveMessageQuery{
+		OrgId:   u.OrgId,
+		Channel: e.Channel,
+		Data:    e.Data,
+	}
+	if err := b.liveMessageStore.SaveLiveMessage(save); err != nil {
+		return models.PublishReply{}, 0, err
+	}
+	return models.PublishReply{}, backend.PublishStreamStatusOK, nil
+}

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -164,6 +164,37 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	g.GrafanaScope.Features["dashboard"] = dash
 	g.GrafanaScope.Features["broadcast"] = features.NewBroadcastRunner(g.storage)
 
+	noticeRunner := features.NewNoticeRunner(g.storage, g.Publish)
+	g.GrafanaScope.Features["notice"] = noticeRunner
+
+	// HACK ALERT... just to show something working!!!
+	go func() {
+		orgId := int64(1)
+		time.Sleep(5 * time.Second)
+		_ = noticeRunner.Process(orgId, models.ROLE_VIEWER, models.LiveNoticeRequest{
+			Action: models.LiveNoticeIncludeKind,
+			Notice: &models.LiveNotice{
+				Kind: "sample-viewer-message",
+			},
+		})
+
+		time.Sleep(5 * time.Second)
+		_ = noticeRunner.Process(orgId, models.ROLE_EDITOR, models.LiveNoticeRequest{
+			Action: models.LiveNoticeIncludeKind,
+			Notice: &models.LiveNotice{
+				Kind: "sample-editor-message",
+			},
+		})
+
+		time.Sleep(5 * time.Second)
+		_ = noticeRunner.Process(orgId, models.ROLE_ADMIN, models.LiveNoticeRequest{
+			Action: models.LiveNoticeIncludeKind,
+			Notice: &models.LiveNotice{
+				Kind: "sample-admin-message",
+			},
+		})
+	}()
+
 	var managedStreamRunner *managedstream.Runner
 	if g.IsHA() {
 		redisClient := redis.NewClient(&redis.Options{

--- a/public/app/features/live/features.ts
+++ b/public/app/features/live/features.ts
@@ -1,5 +1,6 @@
 import { LiveChannelType } from '@grafana/data';
 import { getDashboardChannelsFeature } from './dashboard/dashboardWatcher';
+import { getNoticeChannelsFeature } from './notice/noticeListener';
 import { grafanaLiveCoreFeatures } from './scopes';
 
 export function registerLiveFeatures() {
@@ -31,4 +32,7 @@ export function registerLiveFeatures() {
 
   // dashboard/*
   grafanaLiveCoreFeatures.register(getDashboardChannelsFeature());
+
+  // notice/${role}
+  grafanaLiveCoreFeatures.register(getNoticeChannelsFeature());
 }

--- a/public/app/features/live/notice/noticeListener.ts
+++ b/public/app/features/live/notice/noticeListener.ts
@@ -1,0 +1,79 @@
+import { getGrafanaLiveSrv } from '@grafana/runtime';
+import { appEvents, contextSrv } from 'app/core/core';
+import {
+  AppEvents,
+  isLiveChannelMessageEvent,
+  isLiveChannelStatusEvent,
+  LiveChannelEvent,
+  LiveChannelScope,
+} from '@grafana/data';
+import { CoreGrafanaLiveFeature } from '../scopes';
+import { Subscription } from 'rxjs';
+import { LiveNotices } from './types';
+
+class NoticeListener {
+  subscription?: Subscription;
+
+  init() {
+    const { orgRole } = contextSrv.user;
+    if (!orgRole) {
+      return; // weird state -- just ignore
+    }
+    const channel = {
+      scope: LiveChannelScope.Grafana,
+      namespace: 'notice',
+      path: `system/${orgRole}`,
+    };
+
+    // TODO: use REST when live is disabled/fails
+
+    const live = getGrafanaLiveSrv();
+    if (!live) {
+      return;
+    }
+
+    this.subscription = live.getStream<LiveNotices>(channel).subscribe({
+      next: (event: LiveChannelEvent<LiveNotices>) => {
+        // Send the editing state when connection starts
+        if (isLiveChannelStatusEvent(event)) {
+          this.handleMessage(event.message); // connection message
+        }
+
+        if (isLiveChannelMessageEvent(event)) {
+          this.handleMessage(event.message);
+        }
+      },
+    });
+  }
+
+  handleMessage = (msg: LiveNotices) => {
+    if (msg?.notice) {
+      for (const notice of msg.notice) {
+        console.log('TODO??', notice);
+        appEvents.emit(AppEvents.alertWarning, ['Got Notice', JSON.stringify(notice)]);
+      }
+    }
+  };
+}
+
+export const noticeListener = new NoticeListener();
+
+export function getNoticeChannelsFeature(): CoreGrafanaLiveFeature {
+  setTimeout(() => {
+    if (!noticeListener.subscription) {
+      noticeListener.init();
+    }
+  }, 1000);
+
+  return {
+    name: 'notice',
+    support: {
+      getChannelConfig: (path: string) => ({
+        description: 'Notice change events',
+        hasPresence: true,
+        canPublish: true, // admins can post
+      }),
+    },
+    description: 'Notice listener',
+  };
+}

--- a/public/app/features/live/notice/types.ts
+++ b/public/app/features/live/notice/types.ts
@@ -1,0 +1,11 @@
+export interface LiveNotice {
+  time: number;
+  kind?: string;
+  title?: string;
+  body?: string;
+  severity?: string;
+}
+
+export interface LiveNotices {
+  notice: LiveNotice[];
+}


### PR DESCRIPTION
To help flush out discussions on notification channels, this is a quick POC to show how we can support notification channels.  

Currently this:
1. has a channel for each user role: Viewer/Editor/Admin
2. supports multiple notices in each channel
3. saves notice state in the live channel store (currently in memory, but should be SQL)
4. receives messages in the front end and shows a popup
 
NOTE: this could all be implemented as a plugin easily, but in core we can use it to push the SQL storage and potentially give a better way to send system notifications