### PR TITLE
[v8.1.x] GraphNG: fix crash when trying to diff missing timeRange prop

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -16,6 +16,16 @@ function sameConfig(prevProps: PlotProps, nextProps: PlotProps) {
   return nextProps.config === prevProps.config;
 }
 
+function sameTimeRange(prevProps: PlotProps, nextProps: PlotProps) {
+  let prevTime = prevProps.timeRange;
+  let nextTime = nextProps.timeRange;
+
+  return (
+    prevTime === nextTime ||
+    (nextTime.from.valueOf() === prevTime.from.valueOf() && nextTime.to.valueOf() === prevTime.to.valueOf())
+  );
+}
+
 type UPlotChartState = {
   ctx: PlotContextType;
 };


### PR DESCRIPTION
Backport 4e2516d12ab3fdf13c46b7acaed2e79efa6ca044 from #38654