### PR TITLE
TimeSeries: remove redundant boolean unit displayProcessor override

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -2,6 +2,7 @@
 import { toString, toNumber as _toNumber, isEmpty, isBoolean } from 'lodash';
 
 // Types
+import { StackingMode } from '@grafana/schema';
 import { Field, FieldType } from '../types/dataFrame';
 import { DisplayProcessor, DisplayValue } from '../types/displayValue';
 import { getValueFormat, isBooleanUnit } from '../valueFormats/valueFormats';
@@ -65,6 +66,10 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
   } else if (field.type === FieldType.boolean) {
     if (!isBooleanUnit(unit)) {
       unit = 'bool';
+    }
+  } else if (field.type === FieldType.number) {
+    if (config.custom?.stacking?.mode === StackingMode.Percent) {
+      unit = 'percentunit';
     }
   }
 

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -2,7 +2,6 @@
 import { toString, toNumber as _toNumber, isEmpty, isBoolean } from 'lodash';
 
 // Types
-import { StackingMode } from '@grafana/schema';
 import { Field, FieldType } from '../types/dataFrame';
 import { DisplayProcessor, DisplayValue } from '../types/displayValue';
 import { getValueFormat, isBooleanUnit } from '../valueFormats/valueFormats';
@@ -66,10 +65,6 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
   } else if (field.type === FieldType.boolean) {
     if (!isBooleanUnit(unit)) {
       unit = 'bool';
-    }
-  } else if (field.type === FieldType.number) {
-    if (config.custom?.stacking?.mode === StackingMode.Percent) {
-      unit = 'percentunit';
     }
   }
 

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -1,5 +1,5 @@
-import { ArrayVector, DataFrame, Field, FieldType, GrafanaTheme2 } from '@grafana/data';
-import { GraphFieldConfig, LineInterpolation } from '@grafana/schema';
+import { ArrayVector, DataFrame, Field, FieldType, getDisplayProcessor, GrafanaTheme2 } from '@grafana/data';
+import { GraphFieldConfig, LineInterpolation, StackingMode } from '@grafana/schema';
 
 // This will return a set of frames with only graphable values included
 export function prepareGraphableFields(
@@ -38,6 +38,12 @@ export function prepareGraphableFields(
               })
             ),
           };
+
+          if (copy.config.custom?.stacking?.mode === StackingMode.Percent) {
+            copy.config.unit = 'percentunit';
+            copy.display = getDisplayProcessor({ field: copy, theme });
+          }
+
           fields.push(copy);
           break; // ok
         case FieldType.boolean:

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -1,13 +1,5 @@
-import {
-  ArrayVector,
-  DataFrame,
-  Field,
-  FieldType,
-  getDisplayProcessor,
-  GrafanaTheme2,
-  isBooleanUnit,
-} from '@grafana/data';
-import { GraphFieldConfig, LineInterpolation, StackingMode } from '@grafana/schema';
+import { ArrayVector, DataFrame, Field, FieldType, GrafanaTheme2 } from '@grafana/data';
+import { GraphFieldConfig, LineInterpolation } from '@grafana/schema';
 
 // This will return a set of frames with only graphable values included
 export function prepareGraphableFields(
@@ -46,12 +38,6 @@ export function prepareGraphableFields(
               })
             ),
           };
-
-          if (copy.config.custom?.stacking?.mode === StackingMode.Percent) {
-            copy.config.unit = 'percentunit';
-            copy.display = getDisplayProcessor({ field: copy, theme });
-          }
-
           fields.push(copy);
           break; // ok
         case FieldType.boolean:
@@ -80,10 +66,6 @@ export function prepareGraphableFields(
               })
             ),
           };
-          if (!isBooleanUnit(config.unit)) {
-            config.unit = 'bool';
-            copy.display = getDisplayProcessor({ field: copy, theme });
-          }
           fields.push(copy);
           break;
         default:


### PR DESCRIPTION
the original goal of this PR was to remove all displayProcessor overrides from prepareFields, which opens the door for further simplification. thinking was, since % stacking is now supported in TimeSeries, BarChart, and soon Histogram it seemed possible to move this `percentunit` override up to `getDisplayProcessor()`. unfortunately, it doesnt look like it will work for BarChart or Histogram, since their stacking settings are shared at the panel level and are copied down to each field.

so with that reverted, this changeset now simply removes a boolean unit override that's already handled by `getDisplayProcessor()`:

https://github.com/grafana/grafana/blob/96557ecadcf25908f59b6714d3c9ebc352e03408/packages/grafana-data/src/field/displayProcessor.ts#L65-L69