### PR TITLE
Postgres/MySQL/MSSQL: Fix engine cache not updating after data source update

### DIFF
--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -150,7 +150,7 @@ func NewQueryDataHandler(config DataPluginConfiguration, queryResultTransformer 
 	defer engineCache.Unlock()
 
 	if engine, present := engineCache.cache[config.DSInfo.ID]; present {
-		if updateTime := engineCache.updates[config.DSInfo.ID]; updateTime.Before(config.DSInfo.Updated) {
+		if updateTime := engineCache.updates[config.DSInfo.ID]; updateTime == config.DSInfo.Updated {
 			queryDataHandler.engine = engine
 			return &queryDataHandler, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Happened to notice that MSSQL data source did not use the updated hostname when connecting to database after updating the hostname of a MSSQL data source. 

Seems to have been introduced with #36635. 

**Which issue(s) this PR fixes**:
Ref #36635

**Special notes for your reviewer**:
- Somewhat related to #37299. However after #36635 we shouldn't need to cache engines in sql_engine.go any longer - I'll will try and resolve this in a follow up PR.