### PR TITLE
A11y: Fix fastpass issues for /explore page

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -52,7 +52,7 @@ export const SelectMenuOptions = React.forwardRef<HTMLDivElement, React.PropsWit
         aria-label="Select option"
       >
         {data.icon && <Icon name={data.icon as IconName} className={styles.optionIcon} />}
-        {data.imgUrl && <img className={styles.optionImage} src={data.imgUrl} />}
+        {data.imgUrl && <img className={styles.optionImage} src={data.imgUrl} alt={data.label || data.value} />}
         <div className={styles.optionBody}>
           <span>{renderOptionLabel ? renderOptionLabel(data) : children}</span>
           {data.description && <div className={styles.optionDescription}>{data.description}</div>}

--- a/packages/grafana-ui/src/components/Select/SingleValue.tsx
+++ b/packages/grafana-ui/src/components/Select/SingleValue.tsx
@@ -46,6 +46,8 @@ type StylesType = ReturnType<typeof getStyles>;
 interface Props
   extends SingleValueProps<{
     imgUrl?: string;
+    label?: string;
+    value: string;
     loading?: boolean;
     hideText?: boolean;
   }> {
@@ -61,7 +63,7 @@ export const SingleValue = (props: Props) => {
     <components.SingleValue {...props}>
       <div className={cx(styles.singleValue, disabled && styles.disabled)}>
         {data.imgUrl ? (
-          <FadeWithImage loading={loading} imgUrl={data.imgUrl} styles={styles} />
+          <FadeWithImage loading={loading} imgUrl={data.imgUrl} styles={styles} alt={data.label || data.value} />
         ) : (
           <SlideOutTransition horizontal size={16} visible={loading} duration={150}>
             <div className={styles.container}>
@@ -75,14 +77,14 @@ export const SingleValue = (props: Props) => {
   );
 };
 
-const FadeWithImage = (props: { loading: boolean; imgUrl: string; styles: StylesType }) => {
+const FadeWithImage = (props: { loading: boolean; imgUrl: string; styles: StylesType; alt?: string }) => {
   return (
     <div className={props.styles.container}>
       <FadeTransition duration={150} visible={props.loading}>
         <Spinner className={props.styles.item} inline />
       </FadeTransition>
       <FadeTransition duration={150} visible={!props.loading}>
-        <img className={props.styles.item} src={props.imgUrl} />
+        <img className={props.styles.item} src={props.imgUrl} alt={props.alt} />
       </FadeTransition>
     </div>
   );

--- a/packages/grafana-ui/src/components/Select/SingleValue.tsx
+++ b/packages/grafana-ui/src/components/Select/SingleValue.tsx
@@ -77,7 +77,7 @@ export const SingleValue = (props: Props) => {
   );
 };
 
-const FadeWithImage = (props: { loading: boolean; imgUrl: string; styles: StylesType; alt?: string }) => {
+const FadeWithImage = (props: { loading: boolean; imgUrl: string; styles: StylesType; alt: string }) => {
   return (
     <div className={props.styles.container}>
       <FadeTransition duration={150} visible={props.loading}>

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -146,7 +146,11 @@ export class UnConnectedExploreToolbar extends PureComponent<Props> {
               ) : null}
 
               <Tooltip content={'Copy shortened link to the executed query'} placement="bottom">
-                <ToolbarButton icon="share-alt" onClick={() => createAndCopyShortLink(window.location.href)} />
+                <ToolbarButton
+                  icon="share-alt"
+                  onClick={() => createAndCopyShortLink(window.location.href)}
+                  aria-label="Copy shortened link to the executed query"
+                />
               </Tooltip>
 
               {!isLive && (


### PR DESCRIPTION
 Fixes 2 issues reported by microsoft fastpass in Explore:

- images in `Select` now get their `alt` attribute based on the selected option's label or value
- Add label to "Copy shortened link" toolbar button

There are still 3 issues left:
- DataSourcePicker doesn't have a label
- the first Select in TestDataSource doesn't have a label associated (this is not really explore related, but we will be running tests with this DS selected)
- QueryRows component has nested interactive element, according to Accessibility Insights for Web nested interactive controls are not announced by screen readers. this needs further investigation

**Which issue(s) this PR fixes:**
Part of #39429