### PR TITLE
Plugins: Support multiple HTTP methods in plugin.json routes

### DIFF
--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -184,17 +184,17 @@ For data source plugins. Proxy routes used for plugin authentication and adding 
 
 ### Properties
 
-| Property       | Type                    | Required | Description                                                                                             |
-| -------------- | ----------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `body`         | [object](#body)         | No       | For data source plugins. Route headers set the body content and length to the proxied request.          |
-| `headers`      | array                   | No       | For data source plugins. Route headers adds HTTP headers to the proxied request.                        |
-| `jwtTokenAuth` | [object](#jwttokenauth) | No       | For data source plugins. Token authentication section used with an JWT OAuth API.                       |
-| `method`       | string                  | No       | For data source plugins. Route method matches the HTTP verb like GET or POST.                           |
-| `path`         | string                  | No       | For data source plugins. The route path that is replaced by the route URL field when proxying the call. |
-| `reqRole`      | string                  | No       |                                                                                                         |
-| `reqSignedIn`  | boolean                 | No       |                                                                                                         |
-| `tokenAuth`    | [object](#tokenauth)    | No       | For data source plugins. Token authentication section used with an OAuth API.                           |
-| `url`          | string                  | No       | For data source plugins. Route URL is where the request is proxied to.                                  |
+| Property       | Type                    | Required | Description                                                                                                                               |
+| -------------- | ----------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `body`         | [object](#body)         | No       | For data source plugins. Route headers set the body content and length to the proxied request.                                            |
+| `headers`      | array                   | No       | For data source plugins. Route headers adds HTTP headers to the proxied request.                                                          |
+| `jwtTokenAuth` | [object](#jwttokenauth) | No       | For data source plugins. Token authentication section used with an JWT OAuth API.                                                         |
+| `method`       | string                  | No       | For data source plugins. Route method matches the HTTP verb like GET or POST. Multiple methods can be provided as a comma-separated list. |
+| `path`         | string                  | No       | For data source plugins. The route path that is replaced by the route URL field when proxying the call.                                   |
+| `reqRole`      | string                  | No       |                                                                                                                                           |
+| `reqSignedIn`  | boolean                 | No       |                                                                                                                                           |
+| `tokenAuth`    | [object](#tokenauth)    | No       | For data source plugins. Token authentication section used with an OAuth API.                                                             |
+| `url`          | string                  | No       | For data source plugins. Route URL is where the request is proxied to.                                                                    |
 
 ### body
 

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -340,7 +340,7 @@
           },
           "method": {
             "type": "string",
-            "description": "For data source plugins. Route method matches the HTTP verb like GET or POST."
+            "description": "For data source plugins. Route method matches the HTTP verb like GET or POST. Multiple methods can be provided as a comma-separated list."
           },
           "url": {
             "type": "string",

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/pluginproxy"
@@ -47,7 +48,9 @@ func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
 				}
 			}
 			handlers = append(handlers, AppPluginRoute(route, plugin.Id, hs))
-			r.Handle(route.Method, url, handlers)
+			for _, method := range strings.Split(route.Method, ",") {
+				r.Handle(strings.TrimSpace(method), url, handlers)
+			}
 			log.Debugf("Plugins: Adding proxy route %s", url)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, Grafana supported multiple comma-separated HTTP methods in plugin.json "method" field, i.e. "method": "GET,POST,DELETE". This has never been documented, but was used in worldping app. Macaron migration broke this behaviour causing Grafana to panic with a stack trace when invalid plugin is met.

**Which issue(s) this PR fixes**:

Fixes #38932 