### PR TITLE
Elasticsearch/Prometheus: Fixed usage of proper SigV4 service namespace

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -84,6 +84,11 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 			return nil, fmt.Errorf("error getting http options: %w", err)
 		}
 
+		// Set SigV4 service namespace
+		if httpCliOpts.SigV4 != nil {
+			httpCliOpts.SigV4.Service = "es"
+		}
+
 		version, err := coerceVersion(jsonData["esVersion"])
 
 		if err != nil {

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -94,6 +94,11 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 			return nil, fmt.Errorf("error getting http options: %w", err)
 		}
 
+		// Set SigV4 service namespace
+		if httpCliOpts.SigV4 != nil {
+			httpCliOpts.SigV4.Service = "aps"
+		}
+
 		httpMethod, ok := jsonData["httpMethod"].(string)
 		if !ok {
 			httpMethod = defaultHttpMethod


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes sure to set the SigV4 service namespace for Elasticsearch and Prometheus.

**Which issue(s) this PR fixes**:
Fixes #38440 

**Special notes for your reviewer**:
More information in https://github.com/grafana/grafana/issues/38440#issuecomment-923088527