### PR TITLE
prometheus: query-editor: better duration-completions

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -49,14 +49,21 @@ function getAllFunctionsCompletions(): Completion[] {
   }));
 }
 
-function getAllDurationsCompletions(): Completion[] {
-  // FIXME: get a better list
-  return ['5m', '1m', '30s', '15s'].map((text) => ({
-    type: 'DURATION',
-    label: text,
-    insertText: text,
-  }));
-}
+const DURATION_COMPLETIONS: Completion[] = [
+  '$__interval',
+  '$__range',
+  '$__rate_interval',
+  '1m',
+  '5m',
+  '10m',
+  '30m',
+  '1h',
+  '1d',
+].map((text) => ({
+  type: 'DURATION',
+  label: text,
+  insertText: text,
+}));
 
 async function getAllHistoryCompletions(dataProvider: DataProvider): Promise<Completion[]> {
   // function getAllHistoryCompletions(queryHistory: PromHistoryItem[]): Completion[] {
@@ -137,7 +144,7 @@ async function getLabelValuesForMetricCompletions(
 export async function getCompletions(intent: Intent, dataProvider: DataProvider): Promise<Completion[]> {
   switch (intent.type) {
     case 'ALL_DURATIONS':
-      return getAllDurationsCompletions();
+      return DURATION_COMPLETIONS;
     case 'ALL_METRIC_NAMES':
       return getAllMetricNamesCompletions(dataProvider);
     case 'FUNCTIONS_AND_ALL_METRIC_NAMES': {


### PR DESCRIPTION
in prometheus query-field, the duration-autocomplete-suggestions were improved:
- the list now contains the same items as in the old version
- as the list is fixed, there is no need to construct the list at every call

how to test:
1. enable the `prometheusMonaco` feature flag
2. open a prometheus query-editor, press `[` in the editor. you should see the new list