### PR TITLE
QueryGroup - Every query now has its datasource and id

### DIFF
--- a/packages/grafana-data/src/types/query.ts
+++ b/packages/grafana-data/src/types/query.ts
@@ -43,8 +43,12 @@ export interface DataQuery {
   queryType?: string;
 
   /**
-   * For mixed data sources the selected datasource is on the query level.
-   * For non mixed scenarios this is undefined.
+   * The datasource ref of the datasource. This can be undefined to not break older code.
    */
   datasource?: DatasourceRef;
+
+  /**
+   * The id of the datasource. This can be undefined to not break older code.
+   */
+  datasourceId?: number;
 }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -124,17 +124,9 @@ export class QueryGroup extends PureComponent<Props, State> {
         }
       }
     } else if (dsSettings) {
-      // if switching from mixed
-      if (dsSettings.meta.mixed) {
-        // Remove the explicit datasource
-        for (const query of queries) {
-          if (query.datasource !== ExpressionDatasourceID) {
-            delete query.datasource;
-          }
-        }
-      } else if (dsSettings.meta.id !== newSettings.meta.id) {
+      if (dsSettings.meta.id !== newSettings.meta.id) {
         // we are changing data source type, clear queries
-        queries = [{ refId: 'A' }];
+        queries = [{ refId: 'A', datasource: newSettings.name, datasourceId: newSettings.id }];
       }
     }
 
@@ -162,14 +154,11 @@ export class QueryGroup extends PureComponent<Props, State> {
   };
 
   newQuery(): Partial<DataQuery> {
-    const { dsSettings, defaultDataSource } = this.state;
-
-    if (!dsSettings?.meta.mixed) {
-      return {};
-    }
+    const { defaultDataSource } = this.state;
 
     return {
       datasource: defaultDataSource?.name,
+      datasourceId: defaultDataSource?.id,
     };
   }
 


### PR DESCRIPTION
Problem I am trying to solve:
I would like to know what datasource and datasource id is on a query when I use `QueryEditorRow.renderExtraActions` (this was newly added for the Enterprise feature, Recorded Queries. It allows for buttons to be added to the query row next to copy query) 

What this does:
This PR adds the datasource and datasource id to queries in QueryGroup.tsx when you create a query. Right now datasources are only added to queries when the query group datasource is set to `-- Mixed --`.

An alternative would be to pass the datasource as a parameter, but I think it would be cleaner if we could pass datasource and id.

This PR does not address retroactively adding the datasource and datasource id to already existing queries. I want to see if this idea is ok/worth pursing or if it is too much trouble.

@MasslessParticle 