### PR TITLE
Plugins Catalog: show Grafana and plugin dependencies

### DIFF
--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -87,6 +87,7 @@ interface PluginDependencyInfo {
 }
 
 export interface PluginDependencies {
+  grafanaDependency?: string;
   grafanaVersion: string;
   plugins: PluginDependencyInfo[];
 }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -16,7 +16,7 @@ export async function getCatalogPlugin(id: string): Promise<CatalogPlugin> {
 }
 
 export async function getPluginDetails(id: string): Promise<CatalogPluginDetails> {
-  const localPlugins = await getLocalPlugins(); // /api/plugins/<id>/settings
+  const localPlugins = await getLocalPlugins();
   const local = localPlugins.find((p) => p.id === id);
   const isInstalled = Boolean(local);
   const [remote, versions] = await Promise.all([getRemotePlugin(id, isInstalled), getPluginVersions(id)]);

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -20,9 +20,11 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
   const local = localPlugins.find((p) => p.id === id);
   const isInstalled = Boolean(local);
   const [remote, versions] = await Promise.all([getRemotePlugin(id, isInstalled), getPluginVersions(id)]);
+  const dependencies = remote?.json?.dependencies;
 
   return {
-    grafanaDependency: remote?.json?.dependencies?.grafanaDependency || '',
+    grafanaDependency: dependencies?.grafanaDependency || dependencies?.grafanaVersion || '',
+    pluginDependencies: dependencies?.plugins || [],
     links: remote?.json?.info.links || local?.info.links || [],
     readme: remote?.readme,
     versions,

--- a/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
@@ -143,8 +143,5 @@ export const getStyles = (theme: GrafanaTheme2) => {
     textUnderline: css`
       text-decoration: underline;
     `,
-    textBold: css`
-      font-weight: ${theme.typography.fontWeightBold};
-    `,
   };
 };

--- a/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
@@ -5,6 +5,7 @@ import { useStyles2, Icon } from '@grafana/ui';
 
 import { InstallControls } from './InstallControls';
 import { PluginDetailsHeaderSignature } from './PluginDetailsHeaderSignature';
+import { PluginDetailsHeaderDependencies } from './PluginDetailsHeaderDependencies';
 import { PluginLogo } from './PluginLogo';
 import { CatalogPlugin } from '../types';
 
@@ -73,15 +74,10 @@ export function PluginDetailsHeader({ plugin, currentUrl, parentUrl }: Props): R
           <PluginDetailsHeaderSignature plugin={plugin} />
         </div>
 
-        {/* Plugins dependencies information */}
-        <div className={cx(styles.headerInformationRow, styles.headerInformationRowSecondary)}>
-          <div className={styles.textBold}>Dependencies:</div>
-
-          <div>
-            <Icon name="grafana" />
-            Grafana {plugin.details?.grafanaDependency}
-          </div>
-        </div>
+        <PluginDetailsHeaderDependencies
+          plugin={plugin}
+          className={cx(styles.headerInformationRow, styles.headerInformationRowSecondary)}
+        />
 
         <p>{plugin.description}</p>
 

--- a/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Icon } from '@grafana/ui';
 
@@ -47,7 +47,7 @@ export function PluginDetailsHeader({ plugin, currentUrl, parentUrl }: Props): R
           </ol>
         </nav>
 
-        <div className={styles.headerInformation}>
+        <div className={styles.headerInformationRow}>
           {/* Org name */}
           <span>{plugin.orgName}</span>
 
@@ -71,6 +71,16 @@ export function PluginDetailsHeader({ plugin, currentUrl, parentUrl }: Props): R
 
           {/* Signature information */}
           <PluginDetailsHeaderSignature plugin={plugin} />
+        </div>
+
+        {/* Plugins dependencies information */}
+        <div className={cx(styles.headerInformationRow, styles.headerInformationRowSecondary)}>
+          <div className={styles.textBold}>Dependencies:</div>
+
+          <div>
+            <Icon name="grafana" />
+            Grafana {plugin.details?.grafanaDependency}
+          </div>
         </div>
 
         <p>{plugin.description}</p>
@@ -106,11 +116,11 @@ export const getStyles = (theme: GrafanaTheme2) => {
         }
       }
     `,
-    headerInformation: css`
+    headerInformationRow: css`
       display: flex;
       align-items: center;
       margin-top: ${theme.spacing()};
-      margin-bottom: ${theme.spacing(3)};
+      margin-bottom: ${theme.spacing()};
 
       & > * {
         &::after {
@@ -124,6 +134,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
       }
       font-size: ${theme.typography.h4.fontSize};
     `,
+    headerInformationRowSecondary: css`
+      font-size: ${theme.typography.body.fontSize};
+    `,
     headerOrgName: css`
       font-size: ${theme.typography.h4.fontSize};
     `,
@@ -133,6 +146,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
     `,
     textUnderline: css`
       text-decoration: underline;
+    `,
+    textBold: css`
+      font-weight: ${theme.typography.fontWeightBold};
     `,
   };
 };

--- a/public/app/features/plugins/admin/components/PluginDetailsHeaderDependencies.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeaderDependencies.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, Icon } from '@grafana/ui';
+import { CatalogPlugin } from '../types';
+
+type Props = {
+  plugin: CatalogPlugin;
+  className?: string;
+};
+
+const PluginIconClassName: Record<string, string> = {
+  datasource: 'gicon gicon-datasources',
+  panel: 'icon-gf icon-gf-panel',
+  app: 'icon-gf icon-gf-apps',
+  page: 'icon-gf icon-gf-endpoint-tiny',
+  dashboard: 'gicon gicon-dashboard',
+  default: 'icon-gf icon-gf-apps',
+};
+
+export function PluginDetailsHeaderDependencies({ plugin, className }: Props): React.ReactElement | null {
+  const styles = useStyles2(getStyles);
+  const pluginDependencies = plugin.details?.pluginDependencies;
+  const grafanaDependency = plugin.details?.grafanaDependency;
+  const hasNoDependencyInfo = !grafanaDependency && (!pluginDependencies || !pluginDependencies.length);
+
+  if (hasNoDependencyInfo) {
+    return null;
+  }
+
+  return (
+    <div className={className}>
+      <div className={styles.textBold}>Dependencies:</div>
+
+      {/* Grafana dependency */}
+      {Boolean(grafanaDependency) && (
+        <div>
+          <Icon name="grafana" />
+          Grafana {grafanaDependency}
+        </div>
+      )}
+
+      {/* Plugin dependencies */}
+      {pluginDependencies && pluginDependencies.length > 0 && (
+        <div>
+          {pluginDependencies.map((p) => {
+            return (
+              <span key={p.name}>
+                <i className={PluginIconClassName[p.type] || PluginIconClassName.default} />
+                {p.name} {p.version}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    textBold: css`
+      font-weight: ${theme.typography.fontWeightBold};
+    `,
+  };
+};

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -237,6 +237,7 @@ function remotePlugin(plugin: Partial<RemotePlugin> = {}): RemotePlugin {
       dependencies: {
         grafanaDependency: '>=7.3.0',
         grafanaVersion: '7.3',
+        plugins: [],
       },
       info: {
         links: [],

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -197,6 +197,15 @@ describe('Plugin details page', () => {
     await waitFor(() => expect(queryByRole('link', { name: /update via grafana.com/i })).toBeInTheDocument());
     expect(queryByRole('link', { name: /uninstall via grafana.com/i })).toBeInTheDocument();
   });
+
+  it('should display grafana dependencies for a plugin if they are available', async () => {
+    const { queryByText } = setup('not-installed');
+
+    // Wait for the dependencies part to be loaded
+    await waitFor(() => expect(queryByText(/dependencies:/i)).toBeInTheDocument());
+
+    expect(queryByText('Grafana >=7.3.0')).toBeInTheDocument();
+  });
 });
 
 function remotePlugin(plugin: Partial<RemotePlugin> = {}): RemotePlugin {

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -1,5 +1,5 @@
 import { EntityState } from '@reduxjs/toolkit';
-import { PluginType, PluginSignatureStatus, PluginSignatureType } from '@grafana/data';
+import { PluginType, PluginSignatureStatus, PluginSignatureType, PluginDependencies } from '@grafana/data';
 import { StoreState, PluginsState } from 'app/types';
 
 export type PluginTypeCode = 'app' | 'panel' | 'datasource';
@@ -62,10 +62,7 @@ export type RemotePlugin = {
   id: number;
   internal: boolean;
   json?: {
-    dependencies: {
-      grafanaDependency: string;
-      grafanaVersion: string;
-    };
+    dependencies: PluginDependencies;
     info: {
       links: Array<{
         name: string;

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -44,6 +44,7 @@ export interface CatalogPluginDetails {
     url: string;
   }>;
   grafanaDependency?: string;
+  pluginDependencies?: PluginDependencies['plugins'];
 }
 
 export interface CatalogPluginInfo {

--- a/public/app/plugins/datasource/graphite/state/context.tsx
+++ b/public/app/plugins/datasource/graphite/state/context.tsx
@@ -50,13 +50,13 @@ export const GraphiteQueryEditorContext = ({
     if (state) {
       dispatch(actions.queriesChanged(queries));
     }
-  }, [dispatch, queries]);
+  }, [dispatch, queries, state]);
 
   useEffect(() => {
     if (state && state.target?.target !== query.target) {
       dispatch(actions.queryChanged(query));
     }
-  }, [dispatch, query]);
+  }, [dispatch, query, state]);
 
   if (!state) {
     dispatch(


### PR DESCRIPTION
Fixes #37932 

**What this PR does / why we need it**:
- [x] displays the Grafana dependency for the plugin _(feature-parity)_
- [x] displays dependencies on other plugins _(feature-parity)_ 
- [x] extends the `PluginDependencies` type in `@grafana/data` to be up-to-date


**A plugin with only a Grafana dependency**
![Screenshot 2021-09-10 at 8 12 14](https://user-images.githubusercontent.com/9974811/132808122-d3ea3a74-7144-425e-8e0e-e108933b1328.png)


**A plugin that has both a Grafana and other plugin dependencies**
![Screenshot 2021-09-10 at 7 54 09](https://user-images.githubusercontent.com/9974811/132808087-4ce2e359-b17c-4d68-bc96-7c651a1700f1.png)

---

**Note to the reviewer:** I was planning to add some more test-cases for the different scenarios, but unfortunately we would probably need to massage the mocking part a bit to make these different scenarios easier to test. I am planning to create a separate issue for that.
