### PR TITLE
Doc: Fixed a couple of broken relrefs.

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -9,7 +9,7 @@ Alerts allow you to know about problems in your systems moments after they occur
 
 Grafana 8.0 has new and improved alerts. The new alerting system is an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature that centralizes alerting information for Grafana managed alerts and alerts from Prometheus-compatible data sources in one UI and API.
 
-> **Note:** Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "../old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing Grafana 8 alerts.
+> **Note:** Out of the box, Grafana still supports old [legacy dashboard alerts]({{< relref "./old-alerting/_index.md" >}}). We encourage you to create issues in the Grafana GitHub repository for bugs found while testing Grafana 8 alerts.
 
 Alerts have four main components:
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
@@ -10,7 +10,7 @@ One or more queries and/or expressions, a condition, the frequency of evaluation
 
 - [Create Cortex or Loki managed alert rule]({{< relref "./create-cortex-loki-managed-rule.md" >}})
 - [Create Cortex or Loki managed recording rule]({{< relref "./create-cortex-loki-managed-recording-rule.md" >}})
-- [Edit Cortex or Loki rule groups and namespaces]({{< relref "./edit-cortex-loki-group-namespace.md" >}})
+- [Edit Cortex or Loki rule groups and namespaces]({{< relref "./edit-cortex-loki-namespace-group.md" >}})
 - [Create Grafana managed alert rule]({{< relref "./create-grafana-managed-rule.md" >}})
 - [State and Health of alerting rules]({{< relref "./state-and-health.md" >}})
 - [View existing alert rules and their current state]({{< relref "./rule-list.md" >}})


### PR DESCRIPTION
Pointed out by Robby.

Should fix the following:

latest grafana:
REF_NOT_FOUND: Ref "../old-alerting/_index.md": "/drone/src/content/docs/grafana/latest/alerting/_index.md:12:82": page not found

next grafana:
REF_NOT_FOUND: Ref "../old-alerting/_index.md": "/drone/src/content/docs/grafana/next/alerting/_index.md:12:82": page not found
REF_NOT_FOUND: Ref "./edit-cortex-loki-group-namespace.md": "/drone/src/content/docs/grafana/next/alerting/unified-alerting/alerting-rules/_index.md:13:52": page not found