### PR TITLE
prometheus: query-editor: only allow monaco in explore-mode

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -65,6 +65,7 @@ export const PromExploreQueryEditor: FC<Props> = (props: Props) => {
 
   return (
     <PromQueryField
+      isExplore={true}
       datasource={datasource}
       query={query}
       range={range}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -81,6 +81,7 @@ interface PromQueryFieldProps extends ExploreQueryFieldProps<PrometheusDatasourc
   ExtraFieldElement?: ReactNode;
   placeholder?: string;
   'data-testid'?: string;
+  isExplore?: boolean;
 }
 
 interface PromQueryFieldState {
@@ -281,7 +282,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
     const chooserText = getChooserText(datasource.lookupsDisabled, syntaxLoaded, hasMetrics);
     const buttonDisabled = !(syntaxLoaded && hasMetrics);
 
-    const isMonacoEditorEnabled = config.featureToggles.prometheusMonaco;
+    const isMonacoEditorEnabled = this.props.isExplore && config.featureToggles.prometheusMonaco;
 
     return (
       <>

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`PromExploreQueryEditor should render component 1`] = `
     }
   }
   history={Array []}
+  isExplore={true}
   onBlur={[Function]}
   onChange={[MockFunction]}
   onRunQuery={[MockFunction]}


### PR DESCRIPTION
we have a new monaco-based prometheus query-field. it is behind a feature flag.

there are currently problems when using it in dashboards (the autocomplete-popup is sometimes clipped by other elements on the page), so for now we will only show it if: feature_flag_enabled AND explore_mode.