### PR TITLE
Gauge: Remove any lingering orientation prop

### DIFF
--- a/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
+++ b/packages/grafana-ui/src/components/SingleStatShared/SingleStatBaseOptions.ts
@@ -23,12 +23,11 @@ export interface SingleStatBaseOptions extends OptionsWithTextFormatting {
   orientation: VizOrientation;
 }
 
-const optionsToKeep = ['reduceOptions', 'orientation'];
-
 export function sharedSingleStatPanelChangedHandler(
   panel: PanelModel<Partial<SingleStatBaseOptions>> | any,
   prevPluginId: string,
-  prevOptions: any
+  prevOptions: any,
+  optionsToKeep: string[] = ['reduceOptions', 'orientation']
 ) {
   let options = panel.options;
 

--- a/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.test.ts
@@ -80,12 +80,8 @@ describe('Gauge Panel Migrations', () => {
     const result = gaugePanelMigrationHandler(panel as PanelModel);
     expect(result).toMatchSnapshot();
 
-    // Ignored due to the API change
-    //@ts-ignore
-    expect(result.reduceOptions.defaults).toBeUndefined();
-    // Ignored due to the API change
-    //@ts-ignore
-    expect(result.reduceOptions.overrides).toBeUndefined();
+    // should remove orientation if present
+    expect(result.orientation).toBeUndefined();
 
     expect((panel as PanelModel).fieldConfig).toMatchInlineSnapshot(`
       Object {
@@ -162,5 +158,20 @@ describe('Gauge Panel Migrations', () => {
     expect(panel.fieldConfig.defaults.decimals).toBe(7);
     expect(newOptions.showThresholdMarkers).toBe(true);
     expect(newOptions.showThresholdLabels).toBe(true);
+  });
+
+  it('change from bar gauge to gauge', () => {
+    const prevOptions = {
+      orientation: 'auto',
+      reduceOptions: {
+        values: true,
+        limit: 100,
+      },
+    };
+
+    const panel = ({ options: {} } as unknown) as PanelModel;
+    const newOptions = gaugePanelChangedHandler(panel, 'bargauge', prevOptions);
+    expect(newOptions.orientation).toBe(undefined);
+    expect(newOptions.reduceOptions.limit).toBe(100);
   });
 });

--- a/public/app/plugins/panel/gauge/GaugeMigrations.ts
+++ b/public/app/plugins/panel/gauge/GaugeMigrations.ts
@@ -4,6 +4,11 @@ import { GaugeOptions } from './types';
 
 // This is called when the panel first loads
 export const gaugePanelMigrationHandler = (panel: PanelModel<GaugeOptions>): Partial<GaugeOptions> => {
+  // remove any orientation prop
+  if (panel.options.orientation) {
+    delete (panel.options as any).orientation;
+  }
+
   return sharedSingleStatMigrationHandler(panel);
 };
 
@@ -14,7 +19,7 @@ export const gaugePanelChangedHandler = (
   prevOptions: any
 ) => {
   // This handles most config changes
-  const opts = sharedSingleStatPanelChangedHandler(panel, prevPluginId, prevOptions) as GaugeOptions;
+  const opts = sharedSingleStatPanelChangedHandler(panel, prevPluginId, prevOptions, ['reduceOptions']) as GaugeOptions;
 
   // Changing from angular singlestat
   if (prevPluginId === 'singlestat' && prevOptions.angular) {

--- a/public/app/plugins/panel/gauge/__snapshots__/GaugeMigrations.test.ts.snap
+++ b/public/app/plugins/panel/gauge/__snapshots__/GaugeMigrations.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`Gauge Panel Migrations from 6.1.1 1`] = `
 Object {
-  "orientation": "auto",
   "reduceOptions": Object {
     "calcs": Array [
       "last",


### PR DESCRIPTION
Removes any lingering orientation prop and fixes the panel change handler to it's not preserved when coming from stat or bar gauge.
