### PR TITLE
Alerting: Bugfix not creating filepath for nflog and silences

### DIFF
--- a/pkg/services/ngalert/notifier/file_store.go
+++ b/pkg/services/ngalert/notifier/file_store.go
@@ -93,6 +93,12 @@ func (fs *FileStore) IsExists(fn string) bool {
 
 // WriteFileToDisk writes a file with the provided name and contents to the Alertmanager working directory with the default grafana permission.
 func (fs *FileStore) WriteFileToDisk(fn string, content []byte) error {
+	// Ensure the working directory is created
+	err := os.MkdirAll(fs.workingDirPath, 0750)
+	if err != nil {
+		return fmt.Errorf("unable to create the working directory %q: %s", fs.workingDirPath, err)
+	}
+
 	return os.WriteFile(fs.pathFor(fn), content, 0644)
 }
 


### PR DESCRIPTION
We created this filepath just as we're about to persist the templates - with the latest change, we now need to create it sooner.

Noticed this while deploying a new instance with a new disk. I don't think we need to add to the changelog given this feature has not been released yet. 