### PR TITLE
Bug: Remove copying of grafana schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ WORKDIR $GOPATH/src/github.com/grafana/grafana
 COPY go.mod go.sum embed.go ./
 COPY cue cue
 COPY cue.mod cue.mod
-COPY packages/grafana-schema packages/grafana-schema
 COPY public/app/plugins public/app/plugins
 COPY pkg pkg
 COPY build.go package.json ./

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -26,7 +26,6 @@ COPY build.go package.json ./
 COPY pkg pkg/
 COPY cue cue/
 COPY cue.mod cue.mod/
-COPY packages/grafana-schema packages/grafana-schema/
 COPY public/app/plugins public/app/plugins/
 
 RUN go mod verify


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `COPY packages/grafana-schema packages/grafana-schema`, since `packages/grafana-schema` is not a thing for 8.1.

**Which issue(s) this PR fixes**:

Fixes #39108
