### PR TITLE
Build: fix build.go not providing version build tag

### DIFF
--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -45,6 +45,8 @@ func RunCmd() int {
 		return logError("Error opening package json", err)
 	}
 
+	opts.version = packageJSON.Version
+
 	version, iteration := LinuxPackageVersion(packageJSON.Version, opts.buildID)
 
 	if opts.printGenVersion {


### PR DESCRIPTION
**What this PR does / why we need it**:

The Grafana version was being supplied as an empty string when compiling grafana-server.

![image](https://user-images.githubusercontent.com/5140827/132691162-c5e5707c-025a-471b-aff1-c61c14339c71.png)

---

Now:

```
generate go files
/home/kminehart/go/bin/wire-v0.5.0 gen -tags "oss" ./pkg/server
wire: github.com/grafana/grafana/pkg/server: wrote /home/kminehart/Grafana/grafana/pkg/server/wire_gen.go
build go files
go run build.go build
Version: 8.2.0, Linux Version: 8.2.0, Package Iteration: 1631192800pre
building binaries build
building grafana-server ./pkg/cmd/grafana-server
rm -r ./bin/linux-amd64/grafana-server
rm -r ./bin/linux-amd64/grafana-server.md5
go build -ldflags -w -X main.version=8.2.0-pre -X main.commit=4ca58dac9b -X main.buildstamp=1631192676 -X main.buildBranch=km/fix-version-not-populating -o ./bin/linux-amd64/grafana-server ./pkg/cmd/grafana-server
go version
go version go1.17 linux/amd64
Targeting linux/amd64
building binaries build
building grafana-cli ./pkg/cmd/grafana-cli
rm -r ./bin/linux-amd64/grafana-cli
rm -r ./bin/linux-amd64/grafana-cli.md5
go build -ldflags -w -X main.version=8.2.0-pre -X main.commit=4ca58dac9b -X main.buildstamp=1631192676 -X main.buildBranch=km/fix-version-not-populating -o ./bin/linux-amd64/grafana-cli ./pkg/cmd/grafana-cli
```
