### PR TITLE
LDAP: Search all DNs for users

### DIFF
--- a/pkg/services/ldap/ldap.go
+++ b/pkg/services/ldap/ldap.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
+	"gopkg.in/ldap.v3"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
-	"gopkg.in/ldap.v3"
 )
 
 // IConnection is interface for LDAP connection manipulation
@@ -252,16 +253,11 @@ func (server *Server) Users(logins []string) (
 	[]*models.ExternalUserInfo,
 	error,
 ) {
-	var users []*ldap.Entry
+	var users [][]*ldap.Entry
 	err := getUsersIteration(logins, func(previous, current int) error {
-		entries, err := server.users(logins[previous:current])
-		if err != nil {
-			return err
-		}
-
-		users = append(users, entries...)
-
-		return nil
+		var err error
+		users, err = server.users(logins[previous:current])
+		return err
 	})
 	if err != nil {
 		return nil, err
@@ -308,12 +304,14 @@ func getUsersIteration(logins []string, fn func(int, int) error) error {
 
 // users is helper method for the Users()
 func (server *Server) users(logins []string) (
-	[]*ldap.Entry,
+	[][]*ldap.Entry,
 	error,
 ) {
 	var result *ldap.SearchResult
 	var Config = server.Config
 	var err error
+
+	var entries = make([][]*ldap.Entry, 0, len(Config.SearchBaseDNs))
 
 	for _, base := range Config.SearchBaseDNs {
 		result, err = server.Connection.Search(
@@ -324,11 +322,11 @@ func (server *Server) users(logins []string) (
 		}
 
 		if len(result.Entries) > 0 {
-			break
+			entries = append(entries, result.Entries)
 		}
 	}
 
-	return result.Entries, nil
+	return entries, nil
 }
 
 // validateGrafanaUser validates user access.
@@ -557,17 +555,26 @@ func (server *Server) requestMemberOf(entry *ldap.Entry) ([]string, error) {
 // serializeUsers serializes the users
 // from LDAP result to ExternalInfo struct
 func (server *Server) serializeUsers(
-	entries []*ldap.Entry,
+	entries [][]*ldap.Entry,
 ) ([]*models.ExternalUserInfo, error) {
 	var serialized []*models.ExternalUserInfo
+	var users = map[string]struct{}{}
 
-	for _, user := range entries {
-		extUser, err := server.buildGrafanaUser(user)
-		if err != nil {
-			return nil, err
+	for _, dn := range entries {
+		for _, user := range dn {
+			extUser, err := server.buildGrafanaUser(user)
+			if err != nil {
+				return nil, err
+			}
+
+			if _, exists := users[extUser.Login]; exists {
+				// ignore duplicates
+				continue
+			}
+			users[extUser.Login] = struct{}{}
+
+			serialized = append(serialized, extUser)
 		}
-
-		serialized = append(serialized, extUser)
 	}
 
 	return serialized, nil

--- a/pkg/services/ldap/ldap_login_test.go
+++ b/pkg/services/ldap/ldap_login_test.go
@@ -4,231 +4,227 @@ import (
 	"errors"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"gopkg.in/ldap.v3"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 )
 
-func TestLDAPLogin(t *testing.T) {
-	defaultLogin := &models.LoginUserQuery{
-		Username:  "user",
-		Password:  "pwd",
-		IpAddress: "192.168.1.1:56433",
+var defaultLogin = &models.LoginUserQuery{
+	Username:  "user",
+	Password:  "pwd",
+	IpAddress: "192.168.1.1:56433",
+}
+
+func TestServer_Login_UserBind_Fail(t *testing.T) {
+	connection := &MockConnection{}
+	entry := ldap.Entry{}
+	result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
+	connection.setSearchResult(&result)
+
+	connection.BindProvider = func(username, password string) error {
+		return &ldap.Error{
+			ResultCode: 49,
+		}
+	}
+	server := &Server{
+		Config: &ServerConfig{
+			SearchBaseDNs: []string{"BaseDNHere"},
+		},
+		Connection: connection,
+		log:        log.New("test-logger"),
 	}
 
-	Convey("Login()", t, func() {
-		Convey("Should get invalid credentials when userBind fails", func() {
-			connection := &MockConnection{}
-			entry := ldap.Entry{}
-			result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
-			connection.setSearchResult(&result)
+	_, err := server.Login(defaultLogin)
 
-			connection.BindProvider = func(username, password string) error {
-				return &ldap.Error{
-					ResultCode: 49,
-				}
-			}
-			server := &Server{
-				Config: &ServerConfig{
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-				log:        log.New("test-logger"),
-			}
+	assert.ErrorIs(t, err, ErrInvalidCredentials)
+}
 
-			_, err := server.Login(defaultLogin)
+func TestServer_Login_Search_NoResult(t *testing.T) {
+	connection := &MockConnection{}
+	result := ldap.SearchResult{Entries: []*ldap.Entry{}}
+	connection.setSearchResult(&result)
 
-			So(err, ShouldEqual, ErrInvalidCredentials)
-		})
+	connection.BindProvider = func(username, password string) error {
+		return nil
+	}
+	server := &Server{
+		Config: &ServerConfig{
+			SearchBaseDNs: []string{"BaseDNHere"},
+		},
+		Connection: connection,
+		log:        log.New("test-logger"),
+	}
 
-		Convey("Returns an error when search didn't find anything", func() {
-			connection := &MockConnection{}
-			result := ldap.SearchResult{Entries: []*ldap.Entry{}}
-			connection.setSearchResult(&result)
+	_, err := server.Login(defaultLogin)
+	assert.ErrorIs(t, err, ErrCouldNotFindUser)
+}
 
-			connection.BindProvider = func(username, password string) error {
-				return nil
-			}
-			server := &Server{
-				Config: &ServerConfig{
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-				log:        log.New("test-logger"),
-			}
+func TestServer_Login_Search_Error(t *testing.T) {
+	connection := &MockConnection{}
+	expected := errors.New("Killa-gorilla")
+	connection.setSearchError(expected)
 
-			_, err := server.Login(defaultLogin)
+	connection.BindProvider = func(username, password string) error {
+		return nil
+	}
+	server := &Server{
+		Config: &ServerConfig{
+			SearchBaseDNs: []string{"BaseDNHere"},
+		},
+		Connection: connection,
+		log:        log.New("test-logger"),
+	}
 
-			So(err, ShouldEqual, ErrCouldNotFindUser)
-		})
+	_, err := server.Login(defaultLogin)
+	assert.ErrorIs(t, err, expected)
+}
 
-		Convey("When search returns an error", func() {
-			connection := &MockConnection{}
-			expected := errors.New("Killa-gorilla")
-			connection.setSearchError(expected)
+func TestServer_Login_ValidCredentials(t *testing.T) {
+	connection := &MockConnection{}
+	entry := ldap.Entry{
+		DN: "dn", Attributes: []*ldap.EntryAttribute{
+			{Name: "username", Values: []string{"markelog"}},
+			{Name: "surname", Values: []string{"Gaidarenko"}},
+			{Name: "email", Values: []string{"markelog@gmail.com"}},
+			{Name: "name", Values: []string{"Oleg"}},
+			{Name: "memberof", Values: []string{"admins"}},
+		},
+	}
+	result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
+	connection.setSearchResult(&result)
 
-			connection.BindProvider = func(username, password string) error {
-				return nil
-			}
-			server := &Server{
-				Config: &ServerConfig{
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-				log:        log.New("test-logger"),
-			}
+	connection.BindProvider = func(username, password string) error {
+		return nil
+	}
+	server := &Server{
+		Config: &ServerConfig{
+			Attr: AttributeMap{
+				Username: "username",
+				Name:     "name",
+				MemberOf: "memberof",
+			},
+			SearchBaseDNs: []string{"BaseDNHere"},
+		},
+		Connection: connection,
+		log:        log.New("test-logger"),
+	}
 
-			_, err := server.Login(defaultLogin)
+	resp, err := server.Login(defaultLogin)
+	require.NoError(t, err)
+	assert.Equal(t, "markelog", resp.Login)
+}
 
-			So(err, ShouldEqual, expected)
-		})
+// TestServer_Login_UnauthenticatedBind tests that unauthenticated bind
+// is called when there is no admin password or user wildcard in the
+// bind_dn.
+func TestServer_Login_UnauthenticatedBind(t *testing.T) {
+	connection := &MockConnection{}
+	entry := ldap.Entry{
+		DN: "test",
+	}
+	result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
+	connection.setSearchResult(&result)
 
-		Convey("When login with valid credentials", func() {
-			connection := &MockConnection{}
-			entry := ldap.Entry{
-				DN: "dn", Attributes: []*ldap.EntryAttribute{
-					{Name: "username", Values: []string{"markelog"}},
-					{Name: "surname", Values: []string{"Gaidarenko"}},
-					{Name: "email", Values: []string{"markelog@gmail.com"}},
-					{Name: "name", Values: []string{"Oleg"}},
-					{Name: "memberof", Values: []string{"admins"}},
-				},
-			}
-			result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
-			connection.setSearchResult(&result)
+	connection.UnauthenticatedBindProvider = func() error {
+		return nil
+	}
+	server := &Server{
+		Config: &ServerConfig{
+			SearchBaseDNs: []string{"BaseDNHere"},
+		},
+		Connection: connection,
+		log:        log.New("test-logger"),
+	}
 
-			connection.BindProvider = func(username, password string) error {
-				return nil
-			}
-			server := &Server{
-				Config: &ServerConfig{
-					Attr: AttributeMap{
-						Username: "username",
-						Name:     "name",
-						MemberOf: "memberof",
-					},
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-				log:        log.New("test-logger"),
-			}
+	user, err := server.Login(defaultLogin)
+	require.NoError(t, err)
+	assert.Equal(t, "test", user.AuthId)
+	assert.True(t, connection.UnauthenticatedBindCalled)
+}
 
-			resp, err := server.Login(defaultLogin)
+func TestServer_Login_AuthenticatedBind(t *testing.T) {
+	connection := &MockConnection{}
+	entry := ldap.Entry{
+		DN: "test",
+	}
+	result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
+	connection.setSearchResult(&result)
 
-			So(err, ShouldBeNil)
-			So(resp.Login, ShouldEqual, "markelog")
-		})
+	adminUsername := ""
+	adminPassword := ""
+	username := ""
+	password := ""
 
-		Convey("Should perform unauthenticated bind without admin", func() {
-			connection := &MockConnection{}
-			entry := ldap.Entry{
-				DN: "test",
-			}
-			result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
-			connection.setSearchResult(&result)
+	i := 0
+	connection.BindProvider = func(name, pass string) error {
+		i++
+		if i == 1 {
+			adminUsername = name
+			adminPassword = pass
+		}
 
-			connection.UnauthenticatedBindProvider = func() error {
-				return nil
-			}
-			server := &Server{
-				Config: &ServerConfig{
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-				log:        log.New("test-logger"),
-			}
+		if i == 2 {
+			username = name
+			password = pass
+		}
 
-			user, err := server.Login(defaultLogin)
+		return nil
+	}
+	server := &Server{
+		Config: &ServerConfig{
+			BindDN:        "killa",
+			BindPassword:  "gorilla",
+			SearchBaseDNs: []string{"BaseDNHere"},
+		},
+		Connection: connection,
+		log:        log.New("test-logger"),
+	}
 
-			So(err, ShouldBeNil)
-			So(user.AuthId, ShouldEqual, "test")
-			So(connection.UnauthenticatedBindCalled, ShouldBeTrue)
-		})
+	user, err := server.Login(defaultLogin)
+	require.NoError(t, err)
 
-		Convey("Should perform authenticated binds", func() {
-			connection := &MockConnection{}
-			entry := ldap.Entry{
-				DN: "test",
-			}
-			result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
-			connection.setSearchResult(&result)
+	assert.Equal(t, "test", user.AuthId)
+	assert.True(t, connection.BindCalled)
 
-			adminUsername := ""
-			adminPassword := ""
-			username := ""
-			password := ""
+	assert.Equal(t, "killa", adminUsername)
+	assert.Equal(t, "gorilla", adminPassword)
 
-			i := 0
-			connection.BindProvider = func(name, pass string) error {
-				i++
-				if i == 1 {
-					adminUsername = name
-					adminPassword = pass
-				}
+	assert.Equal(t, "test", username)
+	assert.Equal(t, "pwd", password)
+}
 
-				if i == 2 {
-					username = name
-					password = pass
-				}
+func TestServer_Login_UserWildcardBind(t *testing.T) {
+	connection := &MockConnection{}
+	entry := ldap.Entry{
+		DN: "test",
+	}
+	connection.setSearchResult(&ldap.SearchResult{Entries: []*ldap.Entry{&entry}})
 
-				return nil
-			}
-			server := &Server{
-				Config: &ServerConfig{
-					BindDN:        "killa",
-					BindPassword:  "gorilla",
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-				log:        log.New("test-logger"),
-			}
+	authBindUser := ""
+	authBindPassword := ""
 
-			user, err := server.Login(defaultLogin)
+	connection.BindProvider = func(name, pass string) error {
+		authBindUser = name
+		authBindPassword = pass
+		return nil
+	}
+	server := &Server{
+		Config: &ServerConfig{
+			BindDN:        "cn=%s,ou=users,dc=grafana,dc=org",
+			SearchBaseDNs: []string{"BaseDNHere"},
+		},
+		Connection: connection,
+		log:        log.New("test-logger"),
+	}
 
-			So(err, ShouldBeNil)
+	_, err := server.Login(defaultLogin)
+	require.NoError(t, err)
 
-			So(user.AuthId, ShouldEqual, "test")
-			So(connection.BindCalled, ShouldBeTrue)
-
-			So(adminUsername, ShouldEqual, "killa")
-			So(adminPassword, ShouldEqual, "gorilla")
-
-			So(username, ShouldEqual, "test")
-			So(password, ShouldEqual, "pwd")
-		})
-		Convey("Should bind with user if %s exists in the bind_dn", func() {
-			connection := &MockConnection{}
-			entry := ldap.Entry{
-				DN: "test",
-			}
-			connection.setSearchResult(&ldap.SearchResult{Entries: []*ldap.Entry{&entry}})
-
-			authBindUser := ""
-			authBindPassword := ""
-
-			connection.BindProvider = func(name, pass string) error {
-				authBindUser = name
-				authBindPassword = pass
-				return nil
-			}
-			server := &Server{
-				Config: &ServerConfig{
-					BindDN:        "cn=%s,ou=users,dc=grafana,dc=org",
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-				log:        log.New("test-logger"),
-			}
-
-			_, err := server.Login(defaultLogin)
-
-			So(err, ShouldBeNil)
-
-			So(authBindUser, ShouldEqual, "cn=user,ou=users,dc=grafana,dc=org")
-			So(authBindPassword, ShouldEqual, "pwd")
-			So(connection.BindCalled, ShouldBeTrue)
-		})
-	})
+	assert.Equal(t, "cn=user,ou=users,dc=grafana,dc=org", authBindUser)
+	assert.Equal(t, "pwd", authBindPassword)
+	assert.True(t, connection.BindCalled)
 }

--- a/pkg/services/ldap/ldap_private_test.go
+++ b/pkg/services/ldap/ldap_private_test.go
@@ -3,272 +3,253 @@ package ldap
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"gopkg.in/ldap.v3"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 )
 
-func TestLDAPPrivateMethods(t *testing.T) {
-	Convey("getSearchRequest()", t, func() {
-		Convey("with enabled GroupSearchFilterUserAttribute setting", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Attr: AttributeMap{
-						Username: "username",
-						Name:     "name",
-						MemberOf: "memberof",
-						Email:    "email",
-					},
-					GroupSearchFilterUserAttribute: "gansta",
-					SearchBaseDNs:                  []string{"BaseDNHere"},
-				},
-				log: log.New("test-logger"),
-			}
+func TestServer_getSearchRequest(t *testing.T) {
+	expected := &ldap.SearchRequest{
+		BaseDN:       "killa",
+		Scope:        2,
+		DerefAliases: 0,
+		SizeLimit:    0,
+		TimeLimit:    0,
+		TypesOnly:    false,
+		Filter:       "(|)",
+		Attributes: []string{
+			"username",
+			"email",
+			"name",
+			"memberof",
+			"gansta",
+		},
+		Controls: nil,
+	}
 
-			result := server.getSearchRequest("killa", []string{"gorilla"})
+	server := &Server{
+		Config: &ServerConfig{
+			Attr: AttributeMap{
+				Username: "username",
+				Name:     "name",
+				MemberOf: "memberof",
+				Email:    "email",
+			},
+			GroupSearchFilterUserAttribute: "gansta",
+			SearchBaseDNs:                  []string{"BaseDNHere"},
+		},
+		log: log.New("test-logger"),
+	}
 
-			So(result, ShouldResemble, &ldap.SearchRequest{
-				BaseDN:       "killa",
-				Scope:        2,
-				DerefAliases: 0,
-				SizeLimit:    0,
-				TimeLimit:    0,
-				TypesOnly:    false,
-				Filter:       "(|)",
-				Attributes: []string{
-					"username",
-					"email",
-					"name",
-					"memberof",
-					"gansta",
+	result := server.getSearchRequest("killa", []string{"gorilla"})
+
+	assert.EqualValues(t, expected, result)
+}
+
+func TestSerializeUsers(t *testing.T) {
+	t.Run("simple case", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				Attr: AttributeMap{
+					Username: "username",
+					Name:     "name",
+					MemberOf: "memberof",
+					Email:    "email",
 				},
-				Controls: nil,
-			})
-		})
+				SearchBaseDNs: []string{"BaseDNHere"},
+			},
+			Connection: &MockConnection{},
+			log:        log.New("test-logger"),
+		}
+
+		entry := ldap.Entry{
+			DN: "dn",
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "username", Values: []string{"roelgerrits"}},
+				{Name: "surname", Values: []string{"Gerrits"}},
+				{Name: "email", Values: []string{"roel@test.com"}},
+				{Name: "name", Values: []string{"Roel"}},
+				{Name: "memberof", Values: []string{"admins"}},
+			},
+		}
+		users := [][]*ldap.Entry{{&entry}}
+
+		result, err := server.serializeUsers(users)
+		require.NoError(t, err)
+
+		assert.Equal(t, "roelgerrits", result[0].Login)
+		assert.Equal(t, "roel@test.com", result[0].Email)
+		assert.Contains(t, result[0].Groups, "admins")
 	})
 
-	Convey("serializeUsers()", t, func() {
-		Convey("simple case", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Attr: AttributeMap{
-						Username: "username",
-						Name:     "name",
-						MemberOf: "memberof",
-						Email:    "email",
-					},
-					SearchBaseDNs: []string{"BaseDNHere"},
+	t.Run("without lastname", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				Attr: AttributeMap{
+					Username: "username",
+					Name:     "name",
+					MemberOf: "memberof",
+					Email:    "email",
 				},
-				Connection: &MockConnection{},
-				log:        log.New("test-logger"),
-			}
+				SearchBaseDNs: []string{"BaseDNHere"},
+			},
+			Connection: &MockConnection{},
+			log:        log.New("test-logger"),
+		}
 
-			entry := ldap.Entry{
-				DN: "dn",
-				Attributes: []*ldap.EntryAttribute{
-					{Name: "username", Values: []string{"roelgerrits"}},
-					{Name: "surname", Values: []string{"Gerrits"}},
-					{Name: "email", Values: []string{"roel@test.com"}},
-					{Name: "name", Values: []string{"Roel"}},
-					{Name: "memberof", Values: []string{"admins"}},
-				},
-			}
-			users := [][]*ldap.Entry{{&entry}}
+		entry := ldap.Entry{
+			DN: "dn",
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "username", Values: []string{"roelgerrits"}},
+				{Name: "email", Values: []string{"roel@test.com"}},
+				{Name: "name", Values: []string{"Roel"}},
+				{Name: "memberof", Values: []string{"admins"}},
+			},
+		}
+		users := [][]*ldap.Entry{{&entry}}
 
-			result, err := server.serializeUsers(users)
+		result, err := server.serializeUsers(users)
+		require.NoError(t, err)
 
-			So(err, ShouldBeNil)
-			So(result[0].Login, ShouldEqual, "roelgerrits")
-			So(result[0].Email, ShouldEqual, "roel@test.com")
-			So(result[0].Groups, ShouldContain, "admins")
-		})
-
-		Convey("without lastname", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Attr: AttributeMap{
-						Username: "username",
-						Name:     "name",
-						MemberOf: "memberof",
-						Email:    "email",
-					},
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: &MockConnection{},
-				log:        log.New("test-logger"),
-			}
-
-			entry := ldap.Entry{
-				DN: "dn",
-				Attributes: []*ldap.EntryAttribute{
-					{Name: "username", Values: []string{"roelgerrits"}},
-					{Name: "email", Values: []string{"roel@test.com"}},
-					{Name: "name", Values: []string{"Roel"}},
-					{Name: "memberof", Values: []string{"admins"}},
-				},
-			}
-			users := [][]*ldap.Entry{{&entry}}
-
-			result, err := server.serializeUsers(users)
-
-			So(err, ShouldBeNil)
-			So(result[0].IsDisabled, ShouldBeFalse)
-			So(result[0].Name, ShouldEqual, "Roel")
-		})
-
-		Convey("a user without matching groups should be marked as disabled", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Groups: []*GroupToOrgRole{{
-						GroupDN: "foo",
-						OrgId:   1,
-						OrgRole: models.ROLE_EDITOR,
-					}},
-				},
-				Connection: &MockConnection{},
-				log:        log.New("test-logger"),
-			}
-
-			entry := ldap.Entry{
-				DN: "dn",
-				Attributes: []*ldap.EntryAttribute{
-					{Name: "memberof", Values: []string{"admins"}},
-				},
-			}
-			users := [][]*ldap.Entry{{&entry}}
-
-			result, err := server.serializeUsers(users)
-
-			So(err, ShouldBeNil)
-			So(len(result), ShouldEqual, 1)
-			So(result[0].IsDisabled, ShouldBeTrue)
-		})
+		assert.False(t, result[0].IsDisabled)
+		assert.Equal(t, "Roel", result[0].Name)
 	})
 
-	Convey("validateGrafanaUser()", t, func() {
-		Convey("Returns error when user does not belong in any of the specified LDAP groups", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Groups: []*GroupToOrgRole{
-						{
-							OrgId: 1,
-						},
+	t.Run("mark user without matching group as disabled", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				Groups: []*GroupToOrgRole{{
+					GroupDN: "foo",
+					OrgId:   1,
+					OrgRole: models.ROLE_EDITOR,
+				}},
+			},
+			Connection: &MockConnection{},
+			log:        log.New("test-logger"),
+		}
+
+		entry := ldap.Entry{
+			DN: "dn",
+			Attributes: []*ldap.EntryAttribute{
+				{Name: "memberof", Values: []string{"admins"}},
+			},
+		}
+		users := [][]*ldap.Entry{{&entry}}
+
+		result, err := server.serializeUsers(users)
+		require.NoError(t, err)
+
+		assert.Len(t, result, 1)
+		assert.True(t, result[0].IsDisabled)
+	})
+}
+
+func TestServer_validateGrafanaUser(t *testing.T) {
+	t.Run("no group config", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				Groups: []*GroupToOrgRole{},
+			},
+			log: logger.New("test"),
+		}
+
+		user := &models.ExternalUserInfo{
+			Login: "markelog",
+		}
+
+		err := server.validateGrafanaUser(user)
+		require.NoError(t, err)
+	})
+
+	t.Run("user in group", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				Groups: []*GroupToOrgRole{
+					{
+						OrgId: 1,
 					},
 				},
-				log: logger.New("test"),
-			}
+			},
+			log: logger.New("test"),
+		}
 
-			user := &models.ExternalUserInfo{
-				Login: "markelog",
-			}
+		user := &models.ExternalUserInfo{
+			Login: "markelog",
+			OrgRoles: map[int64]models.RoleType{
+				1: "test",
+			},
+		}
 
-			result := server.validateGrafanaUser(user)
+		err := server.validateGrafanaUser(user)
+		require.NoError(t, err)
+	})
 
-			So(result, ShouldEqual, ErrInvalidCredentials)
-		})
+	t.Run("user not in group", func(t *testing.T) {
 
-		Convey("Does not return error when group config is empty", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Groups: []*GroupToOrgRole{},
-				},
-				log: logger.New("test"),
-			}
-
-			user := &models.ExternalUserInfo{
-				Login: "markelog",
-			}
-
-			result := server.validateGrafanaUser(user)
-
-			So(result, ShouldBeNil)
-		})
-
-		Convey("Does not return error when groups are there", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Groups: []*GroupToOrgRole{
-						{
-							OrgId: 1,
-						},
+		server := &Server{
+			Config: &ServerConfig{
+				Groups: []*GroupToOrgRole{
+					{
+						OrgId: 1,
 					},
 				},
-				log: logger.New("test"),
-			}
+			},
+			log: logger.New("test"),
+		}
 
-			user := &models.ExternalUserInfo{
-				Login: "markelog",
-				OrgRoles: map[int64]models.RoleType{
-					1: "test",
-				},
-			}
+		user := &models.ExternalUserInfo{
+			Login: "markelog",
+		}
 
-			result := server.validateGrafanaUser(user)
+		err := server.validateGrafanaUser(user)
+		require.ErrorIs(t, err, ErrInvalidCredentials)
+	})
+}
 
-			So(result, ShouldBeNil)
-		})
+func TestServer_binds(t *testing.T) {
+	t.Run("single bind with cn wildcard", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				BindDN: "cn=%s,dc=grafana,dc=org",
+			},
+		}
+
+		assert.True(t, server.shouldSingleBind())
+		assert.Equal(t, "cn=test,dc=grafana,dc=org", server.singleBindDN("test"))
 	})
 
-	Convey("shouldAdminBind()", t, func() {
-		Convey("it should require admin userBind", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					BindPassword: "test",
-				},
-			}
+	t.Run("don't single bind", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				BindDN: "cn=admin,dc=grafana,dc=org",
+			},
+		}
 
-			result := server.shouldAdminBind()
-			So(result, ShouldBeTrue)
-		})
-
-		Convey("it should not require admin userBind", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					BindPassword: "",
-				},
-			}
-
-			result := server.shouldAdminBind()
-			So(result, ShouldBeFalse)
-		})
+		assert.False(t, server.shouldSingleBind())
 	})
 
-	Convey("shouldSingleBind()", t, func() {
-		Convey("it should allow single bind", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					BindDN: "cn=%s,dc=grafana,dc=org",
-				},
-			}
+	t.Run("admin user bind", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				BindPassword: "test",
+			},
+		}
 
-			result := server.shouldSingleBind()
-			So(result, ShouldBeTrue)
-		})
-
-		Convey("it should not allow single bind", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					BindDN: "cn=admin,dc=grafana,dc=org",
-				},
-			}
-
-			result := server.shouldSingleBind()
-			So(result, ShouldBeFalse)
-		})
+		assert.True(t, server.shouldAdminBind())
 	})
 
-	Convey("singleBindDN()", t, func() {
-		Convey("it should allow single bind", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					BindDN: "cn=%s,dc=grafana,dc=org",
-				},
-			}
+	t.Run("don't admin user bind", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				BindPassword: "",
+			},
+		}
 
-			result := server.singleBindDN("test")
-			So(result, ShouldEqual, "cn=test,dc=grafana,dc=org")
-		})
+		assert.False(t, server.shouldAdminBind())
 	})
 }

--- a/pkg/services/ldap/ldap_private_test.go
+++ b/pkg/services/ldap/ldap_private_test.go
@@ -3,10 +3,11 @@ package ldap
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/models"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/ldap.v3"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
 )
 
 func TestLDAPPrivateMethods(t *testing.T) {
@@ -74,7 +75,7 @@ func TestLDAPPrivateMethods(t *testing.T) {
 					{Name: "memberof", Values: []string{"admins"}},
 				},
 			}
-			users := []*ldap.Entry{&entry}
+			users := [][]*ldap.Entry{{&entry}}
 
 			result, err := server.serializeUsers(users)
 
@@ -108,7 +109,7 @@ func TestLDAPPrivateMethods(t *testing.T) {
 					{Name: "memberof", Values: []string{"admins"}},
 				},
 			}
-			users := []*ldap.Entry{&entry}
+			users := [][]*ldap.Entry{{&entry}}
 
 			result, err := server.serializeUsers(users)
 
@@ -136,7 +137,7 @@ func TestLDAPPrivateMethods(t *testing.T) {
 					{Name: "memberof", Values: []string{"admins"}},
 				},
 			}
-			users := []*ldap.Entry{&entry}
+			users := [][]*ldap.Entry{{&entry}}
 
 			result, err := server.serializeUsers(users)
 

--- a/pkg/services/ldap/ldap_private_test.go
+++ b/pkg/services/ldap/ldap_private_test.go
@@ -190,7 +190,6 @@ func TestServer_validateGrafanaUser(t *testing.T) {
 	})
 
 	t.Run("user not in group", func(t *testing.T) {
-
 		server := &Server{
 			Config: &ServerConfig{
 				Groups: []*GroupToOrgRole{

--- a/pkg/services/ldap/ldap_test.go
+++ b/pkg/services/ldap/ldap_test.go
@@ -4,224 +4,222 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/ldap.v3"
+
+	"github.com/grafana/grafana/pkg/infra/log"
 )
 
-func TestPublicAPI(t *testing.T) {
-	Convey("New()", t, func() {
-		Convey("Should return ", func() {
-			result := New(&ServerConfig{
+func TestNew(t *testing.T) {
+	result := New(&ServerConfig{
+		Attr:          AttributeMap{},
+		SearchBaseDNs: []string{"BaseDNHere"},
+	})
+
+	assert.Implements(t, (*IServer)(nil), result)
+}
+
+func TestServer_Close(t *testing.T) {
+	t.Run("close the connection", func(t *testing.T) {
+		connection := &MockConnection{}
+
+		server := &Server{
+			Config: &ServerConfig{
 				Attr:          AttributeMap{},
 				SearchBaseDNs: []string{"BaseDNHere"},
-			})
+			},
+			Connection: connection,
+		}
 
-			So(result, ShouldImplement, (*IServer)(nil))
-		})
+		assert.NotPanics(t, server.Close)
+		assert.True(t, connection.CloseCalled)
 	})
 
-	Convey("Close()", t, func() {
-		Convey("Should close the connection", func() {
-			connection := &MockConnection{}
+	t.Run("panic if no connection", func(t *testing.T) {
+		server := &Server{
+			Config: &ServerConfig{
+				Attr:          AttributeMap{},
+				SearchBaseDNs: []string{"BaseDNHere"},
+			},
+			Connection: nil,
+		}
 
-			server := &Server{
-				Config: &ServerConfig{
-					Attr:          AttributeMap{},
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: connection,
-			}
-
-			So(server.Close, ShouldNotPanic)
-			So(connection.CloseCalled, ShouldBeTrue)
-		})
-
-		Convey("Should panic if no connection is established", func() {
-			server := &Server{
-				Config: &ServerConfig{
-					Attr:          AttributeMap{},
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: nil,
-			}
-
-			So(server.Close, ShouldPanic)
-		})
+		assert.Panics(t, server.Close)
 	})
-	Convey("Users()", t, func() {
-		Convey("Finds one user", func() {
-			MockConnection := &MockConnection{}
-			entry := ldap.Entry{
-				DN: "dn", Attributes: []*ldap.EntryAttribute{
-					{Name: "username", Values: []string{"roelgerrits"}},
-					{Name: "surname", Values: []string{"Gerrits"}},
-					{Name: "email", Values: []string{"roel@test.com"}},
-					{Name: "name", Values: []string{"Roel"}},
-					{Name: "memberof", Values: []string{"admins"}},
-				}}
-			result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
-			MockConnection.setSearchResult(&result)
+}
 
-			// Set up attribute map without surname and email
-			server := &Server{
-				Config: &ServerConfig{
-					Attr: AttributeMap{
-						Username: "username",
-						Name:     "name",
-						MemberOf: "memberof",
-					},
-					SearchBaseDNs: []string{"BaseDNHere"},
+func TestServer_Users(t *testing.T) {
+	t.Run("one user", func(t *testing.T) {
+		conn := &MockConnection{}
+		entry := ldap.Entry{
+			DN: "dn", Attributes: []*ldap.EntryAttribute{
+				{Name: "username", Values: []string{"roelgerrits"}},
+				{Name: "surname", Values: []string{"Gerrits"}},
+				{Name: "email", Values: []string{"roel@test.com"}},
+				{Name: "name", Values: []string{"Roel"}},
+				{Name: "memberof", Values: []string{"admins"}},
+			}}
+		result := ldap.SearchResult{Entries: []*ldap.Entry{&entry}}
+		conn.setSearchResult(&result)
+
+		// Set up attribute map without surname and email
+		server := &Server{
+			Config: &ServerConfig{
+				Attr: AttributeMap{
+					Username: "username",
+					Name:     "name",
+					MemberOf: "memberof",
 				},
-				Connection: MockConnection,
-				log:        log.New("test-logger"),
-			}
+				SearchBaseDNs: []string{"BaseDNHere"},
+			},
+			Connection: conn,
+			log:        log.New("test-logger"),
+		}
 
-			searchResult, err := server.Users([]string{"roelgerrits"})
+		searchResult, err := server.Users([]string{"roelgerrits"})
 
-			So(err, ShouldBeNil)
-			So(searchResult, ShouldNotBeNil)
+		require.NoError(t, err)
+		assert.NotNil(t, searchResult)
 
-			// User should be searched in ldap
-			So(MockConnection.SearchCalled, ShouldBeTrue)
-
-			// No empty attributes should be added to the search request
-			So(len(MockConnection.SearchAttributes), ShouldEqual, 3)
-		})
-
-		Convey("Handles a error", func() {
-			expected := errors.New("Killa-gorilla")
-			MockConnection := &MockConnection{}
-			MockConnection.setSearchError(expected)
-
-			// Set up attribute map without surname and email
-			server := &Server{
-				Config: &ServerConfig{
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: MockConnection,
-				log:        log.New("test-logger"),
-			}
-
-			_, err := server.Users([]string{"roelgerrits"})
-
-			So(err, ShouldEqual, expected)
-		})
-
-		Convey("Should return empty slice if none were found", func() {
-			MockConnection := &MockConnection{}
-			result := ldap.SearchResult{Entries: []*ldap.Entry{}}
-			MockConnection.setSearchResult(&result)
-
-			// Set up attribute map without surname and email
-			server := &Server{
-				Config: &ServerConfig{
-					SearchBaseDNs: []string{"BaseDNHere"},
-				},
-				Connection: MockConnection,
-				log:        log.New("test-logger"),
-			}
-
-			searchResult, err := server.Users([]string{"roelgerrits"})
-
-			So(err, ShouldBeNil)
-			So(searchResult, ShouldBeEmpty)
-		})
+		// User should be searched in ldap
+		assert.True(t, conn.SearchCalled)
+		// No empty attributes should be added to the search request
+		assert.Len(t, conn.SearchAttributes, 3)
 	})
 
-	Convey("UserBind()", t, func() {
-		Convey("Should use provided DN and password", func() {
-			connection := &MockConnection{}
-			var actualUsername, actualPassword string
-			connection.BindProvider = func(username, password string) error {
-				actualUsername = username
-				actualPassword = password
-				return nil
-			}
-			server := &Server{
-				Connection: connection,
-				Config: &ServerConfig{
-					BindDN: "cn=admin,dc=grafana,dc=org",
-				},
-			}
+	t.Run("error", func(t *testing.T) {
+		expected := errors.New("Killa-gorilla")
+		conn := &MockConnection{}
+		conn.setSearchError(expected)
 
-			dn := "cn=user,ou=users,dc=grafana,dc=org"
-			err := server.UserBind(dn, "pwd")
+		// Set up attribute map without surname and email
+		server := &Server{
+			Config: &ServerConfig{
+				SearchBaseDNs: []string{"BaseDNHere"},
+			},
+			Connection: conn,
+			log:        log.New("test-logger"),
+		}
 
-			So(err, ShouldBeNil)
-			So(actualUsername, ShouldEqual, dn)
-			So(actualPassword, ShouldEqual, "pwd")
-		})
+		_, err := server.Users([]string{"roelgerrits"})
 
-		Convey("Should handle an error", func() {
-			connection := &MockConnection{}
-			expected := &ldap.Error{
-				ResultCode: uint16(25),
-			}
-			connection.BindProvider = func(username, password string) error {
-				return expected
-			}
-			server := &Server{
-				Connection: connection,
-				Config: &ServerConfig{
-					BindDN: "cn=%s,ou=users,dc=grafana,dc=org",
-				},
-				log: log.New("test-logger"),
-			}
-			err := server.UserBind("user", "pwd")
-			So(err, ShouldEqual, expected)
-		})
+		assert.ErrorIs(t, err, expected)
 	})
 
-	Convey("AdminBind()", t, func() {
-		Convey("Should use admin DN and password", func() {
-			connection := &MockConnection{}
-			var actualUsername, actualPassword string
-			connection.BindProvider = func(username, password string) error {
-				actualUsername = username
-				actualPassword = password
-				return nil
-			}
+	t.Run("no user", func(t *testing.T) {
+		conn := &MockConnection{}
+		result := ldap.SearchResult{Entries: []*ldap.Entry{}}
+		conn.setSearchResult(&result)
 
-			dn := "cn=admin,dc=grafana,dc=org"
+		// Set up attribute map without surname and email
+		server := &Server{
+			Config: &ServerConfig{
+				SearchBaseDNs: []string{"BaseDNHere"},
+			},
+			Connection: conn,
+			log:        log.New("test-logger"),
+		}
 
-			server := &Server{
-				Connection: connection,
-				Config: &ServerConfig{
-					BindPassword: "pwd",
-					BindDN:       dn,
-				},
-			}
+		searchResult, err := server.Users([]string{"roelgerrits"})
 
-			err := server.AdminBind()
+		require.NoError(t, err)
+		assert.Empty(t, searchResult)
+	})
+}
 
-			So(err, ShouldBeNil)
-			So(actualUsername, ShouldEqual, dn)
-			So(actualPassword, ShouldEqual, "pwd")
-		})
+func TestServer_UserBind(t *testing.T) {
+	t.Run("use provided DN and password", func(t *testing.T) {
+		connection := &MockConnection{}
+		var actualUsername, actualPassword string
+		connection.BindProvider = func(username, password string) error {
+			actualUsername = username
+			actualPassword = password
+			return nil
+		}
+		server := &Server{
+			Connection: connection,
+			Config: &ServerConfig{
+				BindDN: "cn=admin,dc=grafana,dc=org",
+			},
+		}
 
-		Convey("Should handle an error", func() {
-			connection := &MockConnection{}
-			expected := &ldap.Error{
-				ResultCode: uint16(25),
-			}
-			connection.BindProvider = func(username, password string) error {
-				return expected
-			}
+		dn := "cn=user,ou=users,dc=grafana,dc=org"
+		err := server.UserBind(dn, "pwd")
 
-			dn := "cn=admin,dc=grafana,dc=org"
+		require.NoError(t, err)
+		assert.Equal(t, dn, actualUsername)
+		assert.Equal(t, "pwd", actualPassword)
+	})
 
-			server := &Server{
-				Connection: connection,
-				Config: &ServerConfig{
-					BindPassword: "pwd",
-					BindDN:       dn,
-				},
-				log: log.New("test-logger"),
-			}
+	t.Run("error", func(t *testing.T) {
+		connection := &MockConnection{}
+		expected := &ldap.Error{
+			ResultCode: uint16(25),
+		}
+		connection.BindProvider = func(username, password string) error {
+			return expected
+		}
+		server := &Server{
+			Connection: connection,
+			Config: &ServerConfig{
+				BindDN: "cn=%s,ou=users,dc=grafana,dc=org",
+			},
+			log: log.New("test-logger"),
+		}
+		err := server.UserBind("user", "pwd")
+		assert.ErrorIs(t, err, expected)
+	})
+}
 
-			err := server.AdminBind()
-			So(err, ShouldEqual, expected)
-		})
+func TestServer_AdminBind(t *testing.T) {
+	t.Run("use admin DN and password", func(t *testing.T) {
+		connection := &MockConnection{}
+		var actualUsername, actualPassword string
+		connection.BindProvider = func(username, password string) error {
+			actualUsername = username
+			actualPassword = password
+			return nil
+		}
+
+		dn := "cn=admin,dc=grafana,dc=org"
+
+		server := &Server{
+			Connection: connection,
+			Config: &ServerConfig{
+				BindPassword: "pwd",
+				BindDN:       dn,
+			},
+		}
+
+		err := server.AdminBind()
+		require.NoError(t, err)
+
+		assert.Equal(t, dn, actualUsername)
+		assert.Equal(t, "pwd", actualPassword)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		connection := &MockConnection{}
+		expected := &ldap.Error{
+			ResultCode: uint16(25),
+		}
+		connection.BindProvider = func(username, password string) error {
+			return expected
+		}
+
+		dn := "cn=admin,dc=grafana,dc=org"
+
+		server := &Server{
+			Connection: connection,
+			Config: &ServerConfig{
+				BindPassword: "pwd",
+				BindDN:       dn,
+			},
+			log: log.New("test-logger"),
+		}
+
+		err := server.AdminBind()
+		assert.ErrorIs(t, err, expected)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes bug when using multiple search base DNs for LDAP.

- [x] Fix bug
- [x] Test

**Which issue(s) this PR fixes**:

Fixes #39028

**Special notes for your reviewer**:

Look at each commit individually, almost all changes line-wise are in 450631f which is a plain conversion from Convey to Testify.