### PR TITLE
BarChart: fix legend and tooltip colors off by 1 after data refresh

### DIFF
--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -246,11 +246,15 @@ export function prepareGraphableFrames(
     };
   }
 
+  let seriesIndex = 0;
+
   for (let frame of series) {
     const fields: Field[] = [];
     for (const field of frame.fields) {
       if (field.type === FieldType.number) {
-        let copy = {
+        field.state!.seriesIndex = seriesIndex++;
+
+        let copy: Field = {
           ...field,
           config: {
             ...field.config,

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -254,7 +254,7 @@ export function prepareGraphableFrames(
       if (field.type === FieldType.number) {
         field.state!.seriesIndex = seriesIndex++;
 
-        let copy: Field = {
+        let copy = {
           ...field,
           config: {
             ...field.config,

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -252,7 +252,9 @@ export function prepareGraphableFrames(
     const fields: Field[] = [];
     for (const field of frame.fields) {
       if (field.type === FieldType.number) {
-        field.state!.seriesIndex = seriesIndex++;
+        field.state = field.state ?? {};
+
+        field.state.seriesIndex = seriesIndex++;
 
         let copy = {
           ...field,


### PR DESCRIPTION
fix by always re-enumerating `state.seriesIndex` during frame prep, not just during initial config.


https://user-images.githubusercontent.com/43234/133442290-998b80bf-c938-460d-8a94-e943b5e0bb42.mp4