### PR TITLE
Alerting: Move alertmanager default config to UnifiedAlertingSettings

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -33,7 +33,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs(t *testing.T) {
 	m := metrics.NewNGAlert(reg)
 	cfg := &setting.Cfg{
 		DataPath:        tmpDir,
-		UnifiedAlerting: setting.UnifiedAlertingSettings{AlertmanagerConfigPollInterval: 3 * time.Minute}, // do not poll in tests.
+		UnifiedAlerting: setting.UnifiedAlertingSettings{AlertmanagerConfigPollInterval: 3 * time.Minute, DefaultConfiguration: setting.AlertmanagerDefaultConfiguration}, // do not poll in tests.
 	}
 	mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, m.GetMultiOrgAlertmanagerMetrics(), log.New("testlogger"))
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestMultiOrgAlertmanager_AlertmanagerFor(t *testing.T) {
 	require.NoError(t, err)
 	cfg := &setting.Cfg{
 		DataPath:        tmpDir,
-		UnifiedAlerting: setting.UnifiedAlertingSettings{AlertmanagerConfigPollInterval: 3 * time.Minute}, // do not poll in tests.
+		UnifiedAlerting: setting.UnifiedAlertingSettings{AlertmanagerConfigPollInterval: 3 * time.Minute, DefaultConfiguration: setting.AlertmanagerDefaultConfiguration}, // do not poll in tests.
 	}
 	kvStore := newFakeKVStore(t)
 	reg := prometheus.NewPedanticRegistry()

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -87,7 +87,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 			uaCfg.HAPeers = append(uaCfg.HAPeers, peer)
 		}
 	}
-	//TODO load from ini file
+	// TODO load from ini file
 	uaCfg.DefaultConfiguration = AlertmanagerDefaultConfiguration
 	cfg.UnifiedAlerting = uaCfg
 	return nil

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -17,6 +17,28 @@ const (
 	AlertmanagerDefaultPushPullInterval     = cluster.DefaultPushPullInterval
 	SchedulerDefaultAdminConfigPollInterval = 60 * time.Second
 	AlertmanagerDefaultConfigPollInterval   = 60 * time.Second
+	// To start, the alertmanager needs at least one route defined.
+	// TODO: we should move this to Grafana settings and define this as the default.
+	AlertmanagerDefaultConfiguration = `{
+	"alertmanager_config": {
+		"route": {
+			"receiver": "grafana-default-email"
+		},
+		"receivers": [{
+			"name": "grafana-default-email",
+			"grafana_managed_receiver_configs": [{
+				"uid": "",
+				"name": "email receiver",
+				"type": "email",
+				"isDefault": true,
+				"settings": {
+					"addresses": "<example@email.com>"
+				}
+			}]
+		}]
+	}
+}
+`
 )
 
 type UnifiedAlertingSettings struct {
@@ -28,6 +50,7 @@ type UnifiedAlertingSettings struct {
 	HAPeerTimeout                  time.Duration
 	HAGossipInterval               time.Duration
 	HAPushPullInterval             time.Duration
+	DefaultConfiguration           string
 }
 
 func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
@@ -64,6 +87,8 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 			uaCfg.HAPeers = append(uaCfg.HAPeers, peer)
 		}
 	}
+	//TODO load from ini file
+	uaCfg.DefaultConfiguration = AlertmanagerDefaultConfiguration
 	cfg.UnifiedAlerting = uaCfg
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The main motivation is to be able to use the configuration during migration because the package reference in the migration causes circular dependency. As a side effect, it moves us closer to loading that config from the config file.

**Which issue(s) this PR fixes**:
Relates to https://github.com/grafana/grafana/pull/39541


