### PR TITLE
Fixed an issue that produced State timeline panel tooltip error when data was not in sync.

### DIFF
--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -37,14 +37,25 @@ export const StateTimelinePanel: React.FC<TimelinePanelProps> = ({
 
   const renderCustomTooltip = useCallback(
     (alignedData: DataFrame, seriesIdx: number | null, datapointIdx: number | null) => {
+      const data = frames ?? [];
       // Not caring about multi mode in StateTimeline
       if (seriesIdx === null || datapointIdx === null) {
         return null;
       }
 
+      /**
+       * There could be a case when the tooltip shows a data from one of a multiple query and the other query finishes first
+       * from refreshing. This causes data to be out of sync. alignedData - 1 because Time field doesn't count.
+       * Render nothing in this case to prevent error.
+       * See https://github.com/grafana/support-escalations/issues/932
+       */
+      if (alignedData.fields.length - 1 !== data.length || !alignedData.fields[seriesIdx]) {
+        return null;
+      }
+
       return (
         <StateTimelineTooltip
-          data={frames ?? []}
+          data={data}
           alignedData={alignedData}
           seriesIdx={seriesIdx}
           datapointIdx={datapointIdx}

--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
@@ -32,6 +32,17 @@ export const StateTimelineTooltip: React.FC<StateTimelineTooltipProps> = ({
   const xFieldFmt = xField.display || getDisplayProcessor({ field: xField, timeZone, theme });
 
   const field = alignedData.fields[seriesIdx!];
+
+  /**
+   * There could be a case when the tooltip shows a data from one of a multiple query and the other query finishes first
+   * from refreshing. This causes data to be out of sync. alignedData - 1 because Time field doesn't count.
+   * Render nothing in this case to prevent error.
+   * See https://github.com/grafana/support-escalations/issues/932
+   */
+  if (alignedData.fields.length - 1 !== data.length || !field) {
+    return null;
+  }
+
   const dataFrameFieldIndex = field.state?.origin;
   const fieldFmt = field.display || getDisplayProcessor({ field, timeZone, theme });
   const value = field.values.get(datapointIdx!);

--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip.tsx
@@ -33,16 +33,6 @@ export const StateTimelineTooltip: React.FC<StateTimelineTooltipProps> = ({
 
   const field = alignedData.fields[seriesIdx!];
 
-  /**
-   * There could be a case when the tooltip shows a data from one of a multiple query and the other query finishes first
-   * from refreshing. This causes data to be out of sync. alignedData - 1 because Time field doesn't count.
-   * Render nothing in this case to prevent error.
-   * See https://github.com/grafana/support-escalations/issues/932
-   */
-  if (alignedData.fields.length - 1 !== data.length || !field) {
-    return null;
-  }
-
   const dataFrameFieldIndex = field.state?.origin;
   const fieldFmt = field.display || getDisplayProcessor({ field, timeZone, theme });
   const value = field.values.get(datapointIdx!);


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR resolves the issue around state timeline panel's tooltip when data is out of sync.

https://user-images.githubusercontent.com/13729989/134032445-905885d2-5067-43bf-96f0-5d1e9703283c.mp4


https://user-images.githubusercontent.com/13729989/134032487-009710dc-d16a-422b-8b96-2130ec030e20.mp4


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/support-escalations/issues/932

**Special notes for your reviewer**:

Repro step:
I've used the [tns-demo](https://github.com/grafana/tns) to generate data.
1. Add a state timeline panel with 2 queries from Loki
2. Set auto refresh to 10s
3. Hover over panel data

<details>
<summary>Panel json</summary>

```json
{
  "id": 23763571993,
  "gridPos": {
    "h": 8,
    "w": 12,
    "x": 0,
    "y": 0
  },
  "type": "state-timeline",
  "title": "Panel Title",
  "datasource": "tns-loki",
  "fieldConfig": {
    "defaults": {
      "custom": {
        "lineWidth": 5,
        "fillOpacity": 76
      },
      "color": {
        "mode": "thresholds"
      },
      "thresholds": {
        "mode": "absolute",
        "steps": [
          {
            "color": "green",
            "value": null
          },
          {
            "color": "#EAB839",
            "value": 0.1
          },
          {
            "color": "#6ED0E0",
            "value": 0.2
          }
        ]
      },
      "mappings": []
    },
    "overrides": []
  },
  "options": {
    "mergeValues": true,
    "showValue": "auto",
    "alignValue": "left",
    "rowHeight": 0.9,
    "legend": {
      "displayMode": "list",
      "placement": "bottom"
    },
    "tooltip": {
      "mode": "single"
    }
  },
  "targets": [
    {
      "expr": "rate({job=\"tns/db\"}[$__interval])",
      "legendFormat": "A",
      "refId": "A"
    },
    {
      "expr": "rate({job=\"monitoring/node_exporter\"}[$__interval])",
      "hide": false,
      "legendFormat": "B",
      "refId": "B"
    }
  ]
}
```
</details>
