### PR TITLE
prometheus: monaco-query-field: fix metrics-list

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -84,15 +84,16 @@ const MonacoQueryField = (props: Props) => {
             Promise.resolve(historyRef.current.map((h) => h.query.expr).filter((expr) => expr !== undefined));
 
           const getAllMetricNames = () => {
-            const { metricsMetadata } = lpRef.current;
-            const result =
-              metricsMetadata == null
-                ? []
-                : Object.entries(metricsMetadata).map(([k, v]) => ({
-                    name: k,
-                    help: v[0].help,
-                    type: v[0].type,
-                  }));
+            const { metrics, metricsMetadata } = lpRef.current;
+            const result = metrics.map((m) => {
+              const metaItem = metricsMetadata?.[m]?.[0];
+              return {
+                name: m,
+                help: metaItem?.help ?? '',
+                type: metaItem?.type ?? '',
+              };
+            });
+
             return Promise.resolve(result);
           };
 


### PR DESCRIPTION
the list-of-metrics is accessible on the prometheus-language-provider as `this.metrics`, and the metadata (help-text etc.) is available on `this.metricsMetadata`. it seems there are metrics without metadata, and there is metadata for metrics that do not exist, so we cannot just loop through `this.metricsMetadata`. we have to loop through `this.metrics` and load help from `this.metricsMetadata` for every metric.