### PR TITLE
Azure Monitor: Add support for numeric fields in ARG 

### DIFF
--- a/pkg/tsdb/azuremonitor/azure-response-table-frame.go
+++ b/pkg/tsdb/azuremonitor/azure-response-table-frame.go
@@ -72,6 +72,7 @@ var converterMap = map[string]data.FieldConverter{
 	"bool":     boolConverter,
 	"decimal":  decimalConverter,
 	"integer":  intConverter,
+	"number":   decimalConverter,
 }
 
 var stringConverter = data.FieldConverter{

--- a/pkg/tsdb/azuremonitor/azure-response-table-frame_test.go
+++ b/pkg/tsdb/azuremonitor/azure-response-table-frame_test.go
@@ -115,10 +115,11 @@ func TestLogTableToFrame(t *testing.T) {
 					data.NewField("XTimeSpan", nil, []*string{pointer.String("00:00:00.0000001")}),
 					data.NewField("XDecimal", nil, []*float64{pointer.Float64(79228162514264337593543950335)}),
 					data.NewField("XObject", nil, []*string{pointer.String(`"{\"person\": \"Daniel\", \"cats\": 23, \"diagnosis\": \"cat problem\"}"`)}),
+					data.NewField("XNumber", nil, []*float64{pointer.Float64(79228162514264337593543950335)}),
 				)
 				frame.Meta = &data.FrameMeta{
 					Custom: &LogAnalyticsMeta{ColumnTypes: []string{"bool", "string", "datetime",
-						"dynamic", "guid", "int", "long", "real", "timespan", "decimal", "object"}},
+						"dynamic", "guid", "int", "long", "real", "timespan", "decimal", "object", "number"}},
 				}
 				return frame
 			},

--- a/pkg/tsdb/azuremonitor/testdata/loganalytics/7-log-analytics-all-types-table.json
+++ b/pkg/tsdb/azuremonitor/testdata/loganalytics/7-log-analytics-all-types-table.json
@@ -46,6 +46,10 @@
           {
             "name":"XObject",
             "type":"object"
+          },
+          {
+            "name":"XNumber",
+            "type":"number"
           }
         ],
         "rows": [
@@ -60,7 +64,8 @@
             1.7976931348623157e+308,
             "00:00:00.0000001",
             "79228162514264337593543950335",
-            "{\"person\": \"Daniel\", \"cats\": 23, \"diagnosis\": \"cat problem\"}"
+            "{\"person\": \"Daniel\", \"cats\": 23, \"diagnosis\": \"cat problem\"}",
+            "79228162514264337593543950335"
           ]
         ]
       }


### PR DESCRIPTION


**What this PR does / why we need it**:
Adds support for parsing numeric fields in the Azure Resource Graph response into golang decimals. Numbers are typically returned by the todouble/toreal KQL function. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38472

**Special notes for your reviewer**:

