### PR TITLE
Chore: infer combined reducer state types

### DIFF
--- a/public/app/core/reducers/root.ts
+++ b/public/app/core/reducers/root.ts
@@ -46,7 +46,7 @@ export const createRootReducer = () => {
     ...addedReducers,
   });
 
-  return (state: any, action: AnyAction): any => {
+  return (state: any, action: AnyAction) => {
     if (action.type !== cleanUpAction.type) {
       return appReducer(state, action);
     }

--- a/public/app/features/plugins/state/reducers.ts
+++ b/public/app/features/plugins/state/reducers.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AnyAction, createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
 import { PluginMeta, PanelPlugin, PluginError } from '@grafana/data';
 import { PluginsState } from 'app/types';
 import { config } from 'app/core/config';
@@ -52,8 +52,8 @@ export const {
   panelPluginLoaded,
 } = pluginsSlice.actions;
 
-export const pluginsReducer: typeof pluginsSlice.reducer = config.pluginAdminEnabled
-  ? pluginCatalogReducer
+export const pluginsReducer: Reducer<PluginsState, AnyAction> = config.pluginAdminEnabled
+  ? ((pluginCatalogReducer as unknown) as Reducer<PluginsState, AnyAction>)
   : pluginsSlice.reducer;
 
 export default {

--- a/public/app/features/plugins/state/reducers.ts
+++ b/public/app/features/plugins/state/reducers.ts
@@ -52,7 +52,9 @@ export const {
   panelPluginLoaded,
 } = pluginsSlice.actions;
 
-export const pluginsReducer = config.pluginAdminEnabled ? pluginCatalogReducer : pluginsSlice.reducer;
+export const pluginsReducer: typeof pluginsSlice.reducer = config.pluginAdminEnabled
+  ? pluginCatalogReducer
+  : pluginsSlice.reducer;
 
 export default {
   plugins: pluginsReducer,

--- a/public/app/features/variables/state/reducers.ts
+++ b/public/app/features/variables/state/reducers.ts
@@ -1,18 +1,9 @@
 import { combineReducers } from '@reduxjs/toolkit';
-import { optionsPickerReducer, OptionsPickerState } from '../pickers/OptionsPicker/reducer';
-import { variableEditorReducer, VariableEditorState } from '../editor/reducer';
+import { optionsPickerReducer } from '../pickers/OptionsPicker/reducer';
+import { variableEditorReducer } from '../editor/reducer';
 import { variablesReducer } from './variablesReducer';
-import { VariableModel } from '../types';
-import { transactionReducer, TransactionState } from './transactionReducer';
-import { variableInspectReducer, VariableInspectState } from '../inspect/reducer';
-
-export interface TemplatingState {
-  variables: Record<string, VariableModel>;
-  optionsPicker: OptionsPickerState;
-  editor: VariableEditorState;
-  transaction: TransactionState;
-  inspect: VariableInspectState;
-}
+import { transactionReducer } from './transactionReducer';
+import { variableInspectReducer } from '../inspect/reducer';
 
 export const templatingReducers = combineReducers({
   editor: variableEditorReducer,
@@ -21,6 +12,8 @@ export const templatingReducers = combineReducers({
   transaction: transactionReducer,
   inspect: variableInspectReducer,
 });
+
+export type TemplatingState = ReturnType<typeof templatingReducers>;
 
 export default {
   templating: templatingReducers,

--- a/public/app/types/store.ts
+++ b/public/app/types/store.ts
@@ -1,49 +1,8 @@
 import { ThunkAction, ThunkDispatch as GenericThunkDispatch } from 'redux-thunk';
 import { Action, PayloadAction } from '@reduxjs/toolkit';
-import { NavIndex } from '@grafana/data';
-import { AlertRulesState, NotificationChannelState } from './alerting';
-import { TeamsState, TeamState } from './teams';
-import { FolderState } from './folders';
-import { DashboardState } from './dashboard';
-import { DataSourceSettingsState, DataSourcesState } from './datasources';
-import { ExploreState } from './explore';
-import { UserAdminState, UserListAdminState, UsersState } from './user';
-import { OrganizationState } from './organization';
-import { AppNotificationsState } from './appNotifications';
-import { PluginsState } from './plugins';
-import { LdapState } from './ldap';
-import { PanelEditorState } from '../features/dashboard/components/PanelEditor/state/reducers';
-import { ApiKeysState } from './apiKeys';
-import { TemplatingState } from '../features/variables/state/reducers';
-import { ImportDashboardState } from '../features/manage-dashboards/state/reducers';
-import { UserState } from 'app/features/profile/state/reducers';
-import { UnifiedAlertingState } from 'app/features/alerting/unified/state/reducers';
+import type { createRootReducer } from 'app/core/reducers/root';
 
-export interface StoreState {
-  navIndex: NavIndex;
-  alertRules: AlertRulesState;
-  teams: TeamsState;
-  team: TeamState;
-  folder: FolderState;
-  dashboard: DashboardState;
-  panelEditor: PanelEditorState;
-  dataSources: DataSourcesState;
-  dataSourceSettings: DataSourceSettingsState;
-  explore: ExploreState;
-  users: UsersState;
-  organization: OrganizationState;
-  appNotifications: AppNotificationsState;
-  user: UserState;
-  plugins: PluginsState;
-  ldap: LdapState;
-  apiKeys: ApiKeysState;
-  userAdmin: UserAdminState;
-  userListAdmin: UserListAdminState;
-  templating: TemplatingState;
-  importDashboard: ImportDashboardState;
-  notificationChannel: NotificationChannelState;
-  unifiedAlerting: UnifiedAlertingState;
-}
+export type StoreState = ReturnType<ReturnType<typeof createRootReducer>>;
 
 /*
  * Utility type to get strongly types thunks


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Just a little bit of type depoilerplating, result of observations made when fixing a problem in https://github.com/grafana/grafana/pull/38872. Store state can be inferred from a reducer's return type. This makes sense in case of combined reducers, removing the need to manually maintain the state type and ensuring it's accurate.

There are no functional changes in this PR

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

