### PR TITLE
Annotations: don't log context.Cancelled as an error when cleaning up

### DIFF
--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -67,7 +67,7 @@ func (srv *CleanUpService) Run(ctx context.Context) error {
 func (srv *CleanUpService) cleanUpOldAnnotations(ctx context.Context) {
 	cleaner := annotations.GetAnnotationCleaner()
 	affected, affectedTags, err := cleaner.CleanAnnotations(ctx, srv.Cfg)
-	if err != nil {
+	if err != nil && err != context.DeadlineExceeded {
 		srv.log.Error("failed to clean up old annotations", "error", err)
 	} else {
 		srv.log.Debug("Deleted excess annotations", "annotations affected", affected, "annotation tags affected", affectedTags)

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path"
@@ -67,7 +68,7 @@ func (srv *CleanUpService) Run(ctx context.Context) error {
 func (srv *CleanUpService) cleanUpOldAnnotations(ctx context.Context) {
 	cleaner := annotations.GetAnnotationCleaner()
 	affected, affectedTags, err := cleaner.CleanAnnotations(ctx, srv.Cfg)
-	if err != nil && err != context.DeadlineExceeded {
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		srv.log.Error("failed to clean up old annotations", "error", err)
 	} else {
 		srv.log.Debug("Deleted excess annotations", "annotations affected", affected, "annotation tags affected", affectedTags)


### PR DESCRIPTION
`context.DeadlineExceeded` is expected if there are more annotation then we can delete in one iteration. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>
