### PR TITLE
PieChart: Display "No data" when there is no data

### DIFF
--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -66,10 +66,6 @@ export const PieChart: FC<PieChartProps> = ({
     return !dv.field.custom.hideFrom.viz;
   });
 
-  if (filteredFieldDisplayValues.length < 0) {
-    return <div>No data</div>;
-  }
-
   const getValue = (d: FieldDisplay) => d.display.numeric;
   const getGradientId = (color: string) => `${componentInstanceId}-${tinycolor(color).toHex()}`;
   const getGradientColor = (color: string) => {

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -49,6 +49,14 @@ export function PieChartPanel(props: Props) {
     timeZone,
   });
 
+  if (!hasFrames(fieldDisplayValues)) {
+    return (
+      <div className="panel-empty">
+        <p>{'No data'}</p>
+      </div>
+    );
+  }
+
   return (
     <VizLayout width={width} height={height} legend={getLegend(props, fieldDisplayValues)}>
       {(vizWidth: number, vizHeight: number) => {
@@ -125,6 +133,15 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
       displayMode={legendOptions.displayMode}
     />
   );
+}
+
+function hasFrames(fieldDisplayValues: FieldDisplay[]) {
+  for (let fd of fieldDisplayValues) {
+    if (fd.view && fd.view.dataFrame.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function useSliceHighlightState() {

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -136,12 +136,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
 }
 
 function hasFrames(fieldDisplayValues: FieldDisplay[]) {
-  for (let fd of fieldDisplayValues) {
-    if (fd.view && fd.view.dataFrame.length > 0) {
-      return true;
-    }
-  }
-  return false;
+  return fieldDisplayValues.some((fd) => fd.view?.dataFrame.length);
 }
 
 function useSliceHighlightState() {

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -52,7 +52,7 @@ export function PieChartPanel(props: Props) {
   if (!hasFrames(fieldDisplayValues)) {
     return (
       <div className="panel-empty">
-        <p>{'No data'}</p>
+        <p>No data</p>
       </div>
     );
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
When there is no data to display the piechart looks a bit weird.
Before:
![image](https://user-images.githubusercontent.com/468940/131806320-7568dd4c-cc7e-4206-9013-601128a2fe7d.png)


After:
![image](https://user-images.githubusercontent.com/468940/131806107-a0e06f80-eb02-4505-bba9-fee280e9610d.png)


**Which issue(s) this PR fixes**:
Fixes #38693

