### PR TITLE
Graphite: Deprecate browser access mode.

### DIFF
--- a/docs/sources/datasources/graphite.md
+++ b/docs/sources/datasources/graphite.md
@@ -18,34 +18,21 @@ Refer to [Add a data source]({{< relref "add-a-data-source.md" >}}) for instruct
 
 To access Graphite settings, hover your mouse over the **Configuration** (gear) icon, then click **Data Sources**, and then click the Graphite data source.
 
-| Name                  | Description                                                                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`                | The data source name. This is how you refer to the data source in panels and queries.                                                 |
-| `Default`             | Default data source means that it will be pre-selected for new panels.                                                                |
-| `URL`                 | The HTTP protocol, IP, and port of your graphite-web or graphite-api install.                                                         |
-| `Access`              | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser. |
-| `Auth`                | Refer to [Authentication]({{< relref "../auth/_index.md" >}}) for more information.                                                   |
-| `Basic Auth`          | Enable basic authentication to the data source.                                                                                       |
-| `User`                | User name for basic authentication.                                                                                                   |
-| `Password`            | Password for basic authentication.                                                                                                    |
-| `Custom HTTP Headers` | Click **Add header** to add a custom HTTP header.                                                                                     |
-| `Header`              | Enter the custom header name.                                                                                                         |
-| `Value`               | Enter the custom header value.                                                                                                        |
+| Name                  | Description                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `Name`                | The data source name. This is how you refer to the data source in panels and queries. |
+| `Default`             | Default data source means that it will be pre-selected for new panels.                |
+| `URL`                 | The HTTP protocol, IP, and port of your graphite-web or graphite-api install.         |
+| `Auth`                | Refer to [Authentication]({{< relref "../auth/_index.md" >}}) for more information.   |
+| `Basic Auth`          | Enable basic authentication to the data source.                                       |
+| `User`                | User name for basic authentication.                                                   |
+| `Password`            | Password for basic authentication.                                                    |
+| `Custom HTTP Headers` | Click **Add header** to add a custom HTTP header.                                     |
+| `Header`              | Enter the custom header name.                                                         |
+| `Value`               | Enter the custom header value.                                                        |
 | `Graphite details`    |
-| `Version`             | Select your version of Graphite.                                                                                                      |
-| `Type`                | Select your type of Graphite.                                                                                                         |
-
-Access mode controls how requests to the data source will be handled. Server should be the preferred way if nothing else is stated.
-
-### Server access mode (default)
-
-All requests will be made from the browser to Grafana backend/server which in turn will forward the requests to the data source and by that circumvent possible Cross-Origin Resource Sharing (CORS) requirements. The URL needs to be accessible from the Grafana backend/server if you select this access mode.
-
-### Browser access mode
-
-> **Warning:** Browser (Direct) access is deprecated and will be removed in the future.
-
-All requests will be made from the browser directly to the data source and may be subject to Cross-Origin Resource Sharing (CORS) requirements. The URL needs to be accessible from the browser if you select this access mode.
+| `Version`             | Select your version of Graphite.                                                      |
+| `Type`                | Select your type of Graphite.                                                         |
 
 ## Graphite query editor
 

--- a/docs/sources/datasources/graphite.md
+++ b/docs/sources/datasources/graphite.md
@@ -43,6 +43,8 @@ All requests will be made from the browser to Grafana backend/server which in tu
 
 ### Browser access mode
 
+> **Warning:** Browser (Direct) access is deprecated and will be removed in the future.
+
 All requests will be made from the browser directly to the data source and may be subject to Cross-Origin Resource Sharing (CORS) requirements. The URL needs to be accessible from the browser if you select this access mode.
 
 ## Graphite query editor

--- a/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { DataSourceHttpSettings, InlineFormLabel, LegacyForms } from '@grafana/ui';
+import { Alert, DataSourceHttpSettings, InlineFormLabel, LegacyForms } from '@grafana/ui';
 const { Select, Switch } = LegacyForms;
 import {
   DataSourcePluginOptionsEditorProps,
@@ -61,8 +61,14 @@ export class ConfigEditor extends PureComponent<Props, State> {
 
     return (
       <>
+        {options.access === 'direct' && (
+          <Alert title="Deprecation Notice" severity="warning">
+            Browser access mode in Graphite datasource is deprecated and will be removed in the future.
+          </Alert>
+        )}
         <DataSourceHttpSettings
           defaultUrl="http://localhost:8080"
+          showAccessOptions={true}
           dataSourceConfig={options}
           onChange={onOptionsChange}
         />

--- a/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
@@ -63,7 +63,8 @@ export class ConfigEditor extends PureComponent<Props, State> {
       <>
         {options.access === 'direct' && (
           <Alert title="Deprecation Notice" severity="warning">
-            Browser access mode in Graphite datasource is deprecated and will be removed in the future.
+            This data source uses browser access mode. This mode is deprecated and will be removed in the future. Please
+            use server access mode instead.
           </Alert>
         )}
         <DataSourceHttpSettings

--- a/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/ConfigEditor.tsx
@@ -68,7 +68,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
         )}
         <DataSourceHttpSettings
           defaultUrl="http://localhost:8080"
-          showAccessOptions={true}
           dataSourceConfig={options}
           onChange={onOptionsChange}
         />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Browser (direct) access mode switcher was removed from Graphite configuration page in Grafana 6.6.0 (#20444). This option was just not added when configuration page was migrated to React and `DataSourceHttpSettings` component which requires explicitly showing it by passing `showAccessOptions={true}`. (Note that a similar thing happened with Prometheus in #20248 but it was fixed in #21833). Since then the only way to set browser access mode for Graphite is to provision the data source with `access: direct` settings.

We plan to remove browser access mode for some data sources and there's no guarantee we will keep it for Graphite so I just added a deprecation warning (similar to a warning that was added to Elastic in #29649) when it's already set:

<img width="1143" alt="Screen Shot 2021-09-01 at 13 56 15" src="https://user-images.githubusercontent.com/745532/131667162-cbe76807-c1f1-47f3-b2cf-1c3cec7f36ff.png">

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38601

**Special notes for your reviewer**: 

For the reference, this is how the config page changed between 6.5.0 and 6.6.0:

| 6.5.0 | 6.6.0 |
|------|------|
| <img width="613" alt="Screen Shot 2021-09-01 at 13 16 04" src="https://user-images.githubusercontent.com/745532/131662458-3a4a6f7d-5e81-4a93-9892-3dd7f77c249a.png"> | <img width="587" alt="Screen Shot 2021-09-01 at 13 19 19" src="https://user-images.githubusercontent.com/745532/131662604-faee41fa-e445-47df-909a-71dcd1d24272.png"> |
