### PR TITLE
Plugins: Change regexp for version validation in schema

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -303,7 +303,7 @@
         "version": {
           "type": "string",
           "description": "Project version of this commit, e.g. `6.7.x`.",
-          "pattern": "^([0-9x]+\\.[0-9x]+\\.*[0-9x]*$|\\%VERSION\\%)"
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*$|\\%VERSION\\%)"
         }
       }
     },


### PR DESCRIPTION
What this PR does / why we need it:

This PR is changing the regexp used by validate the plugin version used by the plugin-validator side-project

Fixes #31983