### PR TITLE
Plugins Catalog: Update to the list of available panels after an install, update or uninstall.

### DIFF
--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -1,8 +1,10 @@
 import { config } from '@grafana/runtime';
 import { gt } from 'semver';
 import { PluginSignatureStatus, dateTimeParse, PluginError } from '@grafana/data';
-import { CatalogPlugin, LocalPlugin, RemotePlugin } from './types';
 import { contextSrv } from 'app/core/services/context_srv';
+import { getBackendSrv } from 'app/core/services/backend_srv';
+import { Settings } from 'app/core/config';
+import { CatalogPlugin, LocalPlugin, RemotePlugin } from './types';
 
 export function isGrafanaAdmin(): boolean {
   return config.bootData.user.isGrafanaAdmin;
@@ -221,3 +223,11 @@ function groupErrorsByPluginId(errors: PluginError[]): Record<string, PluginErro
     return byId;
   }, {} as Record<string, PluginError | undefined>);
 }
+
+// Updates the core Grafana config to have the correct list available panels
+export const updatePanels = () =>
+  getBackendSrv()
+    .get('/api/frontend/settings')
+    .then((settings: Settings) => {
+      config.panels = settings.panels;
+    });


### PR DESCRIPTION
Fixes #38704 

**What this PR does / why we need it**:
It updates the list of available panels after installing, updating or uninstalling a plugin using the UI (Plugins Catalog).

Without this the page had to be refreshed in order to see the installed plugins in the following list of visualisations:
![Screenshot 2021-09-16 at 15 24 23](https://user-images.githubusercontent.com/9974811/133620500-04983976-d759-47d5-818b-ba619a038657.png)
 