### PR TITLE
Annotations: Deprecate AnnotationsSrv

### DIFF
--- a/public/app/features/annotations/annotations_srv.ts
+++ b/public/app/features/annotations/annotations_srv.ts
@@ -1,191 +1,98 @@
-import { cloneDeep, flattenDeep } from 'lodash';
-import { lastValueFrom, Observable, of } from 'rxjs';
+import { cloneDeep } from 'lodash';
+import { Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import {
   AnnotationEvent,
-  AppEvents,
   CoreApp,
   DataQueryRequest,
   DataSourceApi,
+  deprecationWarning,
   rangeUtil,
   ScopedVars,
 } from '@grafana/data';
-import { getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 
 import coreModule from 'app/core/core_module';
-import { dedupAnnotations } from './events_processing';
 import { DashboardModel } from '../dashboard/state';
-import { appEvents } from 'app/core/core';
-import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { AnnotationQueryOptions, AnnotationQueryResponse } from './types';
 import { standardAnnotationSupport } from './standardAnnotationSupport';
 import { runRequest } from '../query/state/runRequest';
-import { RefreshEvent } from 'app/types/events';
 import { deleteAnnotation, saveAnnotation, updateAnnotation } from './api';
 
 let counter = 100;
 function getNextRequestId() {
   return 'AQ' + counter++;
 }
-
+/**
+ * @deprecated AnnotationsSrv is deprecated in favor of DashboardQueryRunner
+ */
 export class AnnotationsSrv {
-  globalAnnotationsPromise: any;
-  alertStatesPromise: any;
-  datasourcePromises: any;
-
+  /**
+   * @deprecated init is deprecated in favor of DashboardQueryRunner.run
+   */
   init(dashboard: DashboardModel) {
-    // always clearPromiseCaches when loading new dashboard
-    this.clearPromiseCaches();
-    // clear promises on refresh events
-    dashboard.events.subscribe(RefreshEvent, this.clearPromiseCaches.bind(this));
+    deprecationWarning('annotations_srv.ts', 'init', 'DashboardQueryRunner.run');
   }
 
+  /**
+   * @deprecated clearPromiseCaches is deprecated
+   */
   clearPromiseCaches() {
-    this.globalAnnotationsPromise = null;
-    this.alertStatesPromise = null;
-    this.datasourcePromises = null;
+    deprecationWarning('annotations_srv.ts', 'clearPromiseCaches', 'DashboardQueryRunner');
   }
 
+  /**
+   * @deprecated getAnnotations is deprecated in favor of DashboardQueryRunner.getResult
+   */
   getAnnotations(options: AnnotationQueryOptions) {
-    return Promise.all([this.getGlobalAnnotations(options), this.getAlertStates(options)])
-      .then((results) => {
-        // combine the annotations and flatten results
-        let annotations: AnnotationEvent[] = flattenDeep(results[0]);
-        // when in edit mode we need to use this function to get the saved ID
-        let panelFilterId = options.panel.getSavedId();
-
-        // filter out annotations that do not belong to requesting panel
-        annotations = annotations.filter((item) => {
-          // if event has panel ID and query is of type dashboard then panel and requesting panel ID must match
-          if (item.panelId && item.source.type === 'dashboard') {
-            return item.panelId === panelFilterId;
-          }
-          return true;
-        });
-
-        annotations = dedupAnnotations(annotations);
-
-        // look for alert state for this panel
-        const alertState: any = results[1].find((res: any) => res.panelId === panelFilterId);
-
-        return {
-          annotations: annotations,
-          alertState: alertState,
-        };
-      })
-      .catch((err) => {
-        if (err.cancelled) {
-          return [];
-        }
-
-        if (!err.message && err.data && err.data.message) {
-          err.message = err.data.message;
-        }
-
-        console.error('AnnotationSrv.query error', err);
-        appEvents.emit(AppEvents.alertError, ['Annotation Query Failed', err.message || err]);
-        return [];
-      });
+    deprecationWarning('annotations_srv.ts', 'getAnnotations', 'DashboardQueryRunner.getResult');
+    return Promise.resolve({ annotations: [], alertState: undefined });
   }
 
+  /**
+   * @deprecated getAlertStates is deprecated in favor of DashboardQueryRunner.getResult
+   */
   getAlertStates(options: any) {
-    if (!options.dashboard.id) {
-      return Promise.resolve([]);
-    }
-
-    // ignore if no alerts
-    if (options.panel && !options.panel.alert) {
-      return Promise.resolve([]);
-    }
-
-    if (options.range.raw.to !== 'now') {
-      return Promise.resolve([]);
-    }
-
-    if (this.alertStatesPromise) {
-      return this.alertStatesPromise;
-    }
-
-    this.alertStatesPromise = getBackendSrv().get(
-      '/api/alerts/states-for-dashboard',
-      {
-        dashboardId: options.dashboard.id,
-      },
-      `get-alert-states-${options.dashboard.id}`
-    );
-
-    return this.alertStatesPromise;
+    deprecationWarning('annotations_srv.ts', 'getAlertStates', 'DashboardQueryRunner.getResult');
+    return Promise.resolve(undefined);
   }
 
+  /**
+   * @deprecated getGlobalAnnotations is deprecated in favor of DashboardQueryRunner.getResult
+   */
   getGlobalAnnotations(options: AnnotationQueryOptions) {
-    const dashboard = options.dashboard;
-
-    if (this.globalAnnotationsPromise) {
-      return this.globalAnnotationsPromise;
-    }
-
-    const range = getTimeSrv().timeRange();
-    const promises = [];
-    const dsPromises = [];
-
-    for (const annotation of dashboard.annotations.list) {
-      if (!annotation.enable) {
-        continue;
-      }
-
-      if (annotation.snapshotData) {
-        return this.translateQueryResult(annotation, annotation.snapshotData);
-      }
-      const datasourcePromise = getDataSourceSrv().get(annotation.datasource);
-      dsPromises.push(datasourcePromise);
-      promises.push(
-        datasourcePromise
-          .then((datasource: DataSourceApi) => {
-            // Use the legacy annotationQuery unless annotation support is explicitly defined
-            if (datasource.annotationQuery && !datasource.annotations) {
-              return datasource.annotationQuery({
-                range,
-                rangeRaw: range.raw,
-                annotation: annotation,
-                dashboard: dashboard,
-              });
-            }
-            // Note: future annotation lifecycle will use observables directly
-            return lastValueFrom(executeAnnotationQuery(options, datasource, annotation)).then((res) => {
-              return res.events ?? [];
-            });
-          })
-          .then((results) => {
-            // store response in annotation object if this is a snapshot call
-            if (dashboard.snapshot) {
-              annotation.snapshotData = cloneDeep(results);
-            }
-            // translate result
-            return this.translateQueryResult(annotation, results);
-          })
-      );
-    }
-    this.datasourcePromises = Promise.all(dsPromises);
-    this.globalAnnotationsPromise = Promise.all(promises);
-    return this.globalAnnotationsPromise;
+    deprecationWarning('annotations_srv.ts', 'getGlobalAnnotations', 'DashboardQueryRunner.getResult');
+    return Promise.resolve([]);
   }
 
+  /**
+   * @deprecated saveAnnotationEvent is deprecated
+   */
   saveAnnotationEvent(annotation: AnnotationEvent) {
-    this.globalAnnotationsPromise = null;
+    deprecationWarning('annotations_srv.ts', 'saveAnnotationEvent', 'api/saveAnnotation');
     return saveAnnotation(annotation);
   }
 
+  /**
+   * @deprecated updateAnnotationEvent is deprecated
+   */
   updateAnnotationEvent(annotation: AnnotationEvent) {
-    this.globalAnnotationsPromise = null;
+    deprecationWarning('annotations_srv.ts', 'updateAnnotationEvent', 'api/updateAnnotation');
     return updateAnnotation(annotation);
   }
 
+  /**
+   * @deprecated deleteAnnotationEvent is deprecated
+   */
   deleteAnnotationEvent(annotation: AnnotationEvent) {
-    this.globalAnnotationsPromise = null;
+    deprecationWarning('annotations_srv.ts', 'deleteAnnotationEvent', 'api/deleteAnnotation');
     return deleteAnnotation(annotation);
   }
 
+  /**
+   * @deprecated translateQueryResult is deprecated in favor of DashboardQueryRunner/utils/translateQueryResult
+   */
   translateQueryResult(annotation: any, results: any) {
+    deprecationWarning('annotations_srv.ts', 'translateQueryResult', 'DashboardQueryRunner/utils/translateQueryResult');
     // if annotation has snapshotData
     // make clone and remove it
     if (annotation.snapshotData) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The old Table panel has an annotation transform that uses AnnotationsSrv (https://github.com/grafana/grafana/issues/37819#issuecomment-927319055). So this PR deprecates AnnotationsSrv and returns empty results.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

