### PR TITLE
InfluxDB: Added support for $__interval and $__interval_ms in Flux queries for alerting.

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -18,11 +18,7 @@ const maxPointsEnforceFactor float64 = 10
 func executeQuery(ctx context.Context, query queryModel, runner queryRunner, maxSeries int) (dr backend.DataResponse) {
 	dr = backend.DataResponse{}
 
-	flux, err := interpolate(query)
-	if err != nil {
-		dr.Error = err
-		return
-	}
+	flux := interpolate(query)
 
 	glog.Debug("Executing Flux query", "flux", flux)
 

--- a/pkg/tsdb/influxdb/flux/macros.go
+++ b/pkg/tsdb/influxdb/flux/macros.go
@@ -9,6 +9,10 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
 
+// $__interval_ms is the exact value in milliseconds
+// $__interval is rounded to nice whole values
+// v.windowPeriod is the exact value string-formatted
+
 func interpolateInterval(flux string, interval time.Duration) string {
 	intervalMs := int64(interval / time.Millisecond)
 	intervalText := intervalv2.FormatDuration(interval)

--- a/pkg/tsdb/influxdb/flux/macros.go
+++ b/pkg/tsdb/influxdb/flux/macros.go
@@ -5,14 +5,16 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
 
 func interpolateInterval(flux string, interval time.Duration) string {
 	intervalMs := int64(interval / time.Millisecond)
+	intervalText := intervalv2.FormatDuration(interval)
 
 	flux = strings.ReplaceAll(flux, "$__interval_ms", strconv.FormatInt(intervalMs, 10))
-	flux = strings.ReplaceAll(flux, "$__interval", interval.String())
-
+	flux = strings.ReplaceAll(flux, "$__interval", intervalText)
 	return flux
 }
 

--- a/pkg/tsdb/influxdb/flux/macros_test.go
+++ b/pkg/tsdb/influxdb/flux/macros_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInterpolate(t *testing.T) {
@@ -29,8 +28,8 @@ func TestInterpolate(t *testing.T) {
 	}{
 		{
 			name:   "interpolate flux variables",
-			before: `v.timeRangeStart, something.timeRangeStop, XYZ.bucket, uuUUu.defaultBucket, aBcDefG.organization, window.windowPeriod, a91{}.bucket`,
-			after:  `2021-09-22T10:12:51.310985041Z, 2021-09-22T11:12:51.310985042Z, "grafana2", "grafana3", "grafana1", 1s, a91{}.bucket`,
+			before: `v.timeRangeStart, something.timeRangeStop, XYZ.bucket, uuUUu.defaultBucket, aBcDefG.organization, window.windowPeriod, a91{}.bucket, $__interval, $__interval_ms`,
+			after:  `2021-09-22T10:12:51.310985041Z, 2021-09-22T11:12:51.310985042Z, "grafana2", "grafana3", "grafana1", 1s, a91{}.bucket, 1s, 1000`,
 		},
 	}
 	for _, tt := range tests {
@@ -42,8 +41,7 @@ func TestInterpolate(t *testing.T) {
 				MaxDataPoints: 1,
 				Interval:      1000 * 1000 * 1000,
 			}
-			interpolatedQuery, err := interpolate(query)
-			require.NoError(t, err)
+			interpolatedQuery := interpolate(query)
 			diff := cmp.Diff(tt.after, interpolatedQuery)
 			assert.Equal(t, "", diff)
 		})

--- a/pkg/tsdb/influxdb/flux/macros_test.go
+++ b/pkg/tsdb/influxdb/flux/macros_test.go
@@ -29,7 +29,7 @@ func TestInterpolate(t *testing.T) {
 		{
 			name:   "interpolate flux variables",
 			before: `v.timeRangeStart, something.timeRangeStop, XYZ.bucket, uuUUu.defaultBucket, aBcDefG.organization, window.windowPeriod, a91{}.bucket, $__interval, $__interval_ms`,
-			after:  `2021-09-22T10:12:51.310985041Z, 2021-09-22T11:12:51.310985042Z, "grafana2", "grafana3", "grafana1", 1s, a91{}.bucket, 1s, 1000`,
+			after:  `2021-09-22T10:12:51.310985041Z, 2021-09-22T11:12:51.310985042Z, "grafana2", "grafana3", "grafana1", 1m1.258s, a91{}.bucket, 1m, 61258`,
 		},
 	}
 	for _, tt := range tests {
@@ -39,7 +39,7 @@ func TestInterpolate(t *testing.T) {
 				Options:       options,
 				TimeRange:     timeRange,
 				MaxDataPoints: 1,
-				Interval:      1000 * 1000 * 1000,
+				Interval:      61258 * 1000 * 1000,
 			}
 			interpolatedQuery := interpolate(query)
 			diff := cmp.Diff(tt.after, interpolatedQuery)

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -188,9 +188,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       throw new Error('applyTemplateVariables called in influxql-mode. this should never happen');
     }
 
+    // We want to interpolate these variables on backend
+    const { __interval, __interval_ms, ...rest } = scopedVars;
+
     return {
       ...query,
-      query: this.templateSrv.replace(query.query ?? '', scopedVars), // The raw query text
+      query: this.templateSrv.replace(query.query ?? '', rest), // The raw query text
     };
   }
 


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/38852

NOTE: this is about the Flux language mode, not about the InfluxQL language mode.

the basic issue is that the variables `$__interval` and `$__interval_ms` are replaced in the browser by javascript, when a dashboard-query is running. so, when an alert is created (which executes on the server), there is noone to replace `$__interval` and `$__interval_ms`.

this pull-request does two things:
- do not replace `$__interval` and `$__interval_ms` in the javascript code. this is needed so that the dashboard-query-situation behaves the same as the alerting-situation
- in the server-code, replace `$__interval` and `$__interval_ms` with the correct values

NOTE: the reason this issue did not surface sooner is that the idiomatic way to refer to interval in flux-queries is by the special variable `v.windowPeriod`, which works correctly.