### PR TITLE
TimeSrv: Do not update URL multiple times for the same, consecutive time range updates

### DIFF
--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -285,6 +285,13 @@ export class TimeSrv {
       const urlRange = this.timeRangeForUrl();
       const urlParams = locationService.getSearch();
 
+      const from = urlParams.get('from');
+      const to = urlParams.get('to');
+
+      if (from && to && from === urlRange.from.toString() && to === urlRange.to.toString()) {
+        return;
+      }
+
       urlParams.set('from', urlRange.from.toString());
       urlParams.set('to', urlRange.to.toString());
 


### PR DESCRIPTION
Fixes #39071

Problem occurs in scenarios when there are multiple GraphNG panels on the dashboard and shared crosshair/tooltip is enabled. It's caused by the ZoomPlugin that performs time range update on every uPlot instance's `setSelect` hook execution. This leads to multiple location updates resulting in the history stack having multiple entries for the same time range. 

This PR makes sure that time range updates that are the same as the currently selected range do not update the location multiple times.