### PR TITLE
Chore: Fix typo in nodes.go

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -19,7 +19,7 @@ var (
 	logger = log.New("expr")
 )
 
-// baseNode includes commmon properties used across DPNodes.
+// baseNode includes common properties used across DPNodes.
 type baseNode struct {
 	id    int64
 	refID string


### PR DESCRIPTION


**What this PR does / why we need it**:

Fixed typo.

**Which issue(s) this PR fixes**:


```
commmon -> common
```