### PR TITLE
Alerting: Cleanups alertmanager namespace from key-value store when disabling Grafana 8 alerts.

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -19,6 +19,8 @@ const DASHBOARD_FOLDER = "Migrated %s"
 // during alert migration cleanup.
 const FOLDER_CREATED_BY = -8
 
+const KV_NAMESPACE = "alertmanager"
+
 var migTitle = "move dashboard alerts to unified alerting"
 
 var rmMigTitle = "remove unified alerting data"
@@ -413,6 +415,18 @@ func (m *rmMigration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	_, err = sess.Exec("delete from alert_instance")
 	if err != nil {
 		return err
+	}
+
+	exists, err := sess.IsTableExist("kv_store")
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		_, err = sess.Exec("delete from kv_store where namespace = ?", KV_NAMESPACE)
+		if err != nil {
+			return err
+		}
 	}
 
 	files, err := getSilenceFileNamesForAllOrgs(mg)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Since #39005 we persist notifications and silences in the database (under kvstore `alertmanager` namespace). This PR cleanups this namespace when deleting Grafana 8 alerting data during the backward migration (when Grafana 8 alerts are disabled).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
I have tested the migration (forward and backward) against all SQL backends.