### PR TITLE
PieChart: Remove ? as header for piechart table legend

### DIFF
--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -116,7 +116,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
                 hidden || isNaN(fractionOfTotal)
                   ? props.fieldConfig.defaults.noValue ?? '-'
                   : percentOfTotal.toFixed(0) + '%',
-              title: valuesToShow.length > 1 ? 'Percent' : undefined,
+              title: valuesToShow.length > 1 ? 'Percent' : '',
             });
           }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the percent value is obvious we have chosen to hide the title. But changes to the legend table has replaced undefined with '?'. This looks a bit odd. This uses an empty string instead of undefined to hide the title.