### PR TITLE
Fix: Prevent yarn start exiting early on TS errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "stats": "webpack --mode production --config scripts/webpack/webpack.prod.js --profile --json > compilation-stats.json",
     "storybook": "yarn workspace @grafana/ui storybook --ci",
     "storybook:build": "yarn workspace @grafana/ui storybook:build",
-    "themes:generate": "ts-node --project ./scripts/cli/tsconfig.json ./scripts/cli/generateSassVariableFiles.ts",
+    "themes:generate": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/generateSassVariableFiles.ts",
     "typecheck": "tsc --noEmit && yarn run packages:typecheck",
     "plugins:build-bundled": "grafana-toolkit plugin:bundle-managed",
     "watch": "yarn start -d watch,start core:start --watchTheme",


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Stops the `theme:generate` script from typechecking so `yarn start` doesn't exit early when the checked out project has TS errors.

| Before | After |
| --- | --- |
| <img width="800" alt="Screenshot 2021-09-01 at 09 46 58" src="https://user-images.githubusercontent.com/73201/131632746-7a545633-0e5d-4085-8d66-aa3425f6b2bf.png"> | <img width="800" alt="Screenshot 2021-09-01 at 09 46 58" src="https://user-images.githubusercontent.com/73201/131633426-c16a01b1-c100-40f4-84df-7f8fff77ccc3.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38776

**Special notes for your reviewer**:
Maybe `theme:generate` should check types and we create a second script that `yarn:start` hooks into?

