### PR TITLE
Adhoc Filters: Fix table filter from mixed datasource panels

### DIFF
--- a/public/app/features/variables/adhoc/actions.test.ts
+++ b/public/app/features/variables/adhoc/actions.test.ts
@@ -86,9 +86,13 @@ describe('adhoc actions', () => {
         .givenRootReducer(getRootReducer())
         .whenAsyncActionIsDispatched(applyFilterFromTable(options), true);
 
-      const variable = adHocBuilder().withId('Filters').withName('Filters').withDatasource(options.datasource).build();
+      const variable = adHocBuilder()
+        .withId('Filters_influxdb')
+        .withName('Filters_influxdb')
+        .withDatasource(options.datasource)
+        .build();
 
-      const expectedQuery = { 'var-Filters': ['filter-key|=|filter-value'] };
+      const expectedQuery = { 'var-Filters_influxdb': ['filter-key|=|filter-value'] };
       const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=', condition: '' };
 
       tester.thenDispatchedActionsShouldEqual(
@@ -144,7 +148,11 @@ describe('adhoc actions', () => {
         .withDatasource('elasticsearch')
         .build();
 
-      const variable = adHocBuilder().withId('Filters').withName('Filters').withDatasource(options.datasource).build();
+      const variable = adHocBuilder()
+        .withId('Filters_influxdb')
+        .withName('Filters_influxdb')
+        .withDatasource(options.datasource)
+        .build();
 
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
@@ -152,7 +160,10 @@ describe('adhoc actions', () => {
         .whenAsyncActionIsDispatched(applyFilterFromTable(options), true);
 
       const expectedFilter = { key: 'filter-key', value: 'filter-value', operator: '=', condition: '' };
-      const expectedQuery = { 'var-elastic-filter': [] as string[], 'var-Filters': ['filter-key|=|filter-value'] };
+      const expectedQuery = {
+        'var-elastic-filter': [] as string[],
+        'var-Filters_influxdb': ['filter-key|=|filter-value'],
+      };
 
       tester.thenDispatchedActionsShouldEqual(
         createAddVariableAction(variable, 1),

--- a/public/app/features/variables/adhoc/actions.ts
+++ b/public/app/features/variables/adhoc/actions.ts
@@ -134,7 +134,7 @@ export const initAdHocVariableEditor = (): ThunkResult<void> => (dispatch) => {
 
 const createAdHocVariable = (options: AdHocTableOptions): ThunkResult<void> => {
   return (dispatch, getState) => {
-    const filterTableName = filterTableNamePrefix + ' ' + options.datasource;
+    const filterTableName = filterTableNamePrefix + '_' + options.datasource.replace(' ', '_');
     const model = {
       ...cloneDeep(initialAdHocVariableModelState),
       datasource: options.datasource,

--- a/public/app/features/variables/adhoc/actions.ts
+++ b/public/app/features/variables/adhoc/actions.ts
@@ -24,7 +24,7 @@ export interface AdHocTableOptions {
   operator: string;
 }
 
-const filterTableName = 'Filters';
+const filterTableNamePrefix = 'Filters';
 
 export const applyFilterFromTable = (options: AdHocTableOptions): ThunkResult<void> => {
   return async (dispatch, getState) => {
@@ -134,6 +134,7 @@ export const initAdHocVariableEditor = (): ThunkResult<void> => (dispatch) => {
 
 const createAdHocVariable = (options: AdHocTableOptions): ThunkResult<void> => {
   return (dispatch, getState) => {
+    const filterTableName = filterTableNamePrefix + ' ' + options.datasource;
     const model = {
       ...cloneDeep(initialAdHocVariableModelState),
       datasource: options.datasource,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes the adhoc filter behaviour on mixed datasource table panels. 
For this to work properly with multiple datasources, the adhoc filters need to be suffixed with its datasource name. 
The label of the adhoc variables can still be changed using the variable editor.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/39386

**Special notes for your reviewer**:

