### PR TITLE
[v8.1.x] Elasticsearch: Set correct service namespace for SigV4 (#39439)

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -88,6 +88,11 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 			return nil, fmt.Errorf("error getting http options: %w", err)
 		}
 
+		// Set SigV4 service namespace
+		if httpCliOpts.SigV4 != nil {
+			httpCliOpts.SigV4.Service = "es"
+		}
+
 		version, err := coerceVersion(jsonData["esVersion"])
 
 		if err != nil {


### PR DESCRIPTION
Backports 45a844e77ee667265a8f27bfa683d8ea8196336d from #39439