### PR TITLE
LibraryPanels: Remove library panel icon from the panel header so you can no longer tell that a panel is a library panel from the dashboard view 

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { cx, css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { DataLink, GrafanaTheme2, PanelData } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
@@ -49,7 +49,6 @@ export const PanelHeader: FC<Props> = ({ panel, error, isViewing, isEditing, dat
             return (
               <div className="panel-title">
                 <PanelHeaderNotices frames={data.series} panelId={panel.id} />
-                {panel.libraryPanel && <Icon name="library-panel" style={{ marginRight: '4px' }} />}
                 {alertState ? (
                   <Icon
                     name={alertState === 'alerting' ? 'heart-break' : 'heart'}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the library panel icon from the panel header for all library panels.
![image](https://user-images.githubusercontent.com/562238/131494281-7c575b25-a764-4721-98c3-686ffda71f6b.png)


**Which issue(s) this PR fixes**:
Fixes #35422

**Special notes for your reviewer**:

