### PR TITLE
Chore: use colon prefix in URL parameters

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -235,7 +235,7 @@ func getAlertNotificationsInternal(c *models.ReqContext) ([]*models.AlertNotific
 func GetAlertNotificationByID(c *models.ReqContext) response.Response {
 	query := &models.GetAlertNotificationsQuery{
 		OrgId: c.OrgId,
-		Id:    c.ParamsInt64("notificationId"),
+		Id:    c.ParamsInt64(":notificationId"),
 	}
 
 	if query.Id == 0 {
@@ -393,7 +393,7 @@ func fillWithSecureSettingsDataByUID(cmd *models.UpdateAlertNotificationWithUidC
 func DeleteAlertNotification(c *models.ReqContext) response.Response {
 	cmd := models.DeleteAlertNotificationCommand{
 		OrgId: c.OrgId,
-		Id:    c.ParamsInt64("notificationId"),
+		Id:    c.ParamsInt64(":notificationId"),
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {
@@ -453,7 +453,7 @@ func NotificationTest(c *models.ReqContext, dto dtos.NotificationTestCommand) re
 
 // POST /api/alerts/:alertId/pause
 func PauseAlert(c *models.ReqContext, dto dtos.PauseAlertCommand) response.Response {
-	alertID := c.ParamsInt64("alertId")
+	alertID := c.ParamsInt64(":alertId")
 	result := make(map[string]interface{})
 	result["alertId"] = alertID
 

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -430,7 +430,7 @@ func convertModelToDtos(ds *models.DataSource) dtos.DataSource {
 // CheckDatasourceHealth sends a health check request to the plugin datasource
 // /api/datasource/:id/health
 func (hs *HTTPServer) CheckDatasourceHealth(c *models.ReqContext) response.Response {
-	datasourceID := c.ParamsInt64("id")
+	datasourceID := c.ParamsInt64(":id")
 
 	ds, err := hs.DataSourceCache.GetDatasource(datasourceID, c.SignedInUser, c.SkipCache)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow-up to #38826 and it fixes the use of unprefixed parameter names in the URLs.