### PR TITLE
Alerting: Get alert rules for a dashboard or a panel using /api/v1/rules endpoints

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -180,6 +180,14 @@ type GetSilencesParams struct {
 	Filter []string `json:"filter"`
 }
 
+// swagger:parameters RouteGetRuleStatuses
+type GetRuleStatusesParams struct {
+	// in: query
+	DashboardUID string
+	// in: query
+	PanelID int64
+}
+
 // swagger:model
 type GettableStatus struct {
 	// cluster

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -86,6 +86,14 @@ type PathRouleGroupConfig struct {
 	Groupname string
 }
 
+// swagger:parameters RouteGetRulesConfig
+type PathGetRulesParams struct {
+	// in: query
+	DashboardUID string
+	// in: query
+	PanelID int64
+}
+
 // swagger:model
 type RuleGroupConfigResponse struct {
 	GettableRuleGroupConfig

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -607,6 +607,13 @@
      "type": "array",
      "x-go-name": "SlackConfigs"
     },
+    "sns_configs": {
+     "items": {
+      "$ref": "#/definitions/SNSConfig"
+     },
+     "type": "array",
+     "x-go-name": "SNSConfigs"
+    },
     "victorops_configs": {
      "items": {
       "$ref": "#/definitions/VictorOpsConfig"
@@ -1216,6 +1223,10 @@
     "tags": {
      "type": "string",
      "x-go-name": "Tags"
+    },
+    "update_alerts": {
+     "type": "boolean",
+     "x-go-name": "UpdateAlerts"
     }
    },
    "title": "OpsGenieConfig configures notifications via OpsGenie.",
@@ -1453,6 +1464,13 @@
      },
      "type": "array",
      "x-go-name": "SlackConfigs"
+    },
+    "sns_configs": {
+     "items": {
+      "$ref": "#/definitions/SNSConfig"
+     },
+     "type": "array",
+     "x-go-name": "SNSConfigs"
     },
     "victorops_configs": {
      "items": {
@@ -1747,6 +1765,13 @@
      "type": "array",
      "x-go-name": "SlackConfigs"
     },
+    "sns_configs": {
+     "items": {
+      "$ref": "#/definitions/SNSConfig"
+     },
+     "type": "array",
+     "x-go-name": "SNSConfigs"
+    },
     "victorops_configs": {
      "items": {
       "$ref": "#/definitions/VictorOpsConfig"
@@ -2013,6 +2038,53 @@
    "type": "string",
    "x-go-package": "github.com/prometheus/client_golang/api/prometheus/v1"
   },
+  "SNSConfig": {
+   "properties": {
+    "api_url": {
+     "type": "string",
+     "x-go-name": "APIUrl"
+    },
+    "attributes": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object",
+     "x-go-name": "Attributes"
+    },
+    "http_config": {
+     "$ref": "#/definitions/HTTPClientConfig"
+    },
+    "message": {
+     "type": "string",
+     "x-go-name": "Message"
+    },
+    "phone_number": {
+     "type": "string",
+     "x-go-name": "PhoneNumber"
+    },
+    "send_resolved": {
+     "type": "boolean",
+     "x-go-name": "VSendResolved"
+    },
+    "sigv4": {
+     "$ref": "#/definitions/SigV4Config"
+    },
+    "subject": {
+     "type": "string",
+     "x-go-name": "Subject"
+    },
+    "target_arn": {
+     "type": "string",
+     "x-go-name": "TargetARN"
+    },
+    "topic_arn": {
+     "type": "string",
+     "x-go-name": "TopicARN"
+    }
+   },
+   "type": "object",
+   "x-go-package": "github.com/prometheus/alertmanager/config"
+  },
   "Sample": {
    "properties": {
     "Metric": {
@@ -2039,6 +2111,28 @@
   "SecretURL": {
    "$ref": "#/definitions/URL",
    "title": "SecretURL is a URL that must not be revealed on marshaling."
+  },
+  "SigV4Config": {
+   "description": "SigV4Config is the configuration for signing remote write requests with\nAWS's SigV4 verification process. Empty values will be retrieved using the\nAWS default credentials chain.",
+   "properties": {
+    "AccessKey": {
+     "type": "string"
+    },
+    "Profile": {
+     "type": "string"
+    },
+    "Region": {
+     "type": "string"
+    },
+    "RoleARN": {
+     "type": "string"
+    },
+    "SecretKey": {
+     "$ref": "#/definitions/Secret"
+    }
+   },
+   "type": "object",
+   "x-go-package": "github.com/prometheus/common/sigv4"
   },
   "SlackAction": {
    "description": "See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons\nfor more information.",
@@ -2548,7 +2642,6 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -2570,14 +2663,17 @@
     "labels",
     "receiver"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "AlertGroup",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "AlertGroups",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertStatus": {
    "description": "AlertStatus alert status",
@@ -2768,6 +2864,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -2819,9 +2916,7 @@
     "status",
     "updatedAt"
    ],
-   "type": "object",
-   "x-go-name": "GettableSilence",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "gettableSilences": {
    "items": {
@@ -3701,6 +3796,17 @@
     "operationId": "RouteGetRuleStatuses",
     "parameters": [
      {
+      "in": "query",
+      "name": "DashboardUID",
+      "type": "string"
+     },
+     {
+      "format": "int64",
+      "in": "query",
+      "name": "PanelID",
+      "type": "integer"
+     },
+     {
       "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
       "name": "Recipient",
@@ -3732,6 +3838,17 @@
       "name": "Recipient",
       "required": true,
       "type": "string"
+     },
+     {
+      "in": "query",
+      "name": "DashboardUID",
+      "type": "string"
+     },
+     {
+      "format": "int64",
+      "in": "query",
+      "name": "PanelID",
+      "type": "integer"
      }
     ],
     "produces": [

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -594,6 +594,17 @@
         "parameters": [
           {
             "type": "string",
+            "name": "DashboardUID",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "name": "PanelID",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
             "name": "Recipient",
             "in": "path",
@@ -627,6 +638,17 @@
             "name": "Recipient",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "DashboardUID",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "name": "PanelID",
+            "in": "query"
           }
         ],
         "responses": {
@@ -1611,6 +1633,13 @@
           },
           "x-go-name": "SlackConfigs"
         },
+        "sns_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SNSConfig"
+          },
+          "x-go-name": "SNSConfigs"
+        },
         "victorops_configs": {
           "type": "array",
           "items": {
@@ -2222,6 +2251,10 @@
         "tags": {
           "type": "string",
           "x-go-name": "Tags"
+        },
+        "update_alerts": {
+          "type": "boolean",
+          "x-go-name": "UpdateAlerts"
         }
       },
       "x-go-package": "github.com/prometheus/alertmanager/config"
@@ -2458,6 +2491,13 @@
             "$ref": "#/definitions/SlackConfig"
           },
           "x-go-name": "SlackConfigs"
+        },
+        "sns_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SNSConfig"
+          },
+          "x-go-name": "SNSConfigs"
         },
         "victorops_configs": {
           "type": "array",
@@ -2753,6 +2793,13 @@
           },
           "x-go-name": "SlackConfigs"
         },
+        "sns_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SNSConfig"
+          },
+          "x-go-name": "SNSConfigs"
+        },
         "victorops_configs": {
           "type": "array",
           "items": {
@@ -3017,6 +3064,53 @@
       "title": "RuleType models the type of a rule.",
       "x-go-package": "github.com/prometheus/client_golang/api/prometheus/v1"
     },
+    "SNSConfig": {
+      "type": "object",
+      "properties": {
+        "api_url": {
+          "type": "string",
+          "x-go-name": "APIUrl"
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Attributes"
+        },
+        "http_config": {
+          "$ref": "#/definitions/HTTPClientConfig"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "phone_number": {
+          "type": "string",
+          "x-go-name": "PhoneNumber"
+        },
+        "send_resolved": {
+          "type": "boolean",
+          "x-go-name": "VSendResolved"
+        },
+        "sigv4": {
+          "$ref": "#/definitions/SigV4Config"
+        },
+        "subject": {
+          "type": "string",
+          "x-go-name": "Subject"
+        },
+        "target_arn": {
+          "type": "string",
+          "x-go-name": "TargetARN"
+        },
+        "topic_arn": {
+          "type": "string",
+          "x-go-name": "TopicARN"
+        }
+      },
+      "x-go-package": "github.com/prometheus/alertmanager/config"
+    },
     "Sample": {
       "type": "object",
       "title": "Sample is a single sample belonging to a metric.",
@@ -3043,6 +3137,28 @@
     "SecretURL": {
       "title": "SecretURL is a URL that must not be revealed on marshaling.",
       "$ref": "#/definitions/URL"
+    },
+    "SigV4Config": {
+      "description": "SigV4Config is the configuration for signing remote write requests with\nAWS's SigV4 verification process. Empty values will be retrieved using the\nAWS default credentials chain.",
+      "type": "object",
+      "properties": {
+        "AccessKey": {
+          "type": "string"
+        },
+        "Profile": {
+          "type": "string"
+        },
+        "Region": {
+          "type": "string"
+        },
+        "RoleARN": {
+          "type": "string"
+        },
+        "SecretKey": {
+          "$ref": "#/definitions/Secret"
+        }
+      },
+      "x-go-package": "github.com/prometheus/common/sigv4"
     },
     "SlackAction": {
       "description": "See https://api.slack.com/docs/message-attachments#action_fields and https://api.slack.com/docs/message-buttons\nfor more information.",
@@ -3552,7 +3668,6 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -3575,14 +3690,17 @@
           "$ref": "#/definitions/receiver"
         }
       },
+      "x-go-name": "AlertGroup",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
       },
+      "x-go-name": "AlertGroups",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroups"
     },
     "alertStatus": {
@@ -3776,6 +3894,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -3828,8 +3947,6 @@
           "x-go-name": "UpdatedAt"
         }
       },
-      "x-go-name": "GettableSilence",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -58,8 +58,10 @@ type AlertRule struct {
 	Updated         time.Time
 	IntervalSeconds int64
 	Version         int64
-	UID             string `xorm:"uid"`
-	NamespaceUID    string `xorm:"namespace_uid"`
+	UID             string  `xorm:"uid"`
+	NamespaceUID    string  `xorm:"namespace_uid"`
+	DashboardUID    *string `xorm:"dashboard_uid"`
+	PanelID         *int64  `xorm:"panel_id"`
 	RuleGroup       string
 	NoDataState     NoDataState
 	ExecErrState    ExecutionErrorState
@@ -137,6 +139,11 @@ type ListAlertRulesQuery struct {
 	NamespaceUIDs []string
 	ExcludeOrgs   []int64
 
+	// DashboardUID and PanelID are optional and allow filtering rules
+	// to return just those for a dashboard and panel.
+	DashboardUID string
+	PanelID      int64
+
 	Result []*AlertRule
 }
 
@@ -156,6 +163,11 @@ type ListRuleGroupAlertRulesQuery struct {
 	NamespaceUID string
 	RuleGroup    string
 
+	// DashboardUID and PanelID are optional and allow filtering rules
+	// to return just those for a dashboard and panel.
+	DashboardUID string
+	PanelID      int64
+
 	Result []*AlertRule
 }
 
@@ -163,6 +175,11 @@ type ListRuleGroupAlertRulesQuery struct {
 type ListOrgRuleGroupsQuery struct {
 	OrgID         int64
 	NamespaceUIDs []string
+
+	// DashboardUID and PanelID are optional and allow filtering rules
+	// to return just those for a dashboard and panel.
+	DashboardUID string
+	PanelID      int64
 
 	Result [][]string
 }

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -342,6 +342,8 @@ func (st DBstore) GetOrgAlertRules(query *ngmodels.ListAlertRulesQuery) error {
 			}
 		}
 
+		q = fmt.Sprintf("%s ORDER BY id ASC", q)
+
 		if err := sess.SQL(q, params...).Find(&alertRules); err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -332,6 +333,15 @@ func (st DBstore) GetOrgAlertRules(query *ngmodels.ListAlertRulesQuery) error {
 			q = fmt.Sprintf("%s AND namespace_uid IN (%s)", q, strings.Join(placeholders, ","))
 		}
 
+		if query.DashboardUID != "" {
+			params = append(params, query.DashboardUID)
+			q = fmt.Sprintf("%s AND dashboard_uid = ?", q)
+			if query.PanelID != 0 {
+				params = append(params, query.PanelID)
+				q = fmt.Sprintf("%s AND panel_id = ?", q)
+			}
+		}
+
 		if err := sess.SQL(q, params...).Find(&alertRules); err != nil {
 			return err
 		}
@@ -359,10 +369,20 @@ func (st DBstore) GetNamespaceAlertRules(query *ngmodels.ListNamespaceAlertRules
 // GetRuleGroupAlertRules is a handler for retrieving rule group alert rules of specific organisation.
 func (st DBstore) GetRuleGroupAlertRules(query *ngmodels.ListRuleGroupAlertRulesQuery) error {
 	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-		alertRules := make([]*ngmodels.AlertRule, 0)
-
 		q := "SELECT * FROM alert_rule WHERE org_id = ? and namespace_uid = ? and rule_group = ?"
-		if err := sess.SQL(q, query.OrgID, query.NamespaceUID, query.RuleGroup).Find(&alertRules); err != nil {
+		args := []interface{}{query.OrgID, query.NamespaceUID, query.RuleGroup}
+
+		if query.DashboardUID != "" {
+			q = fmt.Sprintf("%s and dashboard_uid = ?", q)
+			args = append(args, query.DashboardUID)
+			if query.PanelID != 0 {
+				q = fmt.Sprintf("%s and panel_id = ?", q)
+				args = append(args, query.PanelID)
+			}
+		}
+
+		alertRules := make([]*ngmodels.AlertRule, 0)
+		if err := sess.SQL(q, args...).Find(&alertRules); err != nil {
 			return err
 		}
 
@@ -528,6 +548,18 @@ func (st DBstore) UpdateRuleGroup(cmd UpdateRuleGroupCmd) error {
 				new.Labels = r.ApiRuleNode.Labels
 			}
 
+			if s := new.Annotations["__dashboardUid__"]; s != "" {
+				new.DashboardUID = &s
+			}
+
+			if s := new.Annotations["__panelId__"]; s != "" {
+				panelID, err := strconv.ParseInt(s, 10, 64)
+				if err != nil {
+					return fmt.Errorf("the __panelId__ annotation does not contain a valid Panel ID: %w", err)
+				}
+				new.PanelID = &panelID
+			}
+
 			upsertRule := UpsertRule{
 				New: new,
 			}
@@ -569,7 +601,19 @@ func (st DBstore) UpdateRuleGroup(cmd UpdateRuleGroupCmd) error {
 func (st DBstore) GetOrgRuleGroups(query *ngmodels.ListOrgRuleGroupsQuery) error {
 	return st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		var ruleGroups [][]string
-		q := "SELECT DISTINCT rule_group, namespace_uid, (select title from dashboard where org_id = alert_rule.org_id and uid = alert_rule.namespace_uid) AS namespace_title FROM alert_rule WHERE org_id = ?"
+		q := `
+SELECT DISTINCT
+	rule_group,
+	namespace_uid,
+	(
+		SELECT title
+		FROM dashboard
+		WHERE
+			org_id = alert_rule.org_id AND
+			uid = alert_rule.namespace_uid
+	) AS namespace_title
+FROM alert_rule
+WHERE org_id = ?`
 		params := []interface{}{query.OrgID}
 
 		if len(query.NamespaceUIDs) > 0 {
@@ -580,6 +624,16 @@ func (st DBstore) GetOrgRuleGroups(query *ngmodels.ListOrgRuleGroupsQuery) error
 			}
 			q = fmt.Sprintf(" %s AND namespace_uid IN (%s)", q, strings.Join(placeholders, ","))
 		}
+
+		if query.DashboardUID != "" {
+			q = fmt.Sprintf("%s and dashboard_uid = ?", q)
+			params = append(params, query.DashboardUID)
+			if query.PanelID != 0 {
+				q = fmt.Sprintf("%s and panel_id = ?", q)
+				params = append(params, query.PanelID)
+			}
+		}
+
 		q = fmt.Sprintf(" %s ORDER BY namespace_title", q)
 
 		if err := sess.SQL(q, params...).Find(&ruleGroups); err != nil {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -54,6 +54,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.RerunDashAlertMigration(mg)
 	addSecretsMigration(mg)
 	addKVStoreMigrations(mg)
+	ualert.AddDashboardUIDPanelIDMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -204,6 +204,33 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 	mg.AddMigration("add index in alert_rule on org_id, namespase_uid and title columns", migrator.NewAddIndexMigration(alertRule, &migrator.Index{
 		Cols: []string{"org_id", "namespace_uid", "title"}, Type: migrator.UniqueIndex,
 	}))
+
+	mg.AddMigration("add dashboard_uid column to alert_rule", migrator.NewAddColumnMigration(
+		migrator.Table{Name: "alert_rule"},
+		&migrator.Column{
+			Name:     "dashboard_uid",
+			Type:     migrator.DB_NVarchar,
+			Length:   40,
+			Nullable: true,
+		},
+	))
+
+	mg.AddMigration("add panel_id column to alert_rule", migrator.NewAddColumnMigration(
+		migrator.Table{Name: "alert_rule"},
+		&migrator.Column{
+			Name:     "panel_id",
+			Type:     migrator.DB_BigInt,
+			Nullable: true,
+		},
+	))
+
+	mg.AddMigration("add index in alert_rule on org_id, dashboard_uid and panel_id columns", migrator.NewAddIndexMigration(
+		migrator.Table{Name: "alert_rule"},
+		&migrator.Index{
+			Name: "IDX_alert_rule_org_id_dashboard_uid_panel_id",
+			Cols: []string{"org_id", "dashboard_uid", "panel_id"},
+		},
+	))
 }
 
 func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -722,7 +722,7 @@ func TestDeleteFolderWithRules(t *testing.T) {
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		assert.Equal(t, 202, resp.StatusCode)
+		assert.Equal(t, 200, resp.StatusCode)
 
 		re := regexp.MustCompile(`"uid":"([\w|-]+)"`)
 		b = re.ReplaceAll(b, []byte(`"uid":""`))
@@ -833,7 +833,7 @@ func TestDeleteFolderWithRules(t *testing.T) {
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		assert.Equal(t, 202, resp.StatusCode)
+		assert.Equal(t, 200, resp.StatusCode)
 		assert.JSONEq(t, "{}", string(b))
 	}
 }

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -264,6 +264,301 @@ func TestPrometheusRules(t *testing.T) {
 	}
 }
 
+func TestPrometheusRulesFilterByDashboard(t *testing.T) {
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{"ngalert"},
+		DisableAnonymous:     true,
+	})
+
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	// override bus to get the GetSignedInUserQuery handler
+	store.Bus = bus.GetBus()
+
+	// Create the namespace under default organisation (orgID = 1) where we'll save our alerts to.
+	dashboardUID, err := createFolder(t, store, 0, "default")
+	require.NoError(t, err)
+
+	// Create a user to make authenticated requests
+	createUser(t, store, models.CreateUserCommand{
+		DefaultOrgRole: string(models.ROLE_EDITOR),
+		Password:       "password",
+		Login:          "grafana",
+	})
+
+	interval, err := model.ParseDuration("10s")
+	require.NoError(t, err)
+
+	// Now, let's create some rules
+	{
+		rules := apimodels.PostableRuleGroupConfig{
+			Name: "anotherrulegroup",
+			Rules: []apimodels.PostableExtendedRuleNode{
+				{
+					ApiRuleNode: &apimodels.ApiRuleNode{
+						For:    interval,
+						Labels: map[string]string{},
+						Annotations: map[string]string{
+							"__dashboardUid__": dashboardUID,
+							"__panelId__":      "1",
+						},
+					},
+					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
+						Title:     "AlwaysFiring",
+						Condition: "A",
+						Data: []ngmodels.AlertQuery{
+							{
+								RefID: "A",
+								RelativeTimeRange: ngmodels.RelativeTimeRange{
+									From: ngmodels.Duration(time.Duration(5) * time.Hour),
+									To:   ngmodels.Duration(time.Duration(3) * time.Hour),
+								},
+								DatasourceUID: "-100",
+								Model: json.RawMessage(`{
+									"type": "math",
+									"expression": "2 + 3 > 1"
+									}`),
+							},
+						},
+					},
+				},
+				{
+					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
+						Title:     "AlwaysFiringButSilenced",
+						Condition: "A",
+						Data: []ngmodels.AlertQuery{
+							{
+								RefID: "A",
+								RelativeTimeRange: ngmodels.RelativeTimeRange{
+									From: ngmodels.Duration(time.Duration(5) * time.Hour),
+									To:   ngmodels.Duration(time.Duration(3) * time.Hour),
+								},
+								DatasourceUID: "-100",
+								Model: json.RawMessage(`{
+									"type": "math",
+									"expression": "2 + 3 > 1"
+									}`),
+							},
+						},
+						NoDataState:  apimodels.NoDataState(ngmodels.Alerting),
+						ExecErrState: apimodels.ExecutionErrorState(ngmodels.AlertingErrState),
+					},
+				},
+			},
+		}
+		buf := bytes.Buffer{}
+		enc := json.NewEncoder(&buf)
+		err := enc.Encode(&rules)
+		require.NoError(t, err)
+
+		u := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules/default", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", &buf)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.StatusCode, 202)
+		require.JSONEq(t, `{"message":"rule group updated successfully"}`, string(b))
+	}
+
+	expectedAllJSON := fmt.Sprintf(`
+{
+	"status": "success",
+	"data": {
+		"groups": [{
+			"name": "anotherrulegroup",
+			"file": "default",
+			"rules": [{
+				"state": "inactive",
+				"name": "AlwaysFiring",
+				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"-100\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"duration": 10,
+				"annotations": {
+					"__dashboardUid__": "%s",
+					"__panelId__": "1"
+				},
+				"labels": null,
+				"health": "ok",
+				"lastError": "",
+				"type": "alerting",
+				"lastEvaluation": "0001-01-01T00:00:00Z",
+				"evaluationTime": 0
+			}, {
+				"state": "inactive",
+				"name": "AlwaysFiringButSilenced",
+				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"-100\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"labels": null,
+				"health": "ok",
+				"lastError": "",
+				"type": "alerting",
+				"lastEvaluation": "0001-01-01T00:00:00Z",
+				"evaluationTime": 0
+			}],
+			"interval": 60,
+			"lastEvaluation": "0001-01-01T00:00:00Z",
+			"evaluationTime": 0
+		}]
+	}
+}`, dashboardUID)
+	expectedFilteredByJSON := fmt.Sprintf(`
+{
+	"status": "success",
+	"data": {
+		"groups": [{
+			"name": "anotherrulegroup",
+			"file": "default",
+			"rules": [{
+				"state": "inactive",
+				"name": "AlwaysFiring",
+				"query": "[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":18000,\"to\":10800},\"datasourceUid\":\"-100\",\"model\":{\"expression\":\"2 + 3 \\u003e 1\",\"intervalMs\":1000,\"maxDataPoints\":43200,\"type\":\"math\"}}]",
+				"duration": 10,
+				"annotations": {
+					"__dashboardUid__": "%s",
+					"__panelId__": "1"
+				},
+				"labels": null,
+				"health": "ok",
+				"lastError": "",
+				"type": "alerting",
+				"lastEvaluation": "0001-01-01T00:00:00Z",
+				"evaluationTime": 0
+			}],
+			"interval": 60,
+			"lastEvaluation": "0001-01-01T00:00:00Z",
+			"evaluationTime": 0
+		}]
+	}
+}`, dashboardUID)
+	expectedNoneJSON := `
+{
+	"status": "success",
+	"data": {
+		"groups": []
+	}
+}`
+
+	// Now, let's see how this looks like.
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, expectedAllJSON, string(b))
+	}
+
+	// Now, let's check we get the same rule when filtering by dashboard_uid
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules?dashboard_uid=%s", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, expectedFilteredByJSON, string(b))
+	}
+
+	// Now, let's check we get no rules when filtering by an unknown dashboard_uid
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules?dashboard_uid=%s", grafanaListedAddr, "abc")
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, expectedNoneJSON, string(b))
+	}
+
+	// Now, let's check we get the same rule when filtering by dashboard_uid and panel_id
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules?dashboard_uid=%s&panel_id=1", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, expectedFilteredByJSON, string(b))
+	}
+
+	// Now, let's check we get no rules when filtering by dashboard_uid and unknown panel_id
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules?dashboard_uid=%s&panel_id=2", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, expectedNoneJSON, string(b))
+	}
+
+	// Now, let's check an invalid panel_id returns a 400 Bad Request response
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules?dashboard_uid=%s&panel_id=invalid", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"message":"invalid panel_id: strconv.ParseInt: parsing \"invalid\": invalid syntax"}`, string(b))
+	}
+
+	// Now, let's check a panel_id without dashboard_uid returns a 400 Bad Request response
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules?panel_id=1", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"message":"panel_id must be set with dashboard_uid"}`, string(b))
+	}
+}
+
 func TestPrometheusRulesPermissions(t *testing.T) {
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -536,38 +536,6 @@ func TestRulerRulesFilterByDashboard(t *testing.T) {
 		"interval": "1m",
 		"rules": [{
 			"expr": "",
-			"grafana_alert": {
-				"id": 2,
-				"orgId": 1,
-				"title": "AlwaysFiringButSilenced",
-				"condition": "A",
-				"data": [{
-					"refId": "A",
-					"queryType": "",
-					"relativeTimeRange": {
-						"from": 18000,
-						"to": 10800
-					},
-					"datasourceUid": "-100",
-					"model": {
-						"expression": "2 + 3 \u003e 1",
-						"intervalMs": 1000,
-						"maxDataPoints": 43200,
-						"type": "math"
-					}
-				}],
-				"updated": "2021-02-21T01:10:30Z",
-				"intervalSeconds": 60,
-				"version": 1,
-				"uid": "uid",
-				"namespace_uid": "nsuid",
-				"namespace_id": 1,
-				"rule_group": "anotherrulegroup",
-				"no_data_state": "Alerting",
-				"exec_err_state": "Alerting"
-			}
-		}, {
-			"expr": "",
 			"for": "10s",
 			"annotations": {
 				"__dashboardUid__": "%s",
@@ -601,6 +569,38 @@ func TestRulerRulesFilterByDashboard(t *testing.T) {
 				"namespace_id": 1,
 				"rule_group": "anotherrulegroup",
 				"no_data_state": "NoData",
+				"exec_err_state": "Alerting"
+			}
+		}, {
+			"expr": "",
+			"grafana_alert": {
+				"id": 2,
+				"orgId": 1,
+				"title": "AlwaysFiringButSilenced",
+				"condition": "A",
+				"data": [{
+					"refId": "A",
+					"queryType": "",
+					"relativeTimeRange": {
+						"from": 18000,
+						"to": 10800
+					},
+					"datasourceUid": "-100",
+					"model": {
+						"expression": "2 + 3 \u003e 1",
+						"intervalMs": 1000,
+						"maxDataPoints": 43200,
+						"type": "math"
+					}
+				}],
+				"updated": "2021-02-21T01:10:30Z",
+				"intervalSeconds": 60,
+				"version": 1,
+				"uid": "uid",
+				"namespace_uid": "nsuid",
+				"namespace_id": 1,
+				"rule_group": "anotherrulegroup",
+				"no_data_state": "Alerting",
 				"exec_err_state": "Alerting"
 			}
 		}]

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -65,7 +65,7 @@ func TestAlertRulePermissions(t *testing.T) {
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		assert.Equal(t, resp.StatusCode, 202)
+		assert.Equal(t, resp.StatusCode, 200)
 
 		body, _ := rulesNamespaceWithoutVariableValues(t, b)
 		expectedGetNamespaceResponseBody := `
@@ -187,7 +187,7 @@ func TestAlertRulePermissions(t *testing.T) {
 		b, err = ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 
-		assert.Equal(t, resp.StatusCode, 202)
+		assert.Equal(t, resp.StatusCode, 200)
 
 		body, _ = rulesNamespaceWithoutVariableValues(t, b)
 		expectedGetNamespaceResponseBody = `
@@ -426,4 +426,350 @@ func TestAlertRuleConflictingTitle(t *testing.T) {
 		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
 		require.JSONEq(t, `{"message":"rule group updated successfully"}`, string(b))
 	})
+}
+
+func TestRulerRulesFilterByDashboard(t *testing.T) {
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{"ngalert"},
+		DisableAnonymous:     true,
+	})
+
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+	// override bus to get the GetSignedInUserQuery handler
+	store.Bus = bus.GetBus()
+
+	// Create the namespace under default organisation (orgID = 1) where we'll save our alerts to.
+	dashboardUID, err := createFolder(t, store, 0, "default")
+	require.NoError(t, err)
+
+	// Create a user to make authenticated requests
+	createUser(t, store, models.CreateUserCommand{
+		DefaultOrgRole: string(models.ROLE_EDITOR),
+		Password:       "password",
+		Login:          "grafana",
+	})
+
+	interval, err := model.ParseDuration("10s")
+	require.NoError(t, err)
+
+	// Now, let's create some rules
+	{
+		rules := apimodels.PostableRuleGroupConfig{
+			Name: "anotherrulegroup",
+			Rules: []apimodels.PostableExtendedRuleNode{
+				{
+					ApiRuleNode: &apimodels.ApiRuleNode{
+						For:    interval,
+						Labels: map[string]string{},
+						Annotations: map[string]string{
+							"__dashboardUid__": dashboardUID,
+							"__panelId__":      "1",
+						},
+					},
+					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
+						Title:     "AlwaysFiring",
+						Condition: "A",
+						Data: []ngmodels.AlertQuery{
+							{
+								RefID: "A",
+								RelativeTimeRange: ngmodels.RelativeTimeRange{
+									From: ngmodels.Duration(time.Duration(5) * time.Hour),
+									To:   ngmodels.Duration(time.Duration(3) * time.Hour),
+								},
+								DatasourceUID: "-100",
+								Model: json.RawMessage(`{
+									"type": "math",
+									"expression": "2 + 3 > 1"
+									}`),
+							},
+						},
+					},
+				},
+				{
+					GrafanaManagedAlert: &apimodels.PostableGrafanaRule{
+						Title:     "AlwaysFiringButSilenced",
+						Condition: "A",
+						Data: []ngmodels.AlertQuery{
+							{
+								RefID: "A",
+								RelativeTimeRange: ngmodels.RelativeTimeRange{
+									From: ngmodels.Duration(time.Duration(5) * time.Hour),
+									To:   ngmodels.Duration(time.Duration(3) * time.Hour),
+								},
+								DatasourceUID: "-100",
+								Model: json.RawMessage(`{
+									"type": "math",
+									"expression": "2 + 3 > 1"
+									}`),
+							},
+						},
+						NoDataState:  apimodels.NoDataState(ngmodels.Alerting),
+						ExecErrState: apimodels.ExecutionErrorState(ngmodels.AlertingErrState),
+					},
+				},
+			},
+		}
+		buf := bytes.Buffer{}
+		enc := json.NewEncoder(&buf)
+		err := enc.Encode(&rules)
+		require.NoError(t, err)
+
+		u := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules/default", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", &buf)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.StatusCode, 202)
+		require.JSONEq(t, `{"message":"rule group updated successfully"}`, string(b))
+	}
+
+	expectedAllJSON := fmt.Sprintf(`
+{
+	"default": [{
+		"name": "anotherrulegroup",
+		"interval": "1m",
+		"rules": [{
+			"expr": "",
+			"grafana_alert": {
+				"id": 2,
+				"orgId": 1,
+				"title": "AlwaysFiringButSilenced",
+				"condition": "A",
+				"data": [{
+					"refId": "A",
+					"queryType": "",
+					"relativeTimeRange": {
+						"from": 18000,
+						"to": 10800
+					},
+					"datasourceUid": "-100",
+					"model": {
+						"expression": "2 + 3 \u003e 1",
+						"intervalMs": 1000,
+						"maxDataPoints": 43200,
+						"type": "math"
+					}
+				}],
+				"updated": "2021-02-21T01:10:30Z",
+				"intervalSeconds": 60,
+				"version": 1,
+				"uid": "uid",
+				"namespace_uid": "nsuid",
+				"namespace_id": 1,
+				"rule_group": "anotherrulegroup",
+				"no_data_state": "Alerting",
+				"exec_err_state": "Alerting"
+			}
+		}, {
+			"expr": "",
+			"for": "10s",
+			"annotations": {
+				"__dashboardUid__": "%s",
+				"__panelId__": "1"
+			},
+			"grafana_alert": {
+				"id": 1,
+				"orgId": 1,
+				"title": "AlwaysFiring",
+				"condition": "A",
+				"data": [{
+					"refId": "A",
+					"queryType": "",
+					"relativeTimeRange": {
+						"from": 18000,
+						"to": 10800
+					},
+					"datasourceUid": "-100",
+					"model": {
+						"expression": "2 + 3 \u003e 1",
+						"intervalMs": 1000,
+						"maxDataPoints": 43200,
+						"type": "math"
+					}
+				}],
+				"updated": "2021-02-21T01:10:30Z",
+				"intervalSeconds": 60,
+				"version": 1,
+				"uid": "uid",
+				"namespace_uid": "nsuid",
+				"namespace_id": 1,
+				"rule_group": "anotherrulegroup",
+				"no_data_state": "NoData",
+				"exec_err_state": "Alerting"
+			}
+		}]
+	}]
+}`, dashboardUID)
+	expectedFilteredByJSON := fmt.Sprintf(`
+{
+	"default": [{
+		"name": "anotherrulegroup",
+		"interval": "1m",
+		"rules": [{
+			"expr": "",
+			"for": "10s",
+			"annotations": {
+				"__dashboardUid__": "%s",
+				"__panelId__": "1"
+			},
+			"grafana_alert": {
+				"id": 1,
+				"orgId": 1,
+				"title": "AlwaysFiring",
+				"condition": "A",
+				"data": [{
+					"refId": "A",
+					"queryType": "",
+					"relativeTimeRange": {
+						"from": 18000,
+						"to": 10800
+					},
+					"datasourceUid": "-100",
+					"model": {
+						"expression": "2 + 3 \u003e 1",
+						"intervalMs": 1000,
+						"maxDataPoints": 43200,
+						"type": "math"
+					}
+				}],
+				"updated": "2021-02-21T01:10:30Z",
+				"intervalSeconds": 60,
+				"version": 1,
+				"uid": "uid",
+				"namespace_uid": "nsuid",
+				"namespace_id": 1,
+				"rule_group": "anotherrulegroup",
+				"no_data_state": "NoData",
+				"exec_err_state": "Alerting"
+			}
+		}]
+	}]
+}`, dashboardUID)
+	expectedNoneJSON := `{}`
+
+	// Now, let's see how this looks like.
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		body, _ := rulesNamespaceWithoutVariableValues(t, b)
+		require.JSONEq(t, expectedAllJSON, body)
+	}
+
+	// Now, let's check we get the same rule when filtering by dashboard_uid
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules?dashboard_uid=%s", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		body, _ := rulesNamespaceWithoutVariableValues(t, b)
+		require.JSONEq(t, expectedFilteredByJSON, body)
+	}
+
+	// Now, let's check we get no rules when filtering by an unknown dashboard_uid
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules?dashboard_uid=%s", grafanaListedAddr, "abc")
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, expectedNoneJSON, string(b))
+	}
+
+	// Now, let's check we get the same rule when filtering by dashboard_uid and panel_id
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules?dashboard_uid=%s&panel_id=1", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		body, _ := rulesNamespaceWithoutVariableValues(t, b)
+		require.JSONEq(t, expectedFilteredByJSON, body)
+	}
+
+	// Now, let's check we get no rules when filtering by dashboard_uid and unknown panel_id
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules?dashboard_uid=%s&panel_id=2", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, expectedNoneJSON, string(b))
+	}
+
+	// Now, let's check an invalid panel_id returns a 400 Bad Request response
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules?dashboard_uid=%s&panel_id=invalid", grafanaListedAddr, dashboardUID)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"message":"invalid panel_id: strconv.ParseInt: parsing \"invalid\": invalid syntax"}`, string(b))
+	}
+
+	// Now, let's check a panel_id without dashboard_uid returns a 400 Bad Request response
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules?panel_id=1", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"message":"panel_id must be set with dashboard_uid"}`, string(b))
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request makes it possible to get the alert rules for a dashboard and panel on `/api/v1/rules` with `dashboard_uid` and `panel_id` query string parameters in the URL.

**Which issue(s) this PR fixes**:

Fixes #38920 

