### PR TITLE
Chore: throw an explicit error if multiple data source types exist

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -31,32 +31,43 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricReq
 		Queries:   make([]plugins.DataSubQuery, 0, len(reqDTO.Queries)),
 	}
 
-	// Loop to see if we have an expression.
+	// Check for expressions and assert non-mixed datasource
+	prevType := ""
+	var ds *models.DataSource
 	for _, query := range reqDTO.Queries {
-		if query.Get("datasource").MustString("") == expr.DatasourceName {
+		dsType := query.Get("datasource").MustString("")
+		if dsType == expr.DatasourceName {
 			return hs.handleExpressions(c, reqDTO)
 		}
-	}
-
-	var ds *models.DataSource
-	for i, query := range reqDTO.Queries {
-		hs.log.Debug("Processing metrics query", "query", query)
-
-		datasourceID, err := query.Get("datasourceId").Int64()
-		if err != nil {
+		if prevType != "" && prevType != dsType {
+			// For mixed datasource case, each data source is sent in a single request.
+			// So only the datasource from the first query is needed. As all requests
+			// should be the same data source.
 			hs.log.Debug("Can't process query since it's missing data source ID")
-			return response.Error(http.StatusBadRequest, "Query missing data source ID", nil)
+			return response.Error(http.StatusBadRequest, "All queries must use the same datasource", nil)
 		}
 
-		// For mixed datasource case, each data source is sent in a single request.
-		// So only the datasource from the first query is needed. As all requests
-		// should be the same data source.
-		if i == 0 {
+		if ds == nil {
+			// require ID for everything
+			datasourceID, err := query.Get("datasourceId").Int64()
+			if dsType == "grafana" {
+				datasourceID = -1
+				err = nil
+			}
+			if err != nil {
+				hs.log.Debug("Can't process query since it's missing data source ID")
+				return response.Error(http.StatusBadRequest, "Query missing data source ID", nil)
+			}
 			ds, err = hs.DataSourceCache.GetDatasource(datasourceID, c.SignedInUser, c.SkipCache)
 			if err != nil {
 				return hs.handleGetDataSourceError(err, datasourceID)
 			}
 		}
+		prevType = dsType
+	}
+
+	for _, query := range reqDTO.Queries {
+		hs.log.Debug("Processing metrics query", "query", query)
 
 		request.Queries = append(request.Queries, plugins.DataSubQuery{
 			RefID:         query.Get("refId").MustString("A"),


### PR DESCRIPTION
While working on https://github.com/grafana/grafana/pull/38571 I found the hidden expectation that every query in the metrics request will use the same datasource.

This makes the requirement explicit and throws an error rather than silently using the first datasource found.

I don't see any test infra for this call -- kinda surprising given that it is the root of all plugin queries :grimacing: 