### PR TITLE
InfluxDB: InfluxQL query editor is set to always use resultFormat.

### DIFF
--- a/pkg/tsdb/influxdb/model_parser.go
+++ b/pkg/tsdb/influxdb/model_parser.go
@@ -25,11 +25,6 @@ func (qp *InfluxdbQueryParser) Parse(query backend.DataQuery) (*Query, error) {
 
 	measurement := model.Get("measurement").MustString("")
 
-	resultFormat, err := model.Get("resultFormat").String()
-	if err != nil {
-		return nil, err
-	}
-
 	tags, err := qp.parseTags(model)
 	if err != nil {
 		return nil, err
@@ -55,17 +50,16 @@ func (qp *InfluxdbQueryParser) Parse(query backend.DataQuery) (*Query, error) {
 	}
 
 	return &Query{
-		Measurement:  measurement,
-		Policy:       policy,
-		ResultFormat: resultFormat,
-		GroupBy:      groupBys,
-		Tags:         tags,
-		Selects:      selects,
-		RawQuery:     rawQuery,
-		Interval:     interval,
-		Alias:        alias,
-		UseRawQuery:  useRawQuery,
-		Tz:           tz,
+		Measurement: measurement,
+		Policy:      policy,
+		GroupBy:     groupBys,
+		Tags:        tags,
+		Selects:     selects,
+		RawQuery:    rawQuery,
+		Interval:    interval,
+		Alias:       alias,
+		UseRawQuery: useRawQuery,
+		Tz:          tz,
 	}, nil
 }
 

--- a/pkg/tsdb/influxdb/models.go
+++ b/pkg/tsdb/influxdb/models.go
@@ -3,17 +3,16 @@ package influxdb
 import "time"
 
 type Query struct {
-	Measurement  string
-	Policy       string
-	ResultFormat string
-	Tags         []*Tag
-	GroupBy      []*QueryPart
-	Selects      []*Select
-	RawQuery     string
-	UseRawQuery  bool
-	Alias        string
-	Interval     time.Duration
-	Tz           string
+	Measurement string
+	Policy      string
+	Tags        []*Tag
+	GroupBy     []*QueryPart
+	Selects     []*Select
+	RawQuery    string
+	UseRawQuery bool
+	Alias       string
+	Interval    time.Duration
+	Tz          string
 }
 
 type Tag struct {

--- a/public/app/plugins/datasource/influxdb/components/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/RawInfluxQLEditor.tsx
@@ -20,11 +20,14 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
   const aliasElementId = useUniqueId();
   const selectElementId = useUniqueId();
 
+  const resultFormat = query.resultFormat ?? DEFAULT_RESULT_FORMAT;
+
   const applyDelayedChangesAndRunQuery = () => {
     onChange({
       ...query,
       query: currentQuery,
       alias: currentAlias,
+      resultFormat,
     });
     onRunQuery();
   };
@@ -51,7 +54,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
             onChange({ ...query, resultFormat: v.value });
             onRunQuery();
           }}
-          value={query.resultFormat ?? DEFAULT_RESULT_FORMAT}
+          value={resultFormat}
           options={RESULT_FORMATS}
         />
         <InlineFormLabel htmlFor={aliasElementId}>Alias by</InlineFormLabel>


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/39216

the pull request does two things:

1. for consistency, we always set `query.resultFormat` in javascript.
2. the backend-code never uses the `resultFormat` field, so the code that extracts it from the javascript was removed