### PR TITLE
CloudWatch: Introduced new math expression where it is necessary to specify the period field.

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -55,6 +55,7 @@ Here is a minimal policy example:
         "cloudwatch:ListMetrics",
         "cloudwatch:GetMetricStatistics",
         "cloudwatch:GetMetricData"
+        "cloudwatch:GetInsightRuleReport"
       ],
       "Resource": "*"
     },

--- a/pkg/tsdb/cloudwatch/metric_data_query_builder.go
+++ b/pkg/tsdb/cloudwatch/metric_data_query_builder.go
@@ -18,6 +18,7 @@ func (e *cloudWatchExecutor) buildMetricDataQuery(query *cloudWatchQuery) (*clou
 
 	if query.Expression != "" {
 		mdq.Expression = aws.String(query.Expression)
+		mdq.Period = aws.Int64(int64(query.Period))
 	} else {
 		if query.isSearchExpression() {
 			mdq.Expression = aws.String(buildSearchExpression(query, query.Statistic))


### PR DESCRIPTION
**What this PR does / why we need it**:

When using math expressions, the `MetricDataQuery.Period` field in the GetMetridData api is now set to the period that was specified in the query editor.  

**Which issue(s) this PR fixes**:

Fixes #39191

**Special notes for your reviewer**:
Until now, it has not been necessary to specify the period field when using math expressions. But in the new math expression [INSIGHT_RULE_METRIC](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContributorInsights-GraphReportData.html), this field is mandatory. Please note that for search expression that specifies its own period, the `MetricDataQuery.Period` will be ignored. 
