### PR TITLE
WIP: Enhance configuration of feature toggles

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -995,8 +995,45 @@ grpc_port =
 license_path =
 
 [feature_toggles]
-# enable features, separated by spaces
+# enable features, separated by spaces. Deprecated, please use separate keys below for enable/disable each feature.
 enable =
+
+# Whether to enable the standalone alerts feature.
+ngalert = false
+
+# Whether to enable the access control feature.
+accesscontrol = false
+
+# Whether to enable the live config feature.
+live-config = false
+
+# Whether to enable the live pipeline feature.
+live-pipeline = false
+
+# Whether to enable the remove/apply default values for dashboards feature.
+trimDefaults = false
+
+# Whether to enable the database instrumentation feature.
+database_metrics = false
+
+# Whether to disable the use of request histograms.
+# Will be removed in Grafana 8.x but gives the operator some graceperiod to update all the monitoring tools.
+disable_http_request_histogram = false
+
+# Whether to enable the new navigation feature.
+newNavigation = false
+
+# Whether to enable the Prometheus Monaco feature.
+prometheusMonaco = false
+
+# Whether to enable the tempo search feature.
+tempoSearch = false
+
+# Whether to enable the tempo service graph feature.
+tempoServiceGraph = false
+
+# Whether to enable the Azure Authentication HTTP client middleware.
+httpclientprovider_azure_auth = false
 
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/

--- a/pkg/infra/featuretoggle/feature_toggle.go
+++ b/pkg/infra/featuretoggle/feature_toggle.go
@@ -1,0 +1,110 @@
+package featuretoggle
+
+import (
+	"sync"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var featureToggleGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name:      "feature_toggle",
+	Help:      "A metric value labeled by feature telling if a feature is enabled ('1') or not ('0')",
+	Namespace: "grafana",
+}, []string{"feature"})
+
+func init() {
+	prometheus.MustRegister(featureToggleGauge)
+}
+
+func ProvideService(cfg *setting.Cfg) (*Service, error) {
+	logger := log.New("feature-toggle")
+	features := map[string]bool{}
+	sec := cfg.Raw.Section("feature_toggles")
+
+	for _, k := range sec.Keys() {
+		key := k.Name()
+		if key == "enable" {
+			continue
+		}
+
+		enabled := k.MustBool(false)
+		enabled = cfg.SectionWithEnvOverrides("feature_toggles").Key(key).MustBool(enabled)
+		features[key] = enabled
+
+		label, err := metricutil.SanitizeLabelName(key)
+		if err != nil {
+			return nil, err
+		}
+
+		if enabled {
+			featureToggleGauge.WithLabelValues(label).Set(1)
+		} else {
+			featureToggleGauge.WithLabelValues(label).Set(0)
+		}
+	}
+
+	if enabledStr := sec.Key("enable").MustString(""); enabledStr != "" {
+		logger.Warn("Use of the enable setting is deprecated. Please use a setting per feature toggle instead.")
+		for _, feature := range util.SplitString(enabledStr) {
+			features[feature] = true
+			label, err := metricutil.SanitizeLabelName(feature)
+			if err != nil {
+				return nil, err
+			}
+			featureToggleGauge.WithLabelValues(label).Set(1)
+		}
+	}
+
+	return &Service{
+		log:      logger,
+		cfg:      cfg,
+		features: features,
+		mutex:    &sync.RWMutex{},
+	}, nil
+}
+
+type Service struct {
+	log      log.Logger
+	cfg      *setting.Cfg
+	features map[string]bool
+	mutex    *sync.RWMutex
+}
+
+func (s *Service) IsEnabled(feature string) bool {
+	s.mutex.RLock()
+	enabled, exists := s.features[feature]
+	if exists {
+		s.mutex.RUnlock()
+		return enabled
+	}
+
+	s.mutex.Lock()
+	enabled, exists = s.features[feature]
+	if exists {
+		s.mutex.Unlock()
+		return enabled
+	}
+
+	defer s.mutex.Unlock()
+
+	// In case feature toggle not in defaults.ini and overridden by env variable we try to
+	// read the value from the env variable.
+	s.features[feature] = s.cfg.SectionWithEnvOverrides("feature_toggles").Key(feature).MustBool(false)
+	label, err := metricutil.SanitizeLabelName(feature)
+	if err != nil {
+		s.log.Error("failed to sanitize label name", "error", err)
+		return s.features[feature]
+	}
+
+	if s.features[feature] {
+		featureToggleGauge.WithLabelValues(label).Set(1)
+	} else {
+		featureToggleGauge.WithLabelValues(label).Set(0)
+	}
+
+	return s.features[feature]
+}

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/featuretoggle"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/httpclient/httpclientprovider"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -144,6 +145,7 @@ var wireBasicSet = wire.NewSet(
 	elasticsearch.ProvideService,
 	grafanads.ProvideService,
 	dashboardsnapshots.ProvideService,
+	featuretoggle.ProvideService,
 )
 
 var wireSet = wire.NewSet(


### PR DESCRIPTION
**What this PR does / why we need it**:
First draft to get a feel for in what direction we would like to take this and gather some feedback.

**Which issue(s) this PR fixes**:
Fixes #36511 

**Special notes for your reviewer**:
- There are feature toggles only used client side that are not referenced in the backend currently and makes it hard to figure out if one of those features are enabled/disabled through code and adding metrics for it. With the old solution using "enable" setting key we could only track which ones are enabled, but not disabled.
- Can we/do we require all feature toggles to be defined in defaults.ini? Doing this would allow us to track what features are enabled/disabled using a metric.  This would require enterprise to also do this which doesn't feel optimal.
- As an alternative for always keeping all features in defaults.ini we could require them to be registered in the backend before being able to use them. Similar to prometheus client library using `Registry` and `Gatherer` for registering metrics and gathering the values of them.
- Do we want to deprecate the use of "enable" or not? 

**Possible alternative solution (to compare with/discuss) :** 

```go
// Evaluator evaluates if a feature is enabled or not.
type Evaluator interface {
	IsFeatureEnabled(ctx context.Context, name string, enabledByDefault bool) bool
}

// ConfigEvaluator evaluates if a feature is enabled or not based on configuration settings.
type ConfigEvaluator struct {
	cfg *setting.Cfg
}

func (ce ConfigEvaluator) IsFeatureEnabled(ctx context.Context, name string) bool {
	return cfg.FeatureToggles[name]
}

type Opts struct {
	Name             string
	Description      string
	EnabledByDefault bool
}

type FeatureToggle interface {
	init(e Evaluator)
	Name() string
	Description() string
	IsEnabled() bool
	IsDisabled() bool
}

type featureToggle struct {
	name             string
	description      string
	enabledByDefault bool
	evaluator        Evaluator
}

// New creates a new feature toggle.
func New(opts Opts) FeatureToggle {
	return &featureToggle{
		name:             opts.Name,
		description:      opts.Description,
		enabledByDefault: opts.EnabledByDefault,
	}
}

func (f *featureToggle) init(evaluator Evaluator) {
	f.evaluator = evaluator
}

func (f featureToggle) Name() string {
	return f.name
}

func (f featureToggle) Description() string {
	return f.description
}

func (f featureToggle) IsEnabled() bool {
	if f.evaluator == nil {
		panic("feature toggle not registered")
	}

	return f.evaluator.IsFeatureEnabled(ctx, f.name, f.enabledByDefault)
}

type Registry struct {
	evaluator      Evaluator
	featureToggles map[string]FeatureToggle
	mutex          *sync.Mutex
}

func NewRegistry(evaluator Evaluator) (*Registry, error) {
	if evaluator == nil {
		return nil, errors.New("evaluator cannot be nil")
	}

	return &Registry{
		evaluator:      evaluator,
		featureToggles: map[string]FeatureToggle{},
		mutex:          &sync.Mutex{},
	}, nil
}

func (r *Registry) Register(feature FeatureToggle) error {
	r.mutex.Lock()
	defer r.mutex.Unlock()

	return r.registerInternal(feature)
}

func (r *Registry) MustRegister(features ...FeatureToggle) {
	r.mutex.Lock()
	defer r.mutex.Unlock()

	for _, f := range features {
		if err := r.registerInternal(f); err != nil {
			panic(err)
		}
	}
}

func (r *Registry) registerInternal(featureToggle FeatureToggle) error {
	if featureToggle == nil {
		return errors.New("feature toggle cannot be nil")
	}

	if _, exists := r.featureToggles[featureToggle.Name()]; exists {
		return fmt.Errorf("feature toggle %q already registered", featureToggle.Name())
	}

	featureToggle.init(r.evaluator)
	r.featureToggles[featureToggle.Name()] = featureToggle

	return nil
}
```

Example usage:
Inspired by Prometheus client library. All feature toggles needs to be registered upfront, otherwise you cannot check if feature toggle is enabled/disabled - it will panic. Feature toggles only used by frontend would need to be registered in backend as well.

Advantage with this solution is that Grafana system will have a complete list of feature toggles in use. Think it also would be easier to extend with additional logic in the future, such as 
- storing/reading from the database
- allowing a feature toggle to be toggled on a per request or user basis.

```go
package something

var AwesomeFeatureToggle = featuretoggle.New(featuretoggle.Opts{
  Name: "awesome",
  Description: "This feature toggle is used for the awesome feature",
  EnabledByDefault: false,
})

func ProvideService(registry *featuretoggle.Registry) *Service {
 	r.MustRegister(AwesomeFeatureToggle)
}

func (s *Service) IsDisabled() bool {
	return AwesomeFeatureToggle.IsDisabled()
}
```

compared with changes in this pr:
Biggest drawback is that feature toggles is not registered upfront so only referenced/checked feature toggles are added as metrics and Grafana system don't have the complete knowledge of feature toggles in use. For example those feature toggles only used by frontend would not be tracked (metrics) unless it's enabled via configuration.

```go
const featureToggleTrimDefaults = "trimDefaults"

func ProvideService(featureToggles *featuretoggle.Service) *Service {
 	return &SchemaLoaderService{
 	 	featureToggles: featureToggles,
 	}
}

func (rs *SchemaLoaderService) IsDisabled() bool {
	return !rs.featureToggles.IsEnabled(featureToggleTrimDefaults)
}
```
