### PR TITLE
InfluxDB: Fix regex to identify `/` as separator

### DIFF
--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -16,7 +16,7 @@ import (
 type ResponseParser struct{}
 
 var (
-	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$\s*([\@\/\w-]+?)*`)
+	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$\s*([\@\w-]+?)*`)
 )
 
 func (rp *ResponseParser) Parse(buf io.ReadCloser, query *Query) *backend.QueryDataResponse {

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -16,7 +16,7 @@ import (
 type ResponseParser struct{}
 
 var (
-	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$\s*([\@\w-]+?)*`)
+	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|(\$*([\@\w-]+?))*`)
 )
 
 func (rp *ResponseParser) Parse(buf io.ReadCloser, query *Query) *backend.QueryDataResponse {

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -269,6 +269,20 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)
 		}
 
+		query = &Query{Alias: "alias $tag_datacenter/$tag_datacenter"}
+		result = parser.Parse(prepare(response), query)
+		frame = result.Responses["A"]
+		name = "alias America/America"
+		testFrame.Name = name
+		newField = data.NewField("value", labels, []*float64{
+			pointer.Float64(222),
+		})
+		testFrame.Fields[1] = newField
+		testFrame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: name}
+		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+			t.Errorf("Result mismatch (-want +got):\n%s", diff)
+		}
+
 		query = &Query{Alias: "alias [[col]]", Measurement: "10m"}
 		result = parser.Parse(prepare(response), query)
 		frame = result.Responses["A"]


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/32844, slash (`/`) symbol stopped being used as a separator between aliases and considered only as alias symbol, falsely. This PR fixes the issue, and aliases like `$a/$b` can be identified properly.

**Which issue(s) this PR fixes**:

Fixes #37143
