### PR TITLE
Graphite: Fix drag and drop queries

### DIFF
--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -180,7 +180,7 @@ export default class GraphiteQuery {
     };
 
     if (!this.target.textEditor) {
-      const metricPath = this.getSegmentPathUpTo(this.segments.length).replace(/\.select metric$/, '');
+      const metricPath = this.getSegmentPathUpTo(this.segments.length).replace(/\.?select metric$/, '');
       this.target.target = reduce(this.functions, wrapFunction, metricPath);
     }
 

--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -74,4 +74,25 @@ describe('Graphite query model', () => {
       expect(ctx.queryModel.functions[1].params[0]).toBe('$limit');
     });
   });
+
+  describe('skips "select metric" when target is rendered', () => {
+    beforeEach(() => {
+      ctx.target = { refId: 'A', target: '' };
+      ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
+    });
+
+    it('at the beginning of the metric name', () => {
+      ctx.queryModel.segments = [{ value: 'select metric' }];
+      ctx.queryModel.updateModelTarget(ctx.targets);
+
+      expect(ctx.queryModel.target.target).toBe('');
+    });
+
+    it('in the middle of the metric name', () => {
+      ctx.queryModel.segments = [{ value: 'foo' }, { value: 'select metric' }];
+      ctx.queryModel.updateModelTarget(ctx.targets);
+
+      expect(ctx.queryModel.target.target).toBe('foo');
+    });
+  });
 });

--- a/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/graphite_query.test.ts
@@ -75,24 +75,24 @@ describe('Graphite query model', () => {
     });
   });
 
-  describe('skips "select metric" when target is rendered', () => {
+  describe('when query is generated from segments', () => {
     beforeEach(() => {
       ctx.target = { refId: 'A', target: '' };
       ctx.queryModel = new GraphiteQuery(ctx.datasource, ctx.target, ctx.templateSrv);
     });
 
-    it('at the beginning of the metric name', () => {
+    it('and no segments are selected then the query is empty', () => {
       ctx.queryModel.segments = [{ value: 'select metric' }];
       ctx.queryModel.updateModelTarget(ctx.targets);
 
       expect(ctx.queryModel.target.target).toBe('');
     });
 
-    it('in the middle of the metric name', () => {
-      ctx.queryModel.segments = [{ value: 'foo' }, { value: 'select metric' }];
+    it('and some segments are selected then segments without selected value are omitted', () => {
+      ctx.queryModel.segments = [{ value: 'foo' }, { value: 'bar' }, { value: 'select metric' }];
       ctx.queryModel.updateModelTarget(ctx.targets);
 
-      expect(ctx.queryModel.target.target).toBe('foo');
+      expect(ctx.queryModel.target.target).toBe('foo.bar');
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

In Dashboards: when an empty query (with "select metric" segment only) is dragged it's then an additional `onChange()` is incorrectly triggered (even though the query doesn't change). This leads to keeping stale state on the drop. See the GIF below how refId is set to B after the drop:

![refid 2](https://user-images.githubusercontent.com/745532/133079041-15274123-885c-45d0-ad37-bd9cc1513390.gif)

A segment with value of "select segment" should be ignored but regular expression was working only if it's not the very first segment. I've updated the regex and added some tests.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes N/A

**Special notes for your reviewer**:

This will be needed for https://github.com/grafana/grafana/pull/38942 as well. CC: @Elfo404 
