### PR TITLE
Check navigator property exists before accessing it

### DIFF
--- a/packages/grafana-data/src/datetime/formats.ts
+++ b/packages/grafana-data/src/datetime/formats.ts
@@ -97,7 +97,7 @@ export function localTimeFormat(
   }
 
   // https://momentjs.com/docs/#/displaying/format/
-  const dateTimeFormat = new Intl.DateTimeFormat(locale, options);
+  const dateTimeFormat = new Intl.DateTimeFormat(locale ? locale : undefined, options);
   const parts = dateTimeFormat.formatToParts(new Date());
   const hour12 = dateTimeFormat.resolvedOptions().hour12;
 

--- a/packages/grafana-data/src/datetime/formats.ts
+++ b/packages/grafana-data/src/datetime/formats.ts
@@ -92,7 +92,7 @@ export function localTimeFormat(
     return fallback ?? DEFAULT_SYSTEM_DATE_FORMAT;
   }
 
-  if (!locale) {
+  if (!locale && navigator) {
     locale = [...navigator.languages];
   }
 

--- a/packages/grafana-data/src/datetime/formats.ts
+++ b/packages/grafana-data/src/datetime/formats.ts
@@ -97,7 +97,7 @@ export function localTimeFormat(
   }
 
   // https://momentjs.com/docs/#/displaying/format/
-  const dateTimeFormat = new Intl.DateTimeFormat(locale ? locale : undefined, options);
+  const dateTimeFormat = new Intl.DateTimeFormat(locale || undefined, options);
   const parts = dateTimeFormat.formatToParts(new Date());
   const hour12 = dateTimeFormat.resolvedOptions().hour12;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Check navigator property exists before accessing it

On non-browser environments this property might not exist (e.g. nodejs).

I know these packages are not meant to be used outside the browser but this simple change allows for server side use of the formatting functions which I use to format measurements in SI units

