### PR TITLE
Alerting/Annotations: Bring back metrics and alert state to annotations tooltip

### DIFF
--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -81,7 +81,10 @@ function createReducerPart(model: any) {
 }
 
 function getStateDisplayModel(state: string) {
-  switch (state) {
+  const normalizedState = state.toLowerCase().replace(/_/g, '');
+
+  switch (normalizedState) {
+    case 'normal':
     case 'ok': {
       return {
         text: 'OK',
@@ -96,7 +99,7 @@ function getStateDisplayModel(state: string) {
         stateClass: 'alert-state-critical',
       };
     }
-    case 'no_data': {
+    case 'nodata': {
       return {
         text: 'NO DATA',
         iconClass: 'question-circle',

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -124,7 +124,7 @@ function getStateDisplayModel(state: string) {
       return {
         text: 'UNKNOWN',
         iconClass: 'question-circle',
-        stateClass: 'alert-state-paused',
+        stateClass: '.alert-state-paused',
       };
     }
 
@@ -141,6 +141,14 @@ function getStateDisplayModel(state: string) {
         text: 'INACTIVE',
         iconClass: 'check',
         stateClass: '',
+      };
+    }
+
+    case 'error': {
+      return {
+        text: 'ERROR',
+        iconClass: 'heart-break',
+        stateClass: 'alert-state-critical',
       };
     }
   }

--- a/public/app/features/annotations/annotation_tooltip.ts
+++ b/public/app/features/annotations/annotation_tooltip.ts
@@ -36,7 +36,7 @@ export function annotationTooltipDirective(
       let tooltip = '<div class="graph-annotation">';
       let titleStateClass = '';
 
-      if (event.alertId) {
+      if (event.alertId !== undefined) {
         const stateModel = alertDef.getStateDisplayModel(event.newState);
         titleStateClass = stateModel.stateClass;
         title = `<i class="${stateModel.iconClass}"></i> ${stateModel.text}`;

--- a/public/app/features/annotations/standardAnnotationSupport.test.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.test.ts
@@ -111,6 +111,7 @@ describe('DataFrame to annotations', () => {
         { name: 'newState', values: ['alerting'] },
         { name: 'data', values: [{ text: 'a', value: 'A' }] },
         { name: 'panelId', values: [4] },
+        { name: 'alertId', values: [0] },
       ],
     });
 
@@ -134,6 +135,7 @@ describe('DataFrame to annotations', () => {
           title: 'title',
           type: 'default',
           userId: 'Admin',
+          alertId: 0,
         },
       ],
     ]);

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -123,6 +123,7 @@ const alertEventAndAnnotationFields: AnnotationFieldInfo[] = [
   { key: 'newState' },
   { key: 'data' as any },
   { key: 'panelId' },
+  { key: 'alertId' },
 ];
 
 export function getAnnotationsFromData(

--- a/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationTooltip.tsx
@@ -35,7 +35,7 @@ export const AnnotationTooltip: React.FC<AnnotationTooltipProps> = ({
     avatar = <img className={styles.avatar} src={annotation.avatarUrl} />;
   }
 
-  if (annotation.alertId) {
+  if (annotation.alertId !== undefined) {
     const stateModel = alertDef.getStateDisplayModel(annotation.newState!);
     state = (
       <div className={styles.alertState}>

--- a/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationTooltip.tsx
@@ -35,8 +35,8 @@ export const AnnotationTooltip: React.FC<AnnotationTooltipProps> = ({
     avatar = <img className={styles.avatar} src={annotation.avatarUrl} />;
   }
 
-  if (annotation.alertId !== undefined) {
-    const stateModel = alertDef.getStateDisplayModel(annotation.newState!);
+  if (annotation.alertId !== undefined && annotation.newState) {
+    const stateModel = alertDef.getStateDisplayModel(annotation.newState);
     state = (
       <div className={styles.alertState}>
         <i className={stateModel.stateClass}>{stateModel.text}</i>


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/38902

Since DB can contain mixed values of alert states (either snake_case or PascalCase) this PRs normalizes state names (lowercase, no underscore) when retrieving the UI descriptor of a given state.