### PR TITLE
Tempo: Run search query with keyboard shortcut from duration fields

### DIFF
--- a/public/app/plugins/datasource/tempo/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/NativeSearch.tsx
@@ -131,29 +131,33 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
       </InlineFieldRow>
       <InlineFieldRow>
         <InlineField label="Min Duration" labelWidth={14} grow>
-          <Input
-            value={query.minDuration || ''}
+          <QueryField
+            query={query.minDuration || ''}
             placeholder={durationPlaceholder}
-            onChange={(v) =>
+            onChange={(value) =>
               onChange({
                 ...query,
-                minDuration: v.currentTarget.value,
+                minDuration: value,
               })
             }
+            onRunQuery={onRunQuery}
+            portalOrigin="tempo"
           />
         </InlineField>
       </InlineFieldRow>
       <InlineFieldRow>
         <InlineField label="Max Duration" labelWidth={14} grow>
-          <Input
-            value={query.maxDuration || ''}
+          <QueryField
+            query={query.maxDuration || ''}
             placeholder={durationPlaceholder}
-            onChange={(v) =>
+            onChange={(value) =>
               onChange({
                 ...query,
-                maxDuration: v.currentTarget.value,
+                maxDuration: value,
               })
             }
+            onRunQuery={onRunQuery}
+            portalOrigin="tempo"
           />
         </InlineField>
       </InlineFieldRow>

--- a/public/app/plugins/datasource/tempo/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/NativeSearch.tsx
@@ -72,6 +72,12 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
     return text;
   };
 
+  const onKeyDown = (keyEvent: React.KeyboardEvent) => {
+    if (keyEvent.key === 'Enter' && (keyEvent.shiftKey || keyEvent.ctrlKey)) {
+      onRunQuery();
+    }
+  };
+
   return (
     <div className={css({ maxWidth: '500px' })}>
       <InlineFieldRow>
@@ -131,33 +137,31 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
       </InlineFieldRow>
       <InlineFieldRow>
         <InlineField label="Min Duration" labelWidth={14} grow>
-          <QueryField
-            query={query.minDuration || ''}
+          <Input
+            value={query.minDuration || ''}
             placeholder={durationPlaceholder}
-            onChange={(value) =>
+            onChange={(v) =>
               onChange({
                 ...query,
-                minDuration: value,
+                minDuration: v.currentTarget.value,
               })
             }
-            onRunQuery={onRunQuery}
-            portalOrigin="tempo"
+            onKeyDown={onKeyDown}
           />
         </InlineField>
       </InlineFieldRow>
       <InlineFieldRow>
         <InlineField label="Max Duration" labelWidth={14} grow>
-          <QueryField
-            query={query.maxDuration || ''}
+          <Input
+            value={query.maxDuration || ''}
             placeholder={durationPlaceholder}
-            onChange={(value) =>
+            onChange={(v) =>
               onChange({
                 ...query,
-                maxDuration: value,
+                maxDuration: v.currentTarget.value,
               })
             }
-            onRunQuery={onRunQuery}
-            portalOrigin="tempo"
+            onKeyDown={onKeyDown}
           />
         </InlineField>
       </InlineFieldRow>
@@ -172,6 +176,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
                 limit: v.currentTarget.value ? parseInt(v.currentTarget.value, 10) : undefined,
               })
             }
+            onKeyDown={onKeyDown}
           />
         </InlineField>
       </InlineFieldRow>


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows users to run Tempo search with Ctrl/shift+enter from all text fields in the search UI (tags + duration fields). 

**Which issue(s) this PR fixes**:
Relates to #39241

**Special notes for your reviewer**:
I didn't switch the 'Limit' field because it's a number input which doesn't work with QueryField. Happy to change that (or find another way to run the query with the shortcut) if you think the user should be able to run the query from the limit field.
