### PR TITLE
Sidemenu: Use `<a>` instead of `<Link>` when target is present

### DIFF
--- a/public/app/core/components/sidemenu/SideMenuDropDown.tsx
+++ b/public/app/core/components/sidemenu/SideMenuDropDown.tsx
@@ -5,6 +5,7 @@ import { IconName, Link } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 interface Props {
+  headerTarget?: HTMLAnchorElement['target'];
   headerText: string;
   headerUrl?: string;
   items?: NavModelItem[];
@@ -14,6 +15,7 @@ interface Props {
 }
 
 const SideMenuDropDown = ({
+  headerTarget,
   headerText,
   headerUrl,
   items = [],
@@ -22,15 +24,23 @@ const SideMenuDropDown = ({
   subtitleText,
 }: Props) => {
   const headerContent = <span className="sidemenu-item-text">{headerText}</span>;
-  const header = headerUrl ? (
-    <Link href={headerUrl} onClick={onHeaderClick} className="side-menu-header-link">
-      {headerContent}
-    </Link>
-  ) : (
+  let header = (
     <button onClick={onHeaderClick} className="side-menu-header-link">
       {headerContent}
     </button>
   );
+  if (headerUrl) {
+    header =
+      !headerTarget && headerUrl.startsWith('/') ? (
+        <Link href={headerUrl} onClick={onHeaderClick} className="side-menu-header-link">
+          {headerContent}
+        </Link>
+      ) : (
+        <a href={headerUrl} target={headerTarget} onClick={onHeaderClick} className="side-menu-header-link">
+          {headerContent}
+        </a>
+      );
+  }
 
   const menuClass = css`
     flex-direction: ${reverseDirection ? 'column-reverse' : 'column'};

--- a/public/app/core/components/sidemenu/SideMenuItem.tsx
+++ b/public/app/core/components/sidemenu/SideMenuItem.tsx
@@ -25,27 +25,37 @@ const SideMenuItem = ({
   target,
   url,
 }: Props) => {
-  const anchor = url ? (
-    <Link
-      className="sidemenu-link"
-      href={url}
-      target={target}
-      aria-label={label}
-      onClick={onClick}
-      aria-haspopup="true"
-    >
-      <span className="icon-circle sidemenu-icon">{children}</span>
-    </Link>
-  ) : (
+  let element = (
     <button className="sidemenu-link" onClick={onClick} aria-label={label}>
       <span className="icon-circle sidemenu-icon">{children}</span>
     </button>
   );
 
+  if (url) {
+    element =
+      !target && url.startsWith('/') ? (
+        <Link
+          className="sidemenu-link"
+          href={url}
+          target={target}
+          aria-label={label}
+          onClick={onClick}
+          aria-haspopup="true"
+        >
+          <span className="icon-circle sidemenu-icon">{children}</span>
+        </Link>
+      ) : (
+        <a href={url} target={target} className="sidemenu-link" onClick={onClick} aria-label={label}>
+          <span className="icon-circle sidemenu-icon">{children}</span>
+        </a>
+      );
+  }
+
   return (
     <div className={cx('sidemenu-item', 'dropdown', { dropup: reverseMenuDirection })}>
-      {anchor}
+      {element}
       <SideMenuDropDown
+        headerTarget={target}
         headerText={label}
         headerUrl={url}
         items={menuItems}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- when logging in, the link in the corresponding `SideMenuItem`s needs to be an `<a>` link so it calls the backend router correctly
- only use `<Link>` in the `SideMenuItem` and menu header if there is no `target` and the route is internal (starts with `/`)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes side menu login

**Special notes for your reviewer**:

