### PR TITLE
Docs: Remove an unnecessary legacy alerts notification webhook listing and reduce promotional content

### DIFF
--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -258,7 +258,7 @@ Alertmanager handles alerts sent by client applications such as Prometheus serve
 
 ### Sensu Go
 
-Grafana alert notifications can be sent to [Sensu]((https://sensu.io)) Go as events via the API. This operation requires an API Key. Refer to the [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication) for information on creating this key.
+Grafana alert notifications can be sent to [Sensu]((https://sensu.io)) Go as events via the API. This operation requires an API key. For information on creating this key, refer to the [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication).
 
 ## Enable images in notifications {#external-image-store}
 

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -70,8 +70,7 @@ These examples show how often and when reminders are sent for a triggered alert.
 | Telegram                                      | `telegram`                | yes                | no                      |
 | Threema                                       | `threema`                 | yes, external only | no                      |
 | VictorOps                                     | `victorops`               | yes, external only | yes                     |
-| [Webhook](#webhook)                           | `webhook`                 | yes, external only | yes                     |
-| [Zenduty](#zenduty)                           | `webhook`                 | yes, external only | yes                     |
+| [Webhook](#webhook)                           | `webhook`                 | yes, external only | yes                     |                   |
 
 ### Email
 
@@ -257,13 +256,9 @@ Alertmanager handles alerts sent by client applications such as Prometheus serve
 
 > **Caution:** In case of a high-availability setup, do not load balance traffic between Grafana and Alertmanagers to keep coherence between all your Alertmanager instances. Instead, point Grafana to a list of all Alertmanagers, by listing their URLs comma-separated in the notification channel configuration.
 
-### Zenduty
-
-[Zenduty](https://www.zenduty.com) is an incident alerting and response orchestration platform that not alerts the right teams via SMS, Phone(Voice), Email, Slack, Microsoft Teams and Push notifications(Android/iOS) whenever a Grafana alert is triggered, but also helps you rapidly triage and remediate critical, user impacting incidents. Grafana alert are sent to Zenduty through Grafana's native webhook dispatcher. Refer the Zenduty-Grafana [integration documentation](https://docs.zenduty.com/docs/grafana) for configuring the integration.
-
 ### Sensu Go
 
-[Sensu](https://sensu.io) is a complete solution for monitoring and observability at scale. Sensu Go is designed to give you visibility into everything you care about: traditional server closets, containers, applications, the cloud, and more. Grafana notifications can be sent to Sensu Go as events via the API. This operation requires an API Key. Refer to the [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication) for information on creating this key.
+Grafana alert notifications can be sent to [Sensu]((https://sensu.io)) Go as events via the API. This operation requires an API Key. Refer to the [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication) for information on creating this key.
 
 ## Enable images in notifications {#external-image-store}
 

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -258,7 +258,7 @@ Alertmanager handles alerts sent by client applications such as Prometheus serve
 
 ### Sensu Go
 
-Grafana alert notifications can be sent to [Sensu]((https://sensu.io)) Go as events via the API. This operation requires an API key. For information on creating this key, refer to the [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication).
+Grafana alert notifications can be sent to [Sensu]((https://sensu.io)) Go as events via the API. This operation requires an API key. For information on creating this key, refer to [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication).
 
 ## Enable images in notifications {#external-image-store}
 


### PR DESCRIPTION
This is pr introduces some minor changes to the legacy alerts documentation, focused on Webhooks primarily.

We're reverting a change which added an unuecessary addition to the notifications table by refering to a specific service that uses the generic webhook notification channel. 

Additionally some of the language for the Sensu Go notification channel was changed to focus on how to use it, versus promoting the solution itself. 