### PR TITLE
Plugins: Add list-upgradeable subcommand

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -90,6 +90,10 @@ var pluginCommands = []*cli.Command{
 		Usage:  "list-versions <plugin id>",
 		Action: runPluginCommand(cmd.listVersionsCommand),
 	}, {
+		Name:   "list-upgradeable",
+		Usage:  "list-upgradeable",
+		Action: runPluginCommand(cmd.listUpgradeableCommand),
+	}, {
 		Name:    "update",
 		Usage:   "update <plugin id>",
 		Aliases: []string{"upgrade"},

--- a/pkg/cmd/grafana-cli/commands/list_upgradeable_command.go
+++ b/pkg/cmd/grafana-cli/commands/list_upgradeable_command.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+
+	"github.com/fatih/color"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/services"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/hashicorp/go-version"
+)
+
+func (cmd Command) listUpgradeableCommand(c utils.CommandLine) error {
+	pluginsDir := c.PluginDirectory()
+
+	localPlugins := services.GetLocalPlugins(pluginsDir)
+
+	remotePlugins, err := cmd.Client.ListAllPlugins(c.String("repo"))
+	if err != nil {
+		return err
+	}
+
+	anythingToUpgrade := false
+
+	for _, localPlugin := range localPlugins {
+		for _, remotePlugin := range remotePlugins.Plugins {
+			if localPlugin.ID != remotePlugin.ID {
+				continue
+			}
+			if shouldUpgrade(localPlugin.Info.Version, &remotePlugin) {
+				latest := latestSupportedVersion(&remotePlugin)
+				latestVersion, err := version.NewVersion(latest.Version)
+				if err != nil {
+					return err
+				}
+				anythingToUpgrade = true
+				logger.Infof("%v is upgradeable (%v -> %v)\n", localPlugin.ID, localPlugin.Info.Version, latestVersion)
+			}
+		}
+	}
+
+	if anythingToUpgrade {
+		return errors.New("there are plugins to upgrade")
+	} else {
+		logger.Infof("%s No plugins to upgrade\n", color.GreenString("✔"))
+		return nil
+	}
+}


### PR DESCRIPTION
* Add list-upgradeable which lists plugins that can be upgraded and
exits with an error if there are no upgrades.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Adds list-upgradeable plugin subcommand which checks if there are plugins that can be upgraded and if so exits successfully. If there are no plugins which can be upgraded we exit with an error.
This is meant to be run periodically and programatically to check for newer versions of plugins (if available) and be able to notify operators.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

