### PR TITLE
Chore: update all +build statements

### DIFF
--- a/pkg/components/simplejson/simplejson_go11.go
+++ b/pkg/components/simplejson/simplejson_go11.go
@@ -1,3 +1,4 @@
+//go:build go1.1
 // +build go1.1
 
 package simplejson

--- a/pkg/infra/log/syslog.go
+++ b/pkg/infra/log/syslog.go
@@ -1,4 +1,5 @@
-//+build !windows,!nacl,!plan9
+//go:build !windows && !nacl && !plan9
+// +build !windows,!nacl,!plan9
 
 package log
 

--- a/pkg/infra/log/syslog_windows.go
+++ b/pkg/infra/log/syslog_windows.go
@@ -1,4 +1,5 @@
-//+build windows
+//go:build windows
+// +build windows
 
 package log
 

--- a/pkg/infra/remotecache/memcached_storage_integration_test.go
+++ b/pkg/infra/remotecache/memcached_storage_integration_test.go
@@ -1,3 +1,4 @@
+//go:build memcached
 // +build memcached
 
 package remotecache

--- a/pkg/infra/remotecache/redis_storage_integration_test.go
+++ b/pkg/infra/remotecache/redis_storage_integration_test.go
@@ -1,3 +1,4 @@
+//go:build redis
 // +build redis
 
 package remotecache

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package serverlock

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -1,3 +1,4 @@
+//go:build go1.3
 // +build go1.3
 
 // Copyright 2014 The Macaron Authors

--- a/pkg/ruleguard.rules.go
+++ b/pkg/ruleguard.rules.go
@@ -1,4 +1,6 @@
+//go:build ignore
 // +build ignore
+
 // The MIT License (MIT)
 //
 // Copyright (c) 2020 Grafana Labs <contact@grafana.com>, Damian Gryski <damian@gryski.com>

--- a/pkg/schema/load/constant.go
+++ b/pkg/schema/load/constant.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package load

--- a/pkg/schema/load/constant_windows.go
+++ b/pkg/schema/load/constant_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package load

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -1,3 +1,4 @@
+//go:build wireinject
 // +build wireinject
 
 package server

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -1,3 +1,4 @@
+//go:build wireinject && oss
 // +build wireinject,oss
 
 package server

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package alerting

--- a/pkg/services/dashboards/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/dashboard_service_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package dashboards

--- a/pkg/services/live/database/tests/storage_test.go
+++ b/pkg/services/live/database/tests/storage_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package tests

--- a/pkg/services/live/managedstream/cache_redis_test.go
+++ b/pkg/services/live/managedstream/cache_redis_test.go
@@ -1,3 +1,4 @@
+//go:build redis
 // +build redis
 
 package managedstream

--- a/pkg/services/login/authinfoservice/user_auth_test.go
+++ b/pkg/services/login/authinfoservice/user_auth_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package authinfoservice

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package store_test

--- a/pkg/services/provisioning/dashboards/file_reader_linux_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package dashboards

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/dashboard_acl_test.go
+++ b/pkg/services/sqlstore/dashboard_acl_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/dashboard_provisioning_test.go
+++ b/pkg/services/sqlstore/dashboard_provisioning_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/dashboard_snapshot_test.go
+++ b/pkg/services/sqlstore/dashboard_snapshot_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/dashboard_version_test.go
+++ b/pkg/services/sqlstore/dashboard_version_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/datasource_test.go
+++ b/pkg/services/sqlstore/datasource_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/health_test.go
+++ b/pkg/services/sqlstore/health_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/login_attempt_test.go
+++ b/pkg/services/sqlstore/login_attempt_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/preferences_test.go
+++ b/pkg/services/sqlstore/preferences_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/quota_test.go
+++ b/pkg/services/sqlstore/quota_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/searchstore/search_test.go
+++ b/pkg/services/sqlstore/searchstore/search_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 // package search_test contains integration tests for search

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/stars_test.go
+++ b/pkg/services/sqlstore/stars_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/stats_integration_test.go
+++ b/pkg/services/sqlstore/stats_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/tags_test.go
+++ b/pkg/services/sqlstore/tags_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/temp_user_test.go
+++ b/pkg/services/sqlstore/temp_user_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sqlstore

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package mysql

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package postgres


### PR DESCRIPTION
Since Go 1.17 introduced a new (less error-prone) syntax for `//+build` statement - latest `gofmt` rewrites them now. This PR includes all the files updated with `gofmt` and contains a backwards-compatible solution for Go 1.17 `//go:build` statements. Once Go 1.17 gets higher adoption rate - we can remove old `//+build` statements.

Related Go 1.17 release notes - https://golang.org/doc/go1.17#go-command