### PR TITLE
LibraryPanels: Fix library panel getting saved in the dashboard's folder

### DIFF
--- a/public/app/features/library-panels/state/api.ts
+++ b/public/app/features/library-panels/state/api.ts
@@ -66,15 +66,11 @@ export async function addLibraryPanel(
   return result;
 }
 
-export async function updateLibraryPanel(
-  panelSaveModel: PanelModelWithLibraryPanel,
-  folderId: number
-): Promise<LibraryElementDTO> {
+export async function updateLibraryPanel(panelSaveModel: PanelModelWithLibraryPanel): Promise<LibraryElementDTO> {
   const { uid, name, version } = panelSaveModel.libraryPanel;
   const kind = LibraryElementKind.Panel;
   const model = panelSaveModel;
   const { result } = await getBackendSrv().patch(`/api/library-elements/${uid}`, {
-    folderId,
     name,
     model,
     version,

--- a/public/app/features/library-panels/utils.ts
+++ b/public/app/features/library-panels/utils.ts
@@ -56,5 +56,5 @@ function saveOrUpdateLibraryPanel(panel: any, folderId: number): Promise<Library
     return addLibraryPanel(panel, folderId!);
   }
 
-  return updateLibraryPanel(panel, folderId!);
+  return updateLibraryPanel(panel);
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We accidentally called the `PATCH` endpoint with the `folderId` for the dashboard, where the user invoked saving the existing library panel. This meant that the library panel would move to the same folder as the dashboard.

This PR prevents this from the Grafana frontend but it's still possible in the api.

**Which issue(s) this PR fixes**:
Fixes #38971

**Special notes for your reviewer**:
I'm not back porting this because it has some dependencies that have not been back ported yet because of new features.

