### PR TITLE
Publishing packages: Add grafana/schema

### DIFF
--- a/scripts/build/release-packages.sh
+++ b/scripts/build/release-packages.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PACKAGES=("@grafana/ui" "@grafana/data" "@grafana/toolkit" "@grafana/runtime" "@grafana/e2e" "@grafana/e2e-selectors")
+PACKAGES=("@grafana/ui" "@grafana/data" "@grafana/toolkit" "@grafana/runtime" "@grafana/e2e" "@grafana/e2e-selectors" "@grafana/schema")
 GRAFANA_TAG=${1:-}
 RELEASE_CHANNEL="latest"
 


### PR DESCRIPTION
We were missing @grafana/schema being published to NPM when doing the release. We need that package out as other packages rely on it.

8.2.0-beta.1 was published manually: https://www.npmjs.com/package/@grafana/schema