### PR TITLE
Apply `@cuetsy(kind)` attributes directly to `#PanelSchema`

### DIFF
--- a/cue/scuemata/panel-plugin.cue
+++ b/cue/scuemata/panel-plugin.cue
@@ -8,10 +8,10 @@ package scuemata
 // the larger Dashboard schema.
 #PanelSchema: {
     // Defines plugin specific options for a panel
-    PanelOptions: {...}
+    PanelOptions: {...} @cuetsy(kind="interface")
 
     // Define the custom properties that exist within standard field config
-    PanelFieldConfig?: {...}
+    PanelFieldConfig?: {...} @cuetsy(kind="interface")
 
     // Panels may define their own types
     ...


### PR DESCRIPTION
This is a neat little trick.

We've been struggling with how to ensure the necessary cuetsy attributes are applied to parts of the scuemata declared in `models.cue` files. @ying-jeanne had put a ton of - quite frustrating! - work trying to get the CUE Go API to behave in order to inject these attributes in #35875. But, as i'm discovering is often the case with CUE, it's far easier to do at least some of the work directly in a `.cue` file, then compose bits together from Go. For this case, these are those little bits.

By applying the attributes at the meta-schema level, we ensure that any `Panel` scuemata declared in a `models.cue` will receive these attributes when unified with this meta-schema. Given that the unifiability of those scuemata with the meta-schema is prerequisite anyway, this makes what we want to do that much easier.

Now, this approach is somewhat overbroad - it means that every schema in a panel plugin's scuemata will receive these attributes, rather than just the latest one, which is the only one that cuetsy will translate to Typescript. This isn't a critical flaw, however - as our understanding of the desired behavior in cuetsy has evolved, it's become clear that exercising precise control over exactly _which_ `cue.Value` we pass in for translation is a key part of the design. Thus, having the attribute applied to all schema doesn't pose a problem - it just means it's incumbent on our custom translation logic to _only_ pass that latest schema to cuetsy.