### PR TITLE
Alerting: Change metrics label `user` to `org`

### DIFF
--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -129,7 +129,7 @@ func newSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Name:      "rule_evaluations_total",
 				Help:      "The total number of rule evaluations.",
 			},
-			[]string{"user"},
+			[]string{"org"},
 		),
 		// TODO: once rule groups support multiple rules, consider partitioning
 		// on rule group as well as tenant, similar to loki|cortex.
@@ -140,7 +140,7 @@ func newSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Name:      "rule_evaluation_failures_total",
 				Help:      "The total number of rule evaluation failures.",
 			},
-			[]string{"user"},
+			[]string{"org"},
 		),
 		EvalDuration: promauto.With(r).NewSummaryVec(
 			prometheus.SummaryOpts{
@@ -150,7 +150,7 @@ func newSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:       "The duration for a rule to execute.",
 				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
-			[]string{"user"},
+			[]string{"org"},
 		),
 	}
 }
@@ -166,7 +166,7 @@ func newStateMetrics(r prometheus.Registerer) *State {
 				Name:      "rule_group_rules",
 				Help:      "The number of rules.",
 			},
-			[]string{"user"},
+			[]string{"org"},
 		),
 		AlertState: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,


### PR DESCRIPTION
An user within Grafana has a completely different meaning. Multi-tenancy is done via Organizations as a top-level concept.

En example of this is:

```
# HELP grafana_alerting_rule_evaluation_duration_seconds The duration for a rule to execute.
# TYPE grafana_alerting_rule_evaluation_duration_seconds summary
grafana_alerting_rule_evaluation_duration_seconds{org="1",quantile="0.5"} 0.002464542
grafana_alerting_rule_evaluation_duration_seconds{org="1",quantile="0.9"} 5.003181166
grafana_alerting_rule_evaluation_duration_seconds{org="1",quantile="0.99"} 5.004530292
grafana_alerting_rule_evaluation_duration_seconds_sum{org="1"} 10.145094125000002
grafana_alerting_rule_evaluation_duration_seconds_count{org="1"} 16
grafana_alerting_rule_evaluation_duration_seconds{org="2",quantile="0.5"} 0.001891042
grafana_alerting_rule_evaluation_duration_seconds{org="2",quantile="0.9"} 0.002305542
grafana_alerting_rule_evaluation_duration_seconds{org="2",quantile="0.99"} 0.003132291
grafana_alerting_rule_evaluation_duration_seconds_sum{org="2"} 0.025217581000000003
grafana_alerting_rule_evaluation_duration_seconds_count{org="2"} 13
# HELP grafana_alerting_rule_evaluations_total The total number of rule evaluations.
# TYPE grafana_alerting_rule_evaluations_total counter
grafana_alerting_rule_evaluations_total{org="1"} 16
grafana_alerting_rule_evaluations_total{org="2"} 13
# HELP grafana_alerting_rule_group_rules The number of rules.
# TYPE grafana_alerting_rule_group_rules gauge
grafana_alerting_rule_group_rules{org="1"} 3
grafana_alerting_rule_group_rules{org="2"} 1
```