### PR TITLE
Chore: Fix grafana live stats reset when sending usage stats

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -113,6 +113,8 @@ func (usm *usageStatsMock) ShouldBeReported(_ string) bool {
 	return true
 }
 
+func (usm *usageStatsMock) RegisterSendReportCallback(_ usagestats.SendReportCallbackFunc) {}
+
 func newTestLive(t *testing.T) *live.GrafanaLive {
 	cfg := &setting.Cfg{AppURL: "http://localhost:3000/"}
 	gLive, err := live.ProvideService(nil, cfg, routing.NewRouteRegister(), nil, nil, nil, nil, sqlstore.InitTestDB(t), &usageStatsMock{t: t})

--- a/pkg/infra/usagestats/service.go
+++ b/pkg/infra/usagestats/service.go
@@ -17,8 +17,11 @@ type Report struct {
 
 type MetricsFunc func() (map[string]interface{}, error)
 
+type SendReportCallbackFunc func()
+
 type Service interface {
 	GetUsageReport(context.Context) (Report, error)
 	RegisterMetricsFunc(MetricsFunc)
+	RegisterSendReportCallback(SendReportCallbackFunc)
 	ShouldBeReported(string) bool
 }

--- a/pkg/infra/usagestats/service/service.go
+++ b/pkg/infra/usagestats/service/service.go
@@ -29,6 +29,7 @@ type UsageStats struct {
 	externalMetrics          []usagestats.MetricsFunc
 	concurrentUserStatsCache memoConcurrentUserStats
 	startTime                time.Time
+	sendReportCallbacks      []usagestats.SendReportCallbackFunc
 }
 
 func ProvideService(cfg *setting.Cfg, bus bus.Bus, sqlStore *sqlstore.SQLStore, pluginManager plugins.Manager,
@@ -91,6 +92,10 @@ func (uss *UsageStats) Run(ctx context.Context) error {
 				nextSendInterval = sendInterval
 				sendReportTicker.Reset(nextSendInterval)
 			}
+
+			for _, callback := range uss.sendReportCallbacks {
+				callback()
+			}
 		case <-updateStatsTicker.C:
 			uss.updateTotalStats()
 		case <-ctx.Done():
@@ -137,4 +142,8 @@ FROM (select count(1) as tokens from user_auth_token group by user_id) uat;`
 
 	uss.concurrentUserStatsCache.memoized = time.Now()
 	return uss.concurrentUserStatsCache.stats, nil
+}
+
+func (uss *UsageStats) RegisterSendReportCallback(c usagestats.SendReportCallbackFunc) {
+	uss.sendReportCallbacks = append(uss.sendReportCallbacks, c)
 }

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -71,6 +71,8 @@ func (usm *usageStatsMock) ShouldBeReported(_ string) bool {
 	return true
 }
 
+func (usm *usageStatsMock) RegisterSendReportCallback(_ usagestats.SendReportCallbackFunc) {}
+
 type evaluatingPermissionsTestCase struct {
 	desc       string
 	user       userTestCase

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -67,6 +67,8 @@ func (usm *usageStatsMock) ShouldBeReported(_ string) bool {
 	return true
 }
 
+func (usm *usageStatsMock) RegisterSendReportCallback(_ usagestats.SendReportCallbackFunc) {}
+
 func TestEngineProcessJob(t *testing.T) {
 	Convey("Alerting engine job processing", t, func() {
 		bus := bus.New()

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -1031,7 +1031,13 @@ func (g *GrafanaLive) sampleLiveStats() {
 	}
 }
 
+func (g *GrafanaLive) resetLiveStats() {
+	g.usageStats = usageStats{}
+}
+
 func (g *GrafanaLive) registerUsageMetrics() {
+	g.usageStatsService.RegisterSendReportCallback(g.resetLiveStats)
+
 	g.usageStatsService.RegisterMetricsFunc(func() (map[string]interface{}, error) {
 		liveUsersAvg := 0
 		liveClientsAvg := 0
@@ -1050,8 +1056,6 @@ func (g *GrafanaLive) registerUsageMetrics() {
 			"stats.live_clients_min.count": g.usageStats.numClientsMin,
 			"stats.live_clients_avg.count": liveClientsAvg,
 		}
-
-		g.usageStats = usageStats{}
 
 		return metrics, nil
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds `RegisterSendReportCallback` method to UsageStatsService to solve the issue introduced in this refactoring PR https://github.com/grafana/grafana/pull/39512#issuecomment-925079394

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

