### PR TITLE
PanelOptions: fix array paths with siblings

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/utils.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.test.ts
@@ -98,6 +98,7 @@ describe('setOptionImmutably', () => {
     ${{}}                     | ${'a.b[2]'}   | ${'x'}    | ${{ a: { b: [undefined, undefined, 'x'] } }}
     ${{}}                     | ${'a[0]'}     | ${1}      | ${{ a: [1] }}
     ${{}}                     | ${'a[0].b.c'} | ${1}      | ${{ a: [{ b: { c: 1 } }] }}
+    ${{ a: [{ b: 1 }] }}      | ${'a[0].c'}   | ${2}      | ${{ a: [{ b: 1, c: 2 }] }}
   `('property value:${value', ({ source, path, value, expected }) => {
     expect(setOptionImmutably(source, path, value)).toEqual(expected);
   });

--- a/public/app/features/dashboard/components/PanelEditor/utils.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.ts
@@ -75,6 +75,7 @@ export function setOptionImmutably<T extends object>(options: T, path: string | 
     let current = (options as Record<string, any>)[propKey];
     const arr = Array.isArray(current) ? [...current] : [];
     if (splat.length) {
+      current = arr[index];
       if (current == null || typeof current !== 'object') {
         current = {};
       }


### PR DESCRIPTION
Fixes to #39499, found while working with #39491


