### PR TITLE
GraphNG: fix crash when trying to diff missing timeRange prop

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -19,7 +19,11 @@ function sameConfig(prevProps: PlotProps, nextProps: PlotProps) {
 function sameTimeRange(prevProps: PlotProps, nextProps: PlotProps) {
   let prevTime = prevProps.timeRange;
   let nextTime = nextProps.timeRange;
-  return nextTime.from.valueOf() === prevTime.from.valueOf() && nextTime.to.valueOf() === prevTime.to.valueOf();
+
+  return (
+    prevTime === nextTime ||
+    (nextTime.from.valueOf() === prevTime.from.valueOf() && nextTime.to.valueOf() === prevTime.to.valueOf())
+  );
 }
 
 type UPlotChartState = {


### PR DESCRIPTION
this fixes a crash caused by https://github.com/grafana/grafana/pull/37769 where we try to diff `timeRange` props, but this is missing from some panels, such as Histogram.

BarCharts did not crash because they are GraphNG-based and have a fake timeRange (a current GraphNG requirement, which will soon change):

https://github.com/grafana/grafana/blob/b5e4a0a39aafddb9c2d9dfa15556cbea8bd99d16/public/app/plugins/panel/barchart/BarChartPanel.tsx#L50