### PR TITLE
AccessControl: Restrict more the access to the data sources configuration tab

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -18,6 +18,16 @@ const (
 	darkName  = "dark"
 )
 
+// dataSourcesConfigurationAccessEvaluator is used to protect the "Configure > Data sources" tab access
+var dataSourcesConfigurationAccessEvaluator = ac.EvalAll(
+	ac.EvalPermission(ActionDatasourcesRead, ScopeDatasourcesAll),
+	ac.EvalAny(
+		ac.EvalPermission(ActionDatasourcesCreate),
+		ac.EvalPermission(ActionDatasourcesDelete),
+		ac.EvalPermission(ActionDatasourcesWrite),
+	),
+)
+
 func (hs *HTTPServer) getProfileNode(c *models.ReqContext) *dtos.NavLink {
 	// Only set login if it's different from the name
 	var login string
@@ -253,7 +263,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 
 	configNodes := []*dtos.NavLink{}
 
-	if hasAccess(ac.ReqOrgAdmin, getDataSourcesConfigurationAccessEvaluator()) {
+	if hasAccess(ac.ReqOrgAdmin, dataSourcesConfigurationAccessEvaluator) {
 		configNodes = append(configNodes, &dtos.NavLink{
 			Text:        "Data sources",
 			Icon:        "database",
@@ -541,18 +551,4 @@ func getAppNameBodyClass(validLicense bool) string {
 	}
 
 	return "app-grafana"
-}
-
-// getDataSourcesConfigurationAccessEvaluator returns an accesscontrol evaluator
-// required to allow access to the "Configure > Data sources" tab
-func getDataSourcesConfigurationAccessEvaluator() ac.Evaluator {
-	// Read and at least one of the modifying action is needed
-	return ac.EvalAll(
-		ac.EvalPermission(ActionDatasourcesRead, ScopeDatasourcesAll),
-		ac.EvalAny(
-			ac.EvalPermission(ActionDatasourcesCreate),
-			ac.EvalPermission(ActionDatasourcesDelete),
-			ac.EvalPermission(ActionDatasourcesWrite),
-		),
-	)
 }

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -548,7 +548,7 @@ func getAppNameBodyClass(validLicense bool) string {
 func getDataSourcesConfigurationAccessEvaluator() ac.Evaluator {
 	// Read and at least one of the modifying action is needed
 	return ac.EvalAll(
-		ac.EvalPermission(ActionDatasourcesRead),
+		ac.EvalPermission(ActionDatasourcesRead, ScopeDatasourcesAll),
 		ac.EvalAny(
 			ac.EvalPermission(ActionDatasourcesCreate),
 			ac.EvalPermission(ActionDatasourcesDelete),

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -253,7 +253,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 
 	configNodes := []*dtos.NavLink{}
 
-	if hasAccess(ac.ReqOrgAdmin, ac.EvalPermission(ActionDatasourcesRead)) {
+	if hasAccess(ac.ReqOrgAdmin, getDataSourcesConfigurationAccessEvaluator()) {
 		configNodes = append(configNodes, &dtos.NavLink{
 			Text:        "Data sources",
 			Icon:        "database",
@@ -541,4 +541,18 @@ func getAppNameBodyClass(validLicense bool) string {
 	}
 
 	return "app-grafana"
+}
+
+// getDataSourcesConfigurationAccessEvaluator returns an accesscontrol evaluator
+// required to allow access to the "Configure > Data sources" tab
+func getDataSourcesConfigurationAccessEvaluator() ac.Evaluator {
+	// Read and at least one of the modifying action is needed
+	return ac.EvalAll(
+		ac.EvalPermission(ActionDatasourcesRead),
+		ac.EvalAny(
+			ac.EvalPermission(ActionDatasourcesCreate),
+			ac.EvalPermission(ActionDatasourcesDelete),
+			ac.EvalPermission(ActionDatasourcesWrite),
+		),
+	)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
During the discussion on https://github.com/grafana/grafana-enterprise/issues/1863: "should we grant `datasources:read` to viewers and on which scope", we thought it would be better to restrict the access to the data sources configuration tab to more than just `datasources:read`. The end user should have at least one modifying action to be granted access to this tab.

`datasources:read` has been tied with scope `datasources:*` while we haven't implemented fgac filtering https://github.com/grafana/grafana-enterprise/issues/1864 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

