### PR TITLE
Dashboard: Forces panel re-render when exiting panel edit

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -128,6 +128,7 @@ export function exitPanelEditor(): ThunkResult<void> {
       // But do this after the panel edit editor exit process has completed
       setTimeout(() => {
         sourcePanel.getQueryRunner().useLastResultFrom(panel.getQueryRunner());
+        sourcePanel.render();
       }, 20);
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Forces re-render of changed panel when leaving panel edit.

**Which issue(s) this PR fixes**:
Fixes #38903

**Special notes for your reviewer**:

