### PR TITLE
AccessControl:  "Add data source" button needs create and write rights to be enabled

### DIFF
--- a/public/app/features/datasources/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.tsx
@@ -71,7 +71,10 @@ export class DataSourcesListPage extends PureComponent<Props> {
       hasFetched,
     } = this.props;
 
-    const canCreateDataSource = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
+    const canCreateDataSource =
+      contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) &&
+      contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
+
     const linkButton = {
       href: 'datasources/new',
       title: 'Add data source',

--- a/public/app/features/explore/NoDataSourceCallToAction.tsx
+++ b/public/app/features/explore/NoDataSourceCallToAction.tsx
@@ -8,7 +8,9 @@ import { AccessControlAction } from 'app/types';
 export const NoDataSourceCallToAction = () => {
   const theme = useTheme2();
 
-  const canCreateDataSource = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
+  const canCreateDataSource =
+    contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) &&
+    contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
 
   const message =
     'Explore requires at least one data source. Once you have added a data source, you can query it here.';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Given what has been mentioned in this feature request, https://github.com/grafana/grafana/discussions/38924, to provide the end user with a good user experience, we need to enable the "Add data source" only when the end user has both `datasources:create` and `datasources:write` rights.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana-enterprise/issues/1873
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

