### PR TITLE
prometheus: query-field: autocomplete on space

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -74,7 +74,7 @@ export function getCompletionProvider(
   };
 
   return {
-    triggerCharacters: ['{', ',', '[', '(', '='],
+    triggerCharacters: ['{', ',', '[', '(', '=', ' '],
     provideCompletionItems,
   };
 }


### PR DESCRIPTION
WORK IN PROGRESS: do not review :-) 

i got feedback that there is a use-case where autocomplete is not intuitive:
- (note: i will use the `^` character to mark the cursor-position)
- imaginge writing `go_goroutines{job="prometheus",^}`
- at this point autocomplete triggers and offers you potentian label-keys
- but you want to add a space after the `,` first, so you press the space key
- a space is inserted, and no more autocomplete

this pull-request adds `<space>` to the trigger-characters, so when you do the above-mentioned flow, you will get the autocomplete again