### PR TITLE
Toolkit: fix matchmedia missing

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
@@ -57,6 +57,7 @@ const copyFiles = () => {
     'src/config/eslint.plugin.json',
     'src/config/styles.mock.js',
     'src/config/jest.plugin.config.local.js',
+    'src/config/matchMedia.js',
   ];
 
   return useSpinner(`Moving ${files.join(', ')} files`, async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

After #37643 the matchMedia.js is still missing from the built package and shows the following error.
```
✖ ● Validation Error:

  Module /Users/zoltanb/GitHub/grafana/plugins/google-sheets-datasource/node_modules/@grafana/toolkit/src/config/matchMedia.js in the setupFiles option was not found.
         <rootDir> is: /Users/zoltanb/GitHub/grafana/plugins/google-sheets-datasource

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```

This PR fixes this issue by copying the matchMedia.js file to the dist folder.
