### PR TITLE
Plugins Catalog: Fix a11y issues

### DIFF
--- a/public/app/features/plugins/admin/components/PluginListCard.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListCard.test.tsx
@@ -49,21 +49,21 @@ describe('PluginCard', () => {
     const datasourcePlugin = { ...plugin, type: PluginType.datasource };
     render(<PluginListCard plugin={datasourcePlugin} pathName="" />);
 
-    expect(screen.getByLabelText(/datasource plugin icon/i)).toBeVisible();
+    expect(screen.getByTestId(/datasource plugin icon/i)).toBeVisible();
   });
 
   it('renders a panel plugin with correct icon', () => {
     const panelPlugin = { ...plugin, type: PluginType.panel };
     render(<PluginListCard plugin={panelPlugin} pathName="" />);
 
-    expect(screen.getByLabelText(/panel plugin icon/i)).toBeVisible();
+    expect(screen.getByTestId(/panel plugin icon/i)).toBeVisible();
   });
 
   it('renders an app plugin with correct icon', () => {
     const appPlugin = { ...plugin, type: PluginType.app };
     render(<PluginListCard plugin={appPlugin} pathName="" />);
 
-    expect(screen.getByLabelText(/app plugin icon/i)).toBeVisible();
+    expect(screen.getByTestId(/app plugin icon/i)).toBeVisible();
   });
 
   it('renders a disabled plugin with a badge to indicate its error', () => {

--- a/public/app/features/plugins/admin/components/PluginListCard.tsx
+++ b/public/app/features/plugins/admin/components/PluginListCard.tsx
@@ -26,10 +26,10 @@ export function PluginListCard({ plugin, pathName }: PluginListCardProps) {
             className={styles.image}
             height={LOGO_SIZE}
           />
-          <h3 className={styles.name}>{plugin.name}</h3>
+          <h2 className={styles.name}>{plugin.name}</h2>
           {plugin.type && (
             <div className={styles.icon}>
-              <Icon name={IconName[plugin.type]} aria-label={`${plugin.type} plugin icon`} />
+              <Icon name={IconName[plugin.type]} />
             </div>
           )}
         </div>

--- a/public/app/features/plugins/admin/components/PluginListCard.tsx
+++ b/public/app/features/plugins/admin/components/PluginListCard.tsx
@@ -28,7 +28,7 @@ export function PluginListCard({ plugin, pathName }: PluginListCardProps) {
           />
           <h2 className={styles.name}>{plugin.name}</h2>
           {plugin.type && (
-            <div className={styles.icon}>
+            <div className={styles.icon} data-testid={`${plugin.type} plugin icon`}>
               <Icon name={IconName[plugin.type]} />
             </div>
           )}

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -91,6 +91,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
               <div>
                 <Select
                   menuShouldPortal
+                  aria-label="Sort Plugins List"
                   width={24}
                   value={sortBy}
                   onChange={onSortByChange}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR addresses accessibility issues raised by the axe DevTools extension.

| Before | After |
| --- | --- |
| <img width="501" alt="Screenshot 2021-09-20 at 12 15 13" src="https://user-images.githubusercontent.com/73201/133989097-4704872f-150f-4a34-8d53-7106cb27a658.png"> | <img width="500" alt="Screenshot 2021-09-20 at 12 17 18" src="https://user-images.githubusercontent.com/73201/133989100-955867eb-7ac3-43a6-be1c-16a5568fafaa.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37933

**Special notes for your reviewer**:
There are two remaining "Needs Review" issues in the PluginDetails page that are due to the usage of `aria-label` in the `<Tab />` component.

<img width="501" alt="Screenshot 2021-09-20 at 12 19 59" src="https://user-images.githubusercontent.com/73201/133989418-073ca00c-0541-4e3f-ae07-708fc23fa2f7.png">
