### PR TITLE
Elasticsearch: Limit Histogram field parameter to numeric values

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/hooks/useFields.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useFields.test.tsx
@@ -60,6 +60,11 @@ describe('useFields hook', () => {
     result.current();
     expect(getFields).toHaveBeenLastCalledWith(['date'], timeRange);
 
+    // Histrogram only works on numbers
+    rerender('histogram');
+    result.current();
+    expect(getFields).toHaveBeenLastCalledWith(['number'], timeRange);
+
     // Geohash Grid only works on geo_point data
     rerender('geohash_grid');
     result.current();

--- a/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useFields.ts
@@ -34,6 +34,8 @@ const getFilter = (type: AggregationType) => {
         return ['date'];
       case 'geohash_grid':
         return ['geo_point'];
+      case 'histogram':
+        return ['number'];
       default:
         return [];
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

`Histrogram` bucket aggregation only works on numeric fields as per https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html.

We weren't filtering out non-numeric fields thus showing every type of field in the query editor autocomplete. This PR fixes it by filtering out every non-numeric field.
**Which issue(s) this PR fixes**:


