### PR TITLE
Annotation tooltip: Bring back links styles

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationTooltip.tsx
@@ -130,6 +130,13 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     body: css`
       padding: ${theme.spacing(1)};
+
+      a {
+        color: ${theme.colors.text.link};
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     `,
   };
 };


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/38695