### PR TITLE
Fix: inject request with traceID into the macaron Context

### DIFF
--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -52,6 +52,7 @@ func RequestTracing() macaron.Handler {
 
 		ctx := opentracing.ContextWithSpan(req.Context(), span)
 		c.Req = req.WithContext(ctx)
+		c.Map(c.Req)
 
 		c.Next()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Inside ContextHandler a modified request object is created that contains a contextual traceID. However this request object is not known to the Macaron's DI system and thus - not propagated any further.

This PR maps a modified request object to be injected into the following middleware and handlers.

**Which issue(s) this PR fixes**:

Fixes #38772 