### PR TITLE
Variables: Panel no longer crash when using the adhoc variable in data links.

### DIFF
--- a/public/app/features/templating/formatRegistry.ts
+++ b/public/app/features/templating/formatRegistry.ts
@@ -5,6 +5,7 @@ import { formatVariableLabel } from '../variables/shared/formatVariable';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/state/types';
 import { variableAdapters } from '../variables/adapters';
 import { VariableModel as ExtendedVariableModel } from '../variables/types';
+import { isAdHoc } from '../variables/guard';
 
 export interface FormatOptions {
   value: any;
@@ -13,15 +14,36 @@ export interface FormatOptions {
 }
 
 export interface FormatRegistryItem extends RegistryItem {
+  canHandle(variable: VariableModel): boolean;
   formatter(options: FormatOptions, variable: VariableModel): string;
+}
+
+export enum FormatRegistryID {
+  lucene = 'lucene',
+  raw = 'raw',
+  regex = 'regex',
+  pipe = 'pipe',
+  distributed = 'distributed',
+  csv = 'csv',
+  html = 'html',
+  json = 'json',
+  percentencode = 'percentencode',
+  singlequote = 'singlequote',
+  doublequote = 'doublequote',
+  sqlstring = 'sqlstring',
+  date = 'date',
+  glob = 'glob',
+  text = 'text',
+  queryparam = 'queryparam',
 }
 
 export const formatRegistry = new Registry<FormatRegistryItem>(() => {
   const formats: FormatRegistryItem[] = [
     {
-      id: 'lucene',
+      id: FormatRegistryID.lucene,
       name: 'Lucene',
       description: 'Values are lucene escaped and multi-valued variables generate an OR expression',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (typeof value === 'string') {
           return luceneEscape(value);
@@ -39,15 +61,17 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'raw',
+      id: FormatRegistryID.raw,
       name: 'raw',
       description: 'Keep value as is',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => value,
     },
     {
-      id: 'regex',
+      id: FormatRegistryID.regex,
       name: 'Regex',
       description: 'Values are regex escaped and multi-valued variables generate a (<value>|<value>) expression',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (typeof value === 'string') {
           return kbn.regexEscape(value);
@@ -61,9 +85,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'pipe',
+      id: FormatRegistryID.pipe,
       name: 'Pipe',
       description: 'Values are separated by | character',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (typeof value === 'string') {
           return value;
@@ -72,9 +97,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'distributed',
+      id: FormatRegistryID.distributed,
       name: 'Distributed',
       description: 'Multiple values are formatted like variable=value',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }, variable) => {
         if (typeof value === 'string') {
           return value;
@@ -91,9 +117,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'csv',
+      id: FormatRegistryID.csv,
       name: 'Csv',
       description: 'Comma-separated values',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (isArray(value)) {
           return value.join(',');
@@ -102,9 +129,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'html',
+      id: FormatRegistryID.html,
       name: 'HTML',
       description: 'HTML escaping of values',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (isArray(value)) {
           return textUtil.escapeHtml(value.join(', '));
@@ -113,17 +141,19 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'json',
+      id: FormatRegistryID.json,
       name: 'JSON',
       description: 'JSON stringify valu',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         return JSON.stringify(value);
       },
     },
     {
-      id: 'percentencode',
+      id: FormatRegistryID.percentencode,
       name: 'Percent encode',
       description: 'Useful for URL escaping values',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // like glob, but url escaped
         if (isArray(value)) {
@@ -133,9 +163,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'singlequote',
+      id: FormatRegistryID.singlequote,
       name: 'Single quote',
       description: 'Single quoted values',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // escape single quotes with backslash
         const regExp = new RegExp(`'`, 'g');
@@ -146,9 +177,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'doublequote',
+      id: FormatRegistryID.doublequote,
       name: 'Double quote',
       description: 'Double quoted values',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // escape double quotes with backslash
         const regExp = new RegExp('"', 'g');
@@ -159,9 +191,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'sqlstring',
+      id: FormatRegistryID.sqlstring,
       name: 'SQL string',
       description: 'SQL string quoting and commas for use in IN statements and other scenarios',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // escape single quotes by pairing them
         const regExp = new RegExp(`'`, 'g');
@@ -172,9 +205,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'date',
+      id: FormatRegistryID.date,
       name: 'Date',
       description: 'Format date in different ways',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value, args }) => {
         const arg = args[0] ?? 'iso';
 
@@ -191,9 +225,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'glob',
+      id: FormatRegistryID.glob,
       name: 'Glob',
       description: 'Format multi-valued variables using glob syntax, example {value1,value2}',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (isArray(value) && value.length > 1) {
           return '{' + value.join(',') + '}';
@@ -202,9 +237,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'text',
+      id: FormatRegistryID.text,
       name: 'Text',
       description: 'Format variables in their text representation. Example in multi-variable scenario A + B + C.',
+      canHandle: (variable) => !isAdHoc(variable),
       formatter: (options, variable) => {
         if (typeof options.text === 'string') {
           return options.value === ALL_VARIABLE_VALUE ? ALL_VARIABLE_TEXT : options.text;
@@ -220,10 +256,11 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: 'queryparam',
+      id: FormatRegistryID.queryparam,
       name: 'Query parameter',
       description:
         'Format variables as URL parameters. Example in multi-variable scenario A + B + C => var-foo=A&var-foo=B&var-foo=C.',
+      canHandle: () => true,
       formatter: (options, variable) => {
         const { name, type } = variable;
         const adapter = variableAdapters.get(type);

--- a/public/app/features/templating/formatRegistry.ts
+++ b/public/app/features/templating/formatRegistry.ts
@@ -5,7 +5,6 @@ import { formatVariableLabel } from '../variables/shared/formatVariable';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/state/types';
 import { variableAdapters } from '../variables/adapters';
 import { VariableModel as ExtendedVariableModel } from '../variables/types';
-import { isAdHoc } from '../variables/guard';
 
 export interface FormatOptions {
   value: any;
@@ -14,7 +13,6 @@ export interface FormatOptions {
 }
 
 export interface FormatRegistryItem extends RegistryItem {
-  canHandle(variable: VariableModel): boolean;
   formatter(options: FormatOptions, variable: VariableModel): string;
 }
 
@@ -27,14 +25,14 @@ export enum FormatRegistryID {
   csv = 'csv',
   html = 'html',
   json = 'json',
-  percentencode = 'percentencode',
-  singlequote = 'singlequote',
-  doublequote = 'doublequote',
-  sqlstring = 'sqlstring',
+  percentEncode = 'percentencode',
+  singleQuote = 'singlequote',
+  doubleQuote = 'doublequote',
+  sqlString = 'sqlstring',
   date = 'date',
   glob = 'glob',
   text = 'text',
-  queryparam = 'queryparam',
+  queryParam = 'queryparam',
 }
 
 export const formatRegistry = new Registry<FormatRegistryItem>(() => {
@@ -43,7 +41,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.lucene,
       name: 'Lucene',
       description: 'Values are lucene escaped and multi-valued variables generate an OR expression',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (typeof value === 'string') {
           return luceneEscape(value);
@@ -64,14 +61,12 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.raw,
       name: 'raw',
       description: 'Keep value as is',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => value,
     },
     {
       id: FormatRegistryID.regex,
       name: 'Regex',
       description: 'Values are regex escaped and multi-valued variables generate a (<value>|<value>) expression',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (typeof value === 'string') {
           return kbn.regexEscape(value);
@@ -88,7 +83,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.pipe,
       name: 'Pipe',
       description: 'Values are separated by | character',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (typeof value === 'string') {
           return value;
@@ -100,7 +94,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.distributed,
       name: 'Distributed',
       description: 'Multiple values are formatted like variable=value',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }, variable) => {
         if (typeof value === 'string') {
           return value;
@@ -120,7 +113,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.csv,
       name: 'Csv',
       description: 'Comma-separated values',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (isArray(value)) {
           return value.join(',');
@@ -132,7 +124,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.html,
       name: 'HTML',
       description: 'HTML escaping of values',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (isArray(value)) {
           return textUtil.escapeHtml(value.join(', '));
@@ -144,16 +135,14 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.json,
       name: 'JSON',
       description: 'JSON stringify valu',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         return JSON.stringify(value);
       },
     },
     {
-      id: FormatRegistryID.percentencode,
+      id: FormatRegistryID.percentEncode,
       name: 'Percent encode',
       description: 'Useful for URL escaping values',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // like glob, but url escaped
         if (isArray(value)) {
@@ -163,10 +152,9 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: FormatRegistryID.singlequote,
+      id: FormatRegistryID.singleQuote,
       name: 'Single quote',
       description: 'Single quoted values',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // escape single quotes with backslash
         const regExp = new RegExp(`'`, 'g');
@@ -177,10 +165,9 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: FormatRegistryID.doublequote,
+      id: FormatRegistryID.doubleQuote,
       name: 'Double quote',
       description: 'Double quoted values',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // escape double quotes with backslash
         const regExp = new RegExp('"', 'g');
@@ -191,10 +178,9 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: FormatRegistryID.sqlstring,
+      id: FormatRegistryID.sqlString,
       name: 'SQL string',
       description: 'SQL string quoting and commas for use in IN statements and other scenarios',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         // escape single quotes by pairing them
         const regExp = new RegExp(`'`, 'g');
@@ -208,7 +194,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.date,
       name: 'Date',
       description: 'Format date in different ways',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value, args }) => {
         const arg = args[0] ?? 'iso';
 
@@ -228,7 +213,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.glob,
       name: 'Glob',
       description: 'Format multi-valued variables using glob syntax, example {value1,value2}',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: ({ value }) => {
         if (isArray(value) && value.length > 1) {
           return '{' + value.join(',') + '}';
@@ -240,7 +224,6 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       id: FormatRegistryID.text,
       name: 'Text',
       description: 'Format variables in their text representation. Example in multi-variable scenario A + B + C.',
-      canHandle: (variable) => !isAdHoc(variable),
       formatter: (options, variable) => {
         if (typeof options.text === 'string') {
           return options.value === ALL_VARIABLE_VALUE ? ALL_VARIABLE_TEXT : options.text;
@@ -256,11 +239,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
       },
     },
     {
-      id: FormatRegistryID.queryparam,
+      id: FormatRegistryID.queryParam,
       name: 'Query parameter',
       description:
         'Format variables as URL parameters. Example in multi-variable scenario A + B + C => var-foo=A&var-foo=B&var-foo=C.',
-      canHandle: () => true,
       formatter: (options, variable) => {
         const { name, type } = variable;
         const adapter = variableAdapters.get(type);

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -685,10 +685,10 @@ describe('templateSrv', () => {
       ]);
     });
 
-    it(`should not be handled by any registry items except for ${FormatRegistryID.queryparam}`, () => {
+    it(`should not be handled by any registry items except for queryparam`, () => {
       const registryItems = Object.values(FormatRegistryID);
       for (const registryItem of registryItems) {
-        if (registryItem === FormatRegistryID.queryparam) {
+        if (registryItem === FormatRegistryID.queryParam) {
           continue;
         }
 
@@ -701,7 +701,7 @@ describe('templateSrv', () => {
     });
   });
 
-  describe(`${FormatRegistryID.queryparam}`, () => {
+  describe('queryparam', () => {
     beforeEach(() => {
       _templateSrv = initTemplateSrv([
         {
@@ -737,33 +737,33 @@ describe('templateSrv', () => {
       ]);
     });
 
-    it(`query variable with single value with queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
-      const target = _templateSrv.replace(`\${single:${FormatRegistryID.queryparam}}`, {});
+    it('query variable with single value with queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace(`\${single:queryparam}`, {});
       expect(target).toBe('var-single=value1');
     });
 
-    it(`query variable with single value and queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
-      const target = _templateSrv.replace('${single}', {}, FormatRegistryID.queryparam);
+    it('query variable with single value and queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace('${single}', {}, 'queryparam');
       expect(target).toBe('var-single=value1');
     });
 
-    it(`query variable with multi value with queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
-      const target = _templateSrv.replace(`\${multi:${FormatRegistryID.queryparam}}`, {});
+    it('query variable with multi value with queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace(`\${multi:queryparam}`, {});
       expect(target).toBe('var-multi=value1&var-multi=value2');
     });
 
-    it(`query variable with multi value and queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
-      const target = _templateSrv.replace('${multi}', {}, FormatRegistryID.queryparam);
+    it('query variable with multi value and queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace('${multi}', {}, 'queryparam');
       expect(target).toBe('var-multi=value1&var-multi=value2');
     });
 
-    it(`query variable with adhoc value with queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
-      const target = _templateSrv.replace(`\${adhoc:${FormatRegistryID.queryparam}}`, {});
+    it('query variable with adhoc value with queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace(`\${adhoc:queryparam}`, {});
       expect(target).toBe('var-adhoc=alertstate%7C%3D%7Cfiring&var-adhoc=alertname%7C%3D%7CExampleAlertAlwaysFiring');
     });
 
-    it(`query variable with multi value and queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
-      const target = _templateSrv.replace('${adhoc}', {}, FormatRegistryID.queryparam);
+    it('query variable with multi value and queryparam format should return correct queryparam', () => {
+      const target = _templateSrv.replace('${adhoc}', {}, 'queryparam');
       expect(target).toBe('var-adhoc=alertstate%7C%3D%7Cfiring&var-adhoc=alertname%7C%3D%7CExampleAlertAlwaysFiring');
     });
   });

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -5,6 +5,7 @@ import { VariableAdapter, variableAdapters } from '../variables/adapters';
 import { createQueryVariableAdapter } from '../variables/query/adapter';
 import { createAdHocVariableAdapter } from '../variables/adhoc/adapter';
 import { VariableModel } from '../variables/types';
+import { FormatRegistryID } from './formatRegistry';
 
 variableAdapters.setInit(() => [
   (createQueryVariableAdapter() as unknown) as VariableAdapter<VariableModel>,
@@ -660,7 +661,47 @@ describe('templateSrv', () => {
     });
   });
 
-  describe('queryparam', () => {
+  describe('adhoc variables', () => {
+    beforeEach(() => {
+      _templateSrv = initTemplateSrv([
+        {
+          type: 'adhoc',
+          name: 'adhoc',
+          filters: [
+            {
+              condition: '',
+              key: 'alertstate',
+              operator: '=',
+              value: 'firing',
+            },
+            {
+              condition: '',
+              key: 'alertname',
+              operator: '=',
+              value: 'ExampleAlertAlwaysFiring',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it(`should not be handled by any registry items except for ${FormatRegistryID.queryparam}`, () => {
+      const registryItems = Object.values(FormatRegistryID);
+      for (const registryItem of registryItems) {
+        if (registryItem === FormatRegistryID.queryparam) {
+          continue;
+        }
+
+        const firstTarget = _templateSrv.replace(`\${adhoc:${registryItem}}`, {});
+        expect(firstTarget).toBe('');
+
+        const secondTarget = _templateSrv.replace('${adhoc}', {}, registryItem);
+        expect(secondTarget).toBe('');
+      }
+    });
+  });
+
+  describe(`${FormatRegistryID.queryparam}`, () => {
     beforeEach(() => {
       _templateSrv = initTemplateSrv([
         {
@@ -675,27 +716,55 @@ describe('templateSrv', () => {
           current: { value: ['value1', 'value2'] },
           options: [{ value: 'value1' }, { value: 'value2' }],
         },
+        {
+          type: 'adhoc',
+          name: 'adhoc',
+          filters: [
+            {
+              condition: '',
+              key: 'alertstate',
+              operator: '=',
+              value: 'firing',
+            },
+            {
+              condition: '',
+              key: 'alertname',
+              operator: '=',
+              value: 'ExampleAlertAlwaysFiring',
+            },
+          ],
+        },
       ]);
     });
 
-    it('query variable with single value with queryparam format should return correct queryparam', () => {
-      const target = _templateSrv.replace('${single:queryparam}', {});
+    it(`query variable with single value with queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
+      const target = _templateSrv.replace(`\${single:${FormatRegistryID.queryparam}}`, {});
       expect(target).toBe('var-single=value1');
     });
 
-    it('query variable with single value and queryparam format should return correct queryparam', () => {
-      const target = _templateSrv.replace('${single}', {}, 'queryparam');
+    it(`query variable with single value and queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
+      const target = _templateSrv.replace('${single}', {}, FormatRegistryID.queryparam);
       expect(target).toBe('var-single=value1');
     });
 
-    it('query variable with multi value with queryparam format should return correct queryparam', () => {
-      const target = _templateSrv.replace('${multi:queryparam}', {});
+    it(`query variable with multi value with queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
+      const target = _templateSrv.replace(`\${multi:${FormatRegistryID.queryparam}}`, {});
       expect(target).toBe('var-multi=value1&var-multi=value2');
     });
 
-    it('query variable with multi value and queryparam format should return correct queryparam', () => {
-      const target = _templateSrv.replace('${multi}', {}, 'queryparam');
+    it(`query variable with multi value and queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
+      const target = _templateSrv.replace('${multi}', {}, FormatRegistryID.queryparam);
       expect(target).toBe('var-multi=value1&var-multi=value2');
+    });
+
+    it(`query variable with adhoc value with queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
+      const target = _templateSrv.replace(`\${adhoc:${FormatRegistryID.queryparam}}`, {});
+      expect(target).toBe('var-adhoc=alertstate%7C%3D%7Cfiring&var-adhoc=alertname%7C%3D%7CExampleAlertAlwaysFiring');
+    });
+
+    it(`query variable with multi value and queryparam format should return correct ${FormatRegistryID.queryparam}`, () => {
+      const target = _templateSrv.replace('${adhoc}', {}, FormatRegistryID.queryparam);
+      expect(target).toBe('var-adhoc=alertstate%7C%3D%7Cfiring&var-adhoc=alertname%7C%3D%7CExampleAlertAlwaysFiring');
     });
   });
 });

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -278,7 +278,7 @@ export class TemplateSrv implements BaseTemplateSrv {
         return match;
       }
 
-      if (variable.type === 'adhoc') {
+      if (isAdHoc(variable)) {
         const value = variable.filters;
         const text = variable.id;
 

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -7,6 +7,7 @@ import { VariableModel } from '../variables/types';
 import { setTemplateSrv, TemplateSrv as BaseTemplateSrv } from '@grafana/runtime';
 import { FormatOptions, formatRegistry, FormatRegistryID } from './formatRegistry';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/state/types';
+import { safeStringifyValue } from '../../core/utils/explore';
 
 interface FieldAccessorCache {
   [key: string]: (obj: any) => any;
@@ -115,7 +116,7 @@ export class TemplateSrv implements BaseTemplateSrv {
       return '';
     }
 
-    if (isAdHoc(variable) && format !== FormatRegistryID.queryparam) {
+    if (isAdHoc(variable) && format !== FormatRegistryID.queryParam) {
       return '';
     }
 
@@ -146,10 +147,6 @@ export class TemplateSrv implements BaseTemplateSrv {
     if (!formatItem) {
       console.error(`Variable format ${format} not found. Using glob format as fallback.`);
       formatItem = formatRegistry.get(FormatRegistryID.glob);
-    }
-
-    if (!formatItem.canHandle(variable)) {
-      return '';
     }
 
     const options: FormatOptions = { value, args, text: text ?? value };
@@ -279,7 +276,7 @@ export class TemplateSrv implements BaseTemplateSrv {
       }
 
       if (isAdHoc(variable)) {
-        const value = variable.filters;
+        const value = safeStringifyValue(variable.filters);
         const text = variable.id;
 
         return this.formatValue(value, fmt, variable, text);
@@ -297,7 +294,7 @@ export class TemplateSrv implements BaseTemplateSrv {
         value = this.getAllValue(variable);
         text = ALL_VARIABLE_TEXT;
         // skip formatting of custom all values
-        if (variable.allValue && fmt !== FormatRegistryID.text && fmt !== FormatRegistryID.queryparam) {
+        if (variable.allValue && fmt !== FormatRegistryID.text && fmt !== FormatRegistryID.queryParam) {
           return this.replace(value);
         }
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Not sure about the change in TemplatSrv, it's one of those parts of the code where I haven't understood all the scenarios. But I don't think we've ever supported `adhoc` variables in TemplateSrv so I added some logic to handle that?

Maybe this PR could be simplified so we don't need the `canHandle` function in the formatRegistry? I added a `FormatRegistryID` enum to get rid of some `magic strings` sprinkled throughout the code.

**Which issue(s) this PR fixes**:
Fixes #39514

**Special notes for your reviewer**:

