### PR TITLE
Macaron: Continue on invalid slice type to avoid panic

### DIFF
--- a/pkg/macaron/binding/binding.go
+++ b/pkg/macaron/binding/binding.go
@@ -419,6 +419,10 @@ func validateField(errors Errors, zero interface{}, field reflect.StructField, f
 				sliceVal = sliceVal.Elem()
 			}
 
+			if sliceVal.Kind() == reflect.Invalid {
+				continue
+			}
+
 			sliceValue := sliceVal.Interface()
 			zero := reflect.Zero(sliceVal.Type()).Interface()
 			if sliceVal.Kind() == reflect.Struct ||


### PR DESCRIPTION
I do not currently really get this, but this makes the panic go away.
Otherwise I get a reflect: call of reflect.Value.Interface on zero Value and same if I try CanInterface as well
in this spot. Not sure exactly the type that is triggering it


**Special notes for your reviewer**:

