### PR TITLE
Plugin Catalog: Use routing for PluginDetails Tabs

### DIFF
--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -1,25 +1,26 @@
 import React from 'react';
 import { css, cx } from '@emotion/css';
 
-import { AppPlugin, GrafanaTheme2 } from '@grafana/data';
+import { AppPlugin, GrafanaTheme2, UrlQueryMap } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-import { CatalogPlugin, PluginTabLabels } from '../types';
+import { CatalogPlugin, PluginTabIds } from '../types';
 import { VersionList } from '../components/VersionList';
 import { usePluginConfig } from '../hooks/usePluginConfig';
 import { AppConfigCtrlWrapper } from '../../wrappers/AppConfigWrapper';
 import { PluginDashboards } from '../../PluginDashboards';
 
 type Props = {
-  tab: { label: string };
   plugin: CatalogPlugin;
+  queryParams: UrlQueryMap;
 };
 
-export function PluginDetailsBody({ tab, plugin }: Props): JSX.Element | null {
+export function PluginDetailsBody({ plugin, queryParams }: Props): JSX.Element | null {
   const styles = useStyles2(getStyles);
   const { value: pluginConfig } = usePluginConfig(plugin);
+  const pageId = queryParams.page;
 
-  if (tab?.label === PluginTabLabels.OVERVIEW) {
+  if (pageId === PluginTabIds.OVERVIEW) {
     return (
       <div
         className={cx(styles.readme, styles.container)}
@@ -30,7 +31,7 @@ export function PluginDetailsBody({ tab, plugin }: Props): JSX.Element | null {
     );
   }
 
-  if (tab?.label === PluginTabLabels.VERSIONS) {
+  if (pageId === PluginTabIds.VERSIONS) {
     return (
       <div className={styles.container}>
         <VersionList versions={plugin.details?.versions} />
@@ -38,7 +39,7 @@ export function PluginDetailsBody({ tab, plugin }: Props): JSX.Element | null {
     );
   }
 
-  if (tab?.label === PluginTabLabels.CONFIG && pluginConfig?.angularConfigCtrl) {
+  if (pageId === PluginTabIds.CONFIG && pluginConfig?.angularConfigCtrl) {
     return (
       <div className={styles.container}>
         <AppConfigCtrlWrapper app={pluginConfig as AppPlugin} />
@@ -48,18 +49,17 @@ export function PluginDetailsBody({ tab, plugin }: Props): JSX.Element | null {
 
   if (pluginConfig?.configPages) {
     for (const configPage of pluginConfig.configPages) {
-      if (tab?.label === configPage.title) {
+      if (pageId === configPage.id) {
         return (
           <div className={styles.container}>
-            {/* TODO: we should pass the query params down */}
-            <configPage.body plugin={pluginConfig} query={{}} />
+            <configPage.body plugin={pluginConfig} query={queryParams} />
           </div>
         );
       }
     }
   }
 
-  if (tab?.label === PluginTabLabels.DASHBOARDS && pluginConfig) {
+  if (pageId === PluginTabIds.DASHBOARDS && pluginConfig) {
     return (
       <div className={styles.container}>
         <PluginDashboards plugin={pluginConfig?.meta} />

--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -15,7 +15,7 @@ type Props = {
   queryParams: UrlQueryMap;
 };
 
-export function PluginDetailsBody({ plugin, queryParams }: Props): JSX.Element | null {
+export function PluginDetailsBody({ plugin, queryParams }: Props): JSX.Element {
   const styles = useStyles2(getStyles);
   const { value: pluginConfig } = usePluginConfig(plugin);
   const pageId = queryParams.page;
@@ -67,7 +67,11 @@ export function PluginDetailsBody({ plugin, queryParams }: Props): JSX.Element |
     );
   }
 
-  return null;
+  return (
+    <div className={styles.container}>
+      <p>Page not found.</p>
+    </div>
+  );
 }
 
 export const getStyles = (theme: GrafanaTheme2) => ({

--- a/public/app/features/plugins/admin/components/PluginDetailsHeaderDependencies.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeaderDependencies.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Icon } from '@grafana/ui';
-import { CatalogPlugin, IconName } from '../types';
+import { CatalogPlugin, PluginIconName } from '../types';
 
 type Props = {
   plugin: CatalogPlugin;
@@ -37,7 +37,7 @@ export function PluginDetailsHeaderDependencies({ plugin, className }: Props): R
           {pluginDependencies.map((p) => {
             return (
               <span key={p.name}>
-                <Icon name={IconName[p.type]} className={styles.icon} />
+                <Icon name={PluginIconName[p.type]} className={styles.icon} />
                 {p.name} {p.version}
               </span>
             );

--- a/public/app/features/plugins/admin/components/PluginListCard.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListCard.test.tsx
@@ -33,7 +33,7 @@ describe('PluginCard', () => {
   it('renders a card with link, image, name, orgName and badges', () => {
     render(<PluginListCard plugin={plugin} pathName="/plugins" />);
 
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/plugins/test-plugin');
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/plugins/test-plugin?page=overview');
 
     const logo = screen.getByRole('img');
     expect(logo).toHaveAttribute('src', plugin.info.logos.small);

--- a/public/app/features/plugins/admin/components/PluginListCard.tsx
+++ b/public/app/features/plugins/admin/components/PluginListCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { Icon, useStyles2, CardContainer, HorizontalGroup, VerticalGroup, Tooltip } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
-import { CatalogPlugin, IconName } from '../types';
+import { CatalogPlugin, IconName, PluginTabIds } from '../types';
 import { PluginLogo } from './PluginLogo';
 import { PluginListBadges } from './PluginListBadges';
 
@@ -17,7 +17,7 @@ export function PluginListCard({ plugin, pathName }: PluginListCardProps) {
   const styles = useStyles2(getStyles);
 
   return (
-    <CardContainer href={`${pathName}/${plugin.id}`} className={styles.cardContainer}>
+    <CardContainer href={`${pathName}/${plugin.id}?page=${PluginTabIds.OVERVIEW}`} className={styles.cardContainer}>
       <VerticalGroup spacing="md">
         <div className={styles.headerWrap}>
           <PluginLogo

--- a/public/app/features/plugins/admin/components/PluginListCard.tsx
+++ b/public/app/features/plugins/admin/components/PluginListCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/css';
 import { Icon, useStyles2, CardContainer, HorizontalGroup, VerticalGroup, Tooltip } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
-import { CatalogPlugin, IconName, PluginTabIds } from '../types';
+import { CatalogPlugin, PluginIconName, PluginTabIds } from '../types';
 import { PluginLogo } from './PluginLogo';
 import { PluginListBadges } from './PluginListBadges';
 
@@ -29,7 +29,7 @@ export function PluginListCard({ plugin, pathName }: PluginListCardProps) {
           <h2 className={styles.name}>{plugin.name}</h2>
           {plugin.type && (
             <div className={styles.icon} data-testid={`${plugin.type} plugin icon`}>
-              <Icon name={IconName[plugin.type]} />
+              <Icon name={PluginIconName[plugin.type]} />
             </div>
           )}
         </div>

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { PluginIncludeType, PluginType } from '@grafana/data';
-import { CatalogPlugin, PluginDetailsTab } from '../types';
+import { CatalogPlugin, PluginDetailsTab, PluginTabIds } from '../types';
 import { isOrgAdmin } from '../helpers';
 import { usePluginConfig } from '../hooks/usePluginConfig';
+import { useLocation } from 'react-router-dom';
 
 type ReturnType = {
   error: Error | undefined;
@@ -12,6 +13,7 @@ type ReturnType = {
 
 export const usePluginDetailsTabs = (plugin?: CatalogPlugin, defaultTabs: PluginDetailsTab[] = []): ReturnType => {
   const { loading, error, value: pluginConfig } = usePluginConfig(plugin);
+  const { pathname } = useLocation();
   const tabs = useMemo(() => {
     const canConfigurePlugins = isOrgAdmin();
     const tabs: PluginDetailsTab[] = [...defaultTabs];
@@ -26,6 +28,8 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, defaultTabs: Plugin
         if (pluginConfig.angularConfigCtrl) {
           tabs.push({
             label: 'Config',
+            id: PluginTabIds.CONFIG,
+            href: `${pathname}?page=${PluginTabIds.CONFIG}`,
           });
         }
 
@@ -33,6 +37,8 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, defaultTabs: Plugin
           for (const page of pluginConfig.configPages) {
             tabs.push({
               label: page.title,
+              id: page.id,
+              href: `${pathname}?page=${page.id}`,
             });
           }
         }
@@ -40,13 +46,15 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, defaultTabs: Plugin
         if (pluginConfig.meta.includes?.find((include) => include.type === PluginIncludeType.dashboard)) {
           tabs.push({
             label: 'Dashboards',
+            id: PluginTabIds.DASHBOARDS,
+            href: `${pathname}?page=${PluginTabIds.DASHBOARDS}`,
           });
         }
       }
     }
 
     return tabs;
-  }, [pluginConfig, defaultTabs]);
+  }, [pluginConfig, defaultTabs, pathname]);
 
   return {
     error,

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
@@ -28,6 +28,7 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, defaultTabs: Plugin
         if (pluginConfig.angularConfigCtrl) {
           tabs.push({
             label: 'Config',
+            icon: 'cog',
             id: PluginTabIds.CONFIG,
             href: `${pathname}?page=${PluginTabIds.CONFIG}`,
           });
@@ -37,6 +38,7 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, defaultTabs: Plugin
           for (const page of pluginConfig.configPages) {
             tabs.push({
               label: page.title,
+              icon: page.icon,
               id: page.id,
               href: `${pathname}?page=${page.id}`,
             });
@@ -46,6 +48,7 @@ export const usePluginDetailsTabs = (plugin?: CatalogPlugin, defaultTabs: Plugin
         if (pluginConfig.meta.includes?.find((include) => include.type === PluginIncludeType.dashboard)) {
           tabs.push({
             label: 'Dashboards',
+            icon: 'apps',
             id: PluginTabIds.DASHBOARDS,
             href: `${pathname}?page=${PluginTabIds.DASHBOARDS}`,
           });

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { PluginIncludeType, PluginType } from '@grafana/data';
 import { CatalogPlugin, PluginDetailsTab, PluginTabIds } from '../types';
 import { isOrgAdmin } from '../helpers';
 import { usePluginConfig } from '../hooks/usePluginConfig';
-import { useLocation } from 'react-router-dom';
 
 type ReturnType = {
   error: Error | undefined;

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -12,7 +12,7 @@ import { PluginDetailsBody } from '../components/PluginDetailsBody';
 import { Page as PluginPage } from '../components/Page';
 import { Loader } from '../components/Loader';
 import { PluginTabLabels, PluginTabIds, PluginDetailsTab } from '../types';
-import { useGetSingle, useFetchStatus } from '../state/hooks';
+import { useGetSingle, useFetchStatus, useFetchDetailsStatus } from '../state/hooks';
 import { usePluginDetailsTabs } from '../hooks/usePluginDetailsTabs';
 import { AppNotificationSeverity } from 'app/types';
 import { PluginDetailsDisabledError } from '../components/PluginDetailsDisabledError';
@@ -33,7 +33,8 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
   const [activeTabIndex, setActiveTabIndex] = useState(Object.values(PluginTabIds).indexOf(pageId));
   const plugin = useGetSingle(pluginId); // fetches the localplugin settings
   const { tabs } = usePluginDetailsTabs(plugin, defaultTabs);
-  const { isLoading } = useFetchStatus();
+  const { isLoading: isFetchLoading } = useFetchStatus();
+  const { isLoading: isFetchDetailsLoading } = useFetchDetailsStatus();
   const styles = useStyles2(getStyles);
 
   // If an app plugin is uninstalled we need to reset the active tab when the config / dashboards tabs are removed.
@@ -44,7 +45,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
     }
   }, [url, activeTabIndex, tabs]);
 
-  if (isLoading) {
+  if (isFetchLoading || isFetchDetailsLoading) {
     return (
       <Page>
         <Loader />

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, TabsBar, TabContent, Tab, Alert } from '@grafana/ui';
+import { useStyles2, TabsBar, TabContent, Tab, Alert, IconName } from '@grafana/ui';
 import { locationService } from '@grafana/runtime';
 import { Layout } from '@grafana/ui/src/components/Layout/Layout';
 import { Page } from 'app/core/components/Page/Page';
@@ -26,9 +26,19 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
   } = match;
   const pageId = (queryParams.page as PluginTabIds) || PluginTabIds.OVERVIEW;
   const parentUrl = url.substring(0, url.lastIndexOf('/'));
-  const defaultTabs = [
-    { label: PluginTabLabels.OVERVIEW, id: PluginTabIds.OVERVIEW, href: `${url}?page=${PluginTabIds.OVERVIEW}` },
-    { label: PluginTabLabels.VERSIONS, id: PluginTabIds.VERSIONS, href: `${url}?page=${PluginTabIds.VERSIONS}` },
+  const defaultTabs: PluginDetailsTab[] = [
+    {
+      label: PluginTabLabels.OVERVIEW,
+      icon: 'file-alt',
+      id: PluginTabIds.OVERVIEW,
+      href: `${url}?page=${PluginTabIds.OVERVIEW}`,
+    },
+    {
+      label: PluginTabLabels.VERSIONS,
+      icon: 'history',
+      id: PluginTabIds.VERSIONS,
+      href: `${url}?page=${PluginTabIds.VERSIONS}`,
+    },
   ];
   const [activeTabIndex, setActiveTabIndex] = useState(Object.values(PluginTabIds).indexOf(pageId));
   const plugin = useGetSingle(pluginId); // fetches the localplugin settings
@@ -67,7 +77,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
   return (
     <Page>
       <PluginPage>
-        <PluginDetailsHeader currentUrl={match.url} parentUrl={parentUrl} plugin={plugin} />
+        <PluginDetailsHeader currentUrl={url} parentUrl={parentUrl} plugin={plugin} />
 
         {/* Tab navigation */}
         <TabsBar>
@@ -77,6 +87,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
                 key={tab.label}
                 label={tab.label}
                 href={tab.href}
+                icon={tab.icon as IconName}
                 active={tab.id === pageId}
                 onChangeTab={() => setActiveTabIndex(idx)}
               />

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -77,7 +77,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
   return (
     <Page>
       <PluginPage>
-        <PluginDetailsHeader currentUrl={url} parentUrl={parentUrl} plugin={plugin} />
+        <PluginDetailsHeader currentUrl={`${url}?page=${pageId}`} parentUrl={parentUrl} plugin={plugin} />
 
         {/* Tab navigation */}
         <TabsBar>

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -70,6 +70,13 @@ export const useFetchStatus = () => {
   return { isLoading, error };
 };
 
+export const useFetchDetailsStatus = () => {
+  const isLoading = useSelector(selectIsRequestPending(fetchDetails.typePrefix));
+  const error = useSelector(selectRequestError(fetchDetails.typePrefix));
+
+  return { isLoading, error };
+};
+
 export const useInstallStatus = () => {
   const isInstalling = useSelector(selectIsRequestPending(install.typePrefix));
   const error = useSelector(selectRequestError(install.typePrefix));

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -203,6 +203,13 @@ export enum PluginTabLabels {
   DASHBOARDS = 'Dashboards',
 }
 
+export enum PluginTabIds {
+  OVERVIEW = 'overview',
+  VERSIONS = 'version-history',
+  CONFIG = 'config',
+  DASHBOARDS = 'dashboards',
+}
+
 export enum RequestStatus {
   Pending = 'Pending',
   Fulfilled = 'Fulfilled',
@@ -219,6 +226,8 @@ export type RequestInfo = {
 
 export type PluginDetailsTab = {
   label: PluginTabLabels | string;
+  id: PluginTabIds | string;
+  href?: string;
 };
 
 // TODO<remove `PluginsState &` when the "plugin_admin_enabled" feature flag is removed>

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -6,6 +6,7 @@ import {
   PluginDependencies,
   PluginErrorCode,
 } from '@grafana/data';
+import { IconName } from '@grafana/ui';
 import { StoreState, PluginsState } from 'app/types';
 
 export type PluginTypeCode = 'app' | 'panel' | 'datasource';
@@ -19,7 +20,7 @@ export enum PluginAdminRoutes {
   DetailsAdmin = 'plugins-details-admin',
 }
 
-export enum IconName {
+export enum PluginIconName {
   app = 'apps',
   datasource = 'database',
   panel = 'credit-card',
@@ -226,6 +227,7 @@ export type RequestInfo = {
 
 export type PluginDetailsTab = {
   label: PluginTabLabels | string;
+  icon?: IconName | string;
   id: PluginTabIds | string;
   href?: string;
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The PluginsList feature allows a dev to pass query params to custom config pages. This PR introduces this functionality to the Plugins Catalog for feature parity along with the following:

- [x] add href and id to the PluginDetailsTab so the router drives the tabs
- [x] pass query params to the custom config pages
- [x] add icons to the PluginDetailsTab
- [x] fix a re-render of the PluginDetails page caused by race condition (readme would appear after first render)
- [x] update links  to use `page` query param


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #39423

**Special notes for your reviewer**:

