### PR TITLE
Chore: Add `type/ci` auto-labeling

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -66,15 +66,22 @@
       "packaging/**/*",
       "scripts/build/**/*",
       "scripts/*.sh",
-      "scripts/*.star",
-      ".drone.star",
-      ".drone.yml",
       "Makefile",
       "Dockerfile",
       "Dockerfile.ubuntu"
     ],
     "action": "updateLabel",
     "addLabel": "type/build-packaging"
+  },
+  {
+    "type": "changedfiles",
+    "matches": [
+      "scripts/*.star",
+      ".drone.star",
+      ".drone.yml"
+    ],
+    "action": "updateLabel",
+    "addLabel": "type/ci"
   },
   {
     "type": "changedfiles",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `type/ci` label when modifying:
* `.drone.yml`
* `.drone.star`
* `scriptcs/*.star`