### PR TITLE
Usage Stats: Decouple from GrafanaLive

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -115,7 +115,7 @@ func (usm *usageStatsMock) ShouldBeReported(_ string) bool {
 
 func newTestLive(t *testing.T) *live.GrafanaLive {
 	cfg := &setting.Cfg{AppURL: "http://localhost:3000/"}
-	gLive, err := live.ProvideService(nil, cfg, routing.NewRouteRegister(), nil, nil, nil, nil, sqlstore.InitTestDB(t), &usageStatsMock{})
+	gLive, err := live.ProvideService(nil, cfg, routing.NewRouteRegister(), nil, nil, nil, nil, sqlstore.InitTestDB(t), &usageStatsMock{t: t})
 	require.NoError(t, err)
 	return gLive
 }

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	dboards "github.com/grafana/grafana/pkg/dashboards"
+	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -86,9 +87,35 @@ type testState struct {
 	dashQueries []*models.GetDashboardQuery
 }
 
+type usageStatsMock struct {
+	t            *testing.T
+	metricsFuncs []usagestats.MetricsFunc
+}
+
+func (usm *usageStatsMock) RegisterMetricsFunc(fn usagestats.MetricsFunc) {
+	usm.metricsFuncs = append(usm.metricsFuncs, fn)
+}
+
+func (usm *usageStatsMock) GetUsageReport(_ context.Context) (usagestats.Report, error) {
+	all := make(map[string]interface{})
+	for _, fn := range usm.metricsFuncs {
+		fnMetrics, err := fn()
+		require.NoError(usm.t, err)
+
+		for name, value := range fnMetrics {
+			all[name] = value
+		}
+	}
+	return usagestats.Report{Metrics: all}, nil
+}
+
+func (usm *usageStatsMock) ShouldBeReported(_ string) bool {
+	return true
+}
+
 func newTestLive(t *testing.T) *live.GrafanaLive {
 	cfg := &setting.Cfg{AppURL: "http://localhost:3000/"}
-	gLive, err := live.ProvideService(nil, cfg, routing.NewRouteRegister(), nil, nil, nil, nil, sqlstore.InitTestDB(t))
+	gLive, err := live.ProvideService(nil, cfg, routing.NewRouteRegister(), nil, nil, nil, nil, sqlstore.InitTestDB(t), &usageStatsMock{})
 	require.NoError(t, err)
 	return gLive
 }

--- a/pkg/infra/usagestats/service/usage_stats.go
+++ b/pkg/infra/usagestats/service/usage_stats.go
@@ -83,20 +83,6 @@ func (uss *UsageStats) GetUsageReport(ctx context.Context) (usagestats.Report, e
 	metrics["stats.folders_viewers_can_edit.count"] = statsQuery.Result.FoldersViewersCanEdit
 	metrics["stats.folders_viewers_can_admin.count"] = statsQuery.Result.FoldersViewersCanAdmin
 
-	liveUsersAvg := 0
-	liveClientsAvg := 0
-	if uss.liveStats.sampleCount > 0 {
-		liveUsersAvg = uss.liveStats.numUsersSum / uss.liveStats.sampleCount
-		liveClientsAvg = uss.liveStats.numClientsSum / uss.liveStats.sampleCount
-	}
-	metrics["stats.live_samples.count"] = uss.liveStats.sampleCount
-	metrics["stats.live_users_max.count"] = uss.liveStats.numUsersMax
-	metrics["stats.live_users_min.count"] = uss.liveStats.numUsersMin
-	metrics["stats.live_users_avg.count"] = liveUsersAvg
-	metrics["stats.live_clients_max.count"] = uss.liveStats.numClientsMax
-	metrics["stats.live_clients_min.count"] = uss.liveStats.numClientsMin
-	metrics["stats.live_clients_avg.count"] = liveClientsAvg
-
 	ossEditionCount := 1
 	enterpriseEditionCount := 0
 	if uss.Cfg.IsEnterprise {
@@ -321,34 +307,6 @@ var sendUsageStats = func(uss *UsageStats, data *bytes.Buffer) {
 			uss.log.Warn("Failed to close response body", "err", err)
 		}
 	}()
-}
-
-func (uss *UsageStats) sampleLiveStats() {
-	current := uss.grafanaLive.UsageStats()
-
-	uss.liveStats.sampleCount++
-	uss.liveStats.numClientsSum += current.NumClients
-	uss.liveStats.numUsersSum += current.NumUsers
-
-	if current.NumClients > uss.liveStats.numClientsMax {
-		uss.liveStats.numClientsMax = current.NumClients
-	}
-
-	if current.NumClients < uss.liveStats.numClientsMin {
-		uss.liveStats.numClientsMin = current.NumClients
-	}
-
-	if current.NumUsers > uss.liveStats.numUsersMax {
-		uss.liveStats.numUsersMax = current.NumUsers
-	}
-
-	if current.NumUsers < uss.liveStats.numUsersMin {
-		uss.liveStats.numUsersMin = current.NumUsers
-	}
-}
-
-func (uss *UsageStats) resetLiveStats() {
-	uss.liveStats = liveUsageStats{}
 }
 
 func (uss *UsageStats) updateTotalStats() {

--- a/pkg/infra/usagestats/service/usage_stats_test.go
+++ b/pkg/infra/usagestats/service/usage_stats_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -21,7 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/services/alerting"
-	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
@@ -648,16 +646,8 @@ func createService(t *testing.T, cfg setting.Cfg) *UsageStats {
 		AlertingUsageStats: &alertingUsageMock{},
 		externalMetrics:    make([]usagestats.MetricsFunc, 0),
 		PluginManager:      &fakePluginManager{},
-		grafanaLive:        newTestLive(t),
 		kvStore:            kvstore.WithNamespace(kvstore.ProvideService(sqlStore), 0, "infra.usagestats"),
 		log:                log.New("infra.usagestats"),
 		startTime:          time.Now().Add(-1 * time.Minute),
 	}
-}
-
-func newTestLive(t *testing.T) *live.GrafanaLive {
-	cfg := &setting.Cfg{AppURL: "http://localhost:3000/"}
-	gLive, err := live.ProvideService(nil, cfg, routing.NewRouteRegister(), nil, nil, nil, nil, sqlstore.InitTestDB(t))
-	require.NoError(t, err)
-	return gLive
 }

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -11,11 +11,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/centrifugal/centrifuge"
+	"github.com/go-redis/redis/v8"
+	"github.com/gobwas/glob"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/live"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/manager"
@@ -35,12 +41,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch"
 	"github.com/grafana/grafana/pkg/util"
-
-	"github.com/centrifugal/centrifuge"
-	"github.com/go-redis/redis/v8"
-	"github.com/gobwas/glob"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/live"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/macaron.v1"
 )
 
@@ -59,7 +60,8 @@ type CoreGrafanaScope struct {
 
 func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, routeRegister routing.RouteRegister,
 	logsService *cloudwatch.LogsService, pluginManager *manager.PluginManager, cacheService *localcache.CacheService,
-	dataSourceCache datasources.CacheService, sqlStore *sqlstore.SQLStore) (*GrafanaLive, error) {
+	dataSourceCache datasources.CacheService, sqlStore *sqlstore.SQLStore,
+	usageStatsService usagestats.Service) (*GrafanaLive, error) {
 	g := &GrafanaLive{
 		Cfg:                   cfg,
 		PluginContextProvider: plugCtxProvider,
@@ -73,6 +75,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 		GrafanaScope: CoreGrafanaScope{
 			Features: make(map[string]models.ChannelHandlerFactory),
 		},
+		usageStatsService: usageStatsService,
 	}
 
 	logger.Debug("GrafanaLive initialization", "ha", g.IsHA())
@@ -325,6 +328,8 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 		group.Get("/push/:streamId", g.pushWebsocketHandler)
 	}, middleware.ReqOrgAdmin)
 
+	g.registerUsageMetrics()
+
 	return g, nil
 }
 
@@ -364,11 +369,9 @@ type GrafanaLive struct {
 	contextGetter    *liveplugin.ContextGetter
 	runStreamManager *runstream.Manager
 	storage          *database.Storage
-}
 
-type UsageStats struct {
-	NumClients int
-	NumUsers   int
+	usageStatsService usagestats.Service
+	usageStats        usageStats
 }
 
 func (g *GrafanaLive) getStreamPlugin(pluginID string) (backend.StreamHandler, error) {
@@ -384,11 +387,31 @@ func (g *GrafanaLive) getStreamPlugin(pluginID string) (backend.StreamHandler, e
 }
 
 func (g *GrafanaLive) Run(ctx context.Context) error {
+	eGroup, eCtx := errgroup.WithContext(ctx)
+
+	eGroup.Go(func() error {
+		updateStatsTicker := time.NewTicker(time.Minute * 30)
+		defer updateStatsTicker.Stop()
+
+		for {
+			select {
+			case <-updateStatsTicker.C:
+				g.sampleLiveStats()
+			case <-updateStatsTicker.C:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+
 	if g.runStreamManager != nil {
 		// Only run stream manager if GrafanaLive properly initialized.
-		return g.runStreamManager.Run(ctx)
+		eGroup.Go(func() error {
+			return g.runStreamManager.Run(eCtx)
+		})
 	}
-	return nil
+
+	return eGroup.Wait()
 }
 
 func (g *GrafanaLive) ChannelRuleStorage() pipeline.RuleStorage {
@@ -781,13 +804,6 @@ func (g *GrafanaLive) ClientCount(orgID int64, channel string) (int, error) {
 	return len(p.Presence), nil
 }
 
-func (g *GrafanaLive) UsageStats() UsageStats {
-	clients := g.node.Hub().NumClients()
-	users := g.node.Hub().NumUsers()
-
-	return UsageStats{NumClients: clients, NumUsers: users}
-}
-
 func (g *GrafanaLive) HandleHTTPPublish(ctx *models.ReqContext, cmd dtos.LivePublishCmd) response.Response {
 	addr, err := live.ParseChannel(cmd.Channel)
 	if err != nil {
@@ -989,4 +1005,65 @@ func handleLog(msg centrifuge.LogEntry) {
 	default:
 		loggerCF.Debug(msg.Message, arr...)
 	}
+}
+
+func (g *GrafanaLive) sampleLiveStats() {
+	numClients := g.node.Hub().NumClients()
+	numUsers := g.node.Hub().NumUsers()
+
+	g.usageStats.sampleCount++
+	g.usageStats.numClientsSum += numClients
+	g.usageStats.numUsersSum += numUsers
+
+	if numClients > g.usageStats.numClientsMax {
+		g.usageStats.numClientsMax = numClients
+	}
+
+	if numClients < g.usageStats.numClientsMin {
+		g.usageStats.numClientsMin = numClients
+	}
+
+	if numUsers > g.usageStats.numUsersMax {
+		g.usageStats.numUsersMax = numUsers
+	}
+
+	if numUsers < g.usageStats.numUsersMin {
+		g.usageStats.numUsersMin = numUsers
+	}
+}
+
+func (g *GrafanaLive) registerUsageMetrics() {
+	g.usageStatsService.RegisterMetricsFunc(func() (map[string]interface{}, error) {
+		liveUsersAvg := 0
+		liveClientsAvg := 0
+
+		if g.usageStats.sampleCount > 0 {
+			liveUsersAvg = g.usageStats.numUsersSum / g.usageStats.sampleCount
+			liveClientsAvg = g.usageStats.numClientsSum / g.usageStats.sampleCount
+		}
+
+		metrics := map[string]interface{}{
+			"stats.live_samples.count":     g.usageStats.sampleCount,
+			"stats.live_users_max.count":   g.usageStats.numUsersMax,
+			"stats.live_users_min.count":   g.usageStats.numUsersMin,
+			"stats.live_users_avg.count":   liveUsersAvg,
+			"stats.live_clients_max.count": g.usageStats.numClientsMax,
+			"stats.live_clients_min.count": g.usageStats.numClientsMin,
+			"stats.live_clients_avg.count": liveClientsAvg,
+		}
+
+		g.usageStats = usageStats{}
+
+		return metrics, nil
+	})
+}
+
+type usageStats struct {
+	numClientsMax int
+	numClientsMin int
+	numClientsSum int
+	numUsersMax   int
+	numUsersMin   int
+	numUsersSum   int
+	sampleCount   int
 }

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -397,7 +397,6 @@ func (g *GrafanaLive) Run(ctx context.Context) error {
 			select {
 			case <-updateStatsTicker.C:
 				g.sampleLiveStats()
-			case <-updateStatsTicker.C:
 			case <-ctx.Done():
 				return ctx.Err()
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

The UsageStats service is a common source of cyclic dependencies due to its relationship with "third-party" services. 
So, the idea of this pull request is to invert the relationship between UsageStats service and GrafanaLive service to make the latter use the UsageStats service from a consumer perspective, as the other services does, instead of embedding it within the UsageStats service itself which is much more prone to cause cyclic dependencies.

**Special notes for your reviewer**:

The major tradeoff of this pull request was to either expose the update ticker through a method similar to `RegisterMetricsFunc` or to create a custom ticker for GrafanaLive service. So, I decided to go with the latter to avoid making the UsageStats service public API larger (which is something I'd like to avoid unless actually needed). Also, because that ticker it's not something that's going to change very often (so no big reasons to spread it / share it through an extensible mechanism) and this way we may have flexibility to set up a custom ticker length, if needed.

PS: Funny fact - the name of the branch is wrong, it's not about decoupling GrafanaLive from USS but the other way round! 😝 

Thanks! 🙌🏻 
