### PR TITLE
Live: default to constant label values for pipeline

### DIFF
--- a/pkg/services/live/pipeline/converter_json_exact.go
+++ b/pkg/services/live/pipeline/converter_json_exact.go
@@ -197,6 +197,8 @@ func (c *ExactJsonConverter) Convert(_ context.Context, vars Vars, body []byte) 
 					return nil, err
 				}
 				labels[label.Name] = v
+			} else {
+				labels[label.Name] = label.Value
 			}
 		}
 		field.Labels = labels


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for a constant label value for jsonExact pipeline convertor.