### PR TITLE
Fix: panel crash after esc

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -1,5 +1,5 @@
 import { thunkTester } from '../../../../../../test/core/thunk/thunkTester';
-import { closeCompleted, initialState, PanelEditorState } from './reducers';
+import { closeEditor, initialState, PanelEditorState } from './reducers';
 import { initPanelEditor, exitPanelEditor } from './actions';
 import { cleanUpEditPanel, panelModelAndPluginReady } from '../../../state/reducers';
 import { DashboardModel, PanelModel } from '../../../state';
@@ -52,8 +52,8 @@ describe('panelEditor actions', () => {
         .whenThunkIsDispatched();
 
       expect(dispatchedActions.length).toBe(2);
-      expect(dispatchedActions[0].type).toBe(cleanUpEditPanel.type);
-      expect(dispatchedActions[1].type).toBe(closeCompleted.type);
+      expect(dispatchedActions[0].type).toBe(closeEditor.type);
+      expect(dispatchedActions[1].type).toBe(cleanUpEditPanel.type);
       expect(sourcePanel.getOptions()).toEqual({ prop: true });
       expect(sourcePanel.id).toEqual(12);
     });

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -1,7 +1,7 @@
 import { DashboardModel, PanelModel } from '../../../state';
 import { ThunkResult } from 'app/types';
 import {
-  closeCompleted,
+  closeEditor,
   PANEL_EDITOR_UI_STATE_STORAGE_KEY,
   PanelEditorUIState,
   setPanelEditorUIState,
@@ -105,8 +105,8 @@ export function exitPanelEditor(): ThunkResult<void> {
       dashboard.exitPanelEditor();
     }
 
+    dispatch(closeEditor());
     dispatch(cleanUpEditPanel());
-    dispatch(closeCompleted());
   };
 }
 

--- a/public/app/features/dashboard/components/PanelEditor/state/reducers.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/reducers.ts
@@ -106,7 +106,7 @@ const pluginsSlice = createSlice({
     toggleTableView(state) {
       state.tableViewEnabled = !state.tableViewEnabled;
     },
-    closeCompleted: (state) => {
+    closeEditor: (state) => {
       state.isOpen = false;
       state.initDone = false;
       state.isVizPickerOpen = false;
@@ -119,7 +119,7 @@ export const {
   updateEditorInitState,
   setEditorPanelData,
   setDiscardChanges,
-  closeCompleted,
+  closeEditor,
   setPanelEditorUIState,
   toggleVizPicker,
   toggleTableView,

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -68,14 +68,9 @@ const mapDispatchToProps = {
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-interface OwnProps {
-  isPanelEditorOpen?: boolean;
-}
-
 export type Props = Themeable2 &
   GrafanaRouteComponentProps<DashboardPageRouteParams, DashboardPageRouteSearchParams> &
-  ConnectedProps<typeof connector> &
-  OwnProps;
+  ConnectedProps<typeof connector>;
 
 export interface State {
   editPanel: PanelModel | null;

--- a/public/app/features/dashboard/state/reducers.ts
+++ b/public/app/features/dashboard/state/reducers.ts
@@ -76,14 +76,12 @@ const dashbardSlice = createSlice({
       updatePanelState(state, action.payload.panelId, { plugin: action.payload.plugin });
     },
     cleanUpEditPanel: (state) => {
-      // TODO: refactor, since the state should be mutated by copying only
       delete state.panels[EDIT_PANEL_ID];
     },
     setPanelAngularComponent: (state, action: PayloadAction<SetPanelAngularComponentPayload>) => {
       updatePanelState(state, action.payload.panelId, { angularComponent: action.payload.angularComponent });
     },
     addPanel: (state, action: PayloadAction<PanelModel>) => {
-      // TODO: refactor, since the state should be mutated by copying only
       state.panels[action.payload.id] = { pluginId: action.payload.type };
     },
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

After some changes in https://github.com/grafana/grafana/pull/36460 exiting the edit panel with the esc key caused https://github.com/grafana/grafana/issues/38481

So the problem seemed to be that `cleanUpEditPanel` action triggered a rerender in the Paneleditor which put back the edit panel to the redux dashboard state (after removing it). Setting the editor to closed state first seems to fix the problem.

**Which issue(s) this PR fixes**:

Fixes #38481

**Special notes for your reviewer**:

Repro steps:
- Open a time series panel for edit
- Close with esc key
- Open another type of panel for edit (it should crash)
