### PR TITLE
Live: disable centrifuge-js debug mode

### DIFF
--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -59,9 +59,7 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
     const liveUrl = `${baseURL}${config.appSubUrl}/api/live/ws`;
 
     this.orgId = contextSrv.user.orgId;
-    this.centrifuge = new Centrifuge(liveUrl, {
-      debug: true,
-    });
+    this.centrifuge = new Centrifuge(liveUrl, {});
     this.centrifuge.setConnectData({
       sessionId,
       orgId: this.orgId,


### PR DESCRIPTION
**What this PR does / why we need it**:

Debug mode in centrifuge-js is only for development and can be pretty chatty when enabled.

Maybe we can enable it if some key in localStorage exists.

**Which issue(s) this PR fixes**:

#39621 