### PR TITLE
Prometheus: fix popup positioning in monaco-based query-field

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -16,6 +16,8 @@ const options: CodeEditorMonacoOptions = {
   scrollBeyondLastLine: false,
   renderLineHighlight: 'none',
   fontSize: 14,
+  // we need `fixedOverflowWidgets` because otherwise in grafana-dashboards
+  // the popup is clipped by the panel-visualizations.
   fixedOverflowWidgets: true,
 };
 

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -16,6 +16,7 @@ const options: CodeEditorMonacoOptions = {
   scrollBeyondLastLine: false,
   renderLineHighlight: 'none',
   fontSize: 14,
+  fixedOverflowWidgets: true,
 };
 
 const MonacoQueryField = (props: Props) => {


### PR DESCRIPTION
when the autocomplete-popup opens in the prometheus monaco-based query-editor, it will be clipped by other elements. the flag used in the PR fixes this problem.