### PR TITLE
Fix table column resize wrong z-index (#36934)

### DIFF
--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -148,7 +148,6 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       right: -4px;
       border-radius: 3px;
       top: 0;
-      z-index: ${theme.zIndex.dropdown};
       touch-action: none;
 
       &:hover {


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #36934. z-index removed for table column resize div. It's not needed actually.

**Special notes for your reviewer**:

