### PR TITLE
Doc: Added note on how to uncomment a line in configuration files.

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -8,19 +8,18 @@ weight = 150
 
 # Configuration
 
-Grafana has a number of configuration options that you can specify in a `.ini` configuration file or specified using environment variables.
+You can specify several configuration options in a `.ini` configuration file or by using environment variables. To see all settings currently applied to a Grafana server, refer to [View server settings]({{< relref "view-server/view-server-settings.md" >}}).
 
-> **Note:** You must restart Grafana for any configuration changes to take effect.
+## Configuration file locations
 
-To see all settings currently applied to the Grafana server, refer to [View server settings]({{< relref "view-server/view-server-settings.md" >}}).
+Grafana defaults are stored in the `defaults.ini` file. _Do not_ change the location in this file. Depending on your OS, custom configurations are made in either the `custom.ini` or the `grafana.ini` file.
 
-## Config file locations
+- Default configurations in `$WORKING_DIR/conf/defaults.ini`
+- Custom configurations in `$WORKING_DIR/conf/custom.ini`
 
-_Do not_ change `defaults.ini`! Grafana defaults are stored in this file. Depending on your OS, make all configuration changes in either `custom.ini` or `grafana.ini`.
+The custom configuration file path can be overridden using the `--config` parameter.
 
-- Default configuration from `$WORKING_DIR/conf/defaults.ini`
-- Custom configuration from `$WORKING_DIR/conf/custom.ini`
-- The custom configuration file path can be overridden using the `--config` parameter
+> **Note:** TIn the custom configurations file, uncomment each line you want to update by removing `;` from the beginning of that line. Restart Grafana for the configuration changes to take effect.
 
 ### Linux
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -8,18 +8,15 @@ weight = 150
 
 # Configuration
 
-You can specify several configuration options in a `.ini` configuration file or by using environment variables. To see all settings currently applied to a Grafana server, refer to [View server settings]({{< relref "view-server/view-server-settings.md" >}}).
+Grafana has default and custom configuration files. You can customize your Grafana instance by modifying the custom configuration file or by using environment variables. To see the list of settings for a Grafana instance, refer to [View server settings]({{< relref "view-server/view-server-settings.md" >}}).
 
-## Location of configuration files
+> **Note:** After you add custom options, [uncomment](#remove-comments-in-the-ini-files) the relevant sections of the configuration file. Restart Grafana for your changes to take effect.
 
-Grafana defaults are stored in the `defaults.ini` file. _Do not_ change the location in this file. Depending on your OS, custom configurations are made in either the `custom.ini` or the `grafana.ini` file.
+## Configuration file location
 
-- Default configurations in `$WORKING_DIR/conf/defaults.ini`
-- Custom configurations in `$WORKING_DIR/conf/custom.ini`
+The default settings for a Grafana instance are stored in the `$WORKING_DIR/conf/defaults.ini` file. _Do not_ change the location in this file. 
 
-The custom configuration file path can be overridden using the `--config` parameter.
-
-> **Note:** In the custom configurations file, uncomment each line you want to update by removing `;` from the beginning of that line. Restart Grafana for the configuration changes to take effect.
+Depending on your OS, your custom configuration file is either the `$WORKING_DIR/conf/defaults.ini` file or the `/usr/local/etc/grafana/grafana.ini` file. The custom configuration file path can be overridden using the `--config` parameter.
 
 ### Linux
 
@@ -31,24 +28,22 @@ Refer to [Configure a Grafana Docker image]({{< relref "configure-docker.md" >}}
 
 ### Windows
 
-`sample.ini` is in the same directory as `defaults.ini` and contains all the settings commented out. Copy `sample.ini` and name it `custom.ini`.
+On Windows, the `sample.ini` file is located in the same directory as `defaults.ini` file. It contains all the settings commented out. Copy `sample.ini` and name it `custom.ini`.
 
 ### macOS
 
-By default, the configuration file is located at `/usr/local/etc/grafana/grafana.ini`. For a Grafana instance installed using Homebrew, edit the `grafana.ini` file directly. Otherwise, add a configuration file named `custom.ini` to the `conf` folder to override any of the settings defined in `conf/defaults.ini`.
+By default, the configuration file is located at `/usr/local/etc/grafana/grafana.ini`. For a Grafana instance installed using Homebrew, edit the `grafana.ini` file directly. Otherwise, add a configuration file named `custom.ini` to the `conf` folder to override the settings defined in `conf/defaults.ini`.
 
-## Comments in .ini Files
+## Remove comments in the .ini files
 
-Semicolons (the `;` char) are the standard way to comment out lines in a `.ini` file. If you want to change a setting, you must delete the semicolon (`;`) in front of the setting before it will work.
+Grafana uses semicolons (the `;` char) to comment out lines in a `.ini` file. You must uncomment each line in the `custom.ini` or the `grafana.ini` file that you are modify by removing `;` from the beginning of that line. Otherwise your changes will be ignored.
 
-**Example**
+For example:
 
 ```
 # The HTTP port  to use
 ;http_port = 3000
 ```
-
-A common problem is forgetting to uncomment a line in the `custom.ini` (or `grafana.ini`) file which causes the configuration option to be ignored.
 
 ## Configure with environment variables
 

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -10,7 +10,7 @@ weight = 150
 
 You can specify several configuration options in a `.ini` configuration file or by using environment variables. To see all settings currently applied to a Grafana server, refer to [View server settings]({{< relref "view-server/view-server-settings.md" >}}).
 
-## Configuration file locations
+## Location of configuration files
 
 Grafana defaults are stored in the `defaults.ini` file. _Do not_ change the location in this file. Depending on your OS, custom configurations are made in either the `custom.ini` or the `grafana.ini` file.
 
@@ -19,7 +19,7 @@ Grafana defaults are stored in the `defaults.ini` file. _Do not_ change the loca
 
 The custom configuration file path can be overridden using the `--config` parameter.
 
-> **Note:** TIn the custom configurations file, uncomment each line you want to update by removing `;` from the beginning of that line. Restart Grafana for the configuration changes to take effect.
+> **Note:** In the custom configurations file, uncomment each line you want to update by removing `;` from the beginning of that line. Restart Grafana for the configuration changes to take effect.
 
 ### Linux
 


### PR DESCRIPTION
Added note about removing `;` to uncomment a line. 
Also, reordered content. 

Fixes https://github.com/grafana/grafana/issues/39255.