### PR TITLE
Gauge: Add orientation option to make it more consistent with Stat & Bar Gauge

### DIFF
--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { FieldDisplay, getFieldDisplayValues, PanelProps, VizOrientation } from '@grafana/data';
+import { FieldDisplay, getFieldDisplayValues, PanelProps } from '@grafana/data';
 import { DataLinksContextMenu, Gauge, VizRepeater, VizRepeaterRenderValueProps } from '@grafana/ui';
 import { DataLinksContextMenuApi } from '@grafana/ui/src/components/DataLinks/DataLinksContextMenu';
 
@@ -63,7 +63,8 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
   };
 
   render() {
-    const { height, width, data, renderCounter } = this.props;
+    const { height, width, data, renderCounter, options } = this.props;
+
     return (
       <VizRepeater
         getValues={this.getValues}
@@ -73,7 +74,7 @@ export class GaugePanel extends PureComponent<PanelProps<GaugeOptions>> {
         source={data}
         autoGrid={true}
         renderCounter={renderCounter}
-        orientation={VizOrientation.Auto}
+        orientation={options.orientation}
       />
     );
   }

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -1,7 +1,7 @@
 import { PanelPlugin } from '@grafana/data';
 import { GaugePanel } from './GaugePanel';
 import { GaugeOptions } from './types';
-import { addStandardDataReduceOptions } from '../stat/types';
+import { addOrientationOption, addStandardDataReduceOptions } from '../stat/types';
 import { gaugePanelMigrationHandler, gaugePanelChangedHandler } from './GaugeMigrations';
 import { commonOptionsBuilder } from '@grafana/ui';
 
@@ -9,6 +9,7 @@ export const plugin = new PanelPlugin<GaugeOptions>(GaugePanel)
   .useFieldConfig()
   .setPanelOptions((builder) => {
     addStandardDataReduceOptions(builder);
+    addOrientationOption(builder);
 
     builder
       .addBooleanSwitch({


### PR DESCRIPTION
Adds the orientation prop to Gauge panel to make it's cue model correct and makes it more consistent (And configurable).

Question is if we need a dashboard migration that forces it to auto? There can be some panels out there that have this set to a value if they changed to stat panel and then back to gauge, and the value
set before was ignored but is now used.
