### PR TITLE
InfluxDB: Flux queries can use more precise start and end timestamps with nanosecond-precision.

### DIFF
--- a/pkg/tsdb/influxdb/flux/macros.go
+++ b/pkg/tsdb/influxdb/flux/macros.go
@@ -16,8 +16,8 @@ func interpolate(query queryModel) (string, error) {
 	matches := variableFilterExp.FindAllStringSubmatch(flux, -1)
 	if matches != nil {
 		timeRange := query.TimeRange
-		from := timeRange.From.UTC().Format(time.RFC3339)
-		to := timeRange.To.UTC().Format(time.RFC3339)
+		from := timeRange.From.UTC().Format(time.RFC3339Nano)
+		to := timeRange.To.UTC().Format(time.RFC3339Nano)
 		for _, match := range matches {
 			switch match[2] {
 			case "timeRangeStart":

--- a/pkg/tsdb/influxdb/flux/macros_test.go
+++ b/pkg/tsdb/influxdb/flux/macros_test.go
@@ -11,12 +11,9 @@ import (
 )
 
 func TestInterpolate(t *testing.T) {
-	// Unix sec: 1500376552
-	// Unix ms:  1500376552001
-
 	timeRange := backend.TimeRange{
-		From: time.Unix(0, 0),
-		To:   time.Unix(0, 0),
+		From: time.Unix(1632305571, 310985041),
+		To:   time.Unix(1632309171, 310985042),
 	}
 
 	options := queryOptions{
@@ -33,7 +30,7 @@ func TestInterpolate(t *testing.T) {
 		{
 			name:   "interpolate flux variables",
 			before: `v.timeRangeStart, something.timeRangeStop, XYZ.bucket, uuUUu.defaultBucket, aBcDefG.organization, window.windowPeriod, a91{}.bucket`,
-			after:  `1970-01-01T00:00:00Z, 1970-01-01T00:00:00Z, "grafana2", "grafana3", "grafana1", 1s, a91{}.bucket`,
+			after:  `2021-09-22T10:12:51.310985041Z, 2021-09-22T11:12:51.310985042Z, "grafana2", "grafana3", "grafana1", 1s, a91{}.bucket`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/39195

the flux code used 1second-precision, but by zooming the graph in grafana with the mouse, sub-second-precision timestamps can happen, and the flux code truncated those to 1second-precision. the code was adjusted to work with nanosecond-precision.