### PR TITLE
Explore: No longer hides errors containing refId property.

### DIFF
--- a/public/app/features/explore/ResponseErrorContainer.test.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.test.tsx
@@ -8,35 +8,36 @@ import { DataQueryError, LoadingState } from '@grafana/data';
 
 describe('ResponseErrorContainer', () => {
   it('shows error message if it does not contain refId', async () => {
+    const errorMessage = 'test error';
     setup({
-      message: 'test error',
+      message: errorMessage,
     });
-    expect(screen.getByText('test error')).toBeInTheDocument();
+    const errorEl = screen.getByLabelText('Alert error');
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveTextContent(errorMessage);
+  });
+
+  it('shows error if there is refID', async () => {
+    const errorMessage = 'test error';
+    setup({
+      refId: 'someId',
+      message: errorMessage,
+    });
+    const errorEl = screen.getByLabelText('Alert error');
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveTextContent(errorMessage);
   });
 
   it('shows error.data.message if error.message does not exist', async () => {
+    const errorMessage = 'test error';
     setup({
       data: {
         message: 'test error',
       },
     });
-    expect(screen.getByText('test error')).toBeInTheDocument();
-  });
-
-  it('does not show error if there is refID', async () => {
-    setup({
-      refId: 'someId',
-      message: 'test error',
-    });
-    expect(screen.queryByText('test error')).not.toBeInTheDocument();
-  });
-
-  it('does not show error if there is refID', async () => {
-    setup({
-      refId: 'someId',
-      message: 'test error',
-    });
-    expect(screen.queryByText('test error')).not.toBeInTheDocument();
+    const errorEl = screen.getByLabelText('Alert error');
+    expect(errorEl).toBeInTheDocument();
+    expect(errorEl).toHaveTextContent(errorMessage);
   });
 });
 

--- a/public/app/features/explore/ResponseErrorContainer.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.tsx
@@ -10,12 +10,7 @@ interface Props {
 export function ResponseErrorContainer(props: Props) {
   const queryResponse = useSelector((state: StoreState) => state.explore[props.exploreId]?.queryResponse);
 
-  // Only show error if it does not have refId. Otherwise let query row to handle it so this condition has to be matched
-  // with QueryRow.tsx so we don't loose errors.
-  const queryError =
-    queryResponse?.state === LoadingState.Error && queryResponse?.error && !queryResponse.error.refId
-      ? queryResponse.error
-      : undefined;
+  const queryError = (queryResponse?.state === LoadingState.Error && queryResponse?.error) || undefined;
 
   return <ErrorContainer queryError={queryError} />;
 }

--- a/public/app/features/explore/ResponseErrorContainer.tsx
+++ b/public/app/features/explore/ResponseErrorContainer.tsx
@@ -10,7 +10,7 @@ interface Props {
 export function ResponseErrorContainer(props: Props) {
   const queryResponse = useSelector((state: StoreState) => state.explore[props.exploreId]?.queryResponse);
 
-  const queryError = (queryResponse?.state === LoadingState.Error && queryResponse?.error) || undefined;
+  const queryError = queryResponse?.state === LoadingState.Error ? queryResponse?.error : undefined;
 
   return <ErrorContainer queryError={queryError} />;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.


-->

**What this PR does / why we need it**:
Explore page was not showing an error containing a `refId`. this is because prior to https://github.com/grafana/grafana/pull/38942, errors with a `refId` were being shown next to their editor; Errors in Explore were split between editor-level errors (those with a `refId`) and page-level errors (those without). 
Given the shared QueryRow component doesn't show errors next to the editors, in Explore the former were effectively ignored.

This PR fixes this behavior by always showing every error in Explore at the end of the Query editors container.
