### PR TITLE
Alerting: Fixed alerts with evaluation interval more than 30 seconds resolving before notification

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -158,7 +158,7 @@ func (a *State) TrimResults(alertRule *ngModels.AlertRule) {
 func (a *State) setEndsAt(alertRule *ngModels.AlertRule, result eval.Result) {
 	ends := ResendDelay
 	if alertRule.IntervalSeconds > int64(ResendDelay.Seconds()) {
-		ends = time.Duration(alertRule.IntervalSeconds)
+		ends = time.Second * time.Duration(alertRule.IntervalSeconds)
 	}
 
 	a.EndsAt = result.EvaluatedAt.Add(ends * 3)

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -149,14 +149,14 @@ func TestSetEndsAt(t *testing.T) {
 		},
 		{
 			name:     "more than resend delay: for=unset,interval=1m - endsAt = interval * 3",
-			expected: evaluationTime.Add(60 * 3),
+			expected: evaluationTime.Add(time.Second * 60 * 3),
 			testRule: &ngmodels.AlertRule{
 				IntervalSeconds: 60,
 			},
 		},
 		{
 			name:     "more than resend delay: for=0s,interval=1m - endsAt = resendDelay * 3",
-			expected: evaluationTime.Add(60 * 3),
+			expected: evaluationTime.Add(time.Second * 60 * 3),
 			testRule: &ngmodels.AlertRule{
 				For:             0 * time.Second,
 				IntervalSeconds: 60,
@@ -164,7 +164,7 @@ func TestSetEndsAt(t *testing.T) {
 		},
 		{
 			name:     "more than resend delay: for=1m,interval=5m - endsAt = interval * 3",
-			expected: evaluationTime.Add(300 * 3),
+			expected: evaluationTime.Add(time.Second * 300 * 3),
 			testRule: &ngmodels.AlertRule{
 				For:             60 * time.Second,
 				IntervalSeconds: 300,
@@ -172,7 +172,7 @@ func TestSetEndsAt(t *testing.T) {
 		},
 		{
 			name:     "more than resend delay: for=5m,interval=1m - endsAt = interval * 3",
-			expected: evaluationTime.Add(60 * 3),
+			expected: evaluationTime.Add(time.Second * 60 * 3),
 			testRule: &ngmodels.AlertRule{
 				For:             300 * time.Second,
 				IntervalSeconds: 60,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug introduced in #38648 that is causing some users of Grafana to not receive notifications for firing alerts.

**Which issue(s) this PR fixes**:

#39295 

**Special notes for your reviewer**:
