### PR TITLE
Elasticsearch: change terms default min_doc_count to 1

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -14,7 +14,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
     label: 'Terms',
     requiresField: true,
     defaultSettings: {
-      min_doc_count: '0',
+      min_doc_count: '1',
       size: '10',
       order: 'desc',
       orderBy: '_term',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

As described in https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_minimum_document_count_4, the default elasticsearch value for `min_doc_count` is 1, in order to make Grafana's behavior less surprising we are changing the default value in the query editor from `0` to `1`.

NOTE: Since this value is (and was) saved in the query model, this change only affects newly created queries, so queries created before this change will still have `0` set.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #29616

**Special notes for your reviewer**:

as @csoulios pointed out:
In an effort to fix issue #23636, PR #24204 set the default value of min_doc_count to 0.

However, the issue reported was that users were not able to override the default min_doc_count setting which back then was 1, this is because in the previous editor (before the react migration) `min_doc_count` was a number and the logic was (roughly) `mind_doc_count || 1` so it was impossible to manually set it to 0 (or setting it back to 0 once changed to be 1)

This is not true anymore in the new react editor.


