### PR TITLE
DataFrames: diff field labels even if skipConfig

### DIFF
--- a/packages/grafana-data/src/dataframe/frameComparisons.ts
+++ b/packages/grafana-data/src/dataframe/frameComparisons.ts
@@ -35,14 +35,19 @@ export function compareDataFrameStructures(a: DataFrame, b: DataFrame, skipConfi
       return false;
     }
 
-    // Do not check the config fields
-    if (skipConfig) {
-      continue;
+    // Check if only one field has labels
+    if ((fA.labels != null && fB.labels == null) || (fB.labels != null && fA.labels == null)) {
+      return false;
     }
 
     // Check if labels are different
     if (fA.labels && fB.labels && !shallowCompare(fA.labels, fB.labels)) {
       return false;
+    }
+
+    // Do not check the config fields
+    if (skipConfig) {
+      continue;
     }
 
     const cfgA = fA.config as any;


### PR DESCRIPTION
looks like we didn't compare field labels if skipConfig was true.

also added an early exit if one field has labels and other does not.