### PR TITLE
Chore: update centrifuge to v0.18.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/beevik/etree v1.1.0
 	github.com/benbjohnson/clock v1.1.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	github.com/centrifugal/centrifuge v0.18.2
+	github.com/centrifugal/centrifuge v0.18.3
 	github.com/cortexproject/cortex v1.8.2-0.20210428155238-d382e1d80eaf
 	github.com/crewjam/saml v0.4.6-0.20201227203850-bca570abb2ce
 	github.com/davecgh/go-spew v1.1.1
@@ -137,7 +137,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee // indirect
 	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
-	github.com/centrifugal/protocol v0.7.1 // indirect
+	github.com/centrifugal/protocol v0.7.2 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,10 +339,10 @@ github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1P
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifugal/centrifuge v0.18.2 h1:GXhUg/2Fxr9F5+mP2VZWFTZ/vCNgeYo7HfxBWK4diNk=
-github.com/centrifugal/centrifuge v0.18.2/go.mod h1:VDGuLrz8LWROHSaPOq0SxHX2rzJng7nLk40hV4UgOGU=
-github.com/centrifugal/protocol v0.7.1 h1:gZzR2fk7C5+zUWa8ay5NvdXblvrZj5li1eLQSij6hAw=
-github.com/centrifugal/protocol v0.7.1/go.mod h1:qoeBHrRCi5mJ5XZfrKHnedz9UWpYbDLXr8iZUO3pTtc=
+github.com/centrifugal/centrifuge v0.18.3 h1:JCsbj+v/7HGeSM/Zb02twGbZuONX9wrp/Im+/XpXwzM=
+github.com/centrifugal/centrifuge v0.18.3/go.mod h1:YKHJsWpYw2t7qREy8QLn99+LipbAFslqvik7lX+daVI=
+github.com/centrifugal/protocol v0.7.2 h1:t/JdnNLnjf4mWta+VNO8GCBvBjVyS+KQUKv3lIwZPRo=
+github.com/centrifugal/protocol v0.7.2/go.mod h1:qoeBHrRCi5mJ5XZfrKHnedz9UWpYbDLXr8iZUO3pTtc=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v0.0.0-20181017004759-096ff4a8a059/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=


### PR DESCRIPTION
Centrifuge v0.18.3 contains a fix for encoding formatted JSON (with new lines) - without this we get `unexpected end of JSON input` in JS when streaming formatted JSON data. 