### PR TITLE
Fix: do not perform fast match for routes potentially matching any wildcards

### DIFF
--- a/pkg/macaron/router.go
+++ b/pkg/macaron/router.go
@@ -207,10 +207,12 @@ func (r *Router) NotFound(handlers ...Handler) {
 func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if t, ok := r.routers[req.Method]; ok {
 		// Fast match for static routes
-		leaf := r.getLeaf(req.Method, req.URL.Path)
-		if leaf != nil {
-			leaf.handle(rw, req, nil)
-			return
+		if !strings.ContainsAny(req.URL.Path, ":*") {
+			leaf := r.getLeaf(req.Method, req.URL.Path)
+			if leaf != nil {
+				leaf.handle(rw, req, nil)
+				return
+			}
 		}
 
 		h, p, ok := t.Match(req.URL.EscapedPath())


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an incorrect URL pattern matching