### PR TITLE
Loki: Fixed creating context query for logs with parsed labels.

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -467,8 +467,17 @@ export class LokiDatasource extends DataSourceApi<LokiQuery, LokiOptions> {
   };
 
   prepareLogRowContextQueryTarget = (row: LogRowModel, limit: number, direction: 'BACKWARD' | 'FORWARD') => {
+    const labels = this.languageProvider.getLabelKeys();
     const query = Object.keys(row.labels)
-      .map((label) => `${label}="${row.labels[label].replace(/\\/g, '\\\\')}"`) // escape backslashes in label as users can't escape them by themselves
+      .map((label: string) => {
+        if (labels.includes(label)) {
+          // escape backslashes in label as users can't escape them by themselves
+          return `${label}="${row.labels[label].replace(/\\/g, '\\\\')}"`;
+        }
+        return '';
+      })
+      // Filter empty strings
+      .filter((label) => !!label)
       .join(',');
 
     const contextTimeBuffer = 2 * 60 * 60 * 1000; // 2h buffer


### PR DESCRIPTION
**What this PR does / why we need it**:
Log context didn't work for Loki queries that use parser. When parser are used, we create parsed labels, and in frontend, we used all labels - parsed and actual - to create context query. However, because parsed labels are not actual labels, queries were incorrect and returned either 0 results or if pattern/more complex parser was use - it could throw error.

To fix this, we filter out all parsed labels by going over labels array and using only actual labels in the query.

Fixed: 
![image](https://user-images.githubusercontent.com/30407135/134905098-338df8e4-3aa5-4d04-9309-b6259300e8ed.png)

Before - 0 results:
![image](https://user-images.githubusercontent.com/30407135/134906429-c7e5c940-670f-4005-ba09-3fb790a26e34.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/37736#issuecomment-924021736

**Special notes for your reviewer**:
To review, write Loki query such as `{job="tns/app"} |="err" | logfmt` and click on show context. You should see context logs and not error. If you want to make sure that 
