### PR TITLE
InfluxDB: InfluxQL query editor: Handle unusual characters in tag values better

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_query_model.ts
+++ b/public/app/plugins/datasource/influxdb/influx_query_model.ts
@@ -142,6 +142,7 @@ export default class InfluxQueryModel {
   }
 
   private renderTagCondition(tag: InfluxQueryTag, index: number, interpolate?: boolean) {
+    // FIXME: merge this function with query_builder/renderTagCondition
     let str = '';
     let operator = tag.operator;
     let value = tag.value;

--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -2,6 +2,7 @@ import { reduce } from 'lodash';
 import kbn from 'app/core/utils/kbn';
 
 function renderTagCondition(tag: { operator: any; value: string; condition: any; key: string }, index: number) {
+  // FIXME: merge this function with influx_query_model/renderTagCondition
   let str = '';
   let operator = tag.operator;
   let value = tag.value;
@@ -19,7 +20,7 @@ function renderTagCondition(tag: { operator: any; value: string; condition: any;
 
   // quote value unless regex or number, or if empty-string
   if (value === '' || (operator !== '=~' && operator !== '!~' && isNaN(+value))) {
-    value = "'" + value + "'";
+    value = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
   }
 
   return str + '"' + tag.key + '" ' + operator + ' ' + value;

--- a/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
@@ -178,6 +178,24 @@ describe('InfluxQueryBuilder', () => {
       expect(query).toBe(`SHOW TAG KEYS WHERE "app" == 42`);
     });
 
+    it('should handle tag-value-contains-backslash-character getting tag-keys', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: 'lab\\el', operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe(`SHOW TAG KEYS WHERE "app" == 'lab\\\\el'`);
+    });
+
+    it('should handle tag-value-contains-single-quote-character getting tag-keys', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: "lab'el", operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe(`SHOW TAG KEYS WHERE "app" == 'lab\\'el'`);
+    });
+
     it('should handle tag-value=emptry-string when getting measurements', () => {
       const builder = new InfluxQueryBuilder(
         { measurement: undefined, tags: [{ key: 'app', value: '', operator: '==' }] },


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/39003

when in the influxdb database there are tag-values with problematic characters ( `'` and `\`), they need special handling, they need to be escaped, otherwise they break the whole influxdb query text.

this pull-request does that.

how to test:
- you need to add some strange values to your influxdb database, so:
  - `make devenv sources=influxdb`
  - `docker ps`, get the container_id for the influxdb container
  - run `docker exec -it <influxdb_docker_container_id> influx write -b mybucket -o myorg -t mytoken -m query`
    - where `query` can be (note the single or double quotes):
      - `'m5,tag1=va\l5 val=45'`
      - `"m5,tag1=va'l5 val=45"`
   - now go to grafana, explore, choose the `gdev-influxdb-influxql` datasource, and choose:
     - FROM: `default/m5`
     - WHERE: `tag1=va\l5` ( or `tag1=va'l5`)
     - SELECT: `field(val)`
   - run the query, verify it still runs and returns data
   - try to remove the WHERE-section, and verify that it is possible

NOTE: the basic problem is that we have duplicated code in the influxdb datasource, compare:
- https://github.com/grafana/grafana/blob/gabor/influx-tag-keys/public/app/plugins/datasource/influxdb/query_builder.ts#L4-L27
- https://github.com/grafana/grafana/blob/gabor/influx-tag-keys/public/app/plugins/datasource/influxdb/influx_query_model.ts#L144-L174

they are nearly the same, but fixes are always applied only to one. the better solution would be to merge these two files. that will be done in a separate pull-request.