### PR TITLE
Explore: Ensure logs volume bar colors match legend colors

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -10,6 +10,7 @@ import {
   dateTimeFormat,
   dateTimeFormatTimeAgo,
   FieldCache,
+  FieldColorModeId,
   FieldType,
   FieldWithIndex,
   findCommonLabels,
@@ -143,6 +144,10 @@ export function makeDataFramesForLogs(sortedRows: LogRowModel[], bucketSize: num
 
     data.fields[valueField.index].config.min = 0;
     data.fields[valueField.index].config.decimals = 0;
+    data.fields[valueField.index].config.color = {
+      mode: FieldColorModeId.Fixed,
+      fixedColor: series.color,
+    };
 
     data.fields[valueField.index].config.custom = {
       drawStyle: GraphDrawStyle.Bars,

--- a/public/app/features/explore/utils/decorators.test.ts
+++ b/public/app/features/explore/utils/decorators.test.ts
@@ -4,6 +4,7 @@ import {
   ArrayVector,
   DataFrame,
   DataQueryRequest,
+  FieldColorModeId,
   FieldType,
   LoadingState,
   PanelData,
@@ -361,6 +362,10 @@ describe('decorateWithLogsResult', () => {
               labels: undefined,
               values: new ArrayVector([3]),
               config: {
+                color: {
+                  fixedColor: '#8e8e8e',
+                  mode: FieldColorModeId.Fixed,
+                },
                 min: 0,
                 decimals: 0,
                 unit: undefined,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The color for the legend was not set up causing a mismatch in bars/legend colors.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38827

**Special notes for your reviewer**:

How to test it?
* load logs with levels
* select level from the legend below the graph:-the color in the legend should match the color of visible bars

| before | after |
|-------|-------|
| <img width="382" alt="Screen Shot 2021-09-10 at 10 38 27" src="https://user-images.githubusercontent.com/745532/132826082-11370f2f-f459-4da3-a110-758769632828.png"> | <img width="371" alt="Screen Shot 2021-09-10 at 10 39 30" src="https://user-images.githubusercontent.com/745532/132826116-c4fe2ba8-8013-4a78-bb82-7ca9a54ace1c.png"> |



