### PR TITLE
AccessControl: Add permission to datasource permissions navigation selector

### DIFF
--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -1,5 +1,7 @@
 import { DataSourceSettings, PluginType, PluginInclude, NavModel, NavModelItem } from '@grafana/data';
 import config from 'app/core/config';
+import { contextSrv } from 'app/core/core';
+import { AccessControlAction } from 'app/types';
 import { GenericDataSourcePlugin } from '../settings/PluginSettings';
 
 export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDataSourcePlugin): NavModelItem {
@@ -46,13 +48,15 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
   }
 
   if (config.licenseInfo.hasLicense) {
-    navModel.children!.push({
-      active: false,
-      icon: 'lock',
-      id: `datasource-permissions-${dataSource.id}`,
-      text: 'Permissions',
-      url: `datasources/edit/${dataSource.id}/permissions`,
-    });
+    if (contextSrv.hasPermission(AccessControlAction.DataSourcesPermissionsRead)) {
+      navModel.children!.push({
+        active: false,
+        icon: 'lock',
+        id: `datasource-permissions-${dataSource.id}`,
+        text: 'Permissions',
+        url: `datasources/edit/${dataSource.id}/permissions`,
+      });
+    }
 
     navModel.children!.push({
       active: false,

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -39,6 +39,7 @@ export enum AccessControlAction {
   DataSourcesCreate = 'datasources:create',
   DataSourcesWrite = 'datasources:write',
   DataSourcesDelete = 'datasources:delete',
+  DataSourcesPermissionsRead = 'datasources.permissions:read',
 
   ActionServerStatsRead = 'server.stats:read',
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR is needed to hide the data source permissions tab when a user does not have the right to see data sources permissions. Since knowing the state "enable" "disable" of data source permissions depends on the `read` rights, having `toggle` rights only is not enough to have visibility over the tab.
OSS part of https://github.com/grafana/grafana-enterprise/pull/1848

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partly fixes https://github.com/grafana/grafana-enterprise/issues/1548

**Special notes for your reviewer**:

