### PR TITLE
Explore: Add more error handling to Tempo trace download

### DIFF
--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -440,7 +440,7 @@ function getOTLPStatus(tags: TraceKeyValuePair[]): SpanStatus | undefined {
 }
 
 function getOTLPEvents(logs: TraceLog[]): collectorTypes.opentelemetryProto.trace.v1.Span.Event[] | undefined {
-  if (!logs.length) {
+  if (!logs || !logs.length) {
     return undefined;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Downloading Tempo traces fails occasionally because logs are undefined when getting OTLP events. I downloaded ~20 more traces to check this and most fail without this change, and all download with it. 

**Which issue(s) this PR fixes**:
Fixes #27852

**Special notes for your reviewer**:

