### PR TITLE
Explore: Add filter by trace or span ID to `trace to logs` feature

### DIFF
--- a/docs/sources/datasources/jaeger.md
+++ b/docs/sources/datasources/jaeger.md
@@ -37,7 +37,7 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 - **Filter by Trace ID -** Toggle to append the trace ID to the Loki query.
 - **Filter by Span ID -** Toggle to append the span ID to the Loki query.
 
-![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8.png 'Screenshot of the trace to logs settings')
+![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8-2.png 'Screenshot of the trace to logs settings')
 
 ## Query traces
 

--- a/docs/sources/datasources/jaeger.md
+++ b/docs/sources/datasources/jaeger.md
@@ -34,6 +34,8 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 - **Tags -** The tags that will be used in the Loki query. Default is `'cluster', 'hostname', 'namespace', 'pod'`.
 - **Span start time shift -** Shift in the start time for the Loki query based on the span start time. In order to extend to the past, you need to use a negative value. Use time interval units like 5s, 1m, 3h. The default is 0.
 - **Span end time shift -** Shift in the end time for the Loki query based on the span end time. Time units can be used here, for example, 5s, 1m, 3h. The default is 0.
+- **Filter by Trace ID -** Toggle to append the trace ID to the Loki query.
+- **Filter by Span ID -** Toggle to append the span ID to the Loki query.
 
 ![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8.png 'Screenshot of the trace to logs settings')
 

--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -36,7 +36,7 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 - **Filter by Trace ID -** Toggle to append the trace ID to the Loki query.
 - **Filter by Span ID -** Toggle to append the span ID to the Loki query.
 
-![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8.png 'Screenshot of the trace to logs settings')
+![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8-2.png 'Screenshot of the trace to logs settings')
 
 ## Query traces
 

--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -33,6 +33,8 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 - **Tags -** The tags that will be used in the Loki query. Default is `'cluster', 'hostname', 'namespace', 'pod'`.
 - **Span start time shift -** A shift in the start time for the Loki query based on the start time for the span. To extend the time to the past, use a negative value. You can use time units, for example, 5s, 1m, 3h. The default is 0.
 - **Span end time shift -** Shift in the end time for the Loki query based on the span end time. Time units can be used here, for example, 5s, 1m, 3h. The default is 0.
+- **Filter by Trace ID -** Toggle to append the trace ID to the Loki query.
+- **Filter by Span ID -** Toggle to append the span ID to the Loki query.
 
 ![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8.png 'Screenshot of the trace to logs settings')
 

--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -37,7 +37,7 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 - **Filter by Trace ID -** Toggle to append the trace ID to the Loki query.
 - **Filter by Span ID -** Toggle to append the span ID to the Loki query.
 
-![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8.png 'Screenshot of the trace to logs settings')
+![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8-2.png 'Screenshot of the trace to logs settings')
 
 ## Query traces
 

--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -34,6 +34,8 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 - **Tags -** The tags that will be used in the Loki query. Default is `'cluster', 'hostname', 'namespace', 'pod'`.
 - **Span start time shift -** Shift in the start time for the Loki query based on the span start time. In order to extend to the past, you need to use a negative value. Use time interval units like 5s, 1m, 3h. The default is 0.
 - **Span end time shift -** Shift in the end time for the Loki query based on the span end time. Time units can be used here, for example, 5s, 1m, 3h. The default is 0.
+- **Filter by Trace ID -** Toggle to append the trace ID to the Loki query.
+- **Filter by Span ID -** Toggle to append the span ID to the Loki query.
 
 ![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8.png 'Screenshot of the trace to logs settings')
 

--- a/public/app/core/components/TraceToLogsSettings.tsx
+++ b/public/app/core/components/TraceToLogsSettings.tsx
@@ -6,7 +6,7 @@ import {
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { InlineField, InlineFieldRow, Input, TagsInput, useStyles } from '@grafana/ui';
+import { InlineField, InlineFieldRow, Input, TagsInput, useStyles, InlineSwitch } from '@grafana/ui';
 import React from 'react';
 
 export interface TraceToLogsOptions {
@@ -14,6 +14,8 @@ export interface TraceToLogsOptions {
   tags?: string[];
   spanStartTimeShift?: string;
   spanEndTimeShift?: string;
+  filterByTraceID?: boolean;
+  filterBySpanID?: boolean;
 }
 
 export interface TraceToLogsData extends DataSourceJsonData {
@@ -109,6 +111,44 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
               })
             }
             value={options.jsonData.tracesToLogs?.spanEndTimeShift || ''}
+          />
+        </InlineField>
+      </InlineFieldRow>
+
+      <InlineFieldRow>
+        <InlineField
+          label="Filter by Trace ID"
+          labelWidth={26}
+          grow
+          tooltip="Filters logs by Trace ID. Appends '|=<trace id>' to the query."
+        >
+          <InlineSwitch
+            value={options.jsonData.tracesToLogs?.filterByTraceID}
+            onChange={(event: React.SyntheticEvent<HTMLInputElement>) =>
+              updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToLogs', {
+                ...options.jsonData.tracesToLogs,
+                filterByTraceID: event.currentTarget.checked,
+              })
+            }
+          />
+        </InlineField>
+      </InlineFieldRow>
+
+      <InlineFieldRow>
+        <InlineField
+          label="Filter by Span ID"
+          labelWidth={26}
+          grow
+          tooltip="Filters logs by Span ID. Appends '|=<span id>' to the query."
+        >
+          <InlineSwitch
+            value={options.jsonData.tracesToLogs?.filterBySpanID}
+            onChange={(event: React.SyntheticEvent<HTMLInputElement>) =>
+              updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToLogs', {
+                ...options.jsonData.tracesToLogs,
+                filterBySpanID: event.currentTarget.checked,
+              })
+            }
           />
         </InlineField>
       </InlineFieldRow>

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -174,5 +174,49 @@ describe('createSpanLinkFactory', () => {
         )}`
       );
     });
+
+    it('filters by trace and span ID', () => {
+      const splitOpenFn = jest.fn();
+      const createLink = createSpanLinkFactory(splitOpenFn, {
+        datasourceUid: 'lokiUid',
+        filterBySpanID: true,
+        filterByTraceID: true,
+      });
+      expect(createLink).toBeDefined();
+      const linkDef = createLink!({
+        spanID: '6605c7b08e715d6c',
+        traceID: '7946b05c2e2e4e5a',
+        startTime: new Date('2020-10-14T01:00:00Z').valueOf() * 1000,
+        duration: 1000 * 1000,
+        tags: [
+          {
+            key: 'host',
+            value: 'host',
+          },
+        ],
+        process: {
+          tags: [
+            {
+              key: 'cluster',
+              value: 'cluster1',
+            },
+            {
+              key: 'hostname',
+              value: 'hostname1',
+            },
+            {
+              key: 'label2',
+              value: 'val2',
+            },
+          ],
+        } as any,
+      } as any);
+
+      expect(linkDef.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"loki1","queries":[{"expr":"{cluster=\\"cluster1\\", hostname=\\"hostname1\\"} |=\\"7946b05c2e2e4e5a\\" |=\\"6605c7b08e715d6c\\"","refId":""}]}'
+        )}`
+      );
+    });
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to append the trace or span ID to the Loki query created by the trace to logs feature. 

**Which issue(s) this PR fixes**:
Fixes #35268

TODO: 
- [x] Update traces to logs settings UI screenshot in docs