### PR TITLE
Alerting: Fix tests that create temp file with default template

### DIFF
--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -89,7 +89,9 @@ Labels:
 func templateForTests(t *testing.T) *template.Template {
 	f, err := ioutil.TempFile("/tmp", "template")
 	require.NoError(t, err)
-	defer require.NoError(t, f.Close())
+	defer func(f *os.File) {
+		_ = f.Close()
+	}(f)
 
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(f.Name()))

--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -89,6 +89,7 @@ Labels:
 func templateForTests(t *testing.T) *template.Template {
 	f, err := ioutil.TempFile("/tmp", "template")
 	require.NoError(t, err)
+	defer f.Close()
 
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(f.Name()))

--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -89,7 +89,7 @@ Labels:
 func templateForTests(t *testing.T) *template.Template {
 	f, err := ioutil.TempFile("/tmp", "template")
 	require.NoError(t, err)
-	defer f.Close()
+	defer require.NoError(t, f.Close())
 
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(f.Name()))

--- a/pkg/services/ngalert/notifier/channels/default_template_test.go
+++ b/pkg/services/ngalert/notifier/channels/default_template_test.go
@@ -58,7 +58,7 @@ func TestDefaultTemplateString(t *testing.T) {
 
 	f, err := ioutil.TempFile("/tmp", "template")
 	require.NoError(t, err)
-	defer f.Close()
+	defer require.NoError(t, f.Close())
 
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(f.Name()))

--- a/pkg/services/ngalert/notifier/channels/default_template_test.go
+++ b/pkg/services/ngalert/notifier/channels/default_template_test.go
@@ -58,6 +58,7 @@ func TestDefaultTemplateString(t *testing.T) {
 
 	f, err := ioutil.TempFile("/tmp", "template")
 	require.NoError(t, err)
+	defer f.Close()
 
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(f.Name()))

--- a/pkg/services/ngalert/notifier/channels/default_template_test.go
+++ b/pkg/services/ngalert/notifier/channels/default_template_test.go
@@ -58,7 +58,9 @@ func TestDefaultTemplateString(t *testing.T) {
 
 	f, err := ioutil.TempFile("/tmp", "template")
 	require.NoError(t, err)
-	defer require.NoError(t, f.Close())
+	defer func(f *os.File) {
+		_ = f.Close()
+	}(f)
 
 	t.Cleanup(func() {
 		require.NoError(t, os.RemoveAll(f.Name()))


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This does not touch any production code but just fixes a group of tests that create a temp file. Although those tests pass, the clean up procedure fails (at least in Windows) because the file descriptor is still used.