### PR TITLE
Plugins: Update schema of scopes from string to string array

### DIFF
--- a/docs/sources/developers/plugins/metadata.md
+++ b/docs/sources/developers/plugins/metadata.md
@@ -209,11 +209,11 @@ For data source plugins. Token authentication section used with an JWT OAuth API
 
 #### Properties
 
-| Property | Type              | Required | Description                                          |
-| -------- | ----------------- | -------- | ---------------------------------------------------- |
-| `params` | [object](#params) | No       | Parameters for the JWT token authentication request. |
-| `scopes` | string            | No       |                                                      |
-| `url`    | string            | No       | URL to fetch the JWT token.                          |
+| Property | Type              | Required | Description                                                           |
+| -------- | ----------------- | -------- | --------------------------------------------------------------------- |
+| `params` | [object](#params) | No       | Parameters for the JWT token authentication request.                  |
+| `scopes` | string[]          | No       | The list of scopes that your application should be granted access to. |
+| `url`    | string            | No       | URL to fetch the JWT token.                                           |
 
 #### params
 
@@ -221,12 +221,11 @@ Parameters for the JWT token authentication request.
 
 ##### Properties
 
-| Property       | Type     | Required | Description |
-| -------------- | -------- | -------- | ----------- |
-| `client_email` | string   | No       |             |
-| `private_key`  | string   | No       |             |
-| `scopes`       | string[] | No       |             |
-| `token_uri`    | string   | No       |             |
+| Property       | Type   | Required | Description |
+| -------------- | ------ | -------- | ----------- |
+| `client_email` | string | No       |             |
+| `private_key`  | string | No       |             |
+| `token_uri`    | string | No       |             |
 
 ### tokenAuth
 
@@ -234,11 +233,11 @@ For data source plugins. Token authentication section used with an OAuth API.
 
 #### Properties
 
-| Property | Type              | Required | Description                                      |
-| -------- | ----------------- | -------- | ------------------------------------------------ |
-| `params` | [object](#params) | No       | Parameters for the token authentication request. |
-| `scopes` | string            | No       |                                                  |
-| `url`    | string            | No       | URL to fetch the authentication token.           |
+| Property | Type              | Required | Description                                                           |
+| -------- | ----------------- | -------- | --------------------------------------------------------------------- |
+| `params` | [object](#params) | No       | Parameters for the token authentication request.                      |
+| `scopes` | string[]          | No       | The list of scopes that your application should be granted access to. |
+| `url`    | string            | No       | URL to fetch the authentication token.                                |
 
 #### params
 

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -370,8 +370,11 @@
                 "description": "URL to fetch the authentication token."
               },
               "scopes": {
-                "type": "string",
-                "description": ""
+                "type": "array",
+                "description": "The list of scopes that your application should be granted access to.",
+                "items": {
+                  "type": "string"
+                }
               },
               "params": {
                 "type": "object",
@@ -409,21 +412,17 @@
                 "format": "uri"
               },
               "scopes": {
-                "type": "string",
-                "description": ""
+                "type": "array",
+                "description": "The list of scopes that your application should be granted access to.",
+                "items": {
+                  "type": "string"
+                }
               },
               "params": {
                 "type": "object",
                 "description": "Parameters for the JWT token authentication request.",
                 "additionalProperties": false,
                 "properties": {
-                  "scopes": {
-                    "type": "array",
-                    "description": "",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "token_uri": {
                     "type": "string",
                     "description": ""


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the plugin.json schema. I've based my assumption that the scopes field is not a string but a string array to this https://github.com/grafana/grafana/blob/main/pkg/plugins/app_plugin.go#L61

Also because of this our CI is failing in https://github.com/grafana/google-bigquery-datasource/pull/1


I'm not sure how to trigger an update for the metadata.md.tpl

