### PR TITLE
Alerting: Clarify group by label in documentation of notification policies

### DIFF
--- a/docs/sources/alerting/unified-alerting/notification-policies.md
+++ b/docs/sources/alerting/unified-alerting/notification-policies.md
@@ -35,7 +35,7 @@ To edit a specific policy, find it in the specific routing table and click **Edi
 ### Root policy fields
 
 - **Default contact point -** The [contact point]({{< relref "./contact-points.md" >}}) to send notifications to that did not match any specific policy.
-- **Group by -** Labels to group alerts by. If multiple alerts are matched for this policy, they will be grouped based on these labels and a notification will be sent per group. If the field is empty (the default), then all notifications will be sent in a single group. A special case label `...` can be used to group alerts by all labels, which effectively disables grouping.
+- **Group by -** Labels to group alerts by. If multiple alerts are matched for this policy, they will be grouped based on these labels and a notification will be sent per group. If the field is empty (default), then all notifications are sent in a single group. Use a special label `...` to group alerts by all labels, which effectively disables grouping.
 
 Group timing options
 

--- a/docs/sources/alerting/unified-alerting/notification-policies.md
+++ b/docs/sources/alerting/unified-alerting/notification-policies.md
@@ -35,7 +35,7 @@ To edit a specific policy, find it in the specific routing table and click **Edi
 ### Root policy fields
 
 - **Default contact point -** The [contact point]({{< relref "./contact-points.md" >}}) to send notifications to that did not match any specific policy.
-- **Group by -** Labels to group alerts by. If multiple alerts are matched for this policy, they will be grouped based on these labels and a notification will be sent per group. Mandatory for root policy, optional for nested specific policies. If a specific policy does not specify own grouping, root policy grouping will be used.
+- **Group by -** Labels to group alerts by. If multiple alerts are matched for this policy, they will be grouped based on these labels and a notification will be sent per group. If the field is empty (the default), then all notifications will be sent in a single group. A special case label `...` can be used to group alerts by all labels, which effectively disables grouping.
 
 Group timing options
 
@@ -43,7 +43,7 @@ Group timing options
 - **Group interval -** - How long to wait before sending an notification when an alert has been added to a group for which there has already been a notification. Default is 5 minutes.
 - **Repeat interval -** - How long to wait before re-sending a notification after one has already been sent and no new alerts were added to the group. Default is 4 hours.
 
-### Specific policy fields
+### Specific routing policy fields
 
 - **Contact point -** The [contact point]({{< relref "./contact-points.md" >}}) to send notification to if alert matched this specific policy but did not match any of it's nested policies, or there were no nested specific policies.
 - **Matching labels -** Rules for matching alert labels. See ["How label matching works"](#how-label-matching-works) below for details.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The current description of the field "Group By" in notification polices is not very clear. This PR is to provide more details about the default behavior (field is empty) as well as special-case label. 
**Which issue(s) this PR fixes**:
Related to: https://github.com/grafana/grafana/issues/38760
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
