### PR TITLE
Chore: remove untyped data map from macaron context

### DIFF
--- a/pkg/macaron/context.go
+++ b/pkg/macaron/context.go
@@ -45,7 +45,6 @@ type Context struct {
 	Resp     ResponseWriter
 	params   Params
 	template *template.Template
-	Data     map[string]interface{}
 }
 
 func (ctx *Context) handler() Handler {

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -157,7 +157,6 @@ func (m *Macaron) createContext(rw http.ResponseWriter, req *http.Request) *Cont
 		index:    0,
 		Router:   m.Router,
 		Resp:     NewResponseWriter(req.Method, rw),
-		Data:     make(map[string]interface{}),
 	}
 	req = req.WithContext(context.WithValue(req.Context(), macaronContextKey{}, c))
 	c.Map(c)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -111,9 +111,8 @@ func Auth(options *AuthOptions) macaron.Handler {
 		requireLogin := !c.AllowAnonymous || forceLogin || options.ReqNoAnonynmous
 
 		if !c.IsSignedIn && options.ReqSignedIn && requireLogin {
-			lookupTokenErr, hasTokenErr := c.Data["lookupTokenErr"].(error)
 			var revokedErr *models.TokenRevokedError
-			if hasTokenErr && errors.As(lookupTokenErr, &revokedErr) {
+			if errors.As(c.LookupTokenErr, &revokedErr) {
 				tokenRevoked(c, revokedErr)
 				return
 			}

--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/setting"
 	"gopkg.in/macaron.v1"
 )
@@ -23,8 +24,8 @@ func OrgRedirect(cfg *setting.Cfg) macaron.Handler {
 			return
 		}
 
-		ctx, ok := c.Data["ctx"].(*models.ReqContext)
-		if !ok || !ctx.IsSignedIn {
+		ctx := contexthandler.FromContext(req.Context())
+		if !ctx.IsSignedIn {
 			return
 		}
 

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -21,22 +21,27 @@ type ReqContext struct {
 	Logger         log.Logger
 	// RequestNonce is a cryptographic request identifier for use with Content Security Policy.
 	RequestNonce string
+
+	PerfmonTimer   prometheus.Summary
+	LookupTokenErr error
 }
 
 // Handle handles and logs error by given status.
 func (ctx *ReqContext) Handle(cfg *setting.Cfg, status int, title string, err error) {
+	data := struct {
+		Title     string
+		AppSubUrl string
+		Theme     string
+		ErrorMsg  error
+	}{title, cfg.AppSubURL, "dark", nil}
 	if err != nil {
 		ctx.Logger.Error(title, "error", err)
 		if setting.Env != setting.Prod {
-			ctx.Data["ErrorMsg"] = err
+			data.ErrorMsg = err
 		}
 	}
 
-	ctx.Data["Title"] = title
-	ctx.Data["AppSubUrl"] = cfg.AppSubURL
-	ctx.Data["Theme"] = "dark"
-
-	ctx.HTML(status, cfg.ErrTemplateName, ctx.Data)
+	ctx.HTML(status, cfg.ErrTemplateName, data)
 }
 
 func (ctx *ReqContext) IsApiRequest() bool {
@@ -76,7 +81,7 @@ func (ctx *ReqContext) HasHelpFlag(flag HelpFlags1) bool {
 }
 
 func (ctx *ReqContext) TimeRequest(timer prometheus.Summary) {
-	ctx.Data["perfmon.timer"] = timer
+	ctx.PerfmonTimer = timer
 }
 
 // QueryBoolWithDefault extracts a value from the request query params and applies a bool default if not present.

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -58,11 +58,8 @@ func TestInitContextWithAuthProxy_CachedInvalidUserID(t *testing.T) {
 	req, err := http.NewRequest("POST", "http://example.com", nil)
 	require.NoError(t, err)
 	ctx := &models.ReqContext{
-		Context: &macaron.Context{
-			Req:  req,
-			Data: map[string]interface{}{},
-		},
-		Logger: log.New("Test"),
+		Context: &macaron.Context{Req: req},
+		Logger:  log.New("Test"),
 	}
 	req.Header.Set(svc.Cfg.AuthProxyHeaderName, name)
 	h, err := authproxy.HashCacheKey(name)

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -121,7 +121,6 @@ func (h *ContextHandler) Middleware(mContext *macaron.Context) {
 	}
 
 	reqContext.Logger = log.New("context", "userId", reqContext.UserId, "orgId", reqContext.OrgId, "uname", reqContext.Login)
-	reqContext.Data["ctx"] = reqContext
 
 	span.LogFields(
 		ol.String("uname", reqContext.Login),
@@ -299,7 +298,7 @@ func (h *ContextHandler) initContextWithToken(reqContext *models.ReqContext, org
 	token, err := h.AuthTokenService.LookupToken(ctx, rawToken)
 	if err != nil {
 		reqContext.Logger.Error("Failed to look up user based on cookie", "error", err)
-		reqContext.Data["lookupTokenErr"] = err
+		reqContext.LookupTokenErr = err
 		return false
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR continues the #31071 Macaron removal story. It removes untyped `Data map[string]interface{}` from `macaron.Context` and replaces it with either strongly typed fields or with throw-away data structures for template rendering.

**Special notes for your reviewer**:

Hic sunt dracones, removing untyped data that may or may not be referenced in any other part of the code is always risky.