### PR TITLE
Usage Stats Updates

### DIFF
--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -42,6 +42,7 @@ type UsageStatsService struct {
 	externalMetrics          []MetricsFunc
 	concurrentUserStatsCache memoConcurrentUserStats
 	liveStats                liveUsageStats
+	startTime                time.Time
 }
 
 type liveUsageStats struct {
@@ -68,6 +69,7 @@ func ProvideService(cfg *setting.Cfg, bus bus.Bus, sqlStore *sqlstore.SQLStore,
 		grafanaLive:        grafanaLive,
 		kvStore:            kvStore,
 		log:                log.New("infra.usagestats"),
+		startTime:          time.Now(),
 	}
 	return s
 }

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/plugins"
@@ -33,6 +34,7 @@ type UsageStatsService struct {
 	PluginManager      plugins.Manager
 	SocialService      social.Service
 	grafanaLive        *live.GrafanaLive
+	kvStore            kvstore.KVStore
 
 	log log.Logger
 
@@ -54,7 +56,8 @@ type liveUsageStats struct {
 
 func ProvideService(cfg *setting.Cfg, bus bus.Bus, sqlStore *sqlstore.SQLStore,
 	alertingStats alerting.UsageStatsQuerier, pluginManager plugins.Manager,
-	socialService social.Service, grafanaLive *live.GrafanaLive) *UsageStatsService {
+	socialService social.Service, grafanaLive *live.GrafanaLive,
+	kvStore kvstore.KVStore) *UsageStatsService {
 	s := &UsageStatsService{
 		Cfg:                cfg,
 		Bus:                bus,
@@ -63,6 +66,7 @@ func ProvideService(cfg *setting.Cfg, bus bus.Bus, sqlStore *sqlstore.SQLStore,
 		oauthProviders:     socialService.GetOAuthProviders(),
 		PluginManager:      pluginManager,
 		grafanaLive:        grafanaLive,
+		kvStore:            kvStore,
 		log:                log.New("infra.usagestats"),
 	}
 	return s

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -114,6 +114,7 @@ func (uss *UsageStatsService) Run(ctx context.Context) error {
 				nextSendInterval = sendInterval
 				sendReportTicker.Reset(nextSendInterval)
 			}
+
 			// always reset live stats every report tick
 			uss.resetLiveStats()
 		case <-updateStatsTicker.C:

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -104,11 +104,13 @@ func (uss *UsageStatsService) Run(ctx context.Context) error {
 		select {
 		case <-sendReportTicker.C:
 			if err := uss.sendUsageStats(ctx); err != nil {
-				uss.log.Warn("Failed to send usage stats", "err", err)
+				uss.log.Warn("Failed to send usage stats", "error", err)
 			}
 
 			lastSent = time.Now()
-			uss.kvStore.Set(ctx, "last_sent", lastSent.Format(time.RFC3339))
+			if err := uss.kvStore.Set(ctx, "last_sent", lastSent.Format(time.RFC3339)); err != nil {
+				uss.log.Warn("Failed to update last sent time", "error", err)
+			}
 
 			if nextSendInterval != sendInterval {
 				nextSendInterval = sendInterval

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -272,6 +272,8 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.auth_token_per_user_le_15"] = concurrentUsersStats.BucketLE15
 	metrics["stats.auth_token_per_user_le_inf"] = concurrentUsersStats.BucketLEInf
 
+	metrics["stats.uptime"] = time.Since(uss.startTime).Seconds()
+
 	return report, nil
 }
 

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -271,7 +271,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 	metrics["stats.auth_token_per_user_le_15"] = concurrentUsersStats.BucketLE15
 	metrics["stats.auth_token_per_user_le_inf"] = concurrentUsersStats.BucketLEInf
 
-	metrics["stats.uptime"] = time.Since(uss.startTime).Seconds()
+	metrics["stats.uptime"] = int64(time.Since(uss.startTime).Seconds())
 
 	return report, nil
 }

--- a/pkg/infra/usagestats/usage_stats.go
+++ b/pkg/infra/usagestats/usage_stats.go
@@ -228,7 +228,7 @@ func (uss *UsageStatsService) GetUsageReport(ctx context.Context) (UsageReport, 
 
 	// get stats about alert notifier usage
 	anStats := models.GetAlertNotifierUsageStatsQuery{}
-	if err := uss.Bus.Dispatch(&anStats); err != nil {
+	if err := uss.Bus.DispatchCtx(ctx, &anStats); err != nil {
 		uss.log.Error("Failed to get alert notification stats", "error", err)
 		return report, err
 	}

--- a/pkg/infra/usagestats/usage_stats_service_test.go
+++ b/pkg/infra/usagestats/usage_stats_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,8 @@ func TestUsageStatsService_GetConcurrentUsersStats(t *testing.T) {
 	uss := &UsageStatsService{
 		Bus:      bus.New(),
 		SQLStore: sqlStore,
-		kvStore:  kvstore.ProvideService(sqlStore),
+		kvStore:  kvstore.WithNamespace(kvstore.ProvideService(sqlStore), 0, "infra.usagestats"),
+		log:      log.New("infra.usagestats"),
 	}
 
 	createConcurrentTokens(t, sqlStore)

--- a/pkg/infra/usagestats/usage_stats_service_test.go
+++ b/pkg/infra/usagestats/usage_stats_service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,7 @@ func TestUsageStatsService_GetConcurrentUsersStats(t *testing.T) {
 	uss := &UsageStatsService{
 		Bus:      bus.New(),
 		SQLStore: sqlStore,
+		kvStore:  kvstore.ProvideService(sqlStore),
 	}
 
 	createConcurrentTokens(t, sqlStore)

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -309,6 +309,10 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, runtime.GOOS, j.Get("os").MustString())
 			assert.Equal(t, runtime.GOARCH, j.Get("arch").MustString())
 
+			usageId := uss.GetUsageStatsId(context.Background())
+			assert.NotEmpty(t, usageId)
+			assert.Equal(t, usageId, j.Get("usageStatsId").MustString())
+
 			metrics := j.Get("metrics")
 			assert.Equal(t, getSystemStatsQuery.Result.Dashboards, metrics.Get("stats.dashboards.count").MustInt64())
 			assert.Equal(t, getSystemStatsQuery.Result.Users, metrics.Get("stats.users.count").MustInt64())
@@ -395,6 +399,9 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, 4, metrics.Get("stats.auth_token_per_user_le_12").MustInt())
 			assert.Equal(t, 5, metrics.Get("stats.auth_token_per_user_le_15").MustInt())
 			assert.Equal(t, 6, metrics.Get("stats.auth_token_per_user_le_inf").MustInt())
+
+			assert.LessOrEqual(t, 60, metrics.Get("stats.uptime").MustInt())
+			assert.Greater(t, 70, metrics.Get("stats.uptime").MustInt())
 		})
 	})
 
@@ -643,6 +650,7 @@ func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
 		grafanaLive:        newTestLive(t),
 		kvStore:            kvstore.WithNamespace(kvstore.ProvideService(sqlStore), 0, "infra.usagestats"),
 		log:                log.New("infra.usagestats"),
+		startTime:          time.Now().Add(-1 * time.Minute),
 	}
 }
 

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager"
@@ -629,14 +630,17 @@ type httpResp struct {
 func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
 	t.Helper()
 
+	sqlStore := sqlstore.InitTestDB(t)
+
 	return &UsageStatsService{
 		Bus:                bus.New(),
 		Cfg:                &cfg,
-		SQLStore:           sqlstore.InitTestDB(t),
+		SQLStore:           sqlStore,
 		AlertingUsageStats: &alertingUsageMock{},
 		externalMetrics:    make([]MetricsFunc, 0),
 		PluginManager:      &fakePluginManager{},
 		grafanaLive:        newTestLive(t),
+		kvStore:            kvstore.ProvideService(sqlStore),
 	}
 }
 

--- a/pkg/infra/usagestats/usage_stats_test.go
+++ b/pkg/infra/usagestats/usage_stats_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager"
@@ -220,7 +221,7 @@ func TestMetrics(t *testing.T) {
 				sendUsageStats = origSendUsageStats
 			})
 			statsSent := false
-			sendUsageStats = func(*bytes.Buffer) {
+			sendUsageStats = func(uss *UsageStatsService, b *bytes.Buffer) {
 				statsSent = true
 			}
 
@@ -640,7 +641,8 @@ func createService(t *testing.T, cfg setting.Cfg) *UsageStatsService {
 		externalMetrics:    make([]MetricsFunc, 0),
 		PluginManager:      &fakePluginManager{},
 		grafanaLive:        newTestLive(t),
-		kvStore:            kvstore.ProvideService(sqlStore),
+		kvStore:            kvstore.WithNamespace(kvstore.ProvideService(sqlStore), 0, "infra.usagestats"),
+		log:                log.New("infra.usagestats"),
 	}
 }
 


### PR DESCRIPTION
As a part of our ongoing efforts to better understand how people use Grafana, this PR aims to improve the accuracy of the usage stats subsystem without compromising the anonymity of our users. These usage stats help us measure Grafana usage anonymously and make better, data-driven decisions about project direction and features. In turn, we make this data available [here](https://play.grafana.org/d/000000078/stats-installs?orgId=1) for all open source users.

One of the challenges we face today is that Grafana instances send an initial usage report 24 hours after starting, then every 24 hours thereafter.  This is a problem because the 24 hour counter gets reset when instances are restarted, leading to inaccurate stats.  This PR adds an entry in the KV store to track the last time stats were sent, so that the 24 hour timer isn't reset when the instance is restarted.

This PR also adds a new "uptime" stat which reports how long the instance has been running, so we can better understand how often instances are restarted.

Finally, this PR adds a new anonymous usage stats id, which is a randomly-generated UUID that is also stored in the KV store.  This id is intended to help us understand how Grafana instances change over time and to de-duplicate usage reports sent by clustered Grafana instances, without exposing any personal user information.

As part of this update the usage stats package has been updated to use a service logger, and remove the global `metricsLogger`.