### PR TITLE
Chore: pass url parameters through context.Context

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/search"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func ValidateOrgAlert(c *models.ReqContext) {
@@ -255,7 +256,7 @@ func GetAlertNotificationByID(c *models.ReqContext) response.Response {
 func GetAlertNotificationByUID(c *models.ReqContext) response.Response {
 	query := &models.GetAlertNotificationsWithUidQuery{
 		OrgId: c.OrgId,
-		Uid:   c.Params("uid"),
+		Uid:   macaron.Vars(c.Req)["uid"],
 	}
 
 	if query.Uid == "" {
@@ -315,7 +316,7 @@ func UpdateAlertNotification(c *models.ReqContext, cmd models.UpdateAlertNotific
 
 func UpdateAlertNotificationByUID(c *models.ReqContext, cmd models.UpdateAlertNotificationWithUidCommand) response.Response {
 	cmd.OrgId = c.OrgId
-	cmd.Uid = c.Params("uid")
+	cmd.Uid = macaron.Vars(c.Req)["uid"]
 
 	err := fillWithSecureSettingsDataByUID(&cmd)
 	if err != nil {
@@ -408,7 +409,7 @@ func DeleteAlertNotification(c *models.ReqContext) response.Response {
 func DeleteAlertNotificationByUID(c *models.ReqContext) response.Response {
 	cmd := models.DeleteAlertNotificationWithUidCommand{
 		OrgId: c.OrgId,
-		Uid:   c.Params("uid"),
+		Uid:   macaron.Vars(c.Req)["uid"],
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -256,7 +256,7 @@ func GetAlertNotificationByID(c *models.ReqContext) response.Response {
 func GetAlertNotificationByUID(c *models.ReqContext) response.Response {
 	query := &models.GetAlertNotificationsWithUidQuery{
 		OrgId: c.OrgId,
-		Uid:   macaron.Vars(c.Req)["uid"],
+		Uid:   macaron.Vars(c.Req)[":uid"],
 	}
 
 	if query.Uid == "" {
@@ -316,7 +316,7 @@ func UpdateAlertNotification(c *models.ReqContext, cmd models.UpdateAlertNotific
 
 func UpdateAlertNotificationByUID(c *models.ReqContext, cmd models.UpdateAlertNotificationWithUidCommand) response.Response {
 	cmd.OrgId = c.OrgId
-	cmd.Uid = macaron.Vars(c.Req)["uid"]
+	cmd.Uid = macaron.Vars(c.Req)[":uid"]
 
 	err := fillWithSecureSettingsDataByUID(&cmd)
 	if err != nil {
@@ -409,7 +409,7 @@ func DeleteAlertNotification(c *models.ReqContext) response.Response {
 func DeleteAlertNotificationByUID(c *models.ReqContext) response.Response {
 	cmd := models.DeleteAlertNotificationWithUidCommand{
 		OrgId: c.OrgId,
-		Uid:   macaron.Vars(c.Req)["uid"],
+		Uid:   macaron.Vars(c.Req)[":uid"],
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -256,7 +256,7 @@ func GetAlertNotificationByID(c *models.ReqContext) response.Response {
 func GetAlertNotificationByUID(c *models.ReqContext) response.Response {
 	query := &models.GetAlertNotificationsWithUidQuery{
 		OrgId: c.OrgId,
-		Uid:   macaron.Vars(c.Req)[":uid"],
+		Uid:   macaron.Params(c.Req)[":uid"],
 	}
 
 	if query.Uid == "" {
@@ -316,7 +316,7 @@ func UpdateAlertNotification(c *models.ReqContext, cmd models.UpdateAlertNotific
 
 func UpdateAlertNotificationByUID(c *models.ReqContext, cmd models.UpdateAlertNotificationWithUidCommand) response.Response {
 	cmd.OrgId = c.OrgId
-	cmd.Uid = macaron.Vars(c.Req)[":uid"]
+	cmd.Uid = macaron.Params(c.Req)[":uid"]
 
 	err := fillWithSecureSettingsDataByUID(&cmd)
 	if err != nil {
@@ -409,7 +409,7 @@ func DeleteAlertNotification(c *models.ReqContext) response.Response {
 func DeleteAlertNotificationByUID(c *models.ReqContext) response.Response {
 	cmd := models.DeleteAlertNotificationWithUidCommand{
 		OrgId: c.OrgId,
-		Uid:   macaron.Vars(c.Req)[":uid"],
+		Uid:   macaron.Params(c.Req)[":uid"],
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -58,7 +58,7 @@ func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
 
 func AppPluginRoute(route *plugins.AppPluginRoute, appID string, hs *HTTPServer) macaron.Handler {
 	return func(c *models.ReqContext) {
-		path := macaron.Vars(c.Req)["*"]
+		path := macaron.Params(c.Req)["*"]
 
 		proxy := pluginproxy.NewApiPluginProxy(c, path, route, appID, hs.Cfg)
 		proxy.Transport = pluginProxyTransport

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -58,7 +58,7 @@ func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
 
 func AppPluginRoute(route *plugins.AppPluginRoute, appID string, hs *HTTPServer) macaron.Handler {
 	return func(c *models.ReqContext) {
-		path := c.Params("*")
+		path := macaron.Vars(c.Req)["*"]
 
 		proxy := pluginproxy.NewApiPluginProxy(c, path, route, appID, hs.Cfg)
 		proxy.Transport = pluginProxyTransport

--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	"gopkg.in/macaron.v1"
 
 	gocache "github.com/patrickmn/go-cache"
 )
@@ -77,7 +78,7 @@ type CacheServer struct {
 var validMD5 = regexp.MustCompile("^[a-fA-F0-9]{32}$")
 
 func (a *CacheServer) Handler(ctx *models.ReqContext) {
-	hash := ctx.Params("hash")
+	hash := macaron.Vars(ctx.Req)["hash"]
 
 	if len(hash) != 32 || !validMD5.MatchString(hash) {
 		ctx.JsonApiErr(404, "Avatar not found", nil)

--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -78,7 +78,7 @@ type CacheServer struct {
 var validMD5 = regexp.MustCompile("^[a-fA-F0-9]{32}$")
 
 func (a *CacheServer) Handler(ctx *models.ReqContext) {
-	hash := macaron.Vars(ctx.Req)["hash"]
+	hash := macaron.Vars(ctx.Req)[":hash"]
 
 	if len(hash) != 32 || !validMD5.MatchString(hash) {
 		ctx.JsonApiErr(404, "Avatar not found", nil)

--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -78,7 +78,7 @@ type CacheServer struct {
 var validMD5 = regexp.MustCompile("^[a-fA-F0-9]{32}$")
 
 func (a *CacheServer) Handler(ctx *models.ReqContext) {
-	hash := macaron.Vars(ctx.Req)[":hash"]
+	hash := macaron.Params(ctx.Req)[":hash"]
 
 	if len(hash) != 32 || !validMD5.MatchString(hash) {
 		ctx.JsonApiErr(404, "Avatar not found", nil)

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	macaron "gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -70,7 +71,7 @@ func (hs *HTTPServer) TrimDashboard(c *models.ReqContext, cmd models.TrimDashboa
 }
 
 func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
-	uid := c.Params(":uid")
+	uid := macaron.Vars(c.Req)[":uid"]
 	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, uid)
 	if rsp != nil {
 		return rsp
@@ -214,7 +215,7 @@ func getDashboardHelper(ctx context.Context, orgID int64, id int64, uid string) 
 }
 
 func (hs *HTTPServer) DeleteDashboardBySlug(c *models.ReqContext) response.Response {
-	query := models.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: c.Params(":slug")}
+	query := models.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: macaron.Vars(c.Req)[":slug"]}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return response.Error(500, "Failed to retrieve dashboards by slug", err)
@@ -232,7 +233,7 @@ func (hs *HTTPServer) DeleteDashboardByUID(c *models.ReqContext) response.Respon
 }
 
 func (hs *HTTPServer) deleteDashboard(c *models.ReqContext) response.Response {
-	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, c.Params(":uid"))
+	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, macaron.Vars(c.Req)[":uid"])
 	if rsp != nil {
 		return rsp
 	}

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -71,7 +71,7 @@ func (hs *HTTPServer) TrimDashboard(c *models.ReqContext, cmd models.TrimDashboa
 }
 
 func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
-	uid := macaron.Vars(c.Req)[":uid"]
+	uid := macaron.Params(c.Req)[":uid"]
 	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, uid)
 	if rsp != nil {
 		return rsp
@@ -215,7 +215,7 @@ func getDashboardHelper(ctx context.Context, orgID int64, id int64, uid string) 
 }
 
 func (hs *HTTPServer) DeleteDashboardBySlug(c *models.ReqContext) response.Response {
-	query := models.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: macaron.Vars(c.Req)[":slug"]}
+	query := models.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: macaron.Params(c.Req)[":slug"]}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return response.Error(500, "Failed to retrieve dashboards by slug", err)
@@ -233,7 +233,7 @@ func (hs *HTTPServer) DeleteDashboardByUID(c *models.ReqContext) response.Respon
 }
 
 func (hs *HTTPServer) deleteDashboard(c *models.ReqContext) response.Response {
-	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, macaron.Vars(c.Req)[":uid"])
+	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, macaron.Params(c.Req)[":uid"])
 	if rsp != nil {
 		return rsp
 	}

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 var client = &http.Client{
@@ -145,7 +146,7 @@ func CreateDashboardSnapshot(c *models.ReqContext, cmd models.CreateDashboardSna
 
 // GET /api/snapshots/:key
 func GetDashboardSnapshot(c *models.ReqContext) response.Response {
-	key := c.Params(":key")
+	key := macaron.Vars(c.Req)[":key"]
 	query := &models.GetDashboardSnapshotQuery{Key: key}
 
 	err := bus.Dispatch(query)
@@ -209,7 +210,7 @@ func deleteExternalDashboardSnapshot(externalUrl string) error {
 
 // GET /api/snapshots-delete/:deleteKey
 func DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) response.Response {
-	key := c.Params(":deleteKey")
+	key := macaron.Vars(c.Req)[":deleteKey"]
 
 	query := &models.GetDashboardSnapshotQuery{DeleteKey: key}
 
@@ -239,7 +240,7 @@ func DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) response.Response 
 
 // DELETE /api/snapshots/:key
 func DeleteDashboardSnapshot(c *models.ReqContext) response.Response {
-	key := c.Params(":key")
+	key := macaron.Vars(c.Req)[":key"]
 
 	query := &models.GetDashboardSnapshotQuery{Key: key}
 

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -146,7 +146,7 @@ func CreateDashboardSnapshot(c *models.ReqContext, cmd models.CreateDashboardSna
 
 // GET /api/snapshots/:key
 func GetDashboardSnapshot(c *models.ReqContext) response.Response {
-	key := macaron.Vars(c.Req)[":key"]
+	key := macaron.Params(c.Req)[":key"]
 	query := &models.GetDashboardSnapshotQuery{Key: key}
 
 	err := bus.Dispatch(query)
@@ -210,7 +210,7 @@ func deleteExternalDashboardSnapshot(externalUrl string) error {
 
 // GET /api/snapshots-delete/:deleteKey
 func DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) response.Response {
-	key := macaron.Vars(c.Req)[":deleteKey"]
+	key := macaron.Params(c.Req)[":deleteKey"]
 
 	query := &models.GetDashboardSnapshotQuery{DeleteKey: key}
 
@@ -240,7 +240,7 @@ func DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) response.Response 
 
 // DELETE /api/snapshots/:key
 func DeleteDashboardSnapshot(c *models.ReqContext) response.Response {
-	key := macaron.Vars(c.Req)[":key"]
+	key := macaron.Params(c.Req)[":key"]
 
 	query := &models.GetDashboardSnapshotQuery{Key: key}
 

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/adapters"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -117,7 +118,7 @@ func (hs *HTTPServer) DeleteDataSourceById(c *models.ReqContext) response.Respon
 
 // GET /api/datasources/uid/:uid
 func GetDataSourceByUID(c *models.ReqContext) response.Response {
-	ds, err := getRawDataSourceByUID(c.Params(":uid"), c.OrgId)
+	ds, err := getRawDataSourceByUID(macaron.Vars(c.Req)[":uid"], c.OrgId)
 
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -132,7 +133,7 @@ func GetDataSourceByUID(c *models.ReqContext) response.Response {
 
 // DELETE /api/datasources/uid/:uid
 func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Response {
-	uid := c.Params(":uid")
+	uid := macaron.Vars(c.Req)[":uid"]
 
 	if uid == "" {
 		return response.Error(400, "Missing datasource uid", nil)
@@ -163,7 +164,7 @@ func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Respo
 }
 
 func (hs *HTTPServer) DeleteDataSourceByName(c *models.ReqContext) response.Response {
-	name := c.Params(":name")
+	name := macaron.Vars(c.Req)[":name"]
 
 	if name == "" {
 		return response.Error(400, "Missing valid datasource name", nil)
@@ -328,7 +329,7 @@ func getRawDataSourceByUID(uid string, orgID int64) (*models.DataSource, error) 
 
 // Get /api/datasources/name/:name
 func GetDataSourceByName(c *models.ReqContext) response.Response {
-	query := models.GetDataSourceQuery{Name: c.Params(":name"), OrgId: c.OrgId}
+	query := models.GetDataSourceQuery{Name: macaron.Vars(c.Req)[":name"], OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -343,7 +344,7 @@ func GetDataSourceByName(c *models.ReqContext) response.Response {
 
 // Get /api/datasources/id/:name
 func GetDataSourceIdByName(c *models.ReqContext) response.Response {
-	query := models.GetDataSourceQuery{Name: c.Params(":name"), OrgId: c.OrgId}
+	query := models.GetDataSourceQuery{Name: macaron.Vars(c.Req)[":name"], OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -391,7 +392,7 @@ func (hs *HTTPServer) CallDatasourceResource(c *models.ReqContext) {
 		PluginID:                   plugin.Id,
 		DataSourceInstanceSettings: dsInstanceSettings,
 	}
-	hs.BackendPluginManager.CallResource(pCtx, c, c.Params("*"))
+	hs.BackendPluginManager.CallResource(pCtx, c, macaron.Vars(c.Req)["*"])
 }
 
 func convertModelToDtos(ds *models.DataSource) dtos.DataSource {

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -118,7 +118,7 @@ func (hs *HTTPServer) DeleteDataSourceById(c *models.ReqContext) response.Respon
 
 // GET /api/datasources/uid/:uid
 func GetDataSourceByUID(c *models.ReqContext) response.Response {
-	ds, err := getRawDataSourceByUID(macaron.Vars(c.Req)[":uid"], c.OrgId)
+	ds, err := getRawDataSourceByUID(macaron.Params(c.Req)[":uid"], c.OrgId)
 
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -133,7 +133,7 @@ func GetDataSourceByUID(c *models.ReqContext) response.Response {
 
 // DELETE /api/datasources/uid/:uid
 func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Response {
-	uid := macaron.Vars(c.Req)[":uid"]
+	uid := macaron.Params(c.Req)[":uid"]
 
 	if uid == "" {
 		return response.Error(400, "Missing datasource uid", nil)
@@ -164,7 +164,7 @@ func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Respo
 }
 
 func (hs *HTTPServer) DeleteDataSourceByName(c *models.ReqContext) response.Response {
-	name := macaron.Vars(c.Req)[":name"]
+	name := macaron.Params(c.Req)[":name"]
 
 	if name == "" {
 		return response.Error(400, "Missing valid datasource name", nil)
@@ -329,7 +329,7 @@ func getRawDataSourceByUID(uid string, orgID int64) (*models.DataSource, error) 
 
 // Get /api/datasources/name/:name
 func GetDataSourceByName(c *models.ReqContext) response.Response {
-	query := models.GetDataSourceQuery{Name: macaron.Vars(c.Req)[":name"], OrgId: c.OrgId}
+	query := models.GetDataSourceQuery{Name: macaron.Params(c.Req)[":name"], OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -344,7 +344,7 @@ func GetDataSourceByName(c *models.ReqContext) response.Response {
 
 // Get /api/datasources/id/:name
 func GetDataSourceIdByName(c *models.ReqContext) response.Response {
-	query := models.GetDataSourceQuery{Name: macaron.Vars(c.Req)[":name"], OrgId: c.OrgId}
+	query := models.GetDataSourceQuery{Name: macaron.Params(c.Req)[":name"], OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -392,7 +392,7 @@ func (hs *HTTPServer) CallDatasourceResource(c *models.ReqContext) {
 		PluginID:                   plugin.Id,
 		DataSourceInstanceSettings: dsInstanceSettings,
 	}
-	hs.BackendPluginManager.CallResource(pCtx, c, macaron.Vars(c.Req)["*"])
+	hs.BackendPluginManager.CallResource(pCtx, c, macaron.Params(c.Req)["*"])
 }
 
 func convertModelToDtos(ds *models.DataSource) dtos.DataSource {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -39,7 +39,7 @@ func (hs *HTTPServer) GetFolders(c *models.ReqContext) response.Response {
 
 func (hs *HTTPServer) GetFolderByUID(c *models.ReqContext) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Vars(c.Req)[":uid"])
+	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Params(c.Req)[":uid"])
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -79,7 +79,7 @@ func (hs *HTTPServer) CreateFolder(c *models.ReqContext, cmd models.CreateFolder
 
 func (hs *HTTPServer) UpdateFolder(c *models.ReqContext, cmd models.UpdateFolderCommand) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	err := s.UpdateFolder(c.Req.Context(), macaron.Vars(c.Req)[":uid"], &cmd)
+	err := s.UpdateFolder(c.Req.Context(), macaron.Params(c.Req)[":uid"], &cmd)
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -90,7 +90,7 @@ func (hs *HTTPServer) UpdateFolder(c *models.ReqContext, cmd models.UpdateFolder
 
 func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // temporarily adding this function to HTTPServer, will be removed from HTTPServer when librarypanels featuretoggle is removed
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	err := hs.LibraryElementService.DeleteLibraryElementsInFolder(c, macaron.Vars(c.Req)[":uid"])
+	err := hs.LibraryElementService.DeleteLibraryElementsInFolder(c, macaron.Params(c.Req)[":uid"])
 	if err != nil {
 		if errors.Is(err, libraryelements.ErrFolderHasConnectedLibraryElements) {
 			return response.Error(403, "Folder could not be deleted because it contains library elements in use", err)
@@ -98,7 +98,7 @@ func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // 
 		return apierrors.ToFolderErrorResponse(err)
 	}
 
-	f, err := s.DeleteFolder(c.Req.Context(), macaron.Vars(c.Req)[":uid"], c.QueryBool("forceDeleteRules"))
+	f, err := s.DeleteFolder(c.Req.Context(), macaron.Params(c.Req)[":uid"], c.QueryBool("forceDeleteRules"))
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func (hs *HTTPServer) GetFolders(c *models.ReqContext) response.Response {
@@ -38,7 +39,7 @@ func (hs *HTTPServer) GetFolders(c *models.ReqContext) response.Response {
 
 func (hs *HTTPServer) GetFolderByUID(c *models.ReqContext) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), c.Params(":uid"))
+	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Vars(c.Req)[":uid"])
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -78,7 +79,7 @@ func (hs *HTTPServer) CreateFolder(c *models.ReqContext, cmd models.CreateFolder
 
 func (hs *HTTPServer) UpdateFolder(c *models.ReqContext, cmd models.UpdateFolderCommand) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	err := s.UpdateFolder(c.Req.Context(), c.Params(":uid"), &cmd)
+	err := s.UpdateFolder(c.Req.Context(), macaron.Vars(c.Req)[":uid"], &cmd)
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -89,7 +90,7 @@ func (hs *HTTPServer) UpdateFolder(c *models.ReqContext, cmd models.UpdateFolder
 
 func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // temporarily adding this function to HTTPServer, will be removed from HTTPServer when librarypanels featuretoggle is removed
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	err := hs.LibraryElementService.DeleteLibraryElementsInFolder(c, c.Params(":uid"))
+	err := hs.LibraryElementService.DeleteLibraryElementsInFolder(c, macaron.Vars(c.Req)[":uid"])
 	if err != nil {
 		if errors.Is(err, libraryelements.ErrFolderHasConnectedLibraryElements) {
 			return response.Error(403, "Folder could not be deleted because it contains library elements in use", err)
@@ -97,7 +98,7 @@ func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // 
 		return apierrors.ToFolderErrorResponse(err)
 	}
 
-	f, err := s.DeleteFolder(c.Req.Context(), c.Params(":uid"), c.QueryBool("forceDeleteRules"))
+	f, err := s.DeleteFolder(c.Req.Context(), macaron.Vars(c.Req)[":uid"], c.QueryBool("forceDeleteRules"))
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -11,11 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func (hs *HTTPServer) GetFolderPermissionList(c *models.ReqContext) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), c.Params(":uid"))
+	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Vars(c.Req)[":uid"])
 
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
@@ -63,7 +64,7 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *models.ReqContext, apiCmd dtos.
 	}
 
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), c.Params(":uid"))
+	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Vars(c.Req)[":uid"])
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -16,7 +16,7 @@ import (
 
 func (hs *HTTPServer) GetFolderPermissionList(c *models.ReqContext) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Vars(c.Req)[":uid"])
+	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Params(c.Req)[":uid"])
 
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
@@ -64,7 +64,7 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *models.ReqContext, apiCmd dtos.
 	}
 
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Vars(c.Req)[":uid"])
+	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Params(c.Req)[":uid"])
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 var grafanaComProxyTransport = &http.Transport{
@@ -41,7 +42,7 @@ func ReverseProxyGnetReq(proxyPath string) *httputil.ReverseProxy {
 }
 
 func ProxyGnetRequest(c *models.ReqContext) {
-	proxyPath := c.Params("*")
+	proxyPath := macaron.Vars(c.Req)["*"]
 	proxy := ReverseProxyGnetReq(proxyPath)
 	proxy.Transport = grafanaComProxyTransport
 	proxy.ServeHTTP(c.Resp, c.Req)

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -42,7 +42,7 @@ func ReverseProxyGnetReq(proxyPath string) *httputil.ReverseProxy {
 }
 
 func ProxyGnetRequest(c *models.ReqContext) {
-	proxyPath := macaron.Vars(c.Req)["*"]
+	proxyPath := macaron.Params(c.Req)["*"]
 	proxy := ReverseProxyGnetReq(proxyPath)
 	proxy.Transport = grafanaComProxyTransport
 	proxy.ServeHTTP(c.Resp, c.Req)

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/multildap"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 var (
@@ -238,7 +239,7 @@ func (hs *HTTPServer) GetUserFromLDAP(c *models.ReqContext) response.Response {
 
 	ldap := newLDAP(ldapConfig.Servers)
 
-	username := c.Params(":username")
+	username := macaron.Vars(c.Req)[":username"]
 
 	if len(username) == 0 {
 		return response.Error(http.StatusBadRequest, "Validation error. You must specify an username", nil)

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -239,7 +239,7 @@ func (hs *HTTPServer) GetUserFromLDAP(c *models.ReqContext) response.Response {
 
 	ldap := newLDAP(ldapConfig.Servers)
 
-	username := macaron.Vars(c.Req)[":username"]
+	username := macaron.Params(c.Req)[":username"]
 
 	if len(username) == 0 {
 		return response.Error(http.StatusBadRequest, "Validation error. You must specify an username", nil)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 
 	"golang.org/x/oauth2"
+	macaron "gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -41,7 +42,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	loginInfo := models.LoginInfo{
 		AuthModule: "oauth",
 	}
-	name := ctx.Params(":name")
+	name := macaron.Vars(ctx.Req)[":name"]
 	loginInfo.AuthModule = name
 	provider := hs.SocialService.GetOAuthInfoProvider(name)
 	if provider == nil {

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -42,7 +42,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	loginInfo := models.LoginInfo{
 		AuthModule: "oauth",
 	}
-	name := macaron.Vars(ctx.Req)[":name"]
+	name := macaron.Params(ctx.Req)[":name"]
 	loginInfo.AuthModule = name
 	provider := hs.SocialService.GetOAuthInfoProvider(name)
 	if provider == nil {

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 // GET /api/org
@@ -24,7 +25,7 @@ func GetOrgByID(c *models.ReqContext) response.Response {
 
 // Get /api/orgs/name/:name
 func (hs *HTTPServer) GetOrgByName(c *models.ReqContext) response.Response {
-	org, err := hs.SQLStore.GetOrgByName(c.Params(":name"))
+	org, err := hs.SQLStore.GetOrgByName(macaron.Vars(c.Req)[":name"])
 	if err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
 			return response.Error(404, "Organization not found", err)

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -25,7 +25,7 @@ func GetOrgByID(c *models.ReqContext) response.Response {
 
 // Get /api/orgs/name/:name
 func (hs *HTTPServer) GetOrgByName(c *models.ReqContext) response.Response {
-	org, err := hs.SQLStore.GetOrgByName(macaron.Vars(c.Req)[":name"])
+	org, err := hs.SQLStore.GetOrgByName(macaron.Params(c.Req)[":name"])
 	if err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
 			return response.Error(404, "Organization not found", err)

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func GetPendingOrgInvites(c *models.ReqContext) response.Response {
@@ -131,7 +132,7 @@ func inviteExistingUserToOrg(c *models.ReqContext, user *models.User, inviteDto 
 }
 
 func RevokeInvite(c *models.ReqContext) response.Response {
-	if ok, rsp := updateTempUserStatus(c.Params(":code"), models.TmpUserRevoked); !ok {
+	if ok, rsp := updateTempUserStatus(macaron.Vars(c.Req)[":code"], models.TmpUserRevoked); !ok {
 		return rsp
 	}
 
@@ -142,7 +143,7 @@ func RevokeInvite(c *models.ReqContext) response.Response {
 // A response containing an InviteInfo object is returned if the invite is found.
 // If a (pending) invite is not found, 404 is returned.
 func GetInviteInfoByCode(c *models.ReqContext) response.Response {
-	query := models.GetTempUserByCodeQuery{Code: c.Params(":code")}
+	query := models.GetTempUserByCodeQuery{Code: macaron.Vars(c.Req)[":code"]}
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrTempUserNotFound) {
 			return response.Error(404, "Invite not found", nil)

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -132,7 +132,7 @@ func inviteExistingUserToOrg(c *models.ReqContext, user *models.User, inviteDto 
 }
 
 func RevokeInvite(c *models.ReqContext) response.Response {
-	if ok, rsp := updateTempUserStatus(macaron.Vars(c.Req)[":code"], models.TmpUserRevoked); !ok {
+	if ok, rsp := updateTempUserStatus(macaron.Params(c.Req)[":code"], models.TmpUserRevoked); !ok {
 		return rsp
 	}
 
@@ -143,7 +143,7 @@ func RevokeInvite(c *models.ReqContext) response.Response {
 // A response containing an InviteInfo object is returned if the invite is found.
 // If a (pending) invite is not found, 404 is returned.
 func GetInviteInfoByCode(c *models.ReqContext) response.Response {
-	query := models.GetTempUserByCodeQuery{Code: macaron.Vars(c.Req)[":code"]}
+	query := models.GetTempUserByCodeQuery{Code: macaron.Params(c.Req)[":code"]}
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrTempUserNotFound) {
 			return response.Error(404, "Invite not found", nil)

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -236,7 +236,7 @@ func (hs *HTTPServer) ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDa
 //
 // /api/plugins/:pluginId/metrics
 func (hs *HTTPServer) CollectPluginMetrics(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)["pluginId"]
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 	plugin := hs.PluginManager.GetPlugin(pluginID)
 	if plugin == nil {
 		return response.Error(404, "Plugin not found", nil)
@@ -308,7 +308,7 @@ func (hs *HTTPServer) getPluginAssets(c *models.ReqContext) {
 // CheckHealth returns the health of a plugin.
 // /api/plugins/:pluginId/health
 func (hs *HTTPServer) CheckHealth(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)["pluginId"]
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 
 	pCtx, found, err := hs.PluginContextProvider.Get(pluginID, "", c.SignedInUser, false)
 	if err != nil {
@@ -350,7 +350,7 @@ func (hs *HTTPServer) CheckHealth(c *models.ReqContext) response.Response {
 //
 // /api/plugins/:pluginId/resources/*
 func (hs *HTTPServer) CallResource(c *models.ReqContext) {
-	pluginID := macaron.Vars(c.Req)["pluginId"]
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 
 	pCtx, found, err := hs.PluginContextProvider.Get(pluginID, "", c.SignedInUser, false)
 	if err != nil {
@@ -369,7 +369,7 @@ func (hs *HTTPServer) GetPluginErrorsList(_ *models.ReqContext) response.Respons
 }
 
 func (hs *HTTPServer) InstallPlugin(c *models.ReqContext, dto dtos.InstallPluginCommand) response.Response {
-	pluginID := macaron.Vars(c.Req)["pluginId"]
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 
 	err := hs.PluginManager.Install(c.Req.Context(), pluginID, dto.Version)
 	if err != nil {
@@ -400,7 +400,7 @@ func (hs *HTTPServer) InstallPlugin(c *models.ReqContext, dto dtos.InstallPlugin
 }
 
 func (hs *HTTPServer) UninstallPlugin(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)["pluginId"]
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 
 	err := hs.PluginManager.Uninstall(c.Req.Context(), pluginID)
 	if err != nil {

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/manager/installer"
 	"github.com/grafana/grafana/pkg/setting"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
@@ -100,7 +101,7 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 }
 
 func (hs *HTTPServer) GetPluginSettingByID(c *models.ReqContext) response.Response {
-	pluginID := c.Params(":pluginId")
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 
 	def := hs.PluginManager.GetPlugin(pluginID)
 	if def == nil {
@@ -145,7 +146,7 @@ func (hs *HTTPServer) GetPluginSettingByID(c *models.ReqContext) response.Respon
 }
 
 func (hs *HTTPServer) UpdatePluginSetting(c *models.ReqContext, cmd models.UpdatePluginSettingCmd) response.Response {
-	pluginID := c.Params(":pluginId")
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 
 	if app := hs.PluginManager.GetApp(pluginID); app == nil {
 		return response.Error(404, "Plugin not installed", nil)
@@ -161,7 +162,7 @@ func (hs *HTTPServer) UpdatePluginSetting(c *models.ReqContext, cmd models.Updat
 }
 
 func (hs *HTTPServer) GetPluginDashboards(c *models.ReqContext) response.Response {
-	pluginID := c.Params(":pluginId")
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 
 	list, err := hs.PluginManager.GetPluginDashboards(c.OrgId, pluginID)
 	if err != nil {
@@ -177,8 +178,8 @@ func (hs *HTTPServer) GetPluginDashboards(c *models.ReqContext) response.Respons
 }
 
 func (hs *HTTPServer) GetPluginMarkdown(c *models.ReqContext) response.Response {
-	pluginID := c.Params(":pluginId")
-	name := c.Params(":name")
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	name := macaron.Vars(c.Req)[":name"]
 
 	content, err := hs.PluginManager.GetPluginMarkdown(pluginID, name)
 	if err != nil {
@@ -235,7 +236,7 @@ func (hs *HTTPServer) ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDa
 //
 // /api/plugins/:pluginId/metrics
 func (hs *HTTPServer) CollectPluginMetrics(c *models.ReqContext) response.Response {
-	pluginID := c.Params("pluginId")
+	pluginID := macaron.Vars(c.Req)["pluginId"]
 	plugin := hs.PluginManager.GetPlugin(pluginID)
 	if plugin == nil {
 		return response.Error(404, "Plugin not found", nil)
@@ -256,14 +257,14 @@ func (hs *HTTPServer) CollectPluginMetrics(c *models.ReqContext) response.Respon
 //
 // /public/plugins/:pluginId/*
 func (hs *HTTPServer) getPluginAssets(c *models.ReqContext) {
-	pluginID := c.Params("pluginId")
+	pluginID := macaron.Vars(c.Req)[":pluginId"]
 	plugin := hs.PluginManager.GetPlugin(pluginID)
 	if plugin == nil {
 		c.JsonApiErr(404, "Plugin not found", nil)
 		return
 	}
 
-	requestedFile := filepath.Clean(c.Params("*"))
+	requestedFile := filepath.Clean(macaron.Vars(c.Req)["*"])
 	pluginFilePath := filepath.Join(plugin.PluginDir, requestedFile)
 
 	if !plugin.IncludedInSignature(requestedFile) {
@@ -307,7 +308,7 @@ func (hs *HTTPServer) getPluginAssets(c *models.ReqContext) {
 // CheckHealth returns the health of a plugin.
 // /api/plugins/:pluginId/health
 func (hs *HTTPServer) CheckHealth(c *models.ReqContext) response.Response {
-	pluginID := c.Params("pluginId")
+	pluginID := macaron.Vars(c.Req)["pluginId"]
 
 	pCtx, found, err := hs.PluginContextProvider.Get(pluginID, "", c.SignedInUser, false)
 	if err != nil {
@@ -349,7 +350,7 @@ func (hs *HTTPServer) CheckHealth(c *models.ReqContext) response.Response {
 //
 // /api/plugins/:pluginId/resources/*
 func (hs *HTTPServer) CallResource(c *models.ReqContext) {
-	pluginID := c.Params("pluginId")
+	pluginID := macaron.Vars(c.Req)["pluginId"]
 
 	pCtx, found, err := hs.PluginContextProvider.Get(pluginID, "", c.SignedInUser, false)
 	if err != nil {
@@ -360,7 +361,7 @@ func (hs *HTTPServer) CallResource(c *models.ReqContext) {
 		c.JsonApiErr(404, "Plugin not found", nil)
 		return
 	}
-	hs.BackendPluginManager.CallResource(pCtx, c, c.Params("*"))
+	hs.BackendPluginManager.CallResource(pCtx, c, macaron.Vars(c.Req)["*"])
 }
 
 func (hs *HTTPServer) GetPluginErrorsList(_ *models.ReqContext) response.Response {
@@ -368,7 +369,7 @@ func (hs *HTTPServer) GetPluginErrorsList(_ *models.ReqContext) response.Respons
 }
 
 func (hs *HTTPServer) InstallPlugin(c *models.ReqContext, dto dtos.InstallPluginCommand) response.Response {
-	pluginID := c.Params("pluginId")
+	pluginID := macaron.Vars(c.Req)["pluginId"]
 
 	err := hs.PluginManager.Install(c.Req.Context(), pluginID, dto.Version)
 	if err != nil {
@@ -399,7 +400,7 @@ func (hs *HTTPServer) InstallPlugin(c *models.ReqContext, dto dtos.InstallPlugin
 }
 
 func (hs *HTTPServer) UninstallPlugin(c *models.ReqContext) response.Response {
-	pluginID := c.Params("pluginId")
+	pluginID := macaron.Vars(c.Req)["pluginId"]
 
 	err := hs.PluginManager.Uninstall(c.Req.Context(), pluginID)
 	if err != nil {

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -101,7 +101,7 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 }
 
 func (hs *HTTPServer) GetPluginSettingByID(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 
 	def := hs.PluginManager.GetPlugin(pluginID)
 	if def == nil {
@@ -146,7 +146,7 @@ func (hs *HTTPServer) GetPluginSettingByID(c *models.ReqContext) response.Respon
 }
 
 func (hs *HTTPServer) UpdatePluginSetting(c *models.ReqContext, cmd models.UpdatePluginSettingCmd) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 
 	if app := hs.PluginManager.GetApp(pluginID); app == nil {
 		return response.Error(404, "Plugin not installed", nil)
@@ -162,7 +162,7 @@ func (hs *HTTPServer) UpdatePluginSetting(c *models.ReqContext, cmd models.Updat
 }
 
 func (hs *HTTPServer) GetPluginDashboards(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 
 	list, err := hs.PluginManager.GetPluginDashboards(c.OrgId, pluginID)
 	if err != nil {
@@ -178,8 +178,8 @@ func (hs *HTTPServer) GetPluginDashboards(c *models.ReqContext) response.Respons
 }
 
 func (hs *HTTPServer) GetPluginMarkdown(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
-	name := macaron.Vars(c.Req)[":name"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
+	name := macaron.Params(c.Req)[":name"]
 
 	content, err := hs.PluginManager.GetPluginMarkdown(pluginID, name)
 	if err != nil {
@@ -236,7 +236,7 @@ func (hs *HTTPServer) ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDa
 //
 // /api/plugins/:pluginId/metrics
 func (hs *HTTPServer) CollectPluginMetrics(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 	plugin := hs.PluginManager.GetPlugin(pluginID)
 	if plugin == nil {
 		return response.Error(404, "Plugin not found", nil)
@@ -257,14 +257,14 @@ func (hs *HTTPServer) CollectPluginMetrics(c *models.ReqContext) response.Respon
 //
 // /public/plugins/:pluginId/*
 func (hs *HTTPServer) getPluginAssets(c *models.ReqContext) {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 	plugin := hs.PluginManager.GetPlugin(pluginID)
 	if plugin == nil {
 		c.JsonApiErr(404, "Plugin not found", nil)
 		return
 	}
 
-	requestedFile := filepath.Clean(macaron.Vars(c.Req)["*"])
+	requestedFile := filepath.Clean(macaron.Params(c.Req)["*"])
 	pluginFilePath := filepath.Join(plugin.PluginDir, requestedFile)
 
 	if !plugin.IncludedInSignature(requestedFile) {
@@ -308,7 +308,7 @@ func (hs *HTTPServer) getPluginAssets(c *models.ReqContext) {
 // CheckHealth returns the health of a plugin.
 // /api/plugins/:pluginId/health
 func (hs *HTTPServer) CheckHealth(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 
 	pCtx, found, err := hs.PluginContextProvider.Get(pluginID, "", c.SignedInUser, false)
 	if err != nil {
@@ -350,7 +350,7 @@ func (hs *HTTPServer) CheckHealth(c *models.ReqContext) response.Response {
 //
 // /api/plugins/:pluginId/resources/*
 func (hs *HTTPServer) CallResource(c *models.ReqContext) {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 
 	pCtx, found, err := hs.PluginContextProvider.Get(pluginID, "", c.SignedInUser, false)
 	if err != nil {
@@ -361,7 +361,7 @@ func (hs *HTTPServer) CallResource(c *models.ReqContext) {
 		c.JsonApiErr(404, "Plugin not found", nil)
 		return
 	}
-	hs.BackendPluginManager.CallResource(pCtx, c, macaron.Vars(c.Req)["*"])
+	hs.BackendPluginManager.CallResource(pCtx, c, macaron.Params(c.Req)["*"])
 }
 
 func (hs *HTTPServer) GetPluginErrorsList(_ *models.ReqContext) response.Response {
@@ -369,7 +369,7 @@ func (hs *HTTPServer) GetPluginErrorsList(_ *models.ReqContext) response.Respons
 }
 
 func (hs *HTTPServer) InstallPlugin(c *models.ReqContext, dto dtos.InstallPluginCommand) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 
 	err := hs.PluginManager.Install(c.Req.Context(), pluginID, dto.Version)
 	if err != nil {
@@ -400,7 +400,7 @@ func (hs *HTTPServer) InstallPlugin(c *models.ReqContext, dto dtos.InstallPlugin
 }
 
 func (hs *HTTPServer) UninstallPlugin(c *models.ReqContext) response.Response {
-	pluginID := macaron.Vars(c.Req)[":pluginId"]
+	pluginID := macaron.Params(c.Req)[":pluginId"]
 
 	err := hs.PluginManager.Uninstall(c.Req.Context(), pluginID)
 	if err != nil {

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func GetOrgQuotas(c *models.ReqContext) response.Response {
@@ -25,7 +26,7 @@ func UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.OrgId = c.ParamsInt64(":orgId")
-	cmd.Target = c.Params(":target")
+	cmd.Target = macaron.Vars(c.Req)[":target"]
 
 	if _, ok := setting.Quota.Org.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)
@@ -55,7 +56,7 @@ func UpdateUserQuota(c *models.ReqContext, cmd models.UpdateUserQuotaCmd) respon
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.UserId = c.ParamsInt64(":id")
-	cmd.Target = c.Params(":target")
+	cmd.Target = macaron.Vars(c.Req)[":target"]
 
 	if _, ok := setting.Quota.User.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -26,7 +26,7 @@ func UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.OrgId = c.ParamsInt64(":orgId")
-	cmd.Target = macaron.Vars(c.Req)[":target"]
+	cmd.Target = macaron.Params(c.Req)[":target"]
 
 	if _, ok := setting.Quota.Org.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)
@@ -56,7 +56,7 @@ func UpdateUserQuota(c *models.ReqContext, cmd models.UpdateUserQuotaCmd) respon
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.UserId = c.ParamsInt64(":id")
-	cmd.Target = macaron.Vars(c.Req)[":target"]
+	cmd.Target = macaron.Params(c.Req)[":target"]
 
 	if _, ok := setting.Quota.User.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 func (hs *HTTPServer) RenderToPng(c *models.ReqContext) {
@@ -58,7 +59,7 @@ func (hs *HTTPServer) RenderToPng(c *models.ReqContext) {
 		OrgID:             c.OrgId,
 		UserID:            c.UserId,
 		OrgRole:           c.OrgRole,
-		Path:              c.Params("*") + queryParams,
+		Path:              macaron.Vars(c.Req)["*"] + queryParams,
 		Timezone:          queryReader.Get("tz", ""),
 		Encoding:          queryReader.Get("encoding", ""),
 		ConcurrentLimit:   hs.Cfg.RendererConcurrentRequestLimit,

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -59,7 +59,7 @@ func (hs *HTTPServer) RenderToPng(c *models.ReqContext) {
 		OrgID:             c.OrgId,
 		UserID:            c.UserId,
 		OrgRole:           c.OrgRole,
-		Path:              macaron.Vars(c.Req)["*"] + queryParams,
+		Path:              macaron.Params(c.Req)["*"] + queryParams,
 		Timezone:          queryReader.Get("tz", ""),
 		Encoding:          queryReader.Get("encoding", ""),
 		ConcurrentLimit:   hs.Cfg.RendererConcurrentRequestLimit,

--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	macaron "gopkg.in/macaron.v1"
 )
 
 // createShortURL handles requests to create short URLs.
@@ -45,7 +46,7 @@ func (hs *HTTPServer) createShortURL(c *models.ReqContext, cmd dtos.CreateShortU
 }
 
 func (hs *HTTPServer) redirectFromShortURL(c *models.ReqContext) {
-	shortURLUID := c.Params(":uid")
+	shortURLUID := macaron.Vars(c.Req)[":uid"]
 
 	if !util.IsValidShortUID(shortURLUID) {
 		return

--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -46,7 +46,7 @@ func (hs *HTTPServer) createShortURL(c *models.ReqContext, cmd dtos.CreateShortU
 }
 
 func (hs *HTTPServer) redirectFromShortURL(c *models.ReqContext) {
-	shortURLUID := macaron.Vars(c.Req)[":uid"]
+	shortURLUID := macaron.Params(c.Req)[":uid"]
 
 	if !util.IsValidShortUID(shortURLUID) {
 		return

--- a/pkg/macaron/binding/binding.go
+++ b/pkg/macaron/binding/binding.go
@@ -219,7 +219,7 @@ func URL(obj interface{}, ifacePtr ...interface{}) macaron.Handler {
 		obj := reflect.New(reflect.TypeOf(obj))
 
 		val := obj.Elem()
-		for k, v := range ctx.AllParams() {
+		for k, v := range macaron.Vars(ctx.Req) {
 			field := val.FieldByName(k[1:])
 			if field.IsValid() {
 				errors = setWithProperType(field.Kind(), v, field, k, errors)

--- a/pkg/macaron/binding/binding.go
+++ b/pkg/macaron/binding/binding.go
@@ -219,7 +219,7 @@ func URL(obj interface{}, ifacePtr ...interface{}) macaron.Handler {
 		obj := reflect.New(reflect.TypeOf(obj))
 
 		val := obj.Elem()
-		for k, v := range macaron.Vars(ctx.Req) {
+		for k, v := range macaron.Params(ctx.Req) {
 			field := val.FieldByName(k[1:])
 			if field.IsValid() {
 				errors = setWithProperType(field.Kind(), v, field, k, errors)

--- a/pkg/macaron/context.go
+++ b/pkg/macaron/context.go
@@ -43,7 +43,6 @@ type Context struct {
 	*Router
 	Req      *http.Request
 	Resp     ResponseWriter
-	params   Params
 	template *template.Template
 }
 
@@ -180,32 +179,10 @@ func (ctx *Context) QueryInt64(name string) int64 {
 	return n
 }
 
-// Params returns value of given param name.
-// e.g. ctx.Params(":uid") or ctx.Params("uid")
-func (ctx *Context) Params(name string) string {
-	if len(name) == 0 {
-		return ""
-	}
-	if len(name) > 1 && name[0] != ':' {
-		name = ":" + name
-	}
-	return ctx.params[name]
-}
-
-// AllParams returns all params.
-func (ctx *Context) AllParams() Params {
-	return ctx.params
-}
-
-// ReplaceAllParams replace all current params with given params
-func (ctx *Context) ReplaceAllParams(params Params) {
-	ctx.params = params
-}
-
 // ParamsInt64 returns params result in int64 type.
 // e.g. ctx.ParamsInt64(":uid")
 func (ctx *Context) ParamsInt64(name string) int64 {
-	n, _ := strconv.ParseInt(ctx.Params(name), 10, 64)
+	n, _ := strconv.ParseInt(Vars(ctx.Req)[name], 10, 64)
 	return n
 }
 

--- a/pkg/macaron/context.go
+++ b/pkg/macaron/context.go
@@ -182,7 +182,7 @@ func (ctx *Context) QueryInt64(name string) int64 {
 // ParamsInt64 returns params result in int64 type.
 // e.g. ctx.ParamsInt64(":uid")
 func (ctx *Context) ParamsInt64(name string) int64 {
-	n, _ := strconv.ParseInt(Vars(ctx.Req)[name], 10, 64)
+	n, _ := strconv.ParseInt(Params(ctx.Req)[name], 10, 64)
 	return n
 }
 

--- a/pkg/macaron/inject.go
+++ b/pkg/macaron/inject.go
@@ -130,7 +130,7 @@ func (inj *injector) fastInvoke(f FastInvoker, t reflect.Type, numIn int) ([]ref
 			argType = t.In(i)
 			val = inj.GetVal(argType)
 			if !val.IsValid() {
-				return nil, fmt.Errorf("Value not found for type %v", argType)
+				return nil, fmt.Errorf("value not found for type %v", argType)
 			}
 
 			in[i] = val.Interface()
@@ -150,7 +150,7 @@ func (inj *injector) callInvoke(f interface{}, t reflect.Type, numIn int) ([]ref
 			argType = t.In(i)
 			val = inj.GetVal(argType)
 			if !val.IsValid() {
-				return nil, fmt.Errorf("Value not found for type %v", argType)
+				return nil, fmt.Errorf("value not found for type %v", argType)
 			}
 
 			in[i] = val

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -118,6 +118,19 @@ func FromContext(c context.Context) *Context {
 	return nil
 }
 
+type varsKey struct{}
+
+func Vars(r *http.Request) map[string]string {
+	if rv := r.Context().Value(varsKey{}); rv != nil {
+		return rv.(map[string]string)
+	}
+	return map[string]string{}
+}
+
+func SetURLVars(r *http.Request, vars map[string]string) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), varsKey{}, vars))
+}
+
 // UseMiddleware is a traditional approach to writing middleware in Go.
 // A middleware is a function that has a reference to the next handler in the chain
 // and returns the actual middleware handler, that may do its job and optionally

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -120,6 +120,7 @@ func FromContext(c context.Context) *Context {
 
 type paramsKey struct{}
 
+// Params returns the named route parameters for the current request, if any.
 func Params(r *http.Request) map[string]string {
 	if rv := r.Context().Value(paramsKey{}); rv != nil {
 		return rv.(map[string]string)
@@ -127,6 +128,7 @@ func Params(r *http.Request) map[string]string {
 	return map[string]string{}
 }
 
+// SetURLParams sets the named URL parameters for the given request. This should only be used for testing purposes.
 func SetURLParams(r *http.Request, vars map[string]string) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), paramsKey{}, vars))
 }

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -118,17 +118,17 @@ func FromContext(c context.Context) *Context {
 	return nil
 }
 
-type varsKey struct{}
+type paramsKey struct{}
 
-func Vars(r *http.Request) map[string]string {
-	if rv := r.Context().Value(varsKey{}); rv != nil {
+func Params(r *http.Request) map[string]string {
+	if rv := r.Context().Value(paramsKey{}); rv != nil {
 		return rv.(map[string]string)
 	}
 	return map[string]string{}
 }
 
-func SetURLVars(r *http.Request, vars map[string]string) *http.Request {
-	return r.WithContext(context.WithValue(r.Context(), varsKey{}, vars))
+func SetURLParams(r *http.Request, vars map[string]string) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), paramsKey{}, vars))
 }
 
 // UseMiddleware is a traditional approach to writing middleware in Go.

--- a/pkg/macaron/router.go
+++ b/pkg/macaron/router.go
@@ -90,11 +90,9 @@ func NewRouter() *Router {
 	}
 }
 
-type Params map[string]string
-
 // Handle is a function that can be registered to a route to handle HTTP requests.
 // Like http.HandlerFunc, but has a third parameter for the values of wildcards (variables).
-type Handle func(http.ResponseWriter, *http.Request, Params)
+type Handle func(http.ResponseWriter, *http.Request, map[string]string)
 
 // handle adds new route to the router tree.
 func (r *Router) handle(method, pattern string, handle Handle) {
@@ -150,9 +148,8 @@ func (r *Router) Handle(method string, pattern string, handlers []Handler) {
 	}
 	handlers = validateAndWrapHandlers(handlers)
 
-	r.handle(method, pattern, func(resp http.ResponseWriter, req *http.Request, params Params) {
-		c := r.m.createContext(resp, req)
-		c.params = params
+	r.handle(method, pattern, func(resp http.ResponseWriter, req *http.Request, params map[string]string) {
+		c := r.m.createContext(resp, SetURLVars(req, params))
 		c.handlers = make([]Handler, 0, len(r.m.handlers)+len(handlers))
 		c.handlers = append(c.handlers, r.m.handlers...)
 		c.handlers = append(c.handlers, handlers...)

--- a/pkg/macaron/router.go
+++ b/pkg/macaron/router.go
@@ -149,7 +149,7 @@ func (r *Router) Handle(method string, pattern string, handlers []Handler) {
 	handlers = validateAndWrapHandlers(handlers)
 
 	r.handle(method, pattern, func(resp http.ResponseWriter, req *http.Request, params map[string]string) {
-		c := r.m.createContext(resp, SetURLVars(req, params))
+		c := r.m.createContext(resp, SetURLParams(req, params))
 		c.handlers = make([]Handler, 0, len(r.m.handlers)+len(handlers))
 		c.handlers = append(c.handlers, r.m.handlers...)
 		c.handlers = append(c.handlers, handlers...)

--- a/pkg/macaron/tree.go
+++ b/pkg/macaron/tree.go
@@ -260,7 +260,7 @@ func (t *Tree) Add(pattern string, handle Handle) *Leaf {
 	return t.addNextSegment(pattern, handle)
 }
 
-func (t *Tree) matchLeaf(globLevel int, url string, params Params) (Handle, bool) {
+func (t *Tree) matchLeaf(globLevel int, url string, params map[string]string) (Handle, bool) {
 	url, err := urlpkg.PathUnescape(url)
 	if err != nil {
 		return nil, false
@@ -303,7 +303,7 @@ func (t *Tree) matchLeaf(globLevel int, url string, params Params) (Handle, bool
 	return nil, false
 }
 
-func (t *Tree) matchSubtree(globLevel int, segment, url string, params Params) (Handle, bool) {
+func (t *Tree) matchSubtree(globLevel int, segment, url string, params map[string]string) (Handle, bool) {
 	unescapedSegment, err := urlpkg.PathUnescape(segment)
 	if err != nil {
 		return nil, false
@@ -365,7 +365,7 @@ func (t *Tree) matchSubtree(globLevel int, segment, url string, params Params) (
 	return nil, false
 }
 
-func (t *Tree) matchNextSegment(globLevel int, url string, params Params) (Handle, bool) {
+func (t *Tree) matchNextSegment(globLevel int, url string, params map[string]string) (Handle, bool) {
 	i := strings.Index(url, "/")
 	if i == -1 {
 		return t.matchLeaf(globLevel, url, params)
@@ -373,10 +373,10 @@ func (t *Tree) matchNextSegment(globLevel int, url string, params Params) (Handl
 	return t.matchSubtree(globLevel, url[:i], url[i+1:], params)
 }
 
-func (t *Tree) Match(url string) (Handle, Params, bool) {
+func (t *Tree) Match(url string) (Handle, map[string]string, bool) {
 	url = strings.TrimPrefix(url, "/")
 	url = strings.TrimSuffix(url, "/")
-	params := make(Params)
+	params := map[string]string{}
 	handle, ok := t.matchNextSegment(0, url, params)
 	return handle, params, ok
 }

--- a/pkg/plugins/backendplugin/pluginextensionv2/rendererv2.pb.go
+++ b/pkg/plugins/backendplugin/pluginextensionv2/rendererv2.pb.go
@@ -8,13 +8,14 @@ package pluginextensionv2
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -19,7 +19,7 @@ func Middleware(ac accesscontrol.AccessControl) func(macaron.Handler, accesscont
 		}
 
 		return func(c *models.ReqContext) {
-			injected, err := evaluator.Inject(c.AllParams())
+			injected, err := evaluator.Inject(macaron.Vars(c.Req))
 			if err != nil {
 				c.JsonApiErr(http.StatusInternalServerError, "Internal server error", err)
 				return

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -19,7 +19,7 @@ func Middleware(ac accesscontrol.AccessControl) func(macaron.Handler, accesscont
 		}
 
 		return func(c *models.ReqContext) {
-			injected, err := evaluator.Inject(macaron.Vars(c.Req))
+			injected, err := evaluator.Inject(macaron.Params(c.Req))
 			if err != nil {
 				c.JsonApiErr(http.StatusInternalServerError, "Internal server error", err)
 				return

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/go-macaron/binding"
+	"gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -35,7 +36,7 @@ func (l *LibraryElementService) createHandler(c *models.ReqContext, cmd CreateLi
 
 // deleteHandler handles DELETE /api/library-elements/:uid.
 func (l *LibraryElementService) deleteHandler(c *models.ReqContext) response.Response {
-	err := l.deleteLibraryElement(c, c.Params(":uid"))
+	err := l.deleteLibraryElement(c, macaron.Vars(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to delete library element")
 	}
@@ -75,7 +76,7 @@ func (l *LibraryElementService) getAllHandler(c *models.ReqContext) response.Res
 
 // patchHandler handles PATCH /api/library-elements/:uid
 func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibraryElementCommand) response.Response {
-	element, err := l.patchLibraryElement(c, cmd, c.Params(":uid"))
+	element, err := l.patchLibraryElement(c, cmd, macaron.Vars(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to update library element")
 	}
@@ -85,7 +86,7 @@ func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibr
 
 // getConnectionsHandler handles GET /api/library-panels/:uid/connections/.
 func (l *LibraryElementService) getConnectionsHandler(c *models.ReqContext) response.Response {
-	connections, err := l.getConnections(c, c.Params(":uid"))
+	connections, err := l.getConnections(c, macaron.Vars(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to get connections")
 	}

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -36,7 +36,7 @@ func (l *LibraryElementService) createHandler(c *models.ReqContext, cmd CreateLi
 
 // deleteHandler handles DELETE /api/library-elements/:uid.
 func (l *LibraryElementService) deleteHandler(c *models.ReqContext) response.Response {
-	err := l.deleteLibraryElement(c, macaron.Vars(c.Req)[":uid"])
+	err := l.deleteLibraryElement(c, macaron.Params(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to delete library element")
 	}
@@ -76,7 +76,7 @@ func (l *LibraryElementService) getAllHandler(c *models.ReqContext) response.Res
 
 // patchHandler handles PATCH /api/library-elements/:uid
 func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibraryElementCommand) response.Response {
-	element, err := l.patchLibraryElement(c, cmd, macaron.Vars(c.Req)[":uid"])
+	element, err := l.patchLibraryElement(c, cmd, macaron.Params(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to update library element")
 	}
@@ -86,7 +86,7 @@ func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibr
 
 // getConnectionsHandler handles GET /api/library-panels/:uid/connections/.
 func (l *LibraryElementService) getConnectionsHandler(c *models.ReqContext) response.Response {
-	connections, err := l.getConnections(c, macaron.Vars(c.Req)[":uid"])
+	connections, err := l.getConnections(c, macaron.Params(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to get connections")
 	}

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/util"
+	"gopkg.in/macaron.v1"
 )
 
 const (
@@ -274,7 +275,7 @@ func (l *LibraryElementService) getLibraryElements(c *models.ReqContext, params 
 
 // getLibraryElementByUid gets a Library Element by uid.
 func (l *LibraryElementService) getLibraryElementByUid(c *models.ReqContext) (LibraryElementDTO, error) {
-	libraryElements, err := l.getLibraryElements(c, []Pair{{key: "org_id", value: c.SignedInUser.OrgId}, {key: "uid", value: c.Params(":uid")}})
+	libraryElements, err := l.getLibraryElements(c, []Pair{{key: "org_id", value: c.SignedInUser.OrgId}, {key: "uid", value: macaron.Vars(c.Req)[":uid"]}})
 	if err != nil {
 		return LibraryElementDTO{}, err
 	}
@@ -287,7 +288,7 @@ func (l *LibraryElementService) getLibraryElementByUid(c *models.ReqContext) (Li
 
 // getLibraryElementByName gets a Library Element by name.
 func (l *LibraryElementService) getLibraryElementsByName(c *models.ReqContext) ([]LibraryElementDTO, error) {
-	return l.getLibraryElements(c, []Pair{{"org_id", c.SignedInUser.OrgId}, {"name", c.Params(":name")}})
+	return l.getLibraryElements(c, []Pair{{"org_id", c.SignedInUser.OrgId}, {"name", macaron.Vars(c.Req)[":name"]}})
 }
 
 // getAllLibraryElements gets all Library Elements.

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -275,7 +275,7 @@ func (l *LibraryElementService) getLibraryElements(c *models.ReqContext, params 
 
 // getLibraryElementByUid gets a Library Element by uid.
 func (l *LibraryElementService) getLibraryElementByUid(c *models.ReqContext) (LibraryElementDTO, error) {
-	libraryElements, err := l.getLibraryElements(c, []Pair{{key: "org_id", value: c.SignedInUser.OrgId}, {key: "uid", value: macaron.Vars(c.Req)[":uid"]}})
+	libraryElements, err := l.getLibraryElements(c, []Pair{{key: "org_id", value: c.SignedInUser.OrgId}, {key: "uid", value: macaron.Params(c.Req)[":uid"]}})
 	if err != nil {
 		return LibraryElementDTO{}, err
 	}
@@ -288,7 +288,7 @@ func (l *LibraryElementService) getLibraryElementByUid(c *models.ReqContext) (Li
 
 // getLibraryElementByName gets a Library Element by name.
 func (l *LibraryElementService) getLibraryElementsByName(c *models.ReqContext) ([]LibraryElementDTO, error) {
-	return l.getLibraryElements(c, []Pair{{"org_id", c.SignedInUser.OrgId}, {"name", macaron.Vars(c.Req)[":name"]}})
+	return l.getLibraryElements(c, []Pair{{"org_id", c.SignedInUser.OrgId}, {"name", macaron.Params(c.Req)[":name"]}})
 }
 
 // getAllLibraryElements gets all Library Elements.

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"gopkg.in/macaron.v1"
 
 	"github.com/stretchr/testify/require"
 
@@ -19,14 +20,14 @@ func TestDeleteLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel that exists, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 		})
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel in another org, it should fail",
 		func(t *testing.T, sc scenarioContext) {
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.reqContext.SignedInUser.OrgId = 2
 			sc.reqContext.SignedInUser.OrgRole = models.ROLE_ADMIN
 			resp := sc.service.deleteHandler(sc.reqContext)
@@ -69,7 +70,7 @@ func TestDeleteLibraryElement(t *testing.T) {
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext, []string{sc.initialResult.Result.UID}, dashInDB.Id)
 			require.NoError(t, err)
 
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 403, resp.Status())
 		})

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -20,14 +20,14 @@ func TestDeleteLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel that exists, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 		})
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel in another org, it should fail",
 		func(t *testing.T, sc scenarioContext) {
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.reqContext.SignedInUser.OrgId = 2
 			sc.reqContext.SignedInUser.OrgRole = models.ROLE_ADMIN
 			resp := sc.service.deleteHandler(sc.reqContext)
@@ -70,7 +70,7 @@ func TestDeleteLibraryElement(t *testing.T) {
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext, []string{sc.initialResult.Result.UID}, dashInDB.Id)
 			require.NoError(t, err)
 
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 403, resp.Status())
 		})

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"gopkg.in/macaron.v1"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -15,12 +16,12 @@ func TestGetLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// by uid
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": "unknown"})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": "unknown"})
 			resp := sc.service.getHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 
 			// by name
-			sc.reqContext.ReplaceAllParams(map[string]string{":name": "unknown"})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": "unknown"})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -68,7 +69,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by uid
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			var result = validateAndUnMarshalResponse(t, resp)
 
@@ -77,7 +78,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by name
-			sc.reqContext.ReplaceAllParams(map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			arrayResult := validateAndUnMarshalArrayResponse(t, resp)
 
@@ -163,7 +164,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by uid
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			result := validateAndUnMarshalResponse(t, resp)
 
@@ -172,7 +173,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by name
-			sc.reqContext.ReplaceAllParams(map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			arrayResult := validateAndUnMarshalArrayResponse(t, resp)
 			if diff := cmp.Diff(libraryElementArrayResult{Result: []libraryElement{expected(result).Result}}, arrayResult, getCompareOptions()...); diff != "" {
@@ -186,12 +187,12 @@ func TestGetLibraryElement(t *testing.T) {
 			sc.reqContext.SignedInUser.OrgRole = models.ROLE_ADMIN
 
 			// by uid
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 
 			// by name
-			sc.reqContext.ReplaceAllParams(map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 		})

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -16,12 +16,12 @@ func TestGetLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// by uid
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": "unknown"})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": "unknown"})
 			resp := sc.service.getHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 
 			// by name
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": "unknown"})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": "unknown"})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -69,7 +69,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by uid
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			var result = validateAndUnMarshalResponse(t, resp)
 
@@ -78,7 +78,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by name
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			arrayResult := validateAndUnMarshalArrayResponse(t, resp)
 
@@ -164,7 +164,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by uid
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			result := validateAndUnMarshalResponse(t, resp)
 
@@ -173,7 +173,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by name
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			arrayResult := validateAndUnMarshalArrayResponse(t, resp)
 			if diff := cmp.Diff(libraryElementArrayResult{Result: []libraryElement{expected(result).Result}}, arrayResult, getCompareOptions()...); diff != "" {
@@ -187,12 +187,12 @@ func TestGetLibraryElement(t *testing.T) {
 			sc.reqContext.SignedInUser.OrgRole = models.ROLE_ADMIN
 
 			// by uid
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 
 			// by name
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 		})

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/models"
 )
@@ -15,7 +16,7 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := patchLibraryElementCommand{Kind: int64(models.PanelElement)}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": "unknown"})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": "unknown"})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -38,7 +39,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:    int64(models.PanelElement),
 				Version: 1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -90,7 +91,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -111,7 +112,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Name = "New Name"
@@ -196,7 +197,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "graph"
@@ -223,7 +224,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "text"
@@ -248,7 +249,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "graph"
@@ -269,7 +270,7 @@ func TestPatchLibraryElement(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			cmd := patchLibraryElementCommand{FolderID: -1, Version: 1, Kind: int64(models.PanelElement)}
 			sc.reqContext.UserId = 2
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Meta.UpdatedBy.ID = int64(2)
@@ -291,7 +292,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version: 1,
 				Kind:    int64(models.PanelElement),
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -307,7 +308,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.PanelElement),
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -320,7 +321,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 			}
 			sc.reqContext.OrgId = 2
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -332,7 +333,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.PanelElement),
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
@@ -346,7 +347,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.VariableElement),
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -133,7 +133,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.UID = cmd.UID
@@ -154,7 +154,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -167,7 +167,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -184,7 +184,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.reqContext.ReplaceAllParams(map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -16,7 +16,7 @@ func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := patchLibraryElementCommand{Kind: int64(models.PanelElement)}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": "unknown"})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": "unknown"})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -39,7 +39,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:    int64(models.PanelElement),
 				Version: 1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -91,7 +91,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -112,7 +112,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Name = "New Name"
@@ -133,7 +133,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.UID = cmd.UID
@@ -154,7 +154,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -167,7 +167,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -184,7 +184,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -197,7 +197,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "graph"
@@ -224,7 +224,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "text"
@@ -249,7 +249,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "graph"
@@ -270,7 +270,7 @@ func TestPatchLibraryElement(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			cmd := patchLibraryElementCommand{FolderID: -1, Version: 1, Kind: int64(models.PanelElement)}
 			sc.reqContext.UserId = 2
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Meta.UpdatedBy.ID = int64(2)
@@ -292,7 +292,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version: 1,
 				Kind:    int64(models.PanelElement),
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -308,7 +308,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.PanelElement),
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -321,7 +321,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 			}
 			sc.reqContext.OrgId = 2
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -333,7 +333,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.PanelElement),
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
@@ -347,7 +347,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.VariableElement),
 			}
-			sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/models"
 )
@@ -85,7 +86,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: toFolder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -100,7 +101,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: toFolder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -113,7 +114,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result := validateAndUnMarshalResponse(t, resp)
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.deleteHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -147,7 +148,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: 0, Version: 1, Kind: int64(models.PanelElement)}
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -161,7 +162,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: folder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -173,7 +174,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result := validateAndUnMarshalResponse(t, resp)
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.deleteHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -206,7 +207,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: -100, Version: 1, Kind: int64(models.PanelElement)}
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, 404, resp.Status())
 			})
@@ -241,7 +242,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				for i, result := range results {
-					sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.UID})
+					sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.UID})
 					resp := sc.service.getHandler(sc.reqContext)
 					require.Equal(t, testCase.statuses[i], resp.Status())
 				}
@@ -260,7 +261,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result.Result.Meta.FolderUID = ""
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.reqContext.ReplaceAllParams(map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.getHandler(sc.reqContext)
 				require.Equal(t, 200, resp.Status())
 				var actual libraryElementResult

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -86,7 +86,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: toFolder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -101,7 +101,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: toFolder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -114,7 +114,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result := validateAndUnMarshalResponse(t, resp)
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.deleteHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -148,7 +148,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: 0, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -162,7 +162,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: folder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -174,7 +174,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result := validateAndUnMarshalResponse(t, resp)
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.deleteHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -207,7 +207,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: -100, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, 404, resp.Status())
 			})
@@ -242,7 +242,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				for i, result := range results {
-					sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.UID})
+					sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.UID})
 					resp := sc.service.getHandler(sc.reqContext)
 					require.Equal(t, testCase.statuses[i], resp.Status())
 				}
@@ -261,7 +261,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result.Result.Meta.FolderUID = ""
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.ctx.Req = macaron.SetURLVars(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.getHandler(sc.reqContext)
 				require.Equal(t, 200, resp.Status())
 				var actual libraryElementResult

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/live"
+	"gopkg.in/macaron.v1"
 	"gopkg.in/redis.v5"
 )
 
@@ -307,7 +308,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	g.pushWebsocketHandler = func(ctx *models.ReqContext) {
 		user := ctx.SignedInUser
 		newCtx := livecontext.SetContextSignedUser(ctx.Req.Context(), user)
-		newCtx = livecontext.SetContextStreamID(newCtx, ctx.Params(":streamId"))
+		newCtx = livecontext.SetContextStreamID(newCtx, macaron.Vars(ctx.Req)[":streamId"])
 		r := ctx.Req.WithContext(newCtx)
 		pushWSHandler.ServeHTTP(ctx.Resp, r)
 	}
@@ -816,7 +817,7 @@ func (g *GrafanaLive) HandleListHTTP(c *models.ReqContext) response.Response {
 
 // HandleInfoHTTP special http response for
 func (g *GrafanaLive) HandleInfoHTTP(ctx *models.ReqContext) response.Response {
-	path := ctx.Params("*")
+	path := macaron.Vars(ctx.Req)["*"]
 	if path == "grafana/dashboards/gitops" {
 		return response.JSON(200, util.DynMap{
 			"active": g.GrafanaScope.Dashboards.HasGitOpsObserver(ctx.SignedInUser.OrgId),

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -308,7 +308,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	g.pushWebsocketHandler = func(ctx *models.ReqContext) {
 		user := ctx.SignedInUser
 		newCtx := livecontext.SetContextSignedUser(ctx.Req.Context(), user)
-		newCtx = livecontext.SetContextStreamID(newCtx, macaron.Vars(ctx.Req)[":streamId"])
+		newCtx = livecontext.SetContextStreamID(newCtx, macaron.Params(ctx.Req)[":streamId"])
 		r := ctx.Req.WithContext(newCtx)
 		pushWSHandler.ServeHTTP(ctx.Resp, r)
 	}
@@ -817,7 +817,7 @@ func (g *GrafanaLive) HandleListHTTP(c *models.ReqContext) response.Response {
 
 // HandleInfoHTTP special http response for
 func (g *GrafanaLive) HandleInfoHTTP(ctx *models.ReqContext) response.Response {
-	path := macaron.Vars(ctx.Req)["*"]
+	path := macaron.Params(ctx.Req)["*"]
 	if path == "grafana/dashboards/gitops" {
 		return response.JSON(200, util.DynMap{
 			"active": g.GrafanaScope.Dashboards.HasGitOpsObserver(ctx.SignedInUser.OrgId),

--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -97,8 +97,8 @@ func (g *Gateway) Handle(ctx *models.ReqContext) {
 }
 
 func (g *Gateway) HandlePath(ctx *models.ReqContext) {
-	streamID := ctx.Params(":streamId")
-	path := ctx.Params(":path")
+	streamID := macaron.Vars(ctx.Req)[":streamId"]
+	path := macaron.Vars(ctx.Req)[":path"]
 
 	body, err := io.ReadAll(ctx.Req.Body)
 	if err != nil {

--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 
 	liveDto "github.com/grafana/grafana-plugin-sdk-go/live"
+	"gopkg.in/macaron.v1"
 )
 
 var (
@@ -45,7 +46,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 }
 
 func (g *Gateway) Handle(ctx *models.ReqContext) {
-	streamID := ctx.Params(":streamId")
+	streamID := macaron.Vars(ctx.Req)[":streamId"]
 
 	stream, err := g.GrafanaLive.ManagedStreamRunner.GetOrCreateStream(ctx.SignedInUser.OrgId, liveDto.ScopeStream, streamID)
 	if err != nil {

--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -46,7 +46,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 }
 
 func (g *Gateway) Handle(ctx *models.ReqContext) {
-	streamID := macaron.Vars(ctx.Req)[":streamId"]
+	streamID := macaron.Params(ctx.Req)[":streamId"]
 
 	stream, err := g.GrafanaLive.ManagedStreamRunner.GetOrCreateStream(ctx.SignedInUser.OrgId, liveDto.ScopeStream, streamID)
 	if err != nil {
@@ -97,8 +97,8 @@ func (g *Gateway) Handle(ctx *models.ReqContext) {
 }
 
 func (g *Gateway) HandlePath(ctx *models.ReqContext) {
-	streamID := macaron.Vars(ctx.Req)[":streamId"]
-	path := macaron.Vars(ctx.Req)[":path"]
+	streamID := macaron.Params(ctx.Req)[":streamId"]
+	path := macaron.Params(ctx.Req)[":path"]
 
 	body, err := io.ReadAll(ctx.Req.Body)
 	if err != nil {

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/util"
+	"gopkg.in/macaron.v1"
 )
 
 const (
@@ -154,7 +155,7 @@ func (srv AlertmanagerSrv) RouteDeleteSilence(c *models.ReqContext) response.Res
 		return errResp
 	}
 
-	silenceID := c.Params(":SilenceId")
+	silenceID := macaron.Vars(c.Req)[":SilenceId"]
 	if err := am.DeleteSilence(silenceID); err != nil {
 		if errors.Is(err, notifier.ErrSilenceNotFound) {
 			return ErrResp(http.StatusNotFound, err, "")
@@ -281,7 +282,7 @@ func (srv AlertmanagerSrv) RouteGetSilence(c *models.ReqContext) response.Respon
 		return errResp
 	}
 
-	silenceID := c.Params(":SilenceId")
+	silenceID := macaron.Vars(c.Req)[":SilenceId"]
 	gettableSilence, err := am.GetSilence(silenceID)
 	if err != nil {
 		if errors.Is(err, notifier.ErrSilenceNotFound) {

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -155,7 +155,7 @@ func (srv AlertmanagerSrv) RouteDeleteSilence(c *models.ReqContext) response.Res
 		return errResp
 	}
 
-	silenceID := macaron.Vars(c.Req)[":SilenceId"]
+	silenceID := macaron.Params(c.Req)[":SilenceId"]
 	if err := am.DeleteSilence(silenceID); err != nil {
 		if errors.Is(err, notifier.ErrSilenceNotFound) {
 			return ErrResp(http.StatusNotFound, err, "")
@@ -282,7 +282,7 @@ func (srv AlertmanagerSrv) RouteGetSilence(c *models.ReqContext) response.Respon
 		return errResp
 	}
 
-	silenceID := macaron.Vars(c.Req)[":SilenceId"]
+	silenceID := macaron.Params(c.Req)[":SilenceId"]
 	gettableSilence, err := am.GetSilence(silenceID)
 	if err != nil {
 		if errors.Is(err, notifier.ErrSilenceNotFound) {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/quota"
+	"gopkg.in/macaron.v1"
 
 	"github.com/grafana/grafana/pkg/api/apierrors"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -30,7 +31,7 @@ type RulerSrv struct {
 }
 
 func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := c.Params(":Namespace")
+	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -49,12 +50,12 @@ func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) respon
 }
 
 func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := c.Params(":Namespace")
+	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
 	}
-	ruleGroup := c.Params(":Groupname")
+	ruleGroup := macaron.Vars(c.Req)[":Groupname"]
 	uids, err := srv.store.DeleteRuleGroupAlertRules(c.SignedInUser.OrgId, namespace.Uid, ruleGroup)
 
 	if err != nil {
@@ -72,7 +73,7 @@ func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Re
 }
 
 func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := c.Params(":Namespace")
+	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, false)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -113,13 +114,13 @@ func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.
 }
 
 func (srv RulerSrv) RouteGetRulegGroupConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := c.Params(":Namespace")
+	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, false)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
 	}
 
-	ruleGroup := c.Params(":Groupname")
+	ruleGroup := macaron.Vars(c.Req)[":Groupname"]
 	q := ngmodels.ListRuleGroupAlertRulesQuery{
 		OrgID:        c.SignedInUser.OrgId,
 		NamespaceUID: namespace.Uid,
@@ -213,7 +214,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response 
 }
 
 func (srv RulerSrv) RoutePostNameRulesConfig(c *models.ReqContext, ruleGroupConfig apimodels.PostableRuleGroupConfig) response.Response {
-	namespaceTitle := c.Params(":Namespace")
+	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -31,7 +31,7 @@ type RulerSrv struct {
 }
 
 func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
+	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -50,12 +50,12 @@ func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) respon
 }
 
 func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
+	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
 	}
-	ruleGroup := macaron.Vars(c.Req)[":Groupname"]
+	ruleGroup := macaron.Params(c.Req)[":Groupname"]
 	uids, err := srv.store.DeleteRuleGroupAlertRules(c.SignedInUser.OrgId, namespace.Uid, ruleGroup)
 
 	if err != nil {
@@ -73,7 +73,7 @@ func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Re
 }
 
 func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
+	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, false)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -114,13 +114,13 @@ func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.
 }
 
 func (srv RulerSrv) RouteGetRulegGroupConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
+	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, false)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
 	}
 
-	ruleGroup := macaron.Vars(c.Req)[":Groupname"]
+	ruleGroup := macaron.Params(c.Req)[":Groupname"]
 	q := ngmodels.ListRuleGroupAlertRulesQuery{
 		OrgID:        c.SignedInUser.OrgId,
 		NamespaceUID: namespace.Uid,
@@ -214,7 +214,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response 
 }
 
 func (srv RulerSrv) RoutePostNameRulesConfig(c *models.ReqContext, ruleGroupConfig apimodels.PostableRuleGroupConfig) response.Response {
-	namespaceTitle := macaron.Vars(c.Req)[":Namespace"]
+	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
+	"gopkg.in/macaron.v1"
 )
 
 type TestingApiSrv struct {
@@ -26,7 +27,7 @@ type TestingApiSrv struct {
 }
 
 func (srv TestingApiSrv) RouteTestRuleConfig(c *models.ReqContext, body apimodels.TestRulePayload) response.Response {
-	recipient := c.Params("Recipient")
+	recipient := macaron.Vars(c.Req)[":Recipient"]
 	if recipient == apimodels.GrafanaBackend.String() {
 		if body.Type() != apimodels.GrafanaBackend || body.GrafanaManagedCondition == nil {
 			return ErrResp(http.StatusBadRequest, errors.New("unexpected payload"), "")

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -27,7 +27,7 @@ type TestingApiSrv struct {
 }
 
 func (srv TestingApiSrv) RouteTestRuleConfig(c *models.ReqContext, body apimodels.TestRulePayload) response.Response {
-	recipient := macaron.Vars(c.Req)[":Recipient"]
+	recipient := macaron.Params(c.Req)[":Recipient"]
 	if recipient == apimodels.GrafanaBackend.String() {
 		if body.Type() != apimodels.GrafanaBackend || body.GrafanaManagedCondition == nil {
 			return ErrResp(http.StatusBadRequest, errors.New("unexpected payload"), "")

--- a/pkg/services/ngalert/api/lotex_am.go
+++ b/pkg/services/ngalert/api/lotex_am.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"gopkg.in/macaron.v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -83,7 +84,7 @@ func (am *LotexAM) RouteDeleteSilence(ctx *models.ReqContext) response.Response 
 		http.MethodDelete,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf(amSilencePath, ctx.Params(":SilenceId")),
+			fmt.Sprintf(amSilencePath, macaron.Vars(ctx.Req)[":SilenceId"]),
 		),
 		nil,
 		messageExtractor,
@@ -139,7 +140,7 @@ func (am *LotexAM) RouteGetSilence(ctx *models.ReqContext) response.Response {
 		http.MethodGet,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf(amSilencePath, ctx.Params(":SilenceId")),
+			fmt.Sprintf(amSilencePath, macaron.Vars(ctx.Req)[":SilenceId"]),
 		),
 		nil,
 		jsonExtractor(&apimodels.GettableSilence{}),

--- a/pkg/services/ngalert/api/lotex_am.go
+++ b/pkg/services/ngalert/api/lotex_am.go
@@ -84,7 +84,7 @@ func (am *LotexAM) RouteDeleteSilence(ctx *models.ReqContext) response.Response 
 		http.MethodDelete,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf(amSilencePath, macaron.Vars(ctx.Req)[":SilenceId"]),
+			fmt.Sprintf(amSilencePath, macaron.Params(ctx.Req)[":SilenceId"]),
 		),
 		nil,
 		messageExtractor,
@@ -140,7 +140,7 @@ func (am *LotexAM) RouteGetSilence(ctx *models.ReqContext) response.Response {
 		http.MethodGet,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf(amSilencePath, macaron.Vars(ctx.Req)[":SilenceId"]),
+			fmt.Sprintf(amSilencePath, macaron.Params(ctx.Req)[":SilenceId"]),
 		),
 		nil,
 		jsonExtractor(&apimodels.GettableSilence{}),

--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -76,7 +76,7 @@ func (p *LotexProm) RouteGetRuleStatuses(ctx *models.ReqContext) response.Respon
 }
 
 func (p *LotexProm) getEndpoints(ctx *models.ReqContext) (*promEndpoints, error) {
-	ds, err := p.DataProxy.DataSourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
+	ds, err := p.DataProxy.DataSourceCache.GetDatasource(ctx.ParamsInt64(":Recipient"), ctx.SignedInUser, ctx.SkipCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"gopkg.in/macaron.v1"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -41,7 +42,7 @@ func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) res
 		http.MethodDelete,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf("%s/%s", legacyRulerPrefix, ctx.Params("Namespace")),
+			fmt.Sprintf("%s/%s", legacyRulerPrefix, macaron.Vars(ctx.Req)["Namespace"]),
 		),
 		nil,
 		messageExtractor,
@@ -62,8 +63,8 @@ func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				ctx.Params("Namespace"),
-				ctx.Params("Groupname"),
+				macaron.Vars(ctx.Req)["Namespace"],
+				macaron.Vars(ctx.Req)["Groupname"],
 			),
 		),
 		nil,
@@ -85,7 +86,7 @@ func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respon
 			fmt.Sprintf(
 				"%s/%s",
 				legacyRulerPrefix,
-				ctx.Params("Namespace"),
+				macaron.Vars(ctx.Req)["Namespace"],
 			),
 		),
 		nil,
@@ -107,8 +108,8 @@ func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.R
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				ctx.Params("Namespace"),
-				ctx.Params("Groupname"),
+				macaron.Vars(ctx.Req)["Namespace"],
+				macaron.Vars(ctx.Req)["Groupname"],
 			),
 		),
 		nil,
@@ -144,7 +145,7 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 	if err != nil {
 		return ErrResp(500, err, "Failed marshal rule group")
 	}
-	ns := ctx.Params("Namespace")
+	ns := macaron.Vars(ctx.Req)["Namespace"]
 	u := withPath(*ctx.Req.URL, fmt.Sprintf("%s/%s", legacyRulerPrefix, ns))
 	return r.withReq(ctx, http.MethodPost, u, bytes.NewBuffer(yml), jsonExtractor(nil), nil)
 }

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -42,7 +42,7 @@ func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) res
 		http.MethodDelete,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf("%s/%s", legacyRulerPrefix, macaron.Vars(ctx.Req)["Namespace"]),
+			fmt.Sprintf("%s/%s", legacyRulerPrefix, macaron.Vars(ctx.Req)[":Namespace"]),
 		),
 		nil,
 		messageExtractor,
@@ -63,8 +63,8 @@ func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				macaron.Vars(ctx.Req)["Namespace"],
-				macaron.Vars(ctx.Req)["Groupname"],
+				macaron.Vars(ctx.Req)[":Namespace"],
+				macaron.Vars(ctx.Req)[":Groupname"],
 			),
 		),
 		nil,
@@ -86,7 +86,7 @@ func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respon
 			fmt.Sprintf(
 				"%s/%s",
 				legacyRulerPrefix,
-				macaron.Vars(ctx.Req)["Namespace"],
+				macaron.Vars(ctx.Req)[":Namespace"],
 			),
 		),
 		nil,
@@ -108,8 +108,8 @@ func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.R
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				macaron.Vars(ctx.Req)["Namespace"],
-				macaron.Vars(ctx.Req)["Groupname"],
+				macaron.Vars(ctx.Req)[":Namespace"],
+				macaron.Vars(ctx.Req)[":Groupname"],
 			),
 		),
 		nil,
@@ -145,7 +145,7 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 	if err != nil {
 		return ErrResp(500, err, "Failed marshal rule group")
 	}
-	ns := macaron.Vars(ctx.Req)["Namespace"]
+	ns := macaron.Vars(ctx.Req)[":Namespace"]
 	u := withPath(*ctx.Req.URL, fmt.Sprintf("%s/%s", legacyRulerPrefix, ns))
 	return r.withReq(ctx, http.MethodPost, u, bytes.NewBuffer(yml), jsonExtractor(nil), nil)
 }

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -42,7 +42,7 @@ func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) res
 		http.MethodDelete,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf("%s/%s", legacyRulerPrefix, macaron.Vars(ctx.Req)[":Namespace"]),
+			fmt.Sprintf("%s/%s", legacyRulerPrefix, macaron.Params(ctx.Req)[":Namespace"]),
 		),
 		nil,
 		messageExtractor,
@@ -63,8 +63,8 @@ func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				macaron.Vars(ctx.Req)[":Namespace"],
-				macaron.Vars(ctx.Req)[":Groupname"],
+				macaron.Params(ctx.Req)[":Namespace"],
+				macaron.Params(ctx.Req)[":Groupname"],
 			),
 		),
 		nil,
@@ -86,7 +86,7 @@ func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respon
 			fmt.Sprintf(
 				"%s/%s",
 				legacyRulerPrefix,
-				macaron.Vars(ctx.Req)[":Namespace"],
+				macaron.Params(ctx.Req)[":Namespace"],
 			),
 		),
 		nil,
@@ -108,8 +108,8 @@ func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.R
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				macaron.Vars(ctx.Req)[":Namespace"],
-				macaron.Vars(ctx.Req)[":Groupname"],
+				macaron.Params(ctx.Req)[":Namespace"],
+				macaron.Params(ctx.Req)[":Groupname"],
 			),
 		),
 		nil,
@@ -145,13 +145,13 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 	if err != nil {
 		return ErrResp(500, err, "Failed marshal rule group")
 	}
-	ns := macaron.Vars(ctx.Req)[":Namespace"]
+	ns := macaron.Params(ctx.Req)[":Namespace"]
 	u := withPath(*ctx.Req.URL, fmt.Sprintf("%s/%s", legacyRulerPrefix, ns))
 	return r.withReq(ctx, http.MethodPost, u, bytes.NewBuffer(yml), jsonExtractor(nil), nil)
 }
 
 func (r *LotexRuler) getPrefix(ctx *models.ReqContext) (string, error) {
-	ds, err := r.DataProxy.DataSourceCache.GetDatasource(ctx.ParamsInt64("Recipient"), ctx.SignedInUser, ctx.SkipCache)
+	ds, err := r.DataProxy.DataSourceCache.GetDatasource(ctx.ParamsInt64(":Recipient"), ctx.SignedInUser, ctx.SkipCache)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -40,7 +40,7 @@ func toMacaronPath(path string) string {
 }
 
 func backendType(ctx *models.ReqContext, cache datasources.CacheService) (apimodels.Backend, error) {
-	recipient := ctx.Params("Recipient")
+	recipient := macaron.Vars(ctx.Req)["Recipient"]
 	if recipient == apimodels.GrafanaBackend.String() {
 		return apimodels.GrafanaBackend, nil
 	}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -40,7 +40,7 @@ func toMacaronPath(path string) string {
 }
 
 func backendType(ctx *models.ReqContext, cache datasources.CacheService) (apimodels.Backend, error) {
-	recipient := macaron.Vars(ctx.Req)["Recipient"]
+	recipient := macaron.Vars(ctx.Req)[":Recipient"]
 	if recipient == apimodels.GrafanaBackend.String() {
 		return apimodels.GrafanaBackend, nil
 	}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -40,7 +40,7 @@ func toMacaronPath(path string) string {
 }
 
 func backendType(ctx *models.ReqContext, cache datasources.CacheService) (apimodels.Backend, error) {
-	recipient := macaron.Vars(ctx.Req)[":Recipient"]
+	recipient := macaron.Params(ctx.Req)[":Recipient"]
 	if recipient == apimodels.GrafanaBackend.String() {
 		return apimodels.GrafanaBackend, nil
 	}
@@ -104,7 +104,7 @@ func (p *AlertingProxy) withReq(
 	}
 	newCtx, resp := replacedResponseWriter(ctx)
 	newCtx.Req = req
-	p.DataProxy.ProxyDatasourceRequestWithID(newCtx, ctx.ParamsInt64("Recipient"))
+	p.DataProxy.ProxyDatasourceRequestWithID(newCtx, ctx.ParamsInt64(":Recipient"))
 
 	status := resp.Status()
 	if status >= 400 {

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -263,7 +263,7 @@ func Instrument(
 
 		// TODO: We could look up the datasource type via our datasource service
 		var backend string
-		recipient := macaron.Vars(c.Req)[":Recipient"]
+		recipient := macaron.Params(c.Req)[":Recipient"]
 		if recipient == apimodels.GrafanaBackend.String() || recipient == "" {
 			backend = GrafanaBackend
 		} else {

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -263,7 +263,7 @@ func Instrument(
 
 		// TODO: We could look up the datasource type via our datasource service
 		var backend string
-		recipient := c.Params("Recipient")
+		recipient := macaron.Vars(c.Req)["Recipient"]
 		if recipient == apimodels.GrafanaBackend.String() || recipient == "" {
 			backend = GrafanaBackend
 		} else {

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -263,7 +263,7 @@ func Instrument(
 
 		// TODO: We could look up the datasource type via our datasource service
 		var backend string
-		recipient := macaron.Vars(c.Req)["Recipient"]
+		recipient := macaron.Vars(c.Req)[":Recipient"]
 		if recipient == apimodels.GrafanaBackend.String() || recipient == "" {
 			backend = GrafanaBackend
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a continuation of the Macaron migration plan #31071.

This PR parses a URL in Macaron router and injects named URL variables into context.Context.
It also provides accessors to get URL parameters (variables) from http.Request instance (independent of Macaron).
Finally, it refactors all uses of ctx.Params and ctx.AllParams into new API that relies on context.Context.
Effectively, it removes the `Params` field from macaron.Context, making code less dependent on a particular web framework.

**Which issue(s) this PR fixes**:

Closes #38721.