### PR TITLE
UsageStats: Add connected users and client

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -31,6 +32,7 @@ type UsageStatsService struct {
 	AlertingUsageStats alerting.UsageStatsQuerier
 	PluginManager      plugins.Manager
 	SocialService      social.Service
+	grafanaLive        *live.GrafanaLive
 
 	log log.Logger
 
@@ -41,7 +43,7 @@ type UsageStatsService struct {
 
 func ProvideService(cfg *setting.Cfg, bus bus.Bus, sqlStore *sqlstore.SQLStore,
 	alertingStats alerting.UsageStatsQuerier, pluginManager plugins.Manager,
-	socialService social.Service) *UsageStatsService {
+	socialService social.Service, grafanaLive *live.GrafanaLive) *UsageStatsService {
 	s := &UsageStatsService{
 		Cfg:                cfg,
 		Bus:                bus,
@@ -49,6 +51,7 @@ func ProvideService(cfg *setting.Cfg, bus bus.Bus, sqlStore *sqlstore.SQLStore,
 		AlertingUsageStats: alertingStats,
 		oauthProviders:     socialService.GetOAuthProviders(),
 		PluginManager:      pluginManager,
+		grafanaLive:        grafanaLive,
 		log:                log.New("infra.usagestats"),
 	}
 	return s

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -80,9 +80,13 @@ func (uss *UsageStatsService) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-sendReportTicker.C:
-			if err := uss.sendUsageStats(ctx); err != nil {
-				metricsLogger.Warn("Failed to send usage stats", "err", err)
+			if uss.Cfg.ReportingEnabled {
+				if err := uss.sendUsageStats(ctx); err != nil {
+					metricsLogger.Warn("Failed to send usage stats", "err", err)
+				}
 			}
+			// always reset stats every report tick
+			uss.resetLiveStats()
 		case <-updateStatsTicker.C:
 			uss.updateTotalStats()
 			uss.sampleLiveStats()

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -80,12 +80,10 @@ func (uss *UsageStatsService) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-sendReportTicker.C:
-			if uss.Cfg.ReportingEnabled {
-				if err := uss.sendUsageStats(ctx); err != nil {
-					metricsLogger.Warn("Failed to send usage stats", "err", err)
-				}
+			if err := uss.sendUsageStats(ctx); err != nil {
+				metricsLogger.Warn("Failed to send usage stats", "err", err)
 			}
-			// always reset stats every report tick
+			// always reset live stats every report tick
 			uss.resetLiveStats()
 		case <-updateStatsTicker.C:
 			uss.updateTotalStats()

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -79,12 +79,19 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
 	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
 
+	liveUsersAvg := 0
+	liveClientsAvg := 0
+	if uss.liveStats.sampleCount > 0 {
+		liveUsersAvg = uss.liveStats.numUsersSum / uss.liveStats.sampleCount
+		liveClientsAvg = uss.liveStats.numClientsSum / uss.liveStats.sampleCount
+	}
+	metrics["stats.live_samples.count"] = uss.liveStats.sampleCount
 	metrics["stats.live_users_max.count"] = uss.liveStats.numUsersMax
 	metrics["stats.live_users_min.count"] = uss.liveStats.numUsersMin
-	metrics["stats.live_users_avg.count"] = uss.liveStats.numUsersSum / uss.liveStats.sampleCount
+	metrics["stats.live_users_avg.count"] = liveUsersAvg
 	metrics["stats.live_clients_max.count"] = uss.liveStats.numClientsMax
 	metrics["stats.live_clients_min.count"] = uss.liveStats.numClientsMin
-	metrics["stats.live_clients_avg.count"] = uss.liveStats.numClientsSum / uss.liveStats.sampleCount
+	metrics["stats.live_clients_avg.count"] = liveClientsAvg
 
 	ossEditionCount := 1
 	enterpriseEditionCount := 0
@@ -289,6 +296,8 @@ func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
 	}
 	data := bytes.NewBuffer(out)
 	sendUsageStats(data)
+
+	uss.resetLiveStats()
 
 	return nil
 }

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -50,6 +50,8 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 		return report, err
 	}
 
+	liveUsage := uss.grafanaLive.UsageStats()
+
 	metrics["stats.dashboards.count"] = statsQuery.Result.Dashboards
 	metrics["stats.users.count"] = statsQuery.Result.Users
 	metrics["stats.orgs.count"] = statsQuery.Result.Orgs
@@ -77,6 +79,9 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.dashboards_viewers_can_admin.count"] = statsQuery.Result.DashboardsViewersCanAdmin
 	metrics["stats.folders_viewers_can_edit.count"] = statsQuery.Result.FoldersViewersCanEdit
 	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
+	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
+	metrics["stats.live_users.count"] = liveUsage.NumUsers
+	metrics["stats.live_clients.count"] = liveUsage.NumClients
 
 	ossEditionCount := 1
 	enterpriseEditionCount := 0

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -77,7 +77,6 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.dashboards_viewers_can_admin.count"] = statsQuery.Result.DashboardsViewersCanAdmin
 	metrics["stats.folders_viewers_can_edit.count"] = statsQuery.Result.FoldersViewersCanEdit
 	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
-	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
 
 	liveUsersAvg := 0
 	liveClientsAvg := 0
@@ -279,9 +278,6 @@ func (uss *UsageStatsService) RegisterMetricsFunc(fn MetricsFunc) {
 }
 
 func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
-	if !uss.Cfg.ReportingEnabled {
-		return nil
-	}
 
 	metricsLogger.Debug(fmt.Sprintf("Sending anonymous usage stats to %s", usageStatsURL))
 
@@ -294,11 +290,9 @@ func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	data := bytes.NewBuffer(out)
 	sendUsageStats(data)
-
-	uss.resetLiveStats()
-
 	return nil
 }
 

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -278,6 +278,10 @@ func (uss *UsageStatsService) RegisterMetricsFunc(fn MetricsFunc) {
 }
 
 func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
+	if !uss.Cfg.ReportingEnabled {
+		return nil
+	}
+
 	metricsLogger.Debug(fmt.Sprintf("Sending anonymous usage stats to %s", usageStatsURL))
 
 	report, err := uss.GetUsageReport(ctx)

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -278,7 +278,6 @@ func (uss *UsageStatsService) RegisterMetricsFunc(fn MetricsFunc) {
 }
 
 func (uss *UsageStatsService) sendUsageStats(ctx context.Context) error {
-
 	metricsLogger.Debug(fmt.Sprintf("Sending anonymous usage stats to %s", usageStatsURL))
 
 	report, err := uss.GetUsageReport(ctx)

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -722,7 +722,7 @@ func (g *GrafanaLive) ClientCount(orgID int64, channel string) (int, error) {
 
 func (g *GrafanaLive) UsageStats() UsageStats {
 	clients := g.node.Hub().NumClients()
-	users := g.node.Hub().NumClients()
+	users := g.node.Hub().NumUsers()
 
 	return UsageStats{NumClients: clients, NumUsers: users}
 }

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -47,15 +47,6 @@ var (
 	loggerCF = log.New("live.centrifuge")
 )
 
-func NewGrafanaLive() *GrafanaLive {
-	return &GrafanaLive{
-		channels: make(map[string]models.ChannelHandler),
-		GrafanaScope: CoreGrafanaScope{
-			Features: make(map[string]models.ChannelHandlerFactory),
-		},
-	}
-}
-
 // CoreGrafanaScope list of core features
 type CoreGrafanaScope struct {
 	Features map[string]models.ChannelHandlerFactory
@@ -341,6 +332,11 @@ type GrafanaLive struct {
 	contextGetter    *liveplugin.ContextGetter
 	runStreamManager *runstream.Manager
 	storage          *database.Storage
+}
+
+type UsageStats struct {
+	NumClients int
+	NumUsers   int
 }
 
 func (g *GrafanaLive) getStreamPlugin(pluginID string) (backend.StreamHandler, error) {
@@ -722,6 +718,13 @@ func (g *GrafanaLive) ClientCount(orgID int64, channel string) (int, error) {
 		return 0, err
 	}
 	return len(p.Presence), nil
+}
+
+func (g *GrafanaLive) UsageStats() UsageStats {
+	clients := g.node.Hub().NumClients()
+	users := g.node.Hub().NumClients()
+
+	return UsageStats{NumClients: clients, NumUsers: users}
 }
 
 func (g *GrafanaLive) HandleHTTPPublish(ctx *models.ReqContext, cmd dtos.LivePublishCmd) response.Response {


### PR DESCRIPTION
This adds two new metrics to usage stats

* live_users
* live_clients

Stats taken from the websocket centrifuge servers. Currently these are always the same, so same user in two tabs counts as different users. @FZambia do you know why?
