### PR TITLE
Chore: Move `jwilder/dockerize` installation to build-container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,9 +20,6 @@ steps:
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -271,9 +268,6 @@ steps:
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -750,9 +744,6 @@ steps:
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version ${DRONE_TAG}
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -1119,9 +1110,6 @@ steps:
   - mv /tmp/grabpl bin/
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version ${DRONE_TAG}
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -1696,9 +1684,6 @@ steps:
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version v7.3.0-test
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -2054,9 +2039,6 @@ steps:
   - mv /tmp/grabpl bin/
   - ./bin/grabpl verify-drone
   - ./bin/grabpl verify-version v7.3.0-test
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -2624,9 +2606,6 @@ steps:
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -2953,9 +2932,6 @@ steps:
   - mkdir bin
   - mv /tmp/grabpl bin/
   - ./bin/grabpl verify-drone
-  - curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
-  - rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz
   - yarn install --frozen-lockfile --no-progress
   environment:
     DOCKERIZE_VERSION: 0.6.1
@@ -3492,6 +3468,6 @@ get:
 
 ---
 kind: signature
-hmac: 9211e316cd24660667ba57b860129d2f06b0a4a669aa4d5c1f13156667ae027f
+hmac: b51ec2cb772fb17475c1f53381965a852f23c50cebc9962afe1074a5589271c8
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -25,7 +25,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -33,14 +33,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition oss
@@ -50,7 +50,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -59,7 +59,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -68,35 +68,35 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --variants linux-x64,linux-x64-musl,osx64,win64,armv6 --no-pull-enterprise
   depends_on:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -107,14 +107,14 @@ steps:
   - shellcheck
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64,armv6
   depends_on:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -134,7 +134,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -158,7 +158,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
@@ -174,7 +174,7 @@ steps:
   - build-frontend-docs
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -191,7 +191,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -208,7 +208,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -262,7 +262,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -285,7 +285,7 @@ steps:
       from_secret: drone_token
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -293,14 +293,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition oss
@@ -310,7 +310,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -319,7 +319,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -328,21 +328,21 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -352,14 +352,14 @@ steps:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -370,7 +370,7 @@ steps:
   - shellcheck
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -388,7 +388,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -408,7 +408,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -445,7 +445,7 @@ steps:
   - end-to-end-tests-server
 
 - name: publish-frontend-metrics
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
   environment:
@@ -456,14 +456,14 @@ steps:
   - test-a11y-frontend
 
 - name: build-frontend-docs
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -494,7 +494,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -511,7 +511,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -527,7 +527,7 @@ steps:
   - test-frontend
 
 - name: release-canary-npm-packages
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./scripts/circle-release-canary-packages.sh
   environment:
@@ -649,7 +649,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -737,7 +737,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -749,7 +749,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -757,14 +757,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition oss
@@ -774,7 +774,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss --tries 5
@@ -783,7 +783,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -792,7 +792,7 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -802,14 +802,14 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise ${DRONE_TAG}
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -819,14 +819,14 @@ steps:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
@@ -837,7 +837,7 @@ steps:
   - shellcheck
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -855,7 +855,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -875,7 +875,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -885,7 +885,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -916,7 +916,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -933,7 +933,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -985,7 +985,7 @@ steps:
   - end-to-end-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./scripts/build/release-packages.sh ${DRONE_TAG}
   environment:
@@ -1086,7 +1086,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -1099,7 +1099,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -1117,7 +1117,7 @@ steps:
   - clone
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1125,14 +1125,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition enterprise
@@ -1142,7 +1142,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise --tries 5
@@ -1151,7 +1151,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1160,7 +1160,7 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -1170,14 +1170,14 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise ${DRONE_TAG}
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -1187,14 +1187,14 @@ steps:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -1204,7 +1204,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise2 --tries 5
@@ -1213,7 +1213,7 @@ steps:
   - lint-backend
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise ${DRONE_TAG}
   environment:
@@ -1223,7 +1223,7 @@ steps:
   - test-backend-enterprise2
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
@@ -1236,7 +1236,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -1254,7 +1254,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -1276,7 +1276,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -1307,7 +1307,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1324,7 +1324,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1340,7 +1340,7 @@ steps:
   - test-frontend
 
 - name: redis-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
@@ -1351,7 +1351,7 @@ steps:
   - test-frontend
 
 - name: memcached-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
@@ -1386,7 +1386,7 @@ steps:
   - memcached-integration-tests
 
 - name: package-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign ${DRONE_TAG}
   environment:
@@ -1404,7 +1404,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -1569,7 +1569,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -1677,7 +1677,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -1689,7 +1689,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -1697,14 +1697,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition oss
@@ -1714,7 +1714,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss --tries 5
@@ -1723,7 +1723,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -1732,7 +1732,7 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -1742,14 +1742,14 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition oss --no-pull-enterprise v7.3.0-test
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -1759,14 +1759,14 @@ steps:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version v7.3.0-test
   depends_on:
@@ -1777,7 +1777,7 @@ steps:
   - shellcheck
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -1795,7 +1795,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -1815,7 +1815,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1825,7 +1825,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -1850,7 +1850,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -1867,7 +1867,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -1916,7 +1916,7 @@ steps:
   - end-to-end-tests
 
 - name: release-npm-packages
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   environment:
     GITHUB_PACKAGE_TOKEN:
       from_secret: github_package_token
@@ -2015,7 +2015,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -2028,7 +2028,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -2046,7 +2046,7 @@ steps:
   - clone
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2054,14 +2054,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition enterprise
@@ -2071,7 +2071,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise --tries 5
@@ -2080,7 +2080,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2089,7 +2089,7 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -2099,14 +2099,14 @@ steps:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps --edition enterprise --no-pull-enterprise v7.3.0-test
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -2116,14 +2116,14 @@ steps:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -2133,7 +2133,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise2 --tries 5
@@ -2142,7 +2142,7 @@ steps:
   - lint-backend
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise v7.3.0-test
   environment:
@@ -2152,7 +2152,7 @@ steps:
   - test-backend-enterprise2
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version v7.3.0-test
   depends_on:
@@ -2165,7 +2165,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -2183,7 +2183,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -2205,7 +2205,7 @@ steps:
   - end-to-end-tests-server
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -2230,7 +2230,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2247,7 +2247,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2263,7 +2263,7 @@ steps:
   - test-frontend
 
 - name: redis-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
@@ -2274,7 +2274,7 @@ steps:
   - test-frontend
 
 - name: memcached-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
@@ -2309,7 +2309,7 @@ steps:
   - memcached-integration-tests
 
 - name: package-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN} --no-pull-enterprise --sign v7.3.0-test
   environment:
@@ -2327,7 +2327,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -2492,7 +2492,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -2600,7 +2600,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -2611,7 +2611,7 @@ steps:
     DOCKERIZE_VERSION: 0.6.1
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2619,14 +2619,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition oss
@@ -2636,7 +2636,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition oss
@@ -2645,7 +2645,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2654,21 +2654,21 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   environment:
@@ -2678,14 +2678,14 @@ steps:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -2696,7 +2696,7 @@ steps:
   - shellcheck
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -2714,7 +2714,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -2734,7 +2734,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -2744,7 +2744,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -2769,7 +2769,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -2786,7 +2786,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -2909,7 +2909,7 @@ steps:
   - echo $DRONE_RUNNER_NAME
 
 - name: clone
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mkdir -p bin
   - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.4.6/grabpl
@@ -2922,7 +2922,7 @@ steps:
       from_secret: github_token
 
 - name: initialize
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - mv bin/grabpl /tmp/
   - rmdir bin
@@ -2939,7 +2939,7 @@ steps:
   - clone
 
 - name: codespell
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "echo -e \"unknwon\nreferer\nerrorstring\neror\niam\nwan\" > words_to_ignore.txt"
   - codespell -I words_to_ignore.txt docs/
@@ -2947,14 +2947,14 @@ steps:
   - initialize
 
 - name: shellcheck
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
 
 - name: lint-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition enterprise
@@ -2964,7 +2964,7 @@ steps:
   - initialize
 
 - name: test-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise
@@ -2973,7 +2973,7 @@ steps:
   - lint-backend
 
 - name: test-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn run ci:test-frontend
   environment:
@@ -2982,21 +2982,21 @@ steps:
   - lint-backend
 
 - name: build-backend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-backend
 
 - name: build-frontend
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
 
 - name: build-plugins
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign --signing-admin
   environment:
@@ -3006,14 +3006,14 @@ steps:
   - lint-backend
 
 - name: validate-scuemata
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
 
 - name: lint-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - make gen-go
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -3023,7 +3023,7 @@ steps:
   - initialize
 
 - name: test-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - "[ $(grep FocusConvey -R pkg | wc -l) -eq \"0\" ] || exit 1"
   - ./bin/grabpl test-backend --edition enterprise2
@@ -3032,14 +3032,14 @@ steps:
   - lint-backend
 
 - name: build-backend-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER} --variants linux-x64 --no-pull-enterprise
   depends_on:
   - test-backend-enterprise2
 
 - name: gen-version
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -3052,7 +3052,7 @@ steps:
   - test-backend-enterprise2
 
 - name: package
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --sign
   environment:
@@ -3070,7 +3070,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -3092,7 +3092,7 @@ steps:
   - end-to-end-tests-server
 
 - name: build-storybook
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -3102,7 +3102,7 @@ steps:
   - package
 
 - name: copy-packages-for-docker
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -3127,7 +3127,7 @@ steps:
   - copy-packages-for-docker
 
 - name: postgres-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
@@ -3144,7 +3144,7 @@ steps:
   - test-frontend
 
 - name: mysql-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
@@ -3160,7 +3160,7 @@ steps:
   - test-frontend
 
 - name: redis-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
@@ -3171,7 +3171,7 @@ steps:
   - test-frontend
 
 - name: memcached-integration-tests
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
@@ -3206,7 +3206,7 @@ steps:
   - memcached-integration-tests
 
 - name: package-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64 --sign
   environment:
@@ -3224,7 +3224,7 @@ steps:
   - gen-version
 
 - name: end-to-end-tests-server-enterprise2
-  image: grafana/build-container:1.4.2
+  image: grafana/build-container:1.4.3
   detach: true
   commands:
   - ./e2e/start-server
@@ -3468,6 +3468,6 @@ get:
 
 ---
 kind: signature
-hmac: 550c55a45a2a5c457e6f063c719d008f1087c33a35a62a4631fa1f27b6281cd9
+hmac: 9d5ee57b9eff4ba3df8f70c8f7625c2ff1e07c2ce438182a97f81e6e8dbbb1dc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -195,7 +195,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -212,7 +212,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -498,7 +498,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -515,7 +515,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -920,7 +920,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -937,7 +937,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -1311,7 +1311,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -1328,7 +1328,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -1342,7 +1342,7 @@ steps:
 - name: redis-integration-tests
   image: grafana/build-container:1.4.2
   commands:
-  - ./bin/dockerize -wait tcp://redis:6379/0 -timeout 120s
+  - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   environment:
     REDIS_URL: redis://redis:6379/0
@@ -1353,7 +1353,7 @@ steps:
 - name: memcached-integration-tests
   image: grafana/build-container:1.4.2
   commands:
-  - ./bin/dockerize -wait tcp://memcached:11211 -timeout 120s
+  - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   environment:
     MEMCACHED_HOSTS: memcached:11211
@@ -1854,7 +1854,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -1871,7 +1871,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -2234,7 +2234,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -2251,7 +2251,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -2265,7 +2265,7 @@ steps:
 - name: redis-integration-tests
   image: grafana/build-container:1.4.2
   commands:
-  - ./bin/dockerize -wait tcp://redis:6379/0 -timeout 120s
+  - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   environment:
     REDIS_URL: redis://redis:6379/0
@@ -2276,7 +2276,7 @@ steps:
 - name: memcached-integration-tests
   image: grafana/build-container:1.4.2
   commands:
-  - ./bin/dockerize -wait tcp://memcached:11211 -timeout 120s
+  - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   environment:
     MEMCACHED_HOSTS: memcached:11211
@@ -2773,7 +2773,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -2790,7 +2790,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -3131,7 +3131,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq postgresql-client
-  - ./bin/dockerize -wait tcp://postgres:5432 -timeout 120s
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
@@ -3148,7 +3148,7 @@ steps:
   commands:
   - apt-get update
   - apt-get install -yq default-mysql-client
-  - ./bin/dockerize -wait tcp://mysql:3306 -timeout 120s
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
@@ -3162,7 +3162,7 @@ steps:
 - name: redis-integration-tests
   image: grafana/build-container:1.4.2
   commands:
-  - ./bin/dockerize -wait tcp://redis:6379/0 -timeout 120s
+  - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   environment:
     REDIS_URL: redis://redis:6379/0
@@ -3173,7 +3173,7 @@ steps:
 - name: memcached-integration-tests
   image: grafana/build-container:1.4.2
   commands:
-  - ./bin/dockerize -wait tcp://memcached:11211 -timeout 120s
+  - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   environment:
     MEMCACHED_HOSTS: memcached:11211
@@ -3468,6 +3468,6 @@ get:
 
 ---
 kind: signature
-hmac: b51ec2cb772fb17475c1f53381965a852f23c50cebc9962afe1074a5589271c8
+hmac: 550c55a45a2a5c457e6f063c719d008f1087c33a35a62a4631fa1f27b6281cd9
 
 ...

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -96,6 +96,11 @@ RUN curl -fLO https://github.com/cuelang/cue/releases/download/v${CUE_VERSION}/c
 RUN echo $CUE_CHKSUM cue_${CUE_VERSION}_Linux_x86_64.tar.gz | sha256sum --check --strict --status
 RUN tar xf cue_${CUE_VERSION}_Linux_x86_64.tar.gz -C /tmp cue
 
+ARG DOCKERIZE_VERSION=0.6.1
+RUN curl -fLO https://github.com/jwilder/dockerize/releases/download/v${DOCKERIZE_VERSION}/dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
+RUN tar -xzvf dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz -C /tmp/
+RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
+
 # Base image to crossbuild grafana.
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20210208

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -108,7 +108,7 @@ FROM debian:stretch-20210208
 ENV GOVERSION=1.17 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=14.17.5-1nodesource1 \
+    NODEVERSION=14.17.6-1nodesource1 \
     YARNVERSION=1.22.5-1
 
 # Use ARG so as not to persist environment variable in image
@@ -118,6 +118,7 @@ COPY --from=toolchain /tmp/x86_64-centos6-linux-gnu.tar.xz /tmp/osxcross.tar.xz 
 COPY --from=toolchain /tmp/golangci-lint /usr/local/bin/
 COPY --from=toolchain /tmp/shellcheck /usr/local/bin/
 COPY --from=toolchain /tmp/cue /usr/local/bin/
+COPY --from=toolchain /tmp/dockerize /usr/local/bin/
 
 RUN apt-get update && \
     apt-get install -yq  \

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.4.2"
+_version="1.4.3"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -60,9 +60,6 @@ def initialize_step(edition, platform, ver_mode, is_downstream=False, install_de
 
     if install_deps:
         common_cmds.extend([
-            'curl -fLO https://github.com/jwilder/dockerize/releases/download/v$${DOCKERIZE_VERSION}/dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz',
-            'tar -C bin -xzvf dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz',
-            'rm dockerize-linux-amd64-v$${DOCKERIZE_VERSION}.tar.gz',
             'yarn install --frozen-lockfile --no-progress',
         ])
     if edition in ('enterprise', 'enterprise2'):

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token')
 
 grabpl_version = '2.4.6'
-build_image = 'grafana/build-container:1.4.2'
+build_image = 'grafana/build-container:1.4.3'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -177,7 +177,7 @@ def benchmark_ldap_step():
 	  'LDAP_HOSTNAME': 'ldap',
         },
         'commands': [
-            './bin/dockerize -wait tcp://ldap:389 -timeout 120s',
+            'dockerize -wait tcp://ldap:389 -timeout 120s',
             'go test -benchmem -run=^$ ./pkg/extensions/ldapsync -bench "^(Benchmark50Users)$"',
         ],
     }
@@ -695,7 +695,7 @@ def postgres_integration_tests_step():
         'commands': [
             'apt-get update',
             'apt-get install -yq postgresql-client',
-            './bin/dockerize -wait tcp://postgres:5432 -timeout 120s',
+            'dockerize -wait tcp://postgres:5432 -timeout 120s',
             'psql -p 5432 -h postgres -U grafanatest -d grafanatest -f ' +
                 'devenv/docker/blocks/postgres_tests/setup.sql',
             # Make sure that we don't use cached results for another database
@@ -719,7 +719,7 @@ def mysql_integration_tests_step():
         'commands': [
             'apt-get update',
             'apt-get install -yq default-mysql-client',
-            './bin/dockerize -wait tcp://mysql:3306 -timeout 120s',
+            'dockerize -wait tcp://mysql:3306 -timeout 120s',
             'cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass',
             # Make sure that we don't use cached results for another database
             'go clean -testcache',
@@ -739,7 +739,7 @@ def redis_integration_tests_step():
             'REDIS_URL': 'redis://redis:6379/0',
         },
         'commands': [
-            './bin/dockerize -wait tcp://redis:6379/0 -timeout 120s',
+            'dockerize -wait tcp://redis:6379/0 -timeout 120s',
             './bin/grabpl integration-tests',
         ],
     }
@@ -756,7 +756,7 @@ def memcached_integration_tests_step():
             'MEMCACHED_HOSTS': 'memcached:11211',
         },
         'commands': [
-            './bin/dockerize -wait tcp://memcached:11211 -timeout 120s',
+            'dockerize -wait tcp://memcached:11211 -timeout 120s',
             './bin/grabpl integration-tests',
         ],
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `jwilder/dockerize` step to dockerize drone services, to build-container instead of having to install it every time.