### PR TITLE
Plugins: Track signed files + add warn log for plugin assets which are not signed

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -133,7 +133,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/api/login/ping", quota("session"), routing.Wrap(hs.LoginAPIPing))
 
 	// expose plugin file system assets
-	r.Get("/public/plugins/:pluginId/*", hs.GetPluginAssets)
+	r.Get("/public/plugins/:pluginId/*", hs.getPluginAssets)
 
 	// authed api
 	r.Group("/api", func(apiRoute routing.RouteRegister) {

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -512,6 +512,7 @@ func (pm *PluginManager) loadPlugin(jsonParser *json.Decoder, pluginBase *plugin
 	pb.Signature = pluginBase.Signature
 	pb.SignatureType = pluginBase.SignatureType
 	pb.SignatureOrg = pluginBase.SignatureOrg
+	pb.SignedFiles = pluginBase.SignedFiles
 
 	pm.plugins[pb.Id] = pb
 	pm.log.Debug("Successfully added plugin", "id", pb.Id)
@@ -581,6 +582,7 @@ func (s *PluginScanner) loadPlugin(pluginJSONFilePath string) error {
 	pluginCommon.Signature = signatureState.Status
 	pluginCommon.SignatureType = signatureState.Type
 	pluginCommon.SignatureOrg = signatureState.SigningOrg
+	pluginCommon.SignedFiles = signatureState.Files
 
 	s.plugins[currentDir] = &pluginCommon
 

--- a/pkg/plugins/manager/manager_test.go
+++ b/pkg/plugins/manager/manager_test.go
@@ -232,6 +232,7 @@ func TestPluginManager_Init(t *testing.T) {
 				Signature:     plugins.PluginSignatureValid,
 				SignatureType: plugins.GrafanaType,
 				SignatureOrg:  "Grafana Labs",
+				SignedFiles:   plugins.PluginFiles{"plugin.json": {}},
 				Dependencies: plugins.PluginDependencies{
 					GrafanaVersion: "*",
 					Plugins:        []plugins.PluginDependencyItem{},
@@ -497,6 +498,7 @@ func TestPluginManager_Installer(t *testing.T) {
 			Signature:     plugins.PluginSignatureValid,
 			SignatureType: plugins.GrafanaType,
 			SignatureOrg:  "Grafana Labs",
+			SignedFiles:   plugins.PluginFiles{"plugin.json": {}},
 			Dependencies: plugins.PluginDependencies{
 				GrafanaVersion: "*",
 				Plugins:        []plugins.PluginDependencyItem{},

--- a/pkg/plugins/manager/manifest.go
+++ b/pkg/plugins/manager/manifest.go
@@ -169,7 +169,7 @@ func getPluginSignatureState(log log.Logger, plugin *plugins.PluginBase) (plugin
 		}
 	}
 
-	manifestFiles := make(map[string]bool, len(manifest.Files))
+	manifestFiles := make(map[string]struct{}, len(manifest.Files))
 
 	// Verify the manifest contents
 	log.Debug("Verifying contents of plugin manifest", "plugin", plugin.Id)
@@ -207,7 +207,7 @@ func getPluginSignatureState(log log.Logger, plugin *plugins.PluginBase) (plugin
 				Status: plugins.PluginSignatureModified,
 			}, nil
 		}
-		manifestFiles[p] = true
+		manifestFiles[p] = struct{}{}
 	}
 
 	if manifest.isV2() {
@@ -241,6 +241,7 @@ func getPluginSignatureState(log log.Logger, plugin *plugins.PluginBase) (plugin
 		Status:     plugins.PluginSignatureValid,
 		Type:       manifest.SignatureType,
 		SigningOrg: manifest.SignedByOrgName,
+		Files:      manifestFiles,
 	}, nil
 }
 

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -73,11 +73,29 @@ type PluginBase struct {
 	IsCorePlugin    bool                `json:"-"`
 	SignatureType   PluginSignatureType `json:"-"`
 	SignatureOrg    string              `json:"-"`
+	SignedFiles     PluginFiles         `json:"-"`
 
 	GrafanaNetVersion   string `json:"-"`
 	GrafanaNetHasUpdate bool   `json:"-"`
 
 	Root *PluginBase
+}
+
+func (p *PluginBase) IncludedInSignature(file string) bool {
+	// permit Core plugin files
+	if p.IsCorePlugin {
+		return true
+	}
+
+	// permit when no signed files (no MANIFEST)
+	if p.SignedFiles == nil {
+		return true
+	}
+
+	if _, exists := p.SignedFiles[file]; !exists {
+		return false
+	}
+	return true
 }
 
 type PluginDependencies struct {

--- a/pkg/plugins/state.go
+++ b/pkg/plugins/state.go
@@ -31,8 +31,11 @@ const (
 	PrivateType PluginSignatureType = "private"
 )
 
+type PluginFiles map[string]struct{}
+
 type PluginSignatureState struct {
 	Status     PluginSignatureStatus
 	Type       PluginSignatureType
 	SigningOrg string
+	Files      PluginFiles
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of keeping a file extension allowlist, add a step towards serve plugin files which are signed in the MANIFEST only. Currently this will only log for plugins which have a MANIFEST.txt (IE are signed) and are request a file that is not listed within the MANIFEST. If the plugin is unsigned, we will not log. In all cases, we will still serve the static file.

Fixes: #38690 #38570
