### PR TITLE
Fix: Remove test code for thresholds in PanelChrome

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -14,7 +14,6 @@ import {
   PanelData,
   PanelPlugin,
   PanelPluginMeta,
-  ThresholdsConfig,
   TimeRange,
   toDataFrameDTO,
   toUtc,
@@ -85,9 +84,6 @@ export class PanelChrome extends Component<Props, State> {
         onAnnotationUpdate: this.onAnnotationUpdate,
         onAnnotationDelete: this.onAnnotationDelete,
         canAddAnnotations: () => Boolean(props.dashboard.meta.canEdit || props.dashboard.meta.canMakeEditable),
-        // TODO: remove, added only for testing now
-        canEditThresholds: true,
-        onThresholdsChange: this.onThresholdsChange,
       },
       data: this.getInitialPanelDataState(),
     };
@@ -344,16 +340,6 @@ export class PanelChrome extends Component<Props, State> {
 
     getDashboardQueryRunner().run({ dashboard: this.props.dashboard, range: this.timeSrv.timeRange() });
     this.state.context.eventBus.publish(new AnnotationChangeEvent(anno));
-  };
-
-  onThresholdsChange = (thresholds: ThresholdsConfig) => {
-    this.onFieldConfigChange({
-      defaults: {
-        ...this.props.panel.fieldConfig.defaults,
-        thresholds,
-      },
-      overrides: this.props.panel.fieldConfig.overrides,
-    });
   };
 
   get hasPanelSnapshot() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Forgot to remove the test code we used for panelchrome when merging this.

Fixes #39262

**Special notes for your reviewer**:

