### PR TITLE
Dashboard: Fix UIDs are not preserved when importing/creating dashboards thru importing .json file

### DIFF
--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -36,6 +36,14 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
         });
       });
     });
+  // inspect if dashboard kept the uid from json
+  e2e.components.PageToolbar.item('Dashboard settings').click();
+  e2e.pages.Dashboard.Settings.General.sectionItems('JSON Model').click({ force: true }).wait(2000);
+
+  e2e.components.CodeEditor.container().contains('"uid": "6V0Nzyz7k"').wait(2000);
+
+  // click to go back to the dashboard.
+  e2e.components.BackButton.backArrow().click({ force: true }).wait(2000);
 
   // inspect first panel and verify data has been processed for it
   e2e.components.Panels.Panel.title(dashboardToImport.panels[0].title).click({ force: true });

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -37,10 +37,12 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
       });
     });
   // inspect if dashboard kept the uid from json
-  e2e.components.PageToolbar.item('Dashboard settings').click();
-  e2e.pages.Dashboard.Settings.General.sectionItems('JSON Model').click({ force: true }).wait(2000);
+  e2e.getScenarioContext().then(({ lastAddedDashboardUid }: any) => {
+    e2e.components.PageToolbar.item('Dashboard settings').click();
+    e2e.pages.Dashboard.Settings.General.sectionItems('JSON Model').click({ force: true }).wait(2000);
 
-  e2e.components.CodeEditor.container().contains('"uid": "6V0Nzyz7k"').wait(2000);
+    e2e.components.CodeEditor.container().contains(`"uid": "${lastAddedDashboardUid}"`).wait(2000);
+  });
 
   // click to go back to the dashboard.
   e2e.components.BackButton.backArrow().click({ force: true }).wait(2000);

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -7,7 +7,7 @@ type Panel = {
   [key: string]: unknown;
 };
 
-type Dashboard = { title: string; panels: Panel[]; [key: string]: unknown };
+type Dashboard = { title: string; panels: Panel[]; uid: string; [key: string]: unknown };
 
 /**
  * Smoke test a datasource by quickly importing a test dashboard for it
@@ -17,10 +17,13 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
   e2e().visit(fromBaseUrl('/dashboard/import'));
 
   // Note: normally we'd use 'click' and then 'type' here, but the json object is so big that using 'val' is much faster
-  e2e.components.DashboardImportPage.textarea().click({ force: true }).invoke('val', JSON.stringify(dashboardToImport));
-  e2e.components.DashboardImportPage.submit().click({ force: true });
-  e2e.components.ImportDashboardForm.name().click({ force: true }).clear().type(dashboardToImport.title);
-  e2e.components.ImportDashboardForm.submit().click({ force: true });
+  e2e.components.DashboardImportPage.textarea()
+    .should('be.visible')
+    .click()
+    .invoke('val', JSON.stringify(dashboardToImport));
+  e2e.components.DashboardImportPage.submit().should('be.visible').click();
+  e2e.components.ImportDashboardForm.name().should('be.visible').click().clear().type(dashboardToImport.title);
+  e2e.components.ImportDashboardForm.submit().should('be.visible').click();
   e2e().wait(3000);
 
   // save the newly imported dashboard to context so it'll get properly deleted later
@@ -35,31 +38,20 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
           addedDashboards: [...addedDashboards, { title: dashboardToImport.title, uid }],
         });
       });
+
+      expect(dashboardToImport.uid).to.equal(uid);
     });
-  // inspect if dashboard kept the uid from json
-  e2e.getScenarioContext().then(({ lastAddedDashboardUid }: any) => {
-    e2e.components.PageToolbar.item('Dashboard settings').click();
-    e2e.pages.Dashboard.Settings.General.sectionItems('JSON Model').click({ force: true }).wait(2000);
-
-    e2e.components.CodeEditor.container().contains(`"uid": "${lastAddedDashboardUid}"`).wait(2000);
-  });
-
-  // click to go back to the dashboard.
-  e2e.components.BackButton.backArrow().click({ force: true }).wait(2000);
 
   // inspect first panel and verify data has been processed for it
-  e2e.components.Panels.Panel.title(dashboardToImport.panels[0].title).click({ force: true });
-  e2e.components.Panels.Panel.headerItems('Inspect').click({ force: true });
-  e2e.components.Tab.title('JSON').click({ force: true });
-  e2e().wait(3000);
-  e2e.components.PanelInspector.Json.content().contains('Panel JSON').click({ force: true });
-  e2e().wait(3000);
-  e2e.components.Select.option().contains('Data').click({ force: true });
-  e2e().wait(3000);
+  e2e.components.Panels.Panel.title(dashboardToImport.panels[0].title).should('be.visible').click();
+  e2e.components.Panels.Panel.headerItems('Inspect').should('be.visible').click();
+  e2e.components.Tab.title('JSON').should('be.visible').click();
+  e2e.components.PanelInspector.Json.content().should('be.visible').contains('Panel JSON').click();
+  e2e.components.Select.option().should('be.visible').contains('Data').click();
 
   // ensures that panel has loaded without knowingly hitting an error
   // note: this does not prove that data came back as we expected it,
   // it could get `state: Done` for no data for example
   // but it ensures we didn't hit a 401 or 500 or something like that
-  e2e.components.CodeEditor.container().contains('"state": "Done"');
+  e2e.components.CodeEditor.container().should('be.visible').contains('"state": "Done"');
 };

--- a/packages/grafana-e2e/src/flows/importDashboard.ts
+++ b/packages/grafana-e2e/src/flows/importDashboard.ts
@@ -46,8 +46,11 @@ export const importDashboard = (dashboardToImport: Dashboard) => {
   e2e.components.Panels.Panel.title(dashboardToImport.panels[0].title).should('be.visible').click();
   e2e.components.Panels.Panel.headerItems('Inspect').should('be.visible').click();
   e2e.components.Tab.title('JSON').should('be.visible').click();
+  e2e().wait(3000);
   e2e.components.PanelInspector.Json.content().should('be.visible').contains('Panel JSON').click();
+  e2e().wait(3000);
   e2e.components.Select.option().should('be.visible').contains('Data').click();
+  e2e().wait(3000);
 
   // ensures that panel has loaded without knowingly hitting an error
   // note: this does not prove that data came back as we expected it,

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -94,7 +94,10 @@ export function importDashboard(importDashboardForm: ImportDashboardDTO): ThunkR
     });
 
     const result = await getBackendSrv().post('api/dashboards/import', {
-      dashboard: { ...dashboard, title: importDashboardForm.title, uid: importDashboardForm.uid },
+      // uid: if user changed it, take the new uid from importDashboardForm,
+      // else read it from original dashboard
+      // by default the uid input is disabled, onSubmit ignores values from disabled inputs
+      dashboard: { ...dashboard, title: importDashboardForm.title, uid: importDashboardForm.uid || dashboard.uid },
       overwrite: true,
       inputs: inputsToPersist,
       folderId: importDashboardForm.folder.id,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

By default input field is disabled in the form. 

![disabledInputField](https://user-images.githubusercontent.com/239999/131184191-57acff7f-4d17-4ac0-adda-ab397489883c.png)


Values of disabled input are not submitted, I added a fallback to the original dashboard uid, if the user did not change the uid through the form.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37944

**Special notes for your reviewer**:

