### PR TITLE
Fix: Include Buffer in webpack build

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
+const webpack = require('webpack');
 
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
@@ -58,6 +59,9 @@ module.exports = {
     source: false,
   },
   plugins: [
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
     new CopyUniconsPlugin(),
     new CopyWebpackPlugin({
       patterns: [


### PR DESCRIPTION
**What this PR does / why we need it**:

Nodejs core modules are no longer added in webpack 5. We use `Buffer` in the Tempo code to convert base64 string to hex. This pr adds back the support for Buffer. See also https://github.com/webpack/changelog-v5/issues/10

**Which issue(s) this PR fixes**:

Fixes #38817

