### PR TITLE
old-alert: interval calculation: apply default-min-interval of 1ms

### DIFF
--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -110,12 +110,17 @@ func (c *QueryCondition) Eval(context *alerting.EvalContext, requestHandler plug
 }
 
 func calculateInterval(timeRange plugins.DataTimeRange, model *simplejson.Json, dsInfo *models.DataSource) (time.Duration, error) {
+	// if there is no min-interval specified in the datasource or in the dashboard-panel,
+	// the value of 1ms is used (this is how it is done in the dashboard-interval-calculation too,
+	// see https://github.com/grafana/grafana/blob/9a0040c0aeaae8357c650cec2ee644a571dddf3d/packages/grafana-data/src/datetime/rangeutil.ts#L264)
+	defaultMinInterval := time.Millisecond * 1
+
 	// interval.GetIntervalFrom has two problems (but they do not affect us here):
 	// - it returns the min-interval, so it should be called interval.GetMinIntervalFrom
 	// - it falls back to model.intervalMs. it should not, because that one is the real final
 	//   interval-value calculated by the browser. but, in this specific case (old-alert),
 	//   that value is not set, so the fallback never happens.
-	minInterval, err := interval.GetIntervalFrom(dsInfo, model, time.Duration(0))
+	minInterval, err := interval.GetIntervalFrom(dsInfo, model, defaultMinInterval)
 
 	if err != nil {
 		return time.Duration(0), err


### PR DESCRIPTION
the old-alert interval-calculation is based on how the dashboard-interval-calculation works, and that applies a default-min-interval of 1 millisecond, see here: https://github.com/grafana/grafana/blob/9a0040c0aeaae8357c650cec2ee644a571dddf3d/packages/grafana-data/src/datetime/rangeutil.ts#L264

we do the same for old-alert interval calculation.

this will only apply in very specific and uncommon situations (where you specify a time-range smaller than 1500milliseconds), but just to be safe.