### PR TITLE
QueryRow: prevent row headers to horizontally overflow

### DIFF
--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -147,6 +147,7 @@ const getStyles = (theme: GrafanaTheme) => {
       align-items: center;
       flex-grow: 1;
       margin-left: ${theme.spacing.xs};
+      overflow: hidden;
 
       &:hover {
         .query-name-wrapper {

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -142,6 +142,7 @@
   flex: 1 1 auto;
   flex-direction: column;
   height: 100vh;
+  width: 100%;
 }
 
 .explore.explore-live {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
the `QueryEditorRow` had some overflow issues when having a long `collapsedText` as you can see below:
![Screenshot 2021-09-20 at 13 59 06](https://user-images.githubusercontent.com/1170767/134006373-4dec3316-bbed-4cb9-8f3f-e7179940cea5.png)
![Screenshot 2021-09-20 at 13 59 30](https://user-images.githubusercontent.com/1170767/134006377-25f9ad5c-767e-4ca8-ada2-63d542eab935.png)
 

This PR sets `overflow: hidden` to the header wrapper so that the text gets properly ellipsed:
![Screenshot 2021-09-20 at 13 54 09](https://user-images.githubusercontent.com/1170767/134006816-9a69c6a3-bd61-4e2f-ae90-7fd8bf9b070a.png)

It also sets a width of `100%` to the explore page to prevent content from expanding the page horizontally so that this components behaves the same in explore as well when not splitted:
![Screenshot 2021-09-20 at 14 06 04](https://user-images.githubusercontent.com/1170767/134007297-6cdfa0be-68a1-42a9-aebc-3f8f629e9978.png)

No change is needed when in split mode as there's a width of `50%` already set:

![Screenshot 2021-09-20 at 13 54 21](https://user-images.githubusercontent.com/1170767/134007124-7a68a1d6-d193-4654-a839-75f2db84d1e2.png)


