### PR TITLE
Alerting: Make alert state indicator in panel header work with Grafana 8 alerts

### DIFF
--- a/packages/grafana-data/src/types/alerts.ts
+++ b/packages/grafana-data/src/types/alerts.ts
@@ -1,5 +1,5 @@
 /**
- * @internal -- might be replaced by next generation Alerting
+ * @internal
  */
 export enum AlertState {
   NoData = 'no_data',
@@ -11,12 +11,11 @@ export enum AlertState {
 }
 
 /**
- * @internal -- might be replaced by next generation Alerting
+ * @internal
  */
 export interface AlertStateInfo {
   id: number;
   dashboardId: number;
   panelId: number;
   state: AlertState;
-  newStateDate: string;
 }

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -42,7 +42,6 @@ export interface PanelData {
 
   /**
    * @internal
-   * @deprecated alertState is deprecated and will be removed when the next generation Alerting is in place
    */
   alertState?: AlertStateInfo;
 

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -14,7 +14,7 @@ import {
   mockPromRuleNamespace,
   mockRulerGrafanaRule,
 } from './mocks';
-import { DataSourceType } from './utils/datasource';
+import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 import { typeAsJestMock } from 'test/helpers/typeAsJestMock';
 import { getAllDataSources } from './utils/config';
 import { fetchRules } from './api/prometheus';
@@ -269,6 +269,15 @@ describe('PanelAlertTabContent', () => {
         { key: '__dashboardUid__', value: '12' },
         { key: '__panelId__', value: '34' },
       ],
+    });
+
+    expect(mocks.api.fetchRulerRules).toHaveBeenCalledWith(GRAFANA_RULES_SOURCE_NAME, {
+      dashboardUID: dashboard.uid,
+      panelId: panel.editSourceId,
+    });
+    expect(mocks.api.fetchRules).toHaveBeenCalledWith(GRAFANA_RULES_SOURCE_NAME, {
+      dashboardUID: dashboard.uid,
+      panelId: panel.editSourceId,
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/AlertTypeStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertTypeStep.tsx
@@ -130,7 +130,7 @@ export const AlertTypeStep: FC<Props> = ({ editingExistingRule }) => {
         )}
       </div>
       {(ruleFormType === RuleFormType.cloudRecording || ruleFormType === RuleFormType.cloudAlerting) &&
-        dataSourceName && <GroupAndNamespaceFields dataSourceName={dataSourceName} />}
+        dataSourceName && <GroupAndNamespaceFields rulesSourceName={dataSourceName} />}
 
       {ruleFormType === RuleFormType.grafana && (
         <Field

--- a/public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx
@@ -10,10 +10,10 @@ import { Field, InputControl, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 interface Props {
-  dataSourceName: string;
+  rulesSourceName: string;
 }
 
-export const GroupAndNamespaceFields: FC<Props> = ({ dataSourceName }) => {
+export const GroupAndNamespaceFields: FC<Props> = ({ rulesSourceName }) => {
   const {
     control,
     watch,
@@ -28,10 +28,10 @@ export const GroupAndNamespaceFields: FC<Props> = ({ dataSourceName }) => {
   const rulerRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(fetchRulerRulesAction(dataSourceName));
-  }, [dataSourceName, dispatch]);
+    dispatch(fetchRulerRulesAction({ rulesSourceName }));
+  }, [rulesSourceName, dispatch]);
 
-  const rulesConfig = rulerRequests[dataSourceName]?.result;
+  const rulesConfig = rulerRequests[rulesSourceName]?.result;
 
   const namespace = watch('namespace');
 

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -75,21 +75,21 @@ export function useCombinedRulesMatching(
   };
 }
 
-function useCombinedRulesLoader(ruleSourceName: string | undefined): AsyncRequestState<void> {
+function useCombinedRulesLoader(rulesSourceName: string | undefined): AsyncRequestState<void> {
   const dispatch = useDispatch();
   const promRuleRequests = useUnifiedAlertingSelector((state) => state.promRules);
-  const promRuleRequest = getRequestState(ruleSourceName, promRuleRequests);
+  const promRuleRequest = getRequestState(rulesSourceName, promRuleRequests);
   const rulerRuleRequests = useUnifiedAlertingSelector((state) => state.rulerRules);
-  const rulerRuleRequest = getRequestState(ruleSourceName, rulerRuleRequests);
+  const rulerRuleRequest = getRequestState(rulesSourceName, rulerRuleRequests);
 
   useEffect(() => {
-    if (!ruleSourceName) {
+    if (!rulesSourceName) {
       return;
     }
 
-    dispatch(fetchPromRulesAction(ruleSourceName));
-    dispatch(fetchRulerRulesAction(ruleSourceName));
-  }, [dispatch, ruleSourceName]);
+    dispatch(fetchPromRulesAction({ rulesSourceName }));
+    dispatch(fetchRulerRulesAction({ rulesSourceName }));
+  }, [dispatch, rulesSourceName]);
 
   return {
     loading: promRuleRequest.loading || rulerRuleRequest.loading,

--- a/public/app/features/alerting/unified/hooks/usePanelCombinedRules.ts
+++ b/public/app/features/alerting/unified/hooks/usePanelCombinedRules.ts
@@ -34,8 +34,18 @@ export function usePanelCombinedRules({ dashboard, panel, poll = false }: Option
   // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
   useEffect(() => {
     const fetch = () => {
-      dispatch(fetchPromRulesAction(GRAFANA_RULES_SOURCE_NAME));
-      dispatch(fetchRulerRulesAction(GRAFANA_RULES_SOURCE_NAME));
+      dispatch(
+        fetchPromRulesAction({
+          rulesSourceName: GRAFANA_RULES_SOURCE_NAME,
+          filter: { dashboardUID: dashboard.uid, panelId: panel.editSourceId },
+        })
+      );
+      dispatch(
+        fetchRulerRulesAction({
+          rulesSourceName: GRAFANA_RULES_SOURCE_NAME,
+          filter: { dashboardUID: dashboard.uid, panelId: panel.editSourceId },
+        })
+      );
     };
     fetch();
     if (poll) {
@@ -45,7 +55,7 @@ export function usePanelCombinedRules({ dashboard, panel, poll = false }: Option
       };
     }
     return () => {};
-  }, [dispatch, poll]);
+  }, [dispatch, poll, panel.editSourceId, dashboard.uid]);
 
   const loading = promRuleRequest.loading || rulerRuleRequest.loading;
   const errors = [promRuleRequest.error, rulerRuleRequest.error].filter(

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -29,13 +29,14 @@ import {
   deleteAlertManagerConfig,
   testReceivers,
 } from '../api/alertmanager';
-import { fetchRules } from '../api/prometheus';
+import { FetchPromRulesFilter, fetchRules } from '../api/prometheus';
 import {
   deleteNamespace,
   deleteRulerRulesGroup,
   fetchRulerRules,
   fetchRulerRulesGroup,
   fetchRulerRulesNamespace,
+  FetchRulerRulesFilter,
   setRulerRuleGroup,
 } from '../api/ruler';
 import { RuleFormType, RuleFormValues } from '../types/rule-form';
@@ -64,7 +65,8 @@ const FETCH_CONFIG_RETRY_TIMEOUT = 30 * 1000;
 
 export const fetchPromRulesAction = createAsyncThunk(
   'unifiedalerting/fetchPromRules',
-  (rulesSourceName: string): Promise<RuleNamespace[]> => withSerializedError(fetchRules(rulesSourceName))
+  ({ rulesSourceName, filter }: { rulesSourceName: string; filter?: FetchPromRulesFilter }): Promise<RuleNamespace[]> =>
+    withSerializedError(fetchRules(rulesSourceName, filter))
 );
 
 export const fetchAlertManagerConfigAction = createAsyncThunk(
@@ -106,8 +108,14 @@ export const fetchAlertManagerConfigAction = createAsyncThunk(
 
 export const fetchRulerRulesAction = createAsyncThunk(
   'unifiedalerting/fetchRulerRules',
-  (rulesSourceName: string): Promise<RulerRulesConfigDTO | null> => {
-    return withSerializedError(fetchRulerRules(rulesSourceName));
+  ({
+    rulesSourceName,
+    filter,
+  }: {
+    rulesSourceName: string;
+    filter?: FetchRulerRulesFilter;
+  }): Promise<RulerRulesConfigDTO | null> => {
+    return withSerializedError(fetchRulerRules(rulesSourceName, filter));
   }
 );
 
@@ -119,12 +127,12 @@ export const fetchSilencesAction = createAsyncThunk(
 );
 
 // this will only trigger ruler rules fetch if rules are not loaded yet and request is not in flight
-export function fetchRulerRulesIfNotFetchedYet(dataSourceName: string): ThunkResult<void> {
+export function fetchRulerRulesIfNotFetchedYet(rulesSourceName: string): ThunkResult<void> {
   return (dispatch, getStore) => {
     const { rulerRules } = getStore().unifiedAlerting;
-    const resp = rulerRules[dataSourceName];
+    const resp = rulerRules[rulesSourceName];
     if (!resp?.result && !(resp && isRulerNotSupportedResponse(resp)) && !resp?.loading) {
-      dispatch(fetchRulerRulesAction(dataSourceName));
+      dispatch(fetchRulerRulesAction({ rulesSourceName }));
     }
   };
 }
@@ -132,12 +140,12 @@ export function fetchRulerRulesIfNotFetchedYet(dataSourceName: string): ThunkRes
 export function fetchAllPromAndRulerRulesAction(force = false): ThunkResult<void> {
   return (dispatch, getStore) => {
     const { promRules, rulerRules } = getStore().unifiedAlerting;
-    getAllRulesSourceNames().map((name) => {
-      if (force || !promRules[name]?.loading) {
-        dispatch(fetchPromRulesAction(name));
+    getAllRulesSourceNames().map((rulesSourceName) => {
+      if (force || !promRules[rulesSourceName]?.loading) {
+        dispatch(fetchPromRulesAction({ rulesSourceName }));
       }
-      if (force || !rulerRules[name]?.loading) {
-        dispatch(fetchRulerRulesAction(name));
+      if (force || !rulerRules[rulesSourceName]?.loading) {
+        dispatch(fetchRulerRulesAction({ rulesSourceName }));
       }
     });
   };
@@ -146,9 +154,9 @@ export function fetchAllPromAndRulerRulesAction(force = false): ThunkResult<void
 export function fetchAllPromRulesAction(force = false): ThunkResult<void> {
   return (dispatch, getStore) => {
     const { promRules } = getStore().unifiedAlerting;
-    getAllRulesSourceNames().map((name) => {
-      if (force || !promRules[name]?.loading) {
-        dispatch(fetchPromRulesAction(name));
+    getAllRulesSourceNames().map((rulesSourceName) => {
+      if (force || !promRules[rulesSourceName]?.loading) {
+        dispatch(fetchPromRulesAction({ rulesSourceName }));
       }
     });
   };
@@ -250,8 +258,8 @@ export function deleteRuleAction(
         }
         await deleteRule(ruleWithLocation);
         // refetch rules for this rules source
-        dispatch(fetchRulerRulesAction(ruleWithLocation.ruleSourceName));
-        dispatch(fetchPromRulesAction(ruleWithLocation.ruleSourceName));
+        dispatch(fetchRulerRulesAction({ rulesSourceName: ruleWithLocation.ruleSourceName }));
+        dispatch(fetchPromRulesAction({ rulesSourceName: ruleWithLocation.ruleSourceName }));
 
         if (options.navigateTo) {
           locationService.replace(options.navigateTo);
@@ -712,7 +720,7 @@ export const updateLotexNamespaceAndGroupAction = createAsyncThunk(
           }
 
           // refetch all rules
-          await thunkAPI.dispatch(fetchRulerRulesAction(rulesSourceName));
+          await thunkAPI.dispatch(fetchRulerRulesAction({ rulesSourceName }));
         })()
       ),
       {

--- a/public/app/features/alerting/unified/state/reducers.ts
+++ b/public/app/features/alerting/unified/state/reducers.ts
@@ -20,8 +20,9 @@ import {
 } from './actions';
 
 export const reducer = combineReducers({
-  promRules: createAsyncMapSlice('promRules', fetchPromRulesAction, (dataSourceName) => dataSourceName).reducer,
-  rulerRules: createAsyncMapSlice('rulerRules', fetchRulerRulesAction, (dataSourceName) => dataSourceName).reducer,
+  promRules: createAsyncMapSlice('promRules', fetchPromRulesAction, ({ rulesSourceName }) => rulesSourceName).reducer,
+  rulerRules: createAsyncMapSlice('rulerRules', fetchRulerRulesAction, ({ rulesSourceName }) => rulesSourceName)
+    .reducer,
   amConfigs: createAsyncMapSlice(
     'amConfigs',
     fetchAlertManagerConfigAction,

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -36,6 +36,8 @@ export const PanelEditorTabs: FC<PanelEditorTabsProps> = React.memo(({ panel, da
     return null;
   }
 
+  console.log(config.unifiedAlertingEnabled, tabs);
+
   return (
     <div className={styles.wrapper}>
       <TabsBar className={styles.tabBar} hideBorder>

--- a/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/selectors.ts
@@ -34,7 +34,10 @@ export const getPanelEditorTabs = memoizeOne((tab?: string, plugin?: PanelPlugin
     });
   }
 
-  if ((getConfig().alertingEnabled && plugin.meta.id === 'graph') || plugin.meta.id === 'timeseries') {
+  if (
+    ((getConfig().alertingEnabled || getConfig().unifiedAlertingEnabled) && plugin.meta.id === 'graph') ||
+    plugin.meta.id === 'timeseries'
+  ) {
     tabs.push({
       id: PanelEditorTabId.Alert,
       text: 'Alert',

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -475,7 +475,7 @@ export class PanelChrome extends Component<Props, State> {
     const { errorMessage, data } = this.state;
     const { transparent } = panel;
 
-    let alertState = config.unifiedAlertingEnabled ? undefined : data.alertState?.state;
+    const alertState = data.alertState?.state;
 
     const containerClassNames = classNames({
       'panel-container': true,

--- a/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChromeAngular.tsx
@@ -186,7 +186,7 @@ export class PanelChromeAngularUnconnected extends PureComponent<Props, State> {
     const { errorMessage, data } = this.state;
     const { transparent } = panel;
 
-    let alertState = config.unifiedAlertingEnabled ? undefined : data.alertState?.state;
+    const alertState = data.alertState?.state;
 
     const containerClassNames = classNames({
       'panel-container': true,

--- a/public/app/features/query/state/DashboardQueryRunner/AlertStatesWorker.test.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/AlertStatesWorker.test.ts
@@ -12,7 +12,7 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 function getDefaultOptions(): DashboardQueryRunnerOptions {
-  const dashboard: any = { id: 'an id' };
+  const dashboard: any = { id: 'an id', panels: [{ alert: {} }] };
   const range = getDefaultTimeRange();
 
   return { dashboard, range };
@@ -53,6 +53,14 @@ describe('AlertStatesWorker', () => {
       const range: TimeRange = { ...defaultRange, raw: { ...defaultRange.raw, to: 'now-6h' } };
       const options = { ...getDefaultOptions(), range };
 
+      expect(worker.canWork(options)).toBe(false);
+    });
+  });
+
+  describe('when canWork is called for dashboard with no alert panels', () => {
+    it('then it should return false', () => {
+      const options = getDefaultOptions();
+      options.dashboard.panels.forEach((panel) => delete panel.alert);
       expect(worker.canWork(options)).toBe(false);
     });
   });

--- a/public/app/features/query/state/DashboardQueryRunner/AlertStatesWorker.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/AlertStatesWorker.ts
@@ -14,6 +14,11 @@ export class AlertStatesWorker implements DashboardQueryRunnerWorker {
       return false;
     }
 
+    // if dashboard has no alerts, no point to query alert states
+    if (!dashboard.panels.find((panel) => !!panel.alert)) {
+      return false;
+    }
+
     return true;
   }
 

--- a/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.test.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.test.ts
@@ -23,8 +23,8 @@ function getTestContext() {
   const runner = createDashboardQueryRunner({ dashboard: options.dashboard, timeSrv: timeSrvMock });
 
   const getResults: AlertStateInfo[] = [
-    { id: 1, state: AlertState.Alerting, newStateDate: '2021-01-01', dashboardId: 1, panelId: 1 },
-    { id: 2, state: AlertState.Alerting, newStateDate: '2021-02-01', dashboardId: 1, panelId: 2 },
+    { id: 1, state: AlertState.Alerting, dashboardId: 1, panelId: 1 },
+    { id: 2, state: AlertState.Alerting, dashboardId: 1, panelId: 2 },
   ];
   const getMock = jest.spyOn(backendSrv, 'get').mockResolvedValue(getResults);
   const executeAnnotationQueryMock = jest
@@ -291,7 +291,6 @@ function getExpectedForAllResult(): DashboardQueryRunnerResult {
     alertState: {
       dashboardId: 1,
       id: 1,
-      newStateDate: '2021-01-01',
       panelId: 1,
       state: AlertState.Alerting,
     },

--- a/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
@@ -17,6 +17,8 @@ import { getAnnotationsByPanelId } from './utils';
 import { DashboardModel } from '../../../dashboard/state';
 import { getTimeSrv, TimeSrv } from '../../../dashboard/services/TimeSrv';
 import { RefreshEvent } from '../../../../types/events';
+import { config } from 'app/core/config';
+import { UnifiedAlertStatesWorker } from './UnifiedAlertStatesWorker';
 
 class DashboardQueryRunnerImpl implements DashboardQueryRunner {
   private readonly results: ReplaySubject<DashboardQueryRunnerWorkerResult>;
@@ -29,7 +31,7 @@ class DashboardQueryRunnerImpl implements DashboardQueryRunner {
     private readonly dashboard: DashboardModel,
     private readonly timeSrv: TimeSrv = getTimeSrv(),
     private readonly workers: DashboardQueryRunnerWorker[] = [
-      new AlertStatesWorker(),
+      config.featureToggles.ngalert ? new UnifiedAlertStatesWorker() : new AlertStatesWorker(),
       new SnapshotWorker(),
       new AnnotationsWorker(),
     ]

--- a/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.test.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.test.ts
@@ -155,8 +155,14 @@ describe('UnifiedAlertStatesWorker', () => {
           ],
           annotations: [],
         });
-        expect(getMock).toHaveBeenCalledTimes(1);
       });
+
+      expect(getMock).toHaveBeenCalledTimes(1);
+      expect(getMock).toHaveBeenCalledWith(
+        '/api/prometheus/grafana/api/v1/rules',
+        { dashboard_uid: 'a uid' },
+        'dashboard-query-runner-unified-alert-states-an id'
+      );
     });
   });
 

--- a/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.ts
@@ -39,7 +39,9 @@ export class UnifiedAlertStatesWorker implements DashboardQueryRunnerWorker {
     return from(
       getBackendSrv().get(
         '/api/prometheus/grafana/api/v1/rules',
-        {},
+        {
+          dashboard_uid: dashboard.uid,
+        },
         `dashboard-query-runner-unified-alert-states-${dashboard.id}`
       )
     ).pipe(
@@ -49,12 +51,7 @@ export class UnifiedAlertStatesWorker implements DashboardQueryRunnerWorker {
           const panelIdToAlertState: Record<number, AlertStateInfo> = {};
           result.data.groups.forEach((group) =>
             group.rules.forEach((rule) => {
-              if (
-                isAlertingRule(rule) &&
-                rule.annotations &&
-                rule.annotations[Annotation.dashboardUID] === dashboard.uid &&
-                rule.annotations[Annotation.panelID]
-              ) {
+              if (isAlertingRule(rule) && rule.annotations && rule.annotations[Annotation.panelID]) {
                 this.hasAlertRules[dashboard.uid] = true;
                 const panelId = Number(rule.annotations[Annotation.panelID]);
                 const state = promAlertStateToAlertState(rule.state);

--- a/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.ts
@@ -1,0 +1,91 @@
+import { DashboardQueryRunnerOptions, DashboardQueryRunnerWorker, DashboardQueryRunnerWorkerResult } from './types';
+import { from, Observable } from 'rxjs';
+import { getBackendSrv } from '@grafana/runtime';
+import { catchError, map } from 'rxjs/operators';
+import { emptyResult, handleDashboardQueryRunnerWorkerError } from './utils';
+import { PromAlertingRuleState, PromRulesResponse } from 'app/types/unified-alerting-dto';
+import { AlertState, AlertStateInfo } from '@grafana/data';
+import { isAlertingRule } from 'app/features/alerting/unified/utils/rules';
+import { Annotation } from 'app/features/alerting/unified/utils/constants';
+
+export class UnifiedAlertStatesWorker implements DashboardQueryRunnerWorker {
+  canWork({ dashboard, range }: DashboardQueryRunnerOptions): boolean {
+    if (!dashboard.uid) {
+      return false;
+    }
+
+    if (range.raw.to !== 'now') {
+      return false;
+    }
+
+    return true;
+  }
+
+  work(options: DashboardQueryRunnerOptions): Observable<DashboardQueryRunnerWorkerResult> {
+    if (!this.canWork(options)) {
+      return emptyResult();
+    }
+
+    const { dashboard } = options;
+    return from(
+      getBackendSrv().get(
+        '/api/prometheus/grafana/api/v1/rules',
+        {},
+        `dashboard-query-runner-unified-alert-states-${dashboard.id}`
+      )
+    ).pipe(
+      map((result: PromRulesResponse) => {
+        if (result.status === 'success') {
+          const panelIdToAlertState: Record<number, AlertStateInfo> = {};
+          result.data.groups.forEach((group) =>
+            group.rules.forEach((rule) => {
+              if (
+                isAlertingRule(rule) &&
+                rule.annotations &&
+                rule.annotations[Annotation.dashboardUID] === dashboard.uid &&
+                rule.annotations[Annotation.panelID]
+              ) {
+                const panelId = Number(rule.annotations[Annotation.panelID]);
+                const state = promAlertStateToAlertState(rule.state);
+
+                // there can be multiple alerts per panel, so we make sure we get the most severe state:
+                // alerting > pending > ok
+                if (!panelIdToAlertState[panelId]) {
+                  panelIdToAlertState[panelId] = {
+                    state,
+                    id: Object.keys(panelIdToAlertState).length,
+                    panelId,
+                    dashboardId: dashboard.id,
+                  };
+                } else if (
+                  state === AlertState.Alerting &&
+                  panelIdToAlertState[panelId].state !== AlertState.Alerting
+                ) {
+                  panelIdToAlertState[panelId].state = AlertState.Alerting;
+                } else if (
+                  state === AlertState.Pending &&
+                  panelIdToAlertState[panelId].state !== AlertState.Alerting &&
+                  panelIdToAlertState[panelId].state !== AlertState.Pending
+                ) {
+                  panelIdToAlertState[panelId].state = AlertState.Pending;
+                }
+              }
+            })
+          );
+          return { alertStates: Object.values(panelIdToAlertState), annotations: [] };
+        }
+        throw new Error(`Unexpected alert rules response.`);
+      }),
+      catchError(handleDashboardQueryRunnerWorkerError)
+    );
+  }
+}
+
+function promAlertStateToAlertState(state: PromAlertingRuleState): AlertState {
+  if (state === PromAlertingRuleState.Firing) {
+    return AlertState.Alerting;
+  } else if (state === PromAlertingRuleState.Pending) {
+    return AlertState.Pending;
+  }
+  return AlertState.OK;
+}

--- a/public/app/features/query/state/DashboardQueryRunner/testHelpers.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/testHelpers.ts
@@ -52,6 +52,7 @@ export function getDefaultOptions(): DashboardQueryRunnerOptions {
       subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
       publish: jest.fn(),
     },
+    panels: [{ alert: {} } as any],
   };
   const range = getDefaultTimeRange();
 

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -42,7 +42,7 @@ export interface PromAlertingRuleDTO extends PromRuleDTOBase {
     value: string;
   }>;
   labels: Labels;
-  annotations: Annotations;
+  annotations?: Annotations;
   duration?: number; // for
   state: PromAlertingRuleState;
   type: PromRuleType.Alerting;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Make alert state indicator great again!

If `ngalert` flag is on, `AlertStateWorker` dashboard query worker is replaces with  brand new `UnifiedAlertStateWorker` which will query the new prometheus alert state endpoint, correlate alerts to panels in the open dashboard and extract states.

Since in the new system multiple alerts can be linked to a dashboard, it will get the most severe state: `alerting` > `pending` > `ok`. 

TODO
 - [x] retrieve from backend only rules connected to current dashboard, instead of all rules. Pending https://github.com/grafana/grafana/issues/38920

![alert-state](https://user-images.githubusercontent.com/847684/131343305-b5f446f5-46fb-43f6-8716-b6ee39b5e0d8.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38459

**Special notes for your reviewer**:

Maybe we should build on this to load entire alert definitions into panel data? Use that for extracting thresholds in the next PR 