### PR TITLE
Plugins Catalog: show a confirmation modal when uninstalling a plugin

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -18,7 +18,9 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
   const { isUninstalling, error: errorUninstalling } = useUninstallStatus();
   const install = useInstall();
   const uninstall = useUninstall();
-  const [hasRequestedUninstall, setHasRequestedUninstall] = useState(false);
+  const [isConfirmModalVisible, setIsConfirmModalVisible] = useState(false);
+  const showConfirmModal = () => setIsConfirmModalVisible(true);
+  const hideConfirmModal = () => setIsConfirmModalVisible(false);
   const [hasInstalledPanel, setHasInstalledPanel] = useState(false);
   const styles = useStyles2(getStyles);
   const uninstallBtnText = isUninstalling ? 'Uninstalling' : 'Uninstall';
@@ -35,6 +37,7 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
   };
 
   const onUninstall = async () => {
+    hideConfirmModal();
     await uninstall(plugin.id);
     if (!errorUninstalling) {
       appEvents.emit(AppEvents.alertSuccess, [`Uninstalled ${plugin.name}`]);
@@ -52,16 +55,16 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
     return (
       <>
         <ConfirmModal
-          isOpen={hasRequestedUninstall}
+          isOpen={isConfirmModalVisible}
           title={`Uninstall ${plugin.name}`}
           body="Are you sure you want to uninstall this plugin?"
           confirmText="Confirm"
           icon="exclamation-triangle"
           onConfirm={onUninstall}
-          onDismiss={() => setHasRequestedUninstall(false)}
+          onDismiss={hideConfirmModal}
         />
         <HorizontalGroup height="auto">
-          <Button variant="destructive" disabled={isUninstalling} onClick={() => setHasRequestedUninstall(true)}>
+          <Button variant="destructive" disabled={isUninstalling} onClick={showConfirmModal}>
             {uninstallBtnText}
           </Button>
           {hasInstalledPanel && (

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useMountedState } from 'react-use';
 import { AppEvents, PluginType } from '@grafana/data';
-import { Button, HorizontalGroup, useStyles2 } from '@grafana/ui';
+import { Button, HorizontalGroup, ConfirmModal, useStyles2 } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 
 import { CatalogPlugin, PluginStatus } from '../../types';
@@ -18,6 +18,7 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
   const { isUninstalling, error: errorUninstalling } = useUninstallStatus();
   const install = useInstall();
   const uninstall = useUninstall();
+  const [hasRequestedUninstall, setHasRequestedUninstall] = useState(false);
   const [hasInstalledPanel, setHasInstalledPanel] = useState(false);
   const styles = useStyles2(getStyles);
   const uninstallBtnText = isUninstalling ? 'Uninstalling' : 'Uninstall';
@@ -49,14 +50,25 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
 
   if (pluginStatus === PluginStatus.UNINSTALL) {
     return (
-      <HorizontalGroup height="auto">
-        <Button variant="destructive" disabled={isUninstalling} onClick={onUninstall}>
-          {uninstallBtnText}
-        </Button>
-        {hasInstalledPanel && (
-          <div className={styles.message}>Please refresh your browser window before using this plugin.</div>
-        )}
-      </HorizontalGroup>
+      <>
+        <ConfirmModal
+          isOpen={hasRequestedUninstall}
+          title={`Uninstall ${plugin.name}`}
+          body="Are you sure you want to uninstall this plugin?"
+          confirmText="Confirm"
+          icon="exclamation-triangle"
+          onConfirm={onUninstall}
+          onDismiss={() => setHasRequestedUninstall(false)}
+        />
+        <HorizontalGroup height="auto">
+          <Button variant="destructive" disabled={isUninstalling} onClick={() => setHasRequestedUninstall(true)}>
+            {uninstallBtnText}
+          </Button>
+          {hasInstalledPanel && (
+            <div className={styles.message}>Please refresh your browser window before using this plugin.</div>
+          )}
+        </HorizontalGroup>
+      </>
     );
   }
 

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -7,6 +7,7 @@ import { configureStore } from 'app/store/configureStore';
 import PluginDetailsPage from './PluginDetails';
 import { getRouteComponentProps } from 'app/core/navigation/__mocks__/routeProps';
 import { CatalogPlugin } from '../types';
+import * as api from '../api';
 import { mockPluginApis, getCatalogPluginMock, getPluginsStateMock } from '../__mocks__';
 
 // Mock the config to enable the plugin catalog
@@ -46,6 +47,8 @@ describe('Plugin details page', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    config.pluginAdminExternalManageEnabled = false;
+    config.licenseInfo.hasValidLicense = false;
   });
 
   afterAll(() => {
@@ -207,5 +210,36 @@ describe('Plugin details page', () => {
     await waitFor(() => expect(queryByText(/dependencies:/i)).toBeInTheDocument());
 
     expect(queryByText('Grafana >=8.0.0')).toBeInTheDocument();
+  });
+
+  it('should show a confirm modal when trying to uninstall a plugin', async () => {
+    // @ts-ignore
+    api.uninstallPlugin = jest.fn();
+
+    const { queryByText, queryByRole, getByRole } = renderPluginDetails({
+      id,
+      name: 'Akumuli',
+      isInstalled: true,
+      details: {
+        pluginDependencies: [],
+        grafanaDependency: '>=8.0.0',
+        links: [],
+      },
+    });
+
+    // Wait for the install controls to be loaded
+    await waitFor(() => expect(queryByRole('button', { name: /install/i })).toBeInTheDocument());
+
+    // Open the confirmation modal
+    userEvent.click(getByRole('button', { name: /uninstall/i }));
+
+    expect(queryByText('Uninstall Akumuli')).toBeInTheDocument();
+    expect(queryByText('Are you sure you want to uninstall this plugin?')).toBeInTheDocument();
+    expect(api.uninstallPlugin).toHaveBeenCalledTimes(0);
+
+    // Confirm the uninstall
+    userEvent.click(getByRole('button', { name: /confirm/i }));
+    expect(api.uninstallPlugin).toHaveBeenCalledTimes(1);
+    expect(api.uninstallPlugin).toHaveBeenCalledWith(id);
   });
 });

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -241,5 +241,8 @@ describe('Plugin details page', () => {
     userEvent.click(getByRole('button', { name: /confirm/i }));
     expect(api.uninstallPlugin).toHaveBeenCalledTimes(1);
     expect(api.uninstallPlugin).toHaveBeenCalledWith(id);
+
+    // Check if the modal disappeared
+    expect(queryByText('Uninstall Akumuli')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Related issue:** #39048 

**What this PR does / why we need it**:
- [x] shows a confirmation modal when the user tries uninstalling a plugin

https://user-images.githubusercontent.com/9974811/133461658-f6e07e39-b9d9-4c19-a513-e795c0ab8cf1.mov

