### PR TITLE
LibraryElements: Enable specifying UID for new and existing library elements

### DIFF
--- a/pkg/services/dashboards/dashboard_service.go
+++ b/pkg/services/dashboards/dashboard_service.go
@@ -103,7 +103,7 @@ func (dr *dashboardServiceImpl) buildSaveDashboardCommand(dto *SaveDashboardDTO,
 
 	if !util.IsValidShortUID(dash.Uid) {
 		return nil, models.ErrDashboardInvalidUid
-	} else if len(dash.Uid) > 40 {
+	} else if util.IsShortUIDTooLong(dash.Uid) {
 		return nil, models.ErrDashboardUidTooLong
 	}
 

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -128,5 +128,8 @@ func toLibraryElementError(err error, message string) response.Response {
 	if errors.Is(err, errLibraryElementInvalidUID) {
 		return response.Error(400, errLibraryElementInvalidUID.Error(), err)
 	}
+	if errors.Is(err, errLibraryElementUIDTooLong) {
+		return response.Error(400, errLibraryElementUIDTooLong.Error(), err)
+	}
 	return response.Error(500, message, err)
 }

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -125,5 +125,8 @@ func toLibraryElementError(err error, message string) response.Response {
 	if errors.Is(err, errLibraryElementHasConnections) {
 		return response.Error(403, errLibraryElementHasConnections.Error(), err)
 	}
+	if errors.Is(err, errLibraryElementInvalidUID) {
+		return response.Error(400, errLibraryElementInvalidUID.Error(), err)
+	}
 	return response.Error(500, message, err)
 }

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -98,7 +98,7 @@ func (l *LibraryElementService) createLibraryElement(c *models.ReqContext, cmd C
 	}
 	if !util.IsValidShortUID(UID) {
 		return LibraryElementDTO{}, errLibraryElementInvalidUID
-	} else if len(UID) > 40 {
+	} else if util.IsShortUIDTooLong(UID) {
 		return LibraryElementDTO{}, errLibraryElementUIDTooLong
 	}
 	element := LibraryElement{

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -92,10 +92,17 @@ func (l *LibraryElementService) createLibraryElement(c *models.ReqContext, cmd C
 	if err := l.requireSupportedElementKind(cmd.Kind); err != nil {
 		return LibraryElementDTO{}, err
 	}
+	UID := cmd.UID
+	if len(UID) == 0 {
+		UID = util.GenerateShortUID()
+	}
+	if !util.IsValidShortUID(UID) {
+		return LibraryElementDTO{}, errLibraryElementInvalidUID
+	}
 	element := LibraryElement{
 		OrgID:    c.SignedInUser.OrgId,
 		FolderID: cmd.FolderID,
-		UID:      util.GenerateShortUID(),
+		UID:      UID,
 		Name:     cmd.Name,
 		Model:    cmd.Model,
 		Version:  1,

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -98,6 +98,8 @@ func (l *LibraryElementService) createLibraryElement(c *models.ReqContext, cmd C
 	}
 	if !util.IsValidShortUID(UID) {
 		return LibraryElementDTO{}, errLibraryElementInvalidUID
+	} else if len(UID) > 40 {
+		return LibraryElementDTO{}, errLibraryElementUIDTooLong
 	}
 	element := LibraryElement{
 		OrgID:    c.SignedInUser.OrgId,

--- a/pkg/services/libraryelements/libraryelements_create_test.go
+++ b/pkg/services/libraryelements/libraryelements_create_test.go
@@ -122,6 +122,14 @@ func TestCreateLibraryElement(t *testing.T) {
 			require.Equal(t, 400, resp.Status())
 		})
 
+	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an UID that is too long, it should fail",
+		func(t *testing.T, sc scenarioContext) {
+			command := getCreatePanelCommand(sc.folder.Id, "Invalid UID")
+			command.UID = "j6T00KRZzj6T00KRZzj6T00KRZzj6T00KRZzj6T00K"
+			resp := sc.service.createHandler(sc.reqContext, command)
+			require.Equal(t, 400, resp.Status())
+		})
+
 	testScenario(t, "When an admin tries to create a library panel where name and panel title differ, it should not update panel title",
 		func(t *testing.T, sc scenarioContext) {
 			command := getCreatePanelCommand(1, "Library Panel Name")

--- a/pkg/services/libraryelements/libraryelements_create_test.go
+++ b/pkg/services/libraryelements/libraryelements_create_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestCreateLibraryElement(t *testing.T) {
@@ -57,6 +58,68 @@ func TestCreateLibraryElement(t *testing.T) {
 			if diff := cmp.Diff(expected, sc.initialResult, getCompareOptions()...); diff != "" {
 				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 			}
+		})
+
+	testScenario(t, "When an admin tries to create a library panel that does not exists using an nonexistent UID, it should succeed",
+		func(t *testing.T, sc scenarioContext) {
+			command := getCreatePanelCommand(sc.folder.Id, "Nonexistent UID")
+			command.UID = util.GenerateShortUID()
+			resp := sc.service.createHandler(sc.reqContext, command)
+			var result = validateAndUnMarshalResponse(t, resp)
+			var expected = libraryElementResult{
+				Result: libraryElement{
+					ID:          1,
+					OrgID:       1,
+					FolderID:    1,
+					UID:         command.UID,
+					Name:        "Nonexistent UID",
+					Kind:        int64(models.PanelElement),
+					Type:        "text",
+					Description: "A description",
+					Model: map[string]interface{}{
+						"datasource":  "${DS_GDEV-TESTDATA}",
+						"description": "A description",
+						"id":          float64(1),
+						"title":       "Text - Library Panel",
+						"type":        "text",
+					},
+					Version: 1,
+					Meta: LibraryElementDTOMeta{
+						ConnectedDashboards: 0,
+						Created:             result.Result.Meta.Created,
+						Updated:             result.Result.Meta.Updated,
+						CreatedBy: LibraryElementDTOMetaUser{
+							ID:        1,
+							Name:      "signed_in_user",
+							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+						},
+						UpdatedBy: LibraryElementDTOMetaUser{
+							ID:        1,
+							Name:      "signed_in_user",
+							AvatarURL: "/avatar/37524e1eb8b3e32850b57db0a19af93b",
+						},
+					},
+				},
+			}
+			if diff := cmp.Diff(expected, result, getCompareOptions()...); diff != "" {
+				t.Fatalf("Result mismatch (-want +got):\n%s", diff)
+			}
+		})
+
+	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an existent UID, it should fail",
+		func(t *testing.T, sc scenarioContext) {
+			command := getCreatePanelCommand(sc.folder.Id, "Existing UID")
+			command.UID = sc.initialResult.Result.UID
+			resp := sc.service.createHandler(sc.reqContext, command)
+			require.Equal(t, 400, resp.Status())
+		})
+
+	scenarioWithPanel(t, "When an admin tries to create a library panel that does not exists using an invalid UID, it should fail",
+		func(t *testing.T, sc scenarioContext) {
+			command := getCreatePanelCommand(sc.folder.Id, "Invalid UID")
+			command.UID = "Testing an invalid UID"
+			resp := sc.service.createHandler(sc.reqContext, command)
+			require.Equal(t, 400, resp.Status())
 		})
 
 	testScenario(t, "When an admin tries to create a library panel where name and panel title differ, it should not update panel title",

--- a/pkg/services/libraryelements/models.go
+++ b/pkg/services/libraryelements/models.go
@@ -147,8 +147,10 @@ var (
 	errLibraryElementVersionMismatch = errors.New("the library element has been changed by someone else")
 	// errLibraryElementUnSupportedElementKind is an error for when the kind is unsupported.
 	errLibraryElementUnSupportedElementKind = errors.New("the element kind is not supported")
-	// ErrFolderHasConnectedLibraryElements is an error for when an user deletes a folder that contains connected library elements.
+	// ErrFolderHasConnectedLibraryElements is an error for when a user deletes a folder that contains connected library elements.
 	ErrFolderHasConnectedLibraryElements = errors.New("folder contains library elements that are linked in use")
+	// errLibraryElementInvalidUID is an error for when the uid of a library element is invalid
+	errLibraryElementInvalidUID = errors.New("uid contains illegal characters")
 )
 
 // Commands
@@ -159,6 +161,7 @@ type CreateLibraryElementCommand struct {
 	Name     string          `json:"name"`
 	Model    json.RawMessage `json:"model"`
 	Kind     int64           `json:"kind" binding:"Required"`
+	UID      string          `json:"uid"`
 }
 
 // patchLibraryElementCommand is the command for patching a LibraryElement

--- a/pkg/services/libraryelements/models.go
+++ b/pkg/services/libraryelements/models.go
@@ -136,7 +136,7 @@ type LibraryElementConnectionDTO struct {
 
 var (
 	// errLibraryElementAlreadyExists is an error for when the user tries to add a library element that already exists.
-	errLibraryElementAlreadyExists = errors.New("library element with that name already exists")
+	errLibraryElementAlreadyExists = errors.New("library element with that name or UID already exists")
 	// errLibraryElementNotFound is an error for when a library element can't be found.
 	errLibraryElementNotFound = errors.New("library element could not be found")
 	// errLibraryElementDashboardNotFound is an error for when a library element connection can't be found.
@@ -173,6 +173,7 @@ type patchLibraryElementCommand struct {
 	Model    json.RawMessage `json:"model"`
 	Kind     int64           `json:"kind" binding:"Required"`
 	Version  int64           `json:"version" binding:"Required"`
+	UID      string          `json:"uid"`
 }
 
 // searchLibraryElementsQuery is the query used for searching for Elements

--- a/pkg/services/libraryelements/models.go
+++ b/pkg/services/libraryelements/models.go
@@ -151,6 +151,8 @@ var (
 	ErrFolderHasConnectedLibraryElements = errors.New("folder contains library elements that are linked in use")
 	// errLibraryElementInvalidUID is an error for when the uid of a library element is invalid
 	errLibraryElementInvalidUID = errors.New("uid contains illegal characters")
+	// errLibraryElementUIDTooLong is an error for when the uid of a library element is invalid
+	errLibraryElementUIDTooLong = errors.New("uid too long, max 40 characters")
 )
 
 // Commands

--- a/pkg/services/sqlstore/migrations/libraryelements.go
+++ b/pkg/services/sqlstore/migrations/libraryelements.go
@@ -50,4 +50,8 @@ func addLibraryElementsMigrations(mg *migrator.Migrator) {
 
 	mg.AddMigration("create "+models.LibraryElementConnectionTableName+" table v1", migrator.NewAddTableMigration(libraryElementConnectionV1))
 	mg.AddMigration("add index "+models.LibraryElementConnectionTableName+" element_id-kind-connection_id", migrator.NewAddIndexMigration(libraryElementConnectionV1, libraryElementConnectionV1.Indices[0]))
+
+	mg.AddMigration("add unique index library_element org_id_uid", migrator.NewAddIndexMigration(libraryElementsV1, &migrator.Index{
+		Cols: []string{"org_id", "uid"}, Type: migrator.UniqueIndex,
+	}))
 }

--- a/pkg/util/shortid_generator.go
+++ b/pkg/util/shortid_generator.go
@@ -20,6 +20,11 @@ func IsValidShortUID(uid string) bool {
 	return validUIDPattern(uid)
 }
 
+// IsShortUIDTooLong checks if short unique identifier is too long
+func IsShortUIDTooLong(uid string) bool {
+	return len(uid) > 40
+}
+
 // GenerateShortUID generates a short unique identifier.
 func GenerateShortUID() string {
 	return shortid.MustGenerate()

--- a/pkg/util/shortid_generator_test.go
+++ b/pkg/util/shortid_generator_test.go
@@ -1,11 +1,45 @@
 package util
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestAllowedCharMatchesUidPattern(t *testing.T) {
 	for _, c := range allowedChars {
 		if !IsValidShortUID(string(c)) {
 			t.Fatalf("charset for creating new shortids contains chars not present in uid pattern")
 		}
+	}
+}
+
+func TestIsShortUIDTooLong(t *testing.T) {
+	var tests = []struct {
+		name     string
+		uid      string
+		expected bool
+	}{
+		{
+			name:     "when the length of uid is longer than 40 chars then IsShortUIDTooLong should return true",
+			uid:      allowedChars,
+			expected: true,
+		},
+		{
+			name:     "when the length of uid is equal too 40 chars then IsShortUIDTooLong should return false",
+			uid:      "0123456789012345678901234567890123456789",
+			expected: false,
+		},
+		{
+			name:     "when the length of uid is shorter than 40 chars then IsShortUIDTooLong should return false",
+			uid:      "012345678901234567890123456789012345678",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsShortUIDTooLong(tt.uid))
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Thought about how to enable a better import/export experience between orgs for dashboards that contain library elements. First step is to add UID as a new argument to the library elements api `POST` endpoints.

- This PR adds the new `UID` argument to the api, how do we handle api changes like this? Should we add the breaking change label?
- Should we also add an `Overwrite` argument to the `POST` endpoint? (I guess users can delete existing and call POST again)
- This PR also adds a new `UniqueIndex` migration. Is there anything we need to think about there?
- Should we support UID changes in the `PATCH` endpoint? What would the HTTP response be in that case, a redirect to the new UID resource?

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@marefr @ying-jeanne @sdboyer I could need some extra pair of backend/as code eyes on this one. Thank you 🙏 
