### PR TITLE
prometheus: monaco: better popup-font-size

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -16,6 +16,7 @@ const options: CodeEditorMonacoOptions = {
   scrollBeyondLastLine: false,
   renderLineHighlight: 'none',
   fontSize: 14,
+  suggestFontSize: 12,
   // we need `fixedOverflowWidgets` because otherwise in grafana-dashboards
   // the popup is clipped by the panel-visualizations.
   fixedOverflowWidgets: true,


### PR DESCRIPTION
this sets the font-size for the suggestion-popup to be the same as it is in the "old" editor.

screenshot of the popup in the old slate-based editor:
<img width="592" alt="slate" src="https://user-images.githubusercontent.com/51989/133268481-0667b760-f546-4e14-83b8-3f90c7d34f02.png">


screenshot of the popup in the new monaco-based editor (with the change from this pull-request applied):
<img width="643" alt="monaco" src="https://user-images.githubusercontent.com/51989/133268529-b7f96fe6-c57c-4b1d-ac80-98cf4d25dd09.png">
