### PR TITLE
Chore: Disable alerting backend test for now since it adds 10 minutes extra in CI

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs(t *testing.T) {
+	t.Skipf("Skipping multiorg alertmanager tests for now")
 	configStore := &FakeConfigStore{
 		configs: map[int64]*models.AlertConfiguration{},
 	}
@@ -43,6 +44,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs(t *testing.T) {
 }
 
 func TestMultiOrgAlertmanager_AlertmanagerFor(t *testing.T) {
+	t.Skipf("Skipping multiorg alertmanager tests for now")
 	configStore := &FakeConfigStore{
 		configs: map[int64]*models.AlertConfiguration{},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Should make the test-backend step in CI a lot faster.

**Which issue(s) this PR fixes**:
Ref #38586

**Special notes for your reviewer**:
- Before
![Selection_1051](https://user-images.githubusercontent.com/1668778/133123552-e69e15d0-7ea7-4eb5-b439-d7a63ba89dc7.png)
- After
![Selection_1050](https://user-images.githubusercontent.com/1668778/133123433-fcfe5b51-c6b6-478a-929b-d96c16208a04.png)