### PR TITLE
Colors: rename getThresholdRange() -> getGradientRange()

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
@@ -1,6 +1,6 @@
 import { GrafanaTheme2, ThresholdsConfig, ThresholdsMode } from '@grafana/data';
 import { GraphThresholdsStyleConfig, GraphTresholdsStyleMode } from '@grafana/schema';
-import { getThresholdRange, GradientDirection, scaleGradient } from './gradientFills';
+import { getGradientRange, GradientDirection, scaleGradient } from './gradientFills';
 import tinycolor from 'tinycolor2';
 
 export interface UPlotThresholdOptions {
@@ -28,7 +28,7 @@ export function getThresholdsDrawHook(options: UPlotThresholdOptions) {
     let { steps, mode } = thresholds;
 
     if (mode === ThresholdsMode.Percentage) {
-      let [min, max] = getThresholdRange(u, scaleKey, hardMin, hardMax, softMin, softMax);
+      let [min, max] = getGradientRange(u, scaleKey, hardMin, hardMax, softMin, softMax);
       let range = max - min;
 
       steps = steps.map((step) => ({

--- a/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
@@ -237,8 +237,14 @@ export function getScaleGradientFn(
       }
     } else if (colorMode.getColors) {
       const colors = colorMode.getColors(theme);
-      const [min, max] = getThresholdRange(plot, scaleKey, hardMin, hardMax, softMin, softMax);
+      const { min: scaleMin, max: scaleMax } = plot.scales[scaleKey];
+
+      // 1.1 divisor is to remove the 10% scale padding added to the raw data when auto-ranging
+      let min = scaleMin === 0 ? 0 : scaleMin! / 1.1;
+      let max = scaleMax === 0 ? 0 : scaleMax! / 1.1;
+
       const range = max - min;
+
       const valueStops = colors.map(
         (color, i) =>
           [

--- a/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
@@ -172,7 +172,7 @@ export function getDataRange(plot: uPlot, scaleKey: string) {
   return [min, max];
 }
 
-export function getThresholdRange(
+export function getGradientRange(
   u: uPlot,
   scaleKey: string,
   hardMin?: number | null,
@@ -224,7 +224,7 @@ export function getScaleGradientFn(
         );
         gradient = scaleGradient(plot, scaleKey, GradientDirection.Up, valueStops, true);
       } else {
-        const [min, max] = getThresholdRange(plot, scaleKey, hardMin, hardMax, softMin, softMax);
+        const [min, max] = getGradientRange(plot, scaleKey, hardMin, hardMax, softMin, softMax);
         const range = max - min;
         const valueStops = thresholds.steps.map(
           (step) =>
@@ -237,14 +237,8 @@ export function getScaleGradientFn(
       }
     } else if (colorMode.getColors) {
       const colors = colorMode.getColors(theme);
-      const { min: scaleMin, max: scaleMax } = plot.scales[scaleKey];
-
-      // 1.1 divisor is to remove the 10% scale padding added to the raw data when auto-ranging
-      let min = scaleMin === 0 ? 0 : scaleMin! / 1.1;
-      let max = scaleMax === 0 ? 0 : scaleMax! / 1.1;
-
+      const [min, max] = getGradientRange(plot, scaleKey, hardMin, hardMax, softMin, softMax);
       const range = max - min;
-
       const valueStops = colors.map(
         (color, i) =>
           [


### PR DESCRIPTION
a regression originally introduced in https://github.com/grafana/grafana/pull/37670, where the gradient range was computed from the raw y data range. this results in an extremely narrow gradient if someone sets e.g. min=0, max = 100, but their values are mostly flat with a range of e.g. 45-50.

https://github.com/grafana/grafana/pull/38528 inadvertently "fixed" this by preferring any configured hard or soft limits before falling back to the y data limits. however, the function it uses, `getThresholdRange()`, doesnt make much sense when the gradient color scheme is not by thresholds.

this PR ~~simply uses the visible y axis range and deducts the 10% scale padding that's typically added to non-0 y limits. the differences here would be visible if both hard and soft limits were set. the prior strategy would use the hard limits for the gradient range (which would typically be off-scale). the new code will always have the full color range match the height of the grid area, minus 10%.~~

~~i'm not 100% sure if this is the desired behavior, so we can close this and continue preferring any configured hard and soft limits for the gradient ranges. in this case, we can~~ just renames the function to something more general, like `getGradientRange()`.