### PR TITLE
influxdb: influxql: explicit min-interval check

### DIFF
--- a/pkg/tsdb/influxdb/model_parser.go
+++ b/pkg/tsdb/influxdb/model_parser.go
@@ -3,6 +3,7 @@ package influxdb
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -44,6 +45,15 @@ func (qp *InfluxdbQueryParser) Parse(query backend.DataQuery) (*Query, error) {
 		return nil, err
 	}
 
+	interval := query.Interval
+
+	// we make sure it is at least 1 millisecond
+	minInterval := time.Millisecond
+
+	if interval < minInterval {
+		interval = minInterval
+	}
+
 	return &Query{
 		Measurement:  measurement,
 		Policy:       policy,
@@ -52,7 +62,7 @@ func (qp *InfluxdbQueryParser) Parse(query backend.DataQuery) (*Query, error) {
 		Tags:         tags,
 		Selects:      selects,
 		RawQuery:     rawQuery,
-		Interval:     query.Interval,
+		Interval:     interval,
 		Alias:        alias,
 		UseRawQuery:  useRawQuery,
 		Tz:           tz,

--- a/pkg/tsdb/influxdb/model_parser_test.go
+++ b/pkg/tsdb/influxdb/model_parser_test.go
@@ -175,4 +175,23 @@ func TestInfluxdbQueryParser_Parse(t *testing.T) {
 		require.Empty(t, res.Tags)
 		require.Equal(t, time.Second*10, res.Interval)
 	})
+
+	t.Run("will enforce a minInterval of 1 millisecond", func(t *testing.T) {
+		json := `
+      {
+        "query": "RawDummyQuery",
+        "rawQuery": true,
+        "resultFormat": "time_series"
+      }
+      `
+
+		query := backend.DataQuery{
+			JSON:     []byte(json),
+			Interval: time.Millisecond * 0,
+		}
+
+		res, err := parser.Parse(query)
+		require.NoError(t, err)
+		require.Equal(t, time.Millisecond*1, res.Interval)
+	})
 }


### PR DESCRIPTION
in the influxdb influxql mode we explicitly make sure the interval is at least 1 millisecond. this was there in the past, but my [previous PR](https://github.com/grafana/grafana/pull/37588) changed the code, and the 1millisecond-thing got lost.

NOTE1: this change very probably has no effect in reality, because such low numbers will never happen. and even if they did, they will be rounded up to 10milliseconds. i'm doing this change to be 100% backward-compatible with the previous version.


NOTE2: i know the 1millisecond limit is too small, it should be at least 10seconds. but i do not want to break backward-compatibility.