### PR TITLE
AccessControl: Add FGAC to orgs endpoints

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -200,8 +200,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// org information available to all users.
 		apiRoute.Group("/org", func(orgRoute routing.RouteRegister) {
-			orgRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead, ScopeOrgsCurrentID)), routing.Wrap(GetCurrentOrg))
-			orgRoute.Get("/quotas", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead, ScopeOrgsCurrentID)), routing.Wrap(hs.GetCurrentOrgQuotas))
+			orgRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead, ScopeOrgCurrentID)), routing.Wrap(GetCurrentOrg))
+			orgRoute.Get("/quotas", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead, ScopeOrgCurrentID)), routing.Wrap(hs.GetCurrentOrgQuotas))
 		})
 
 		// current org
@@ -234,12 +234,12 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Post("/orgs", quota("org"), bind(models.CreateOrgCommand{}), routing.Wrap(CreateOrg))
 
 		// search all orgs
-		apiRoute.Get("/orgs", reqGrafanaAdmin, routing.Wrap(SearchOrgs))
+		apiRoute.Get("/orgs", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsAll)), routing.Wrap(SearchOrgs))
 
 		// orgs (admin routes)
 		apiRoute.Group("/orgs/:orgId", func(orgsRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
-			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsID)), routing.Wrap(GetOrgByID))
+			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgID)), routing.Wrap(GetOrgByID))
 			orgsRoute.Put("/", reqGrafanaAdmin, bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
 			orgsRoute.Put("/address", reqGrafanaAdmin, bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
 			orgsRoute.Delete("/", reqGrafanaAdmin, routing.Wrap(DeleteOrgByID))
@@ -247,7 +247,7 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Post("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
 			orgsRoute.Patch("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))
 			orgsRoute.Delete("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUser))
-			orgsRoute.Get("/quotas", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsID)), routing.Wrap(hs.GetOrgQuotas))
+			orgsRoute.Get("/quotas", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgID)), routing.Wrap(hs.GetOrgQuotas))
 			orgsRoute.Put("/quotas/:target", reqGrafanaAdmin, bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(UpdateOrgQuota))
 		})
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -200,8 +200,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// org information available to all users.
 		apiRoute.Group("/org", func(orgRoute routing.RouteRegister) {
-			orgRoute.Get("/", routing.Wrap(GetOrgCurrent))
-			orgRoute.Get("/quotas", routing.Wrap(GetOrgQuotas))
+			orgRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead, ScopeOrgsCurrentID)), routing.Wrap(GetCurrentOrg))
+			orgRoute.Get("/quotas", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead, ScopeOrgsCurrentID)), routing.Wrap(hs.GetCurrentOrgQuotas))
 		})
 
 		// current org
@@ -239,7 +239,7 @@ func (hs *HTTPServer) registerRoutes() {
 		// orgs (admin routes)
 		apiRoute.Group("/orgs/:orgId", func(orgsRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
-			orgsRoute.Get("/", reqGrafanaAdmin, routing.Wrap(GetOrgByID))
+			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsID)), routing.Wrap(GetOrgByID))
 			orgsRoute.Put("/", reqGrafanaAdmin, bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
 			orgsRoute.Put("/address", reqGrafanaAdmin, bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
 			orgsRoute.Delete("/", reqGrafanaAdmin, routing.Wrap(DeleteOrgByID))
@@ -247,7 +247,7 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Post("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
 			orgsRoute.Patch("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))
 			orgsRoute.Delete("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUser))
-			orgsRoute.Get("/quotas", reqGrafanaAdmin, routing.Wrap(GetOrgQuotas))
+			orgsRoute.Get("/quotas", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsID)), routing.Wrap(hs.GetOrgQuotas))
 			orgsRoute.Put("/quotas/:target", reqGrafanaAdmin, bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(UpdateOrgQuota))
 		})
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -207,8 +207,8 @@ func (hs *HTTPServer) registerRoutes() {
 		// current org
 		apiRoute.Group("/org", func(orgRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
-			orgRoute.Put("/", reqOrgAdmin, bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrgCurrent))
-			orgRoute.Put("/address", reqOrgAdmin, bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddressCurrent))
+			orgRoute.Put("/", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgCurrentID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateCurrentOrg))
+			orgRoute.Put("/address", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgCurrentID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateCurrentOrgAddress))
 			orgRoute.Get("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsersForCurrentOrg))
 			orgRoute.Get("/users/search", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.SearchOrgUsersWithPaging))
 			orgRoute.Post("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), quota("user"), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUserToCurrentOrg))
@@ -222,7 +222,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 			// prefs
 			orgRoute.Get("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesRead, ScopeOrgCurrentID)), routing.Wrap(GetOrgPreferences))
-			orgRoute.Put("/preferences", reqOrgAdmin, bind(dtos.UpdatePrefsCmd{}), routing.Wrap(UpdateOrgPreferences))
+			orgRoute.Put("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesWrite, ScopeOrgCurrentID)), bind(dtos.UpdatePrefsCmd{}), routing.Wrap(UpdateOrgPreferences))
 		})
 
 		// current org without requirement of user to be org admin
@@ -240,15 +240,15 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Group("/orgs/:orgId", func(orgsRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
 			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgID)), routing.Wrap(GetOrgByID))
-			orgsRoute.Put("/", reqGrafanaAdmin, bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
-			orgsRoute.Put("/address", reqGrafanaAdmin, bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
+			orgsRoute.Put("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
+			orgsRoute.Put("/address", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
 			orgsRoute.Delete("/", reqGrafanaAdmin, routing.Wrap(DeleteOrgByID))
 			orgsRoute.Get("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsers))
 			orgsRoute.Post("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
 			orgsRoute.Patch("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))
 			orgsRoute.Delete("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUser))
 			orgsRoute.Get("/quotas", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsQuotasRead, ScopeOrgID)), routing.Wrap(hs.GetOrgQuotas))
-			orgsRoute.Put("/quotas/:target", reqGrafanaAdmin, bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(UpdateOrgQuota))
+			orgsRoute.Put("/quotas/:target", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsQuotasWrite, ScopeOrgID)), bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(hs.UpdateOrgQuota))
 		})
 
 		// orgs (admin routes)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -231,7 +231,7 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		// create new org
-		apiRoute.Post("/orgs", quota("org"), bind(models.CreateOrgCommand{}), routing.Wrap(CreateOrg))
+		apiRoute.Post("/orgs", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsCreate)), quota("org"), bind(models.CreateOrgCommand{}), routing.Wrap(hs.CreateOrg))
 
 		// search all orgs
 		apiRoute.Get("/orgs", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsAll)), routing.Wrap(SearchOrgs))
@@ -242,7 +242,7 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgID)), routing.Wrap(GetOrgByID))
 			orgsRoute.Put("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
 			orgsRoute.Put("/address", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
-			orgsRoute.Delete("/", reqGrafanaAdmin, routing.Wrap(DeleteOrgByID))
+			orgsRoute.Delete("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsDelete, ScopeOrgID)), routing.Wrap(DeleteOrgByID))
 			orgsRoute.Get("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsers))
 			orgsRoute.Post("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
 			orgsRoute.Patch("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -8,13 +8,14 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
 
 // GET /api/org
-func GetOrgCurrent(c *models.ReqContext) response.Response {
+func GetCurrentOrg(c *models.ReqContext) response.Response {
 	return getOrgHelper(c.OrgId)
 }
 
@@ -52,7 +53,7 @@ func (hs *HTTPServer) GetOrgByName(c *models.ReqContext) response.Response {
 func getOrgHelper(orgID int64) response.Response {
 	query := models.GetOrgByIdQuery{Id: orgID}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := sqlstore.GetOrgById(&query); err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
 			return response.Error(404, "Organization not found", err)
 		}

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -101,7 +101,7 @@ func CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Respo
 }
 
 // PUT /api/org
-func UpdateOrgCurrent(c *models.ReqContext, form dtos.UpdateOrgForm) response.Response {
+func UpdateCurrentOrg(c *models.ReqContext, form dtos.UpdateOrgForm) response.Response {
 	return updateOrgHelper(form, c.OrgId)
 }
 
@@ -112,7 +112,7 @@ func UpdateOrg(c *models.ReqContext, form dtos.UpdateOrgForm) response.Response 
 
 func updateOrgHelper(form dtos.UpdateOrgForm, orgID int64) response.Response {
 	cmd := models.UpdateOrgCommand{Name: form.Name, OrgId: orgID}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := sqlstore.UpdateOrg(&cmd); err != nil {
 		if errors.Is(err, models.ErrOrgNameTaken) {
 			return response.Error(400, "Organization name taken", err)
 		}
@@ -123,7 +123,7 @@ func updateOrgHelper(form dtos.UpdateOrgForm, orgID int64) response.Response {
 }
 
 // PUT /api/org/address
-func UpdateOrgAddressCurrent(c *models.ReqContext, form dtos.UpdateOrgAddressForm) response.Response {
+func UpdateCurrentOrgAddress(c *models.ReqContext, form dtos.UpdateOrgAddressForm) response.Response {
 	return updateOrgAddressHelper(form, c.OrgId)
 }
 
@@ -145,7 +145,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgID int64) respons
 		},
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := sqlstore.UpdateOrgAddress(&cmd); err != nil {
 		return response.Error(500, "Failed to update org address", err)
 	}
 

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -184,7 +184,7 @@ func SearchOrgs(c *models.ReqContext) response.Response {
 		Limit: perPage,
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := sqlstore.SearchOrgs(&query); err != nil {
 		return response.Error(500, "Failed to search orgs", err)
 	}
 

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -8,139 +8,212 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
 
-var searchOrgsUrl = "/api/orgs/"
-var getCurrentOrgUrl = "/api/org/"
-var getOrgsUrl = "/api/orgs/%v"
+var (
+	searchOrgsURL    = "/api/orgs/"
+	getCurrentOrgURL = "/api/org/"
+	getOrgsURL       = "/api/orgs/%v"
+	getOrgsByNameURL = "/api/orgs/name/%v"
+)
 
 func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, _ := setupHTTPServer(t, false, testuser)
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
-	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
 	require.NoError(t, err)
 
 	t.Run("Viewer cannot list Orgs", func(t *testing.T) {
-		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 
-	testuser.IsGrafanaAdmin = true
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
 	t.Run("Grafana Admin viewer can list Orgs", func(t *testing.T) {
-		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 }
 
 func TestAPIEndpoint_SearchOrgs_AccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, acmock := setupHTTPServer(t, true, testuser)
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
-	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows listing Orgs with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
-		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl prevents listing Orgs with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
-		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
-	t.Run("AccessControl prevents viewing CurrentOrg with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+	t.Run("AccessControl prevents listing Orgs with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, _ := setupHTTPServer(t, false, testuser)
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
 
 	t.Run("Viewer can view CurrentOrg", func(t *testing.T) {
-		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	sc.initCtx.IsSignedIn = false
+	t.Run("Unsigned user cannot view CurrentOrg", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, acmock := setupHTTPServer(t, true, testuser)
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows viewing CurrentOrg with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
-		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl allows viewing CurrentOrg with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
-		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl prevents viewing CurrentOrg with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetOrg_LegacyAccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_ADMIN, Login: testUserLogin, IsGrafanaAdmin: true}
-	server, hs, _ := setupHTTPServer(t, false, testuser)
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
-	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
 	require.NoError(t, err)
 
-	t.Run("Admin can view another Org", func(t *testing.T) {
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+	t.Run("Viewer cannot view another Org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana admin viewer can view another Org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetOrg_AccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, acmock := setupHTTPServer(t, true, testuser)
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
-	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows viewing another org with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl allows viewing another org with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "2")}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetOrgByName_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to fetch another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Viewer cannot view another Org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana admin viewer can view another Org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetOrgByName_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to fetch another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows viewing another org with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl allows viewing another org with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "name", "TestOrg2")}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents viewing another org with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "name", "TestOrg1")}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -12,8 +12,58 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
 
+var searchOrgsUrl = "/api/orgs/"
 var getCurrentOrgUrl = "/api/org/"
 var getOrgsUrl = "/api/orgs/%v"
+
+func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, _ := setupHTTPServer(t, false, testuser)
+
+	// Create two orgs
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Viewer cannot list Orgs", func(t *testing.T) {
+		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	testuser.IsGrafanaAdmin = true
+	t.Run("Grafana Admin viewer can list Orgs", func(t *testing.T) {
+		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_SearchOrgs_AccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, acmock := setupHTTPServer(t, true, testuser)
+
+	// Create two orgs
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows listing Orgs with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents listing Orgs with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
+		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents viewing CurrentOrg with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(server, http.MethodGet, searchOrgsUrl, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
 
 func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
 	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+var getCurrentOrgUrl = "/api/org/"
+var getOrgsUrl = "/api/orgs/%v"
+
+func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, _ := setupHTTPServer(t, false, testuser)
+
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Viewer can view CurrentOrg", func(t *testing.T) {
+		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, acmock := setupHTTPServer(t, true, testuser)
+
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows viewing CurrentOrg with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl allows viewing CurrentOrg with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
+		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents viewing CurrentOrg with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(server, http.MethodGet, getCurrentOrgUrl, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetOrg_LegacyAccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_ADMIN, Login: testUserLogin, IsGrafanaAdmin: true}
+	server, hs, _ := setupHTTPServer(t, false, testuser)
+
+	// Create two orgs, to fetch another one than the logged in one
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Admin can view another Org", func(t *testing.T) {
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetOrg_AccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, acmock := setupHTTPServer(t, true, testuser)
+
+	// Create two orgs, to fetch another one than the logged in one
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows viewing another org with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents viewing another org with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsUrl, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var (
@@ -29,7 +30,120 @@ var (
 	"ZipCode": "TESTZIPCODE",
 	"State": "TestState",
 	"Country": "TestCountry" }`
+
+	deleteOrgsURL = "/api/orgs/%v"
+
+	createOrgsURL    = "/api/orgs/"
+	testCreateOrgCmd = `{ "name": "TestOrg%v"}`
 )
+
+func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	setting.AllowUserOrgCreate = false
+	input := strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 2))
+	t.Run("Viewer cannot create Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 3))
+	t.Run("Grafana Admin viewer can create Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = false
+	setting.AllowUserOrgCreate = true
+	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 4))
+	t.Run("User viewer can create Orgs when AllowUserOrgCreate setting is true", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_CreateOrgs_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 2))
+	t.Run("AccessControl allows creating Orgs with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsCreate}})
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 3))
+	t.Run("AccessControl prevents creating Orgs with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_DeleteOrgs_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Viewer cannot delete Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana Admin viewer can delete Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_DeleteOrgs_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create three orgs (to delete org2 then org3)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg3", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows deleting Orgs with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl allows deleting Orgs with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: accesscontrol.Scope("orgs", "id", "3")}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 3), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents deleting Orgs with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents deleting Orgs with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
 
 func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, false)

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,10 +13,22 @@ import (
 )
 
 var (
-	searchOrgsURL    = "/api/orgs/"
-	getCurrentOrgURL = "/api/org/"
-	getOrgsURL       = "/api/orgs/%v"
-	getOrgsByNameURL = "/api/orgs/name/%v"
+	searchOrgsURL           = "/api/orgs/"
+	getCurrentOrgURL        = "/api/org/"
+	getOrgsURL              = "/api/orgs/%v"
+	getOrgsByNameURL        = "/api/orgs/name/%v"
+	putCurrentOrgURL        = "/api/org/"
+	putOrgsURL              = "/api/orgs/%v"
+	putCurrentOrgAddressURL = "/api/org/address"
+	putOrgsAddressURL       = "/api/orgs/%v/address"
+
+	testUpdateOrgNameForm    = `{ "name": "TestOrgChanged" }`
+	testUpdateOrgAddressForm = `{ "address1": "1 test road",
+	"address2": "2 test road",
+	"city": "TestCity",
+	"ZipCode": "TESTZIPCODE",
+	"State": "TestState",
+	"Country": "TestCountry" }`
 )
 
 func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
@@ -214,6 +227,227 @@ func TestAPIEndpoint_GetOrgByName_AccessControl(t *testing.T) {
 	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
 		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	t.Run("Viewer cannot update current org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	t.Run("Admin can update current org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating current org with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating current org with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "2")}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrg_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+
+	t.Run("Viewer cannot update another org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana Admin can update another org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrg_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating another org with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating another org with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "2")}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl prevents updating another org with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating another org with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	t.Run("Viewer cannot update current org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	t.Run("Admin can update current org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl allows updating current org address with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl allows updating current org address with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org address with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrgAddress_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+
+	t.Run("Viewer cannot update another org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana Admin can update another org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrgAddress_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl allows updating another org address with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl prevents updating another org address with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating another org address with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
 const (
@@ -33,7 +34,7 @@ func GetUserPreferences(c *models.ReqContext) response.Response {
 func getPreferencesFor(orgID, userID, teamID int64) response.Response {
 	prefsQuery := models.GetPreferencesQuery{UserId: userID, OrgId: orgID, TeamId: teamID}
 
-	if err := bus.Dispatch(&prefsQuery); err != nil {
+	if err := sqlstore.GetPreferences(&prefsQuery); err != nil {
 		return response.Error(500, "Failed to get preferences", err)
 	}
 

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -67,7 +67,7 @@ func updatePreferencesFor(orgID, userID, teamId int64, dtoCmd *dtos.UpdatePrefsC
 		HomeDashboardId: dtoCmd.HomeDashboardID,
 	}
 
-	if err := bus.Dispatch(&saveCmd); err != nil {
+	if err := sqlstore.SavePreferences(&saveCmd); err != nil {
 		return response.Error(500, "Failed to save preferences", err)
 	}
 

--- a/pkg/api/preferences_test.go
+++ b/pkg/api/preferences_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	getOrgPreferencesURL = "/api/org/preferences/"
+)
+
+func TestAPIEndpoint_GetCurrentOrgPreferences_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	t.Run("Viewer cannot get org preferences", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, getOrgPreferencesURL, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	t.Run("Org Admin can get org preferences", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, getOrgPreferencesURL, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetCurrentOrgPreferences_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows getting org preferences with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsPreferencesRead, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodGet, getOrgPreferencesURL, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl allows getting org preferences with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsPreferencesRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodGet, getOrgPreferencesURL, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents getting org preferences with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodGet, getOrgPreferencesURL, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}

--- a/pkg/api/preferences_test.go
+++ b/pkg/api/preferences_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -11,6 +12,9 @@ import (
 
 var (
 	getOrgPreferencesURL = "/api/org/preferences/"
+	putOrgPreferencesURL = "/api/org/preferences/"
+
+	testUpdateOrgPreferencesCmd = `{ "theme": "light", "homeDashboardId": 1 }`
 )
 
 func TestAPIEndpoint_GetCurrentOrgPreferences_LegacyAccessControl(t *testing.T) {
@@ -52,6 +56,56 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_AccessControl(t *testing.T) {
 	t.Run("AccessControl prevents getting org preferences with incorrect permissions", func(t *testing.T) {
 		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
 		response := callAPI(sc.server, http.MethodGet, getOrgPreferencesURL, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgPreferences_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	input := strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("Viewer cannot update org preferences", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	input = strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("Org Admin can update org preferences", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgPreferences_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("AccessControl allows updating org preferences with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsPreferencesWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("AccessControl allows updating org preferences with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsPreferencesWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("AccessControl prevents updating org preferences with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -29,18 +29,18 @@ func (hs *HTTPServer) getOrgQuotasHelper(c *models.ReqContext, orgID int64) resp
 	return response.JSON(200, query.Result)
 }
 
-func UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response.Response {
-	if !setting.Quota.Enabled {
+func (hs *HTTPServer) UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response.Response {
+	if !hs.Cfg.Quota.Enabled {
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.OrgId = c.ParamsInt64(":orgId")
 	cmd.Target = web.Params(c.Req)[":target"]
 
-	if _, ok := setting.Quota.Org.ToMap()[cmd.Target]; !ok {
+	if _, ok := hs.Cfg.Quota.Org.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)
 	}
 
-	if err := bus.DispatchCtx(c.Req.Context(), &cmd); err != nil {
+	if err := hs.SQLStore.UpdateOrgQuota(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to update org quotas", err)
 	}
 	return response.Success("Organization quota updated")

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -8,13 +8,21 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
-func GetOrgQuotas(c *models.ReqContext) response.Response {
-	if !setting.Quota.Enabled {
+func (hs *HTTPServer) GetCurrentOrgQuotas(c *models.ReqContext) response.Response {
+	return hs.getOrgQuotasHelper(c, c.OrgId)
+}
+
+func (hs *HTTPServer) GetOrgQuotas(c *models.ReqContext) response.Response {
+	return hs.getOrgQuotasHelper(c, c.ParamsInt64(":orgId"))
+}
+
+func (hs *HTTPServer) getOrgQuotasHelper(c *models.ReqContext, orgID int64) response.Response {
+	if !hs.Cfg.Quota.Enabled {
 		return response.Error(404, "Quotas not enabled", nil)
 	}
-	query := models.GetOrgQuotasQuery{OrgId: c.ParamsInt64(":orgId")}
+	query := models.GetOrgQuotasQuery{OrgId: orgID}
 
-	if err := bus.DispatchCtx(c.Req.Context(), &query); err != nil {
+	if err := hs.SQLStore.GetOrgQuotas(c.Req.Context(), &query); err != nil {
 		return response.Error(500, "Failed to get org quotas", err)
 	}
 

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var getCurrentOrgQuotasUrl = "/api/org/quotas"
+var getOrgsQuotasUrl = "/api/orgs/%v/quotas"
+
+var testOrgQuota = setting.OrgQuota{
+	User:       10,
+	DataSource: 10,
+	Dashboard:  10,
+	ApiKey:     10,
+	AlertRule:  10,
+}
+
+func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, _ := setupHTTPServer(t, false, testuser)
+
+	hs.Cfg.Quota.Enabled = true
+	hs.Cfg.Quota.Org = &testOrgQuota
+	// Required while sqlstore quota.go relies on setting global variables
+	setting.Quota = hs.Cfg.Quota
+
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
+		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetCurrentOrgQuotas_AccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, acmock := setupHTTPServer(t, true, testuser)
+
+	hs.Cfg.Quota.Enabled = true
+	hs.Cfg.Quota.Org = &testOrgQuota
+	// Required while sqlstore quota.go relies on setting global variables
+	setting.Quota = hs.Cfg.Quota
+
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows viewing CurrentOrgQuotas with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl allows viewing CurrentOrgQuotas with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
+		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents viewing CurrentOrgQuotas with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_ADMIN, Login: testUserLogin, IsGrafanaAdmin: true}
+	server, hs, _ := setupHTTPServer(t, false, testuser)
+
+	hs.Cfg.Quota.Enabled = true
+	hs.Cfg.Quota.Org = &testOrgQuota
+	// Required while sqlstore quota.go relies on setting global variables
+	setting.Quota = hs.Cfg.Quota
+
+	// Create two orgs, to fetch another one than the logged in one
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Admin can view another org quotas", func(t *testing.T) {
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetOrgQuotas_AccessControl(t *testing.T) {
+	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
+	server, hs, acmock := setupHTTPServer(t, true, testuser)
+
+	hs.Cfg.Quota.Enabled = true
+	hs.Cfg.Quota.Org = &testOrgQuota
+	// Required while sqlstore quota.go relies on setting global variables
+	setting.Quota = hs.Cfg.Quota
+
+	// Create two orgs, to fetch another one than the logged in one
+	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows viewing another org quotas with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents viewing another org quotas with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents viewing another org quotas with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var getCurrentOrgQuotasUrl = "/api/org/quotas"
-var getOrgsQuotasUrl = "/api/orgs/%v/quotas"
+var getCurrentOrgQuotasURL = "/api/org/quotas"
+var getOrgsQuotasURL = "/api/orgs/%v/quotas"
 
 var testOrgQuota = setting.OrgQuota{
 	User:       10,
@@ -25,101 +24,118 @@ var testOrgQuota = setting.OrgQuota{
 }
 
 func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, _ := setupHTTPServer(t, false, testuser)
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
 
-	hs.Cfg.Quota.Enabled = true
-	hs.Cfg.Quota.Org = &testOrgQuota
+	sc.hs.Cfg.Quota.Enabled = true
+	sc.hs.Cfg.Quota.Org = &testOrgQuota
 	// Required while sqlstore quota.go relies on setting global variables
-	setting.Quota = hs.Cfg.Quota
+	setting.Quota = sc.hs.Cfg.Quota
 
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
 
 	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
-		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	sc.initCtx.IsSignedIn = false
+	t.Run("Unsigned user cannot view CurrentOrgQuotas", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetCurrentOrgQuotas_AccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, acmock := setupHTTPServer(t, true, testuser)
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
 
-	hs.Cfg.Quota.Enabled = true
-	hs.Cfg.Quota.Org = &testOrgQuota
+	sc.hs.Cfg.Quota.Enabled = true
+	sc.hs.Cfg.Quota.Org = &testOrgQuota
 	// Required while sqlstore quota.go relies on setting global variables
-	setting.Quota = hs.Cfg.Quota
+	setting.Quota = sc.hs.Cfg.Quota
 
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows viewing CurrentOrgQuotas with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
-		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl allows viewing CurrentOrgQuotas with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
-		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl prevents viewing CurrentOrgQuotas with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(server, http.MethodGet, getCurrentOrgQuotasUrl, nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_ADMIN, Login: testUserLogin, IsGrafanaAdmin: true}
-	server, hs, _ := setupHTTPServer(t, false, testuser)
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
 
-	hs.Cfg.Quota.Enabled = true
-	hs.Cfg.Quota.Org = &testOrgQuota
+	sc.hs.Cfg.Quota.Enabled = true
+	sc.hs.Cfg.Quota.Org = &testOrgQuota
 	// Required while sqlstore quota.go relies on setting global variables
-	setting.Quota = hs.Cfg.Quota
+	setting.Quota = sc.hs.Cfg.Quota
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
-	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
 	require.NoError(t, err)
 
-	t.Run("Admin can view another org quotas", func(t *testing.T) {
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+	t.Run("Viewer cannot view another org quotas", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana admin viewer can view another org quotas", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetOrgQuotas_AccessControl(t *testing.T) {
-	testuser := &models.SignedInUser{UserId: testUserID, OrgId: 1, OrgRole: models.ROLE_VIEWER, Login: testUserLogin}
-	server, hs, acmock := setupHTTPServer(t, true, testuser)
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
 
-	hs.Cfg.Quota.Enabled = true
-	hs.Cfg.Quota.Org = &testOrgQuota
+	sc.hs.Cfg.Quota.Enabled = true
+	sc.hs.Cfg.Quota.Org = &testOrgQuota
 	// Required while sqlstore quota.go relies on setting global variables
-	setting.Quota = hs.Cfg.Quota
+	setting.Quota = sc.hs.Cfg.Quota
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := hs.SQLStore.CreateOrgWithMember("TestOrg", testUserID)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
-	_, err = hs.SQLStore.CreateOrgWithMember("TestOrg2", testUserID)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
 	require.NoError(t, err)
 
 	t.Run("AccessControl allows viewing another org quotas with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl allows viewing another org quotas with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: accesscontrol.Scope("orgs", "id", "2")}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org quotas with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "1")}})
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org quotas with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(server, http.MethodGet, fmt.Sprintf(getOrgsQuotasUrl, 2), nil, t)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -15,6 +15,8 @@ const (
 	ActionDatasourcesWrite  = "datasources:write"
 	ActionDatasourcesDelete = "datasources:delete"
 	ActionDatasourcesIDRead = "datasources.id:read"
+
+	ActionOrgsRead = "orgs:read"
 )
 
 // API related scopes
@@ -29,6 +31,10 @@ var (
 	ScopeDatasourceID   = accesscontrol.Scope("datasources", "id", accesscontrol.Parameter(":id"))
 	ScopeDatasourceUID  = accesscontrol.Scope("datasources", "uid", accesscontrol.Parameter(":uid"))
 	ScopeDatasourceName = accesscontrol.Scope("datasources", "name", accesscontrol.Parameter(":name"))
+
+	ScopeOrgsAll       = accesscontrol.Scope("orgs", "*")
+	ScopeOrgsID        = accesscontrol.Scope("orgs", accesscontrol.Parameter(":orgId"))
+	ScopeOrgsCurrentID = accesscontrol.Scope("orgs", accesscontrol.Field("OrgID"))
 )
 
 // declareFixedRoles declares to the AccessControl service fixed roles and their

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -22,6 +22,8 @@ const (
 	ActionOrgsWrite            = "orgs:write"
 	ActionOrgsPreferencesWrite = "orgs.preferences:write"
 	ActionOrgsQuotasWrite      = "orgs.quotas:write"
+	ActionOrgsDelete           = "orgs:delete"
+	ActionOrgsCreate           = "orgs:create"
 )
 
 // API related scopes

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -16,9 +16,12 @@ const (
 	ActionDatasourcesDelete = "datasources:delete"
 	ActionDatasourcesIDRead = "datasources.id:read"
 
-	ActionOrgsRead            = "orgs:read"
-	ActionOrgsPreferencesRead = "orgs.preferences:read"
-	ActionOrgsQuotasRead      = "orgs.quotas:read"
+	ActionOrgsRead             = "orgs:read"
+	ActionOrgsPreferencesRead  = "orgs.preferences:read"
+	ActionOrgsQuotasRead       = "orgs.quotas:read"
+	ActionOrgsWrite            = "orgs:write"
+	ActionOrgsPreferencesWrite = "orgs.preferences:write"
+	ActionOrgsQuotasWrite      = "orgs.quotas:write"
 )
 
 // API related scopes

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -32,7 +32,7 @@ var (
 	ScopeDatasourceUID  = accesscontrol.Scope("datasources", "uid", accesscontrol.Parameter(":uid"))
 	ScopeDatasourceName = accesscontrol.Scope("datasources", "name", accesscontrol.Parameter(":name"))
 
-	ScopeOrgsAll       = accesscontrol.Scope("orgs", "*")
+	ScopeOrgsAll      = accesscontrol.Scope("orgs", "*")
 	ScopeOrgID        = accesscontrol.Scope("orgs", accesscontrol.Parameter(":orgId"))
 	ScopeOrgCurrentID = accesscontrol.Scope("orgs", accesscontrol.Field("OrgID"))
 )

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -33,8 +33,8 @@ var (
 	ScopeDatasourceName = accesscontrol.Scope("datasources", "name", accesscontrol.Parameter(":name"))
 
 	ScopeOrgsAll       = accesscontrol.Scope("orgs", "*")
-	ScopeOrgsID        = accesscontrol.Scope("orgs", accesscontrol.Parameter(":orgId"))
-	ScopeOrgsCurrentID = accesscontrol.Scope("orgs", accesscontrol.Field("OrgID"))
+	ScopeOrgID        = accesscontrol.Scope("orgs", accesscontrol.Parameter(":orgId"))
+	ScopeOrgCurrentID = accesscontrol.Scope("orgs", accesscontrol.Field("OrgID"))
 )
 
 // declareFixedRoles declares to the AccessControl service fixed roles and their

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -16,7 +16,9 @@ const (
 	ActionDatasourcesDelete = "datasources:delete"
 	ActionDatasourcesIDRead = "datasources.id:read"
 
-	ActionOrgsRead = "orgs:read"
+	ActionOrgsRead            = "orgs:read"
+	ActionOrgsPreferencesRead = "orgs.preferences:read"
+	ActionOrgsQuotasRead      = "orgs.quotas:read"
 )
 
 // API related scopes
@@ -33,8 +35,9 @@ var (
 	ScopeDatasourceName = accesscontrol.Scope("datasources", "name", accesscontrol.Parameter(":name"))
 
 	ScopeOrgsAll      = accesscontrol.Scope("orgs", "*")
-	ScopeOrgID        = accesscontrol.Scope("orgs", accesscontrol.Parameter(":orgId"))
-	ScopeOrgCurrentID = accesscontrol.Scope("orgs", accesscontrol.Field("OrgID"))
+	ScopeOrgID        = accesscontrol.Scope("orgs", "id", accesscontrol.Parameter(":orgId"))
+	ScopeOrgCurrentID = accesscontrol.Scope("orgs", "id", accesscontrol.Field("OrgID"))
+	ScopeOrgName      = accesscontrol.Scope("orgs", "name", accesscontrol.Parameter(":name"))
 )
 
 // declareFixedRoles declares to the AccessControl service fixed roles and their


### PR DESCRIPTION
**What this PR does / why we need it**:

> While in the first milestone we covered mostly all organization relevant endpoints with fine-grained permissions, there are few still missing the construction blocks.

In this first PR, I cover the following endpoints:
| Method | Url                        | Legacy AC       | Action                  | Scope                  |
|--------|----------------------------|-----------------|-------------------------|------------------------|
| GET    | /api/org/                  | reqSignedIn     | `orgs:read`             | `orgs:id:{OrgID}`      |
| GET    | /api/org/quotas            | reqSignedIn     | `orgs.quotas:read`      | `orgs:id:{OrgID}`      |
| GET    | /api/org/preferences       | reqOrgAdmin     | `orgs.preferences:read` | `orgs:id:{OrgID}`      |
| GET    | /api/orgs/:orgId           | reqGrafanaAdmin | `orgs:read`             | `orgs:id:{:orgId}`     |
| GET    | /api/orgs/:orgId/quotas    | reqGrafanaAdmin | `orgs.quotas:read`      | `orgs:id:{:orgId}`     |
| GET    | /api/orgs?perpage=x&page=y | reqGrafanaAdmin | `orgs:read`             | `orgs:*`               |
| GET    | /api/orgs/name/:orgName    | reqGrafanaAdmin | `orgs:read`             | `orgs:name:{:orgName}` |

I used this PR to correct a little bug I found on the `GET /api/org/quotas`, the `orgID` wasn't provided to the handler, resulting in `orgID: 0` quotas being displayed.

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana-enterprise/issues/1550

**Special notes for your reviewer**:
I won't merge this until I create the associated roles :slightly_smiling_face: 