### PR TITLE
Alerting: Move spammy log line to debug in the state manager

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -205,7 +205,7 @@ func (st *Manager) recordMetrics() {
 	for {
 		select {
 		case <-ticker.C:
-			st.log.Info("recording state cache metrics", "now", time.Now())
+			st.log.Debug("recording state cache metrics", "now", time.Now())
 			st.cache.recordMetrics()
 		case <-st.quit:
 			st.log.Debug("stopping state cache metrics recording", "now", time.Now())


### PR DESCRIPTION
It is quite spammy every 15 seconds. 