### PR TITLE
Azure: Add user identity token option for Azure token provider.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -592,6 +592,16 @@ managed_identity_enabled = false
 # Should be set for user-assigned identity and should be empty for system-assigned identity
 managed_identity_client_id =
 
+# Enable the user identity token mode
+# Disabled by default, needs to be explicitly enabled
+user_identity_enabled = false
+
+# Specify the endpoint to be used to retrieve access token of a user for the plugin
+user_identity_token_endpoint =
+
+# Specify the credential (Authorization header) to be used to communicate with the token endpoint
+user_identity_auth_header =
+
 #################################### SMTP / Emailing #####################
 [smtp]
 enabled = false

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -859,6 +859,18 @@ The client ID to use for user-assigned managed identity.
 
 Should be set for user-assigned identity and should be empty for system-assigned identity.
 
+### user_identity_enabled
+
+Enable the user identity token mode (separate token endpoint for user token). Disabled by default, needs to be explicitly enabled.
+
+### user_identity_token_endpoint
+
+Specify the endpoint to be used to retrieve access token of a user for the plugin
+
+### user_identity_auth_header
+
+Specify the credential (Authorization header) to be used to communicate with the token endpoint
+
 ## [auth.jwt]
 
 Refer to [JWT authentication]({{< relref "../auth/jwt.md" >}}) for more information.

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -264,6 +264,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"azure": map[string]interface{}{
 			"cloud":                  hs.Cfg.Azure.Cloud,
 			"managedIdentityEnabled": hs.Cfg.Azure.ManagedIdentityEnabled,
+			"userIdentityEnabled":    hs.Cfg.Azure.UserIdentityEnabled,
 		},
 		"caching": map[string]bool{
 			"enabled": hs.Cfg.SectionWithEnvOverrides("caching").Key("enabled").MustBool(true),

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -31,8 +31,6 @@ var (
 	client = newHTTPClient()
 )
 
-const ContextKeyLoginUser string = "loginUser"
-
 type DataSourceProxy struct {
 	ds                *models.DataSource
 	ctx               *models.ReqContext
@@ -242,7 +240,7 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 		// Pass in the context with signed-in userId, so that it can be used to obtain user token if the configured token provider supports
 		ctx := proxy.ctx.Req.Context()
 		if proxy.ctx.SignedInUser != nil {
-			ctx = context.WithValue(ctx, ContextKeyLoginUser, proxy.ctx.SignedInUser.Login)
+			ctx = context.WithValue(ctx, proxyutil.ContextKeyLoginUser{}, proxy.ctx.SignedInUser.Login)
 		}
 		ApplyRoute(ctx, req, proxy.proxyPath, proxy.route, proxy.ds, proxy.cfg)
 	}

--- a/pkg/api/pluginproxy/token_provider_azure.go
+++ b/pkg/api/pluginproxy/token_provider_azure.go
@@ -53,7 +53,6 @@ func getAzureCredentials(cfg *setting.Cfg, authParams *plugins.JwtTokenAuth) azc
 			TokenEndpoint: cfg.Azure.UserIdentityTokenEndpoint,
 			AuthHeader:    cfg.Azure.UserIdentityAuthHeader,
 		}
-
 	} else {
 		return &azcredentials.AzureClientSecretCredentials{
 			AzureCloud:   authParams.Params["azure_cloud"],

--- a/pkg/api/pluginproxy/token_provider_azure.go
+++ b/pkg/api/pluginproxy/token_provider_azure.go
@@ -44,15 +44,12 @@ func getAzureCredentials(cfg *setting.Cfg, authParams *plugins.JwtTokenAuth) azc
 	// * If authType and other fields aren't set then it means the datasource never been configured
 	//   and managed identity is the default authentication choice as long as managed identities are enabled
 	isManagedIdentity := authType == "msi" || (authType == "" && clientId == "" && cfg.Azure.ManagedIdentityEnabled)
-	isUserIdentity := authType == "userid" && cfg.Azure.UserIdentityEnabled
+	isUserIdentity := authType == "userid"
 
 	if isManagedIdentity {
 		return &azcredentials.AzureManagedIdentityCredentials{}
 	} else if isUserIdentity {
-		return &azcredentials.AzureUserIdentityCredentials{
-			TokenEndpoint: cfg.Azure.UserIdentityTokenEndpoint,
-			AuthHeader:    cfg.Azure.UserIdentityAuthHeader,
-		}
+		return &azcredentials.AzureUserIdentityCredentials{}
 	} else {
 		return &azcredentials.AzureClientSecretCredentials{
 			AzureCloud:   authParams.Params["azure_cloud"],

--- a/pkg/api/pluginproxy/token_provider_azure.go
+++ b/pkg/api/pluginproxy/token_provider_azure.go
@@ -44,9 +44,16 @@ func getAzureCredentials(cfg *setting.Cfg, authParams *plugins.JwtTokenAuth) azc
 	// * If authType and other fields aren't set then it means the datasource never been configured
 	//   and managed identity is the default authentication choice as long as managed identities are enabled
 	isManagedIdentity := authType == "msi" || (authType == "" && clientId == "" && cfg.Azure.ManagedIdentityEnabled)
+	isUserIdentity := authType == "userid" && cfg.Azure.UserIdentityEnabled
 
 	if isManagedIdentity {
 		return &azcredentials.AzureManagedIdentityCredentials{}
+	} else if isUserIdentity {
+		return &azcredentials.AzureUserIdentityCredentials{
+			TokenEndpoint: cfg.Azure.UserIdentityTokenEndpoint,
+			AuthHeader:    cfg.Azure.UserIdentityAuthHeader,
+		}
+
 	} else {
 		return &azcredentials.AzureClientSecretCredentials{
 			AzureCloud:   authParams.Params["azure_cloud"],

--- a/pkg/plugins/backendplugin/coreplugin/core_plugin.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
+	"github.com/grafana/grafana/pkg/util/proxyutil"
 )
 
 // corePlugin represents a plugin that's part of Grafana core.
@@ -78,6 +79,10 @@ func (cp *corePlugin) CheckHealth(ctx context.Context, req *backend.CheckHealthR
 
 func (cp *corePlugin) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	if cp.QueryDataHandler != nil {
+		// Pass in the context with logged in userId
+		if req.PluginContext.User != nil {
+			ctx = context.WithValue(ctx, proxyutil.ContextKeyLoginUser{}, req.PluginContext.User.Login)
+		}
 		return cp.QueryDataHandler.QueryData(ctx, req)
 	}
 
@@ -86,6 +91,10 @@ func (cp *corePlugin) QueryData(ctx context.Context, req *backend.QueryDataReque
 
 func (cp *corePlugin) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 	if cp.CallResourceHandler != nil {
+		// Pass in the context with logged in userId
+		if req.PluginContext.User != nil {
+			ctx = context.WithValue(ctx, proxyutil.ContextKeyLoginUser{}, req.PluginContext.User.Login)
+		}
 		return cp.CallResourceHandler.CallResource(ctx, req, sender)
 	}
 

--- a/pkg/plugins/backendplugin/coreplugin/core_plugin_test.go
+++ b/pkg/plugins/backendplugin/coreplugin/core_plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
+	"github.com/grafana/grafana/pkg/util/proxyutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,5 +66,55 @@ func TestCorePlugin(t *testing.T) {
 		err = p.CallResource(context.Background(), &backend.CallResourceRequest{}, nil)
 		require.NoError(t, err)
 		require.True(t, callResourceCalled)
+	})
+
+	t.Run("Core plugin will pass the signed-in userId in the context", func(t *testing.T) {
+		queryDataVerified := false
+		callResourceVerified := false
+		var expectedUserID string = "test@test.io"
+		factory := coreplugin.New(backend.ServeOpts{
+			CallResourceHandler: backend.CallResourceHandlerFunc(func(ctx context.Context,
+				req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+				value := ctx.Value(proxyutil.ContextKeyLoginUser{})
+				if value != nil {
+					userID := value.(string)
+					callResourceVerified = userID == expectedUserID
+				}
+
+				return nil
+			}),
+			QueryDataHandler: backend.QueryDataHandlerFunc(func(ctx context.Context,
+				req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+				value := ctx.Value(proxyutil.ContextKeyLoginUser{})
+				if value != nil {
+					userID := value.(string)
+					queryDataVerified = userID == expectedUserID
+				}
+				return &backend.QueryDataResponse{}, nil
+			}),
+		})
+		p, err := factory("plugin", log.New("test"), nil)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		require.NoError(t, p.Start(context.Background()))
+		require.NoError(t, p.Stop(context.Background()))
+		require.True(t, p.IsManaged())
+		require.False(t, p.Exited())
+
+		_, err = p.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				User: &backend.User{
+					Login: expectedUserID,
+				}}})
+		require.NoError(t, err)
+		require.True(t, queryDataVerified)
+
+		err = p.CallResource(context.Background(), &backend.CallResourceRequest{
+			PluginContext: backend.PluginContext{
+				User: &backend.User{
+					Login: expectedUserID,
+				}}}, nil)
+		require.NoError(t, err)
+		require.True(t, callResourceVerified)
 	})
 }

--- a/pkg/plugins/backendplugin/manager/manager.go
+++ b/pkg/plugins/backendplugin/manager/manager.go
@@ -180,6 +180,15 @@ func (m *Manager) getAzureEnvironmentVariables() []string {
 	if m.Cfg.Azure.ManagedIdentityEnabled {
 		variables = append(variables, "AZURE_MANAGED_IDENTITY_ENABLED=true")
 	}
+	if m.Cfg.Azure.UserIdentityTokenEndpoint != "" {
+		variables = append(variables, "AZURE_USER_IDENTITY_TOKEN_ENDPOINT="+m.Cfg.Azure.UserIdentityTokenEndpoint)
+	}
+	if m.Cfg.Azure.UserIdentityAuthHeader != "" {
+		variables = append(variables, "AZURE_USER_IDENTITY_AUTH_HEADER="+m.Cfg.Azure.UserIdentityAuthHeader)
+	}
+	if m.Cfg.Azure.UserIdentityEnabled {
+		variables = append(variables, "AZURE_USER_IDENTITY_ENABLED=true")
+	}
 
 	return variables
 }

--- a/pkg/plugins/backendplugin/manager/manager.go
+++ b/pkg/plugins/backendplugin/manager/manager.go
@@ -180,14 +180,14 @@ func (m *Manager) getAzureEnvironmentVariables() []string {
 	if m.Cfg.Azure.ManagedIdentityEnabled {
 		variables = append(variables, "AZURE_MANAGED_IDENTITY_ENABLED=true")
 	}
+	if m.Cfg.Azure.UserIdentityEnabled {
+		variables = append(variables, "AZURE_USER_IDENTITY_ENABLED=true")
+	}
 	if m.Cfg.Azure.UserIdentityTokenEndpoint != "" {
 		variables = append(variables, "AZURE_USER_IDENTITY_TOKEN_ENDPOINT="+m.Cfg.Azure.UserIdentityTokenEndpoint)
 	}
 	if m.Cfg.Azure.UserIdentityAuthHeader != "" {
 		variables = append(variables, "AZURE_USER_IDENTITY_AUTH_HEADER="+m.Cfg.Azure.UserIdentityAuthHeader)
-	}
-	if m.Cfg.Azure.UserIdentityEnabled {
-		variables = append(variables, "AZURE_USER_IDENTITY_ENABLED=true")
 	}
 
 	return variables

--- a/pkg/plugins/backendplugin/manager/manager_test.go
+++ b/pkg/plugins/backendplugin/manager/manager_test.go
@@ -63,7 +63,7 @@ func TestManager(t *testing.T) {
 				})
 
 				t.Run("Should provide expected host environment variables", func(t *testing.T) {
-					require.Len(t, ctx.env, 7)
+					require.Len(t, ctx.env, 9)
 					require.EqualValues(t, []string{
 						"GF_VERSION=7.0.0",
 						"GF_EDITION=Open Source",
@@ -71,7 +71,9 @@ func TestManager(t *testing.T) {
 						fmt.Sprintf("%s=keys,credentials", awsds.AllowedAuthProvidersEnvVarKeyName),
 						"AZURE_CLOUD=AzureCloud",
 						"AZURE_MANAGED_IDENTITY_CLIENT_ID=client-id",
-						"AZURE_MANAGED_IDENTITY_ENABLED=true"},
+						"AZURE_MANAGED_IDENTITY_ENABLED=true",
+						"AZURE_USER_IDENTITY_ENABLED=true",
+						"AZURE_USER_IDENTITY_TOKEN_ENDPOINT=test_endpoint"},
 						ctx.env)
 				})
 
@@ -290,7 +292,7 @@ func TestManager(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("Should provide expected host environment variables", func(t *testing.T) {
-				require.Len(t, ctx.env, 9)
+				require.Len(t, ctx.env, 11)
 				require.EqualValues(t, []string{
 					"GF_VERSION=7.0.0",
 					"GF_EDITION=Enterprise",
@@ -300,7 +302,9 @@ func TestManager(t *testing.T) {
 					fmt.Sprintf("%s=keys,credentials", awsds.AllowedAuthProvidersEnvVarKeyName),
 					"AZURE_CLOUD=AzureCloud",
 					"AZURE_MANAGED_IDENTITY_CLIENT_ID=client-id",
-					"AZURE_MANAGED_IDENTITY_ENABLED=true"},
+					"AZURE_MANAGED_IDENTITY_ENABLED=true",
+					"AZURE_USER_IDENTITY_ENABLED=true",
+					"AZURE_USER_IDENTITY_TOKEN_ENDPOINT=test_endpoint"},
 					ctx.env)
 			})
 		})
@@ -325,6 +329,9 @@ func newManagerScenario(t *testing.T, managed bool, fn func(t *testing.T, ctx *m
 	cfg.Azure.ManagedIdentityEnabled = true
 	cfg.Azure.Cloud = "AzureCloud"
 	cfg.Azure.ManagedIdentityClientId = "client-id"
+	cfg.Azure.UserIdentityEnabled = true
+	cfg.Azure.UserIdentityTokenEndpoint = "test_endpoint"
+	cfg.Azure.UserIdentityAuthHeader = ""
 
 	license := &testLicensingService{}
 	validator := &testPluginRequestValidator{}

--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -32,7 +32,6 @@ func (cfg *Cfg) readAzureSettings() {
 	cfg.Azure.UserIdentityEnabled = azureSection.Key("user_identity_enabled").MustBool(false)
 	cfg.Azure.UserIdentityTokenEndpoint = azureSection.Key("user_identity_token_endpoint").String()
 	cfg.Azure.UserIdentityAuthHeader = azureSection.Key("user_identity_auth_header").String()
-
 }
 
 func normalizeAzureCloud(cloudName string) string {

--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -10,9 +10,12 @@ const (
 )
 
 type AzureSettings struct {
-	Cloud                   string
-	ManagedIdentityEnabled  bool
-	ManagedIdentityClientId string
+	Cloud                     string
+	ManagedIdentityEnabled    bool
+	ManagedIdentityClientId   string
+	UserIdentityEnabled       bool
+	UserIdentityTokenEndpoint string
+	UserIdentityAuthHeader    string
 }
 
 func (cfg *Cfg) readAzureSettings() {
@@ -25,6 +28,11 @@ func (cfg *Cfg) readAzureSettings() {
 	// Managed Identity
 	cfg.Azure.ManagedIdentityEnabled = azureSection.Key("managed_identity_enabled").MustBool(false)
 	cfg.Azure.ManagedIdentityClientId = azureSection.Key("managed_identity_client_id").String()
+	// User Identity toke endpoint
+	cfg.Azure.UserIdentityEnabled = azureSection.Key("user_identity_enabled").MustBool(false)
+	cfg.Azure.UserIdentityTokenEndpoint = azureSection.Key("user_identity_token_endpoint").String()
+	cfg.Azure.UserIdentityAuthHeader = azureSection.Key("user_identity_auth_header").String()
+
 }
 
 func normalizeAzureCloud(cloudName string) string {

--- a/pkg/setting/setting_azure.go
+++ b/pkg/setting/setting_azure.go
@@ -28,7 +28,7 @@ func (cfg *Cfg) readAzureSettings() {
 	// Managed Identity
 	cfg.Azure.ManagedIdentityEnabled = azureSection.Key("managed_identity_enabled").MustBool(false)
 	cfg.Azure.ManagedIdentityClientId = azureSection.Key("managed_identity_client_id").String()
-	// User Identity toke endpoint
+	// User Identity authentication
 	cfg.Azure.UserIdentityEnabled = azureSection.Key("user_identity_enabled").MustBool(false)
 	cfg.Azure.UserIdentityTokenEndpoint = azureSection.Key("user_identity_token_endpoint").String()
 	cfg.Azure.UserIdentityAuthHeader = azureSection.Key("user_identity_auth_header").String()

--- a/pkg/tsdb/azuremonitor/azcredentials/builder.go
+++ b/pkg/tsdb/azuremonitor/azcredentials/builder.go
@@ -24,7 +24,9 @@ func getFromCredentialsObject(credentialsObj map[string]interface{}, secureData 
 	case AzureAuthManagedIdentity:
 		credentials := &AzureManagedIdentityCredentials{}
 		return credentials, nil
-
+	case AzureAuthUserIdentity:
+		credentials := &AzureUserIdentityCredentials{}
+		return credentials, nil
 	case AzureAuthClientSecret:
 		cloud, err := getStringValue(credentialsObj, "azureCloud")
 		if err != nil {

--- a/pkg/tsdb/azuremonitor/azcredentials/builder.go
+++ b/pkg/tsdb/azuremonitor/azcredentials/builder.go
@@ -24,9 +24,11 @@ func getFromCredentialsObject(credentialsObj map[string]interface{}, secureData 
 	case AzureAuthManagedIdentity:
 		credentials := &AzureManagedIdentityCredentials{}
 		return credentials, nil
+
 	case AzureAuthUserIdentity:
 		credentials := &AzureUserIdentityCredentials{}
 		return credentials, nil
+
 	case AzureAuthClientSecret:
 		cloud, err := getStringValue(credentialsObj, "azureCloud")
 		if err != nil {

--- a/pkg/tsdb/azuremonitor/azcredentials/credentials.go
+++ b/pkg/tsdb/azuremonitor/azcredentials/credentials.go
@@ -3,6 +3,7 @@ package azcredentials
 const (
 	AzureAuthManagedIdentity = "msi"
 	AzureAuthClientSecret    = "clientsecret"
+	AzureAuthUserIdentity    = "userid"
 )
 
 type AzureCredentials interface {
@@ -21,10 +22,19 @@ type AzureClientSecretCredentials struct {
 	ClientSecret string
 }
 
+type AzureUserIdentityCredentials struct {
+	TokenEndpoint string // token endpoint to retrieve the token from
+	AuthHeader    string // exact Authorization header to be used to talk to the token endpoint
+}
+
 func (credentials *AzureManagedIdentityCredentials) AzureAuthType() string {
 	return AzureAuthManagedIdentity
 }
 
 func (credentials *AzureClientSecretCredentials) AzureAuthType() string {
 	return AzureAuthClientSecret
+}
+
+func (credentials *AzureUserIdentityCredentials) AzureAuthType() string {
+	return AzureAuthUserIdentity
 }

--- a/pkg/tsdb/azuremonitor/azcredentials/credentials.go
+++ b/pkg/tsdb/azuremonitor/azcredentials/credentials.go
@@ -23,8 +23,6 @@ type AzureClientSecretCredentials struct {
 }
 
 type AzureUserIdentityCredentials struct {
-	TokenEndpoint string // token endpoint to retrieve the token from
-	AuthHeader    string // exact Authorization header to be used to talk to the token endpoint
 }
 
 func (credentials *AzureManagedIdentityCredentials) AzureAuthType() string {

--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_cache_test.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_cache_test.go
@@ -20,7 +20,7 @@ type fakeRetriever struct {
 	getAccessTokenFunc func(ctx context.Context, scopes []string) (*AccessToken, error)
 }
 
-func (c *fakeRetriever) GetCacheKey() string {
+func (c *fakeRetriever) GetCacheKey(ctx context.Context) string {
 	return c.key
 }
 

--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
@@ -3,10 +3,19 @@ package aztokenprovider
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azcredentials"
@@ -15,6 +24,8 @@ import (
 var (
 	azureTokenCache = NewConcurrentTokenCache()
 )
+
+const ContextKeyLoginUser string = "loginUser"
 
 type AzureTokenProvider interface {
 	GetAccessToken(ctx context.Context, scopes []string) (string, error)
@@ -46,6 +57,13 @@ func NewAzureAccessTokenProvider(cfg *setting.Cfg, credentials azcredentials.Azu
 		}
 	case *azcredentials.AzureClientSecretCredentials:
 		tokenRetriever = getClientSecretTokenRetriever(c)
+	case *azcredentials.AzureUserIdentityCredentials:
+		if !cfg.Azure.UserIdentityEnabled {
+			err := fmt.Errorf("user identity authentication is not enabled in Grafana config")
+			return nil, err
+		} else {
+			tokenRetriever = getUserIdentityTokenRetriever(cfg, c)
+		}
 	default:
 		err := fmt.Errorf("credentials of type '%s' not supported by authentication provider", c.AzureAuthType())
 		return nil, err
@@ -99,6 +117,23 @@ func getClientSecretTokenRetriever(credentials *azcredentials.AzureClientSecretC
 		tenantId:     credentials.TenantId,
 		clientId:     credentials.ClientId,
 		clientSecret: credentials.ClientSecret,
+	}
+}
+
+func getUserIdentityTokenRetriever(cfg *setting.Cfg, credentials *azcredentials.AzureUserIdentityCredentials) TokenRetriever {
+	tokenEndpoint := credentials.TokenEndpoint
+	if tokenEndpoint == "" {
+		tokenEndpoint = cfg.Azure.UserIdentityTokenEndpoint
+	}
+
+	authHeader := credentials.AuthHeader
+	if authHeader == "" {
+		authHeader = cfg.Azure.UserIdentityAuthHeader
+	}
+
+	return &userIdentityTokenRetriever{
+		tokenEndpoint: tokenEndpoint,
+		authHeader:    authHeader,
 	}
 }
 
@@ -178,6 +213,115 @@ func (c *clientSecretTokenRetriever) GetAccessToken(ctx context.Context, scopes 
 	}
 
 	return &AccessToken{Token: accessToken.Token, ExpiresOn: accessToken.ExpiresOn}, nil
+}
+
+type userIdentityTokenRetriever struct {
+	tokenEndpoint string // token endpoint to retrieve the token from
+	authHeader    string // exact Authorization header to be used to talk to the token endpoint
+	client        *http.Client
+}
+
+func (c *userIdentityTokenRetriever) GetCacheKey() string {
+	return fmt.Sprintf("azure|useridtoken|%s", c.tokenEndpoint)
+}
+
+func (c *userIdentityTokenRetriever) Init() error {
+	c.client = &http.Client{Timeout: time.Second * 10}
+	return nil
+}
+
+func (c *userIdentityTokenRetriever) GetAccessToken(ctx context.Context, scopes []string) (*AccessToken, error) {
+	value := ctx.Value(ContextKeyLoginUser)
+	if value == nil {
+		return nil, fmt.Errorf("Failed to get signed-in user")
+	}
+
+	userId := value.(string)
+	if userId == "" {
+		return nil, fmt.Errorf("Empty signed-in userId")
+	}
+
+	return c.getUserAccessToken(userId, scopes)
+}
+
+func (c *userIdentityTokenRetriever) getUserAccessToken(userId string, scopes []string) (*AccessToken, error) {
+	// The token endpoint needs to support the following API:
+	// POST {endpoint url}
+	//
+	// Headers:
+	// "Content-Type", "application/x-www-form-urlencoded"
+	// "Accept", "application/json"
+	//
+	// Body:
+	// scope=xxx&user_id=xxx
+	req, err := http.NewRequest("POST", c.tokenEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create token request, %w", err)
+	}
+
+	// Token server supports POST method with parameters in the body
+	data := url.Values{}
+	data.Set("scope", strings.Join(scopes, " "))
+	data.Set("user_id", userId)
+	dataEncoded := data.Encode()
+	body := streaming.NopCloser(strings.NewReader(dataEncoded))
+
+	size, err := body.Seek(0, io.SeekEnd) // Seek to the end to get the stream's size
+	if err != nil {
+		return nil, err
+	}
+	_, err = body.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = body
+	req.ContentLength = size
+	req.Header.Set("Content-Length", strconv.FormatInt(size, 10))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get AccessToken: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return c.getAccessTokenFromResponse(resp)
+}
+
+func (c *userIdentityTokenRetriever) getAccessTokenFromResponse(resp *http.Response) (*AccessToken, error) {
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+
+		return nil, fmt.Errorf("Bad statuscode on token request: %d", resp.StatusCode)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read token response: %w", err)
+	}
+
+	value := struct {
+		Token     string      `json:"access_token"`
+		ExpiresIn json.Number `json:"expires_in"`
+		ExpiresOn string      `json:"expires_on"`
+	}{}
+
+	if err := json.Unmarshal(respBody, &value); err != nil {
+		return nil, fmt.Errorf("Failed to deserialize token response: %w", err)
+	}
+	t, err := value.ExpiresIn.Int64()
+	if err != nil {
+		return nil, fmt.Errorf("Faile to get ExpiresIn property of the token: %w", err)
+	}
+	return &AccessToken{
+		Token:     value.Token,
+		ExpiresOn: time.Now().Add(time.Second * time.Duration(t)).UTC(),
+	}, nil
 }
 
 func hashSecret(secret string) string {

--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_provider.go
@@ -43,18 +43,16 @@ func NewAzureAccessTokenProvider(cfg *setting.Cfg, credentials azcredentials.Azu
 		if !cfg.Azure.ManagedIdentityEnabled {
 			err := fmt.Errorf("managed identity authentication is not enabled in Grafana config")
 			return nil, err
-		} else {
-			tokenRetriever = getManagedIdentityTokenRetriever(cfg, c)
 		}
+		tokenRetriever = getManagedIdentityTokenRetriever(cfg, c)
 	case *azcredentials.AzureClientSecretCredentials:
 		tokenRetriever = getClientSecretTokenRetriever(c)
 	case *azcredentials.AzureUserIdentityCredentials:
 		if !cfg.Azure.UserIdentityEnabled {
 			err := fmt.Errorf("user identity authentication is not enabled in Grafana config")
 			return nil, err
-		} else {
-			tokenRetriever = getUserIdentityTokenRetriever(cfg)
 		}
+		tokenRetriever = getUserIdentityTokenRetriever(cfg)
 	default:
 		err := fmt.Errorf("credentials of type '%s' not supported by authentication provider", c.AzureAuthType())
 		return nil, err

--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_provider_test.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_provider_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azcredentials"
+	"github.com/grafana/grafana/pkg/util/proxyutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -178,16 +179,16 @@ func TestAzureTokenProvider_GetUserIdAccessToken(t *testing.T) {
 		assert.IsType(t, &userIdentityTokenRetriever{}, tokenRetriver)
 
 		_, err := tokenRetriver.GetAccessToken(ctx, scope)
-		assert.Error(t, err, "Failed to get signed-in user")
+		assert.Error(t, err, "failed to get signed-in user")
 	})
 
 	t.Run("return error if there is empty signed in user", func(t *testing.T) {
 		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials)
 		assert.IsType(t, &userIdentityTokenRetriever{}, tokenRetriver)
 
-		ctx = context.WithValue(ctx, ContextKeyLoginUser, "")
+		ctx = context.WithValue(ctx, proxyutil.ContextKeyLoginUser{}, "")
 		_, err := tokenRetriver.GetAccessToken(ctx, scope)
-		assert.Error(t, err, "Empty signed-in userId")
+		assert.Error(t, err, "empty signed-in userId")
 	})
 }
 
@@ -203,7 +204,7 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 		AuthHeader:    "Bear xxxxx",
 	}
 
-	t.Run("Sucessful token parse", func(t *testing.T) {
+	t.Run("Successful token parse", func(t *testing.T) {
 		value := struct {
 			Token     string      `json:"access_token"`
 			ExpiresIn json.Number `json:"expires_in"`

--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_provider_test.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_provider_test.go
@@ -202,25 +202,24 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 		TokenEndpoint: "https://test.io",
 		AuthHeader:    "Bear xxxxx",
 	}
-	value := struct {
-		Token     string      `json:"access_token"`
-		ExpiresIn json.Number `json:"expires_in"`
-		ExpiresOn string      `json:"expires_on"`
-	}{
-		Token:     "testtoken",
-		ExpiresIn: "1000",
-	}
 
-	data, err := json.Marshal(value)
-	assert.Empty(t, err, "Failed to marshal data")
+	t.Run("Sucessful token parse", func(t *testing.T) {
+		value := struct {
+			Token     string      `json:"access_token"`
+			ExpiresIn json.Number `json:"expires_in"`
+			ExpiresOn string      `json:"expires_on"`
+		}{
+			Token:     "testtoken",
+			ExpiresIn: "1000",
+		}
+		data, err := json.Marshal(value)
+		assert.Empty(t, err, "Failed to marshal data")
 
-	body := io.NopCloser(bytes.NewReader(data))
-	var resp = &http.Response{
-		StatusCode: 200,
-		Body:       body,
-	}
-
-	t.Run("return error if there is empty signed in user", func(t *testing.T) {
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 200,
+			Body:       body,
+		}
 		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
 		token, err := tokenRetriver.getAccessTokenFromResponse(resp)
 		assert.Empty(t, err, "Failed on getting token")
@@ -231,5 +230,63 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 		timeMax := timeMin.Add(time.Second * 100)
 		assert.True(t, token.ExpiresOn.After(timeMin), "token.ExpiresOn is not after timeMin")
 		assert.True(t, token.ExpiresOn.Before(timeMax), "token.ExpiresOn is not before timeMax")
+	})
+
+	t.Run("Fail token parse on bad status code", func(t *testing.T) {
+		value := struct {
+			Token     string      `json:"access_token"`
+			ExpiresIn json.Number `json:"expires_in"`
+			ExpiresOn string      `json:"expires_on"`
+		}{
+			Token:     "testtoken",
+			ExpiresIn: "1000",
+		}
+		data, err := json.Marshal(value)
+		assert.Empty(t, err, "Failed to marshal data")
+
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 401,
+			Body:       body,
+		}
+		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
+		_, err = tokenRetriver.getAccessTokenFromResponse(resp)
+		assert.Error(t, err, "Bad statuscode on token request: 401")
+	})
+
+	t.Run("Fail token parse on bad data", func(t *testing.T) {
+		data, err := json.Marshal("bad test")
+		assert.Empty(t, err, "Failed to marshal data")
+
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 200,
+			Body:       body,
+		}
+		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
+		_, err = tokenRetriver.getAccessTokenFromResponse(resp)
+		assert.Contains(t, err.Error(), "Failed to deserialize token response")
+	})
+
+	t.Run("Fail token parse on bad expiresIn", func(t *testing.T) {
+		value := struct {
+			Token     string      `json:"access_token"`
+			ExpiresIn json.Number `json:"expires_in"`
+			ExpiresOn string      `json:"expires_on"`
+		}{
+			Token:     "testtoken",
+			ExpiresIn: "99.999",
+		}
+		data, err := json.Marshal(value)
+		assert.Empty(t, err, "Failed to marshal data")
+
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 200,
+			Body:       body,
+		}
+		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
+		_, err = tokenRetriver.getAccessTokenFromResponse(resp)
+		assert.Contains(t, err.Error(), "Faile to get ExpiresIn property of the token")
 	})
 }

--- a/pkg/tsdb/azuremonitor/aztokenprovider/token_provider_test.go
+++ b/pkg/tsdb/azuremonitor/aztokenprovider/token_provider_test.go
@@ -214,7 +214,7 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 			ExpiresIn: "1000",
 		}
 		data, err := json.Marshal(value)
-		assert.Empty(t, err, "Failed to marshal data")
+		assert.Empty(t, err, "failed to marshal data")
 
 		body := io.NopCloser(bytes.NewReader(data))
 		var resp = &http.Response{
@@ -223,7 +223,7 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 		}
 		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
 		token, err := tokenRetriver.getAccessTokenFromResponse(resp)
-		assert.Empty(t, err, "Failed on getting token")
+		assert.Empty(t, err, "failed on getting token")
 
 		assert.Equal(t, value.Token, token.Token)
 
@@ -243,7 +243,7 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 			ExpiresIn: "1000",
 		}
 		data, err := json.Marshal(value)
-		assert.Empty(t, err, "Failed to marshal data")
+		assert.Empty(t, err, "failed to marshal data")
 
 		body := io.NopCloser(bytes.NewReader(data))
 		var resp = &http.Response{
@@ -252,12 +252,12 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 		}
 		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
 		_, err = tokenRetriver.getAccessTokenFromResponse(resp)
-		assert.Error(t, err, "Bad statuscode on token request: 401")
+		assert.Error(t, err, "bad statuscode on token request: 401")
 	})
 
 	t.Run("Fail token parse on bad data", func(t *testing.T) {
 		data, err := json.Marshal("bad test")
-		assert.Empty(t, err, "Failed to marshal data")
+		assert.Empty(t, err, "failed to marshal data")
 
 		body := io.NopCloser(bytes.NewReader(data))
 		var resp = &http.Response{
@@ -266,7 +266,7 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 		}
 		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
 		_, err = tokenRetriver.getAccessTokenFromResponse(resp)
-		assert.Contains(t, err.Error(), "Failed to deserialize token response")
+		assert.Contains(t, err.Error(), "failed to deserialize token response")
 	})
 
 	t.Run("Fail token parse on bad expiresIn", func(t *testing.T) {
@@ -279,7 +279,7 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 			ExpiresIn: "99.999",
 		}
 		data, err := json.Marshal(value)
-		assert.Empty(t, err, "Failed to marshal data")
+		assert.Empty(t, err, "failed to marshal data")
 
 		body := io.NopCloser(bytes.NewReader(data))
 		var resp = &http.Response{
@@ -288,6 +288,6 @@ func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
 		}
 		tokenRetriver := getUserIdentityTokenRetriever(cfg, credentials).(*userIdentityTokenRetriever)
 		_, err = tokenRetriver.getAccessTokenFromResponse(resp)
-		assert.Contains(t, err.Error(), "Faile to get ExpiresIn property of the token")
+		assert.Contains(t, err.Error(), "failed to get ExpiresIn property of the token")
 	})
 }

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azcredentials"
-	"github.com/grafana/grafana/pkg/util/proxyutil"
 )
 
 const (
@@ -196,10 +195,6 @@ func (s *Service) newMux() *datasource.QueryTypeMux {
 			service, ok := dsInfo.Services[dst]
 			if !ok {
 				return nil, fmt.Errorf("missing service for %s", dst)
-			}
-			// Pass in the context with logged in userId
-			if req.PluginContext.User != nil {
-				ctx = context.WithValue(ctx, proxyutil.ContextKeyLoginUser{}, req.PluginContext.User.Login)
 			}
 			return executor.executeTimeSeriesQuery(ctx, req.Queries, dsInfo, service.HTTPClient, service.URL)
 		})

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azcredentials"
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/aztokenprovider"
 )
 
 const (
@@ -195,6 +196,10 @@ func (s *Service) newMux() *datasource.QueryTypeMux {
 			service, ok := dsInfo.Services[dst]
 			if !ok {
 				return nil, fmt.Errorf("missing service for %s", dst)
+			}
+			// Pass in the context with logged in userId
+			if req.PluginContext.User != nil {
+				ctx = context.WithValue(ctx, aztokenprovider.ContextKeyLoginUser, req.PluginContext.User.Login)
 			}
 			return executor.executeTimeSeriesQuery(ctx, req.Queries, dsInfo, service.HTTPClient, service.URL)
 		})

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -19,7 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azcredentials"
-	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/aztokenprovider"
+	"github.com/grafana/grafana/pkg/util/proxyutil"
 )
 
 const (
@@ -199,7 +199,7 @@ func (s *Service) newMux() *datasource.QueryTypeMux {
 			}
 			// Pass in the context with logged in userId
 			if req.PluginContext.User != nil {
-				ctx = context.WithValue(ctx, aztokenprovider.ContextKeyLoginUser, req.PluginContext.User.Login)
+				ctx = context.WithValue(ctx, proxyutil.ContextKeyLoginUser{}, req.PluginContext.User.Login)
 			}
 			return executor.executeTimeSeriesQuery(ctx, req.Queries, dsInfo, service.HTTPClient, service.URL)
 		})

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -40,6 +40,25 @@ func TestNewInstanceSettings(t *testing.T) {
 			},
 			Err: require.NoError,
 		},
+		{
+			name: "creates an instance with azureAuthType of userid",
+			settings: backend.DataSourceInstanceSettings{
+				JSONData:                []byte(`{"azureAuthType":"userid"}`),
+				DecryptedSecureJSONData: map[string]string{"key": "value"},
+				ID:                      40,
+			},
+			expectedModel: datasourceInfo{
+				Cloud:                   setting.AzurePublic,
+				Credentials:             &azcredentials.AzureUserIdentityCredentials{},
+				Settings:                azureMonitorSettings{},
+				Routes:                  routes[setting.AzurePublic],
+				JSONData:                map[string]interface{}{"azureAuthType": "userid"},
+				DatasourceID:            40,
+				DecryptedSecureJSONData: map[string]string{"key": "value"},
+				Services:                map[string]datasourceService{},
+			},
+			Err: require.NoError,
+		},
 	}
 
 	cfg := &setting.Cfg{

--- a/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_client.go
+++ b/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_client.go
@@ -1,0 +1,114 @@
+package azuseridentityclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+)
+
+// TokenResponse is the response from the UserIdentityClient
+type TokenResponse struct {
+	Token     string
+	ExpiresOn time.Time
+}
+
+// UserIdentityClient is the client to retrieve user identity token
+type UserIdentityClient struct {
+	tokenEndpoint string // token endpoint to retrieve the token from
+	authHeader    string // exact Authorization header to be used to talk to the token endpoint
+	client        *http.Client
+}
+
+// GetUserAccessToken retieves the access token for a user and the specified scopes
+func (c *UserIdentityClient) GetUserAccessToken(userID string, scopes []string) (*TokenResponse, error) {
+	req, err := http.NewRequest("POST", c.tokenEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request, %w", err)
+	}
+
+	// Token server supports POST method with parameters in the body
+	data := url.Values{}
+	data.Set("scope", strings.Join(scopes, " "))
+	data.Set("user_id", userID)
+	dataEncoded := data.Encode()
+	body := streaming.NopCloser(strings.NewReader(dataEncoded))
+
+	size, err := body.Seek(0, io.SeekEnd) // Seek to the end to get the stream's size
+	if err != nil {
+		return nil, err
+	}
+	_, err = body.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = body
+	req.ContentLength = size
+	req.Header.Set("Content-Length", strconv.FormatInt(size, 10))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AccessToken: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Println("error closing response:", err)
+		}
+	}()
+
+	return c.getAccessTokenFromResponse(resp)
+}
+
+func (c *UserIdentityClient) getAccessTokenFromResponse(resp *http.Response) (*TokenResponse, error) {
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		return nil, fmt.Errorf("bad statuscode on token request: %d", resp.StatusCode)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	value := struct {
+		Token     string      `json:"access_token"`
+		ExpiresIn json.Number `json:"expires_in"`
+		ExpiresOn string      `json:"expires_on"`
+	}{}
+
+	if err := json.Unmarshal(respBody, &value); err != nil {
+		return nil, fmt.Errorf("failed to deserialize token response: %w", err)
+	}
+	t, err := value.ExpiresIn.Int64()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ExpiresIn property of the token: %w", err)
+	}
+	return &TokenResponse{
+		Token:     value.Token,
+		ExpiresOn: time.Now().Add(time.Second * time.Duration(t)).UTC(),
+	}, nil
+}
+
+// NewUserIdentityClient creates a user identity token client
+func NewUserIdentityClient(tokenEndpoint, authHeader string) *UserIdentityClient {
+	return &UserIdentityClient{
+		tokenEndpoint: tokenEndpoint,
+		authHeader:    authHeader,
+		client:        &http.Client{Timeout: time.Second * 10},
+	}
+}

--- a/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_client.go
+++ b/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_client.go
@@ -29,6 +29,7 @@ type UserIdentityClient struct {
 }
 
 // GetUserAccessToken retieves the access token for a user and the specified scopes
+// Token endpoint needs to support the OpenAPI contract defined in user_identity_token_endpoint.yaml
 func (c *UserIdentityClient) GetUserAccessToken(userID string, scopes []string) (*TokenResponse, error) {
 	req, err := http.NewRequest("POST", c.tokenEndpoint, nil)
 	if err != nil {

--- a/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_client_test.go
+++ b/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_client_test.go
@@ -1,0 +1,101 @@
+package azuseridentityclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAzureTokenProvider_GetAccessTokenFromResponse(t *testing.T) {
+	t.Run("Successful token parse", func(t *testing.T) {
+		value := struct {
+			Token     string      `json:"access_token"`
+			ExpiresIn json.Number `json:"expires_in"`
+			ExpiresOn string      `json:"expires_on"`
+		}{
+			Token:     "testtoken",
+			ExpiresIn: "1000",
+		}
+		data, err := json.Marshal(value)
+		assert.Empty(t, err, "failed to marshal data")
+
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 200,
+			Body:       body,
+		}
+		tokenClient := NewUserIdentityClient("https://test.io", "Bear xxxxx")
+		token, err := tokenClient.getAccessTokenFromResponse(resp)
+		assert.Empty(t, err, "failed on getting token")
+
+		assert.Equal(t, value.Token, token.Token)
+
+		timeMin := time.Now().UTC().Add(time.Second * 950)
+		timeMax := timeMin.Add(time.Second * 100)
+		assert.True(t, token.ExpiresOn.After(timeMin), "token.ExpiresOn is not after timeMin")
+		assert.True(t, token.ExpiresOn.Before(timeMax), "token.ExpiresOn is not before timeMax")
+	})
+
+	t.Run("Fail token parse on bad status code", func(t *testing.T) {
+		value := struct {
+			Token     string      `json:"access_token"`
+			ExpiresIn json.Number `json:"expires_in"`
+			ExpiresOn string      `json:"expires_on"`
+		}{
+			Token:     "testtoken",
+			ExpiresIn: "1000",
+		}
+		data, err := json.Marshal(value)
+		assert.Empty(t, err, "failed to marshal data")
+
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 401,
+			Body:       body,
+		}
+		tokenClient := NewUserIdentityClient("https://test.io", "Bear xxxxx")
+		_, err = tokenClient.getAccessTokenFromResponse(resp)
+		assert.Error(t, err, "bad statuscode on token request: 401")
+	})
+
+	t.Run("Fail token parse on bad data", func(t *testing.T) {
+		data, err := json.Marshal("bad test")
+		assert.Empty(t, err, "failed to marshal data")
+
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 200,
+			Body:       body,
+		}
+		tokenClient := NewUserIdentityClient("https://test.io", "Bear xxxxx")
+		_, err = tokenClient.getAccessTokenFromResponse(resp)
+		assert.Contains(t, err.Error(), "failed to deserialize token response")
+	})
+
+	t.Run("Fail token parse on bad expiresIn", func(t *testing.T) {
+		value := struct {
+			Token     string      `json:"access_token"`
+			ExpiresIn json.Number `json:"expires_in"`
+			ExpiresOn string      `json:"expires_on"`
+		}{
+			Token:     "testtoken",
+			ExpiresIn: "99.999",
+		}
+		data, err := json.Marshal(value)
+		assert.Empty(t, err, "failed to marshal data")
+
+		body := io.NopCloser(bytes.NewReader(data))
+		var resp = &http.Response{
+			StatusCode: 200,
+			Body:       body,
+		}
+		tokenClient := NewUserIdentityClient("https://test.io", "Bear xxxxx")
+		_, err = tokenClient.getAccessTokenFromResponse(resp)
+		assert.Contains(t, err.Error(), "failed to get ExpiresIn property of the token")
+	})
+}

--- a/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_token_endpoint.yaml
+++ b/pkg/tsdb/azuremonitor/azuseridentityclient/user_identity_token_endpoint.yaml
@@ -1,0 +1,94 @@
+---
+openapi: 3.0.1
+info:
+  title: Grafana User Identity Token API
+  version: 1.0.0-oas3
+servers:
+- url: /
+paths:
+  /oauth2/v2.0/token:
+    post:
+      tags:
+      - Token
+      description: Get an access token for a user.
+      operationId: Get_Token
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AccessTokenRequestForm'
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessTokenResult'
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - {}
+      - bearerAuth: []
+      - basicAuth: []
+components:
+  schemas:
+    AccessTokenRequestForm:
+      type: object
+      properties:
+        scope:
+          type: string
+          description: A space-separated list of OAuth 2.0 scopes requested for the token.
+          example: https%3A%2F%2Fmyservice1.net%2F.default%20https%3A%2F%2Fmyservice2.io%2F.default
+        user_id:
+          type: string
+          description: user identity
+          example: userid@test.io
+    AccessTokenResult:
+      type: object
+      properties:
+        expires_on:
+          type: integer
+          description: Expiration date of the access token in epoch
+          format: int64
+          example: 1622153553
+        access_token:
+          type: string
+          description: Access token
+          example: eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ilg1ZVhrN...
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+          format: int32
+        detail:
+          type: string
+      description: Problem Details for HTTP APIs defined by RFC7807
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    basicAuth:
+      type: http
+      scheme: basic

--- a/pkg/tsdb/azuremonitor/credentials.go
+++ b/pkg/tsdb/azuremonitor/credentials.go
@@ -105,10 +105,7 @@ func getAzureCredentials(cfg *setting.Cfg, jsonData *simplejson.Json, secureJson
 		credentials := &azcredentials.AzureManagedIdentityCredentials{}
 		return credentials, nil
 	case azcredentials.AzureAuthUserIdentity:
-		credentials := &azcredentials.AzureUserIdentityCredentials{
-			TokenEndpoint: cfg.Azure.UserIdentityTokenEndpoint,
-			AuthHeader:    cfg.Azure.UserIdentityAuthHeader,
-		}
+		credentials := &azcredentials.AzureUserIdentityCredentials{}
 		return credentials, nil
 	case azcredentials.AzureAuthClientSecret:
 		cloud, err := getAzureCloud(cfg, jsonData)

--- a/pkg/tsdb/azuremonitor/credentials.go
+++ b/pkg/tsdb/azuremonitor/credentials.go
@@ -82,6 +82,9 @@ func getAzureCloud(cfg *setting.Cfg, jsonData *simplejson.Json) (string, error) 
 	case azcredentials.AzureAuthManagedIdentity:
 		// In case of managed identity, the cloud is always same as where Grafana is hosted
 		return getDefaultAzureCloud(cfg)
+	case azcredentials.AzureAuthUserIdentity:
+		// In case of user identity, the cloud is always same as where Grafana is hosted
+		return getDefaultAzureCloud(cfg)
 	case azcredentials.AzureAuthClientSecret:
 		if cloud := jsonData.Get("cloudName").MustString(); cloud != "" {
 			return normalizeAzureCloud(cloud)
@@ -101,7 +104,12 @@ func getAzureCredentials(cfg *setting.Cfg, jsonData *simplejson.Json, secureJson
 	case azcredentials.AzureAuthManagedIdentity:
 		credentials := &azcredentials.AzureManagedIdentityCredentials{}
 		return credentials, nil
-
+	case azcredentials.AzureAuthUserIdentity:
+		credentials := &azcredentials.AzureUserIdentityCredentials{
+			TokenEndpoint: cfg.Azure.UserIdentityTokenEndpoint,
+			AuthHeader:    cfg.Azure.UserIdentityAuthHeader,
+		}
+		return credentials, nil
 	case azcredentials.AzureAuthClientSecret:
 		cloud, err := getAzureCloud(cfg, jsonData)
 		if err != nil {

--- a/pkg/tsdb/azuremonitor/credentials_test.go
+++ b/pkg/tsdb/azuremonitor/credentials_test.go
@@ -72,6 +72,56 @@ func TestCredentials_getAuthType(t *testing.T) {
 			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
 		})
 	})
+
+	t.Run("when user identity is enabled", func(t *testing.T) {
+		cfg.Azure.UserIdentityEnabled = true
+		cfg.Azure.ManagedIdentityEnabled = false
+
+		t.Run("should be userid if auth type is set to user identity", func(t *testing.T) {
+			jsonData := simplejson.NewFromAny(map[string]interface{}{
+				"azureAuthType": azcredentials.AzureAuthUserIdentity,
+			})
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthUserIdentity, authType)
+		})
+
+		t.Run("should be client secret if datasource not configured", func(t *testing.T) {
+			jsonData := simplejson.NewFromAny(map[string]interface{}{
+				"azureAuthType": "",
+			})
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+	})
+
+	t.Run("when user identities disabled", func(t *testing.T) {
+		cfg.Azure.UserIdentityEnabled = false
+
+		t.Run("should be user identity if auth type is set to user identity", func(t *testing.T) {
+			jsonData := simplejson.NewFromAny(map[string]interface{}{
+				"azureAuthType": azcredentials.AzureAuthUserIdentity,
+			})
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthUserIdentity, authType)
+		})
+
+		t.Run("should be client secret if datasource not configured", func(t *testing.T) {
+			jsonData := simplejson.NewFromAny(map[string]interface{}{
+				"azureAuthType": "",
+			})
+
+			authType := getAuthType(cfg, jsonData)
+
+			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
+		})
+	})
+
 }
 
 func TestCredentials_getAzureCloud(t *testing.T) {

--- a/pkg/tsdb/azuremonitor/credentials_test.go
+++ b/pkg/tsdb/azuremonitor/credentials_test.go
@@ -121,7 +121,6 @@ func TestCredentials_getAuthType(t *testing.T) {
 			assert.Equal(t, azcredentials.AzureAuthClientSecret, authType)
 		})
 	})
-
 }
 
 func TestCredentials_getAzureCloud(t *testing.T) {

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 )
 
+// ContextKeyLoginUser is the context key for signed-in user
+type ContextKeyLoginUser struct{}
+
 // PrepareProxyRequest prepares a request for being proxied.
 // Removes X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto headers.
 // Set X-Forwarded-For headers.


### PR DESCRIPTION
The PR is to add another option for plugin to retrieve token on Azure in order to talk to the target service.
If there is hosted token endpoint available, admin can enable it in the configuration file. Then datasource can communicate with this token endpoint to retrieve token for the current signed-in user, with proper scopes specified.

If it's enabled, Azure datasources can use it as an option for plugin authentication approach.
For proxy requests, Grafana will call token provider to retrieve a token for communication to the Azure service.
With this mode, token provider will call a configured token endpoint to retrieve a token for the signed-in user.
This is disabled by default. User can enable it if there is a trusted token endpoint that can be used to retrieve user token.

The token endpoint would accept POST request in the following format:
  POST {endpoint url}

  Headers:
    "Content-Type", "application/x-www-form-urlencoded"
    "Accept", "application/json"
	"Authorization", "xxx"

  body:
    scope=xxx&user_id=xxx

