### PR TITLE
Sidemenu: Various accessibility improvements

### DIFF
--- a/public/app/core/components/sidemenu/BottomSection.tsx
+++ b/public/app/core/components/sidemenu/BottomSection.tsx
@@ -75,7 +75,7 @@ export default function BottomSection() {
             url={link.url}
           >
             {link.icon && <Icon name={link.icon as IconName} size="xl" />}
-            {link.img && <img src={link.img} />}
+            {link.img && <img src={link.img} alt={`${link.text} logo`} />}
           </SideMenuItem>
         );
       })}

--- a/public/app/core/components/sidemenu/DropDownChild.tsx
+++ b/public/app/core/components/sidemenu/DropDownChild.tsx
@@ -16,6 +16,11 @@ const DropDownChild = ({ isDivider = false, icon, onClick, target, text, url }: 
   const iconClassName = css`
     margin-right: ${theme.spacing(1)};
   `;
+  const resetButtonStyles = css`
+    background-color: transparent;
+    border: none;
+    width: 100%;
+  `;
 
   const linkContent = (
     <>
@@ -24,9 +29,13 @@ const DropDownChild = ({ isDivider = false, icon, onClick, target, text, url }: 
     </>
   );
 
-  let anchor = <a onClick={onClick}>{linkContent}</a>;
+  let element = (
+    <button className={resetButtonStyles} onClick={onClick}>
+      {linkContent}
+    </button>
+  );
   if (url) {
-    anchor =
+    element =
       !target && url.startsWith('/') ? (
         <Link onClick={onClick} href={url}>
           {linkContent}
@@ -38,7 +47,7 @@ const DropDownChild = ({ isDivider = false, icon, onClick, target, text, url }: 
       );
   }
 
-  return isDivider ? <li data-testid="dropdown-child-divider" className="divider" /> : <li>{anchor}</li>;
+  return isDivider ? <li data-testid="dropdown-child-divider" className="divider" /> : <li>{element}</li>;
 };
 
 export default DropDownChild;

--- a/public/app/core/components/sidemenu/SideMenuDropDown.tsx
+++ b/public/app/core/components/sidemenu/SideMenuDropDown.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import DropDownChild from './DropDownChild';
 import { NavModelItem } from '@grafana/data';
 import { IconName, Link } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
 interface Props {
   headerText: string;
@@ -21,15 +21,19 @@ const SideMenuDropDown = ({
   reverseDirection = false,
   subtitleText,
 }: Props) => {
+  const resetButtonStyles = css`
+    background-color: transparent;
+    font-size: inherit;
+  `;
   const headerContent = <span className="sidemenu-item-text">{headerText}</span>;
   const header = headerUrl ? (
     <Link href={headerUrl} onClick={onHeaderClick} className="side-menu-header-link">
       {headerContent}
     </Link>
   ) : (
-    <a onClick={onHeaderClick} className="side-menu-header-link">
+    <button onClick={onHeaderClick} className={cx(resetButtonStyles, 'side-menu-header-link')}>
       {headerContent}
-    </a>
+    </button>
   );
 
   const menuClass = css`

--- a/public/app/core/components/sidemenu/SideMenuItem.tsx
+++ b/public/app/core/components/sidemenu/SideMenuItem.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import SideMenuDropDown from './SideMenuDropDown';
-import { Link, useStyles2 } from '@grafana/ui';
+import { Link } from '@grafana/ui';
 import { NavModelItem } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 
@@ -25,12 +25,9 @@ const SideMenuItem = ({
   target,
   url,
 }: Props) => {
-  const resetButtonStyles = useStyles2(
-    () =>
-      css`
-        background-color: transparent;
-      `
-  );
+  const resetButtonStyles = css`
+    background-color: transparent;
+  `;
 
   const anchor = url ? (
     <Link

--- a/public/app/core/components/sidemenu/TopSection.tsx
+++ b/public/app/core/components/sidemenu/TopSection.tsx
@@ -29,7 +29,7 @@ const TopSection = () => {
             url={link.url}
           >
             {link.icon && <Icon name={link.icon as IconName} size="xl" />}
-            {link.img && <img src={link.img} />}
+            {link.img && <img src={link.img} alt={`${link.text} logo`} />}
           </SideMenuItem>
         );
       })}

--- a/public/sass/components/_dropdown.scss
+++ b/public/sass/components/_dropdown.scss
@@ -74,7 +74,8 @@
 
   // Links within the dropdown menu
   > li {
-    > a {
+    > a,
+    > button {
       display: block;
       padding: 3px 20px 3px 15px;
       clear: both;
@@ -111,7 +112,8 @@
     box-shadow: $menu-dropdown-shadow;
     margin-top: 0px;
 
-    > li > a {
+    > li > a,
+    > li > button {
       display: flex;
       padding: 5px 10px;
       border-left: 2px solid transparent;
@@ -125,7 +127,8 @@
 
   &--sidemenu {
     li.sidemenu-org-switcher {
-      > a {
+      > a,
+      > button {
         padding: 8px 10px 8px 15px;
       }
     }
@@ -141,7 +144,11 @@
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus,
 .dropdown-submenu:hover > a,
-.dropdown-submenu:focus > a {
+.dropdown-submenu:focus > a,
+.dropdown-menu > li > button:hover,
+.dropdown-menu > li > button:focus,
+.dropdown-submenu:hover > button,
+.dropdown-submenu:focus > button {
   text-decoration: none;
   color: $dropdownLinkColorHover;
   background-color: $dropdownLinkBackgroundHover;
@@ -151,7 +158,10 @@
 // ------------
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
-.dropdown-menu > .active > a:focus {
+.dropdown-menu > .active > a:focus,
+.dropdown-menu > .active > button,
+.dropdown-menu > .active > button:hover,
+.dropdown-menu > .active > button:focus {
   color: $dropdownLinkColorActive;
   text-decoration: none;
   outline: 0;
@@ -163,12 +173,17 @@
 // Gray out text and ensure the hover/focus state remains gray
 .dropdown-menu > .disabled > a,
 .dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
+.dropdown-menu > .disabled > a:focus,
+.dropdown-menu > .disabled > button,
+.dropdown-menu > .disabled > button:hover,
+.dropdown-menu > .disabled > button:focus {
   color: $gray-2;
 }
 // Nuke hover/focus effects
 .dropdown-menu > .disabled > a:hover,
-.dropdown-menu > .disabled > a:focus {
+.dropdown-menu > .disabled > a:focus,
+.dropdown-menu > .disabled > button:hover,
+.dropdown-menu > .disabled > button:focus {
   text-decoration: none;
   background-color: transparent;
   background-image: none; // Remove CSS gradient
@@ -269,7 +284,8 @@
 //   pointer-events: none;
 //   font-size: 11px;
 // }
-.dropdown-submenu:hover > a::after {
+.dropdown-submenu:hover > a::after,
+.dropdown-submenu:hover > button::after {
   border-left-color: $dropdownLinkColorHover;
 }
 
@@ -314,7 +330,8 @@
 }
 
 .dropdown-menu.dropdown-menu--new {
-  li a {
+  li a,
+  li button {
     padding: $spacer/2 $spacer;
     border-left: 2px solid $side-menu-bg;
     background: $side-menu-bg;

--- a/public/sass/components/_sidemenu.scss
+++ b/public/sass/components/_sidemenu.scss
@@ -254,10 +254,6 @@ li.sidemenu-org-switcher {
     }
 
     .sidemenu-link {
-      text-align: left;
-    }
-
-    .sidemenu-icon {
       display: none;
     }
 
@@ -268,7 +264,8 @@ li.sidemenu-org-switcher {
       float: none;
       margin-bottom: $space-sm;
 
-      > li > a {
+      > li > a,
+      > li > button {
         padding-left: 15px;
       }
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

various accessibility improvements:
- when no url is present, use `<button>` instead of an `<a>` element. this can then be tabbed to. e.g. the switch organization button or the keyboard shortcuts button: 
![image](https://user-images.githubusercontent.com/20999846/131829319-7ec291b1-50cf-4e34-b0ff-e6fd6872ce30.png)
or the search dashboards header: 
![image](https://user-images.githubusercontent.com/20999846/131829824-5d5ccd1f-b822-4c5e-a027-76c921a7042c.png)
- some css needed to render the buttons the same as the anchor elements.
- added `alt` attributes to any elements with images. e.g. the profile sidemenuitem
- hide the entire `sidemenu-link` element when in mobile view. this removes some empty elements that could still be accessed via tab like this:
![image](https://user-images.githubusercontent.com/20999846/131829702-663ac153-3e34-43d6-98c4-4bf2d9e0e03c.png)

note: this is not the full accessibility changes needed. we still need some input from ux/design on what the sidemenuitems will look like before we do a full deep dive on accessibility.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/38507

**Special notes for your reviewer**:

