### PR TITLE
Geomap: hide legend for markers with single threshold

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/MarkersLegend.tsx
@@ -52,7 +52,7 @@ export function MarkersLegend(props: MarkersLegendProps) {
   }
 
   const thresholds = color.field?.config?.thresholds;
-  if (!thresholds || thresholds.steps.length <2) {
+  if (!thresholds || thresholds.steps.length < 2) {
     return <div></div>; // don't show anything in the legend
   }
 

--- a/public/app/plugins/panel/geomap/layers/data/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/MarkersLegend.tsx
@@ -52,8 +52,8 @@ export function MarkersLegend(props: MarkersLegendProps) {
   }
 
   const thresholds = color.field?.config?.thresholds;
-  if (!thresholds) {
-    return <div className={style.infoWrap}>no thresholds????</div>;
+  if (!thresholds || thresholds.steps.length <2) {
+    return <div></div>; // don't show anything in the legend
   }
 
   return (


### PR DESCRIPTION
Fixes #38676

This changes the legend so it is only shown when more than one theshold exist:

![Peek 2021-08-30 16-39](https://user-images.githubusercontent.com/705951/131419358-b78fb1c9-f3ba-4bd7-afff-3a78c6f5aa3a.gif)
