### PR TITLE
Dashboard: Don't show SectionHeader unless section has a title

### DIFF
--- a/public/app/features/search/components/SearchResults.test.tsx
+++ b/public/app/features/search/components/SearchResults.test.tsx
@@ -53,4 +53,13 @@ describe('SearchResults', () => {
     expect(mockOnToggleSection).toHaveBeenCalledTimes(1);
     expect(mockOnToggleSection).toHaveBeenCalledWith(generalFolder);
   });
+
+  it('should not throw an error if the search results have an empty title', () => {
+    const mockOnToggleSection = jest.fn();
+    const searchResultsEmptyTitle = searchResults.slice();
+    searchResultsEmptyTitle[0].title = '';
+    expect(() => {
+      setup({ results: searchResultsEmptyTitle, onToggleSection: mockOnToggleSection });
+    }).not.toThrowError();
+  });
 });

--- a/public/app/features/search/components/SearchResults.tsx
+++ b/public/app/features/search/components/SearchResults.tsx
@@ -33,7 +33,9 @@ export const SearchResults: FC<Props> = memo(
           {results.map((section) => {
             return (
               <div aria-label={sectionLabel} className={styles.section} key={section.id || section.title}>
-                <SectionHeader onSectionClick={onToggleSection} {...{ onToggleChecked, editable, section }} />
+                {section.title && (
+                  <SectionHeader onSectionClick={onToggleSection} {...{ onToggleChecked, editable, section }} />
+                )}
                 {section.expanded && (
                   <div aria-label={itemsLabel} className={styles.sectionItems}>
                     {section.items.map((item) => (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- `SectionHeader` needs to have a title to correctly set a key in `localStorage`
- without a title, it attempts to use `''` as the key in `localStorage`. this throws an error with a lovely stack trace.
- don't render `SectionHeader` unless it has a title!

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/39334

**Special notes for your reviewer**:

