### PR TITLE
Alerting: Fixed rules migration to keep existing Grafana 8 alert rules.

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -474,7 +474,7 @@ func (u *upgradeNgAlerting) updateAlertConfigurations(sess *xorm.Session, migrat
 
 	// assigning all configurations to the first org because 0 does not usually point to any
 	migrator.Logger.Info("Assigning all existing records from alert_configuration to the first organization", "org", firstOrg)
-	_, err = sess.Cols("org_id").Update(&AlertConfiguration{OrgID: firstOrg})
+	_, err = sess.Cols("org_id").Where("org_id = 0").Update(&AlertConfiguration{OrgID: firstOrg})
 	if err != nil {
 		return 0, fmt.Errorf("failed to update org_id for all rows in the table alert_configuration: %w", err)
 	}
@@ -484,7 +484,7 @@ func (u *upgradeNgAlerting) updateAlertConfigurations(sess *xorm.Session, migrat
 		return firstOrg, nil
 	}
 	// if there are many organizations we cannot safely assume what organization an alert_configuration belongs to.
-	// Therefore, we apply the default configuration to all organizations. The previous version could
+	// Therefore, we apply the default configuration to all organizations. The previous version could be restored if needed.
 	migrator.Logger.Warn("Detected many organizations. The current alertmanager configuration will be replaced by the default one")
 	configs := make([]*AlertConfiguration, 0, len(orgs))
 	for _, org := range orgs {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Grafana hosted alerts have been available since version 8.0 as an opt-in feature. As soon as the user enables the feature flag and starts the server, all existing alert rules, as well as receivers and notification rules, are migrated. The migration is a one-way road in the sense that after migration Grafana does not update the old alerts (however, it keeps them in the database). It is worth mentioning that the user has an option to disable the feature flag. Disabling the feature flag will remove all data from the tables used by the Grafana hosted alerts and users will see old dashboard alerts.
In 8.2.0 we added proper separation of alertmanager configuration by organizations to Grafana hosted alerts. Prior to this version, the migration consolidated all notification channels of all alerts (in all organizations!) into a single configuration, which was visible to all organizations.
The migration that is introduced in `8.2.0-beta1` simply cleans up all data in tables that are used by Grafana hosted alerts and re-runs the migration from previous alerts with proper separation of configurations (receivers, silences, etc) by organizations.
This approach is not optimal for users that enabled the feature and actively use it because all new rules will be deleted.

Proposed changes will change the migration path for users who opted in the feature prior to 8.2. For users who upgrade from 8.1.5 and earlier versions, the migration will not remove existing alert rules and preserve notification settings unless the deployment has multiple organizations. 

__IMPORTANT__
In the case when the deployment has multiple organizations and the feature flag was enabled in the previous version (8.0.x - 8.1.x), the migration will assign existing notification policies, and contact points to the first organization and then apply the default alertmanager configuration to all organizations. This will effectively reset notification policies for *all* organizations.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/39361

**Special notes for your reviewer**:
The plan is to not preserve the silences file. However, in the latest commit, I update migration to move all known alertmanager files to the organization directory (only if in the case of a single organization installation). This should preserve the silences during migration.


## Testing 
I can see the following test cases:
| upgrade path | alert rules |  notification policies | silences file |
|-|-|-|-|
| 8.0.6 (single org) -> enable ff -> 8.2.0-PR  |  ✅ | ✅ | ✅  |
| 8.0.6 (single org) -> 8.2.0-PR -> enable ff |  ✅ | ✅ | ✅  |
| 8.0.6 (multi org) -> enable ff -> 8.2.0-PR |  ✅  | ❌  |❌ |
| 8.0.6 (muti org) -> 8.2.0-PR -> enable ff |  ✅ | ✅ | ✅  |

there can be variations of the start version.

### Manual testing

- [x] 8.0.6 (single org) -> enable ff -> 8.2.0-PR

<details><summary>Test steps</summary>

- install Grafana 8.0.6 (or other 8.1.x)
- create alerts in dashboards. Add some notification channels
- enable feature flag.
- add silences 
- stop Granfana, start PR. All rules and notification policies should be preserved.
</details>

- [x] 8.0.6 (single org) -> 8.2.0-PR with enabled ff

<details><summary>Test steps</summary>

- install Grafana 8.0.6 (or other 8.1.x)
- create alerts in dashboards. Add some notification channels
- Start PR with ff enabled.
</details>

- [x] 8.0.6 (single org) -> 8.2.0-PR -> enable ff

<details><summary>Test steps</summary>

- install Grafana 8.0.6 (or other 8.1.x)
- create alerts in dashboards. Add some notification channels
- Start PR. Nothing should be migrated
- Enabled FF and restart Grafana. Rules and alertmanager configurations should be migrated.
</details>

- [x] 8.0.6 (multi org) -> enable ff -> 8.2.0-PR
<details><summary>Test steps</summary>

- install Grafana 8.0.6 (or other 8.1.x)
- create alerts in dashboards. Add some notification channels.
- create an organization, add datasource, alerts and notification channels
- Enable feature flag.
- Create a silence rule
- Start PR with the flag enabled. All migrated rules should be kept. Silence rule should be removed. Notification policies as well as the contact points should be reset to default
</details>

- [x] 8.0.6 (muti org) -> 8.2.0-PR -> enable ff

<details><summary>Test steps</summary>

- install Grafana 8.0.6 (or other 8.1.x)
- create alerts in dashboards. Add some notification channels.
- create an organization, add datasource, alerts and notification channels
- Upgrade to PR with flag enabled. All migrated rules should be kept. Notification policies as well as the contact points should be kept.
</details>

# Release notice breaking change

Grafana v8.2.0-beta1 caused data loss for users having enabled `ngalert` in 8.0.x - 8.1.x and created alerts using the new alerting system. This issue is now fixed except if the deployment has multiple organizations and the feature flag was enabled in the previous version (8.0.x - 8.1.x). 

In this scenario (upgrade from 8.0.x - 8.1.x with multiple organizations and `ngalert` enabled to 8.2.0-beta2), the migration will assign existing notification policies and contact points to the first organization and then apply the default alertmanager configuration to all organizations. This will effectively reset notification policies for *all* organizations.