### PR TITLE
grafana-ui: Improve PartialHighlighter error handling

### DIFF
--- a/packages/grafana-ui/src/components/Typeahead/PartialHighlighter.test.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/PartialHighlighter.test.tsx
@@ -45,4 +45,11 @@ describe('PartialHighlighter component', () => {
     assertPart(main.childAt(1), false, ' ipsum dolor sit ');
     assertPart(main.childAt(2), true, 'amet');
   });
+
+  it('returns null if highlightParts is empty', () => {
+    const component = mount(
+      <PartialHighlighter text="Lorem ipsum dolor sit amet" highlightClassName="highlight" highlightParts={[]} />
+    );
+    expect(component.html()).toBe(null);
+  });
 });

--- a/packages/grafana-ui/src/components/Typeahead/PartialHighlighter.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/PartialHighlighter.tsx
@@ -29,7 +29,7 @@ function getStartIndices(parts: HighlightPart[], length: number): number[] {
 export const PartialHighlighter: React.FC<Props> = (props: Props) => {
   let { highlightParts, text, highlightClassName } = props;
 
-  if (!highlightParts) {
+  if (!highlightParts?.length) {
     return null;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
PartialHighlighter was throwing an error because it wasn't correctly checking if highlightParts had values and was accessing the array without checking first. This caused an error when loading autocomplete values for the Prometheus query editor.

**Which issue(s) this PR fixes**:
Fixes #39679

**Special notes for your reviewer**:

