### PR TITLE
devenv: update prom random_data for go1.17 (use go install)

### DIFF
--- a/devenv/docker/blocks/prometheus_random_data/Dockerfile
+++ b/devenv/docker/blocks/prometheus_random_data/Dockerfile
@@ -3,7 +3,7 @@
 # Builder image, where we build the example.
 FROM golang:1.17 AS builder
 # Download prometheus/client_golang/examples/random first
-RUN go install github.com/prometheus/client_golang/examples/random@latest
+RUN CGO_ENABLED=0 GOOS=linux go install -tags netgo -ldflags '-w' github.com/prometheus/client_golang/examples/random@latest
 
 # Final image.
 FROM scratch

--- a/devenv/docker/blocks/prometheus_random_data/Dockerfile
+++ b/devenv/docker/blocks/prometheus_random_data/Dockerfile
@@ -3,16 +3,11 @@
 # Builder image, where we build the example.
 FROM golang:1.17 AS builder
 # Download prometheus/client_golang/examples/random first
-RUN go get github.com/prometheus/client_golang/examples/random
-WORKDIR /go/src/github.com/prometheus/client_golang
-WORKDIR /go/src/github.com/prometheus/client_golang/prometheus
-RUN go get -d
-WORKDIR /go/src/github.com/prometheus/client_golang/examples/random
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w'
+RUN go install github.com/prometheus/client_golang/examples/random@latest
 
 # Final image.
 FROM scratch
 LABEL maintainer "The Prometheus Authors <prometheus-developers@googlegroups.com>"
-COPY --from=builder /go/src/github.com/prometheus/client_golang/examples/random .
+COPY --from=builder /go/bin/random .
 EXPOSE 8080
 ENTRYPOINT ["/random"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates random gen from prom to work with go.17, using the go install command. Before was getting errors:

```
go: downloading github.com/prometheus/client_golang v1.11.0
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.26.0
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/golang/protobuf v1.4.3
go: downloading github.com/prometheus/procfs v0.6.0
go: downloading golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading google.golang.org/protobuf v1.26.0-rc.1
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
Removing intermediate container e883617d903d
 ---> eb6191004571
Step 3/12 : WORKDIR /go/src/github.com/prometheus/client_golang
 ---> Running in 5e21f706f06a
Removing intermediate container 5e21f706f06a
 ---> 747251962bd9
Step 4/12 : WORKDIR /go/src/github.com/prometheus/client_golang/prometheus
 ---> Running in 8acdc4c673e7
Removing intermediate container 8acdc4c673e7
 ---> 09016fce74e1
Step 5/12 : RUN go get -d
 ---> Running in 999ebbe48ebc
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
ERROR: Service 'prometheus-random-data' failed to build: The command '/bin/sh -c go get -d' returned a non-zero code: 1
make: *** [Makefile:120: devenv] Error 1
```

**Special notes for your reviewer**:

I assume introduced in https://github.com/grafana/grafana/commit/8e2ee0a1c855d0b5b9e938017aa4ad4c40efebe6 , cc @gerobinson 