### PR TITLE
Postgres/MySQL/MSSQL: Fix region annotations not displayed correctly

### DIFF
--- a/pkg/tsdb/mssql/mssql_test.go
+++ b/pkg/tsdb/mssql/mssql_test.go
@@ -1163,6 +1163,32 @@ func TestMSSQL(t *testing.T) {
 			// Should be in time.Time
 			require.Nil(t, frames[0].Fields[0].At(0))
 		})
+
+		t.Run("When doing an annotation query with a time and timeend column should return two fields of type time", func(t *testing.T) {
+			query := &backend.QueryDataRequest{
+				Queries: []backend.DataQuery{
+					{
+						JSON: []byte(`{
+							"rawSql": "SELECT 1631053772276 as time, 1631054012276 as timeend, '' as text, '' as tags",
+							"format": "table"
+						}`),
+						RefID: "A",
+					},
+				},
+			}
+
+			resp, err := endpoint.QueryData(context.Background(), query)
+			require.NoError(t, err)
+			queryResult := resp.Responses["A"]
+			require.NoError(t, queryResult.Error)
+
+			frames := queryResult.Frames
+			require.Equal(t, 1, len(frames))
+			require.Equal(t, 4, len(frames[0].Fields))
+
+			require.Equal(t, data.FieldTypeNullableTime, frames[0].Fields[0].Type())
+			require.Equal(t, data.FieldTypeNullableTime, frames[0].Fields[1].Type())
+		})
 	})
 }
 

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -1125,6 +1125,32 @@ func TestMySQL(t *testing.T) {
 			//Should be in time.Time
 			require.Nil(t, frames[0].Fields[0].At(0))
 		})
+
+		t.Run("When doing an annotation query with a time and timeend column should return two fields of type time", func(t *testing.T) {
+			query := &backend.QueryDataRequest{
+				Queries: []backend.DataQuery{
+					{
+						JSON: []byte(`{
+							"rawSql": "SELECT 1631053772276 as time, 1631054012276 as timeend, '' as text, '' as tags",
+							"format": "table"
+						}`),
+						RefID: "A",
+					},
+				},
+			}
+
+			resp, err := exe.QueryData(context.Background(), query)
+			require.NoError(t, err)
+			queryResult := resp.Responses["A"]
+			require.NoError(t, queryResult.Error)
+
+			frames := queryResult.Frames
+			require.Equal(t, 1, len(frames))
+			require.Equal(t, 4, len(frames[0].Fields))
+
+			require.Equal(t, data.FieldTypeNullableTime, frames[0].Fields[0].Type())
+			require.Equal(t, data.FieldTypeNullableTime, frames[0].Fields[1].Type())
+		})
 	})
 }
 

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -1199,6 +1199,32 @@ func TestPostgres(t *testing.T) {
 			// Should be in time.Time
 			assert.Nil(t, frames[0].Fields[0].At(0))
 		})
+
+		t.Run("When doing an annotation query with a time and timeend column should return two fields of type time", func(t *testing.T) {
+			query := &backend.QueryDataRequest{
+				Queries: []backend.DataQuery{
+					{
+						JSON: []byte(`{
+							"rawSql": "SELECT 1631053772276 as time, 1631054012276 as timeend, '' as text, '' as tags",
+							"format": "table"
+						}`),
+						RefID: "A",
+					},
+				},
+			}
+
+			resp, err := exe.QueryData(context.Background(), query)
+			require.NoError(t, err)
+			queryResult := resp.Responses["A"]
+			require.NoError(t, queryResult.Error)
+
+			frames := queryResult.Frames
+			require.Equal(t, 1, len(frames))
+			require.Equal(t, 4, len(frames[0].Fields))
+
+			require.Equal(t, data.FieldTypeNullableTime, frames[0].Fields[0].Type())
+			require.Equal(t, data.FieldTypeNullableTime, frames[0].Fields[1].Type())
+		})
 	})
 }
 

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -457,7 +457,7 @@ func (e *DataSourceHandler) newProcessCfg(query backend.DataQuery, queryContext 
 
 		if qm.Format == dataQueryFormatTable && col == "timeend" {
 			qm.timeEndIndex = i
-			break
+			continue
 		}
 
 		switch col {

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -208,6 +208,7 @@ func (e *DataSourceHandler) QueryData(ctx context.Context, req *backend.QueryDat
 	return result, nil
 }
 
+//nolint: gocyclo
 func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitGroup, queryContext context.Context,
 	ch chan DBDataResponse, queryJson QueryJson) {
 	defer wg.Done()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix region annotations not displayed correctly when returning `timeend` column as epoch timestamp and by that making sure that the returned data frame field named `timeend` is treated as time type.

**Which issue(s) this PR fixes**:
Fixes #38533 

**Special notes for your reviewer**:
- I'll make sure to add a couple tests before merge, but would like a quick review before that trying to get this included in the v8.1.3 release tomorrow.

Have used the following annotations testing things with postgres:
```json
"annotations": {
    "list": [
      {
        "datasource": "gdev-postgres",
        "enable": false,
        "hide": false,
        "iconColor": "rgba(0, 211, 255, 1)",
        "limit": 100,
        "name": "Single timestamp",
        "rawQuery": "SELECT\n  CURRENT_TIMESTAMP - INTERVAL '1 MINUTE' as time,\n  'single timestamp' as text,\n '' as tags\n",
        "showIn": 0,
        "tags": [],
        "type": "tags"
      },
      {
        "datasource": "gdev-postgres",
        "enable": false,
        "iconColor": "red",
        "name": "Single epoch",
        "rawQuery": "SELECT\n  extract(epoch from CURRENT_TIMESTAMP - INTERVAL '1 MINUTE') AS time,\n  'single epoch' as text,\n  '' as tags\n"
      },
      {
        "datasource": "gdev-postgres",
        "enable": false,
        "iconColor": "green",
        "name": "Region timestamp",
        "rawQuery": "SELECT\n  CURRENT_TIMESTAMP - INTERVAL '5 MINUTE' as time,\n  CURRENT_TIMESTAMP - INTERVAL '1 MINUTE' as timeend,\n  'epoch timestamp' as text,\n '' as tags"
      },
      {
        "datasource": "gdev-postgres",
        "enable": false,
        "hide": false,
        "iconColor": "rgba(0, 211, 255, 1)",
        "limit": 100,
        "name": "Region epoch",
        "rawQuery": "SELECT\n  extract(epoch from (CURRENT_TIMESTAMP - INTERVAL '5 MINUTE')) as time,\n  extract(epoch from (CURRENT_TIMESTAMP - INTERVAL '1 MINUTE')) as timeend,\n  'epoch region' as text,\n '' as tags",
        "showIn": 0,
        "tags": [],
        "type": "tags"
      }
    ]
}
```