### PR TITLE
macaron: Handle multiple IP addresses in X-Forwarded-For

### DIFF
--- a/pkg/macaron/context.go
+++ b/pkg/macaron/context.go
@@ -84,6 +84,11 @@ func (ctx *Context) RemoteAddr() string {
 			if i := strings.LastIndex(addr, ":"); i > -1 {
 				addr = addr[:i]
 			}
+		} else {
+			ips := strings.Split(addr, ",")
+			if len(ips) > 1 {
+				addr = ips[0]
+			}
 		}
 	}
 	return addr


### PR DESCRIPTION
This is a bug fix PR.

The value of HTTP [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) header can contain multiple IP addresses if a request goes through multiple proxies.

In this case, IP addresses are delimited by comma, and the left-most IP address is the IP address of the originating client.

However, the macaron library in Grafana currently assumes there is only one IP address in `X-Forwarded-For` header, resulting the errors in logs like the following:

```
t=2021-09-20T04:18:20+0000 lvl=dbug msg="Failed to get client IP address" logger=context userId=1 orgId=1 uname=admin addr="142.250.207.68, 10.0.0.100" err="not a valid IP address or IP address/port pair: \"142.250.207.68, 10.0.0.100\""
```

In this scenario, there are two proxies before Grafana, first proxy is an AWS ALB (application load balancer), the second proxy is another layer-7 load balancer (Nginx, Traefik, etc.). The first IP `142.250.207.68` is the real IP of the originating client , and the second IP `10.0.0.100` is the private IP address of AWS ALB.

This error also leads to Grafana's web UI unable to display IP address of user sessions.

This PR fix this issue by selecting the left-most IP in `X-Forwarded-For` header if there are more than 1 IP address.