### PR TITLE
add daily active counts to stats

### DIFF
--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -59,6 +59,15 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.plugins.datasources.count"] = uss.PluginManager.DataSourceCount()
 	metrics["stats.alerts.count"] = statsQuery.Result.Alerts
 	metrics["stats.active_users.count"] = statsQuery.Result.ActiveUsers
+	metrics["stats.active_admins.count"] = statsQuery.Result.ActiveAdmins
+	metrics["stats.active_editors.count"] = statsQuery.Result.ActiveEditors
+	metrics["stats.active_viewers.count"] = statsQuery.Result.ActiveViewers
+	metrics["stats.active_sessions.count"] = statsQuery.Result.ActiveSessions
+	metrics["stats.daily_active_users.count"] = statsQuery.Result.DailyActiveUsers
+	metrics["stats.daily_active_admins.count"] = statsQuery.Result.DailyActiveAdmins
+	metrics["stats.daily_active_editors.count"] = statsQuery.Result.DailyActiveEditors
+	metrics["stats.daily_active_viewers.count"] = statsQuery.Result.DailyActiveViewers
+	metrics["stats.daily_active_sessions.count"] = statsQuery.Result.DailyActiveSessions
 	metrics["stats.datasources.count"] = statsQuery.Result.Datasources
 	metrics["stats.stars.count"] = statsQuery.Result.Stars
 	metrics["stats.folders.count"] = statsQuery.Result.Folders

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -52,6 +52,9 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 
 	metrics["stats.dashboards.count"] = statsQuery.Result.Dashboards
 	metrics["stats.users.count"] = statsQuery.Result.Users
+	metrics["stats.admins.count"] = statsQuery.Result.Admins
+	metrics["stats.editors.count"] = statsQuery.Result.Editors
+	metrics["stats.viewers.count"] = statsQuery.Result.Viewers
 	metrics["stats.orgs.count"] = statsQuery.Result.Orgs
 	metrics["stats.playlist.count"] = statsQuery.Result.Playlists
 	metrics["stats.plugins.apps.count"] = uss.PluginManager.AppCount()

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -47,7 +47,19 @@ func TestMetrics(t *testing.T) {
 				Dashboards:                1,
 				Datasources:               2,
 				Users:                     3,
+				Admins:                    31,
+				Editors:                   32,
+				Viewers:                   33,
 				ActiveUsers:               4,
+				ActiveAdmins:              21,
+				ActiveEditors:             22,
+				ActiveViewers:             23,
+				ActiveSessions:            24,
+				DailyActiveUsers:          25,
+				DailyActiveAdmins:         26,
+				DailyActiveEditors:        27,
+				DailyActiveViewers:        28,
+				DailyActiveSessions:       29,
 				Orgs:                      5,
 				Playlists:                 6,
 				Alerts:                    7,
@@ -298,6 +310,9 @@ func TestMetrics(t *testing.T) {
 			metrics := j.Get("metrics")
 			assert.Equal(t, getSystemStatsQuery.Result.Dashboards, metrics.Get("stats.dashboards.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Users, metrics.Get("stats.users.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Admins, metrics.Get("stats.admins.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Editors, metrics.Get("stats.editors.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.Viewers, metrics.Get("stats.viewers.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Orgs, metrics.Get("stats.orgs.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Playlists, metrics.Get("stats.playlist.count").MustInt64())
 			assert.Equal(t, uss.PluginManager.AppCount(), metrics.Get("stats.plugins.apps.count").MustInt())
@@ -305,6 +320,15 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, uss.PluginManager.DataSourceCount(), metrics.Get("stats.plugins.datasources.count").MustInt())
 			assert.Equal(t, getSystemStatsQuery.Result.Alerts, metrics.Get("stats.alerts.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.ActiveUsers, metrics.Get("stats.active_users.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.ActiveAdmins, metrics.Get("stats.active_admins.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.ActiveEditors, metrics.Get("stats.active_editors.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.ActiveViewers, metrics.Get("stats.active_viewers.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.ActiveSessions, metrics.Get("stats.active_sessions.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DailyActiveUsers, metrics.Get("stats.daily_active_users.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DailyActiveAdmins, metrics.Get("stats.daily_active_admins.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DailyActiveEditors, metrics.Get("stats.daily_active_editors.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DailyActiveViewers, metrics.Get("stats.daily_active_viewers.count").MustInt64())
+			assert.Equal(t, getSystemStatsQuery.Result.DailyActiveSessions, metrics.Get("stats.daily_active_sessions.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Datasources, metrics.Get("stats.datasources.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Stars, metrics.Get("stats.stars.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Folders, metrics.Get("stats.folders.count").MustInt64())

--- a/pkg/models/stats.go
+++ b/pkg/models/stats.go
@@ -5,6 +5,7 @@ type SystemStats struct {
 	Datasources               int64
 	Users                     int64
 	ActiveUsers               int64
+	DailyActiveUsers          int64
 	Orgs                      int64
 	Playlists                 int64
 	Alerts                    int64
@@ -25,14 +26,17 @@ type SystemStats struct {
 	DashboardsViewersCanAdmin int64
 	FoldersViewersCanEdit     int64
 	FoldersViewersCanAdmin    int64
-
-	Admins         int
-	Editors        int
-	Viewers        int
-	ActiveAdmins   int
-	ActiveEditors  int
-	ActiveViewers  int
-	ActiveSessions int
+	Admins                    int
+	Editors                   int
+	Viewers                   int
+	ActiveAdmins              int
+	ActiveEditors             int
+	ActiveViewers             int
+	ActiveSessions            int
+	DailyActiveAdmins         int
+	DailyActiveEditors        int
+	DailyActiveViewers        int
+	DailyActiveSessions       int
 }
 
 type DataSourceStats struct {
@@ -68,23 +72,28 @@ type GetAlertNotifierUsageStatsQuery struct {
 }
 
 type AdminStats struct {
-	Orgs           int `json:"orgs"`
-	Dashboards     int `json:"dashboards"`
-	Snapshots      int `json:"snapshots"`
-	Tags           int `json:"tags"`
-	Datasources    int `json:"datasources"`
-	Playlists      int `json:"playlists"`
-	Stars          int `json:"stars"`
-	Alerts         int `json:"alerts"`
-	Users          int `json:"users"`
-	Admins         int `json:"admins"`
-	Editors        int `json:"editors"`
-	Viewers        int `json:"viewers"`
-	ActiveUsers    int `json:"activeUsers"`
-	ActiveAdmins   int `json:"activeAdmins"`
-	ActiveEditors  int `json:"activeEditors"`
-	ActiveViewers  int `json:"activeViewers"`
-	ActiveSessions int `json:"activeSessions"`
+	Orgs                int `json:"orgs"`
+	Dashboards          int `json:"dashboards"`
+	Snapshots           int `json:"snapshots"`
+	Tags                int `json:"tags"`
+	Datasources         int `json:"datasources"`
+	Playlists           int `json:"playlists"`
+	Stars               int `json:"stars"`
+	Alerts              int `json:"alerts"`
+	Users               int `json:"users"`
+	Admins              int `json:"admins"`
+	Editors             int `json:"editors"`
+	Viewers             int `json:"viewers"`
+	ActiveUsers         int `json:"activeUsers"`
+	ActiveAdmins        int `json:"activeAdmins"`
+	ActiveEditors       int `json:"activeEditors"`
+	ActiveViewers       int `json:"activeViewers"`
+	ActiveSessions      int `json:"activeSessions"`
+	DailyActiveUsers    int `json:"dailyActiveUsers"`
+	DailyActiveAdmins   int `json:"dailyActiveAdmins"`
+	DailyActiveEditors  int `json:"dailyActiveEditors"`
+	DailyActiveViewers  int `json:"dailyActiveViewers"`
+	DailyActiveSessions int `json:"dailyActiveSessions"`
 }
 
 type GetAdminStatsQuery struct {

--- a/pkg/models/stats.go
+++ b/pkg/models/stats.go
@@ -26,17 +26,17 @@ type SystemStats struct {
 	DashboardsViewersCanAdmin int64
 	FoldersViewersCanEdit     int64
 	FoldersViewersCanAdmin    int64
-	Admins                    int
-	Editors                   int
-	Viewers                   int
-	ActiveAdmins              int
-	ActiveEditors             int
-	ActiveViewers             int
-	ActiveSessions            int
-	DailyActiveAdmins         int
-	DailyActiveEditors        int
-	DailyActiveViewers        int
-	DailyActiveSessions       int
+	Admins                    int64
+	Editors                   int64
+	Viewers                   int64
+	ActiveAdmins              int64
+	ActiveEditors             int64
+	ActiveViewers             int64
+	ActiveSessions            int64
+	DailyActiveAdmins         int64
+	DailyActiveEditors        int64
+	DailyActiveViewers        int64
+	DailyActiveSessions       int64
 }
 
 type DataSourceStats struct {
@@ -72,28 +72,28 @@ type GetAlertNotifierUsageStatsQuery struct {
 }
 
 type AdminStats struct {
-	Orgs                int `json:"orgs"`
-	Dashboards          int `json:"dashboards"`
-	Snapshots           int `json:"snapshots"`
-	Tags                int `json:"tags"`
-	Datasources         int `json:"datasources"`
-	Playlists           int `json:"playlists"`
-	Stars               int `json:"stars"`
-	Alerts              int `json:"alerts"`
-	Users               int `json:"users"`
-	Admins              int `json:"admins"`
-	Editors             int `json:"editors"`
-	Viewers             int `json:"viewers"`
-	ActiveUsers         int `json:"activeUsers"`
-	ActiveAdmins        int `json:"activeAdmins"`
-	ActiveEditors       int `json:"activeEditors"`
-	ActiveViewers       int `json:"activeViewers"`
-	ActiveSessions      int `json:"activeSessions"`
-	DailyActiveUsers    int `json:"dailyActiveUsers"`
-	DailyActiveAdmins   int `json:"dailyActiveAdmins"`
-	DailyActiveEditors  int `json:"dailyActiveEditors"`
-	DailyActiveViewers  int `json:"dailyActiveViewers"`
-	DailyActiveSessions int `json:"dailyActiveSessions"`
+	Orgs                int64 `json:"orgs"`
+	Dashboards          int64 `json:"dashboards"`
+	Snapshots           int64 `json:"snapshots"`
+	Tags                int64 `json:"tags"`
+	Datasources         int64 `json:"datasources"`
+	Playlists           int64 `json:"playlists"`
+	Stars               int64 `json:"stars"`
+	Alerts              int64 `json:"alerts"`
+	Users               int64 `json:"users"`
+	Admins              int64 `json:"admins"`
+	Editors             int64 `json:"editors"`
+	Viewers             int64 `json:"viewers"`
+	ActiveUsers         int64 `json:"activeUsers"`
+	ActiveAdmins        int64 `json:"activeAdmins"`
+	ActiveEditors       int64 `json:"activeEditors"`
+	ActiveViewers       int64 `json:"activeViewers"`
+	ActiveSessions      int64 `json:"activeSessions"`
+	DailyActiveUsers    int64 `json:"dailyActiveUsers"`
+	DailyActiveAdmins   int64 `json:"dailyActiveAdmins"`
+	DailyActiveEditors  int64 `json:"dailyActiveEditors"`
+	DailyActiveViewers  int64 `json:"dailyActiveViewers"`
+	DailyActiveSessions int64 `json:"dailyActiveSessions"`
 }
 
 type GetAdminStatsQuery struct {


### PR DESCRIPTION
This PR adds daily active counts to the system stats, which give a better idea of how many people are using Grafana on any given day rather than only in the past month.