### PR TITLE
Alerting: allow empty auth basic username for webhook

### DIFF
--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -64,7 +64,7 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 	request.Header.Set("Content-Type", webhook.ContentType)
 	request.Header.Set("User-Agent", "Grafana")
 
-	if webhook.User != "" && webhook.Password != "" {
+	if webhook.User != "" || webhook.Password != "" {
 		request.Header.Set("Authorization", util.GetBasicAuthHeader(webhook.User, webhook.Password))
 	}
 


### PR DESCRIPTION
Some services apparently don't have username in auth basic
authentication. Enable specifying empty username so the webhook
receiver can work with them.

Sample usecase: sending monitoring alert heartbeat to OpsGenie via webhook.

* [OpsGenie authentication](https://docs.opsgenie.com/docs/authentication)