### PR TITLE
Plugins: added the possibility to manage field config state outside of the panel renderer.

### DIFF
--- a/packages/grafana-runtime/src/components/PanelRenderer.tsx
+++ b/packages/grafana-runtime/src/components/PanelRenderer.tsx
@@ -13,10 +13,11 @@ export interface PanelRendererProps<P extends object = any, F extends object = a
   data: PanelData;
   pluginId: string;
   title: string;
-  fieldConfig?: FieldConfigSource<F>;
   options?: P;
   onOptionsChange?: (options: P) => void;
   onChangeTimeRange?: (timeRange: AbsoluteTimeRange) => void;
+  fieldConfig?: FieldConfigSource<F>;
+  onFieldConfigChange?: (config: FieldConfigSource<F>) => void;
   timeZone?: string;
   width: number;
   height: number;


### PR DESCRIPTION
**What this PR does / why we need it**:
In alerting we have the need of managing the field config state. Currently that is handled internally in the PanelRenderer but this updates the API so you can manage the field config state outside of the PanelRenderer.

**Special notes for your reviewer**:
Not super happy with how this turned out but I think this is the best way to get the functionality in place without breaking the API.
