### PR TITLE
Table panel: Make sure width of the tooltip is correct

### DIFF
--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -58,7 +58,7 @@ function getStyles(theme: GrafanaTheme2) {
       padding: ${theme.spacing(0.5)};
     `,
     json: css`
-      max-width: fit-content;
+      width: fit-content;
       max-height: 70vh;
       overflow-y: auto;
     `,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/39076

@hugohaggmark I'm altering `max-width: fit-content;` that you added in https://github.com/grafana/grafana/pull/34120 with `width: fit-content`. Tested this a bit and it seems like `max-width: fit-content;` has some troubles when the element is placed within absolutely positioned element. I haven't looked for the underlying issue though.