### PR TITLE
QueryActionComponent: Add dataSourceRef to ActionComponetProps

### DIFF
--- a/public/app/features/query/components/QueryActionComponent.ts
+++ b/public/app/features/query/components/QueryActionComponent.ts
@@ -1,10 +1,11 @@
-import { DataQuery, TimeRange } from '@grafana/data';
+import { DataQuery, DatasourceRef, TimeRange } from '@grafana/data';
 
 interface ActionComponentProps {
   query?: DataQuery;
   queries?: Array<Partial<DataQuery>>;
   onAddQuery?: (q: DataQuery) => void;
   timeRange?: TimeRange;
+  dataSourceRef?: DatasourceRef;
 }
 
 type QueryActionComponent = React.ComponentType<ActionComponentProps>;

--- a/public/app/features/query/components/QueryActionComponent.ts
+++ b/public/app/features/query/components/QueryActionComponent.ts
@@ -1,11 +1,11 @@
-import { DataQuery, DatasourceRef, TimeRange } from '@grafana/data';
+import { DataQuery, DataSourceInstanceSettings, TimeRange } from '@grafana/data';
 
 interface ActionComponentProps {
   query?: DataQuery;
   queries?: Array<Partial<DataQuery>>;
   onAddQuery?: (q: DataQuery) => void;
   timeRange?: TimeRange;
-  dataSourceRef?: DatasourceRef;
+  dataSource?: DataSourceInstanceSettings;
 }
 
 type QueryActionComponent = React.ComponentType<ActionComponentProps>;

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -303,13 +303,14 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   }
 
   renderExtraActions = () => {
-    const { query, queries, data, onAddQuery } = this.props;
+    const { query, queries, data, onAddQuery, dataSource } = this.props;
     return RowActionComponents.getAllExtraRenderAction().map((c) => {
       return React.createElement(c, {
         query,
         queries,
         timeRange: data.timeRange,
         onAddQuery: onAddQuery as (query: DataQuery) => void,
+        dataSourceRef: dataSource.name,
       });
     });
   };

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -310,7 +310,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         queries,
         timeRange: data.timeRange,
         onAddQuery: onAddQuery as (query: DataQuery) => void,
-        dataSourceRef: dataSource.name,
+        dataSource: dataSource,
       });
     });
   };


### PR DESCRIPTION
Continuing from #39453 
We are adding the `DatasourceRef` to the `ActionComponentProp` so we can get the data source when creating an `ActionComponent`. We are using the for Recorded Queries in Enterprise.