### PR TITLE
CloudMonitoring: Fixed INT64 label unmarshal error.

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring_test.go
@@ -942,7 +942,7 @@ func TestCloudMonitoring(t *testing.T) {
 				query := &cloudMonitoringTimeSeriesQuery{
 					ProjectName: "test-proj",
 					Query:       "test-query",
-					AliasBy:     "{{project}} - {{resource.label.zone}} - {{resource.label.instance_id}}",
+					AliasBy:     "{{project}} - {{resource.label.zone}} - {{resource.label.instance_id}} - {{metric.label.response_code_class}}",
 					timeRange: plugins.DataTimeRange{
 						From: fmt.Sprintf("%v", fromStart.Unix()*1000),
 						To:   fmt.Sprintf("%v", fromStart.Add(34*time.Minute).Unix()*1000),
@@ -952,7 +952,7 @@ func TestCloudMonitoring(t *testing.T) {
 				require.NoError(t, err)
 				frames, err := res.Dataframes.Decoded()
 				require.NoError(t, err)
-				assert.Equal(t, "test-proj - asia-northeast1-c - 6724404429462225363", frames[0].Fields[1].Name)
+				assert.Equal(t, "test-proj - asia-northeast1-c - 6724404429462225363 - 200", frames[0].Fields[1].Name)
 			})
 		})
 	})

--- a/pkg/tsdb/cloudmonitoring/test-data/7-series-response-mql.json
+++ b/pkg/tsdb/cloudmonitoring/test-data/7-series-response-mql.json
@@ -9,6 +9,10 @@
       },
       {
         "key": "resource.instance_id"
+      },
+      {
+        "key": "metric.response_code_class",
+        "valueType": "INT64"
       }
     ],
     "pointDescriptors": [
@@ -30,6 +34,9 @@
         },
         {
           "stringValue": "6724404429462225363"
+        },
+        {
+          "int64Value": "200"
         }
       ],
       "pointData": [

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -123,9 +123,8 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *pl
 				labels[key][strVal] = true
 				seriesLabels[key] = strVal
 			case "INT64":
-				intVal := strconv.FormatInt(labelValue.Int64Value, 10)
-				labels[key][intVal] = true
-				seriesLabels[key] = intVal
+				labels[key][labelValue.Int64Value] = true
+				seriesLabels[key] = labelValue.Int64Value
 			default:
 				labels[key][labelValue.StringValue] = true
 				seriesLabels[key] = labelValue.StringValue
@@ -285,8 +284,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseToAnnotations(queryRe
 				strVal := strconv.FormatBool(labelValue.BoolValue)
 				value = strVal
 			case "INT64":
-				intVal := strconv.FormatInt(labelValue.Int64Value, 10)
-				value = intVal
+				value = labelValue.Int64Value
 			default:
 				value = labelValue.StringValue
 			}

--- a/pkg/tsdb/cloudmonitoring/types.go
+++ b/pkg/tsdb/cloudmonitoring/types.go
@@ -118,7 +118,7 @@ type timeSeriesDescriptor struct {
 type timeSeriesData []struct {
 	LabelValues []struct {
 		BoolValue   bool   `json:"boolValue"`
-		Int64Value  int64  `json:"int64Value"`
+		Int64Value  string `json:"int64Value"`
 		StringValue string `json:"stringValue"`
 	} `json:"labelValues"`
 	PointData []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

The CloudMonitoring API returns a string for `timeSeriesData.labelValues[].int64Value` fields:

```json
{
  "timeSeriesDescriptor": {
    "labelDescriptors": [
      {
        "key": "metric.response_code",
        "valueType": "INT64"
      }
    ]
  },
  "timeSeriesData": [
    {
      "labelValues": [
        {
          "int64Value": "200"
        }
      ]
    }
  ]
}
```

But the type definition of the go struct for this field expects it to be an `int64`, which results in an unmarshal error:

https://github.com/grafana/grafana/blob/a6fbb8d72401869c2b13ae8e8a54620bacf8fa95/pkg/tsdb/cloudmonitoring/types.go#L121

This PR fixes the unmarshal error by matching the go struct type with the actual JSON type

**Which issue(s) this PR fixes**:

Fixes #35948 

**Special notes for your reviewer**:

See https://github.com/grafana/grafana/issues/35948#issuecomment-922915695 for details.