### PR TITLE
prometheus: metadata: simplify the metrics-metadata format

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
@@ -404,7 +404,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
         const value: FacettableValue = { name: labelValue };
         // Adding type/help text to metrics
         if (name === METRIC_LABEL && metricsMetadata) {
-          const meta = metricsMetadata[labelValue]?.[0];
+          const meta = metricsMetadata[labelValue];
           if (meta) {
             value.details = `(${meta.type}) ${meta.help}`;
           }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -86,7 +86,7 @@ const MonacoQueryField = (props: Props) => {
           const getAllMetricNames = () => {
             const { metrics, metricsMetadata } = lpRef.current;
             const result = metrics.map((m) => {
-              const metaItem = metricsMetadata?.[m]?.[0];
+              const metaItem = metricsMetadata?.[m];
               return {
                 name: m,
                 help: metaItem?.help ?? '',

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -54,7 +54,7 @@ export function addHistoryMetadata(item: CompletionItem, history: any[]): Comple
 function addMetricsMetadata(metric: string, metadata?: PromMetricsMetadata): CompletionItem {
   const item: CompletionItem = { label: metric };
   if (metadata && metadata[metric]) {
-    const { type, help } = metadata[metric][0];
+    const { type, help } = metadata[metric];
     item.documentation = `${type.toUpperCase()}: ${help}`;
   }
   return item;

--- a/public/app/plugins/datasource/prometheus/language_utils.test.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.test.ts
@@ -73,23 +73,25 @@ describe('parseSelector()', () => {
 
 describe('fixSummariesMetadata', () => {
   const synthetics = {
-    ALERTS: [
-      {
-        type: 'counter',
-        help:
-          'Time series showing pending and firing alerts. The sample value is set to 1 as long as the alert is in the indicated active (pending or firing) state.',
-      },
-    ],
+    ALERTS: {
+      type: 'counter',
+      help:
+        'Time series showing pending and firing alerts. The sample value is set to 1 as long as the alert is in the indicated active (pending or firing) state.',
+    },
   };
   it('returns only synthetics on empty metadata', () => {
     expect(fixSummariesMetadata({})).toEqual({ ...synthetics });
   });
 
   it('returns unchanged metadata if no summary is present', () => {
-    const metadata = {
+    const metadataRaw = {
       foo: [{ type: 'not_a_summary', help: 'foo help' }],
     };
-    expect(fixSummariesMetadata(metadata)).toEqual({ ...metadata, ...synthetics });
+
+    const metadata = {
+      foo: { type: 'not_a_summary', help: 'foo help' },
+    };
+    expect(fixSummariesMetadata(metadataRaw)).toEqual({ ...metadata, ...synthetics });
   });
 
   it('returns metadata with added count and sum for a summary', () => {
@@ -98,10 +100,10 @@ describe('fixSummariesMetadata', () => {
       bar: [{ type: 'summary', help: 'bar help' }],
     };
     const expected = {
-      foo: [{ type: 'not_a_summary', help: 'foo help' }],
-      bar: [{ type: 'summary', help: 'bar help' }],
-      bar_count: [{ type: 'counter', help: 'Count of events that have been observed for the base metric (bar help)' }],
-      bar_sum: [{ type: 'counter', help: 'Total sum of all observed values for the base metric (bar help)' }],
+      foo: { type: 'not_a_summary', help: 'foo help' },
+      bar: { type: 'summary', help: 'bar help' },
+      bar_count: { type: 'counter', help: 'Count of events that have been observed for the base metric (bar help)' },
+      bar_sum: { type: 'counter', help: 'Total sum of all observed values for the base metric (bar help)' },
     };
     expect(fixSummariesMetadata(metadata)).toEqual({ ...expected, ...synthetics });
   });
@@ -112,13 +114,14 @@ describe('fixSummariesMetadata', () => {
       bar: [{ type: 'histogram', help: 'bar help' }],
     };
     const expected = {
-      foo: [{ type: 'not_a_histogram', help: 'foo help' }],
-      bar: [{ type: 'histogram', help: 'bar help' }],
-      bar_bucket: [{ type: 'counter', help: 'Cumulative counters for the observation buckets (bar help)' }],
-      bar_count: [
-        { type: 'counter', help: 'Count of events that have been observed for the histogram metric (bar help)' },
-      ],
-      bar_sum: [{ type: 'counter', help: 'Total sum of all observed values for the histogram metric (bar help)' }],
+      foo: { type: 'not_a_histogram', help: 'foo help' },
+      bar: { type: 'histogram', help: 'bar help' },
+      bar_bucket: { type: 'counter', help: 'Cumulative counters for the observation buckets (bar help)' },
+      bar_count: {
+        type: 'counter',
+        help: 'Count of events that have been observed for the histogram metric (bar help)',
+      },
+      bar_sum: { type: 'counter', help: 'Total sum of all observed values for the histogram metric (bar help)' },
     };
     expect(fixSummariesMetadata(metadata)).toEqual({ ...expected, ...synthetics });
   });

--- a/public/app/plugins/datasource/prometheus/query_hints.test.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.test.ts
@@ -42,7 +42,7 @@ describe('getQueryHints()', () => {
         ],
       },
     ];
-    const mock: unknown = { languageProvider: { metricsMetadata: { foo: [{ type: 'counter' }] } } };
+    const mock: unknown = { languageProvider: { metricsMetadata: { foo: { type: 'counter' } } } };
     const datasource = mock as PrometheusDatasource;
 
     let hints = getQueryHints('foo', series, datasource);

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -40,7 +40,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
       counterNameMetric =
         metricMetadataKeys.find((metricName) => {
           // Only considering first type information, could be non-deterministic
-          const metadata = metricsMetadata[metricName][0];
+          const metadata = metricsMetadata[metricName];
           if (metadata.type.toLowerCase() === 'counter') {
             const metricRegex = new RegExp(`\\b${metricName}\\b`);
             if (query.match(metricRegex)) {

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -50,7 +50,7 @@ export interface PromMetricsMetadataItem {
 }
 
 export interface PromMetricsMetadata {
-  [metric: string]: PromMetricsMetadataItem[];
+  [metric: string]: PromMetricsMetadataItem;
 }
 
 export interface PromDataSuccessResponse<T = PromData> {


### PR DESCRIPTION
the prometheus http api provides metadata-info for metrics. while it can happen that for the given metric-name we receive multiple metadata-info objects. the code always only uses the first item from the list.

this pull-requests simplifies the code so that we also only store the first item in the list.

NOTE: i recommend reading the files-changed section with the "hide whitespace changes" setting enabled 👍