### PR TITLE
Explore: Fix zoom-in the time range

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -195,6 +195,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
           height={400}
           width={width - spacing}
           absoluteRange={absoluteRange}
+          onChangeTime={this.onUpdateTimeRange}
           timeZone={timeZone}
           annotations={queryResponse.annotations}
           splitOpenFn={splitOpen}

--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -46,6 +46,7 @@ interface Props {
   onHiddenSeriesChanged?: (hiddenSeries: string[]) => void;
   tooltipDisplayMode?: TooltipDisplayMode;
   splitOpenFn?: SplitOpen;
+  onChangeTime: (timeRange: AbsoluteTimeRange) => void;
 }
 
 export function ExploreGraph({
@@ -54,6 +55,7 @@ export function ExploreGraph({
   width,
   timeZone,
   absoluteRange,
+  onChangeTime,
   loadingState,
   annotations,
   onHiddenSeriesChanged,
@@ -154,6 +156,7 @@ export function ExploreGraph({
         title=""
         width={width}
         height={height}
+        onChangeTimeRange={onChangeTime}
         options={
           {
             tooltip: { mode: tooltipDisplayMode },

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -308,6 +308,7 @@ export class UnthemedLogs extends PureComponent<Props, State> {
             absoluteRange={visibleRange || absoluteRange}
             timeZone={timeZone}
             loadingState={loadingState}
+            onChangeTime={onChangeTime}
             onHiddenSeriesChanged={this.onToggleLogLevel}
           />
         ) : undefined}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Binding the handler to zoom-in to selected time range was accidentally removed in https://github.com/grafana/grafana/pull/38914. This PR adds them back.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes N/A

**Special notes for your reviewer**:

How to test it?

Make a metric query in Explore (try also with logs query and logs histogram). Select some range in the graph. The selected range should be updated.
