### PR TITLE
Scuemata: Copy `cue.mod` and `packages/grafana-schema` directories to container WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ WORKDIR $GOPATH/src/github.com/grafana/grafana
 
 COPY go.mod go.sum embed.go ./
 COPY cue cue
+COPY cue.mod cue.mod
+COPY packages/grafana-schema packages/grafana-schema
 COPY public/app/plugins public/app/plugins
 COPY pkg pkg
 COPY build.go package.json ./

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -25,6 +25,8 @@ COPY go.mod go.sum embed.go ./
 COPY build.go package.json ./
 COPY pkg pkg/
 COPY cue cue/
+COPY cue.mod cue.mod/
+COPY packages/grafana-schema packages/grafana-schema/
 COPY public/app/plugins public/app/plugins/
 
 RUN go mod verify


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, building our docker image using either `Dockerfile` or `Dockerfile.ubuntu` fails with message:

```
...
embed.go:10:12: pattern cue.mod: no matching files found
exit status 1
exit status 1
```

That's happening because the appropriate directories are not being copied to the docker container workdir.
This PR fixes that by copying:

* `cue.mod` to `cue.mod` directory in the container, and
* `packages/grafana-schema` to `packages/grafana-schema`, for `embed.go` to work properly.

**Which issue(s) this PR fixes**:

Fixes #38946

