### PR TITLE
Alerting: multiorg Alertmanager to load configurations in chunks

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -739,6 +739,12 @@ admin_config_poll_interval = 60s
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 alertmanager_config_poll_interval = 60s
 
+# Specify the maximum number of Alertmanager configurations (for every organization) requested from database in one request.
+# Zero (0) means that all configurations are requested in a single query.
+# It makes sense to change it only in the case of big number of organizations and problems with memory and database performance.
+# Must be positive number
+alertmanager_config_load_chunk_size=0
+
 # Listen address/hostname and port to receive unified alerting messages for other Grafana instances. The port is used for both TCP and UDP. It is assumed other Grafana instances are also running on the same port.
 ha_listen_address = "0.0.0.0:9094"
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -716,6 +716,12 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;alertmanager_config_poll_interval = 60s
 
+# Specify the maximum number of Alertmanager configurations (for every organization) requested from database in one request.
+# Zero (0) means that all configurations are requested in a single query.
+# It makes sense to change it only in the case of big number of organizations and problems with memory and database performance.
+# Must be positive number
+;alertmanager_config_load_chunk_size=0
+
 # Listen address/hostname and port to receive unified alerting messages for other Grafana instances. The port is used for both TCP and UDP. It is assumed other Grafana instances are also running on the same port. The default value is `0.0.0.0:9094`.
 ;ha_listen_address = "0.0.0.0:9094"
 

--- a/pkg/services/ngalert/models/alertmanager.go
+++ b/pkg/services/ngalert/models/alertmanager.go
@@ -13,6 +13,11 @@ type AlertConfiguration struct {
 	OrgID                     int64 `xorm:"org_id"`
 }
 
+type GetLatestAlertmanagerConfigurationsForManyOrganizationsQuery struct {
+	MinOrgId int64
+	MaxOrgId int64
+}
+
 // GetLatestAlertmanagerConfigurationQuery is the query to get the latest alertmanager configuration.
 type GetLatestAlertmanagerConfigurationQuery struct {
 	OrgID  int64

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -296,47 +296,6 @@ func (am *Alertmanager) ApplyConfig(cfg *apimodels.PostableUserConfig) error {
 	return nil
 }
 
-// SyncAndApplyConfigFromDatabase picks the latest config from database and restarts
-// the components with the new config.
-func (am *Alertmanager) SyncAndApplyConfigFromDatabase() error {
-	am.reloadConfigMtx.Lock()
-	defer am.reloadConfigMtx.Unlock()
-
-	// First, let's get the configuration we need from the database.
-	q := &ngmodels.GetLatestAlertmanagerConfigurationQuery{OrgID: am.orgID}
-	if err := am.Store.GetLatestAlertmanagerConfiguration(q); err != nil {
-		// If there's no configuration in the database, let's use the default configuration.
-		if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
-			// First, let's save it to the database. We don't need to use a transaction here as we'll always succeed.
-			am.logger.Info("no Alertmanager configuration found, saving and applying a default")
-			savecmd := &ngmodels.SaveAlertmanagerConfigurationCmd{
-				AlertmanagerConfiguration: alertmanagerDefaultConfiguration,
-				Default:                   true,
-				ConfigurationVersion:      fmt.Sprintf("v%d", ngmodels.AlertConfigurationVersion),
-				OrgID:                     am.orgID,
-			}
-			if err := am.Store.SaveAlertmanagerConfiguration(savecmd); err != nil {
-				return err
-			}
-
-			q.Result = &ngmodels.AlertConfiguration{AlertmanagerConfiguration: alertmanagerDefaultConfiguration, Default: true}
-		} else {
-			return fmt.Errorf("unable to get Alertmanager configuration from the database: %w", err)
-		}
-	}
-
-	cfg, err := Load([]byte(q.Result.AlertmanagerConfiguration))
-	if err != nil {
-		return err
-	}
-
-	if err := am.applyConfig(cfg, nil); err != nil {
-		return fmt.Errorf("unable to reload configuration: %w", err)
-	}
-
-	return nil
-}
-
 func (am *Alertmanager) getTemplate() (*template.Template, error) {
 	am.reloadConfigMtx.RLock()
 	defer am.reloadConfigMtx.RUnlock()

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -285,6 +285,17 @@ func (am *Alertmanager) SaveAndApplyConfig(cfg *apimodels.PostableUserConfig) er
 	return nil
 }
 
+//ApplyConfig applies the configuration to the Alertmanager
+func (am *Alertmanager) ApplyConfig(cfg *apimodels.PostableUserConfig) error {
+	am.reloadConfigMtx.Lock()
+	defer am.reloadConfigMtx.Unlock()
+
+	if err := am.applyConfig(cfg, nil); err != nil {
+		return fmt.Errorf("unable to apply configuration: %w", err)
+	}
+	return nil
+}
+
 // SyncAndApplyConfigFromDatabase picks the latest config from database and restarts
 // the components with the new config.
 func (am *Alertmanager) SyncAndApplyConfigFromDatabase() error {

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -53,12 +53,6 @@ func setupAMTest(t *testing.T) *Alertmanager {
 	return am
 }
 
-func TestAlertmanager_ShouldUseDefaultConfigurationWhenNoConfiguration(t *testing.T) {
-	am := setupAMTest(t)
-	require.NoError(t, am.SyncAndApplyConfigFromDatabase())
-	require.NotNil(t, am.config)
-}
-
 func TestPutAlert(t *testing.T) {
 	am := setupAMTest(t)
 

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -127,7 +128,8 @@ func (moa *MultiOrgAlertmanager) LoadAndSyncAlertmanagersForOrgs(ctx context.Con
 
 //getLatestConfigs retrieves the latest Alertmanager configuration for every organization and returns them as a map where the key is ID of an organization
 func (moa *MultiOrgAlertmanager) getLatestConfigs(ctx context.Context) (map[int64]*models.AlertConfiguration, error) {
-	configs, err := moa.configStore.GetAllLatestAlertmanagerConfiguration(ctx)
+	query := &models.GetLatestAlertmanagerConfigurationsForManyOrganizationsQuery{MinOrgId: math.MinInt64, MaxOrgId: math.MaxInt}
+	configs, err := moa.configStore.GetAllLatestAlertmanagerConfiguration(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -141,13 +141,44 @@ func (moa *MultiOrgAlertmanager) getLatestConfigs(ctx context.Context) (map[int6
 }
 
 func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, orgIDs []int64) {
+	moa.alertmanagersMtx.Lock()
+
+	orgsFound, err := moa.addOrUpdateAlertManagerConfigurations(ctx, orgIDs)
+	if err != nil {
+		moa.alertmanagersMtx.Unlock()
+		return
+	}
+
+	amsToStop := map[int64]*Alertmanager{}
+	for orgId, am := range moa.alertmanagers {
+		if _, exists := orgsFound[orgId]; !exists {
+			amsToStop[orgId] = am
+			delete(moa.alertmanagers, orgId)
+			moa.metrics.RemoveOrgRegistry(orgId)
+		}
+	}
+	moa.metrics.ActiveConfigurations.Set(float64(len(moa.alertmanagers)))
+
+	moa.alertmanagersMtx.Unlock()
+
+	// Now, we can stop the Alertmanagers without having to hold a lock.
+	for orgID, am := range amsToStop {
+		moa.logger.Info("stopping Alertmanager", "org", orgID)
+		am.StopAndWait()
+		moa.logger.Info("stopped Alertmanager", "org", orgID)
+	}
+}
+
+// addOrUpdateAlertManagerConfigurations retrieves the latest configurations for all organizations and then calls addOrUpdateAlertmanager for every organization in orgIDs.
+//The result is either a map that contains ID of all organizations updated or created or error in the case something happened while fetching configurations from database
+//NOTE this is an internal method, and it is not supposed to be called without locked mutex alertmanagersMtx
+func (moa *MultiOrgAlertmanager) addOrUpdateAlertManagerConfigurations(ctx context.Context, orgIDs []int64) (map[int64]struct{}, error) {
 	orgsFound := make(map[int64]struct{}, len(orgIDs))
 	dbConfigs, err := moa.getLatestConfigs(ctx)
 	if err != nil {
 		moa.logger.Error("failed to load Alertmanager configurations", "err", err)
-		return
+		return nil, err
 	}
-	moa.alertmanagersMtx.Lock()
 	for _, orgID := range orgIDs {
 		orgsFound[orgID] = struct{}{}
 
@@ -200,23 +231,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 		}
 	}
 
-	amsToStop := map[int64]*Alertmanager{}
-	for orgId, am := range moa.alertmanagers {
-		if _, exists := orgsFound[orgId]; !exists {
-			amsToStop[orgId] = am
-			delete(moa.alertmanagers, orgId)
-			moa.metrics.RemoveOrgRegistry(orgId)
-		}
-	}
-	moa.metrics.ActiveConfigurations.Set(float64(len(moa.alertmanagers)))
-	moa.alertmanagersMtx.Unlock()
-
-	// Now, we can stop the Alertmanagers without having to hold a lock.
-	for orgID, am := range amsToStop {
-		moa.logger.Info("stopping Alertmanager", "org", orgID)
-		am.StopAndWait()
-		moa.logger.Info("stopped Alertmanager", "org", orgID)
-	}
+	return orgsFound, nil
 }
 
 func (moa *MultiOrgAlertmanager) StopAndWait() {

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -13,6 +13,14 @@ type FakeConfigStore struct {
 	configs map[int64]*models.AlertConfiguration
 }
 
+func (f *FakeConfigStore) GetAllLatestAlertmanagerConfiguration(context.Context) ([]*models.AlertConfiguration, error) {
+	result := make([]*models.AlertConfiguration, 0, len(f.configs))
+	for _, configuration := range f.configs {
+		result = append(result, configuration)
+	}
+	return result, nil
+}
+
 func (f *FakeConfigStore) GetLatestAlertmanagerConfiguration(query *models.GetLatestAlertmanagerConfigurationQuery) error {
 	var ok bool
 	query.Result, ok = f.configs[query.OrgID]

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -13,10 +13,13 @@ type FakeConfigStore struct {
 	configs map[int64]*models.AlertConfiguration
 }
 
-func (f *FakeConfigStore) GetAllLatestAlertmanagerConfiguration(context.Context) ([]*models.AlertConfiguration, error) {
+func (f *FakeConfigStore) GetAllLatestAlertmanagerConfiguration(ctx context.Context, query *models.GetLatestAlertmanagerConfigurationsForManyOrganizationsQuery) ([]*models.AlertConfiguration, error) {
+	f.opsRecording = append(f.opsRecording, query)
 	result := make([]*models.AlertConfiguration, 0, len(f.configs))
-	for _, configuration := range f.configs {
-		result = append(result, configuration)
+	for orgId, configuration := range f.configs {
+		if query.MinOrgId <= orgId && orgId <= query.MaxOrgId {
+			result = append(result, configuration)
+		}
 	}
 	return result, nil
 }

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -10,7 +10,8 @@ import (
 )
 
 type FakeConfigStore struct {
-	configs map[int64]*models.AlertConfiguration
+	configs      map[int64]*models.AlertConfiguration
+	opsRecording []interface{} //keeps all queries the store was called
 }
 
 func (f *FakeConfigStore) GetAllLatestAlertmanagerConfiguration(ctx context.Context, query *models.GetLatestAlertmanagerConfigurationsForManyOrganizationsQuery) ([]*models.AlertConfiguration, error) {
@@ -25,6 +26,7 @@ func (f *FakeConfigStore) GetAllLatestAlertmanagerConfiguration(ctx context.Cont
 }
 
 func (f *FakeConfigStore) GetLatestAlertmanagerConfiguration(query *models.GetLatestAlertmanagerConfigurationQuery) error {
+	f.opsRecording = append(f.opsRecording, query)
 	var ok bool
 	query.Result, ok = f.configs[query.OrgID]
 	if !ok {
@@ -35,6 +37,7 @@ func (f *FakeConfigStore) GetLatestAlertmanagerConfiguration(query *models.GetLa
 }
 
 func (f *FakeConfigStore) SaveAlertmanagerConfiguration(cmd *models.SaveAlertmanagerConfigurationCmd) error {
+	f.opsRecording = append(f.opsRecording, cmd)
 	f.configs[cmd.OrgID] = &models.AlertConfiguration{
 		AlertmanagerConfiguration: cmd.AlertmanagerConfiguration,
 		OrgID:                     cmd.OrgID,
@@ -46,6 +49,7 @@ func (f *FakeConfigStore) SaveAlertmanagerConfiguration(cmd *models.SaveAlertman
 }
 
 func (f *FakeConfigStore) SaveAlertmanagerConfigurationWithCallback(cmd *models.SaveAlertmanagerConfigurationCmd, callback store.SaveCallback) error {
+	f.opsRecording = append(f.opsRecording, cmd)
 	f.configs[cmd.OrgID] = &models.AlertConfiguration{
 		AlertmanagerConfiguration: cmd.AlertmanagerConfiguration,
 		OrgID:                     cmd.OrgID,

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -36,10 +36,12 @@ func (st *DBstore) GetLatestAlertmanagerConfiguration(query *models.GetLatestAle
 }
 
 // GetAllLatestAlertmanagerConfiguration returns the latest configuration of every organization
-func (st *DBstore) GetAllLatestAlertmanagerConfiguration(ctx context.Context) ([]*models.AlertConfiguration, error) {
+func (st *DBstore) GetAllLatestAlertmanagerConfiguration(ctx context.Context, query *models.GetLatestAlertmanagerConfigurationsForManyOrganizationsQuery) ([]*models.AlertConfiguration, error) {
 	var result []*models.AlertConfiguration
 	err := st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		condition := builder.In("id", builder.Select("MAX(id)").From("alert_configuration").GroupBy("org_id"))
+		condition := builder.In("id",
+			builder.Select("MAX(id)").From("alert_configuration").Where(
+				builder.Between{ Col: "org_id", LessVal: query.MinOrgId, MoreVal: query.MaxOrgId }).GroupBy("org_id"))
 		if err := sess.Table("alert_configuration").Where(condition).Find(&result); err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/store/database.go
+++ b/pkg/services/ngalert/store/database.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -17,6 +18,7 @@ const AlertDefinitionMaxTitleLength = 190
 // AlertingStore is the database interface used by the Alertmanager service.
 type AlertingStore interface {
 	GetLatestAlertmanagerConfiguration(*models.GetLatestAlertmanagerConfigurationQuery) error
+	GetAllLatestAlertmanagerConfiguration(ctx context.Context) ([]*models.AlertConfiguration, error)
 	SaveAlertmanagerConfiguration(*models.SaveAlertmanagerConfigurationCmd) error
 	SaveAlertmanagerConfigurationWithCallback(*models.SaveAlertmanagerConfigurationCmd, SaveCallback) error
 }

--- a/pkg/services/ngalert/store/database.go
+++ b/pkg/services/ngalert/store/database.go
@@ -18,7 +18,7 @@ const AlertDefinitionMaxTitleLength = 190
 // AlertingStore is the database interface used by the Alertmanager service.
 type AlertingStore interface {
 	GetLatestAlertmanagerConfiguration(*models.GetLatestAlertmanagerConfigurationQuery) error
-	GetAllLatestAlertmanagerConfiguration(ctx context.Context) ([]*models.AlertConfiguration, error)
+	GetAllLatestAlertmanagerConfiguration(ctx context.Context, query *models.GetLatestAlertmanagerConfigurationsForManyOrganizationsQuery) ([]*models.AlertConfiguration, error)
 	SaveAlertmanagerConfiguration(*models.SaveAlertmanagerConfigurationCmd) error
 	SaveAlertmanagerConfigurationWithCallback(*models.SaveAlertmanagerConfigurationCmd, SaveCallback) error
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -421,6 +421,7 @@ type Cfg struct {
 	// Unified Alerting
 	AdminConfigPollInterval        time.Duration
 	AlertmanagerConfigPollInterval time.Duration
+	AlertmanagerConfigChunkSize    uint
 	HAListenAddr                   string
 	HAAdvertiseAddr                string
 	HAPeers                        []string

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -17,6 +17,7 @@ const (
 	AlertmanagerDefaultPushPullInterval     = cluster.DefaultPushPullInterval
 	SchedulerDefaultAdminConfigPollInterval = 60 * time.Second
 	AlertmanagerDefaultConfigPollInterval   = 60 * time.Second
+	AlertmanagerDefaultConfigChunkSize      = 0
 )
 
 func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
@@ -30,6 +31,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if err != nil {
 		return err
 	}
+	cfg.AlertmanagerConfigChunkSize = ua.Key("alertmanager_config_load_chunk_size").MustUint(AlertmanagerDefaultConfigChunkSize)
 	cfg.HAPeerTimeout, err = gtime.ParseDuration(valueAsString(ua, "ha_peer_timeout", (AlertmanagerDefaultPeerTimeout).String()))
 	if err != nil {
 		return err

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -16,6 +16,7 @@ func TestCfg_ReadUnifiedAlertingSettings(t *testing.T) {
 	{
 		require.Equal(t, 60*time.Second, cfg.AdminConfigPollInterval)
 		require.Equal(t, 60*time.Second, cfg.AlertmanagerConfigPollInterval)
+		require.Equal(t, uint(0), cfg.AlertmanagerConfigChunkSize)
 		require.Equal(t, 15*time.Second, cfg.HAPeerTimeout)
 		require.Equal(t, "0.0.0.0:9094", cfg.HAListenAddr)
 		require.Equal(t, "", cfg.HAAdvertiseAddr)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This is an additional change to the PR https://github.com/grafana/grafana/pull/39237, which changed the way Grafana loads Alertmanager configurations for organizations from one-by-one to all at once.
However, in the case of a big number of organizations with big configurations it can cause a serious impact on memory consumption and in the worst-case scenario can cause OOM panic because there is no upper limit to what is requested from the database. 

This PR proposes an alternative between loading a single configuration at a time and all at once: it updates MultiOrgAlertmanager to load configurations in chunks of a controllable size. The size of chunks can be changed in configuration. The default value is 1000, which I think should cover the majority of usages to pull configs in one chunk.

**Which issue(s) this PR fixes**:
Fixes #38885