### PR TITLE
Plugin Catalog: support Grafana instances that cannot communicate with gcom

### DIFF
--- a/public/app/features/plugins/admin/__mocks__/mockHelpers.ts
+++ b/public/app/features/plugins/admin/__mocks__/mockHelpers.ts
@@ -1,7 +1,6 @@
 import { setBackendSrv } from '@grafana/runtime';
-import { PluginsState } from 'app/types';
 import { API_ROOT, GRAFANA_API_ROOT } from '../constants';
-import { CatalogPlugin, LocalPlugin, RemotePlugin, Version } from '../types';
+import { CatalogPlugin, LocalPlugin, RemotePlugin, Version, ReducerState, RequestStatus } from '../types';
 import remotePluginMock from './remotePlugin.mock';
 import localPluginMock from './localPlugin.mock';
 import catalogPluginMock from './catalogPlugin.mock';
@@ -16,7 +15,7 @@ export const getLocalPluginMock = (overrides?: Partial<LocalPlugin>) => ({ ...lo
 export const getRemotePluginMock = (overrides?: Partial<RemotePlugin>) => ({ ...remotePluginMock, ...overrides });
 
 // Returns a mock for the Redux store state of plugins
-export const getPluginsStateMock = (plugins: CatalogPlugin[] = []): PluginsState => ({
+export const getPluginsStateMock = (plugins: CatalogPlugin[] = []): ReducerState => ({
   // @ts-ignore - We don't need the rest of the properties here as we are using the "new" reducer (public/app/features/plugins/admin/state/reducer.ts)
   items: {
     ids: plugins.map(({ id }) => id),
@@ -24,12 +23,20 @@ export const getPluginsStateMock = (plugins: CatalogPlugin[] = []): PluginsState
   },
   requests: {
     'plugins/fetchAll': {
-      status: 'Fulfilled',
+      status: RequestStatus.Fulfilled,
     },
     'plugins/fetchDetails': {
-      status: 'Fulfilled',
+      status: RequestStatus.Fulfilled,
     },
   },
+  // Backward compatibility
+  plugins: [],
+  errors: [],
+  searchQuery: '',
+  hasFetched: false,
+  dashboards: [],
+  isLoadingPluginDashboards: false,
+  panels: {},
 });
 
 // Mocks a plugin by considering what needs to be mocked from GCOM and what needs to be mocked locally (local Grafana API)

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -1,6 +1,6 @@
 import { getBackendSrv } from '@grafana/runtime';
 import { API_ROOT, GRAFANA_API_ROOT } from './constants';
-import { mergeLocalsAndRemotes, mergeLocalAndRemote } from './helpers';
+import { mergeLocalAndRemote } from './helpers';
 import { PluginError } from '@grafana/data';
 import {
   PluginDetails,
@@ -12,16 +12,6 @@ import {
   Version,
   PluginVersion,
 } from './types';
-
-export async function getCatalogPlugins(): Promise<CatalogPlugin[]> {
-  const [localPlugins, remotePlugins, pluginErrors] = await Promise.all([
-    getLocalPlugins(),
-    getRemotePlugins(),
-    getPluginErrors(),
-  ]);
-
-  return mergeLocalsAndRemotes(localPlugins, remotePlugins, pluginErrors);
-}
 
 export async function getCatalogPlugin(id: string): Promise<CatalogPlugin> {
   const { local, remote } = await getPlugin(id);
@@ -52,7 +42,7 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
   };
 }
 
-async function getRemotePlugins(): Promise<RemotePlugin[]> {
+export async function getRemotePlugins(): Promise<RemotePlugin[]> {
   const res = await getBackendSrv().get(`${GRAFANA_API_ROOT}/plugins`);
   return res.items;
 }
@@ -73,7 +63,7 @@ async function getPlugin(slug: string): Promise<PluginDetails> {
   };
 }
 
-async function getPluginErrors(): Promise<PluginError[]> {
+export async function getPluginErrors(): Promise<PluginError[]> {
   try {
     return await getBackendSrv().get(`${API_ROOT}/errors`);
   } catch (error) {
@@ -103,7 +93,7 @@ async function getPluginVersions(id: string): Promise<Version[]> {
   }
 }
 
-async function getLocalPlugins(): Promise<LocalPlugin[]> {
+export async function getLocalPlugins(): Promise<LocalPlugin[]> {
   const installed = await getBackendSrv().get(`${API_ROOT}`, { embedded: 0 });
   return installed;
 }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -73,10 +73,10 @@ export async function getPluginErrors(): Promise<PluginError[]> {
 
 async function getRemotePlugin(id: string, isInstalled: boolean): Promise<RemotePlugin | undefined> {
   try {
-    return await getBackendSrv().get(`${GRAFANA_API_ROOT}/plugins/${id}`);
+    return await getBackendSrv().get(`${GRAFANA_API_ROOT}/plugins/${id}`, {});
   } catch (error) {
-    // this might be a plugin that doesn't exist on gcom.
-    error.isHandled = isInstalled;
+    // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
+    error.isHandled = true;
     return;
   }
 }
@@ -89,6 +89,8 @@ async function getPluginVersions(id: string): Promise<Version[]> {
 
     return (versions.items || []).map(({ version, createdAt }) => ({ version, createdAt }));
   } catch (error) {
+    // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
+    error.isHandled = true;
     return [];
   }
 }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -1,7 +1,7 @@
 import { getBackendSrv } from '@grafana/runtime';
+import { PluginError } from '@grafana/data';
 import { API_ROOT, GRAFANA_API_ROOT } from './constants';
 import { mergeLocalAndRemote } from './helpers';
-import { PluginError } from '@grafana/data';
 import {
   PluginDetails,
   Org,

--- a/public/app/features/plugins/admin/components/InstallControls/index.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/index.tsx
@@ -6,10 +6,11 @@ import { config } from '@grafana/runtime';
 import { HorizontalGroup, Icon, LinkButton, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { CatalogPlugin, PluginStatus } from '../../types';
-import { isGrafanaAdmin, getExternalManageLink } from '../../helpers';
 import { ExternallyManagedButton } from './ExternallyManagedButton';
 import { InstallControlsButton } from './InstallControlsButton';
+import { CatalogPlugin, PluginStatus } from '../../types';
+import { isGrafanaAdmin, getExternalManageLink } from '../../helpers';
+import { useIsRemotePluginsAvailable } from '../../state/hooks';
 
 interface Props {
   plugin: CatalogPlugin;
@@ -20,6 +21,7 @@ export const InstallControls = ({ plugin }: Props) => {
   const isExternallyManaged = config.pluginAdminExternalManageEnabled;
   const hasPermission = isGrafanaAdmin();
   const grafanaDependency = plugin.details?.grafanaDependency;
+  const isRemotePluginsAvailable = useIsRemotePluginsAvailable();
   const unsupportedGrafanaVersion = grafanaDependency
     ? !satisfies(config.buildInfo.version, grafanaDependency, {
         // needed for when running against main
@@ -76,6 +78,14 @@ export const InstallControls = ({ plugin }: Props) => {
 
   if (isExternallyManaged) {
     return <ExternallyManagedButton pluginId={plugin.id} pluginStatus={pluginStatus} />;
+  }
+
+  if (!isRemotePluginsAvailable) {
+    return (
+      <div className={styles.message}>
+        The install controls have been disabled because the Grafana server cannot access grafana.com.
+      </div>
+    );
   }
 
   return <InstallControlsButton plugin={plugin} pluginStatus={pluginStatus} />;

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -7,8 +7,9 @@ import { config } from '@grafana/runtime';
 import { configureStore } from 'app/store/configureStore';
 import PluginDetailsPage from './PluginDetails';
 import { getRouteComponentProps } from 'app/core/navigation/__mocks__/routeProps';
-import { CatalogPlugin, PluginTabIds } from '../types';
+import { CatalogPlugin, PluginTabIds, RequestStatus, ReducerState } from '../types';
 import * as api from '../api';
+import { fetchRemotePlugins } from '../state/actions';
 import { mockPluginApis, getCatalogPluginMock, getPluginsStateMock } from '../__mocks__';
 import { PluginErrorCode, PluginSignatureStatus } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -25,7 +26,16 @@ jest.mock('@grafana/runtime', () => {
   return mockedRuntime;
 });
 
-const renderPluginDetails = (pluginOverride: Partial<CatalogPlugin>, pageId = PluginTabIds.OVERVIEW): RenderResult => {
+const renderPluginDetails = (
+  pluginOverride: Partial<CatalogPlugin>,
+  {
+    pageId = PluginTabIds.OVERVIEW,
+    pluginsStateOverride,
+  }: {
+    pageId?: PluginTabIds;
+    pluginsStateOverride?: ReducerState;
+  } = {}
+): RenderResult => {
   const plugin = getCatalogPluginMock(pluginOverride);
   const { id } = plugin;
   const props = getRouteComponentProps({
@@ -39,7 +49,7 @@ const renderPluginDetails = (pluginOverride: Partial<CatalogPlugin>, pageId = Pl
     },
   });
   const store = configureStore({
-    plugins: getPluginsStateMock([plugin]),
+    plugins: pluginsStateOverride || getPluginsStateMock([plugin]),
   });
 
   return render(
@@ -163,7 +173,7 @@ describe('Plugin details page', () => {
           ],
         },
       },
-      PluginTabIds.VERSIONS
+      { pageId: PluginTabIds.VERSIONS }
     );
 
     // Check if version information is available
@@ -331,5 +341,41 @@ describe('Plugin details page', () => {
 
     // Check if the modal disappeared
     expect(queryByText('Uninstall Akumuli')).not.toBeInTheDocument();
+  });
+
+  it('should not display the install / uninstall / update buttons if the GCOM api is not available', async () => {
+    let rendered: RenderResult;
+    const plugin = getCatalogPluginMock({ id });
+    const state = getPluginsStateMock([plugin]);
+
+    // Mock the store like if the remote plugins request was rejected
+    const pluginsStateOverride = {
+      ...state,
+      requests: {
+        ...state.requests,
+        [fetchRemotePlugins.typePrefix]: {
+          status: RequestStatus.Rejected,
+        },
+      },
+    };
+
+    // Does not show an Install button
+    rendered = renderPluginDetails({ id }, { pluginsStateOverride });
+    await waitFor(() => expect(rendered.queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument());
+    rendered.unmount();
+
+    // Does not show a Uninstall button
+    rendered = renderPluginDetails({ id, isInstalled: true }, { pluginsStateOverride });
+    await waitFor(() => expect(rendered.queryByRole('button', { name: /(un)?install/i })).not.toBeInTheDocument());
+    rendered.unmount();
+
+    // Does not show an Update button
+    rendered = renderPluginDetails({ id, isInstalled: true, hasUpdate: true }, { pluginsStateOverride });
+    await waitFor(() => expect(rendered.queryByRole('button', { name: /update/i })).not.toBeInTheDocument());
+
+    // Shows a message to the user
+    // TODO<Import these texts from a single source of truth instead of having them defined in multiple places>
+    const message = 'The install controls have been disabled because the Grafana server cannot access grafana.com.';
+    expect(rendered.getByText(message)).toBeInTheDocument();
   });
 });

--- a/public/app/features/plugins/admin/state/hooks.ts
+++ b/public/app/features/plugins/admin/state/hooks.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchAll, fetchDetails, install, uninstall } from './actions';
+import { fetchAll, fetchDetails, fetchRemotePlugins, install, uninstall } from './actions';
 import { CatalogPlugin, PluginCatalogStoreState } from '../types';
 import {
   find,
@@ -61,6 +61,11 @@ export const useUninstall = () => {
   const dispatch = useDispatch();
 
   return (id: string) => dispatch(uninstall(id));
+};
+
+export const useIsRemotePluginsAvailable = () => {
+  const error = useSelector(selectRequestError(fetchRemotePlugins.typePrefix));
+  return error === null;
 };
 
 export const useFetchStatus = () => {

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -216,6 +216,10 @@ export enum RequestStatus {
   Fulfilled = 'Fulfilled',
   Rejected = 'Rejected',
 }
+export type RemotePluginResponse = {
+  plugins: RemotePlugin[];
+  error?: Error;
+};
 
 export type RequestInfo = {
   status: RequestStatus;


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Have a selector for checking if GCOM is not available
- [x] Disable filtering by Installed / All on the Plugins Catalog list page if GCOM is inaccessible 
- [x] Disable install controls on the Plugin Details page if GCOM is inaccessible
- [ ] Render a notice (somewhere) that explains that because GCOM isn't accessible the catalog has limited functionality
- [x] Add tests

**Which issue(s) this PR fixes**:
Fixes #39459

---

**The browse with the limited filtering when GCOM is not available:**
<img width="1447" alt="Screenshot 2021-09-28 at 14 39 06" src="https://user-images.githubusercontent.com/9974811/135088784-f1739490-3786-4027-a4c4-57e5860ca8c0.png">
 

**The plugin details with disabled install controls if GCOM is not available:**
<img width="1427" alt="Screenshot 2021-09-28 at 14 39 20" src="https://user-images.githubusercontent.com/9974811/135088919-e3d485a0-9819-4b43-98f4-9e620eb9cc45.png">
