### PR TITLE
Docs: Fix broken link to signed GCS URLs docs

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1434,7 +1434,7 @@ Optional extra path inside bucket.
 
 ### enable_signed_urls
 
-If set to true, Grafana creates a [signed URL](https://cloud.google.com/storage/docs/access-control/signed-urls] for
+If set to true, Grafana creates a [signed URL](https://cloud.google.com/storage/docs/access-control/signed-urls) for
 the image uploaded to Google Cloud Storage.
 
 ### signed_url_expiration


### PR DESCRIPTION
**What this PR does / why we need it**:

The current version of the docs contains a broken link to the GCS docs about signed URLs. The link (since it contains an additional `]`) generates a 404 and also slightly breaks the rendering of the link.

**Which issue(s) this PR fixes**:

None