### PR TITLE
Graph: Make old graph panel thresholds work even if ngalert is enabled 

### DIFF
--- a/public/app/features/alerting/state/ThresholdMapper.ts
+++ b/public/app/features/alerting/state/ThresholdMapper.ts
@@ -1,9 +1,10 @@
+import { config } from 'app/core/config';
 import { PanelModel } from 'app/features/dashboard/state';
 
 export const hiddenReducerTypes = ['percent_diff', 'percent_diff_abs'];
 export class ThresholdMapper {
   static alertToGraphThresholds(panel: PanelModel) {
-    if (!panel.alert) {
+    if (!panel.alert || config.featureToggles.ngalert) {
       return false; // no update when no alerts
     }
 

--- a/public/app/features/alerting/state/ThresholdMapper.ts
+++ b/public/app/features/alerting/state/ThresholdMapper.ts
@@ -1,10 +1,11 @@
+import { config } from 'app/core/config';
 import { PanelModel } from 'app/features/dashboard/state';
 
 export const hiddenReducerTypes = ['percent_diff', 'percent_diff_abs'];
 export class ThresholdMapper {
   static alertToGraphThresholds(panel: PanelModel) {
-    if (!panel.alert) {
-      return false; // no update when no alerts
+    if (!panel.alert || config.featureToggles.ngalert) {
+      return false; // no update when no alerts or ngalert is enabled (old panel alerts then should not affect anything)
     }
 
     for (let i = 0; i < panel.alert.conditions.length; i++) {

--- a/public/app/features/alerting/state/ThresholdMapper.ts
+++ b/public/app/features/alerting/state/ThresholdMapper.ts
@@ -1,11 +1,10 @@
-import { config } from 'app/core/config';
 import { PanelModel } from 'app/features/dashboard/state';
 
 export const hiddenReducerTypes = ['percent_diff', 'percent_diff_abs'];
 export class ThresholdMapper {
   static alertToGraphThresholds(panel: PanelModel) {
-    if (!panel.alert || config.featureToggles.ngalert) {
-      return false; // no update when no alerts or ngalert is enabled (old panel alerts then should not affect anything)
+    if (!panel.alert) {
+      return false; // no update when no alerts
     }
 
     for (let i = 0; i < panel.alert.conditions.length; i++) {

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -5,6 +5,7 @@ import { Modal, ConfirmModal, Button } from '@grafana/ui';
 import { DashboardModel, PanelModel } from '../../state';
 import { useDashboardDelete } from './useDashboardDelete';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
+import { config } from 'app/core/config';
 
 type DeleteDashboardModalProps = {
   hideModal(): void;
@@ -41,7 +42,7 @@ export const DeleteDashboardModal: React.FC<DeleteDashboardModalProps> = ({ hide
 
 const getModalBody = (panels: PanelModel[], title: string) => {
   const totalAlerts = sumBy(panels, (panel) => (panel.alert ? 1 : 0));
-  return totalAlerts > 0 ? (
+  return totalAlerts > 0 && !config.featureToggles.ngalert ? (
     <>
       <p>Do you want to delete this dashboard?</p>
       <p>

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -220,10 +220,6 @@ export class PanelModel implements DataConfigSource, IPanelModel {
 
     // copy properties from persisted model
     for (const property in model) {
-      // ignore old panel alerts if ngalert is set
-      if (property === 'alert' && config.featureToggles.ngalert) {
-        continue;
-      }
       (this as any)[property] = model[property];
     }
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -220,6 +220,10 @@ export class PanelModel implements DataConfigSource, IPanelModel {
 
     // copy properties from persisted model
     for (const property in model) {
+      // ignore old panel alerts if ngalert is set
+      if (property === 'alert' && config.featureToggles.ngalert) {
+        continue;
+      }
       (this as any)[property] = model[property];
     }
 

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -25,9 +25,10 @@ import { UnlinkModal } from 'app/features/library-panels/components/UnlinkModal/
 export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: boolean) => {
   // confirm deletion
   if (ask !== false) {
-    const text2 = panel.alert
-      ? 'Panel includes an alert rule. removing the panel will also remove the alert rule'
-      : undefined;
+    const text2 =
+      panel.alert && !config.featureToggles.ngalert
+        ? 'Panel includes an alert rule. removing the panel will also remove the alert rule'
+        : undefined;
     const confirmText = panel.alert ? 'YES' : undefined;
 
     appEvents.publish(

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -63,7 +63,7 @@ class GraphElement {
   data: any[] = [];
   panelWidth: number;
   eventManager: EventManager;
-  thresholdManager?: ThresholdManager;
+  thresholdManager: ThresholdManager;
   timeRegionManager: TimeRegionManager;
   declare legendElem: HTMLElement;
 
@@ -76,10 +76,7 @@ class GraphElement {
 
     this.panelWidth = 0;
     this.eventManager = new EventManager(this.ctrl);
-    // unified alerting does not support threshold for graphs, at least for now
-    if (!config.featureToggles.ngalert) {
-      this.thresholdManager = new ThresholdManager(this.ctrl);
-    }
+    this.thresholdManager = new ThresholdManager(this.ctrl);
     this.timeRegionManager = new TimeRegionManager(this.ctrl);
     // @ts-ignore
     this.tooltip = new GraphTooltip(this.elem, this.ctrl.dashboard, this.scope, () => {
@@ -382,9 +379,7 @@ class GraphElement {
       }
       msg.appendTo(this.elem);
     }
-    if (this.thresholdManager) {
-      this.thresholdManager.draw(plot);
-    }
+    this.thresholdManager.draw(plot);
     this.timeRegionManager.draw(plot);
   }
 
@@ -455,9 +450,7 @@ class GraphElement {
     }
 
     // give space to alert editing
-    if (this.thresholdManager) {
-      this.thresholdManager.prepare(this.elem, this.data);
-    }
+    this.thresholdManager.prepare(this.elem, this.data);
 
     // un-check dashes if lines are unchecked
     this.panel.dashes = this.panel.lines ? this.panel.dashes : false;
@@ -466,9 +459,7 @@ class GraphElement {
     const options: any = this.buildFlotOptions(this.panel);
     this.prepareXAxis(options, this.panel);
     this.configureYAxisOptions(this.data, options);
-    if (this.thresholdManager) {
-      this.thresholdManager.addFlotOptions(options, this.panel);
-    }
+    this.thresholdManager.addFlotOptions(options, this.panel);
     this.timeRegionManager.addFlotOptions(options, this.panel);
     this.eventManager.addFlotEvents(this.annotations, options);
     this.sortedSeries = this.sortSeries(this.data, this.panel);

--- a/public/app/plugins/panel/graph/thresholds_form.ts
+++ b/public/app/plugins/panel/graph/thresholds_form.ts
@@ -12,7 +12,7 @@ export class ThresholdFormCtrl {
   $onInit() {
     this.panel = this.panelCtrl.panel;
 
-    if (this.panel.alert) {
+    if (this.panel.alert && !config.featureToggles.ngalert) {
       this.disabled = true;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/grafana/grafana/pull/33850 I mistakenly entirely disabled threshold visualization feature for graph panels. The intention was, if `ngalert` is enabled, to not show threshold for old panel alert which might still be on the panel model. Determining threshold value for any ng alert(s) connected to the panel is not implemented yet.

~~This PR undoes the change and insted does not set `panel.alert` if `ngalert` is enabled.~~

This PR makes sure `panel.alert` is ignored if `ngalert` is enabled.

However, I think there is a problem: it seems that panel alert threshold was persisted to `panel.thresholds`. So even if `panel.alert` is no longer there, the threshold is still shown. While initially this threshold kinda makes sense because panel alert was converted to ng alert which is still attached to the panel, it is no longer synchronized with any changes to the ngalert. I think this would be a source of confusion in the future. However if we delete or disable the threshold, user won't be able to edit thresholds manually.

Maybe ngalert migration should clear `panel.thresholds` for any panels that have a panel alert? If `ngalert` flag is unsert, I think `ThresholdMapper` would populate it again

@hugohaggmark  @torkelo  WDYT, how to proceed here?


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38596

**Special notes for your reviewer**:

