### PR TITLE
WIP: substitute mysql driver to enable kerberos support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN yarn build
 
 FROM golang:1.16.1-alpine3.14 as go-builder
 
-RUN apk add --no-cache gcc g++
+RUN apk add --no-cache gcc g++ krb5-libs krb5-dev
 
 WORKDIR $GOPATH/src/github.com/grafana/grafana
 
@@ -51,7 +51,9 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 WORKDIR $GF_PATHS_HOME
 
 RUN apk add --no-cache ca-certificates bash tzdata && \
-    apk add --no-cache openssl musl-utils libcrypto1.1>1.1.1l-r0 libssl1.1>1.1.1l-r0
+    apk add --no-cache openssl musl-utils libcrypto1.1>1.1.1l-r0 libssl1.1>1.1.1l-r0 && \
+    apk add --no-cache krb5-libs krb5 && \
+    ln -s /usr/lib/libgssapi_krb5.so.2 /usr/lib/libgssapi_krb5.so
 
 COPY conf ./conf
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,9 @@ replace github.com/denisenkom/go-mssqldb => github.com/grafana/go-mssqldb v0.0.0
 // It's also present on grafana/loki's go.mod so we'll need till it gets updated.
 replace k8s.io/client-go => k8s.io/client-go v0.18.8
 
+// Override mysql driver with kerb5 enabled fork
+replace github.com/go-sql-driver/mysql => github.com/grafana/mysql v1.6.2
+
 require (
 	cloud.google.com/go/storage v1.14.0
 	cuelang.org/go v0.3.2

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace github.com/denisenkom/go-mssqldb => github.com/grafana/go-mssqldb v0.0.0
 replace k8s.io/client-go => k8s.io/client-go v0.18.8
 
 // Override mysql driver with kerb5 enabled fork
-replace github.com/go-sql-driver/mysql => github.com/grafana/mysql v1.6.2
+replace github.com/go-sql-driver/mysql => github.com/grafana/mysql v1.6.3
 
 require (
 	cloud.google.com/go/storage v1.14.0
@@ -70,6 +70,7 @@ require (
 	github.com/laher/mergefs v0.1.1
 	github.com/lib/pq v1.10.0
 	github.com/linkedin/goavro/v2 v2.10.0
+	github.com/m3db/prometheus_remote_client_golang v0.4.4 // indirect
 	github.com/magefile/mage v1.11.0
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-sqlite3 v1.14.7

--- a/go.sum
+++ b/go.sum
@@ -998,6 +998,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.112.0 h1:c+3kKJQ1wVZ5pMSF40eUizB5YzG
 github.com/grafana/grafana-plugin-sdk-go v0.112.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103 h1:qCmofFVwQR9QnsinstVqI1NPLMVl33jNCnOCXEAVn6E=
 github.com/grafana/loki v1.6.2-0.20210520072447-15d417efe103/go.mod h1:GHIsn+EohCChsdu5YouNZewqLeV9L2FNw4DEJU3P9qE=
+github.com/grafana/mysql v1.6.2 h1:zGvY6bllu66P4WdgKof7zLlArhUoGfdogxEFMCtszfM=
+github.com/grafana/mysql v1.6.2/go.mod h1:wVq5DBZFP5iZZoA7U94QjEFsuAt2w0JfWF7ZPhEXfwg=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -1184,12 +1186,17 @@ github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGk
 github.com/jackc/pgx v3.6.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jaegertracing/jaeger v1.22.0/go.mod h1:WnwW68MjJEViSLRQhe0nkIsBDaF3CzfFd8wJcpJv24k=
 github.com/jaegertracing/jaeger v1.24.0/go.mod h1:mqdtFDA447va5j0UewDaAWyNlGreGQyhGxXVhbF58gQ=
+github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
+github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
+github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxyjn/mY9zx4tFonSg=
+github.com/jcmturner/gokrb5/v8 v8.4.2 h1:6ZIM6b/JJN0X8UM43ZOM6Z4SJzla+a/u7scXFJzodkA=
 github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aWNYyvBVK62bc=
+github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jessevdk/go-flags v0.0.0-20180331124232-1c38ed7ad0cc/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -1328,6 +1335,8 @@ github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/iostat v1.1.0/go.mod h1:rEPNA0xXgjHQjuI5Cy05sLlS2oRcSlWHRLrvh/AQ+Pg=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
+github.com/m3db/prometheus_remote_client_golang v0.4.4 h1:DsAIjVKoCp7Ym35tAOFL1OuMLIdIikAEHeNPHY+yyM8=
+github.com/m3db/prometheus_remote_client_golang v0.4.4/go.mod h1:wHfVbA3eAK6dQvKjCkHhusWYegCk3bDGkA15zymSHdc=
 github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magefile/mage v1.11.0 h1:C/55Ywp9BpgVVclD3lRnSYCwXTYxmSppIgLeDYlNuls=
@@ -1542,6 +1551,8 @@ github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029/go.mod h1:t+O9It+L
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b h1:it0YPE/evO6/m8t8wxis9KFI2F/aleOKsI6d9uz0cEk=
+github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b/go.mod h1:tNrEB5k8SI+g5kOlsCmL2ELASfpqEofI0+FLBgBdN08=
 github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02/go.mod h1:JNdpVEzCpXBgIiv4ds+TzhN1hrtxq6ClLrTlT9OQRSc=
 github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
 github.com/opentracing-contrib/go-grpc v0.0.0-20210225150812-73cb765af46e h1:4cPxUYdgaGzZIT5/j0IfqOrrXmq6bG8AwvwisMXpdrg=

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -37,6 +37,9 @@ WORKDIR /tmp
 RUN apt-get update && \
     apt-get install -yq \
         clang patch libxml2-dev \
+        krb5-user       \
+        libkrb5-dev     \
+        libkrb5-3       \
         build-essential \
         ca-certificates \
         curl            \
@@ -103,7 +106,7 @@ FROM debian:stretch-20210208
 ENV GOVERSION=1.16.1 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=14.16.0-1nodesource1 \
+    NODEVERSION=14.17.5-1nodesource1 \
     YARNVERSION=1.22.5-1
 
 # Use ARG so as not to persist environment variable in image
@@ -134,7 +137,13 @@ RUN apt-get update && \
         ruby            \
         ruby-dev        \
         rubygems        \
-        unzip &&        \
+        krb5-user       \
+        libkrb5-dev     \
+        libkrb5-3       \
+        cpio            \
+        rpm2cpio        \
+        unzip           \
+        zstd &&         \
     gem install -N fpm && \
     ln -s /usr/bin/llvm-dsymutil-6.0 /usr/bin/dsymutil && \
     curl -fsL https://deb.nodesource.com/setup_14.x | bash - && \
@@ -171,6 +180,28 @@ RUN cd /tmp && \
     tar xf x86_64-linux-musl-cross.tgz && \
     rm x86_64-linux-musl-cross.tgz
 
+# Add kerberos for x64 musl and arm v7/v8
+RUN cd /tmp && \
+    curl -fLO http://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/krb5-dev-1.18.4-r0.apk && \
+    tar xf krb5-dev-1.18.4-r0.apk && \
+    cp -r usr/include/* /tmp/x86_64-linux-musl-cross/x86_64-linux-musl/include/ && \
+    rm krb5-dev-1.18.4-r0.apk && \
+    rm -rf /tmp/usr && \
+    curl -fLO http://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/krb5-dev-1.18.4-r0.apk && \
+    tar xf krb5-dev-1.18.4-r0.apk && \
+    cp -r usr/include/* /tmp/aarch64-linux-musl-cross/aarch64-linux-musl/include/ && \
+    cp -r usr/include/* /tmp/arm-linux-musleabihf-cross/arm-linux-musleabihf/include/ && \
+    rm krb5-dev-1.18.4-r0.apk && \
+    rm -rf /tmp/usr && \
+    curl -fLO http://raspbian.raspberrypi.org/raspbian/pool/main/h/heimdal/heimdal-multidev_7.7.0+dfsg-2+b2_armhf.deb && \
+    mkdir rpi-armv6 && \
+    cd rpi-armv6 && \
+    ar x ../heimdal-multidev_7.7.0+dfsg-2+b2_armhf.deb && \
+    tar xvf data.tar.xz && \
+    cp -r /tmp/rpi-armv6/usr/include/heimdal/* /opt/rpi-tools/arm-bcm2708/arm-linux-gnueabihf/arm-linux-gnueabihf/include/ && \
+    cd .. && \
+    rm -rf rpi-armv6
+#
 RUN go get -u github.com/mgechev/revive@v1.0.2 && \
   mv ${GOPATH}/bin/revive /usr/local/bin/ && \
   go get github.com/google/go-jsonnet/cmd/jsonnetfmt && \

--- a/scripts/build/ci-build/Makefile
+++ b/scripts/build/ci-build/Makefile
@@ -1,4 +1,4 @@
-VERSION = dev
+ VERSION = dev
 TAG = grafana/build-container
 USER_ID = $(shell id -u)
 GROUP_ID = $(shell id -g)
@@ -38,6 +38,18 @@ run-with-local-source-copy:
 		${TAG}:${VERSION} \
 		bash -c "/tmp/bootstrap.sh; tail -f /dev/null"
 	docker cp "${GOPATH}/src/github.com/grafana/grafana" grafana-build:/go/src/github.com/grafana/
+	docker exec -ti grafana-build bash
+
+run-with-local-source-enterprise-copy:
+	docker run -d \
+		-e "CIRCLE_BRANCH=local" \
+		-e "CIRCLE_BUILD_NUM=472" \
+		-w "/go/src/github.com/grafana/grafana" \
+		--name grafana-build \
+		${TAG}:${VERSION} \
+		bash -c "/tmp/bootstrap.sh; tail -f /dev/null"
+	docker cp "${GOPATH}/src/github.com/grafana/grafana" grafana-build:/go/src/github.com/grafana/
+	docker cp "${GOPATH}/src/github.com/grafana/grafana-enterprise" grafana-build:/go/src/github.com/grafana/
 	docker exec -ti grafana-build bash
 
 update-source:

--- a/scripts/build/ci-build/bootstrap.sh
+++ b/scripts/build/ci-build/bootstrap.sh
@@ -3,3 +3,21 @@
 cd /tmp || exit 1
 tar xfJ x86_64-centos6-linux-gnu.tar.xz
 tar xfJ osxcross.tar.xz
+#
+# Add kerberos libs and headers, copy headers to expected path
+export PATH=$PATH:/tmp/osxcross/target/bin
+export MACOSX_DEPLOYMENT_TARGET=10.15
+export OSXCROSS_MACPORTS_MIRROR=packages.macports.org
+osxcross-macports install kerberos5
+osxcross-macports install heimdal
+mkdir -p /usr/local/opt/heimdal/include
+cp -r /tmp/osxcross/target/macports/pkgs/opt/local/libexec/heimdal/include/* /usr/local/opt/heimdal/include/
+
+# Kerberos for centos
+curl -flO http://mirror.centos.org/centos/7/os/x86_64/Packages/krb5-devel-1.15.1-50.el7.x86_64.rpm
+mkdir krb-rpm
+cd krb-rpm
+rpm2cpio ../krb5-devel-1.15.1-50.el7.x86_64.rpm | cpio -idmv
+cp -r usr/include/* /tmp/x86_64-centos6-linux-gnu/x86_64-centos6-linux-gnu/include/ && \
+cd ..
+rm -rf krb-rpm


### PR DESCRIPTION
(Replaces #38119)

**What this PR does / why we need it**:

Switches to a fork of go-mysql-driver/mysql with krb5 support added

(this is a proof of concept, not intended to be merged!)

to use mysql with kerberos, the keytab for the authentication user needs to be set with the "standard" env variable `KRB5_CLIENT_KTNAME` before starting grafana-server.

using grafana with mysql as backing storage + kerberos, use the url option, and increase max_idle_conn to 10.

url = mysql://kirby@myhost.grafana.com:3306/grafanacore
max_idle_conn = 10

building requires additional libraries, and the build-ci container needs some modifications that are included for gssapi

```
krb5-devel
krb5-libs
```

NOTE: this also updates the ci-build toolchain (but not drone.yml), we can separate this into another PR, builds will still fail until drone is updated and the new docker image is pushed
