### PR TITLE
Prometheus: Add interpolation for built-in-time variables to backend

### DIFF
--- a/pkg/tsdb/intervalv2/intervalv2.go
+++ b/pkg/tsdb/intervalv2/intervalv2.go
@@ -82,31 +82,40 @@ func (ic *intervalCalculator) CalculateSafeInterval(timerange backend.TimeRange,
 // queryIntervalMS is a pre-calculated numeric representation of the query interval in milliseconds.
 func GetIntervalFrom(dsInterval, queryInterval string, queryIntervalMS int64, defaultInterval time.Duration) (time.Duration, error) {
 	// Apparently we are setting default value of queryInterval to 0s now
-	if queryInterval == "0s" {
-		queryInterval = ""
+	interval := queryInterval
+	if interval == "0s" {
+		interval = ""
 	}
-
-	if queryInterval == "" {
+	if interval == "" {
 		if queryIntervalMS != 0 {
 			return time.Duration(queryIntervalMS) * time.Millisecond, nil
 		}
 	}
-	interval := queryInterval
-	if queryInterval == "" && dsInterval != "" {
+	if interval == "" && dsInterval != "" {
 		interval = dsInterval
 	}
 	if interval == "" {
 		return defaultInterval, nil
 	}
-	interval = strings.Replace(strings.Replace(interval, "<", "", 1), ">", "", 1)
-	isPureNum, err := regexp.MatchString(`^\d+$`, interval)
+
+	parsedInterval, err := ParseIntervalStringToTimeDuration(interval)
+	if err != nil {
+		return time.Duration(0), err
+	}
+
+	return parsedInterval, nil
+}
+
+func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
+	formattedInterval := strings.Replace(strings.Replace(interval, "<", "", 1), ">", "", 1)
+	isPureNum, err := regexp.MatchString(`^\d+$`, formattedInterval)
 	if err != nil {
 		return time.Duration(0), err
 	}
 	if isPureNum {
-		interval += "s"
+		formattedInterval += "s"
 	}
-	parsedInterval, err := time.ParseDuration(interval)
+	parsedInterval, err := time.ParseDuration(formattedInterval)
 	if err != nil {
 		return time.Duration(0), err
 	}

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -275,7 +275,6 @@ func TestPrometheus_parseQuery(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "rate(ALERTS{job=\"test\" [1m]})", models[0].Expr)
 	})
-
 }
 
 func queryContext(json string, timeRange backend.TimeRange) *backend.QueryDataRequest {

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -13,11 +13,7 @@ import (
 
 var now = time.Now()
 
-func TestPrometheus(t *testing.T) {
-	service := Service{
-		intervalCalculator: intervalv2.NewCalculator(),
-	}
-
+func TestPrometheus_formatLeged(t *testing.T) {
 	t.Run("converting metric name", func(t *testing.T) {
 		metric := map[p.LabelName]p.LabelValue{
 			p.LabelName("app"):    p.LabelValue("backend"),
@@ -44,89 +40,253 @@ func TestPrometheus(t *testing.T) {
 
 		require.Equal(t, `http_request_total{app="backend", device="mobile"}`, formatLegend(metric, query))
 	})
+}
+
+func TestPrometheus_parseQuery(t *testing.T) {
+	service := Service{
+		intervalCalculator: intervalv2.NewCalculator(),
+	}
 
 	t.Run("parsing query model with step", func(t *testing.T) {
-		query := queryContext(`{
-			"expr": "go_goroutines",
-			"format": "time_series",
-			"refId": "A"
-		}`)
 		timeRange := backend.TimeRange{
 			From: now,
 			To:   now.Add(12 * time.Hour),
 		}
-		query.TimeRange = timeRange
-		models, err := service.parseQuery([]backend.DataQuery{query}, &DatasourceInfo{})
+
+		query := queryContext(`{
+			"expr": "go_goroutines",
+			"format": "time_series",
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
 		require.NoError(t, err)
 		require.Equal(t, time.Second*30, models[0].Step)
 	})
 
 	t.Run("parsing query model without step parameter", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(1 * time.Hour),
+		}
+
 		query := queryContext(`{
 			"expr": "go_goroutines",
 			"format": "time_series",
 			"intervalFactor": 1,
 			"refId": "A"
-		}`)
-		models, err := service.parseQuery([]backend.DataQuery{query}, &DatasourceInfo{})
-		require.NoError(t, err)
-		require.Equal(t, time.Minute*2, models[0].Step)
+		}`, timeRange)
 
-		timeRange := backend.TimeRange{
-			From: now,
-			To:   now.Add(1 * time.Hour),
-		}
-		query.TimeRange = timeRange
-		models, err = service.parseQuery([]backend.DataQuery{query}, &DatasourceInfo{})
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
 		require.NoError(t, err)
 		require.Equal(t, time.Second*15, models[0].Step)
 	})
 
 	t.Run("parsing query model with high intervalFactor", func(t *testing.T) {
-		models, err := service.parseQuery([]backend.DataQuery{queryContext(`{
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
 			"expr": "go_goroutines",
 			"format": "time_series",
 			"intervalFactor": 10,
 			"refId": "A"
-		}`)}, &DatasourceInfo{})
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
 		require.NoError(t, err)
 		require.Equal(t, time.Minute*20, models[0].Step)
 	})
 
 	t.Run("parsing query model with low intervalFactor", func(t *testing.T) {
-		models, err := service.parseQuery([]backend.DataQuery{queryContext(`{
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
 			"expr": "go_goroutines",
 			"format": "time_series",
 			"intervalFactor": 1,
 			"refId": "A"
-		}`)}, &DatasourceInfo{})
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
 		require.NoError(t, err)
 		require.Equal(t, time.Minute*2, models[0].Step)
 	})
 
 	t.Run("parsing query model specified scrape-interval in the data source", func(t *testing.T) {
-		models, err := service.parseQuery([]backend.DataQuery{queryContext(`{
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
 			"expr": "go_goroutines",
 			"format": "time_series",
 			"intervalFactor": 1,
 			"refId": "A"
-		}`)}, &DatasourceInfo{
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{
 			TimeInterval: "240s",
-		})
+		}
+		models, err := service.parseQuery(query, dsInfo)
 		require.NoError(t, err)
 		require.Equal(t, time.Minute*4, models[0].Step)
 	})
+
+	t.Run("parsing query model with $__interval variable", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
+			"expr": "rate(ALERTS{job=\"test\" [$__interval]})",
+			"format": "time_series",
+			"intervalFactor": 1,
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
+		require.NoError(t, err)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [2m]})", models[0].Expr)
+	})
+
+	t.Run("parsing query model with $__interval_ms variable", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
+			"expr": "rate(ALERTS{job=\"test\" [$__interval_ms]})",
+			"format": "time_series",
+			"intervalFactor": 1,
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
+		require.NoError(t, err)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [120000]})", models[0].Expr)
+	})
+
+	t.Run("parsing query model with $__interval_ms and $__interval variable", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
+			"expr": "rate(ALERTS{job=\"test\" [$__interval_ms]}) + rate(ALERTS{job=\"test\" [$__interval]})",
+			"format": "time_series",
+			"intervalFactor": 1,
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
+		require.NoError(t, err)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [120000]}) + rate(ALERTS{job=\"test\" [2m]})", models[0].Expr)
+	})
+
+	t.Run("parsing query model with $__range variable", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
+			"expr": "rate(ALERTS{job=\"test\" [$__range]})",
+			"format": "time_series",
+			"intervalFactor": 1,
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
+		require.NoError(t, err)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [172800s]})", models[0].Expr)
+	})
+
+	t.Run("parsing query model with $__range_s variable", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
+			"expr": "rate(ALERTS{job=\"test\" [$__range_s]})",
+			"format": "time_series",
+			"intervalFactor": 1,
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
+		require.NoError(t, err)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [172800]})", models[0].Expr)
+	})
+
+	t.Run("parsing query model with $__range_ms variable", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(48 * time.Hour),
+		}
+
+		query := queryContext(`{
+			"expr": "rate(ALERTS{job=\"test\" [$__range_ms]})",
+			"format": "time_series",
+			"intervalFactor": 1,
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
+		require.NoError(t, err)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [172800000]})", models[0].Expr)
+	})
+
+	t.Run("parsing query model with $__rate_interval variable", func(t *testing.T) {
+		timeRange := backend.TimeRange{
+			From: now,
+			To:   now.Add(5 * time.Minute),
+		}
+
+		query := queryContext(`{
+			"expr": "rate(ALERTS{job=\"test\" [$__rate_interval]})",
+			"format": "time_series",
+			"intervalFactor": 1,
+			"refId": "A"
+		}`, timeRange)
+
+		dsInfo := &DatasourceInfo{}
+		models, err := service.parseQuery(query, dsInfo)
+		require.NoError(t, err)
+		require.Equal(t, "rate(ALERTS{job=\"test\" [1m]})", models[0].Expr)
+	})
+
 }
 
-func queryContext(json string) backend.DataQuery {
-	timeRange := backend.TimeRange{
-		From: now,
-		To:   now.Add(48 * time.Hour),
-	}
-	return backend.DataQuery{
-		TimeRange: timeRange,
-		RefID:     "A",
-		JSON:      []byte(json),
+func queryContext(json string, timeRange backend.TimeRange) *backend.QueryDataRequest {
+	return &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{
+			{
+				JSON:      []byte(json),
+				TimeRange: timeRange,
+				RefID:     "A",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of https://github.com/grafana/grafana/issues/37784

As a part of prometheus migration to backend data source, we need to be handling built-in time-related variables that could be used in queries. Specifically it is:
- $__interval_ms
- $__interval
- $__range_ms
- $__range_s
- $__range
- $__rate_interval

I have also, as a part of this PR added some small clean-ups and refactors such as unmarshaling query.JSON to model defined as QueryModel. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/32786

