### PR TITLE
convert legacy matchers to new object_matchers in routes

### DIFF
--- a/public/app/features/alerting/unified/AmRoutes.test.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.test.tsx
@@ -122,6 +122,11 @@ describe('AmRoutes', () => {
     },
   ];
 
+  const simpleRoute: Route = {
+    receiver: 'simple-receiver',
+    matchers: ['hello=world', 'foo!=bar'],
+  };
+
   const rootRoute: Route = {
     receiver: 'default-receiver',
     group_by: ['a-group', 'another-group'],
@@ -325,6 +330,75 @@ describe('AmRoutes', () => {
     expect(await byText("Alertmanager has exploded. it's gone. Forget about it.").find()).toBeInTheDocument();
     expect(ui.rootReceiver.query()).not.toBeInTheDocument();
     expect(ui.editButton.query()).not.toBeInTheDocument();
+  });
+
+  it('Converts matchers to object_matchers for grafana alertmanager', async () => {
+    const defaultConfig: AlertManagerCortexConfig = {
+      alertmanager_config: {
+        receivers: [{ name: 'default' }, { name: 'critical' }],
+        route: {
+          continue: false,
+          receiver: 'default',
+          group_by: ['alertname'],
+          routes: [simpleRoute],
+          group_interval: '4m',
+          group_wait: '1m',
+          repeat_interval: '5h',
+        },
+        templates: [],
+      },
+      template_files: {},
+    };
+
+    const currentConfig = { current: defaultConfig };
+    mocks.api.updateAlertManagerConfig.mockImplementation((amSourceName, newConfig) => {
+      currentConfig.current = newConfig;
+      return Promise.resolve();
+    });
+
+    mocks.api.fetchAlertManagerConfig.mockImplementation(() => {
+      return Promise.resolve(currentConfig.current);
+    });
+
+    await renderAmRoutes();
+    expect(await ui.rootReceiver.find()).toHaveTextContent('default');
+    expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled();
+
+    // Toggle a save to test new object_matchers
+    const rootRouteContainer = await ui.rootRouteContainer.find();
+    userEvent.click(ui.editButton.get(rootRouteContainer));
+    userEvent.click(ui.saveButton.get(rootRouteContainer));
+
+    await waitFor(() => expect(ui.editButton.query(rootRouteContainer)).not.toBeInTheDocument());
+
+    expect(mocks.api.updateAlertManagerConfig).toHaveBeenCalled();
+    expect(mocks.api.updateAlertManagerConfig).toHaveBeenCalledWith(GRAFANA_RULES_SOURCE_NAME, {
+      alertmanager_config: {
+        receivers: [{ name: 'default' }, { name: 'critical' }],
+        route: {
+          continue: false,
+          group_by: ['alertname'],
+          group_interval: '4m',
+          group_wait: '1m',
+          receiver: 'default',
+          repeat_interval: '5h',
+          routes: [
+            {
+              continue: false,
+              group_by: [],
+              object_matchers: [
+                ['hello', '=', 'world'],
+                ['foo', '!=', 'bar'],
+              ],
+              receiver: 'simple-receiver',
+              routes: [],
+            },
+          ],
+        },
+        templates: [],
+      },
+      template_files: {},
+    });
   });
 });
 

--- a/public/app/features/alerting/unified/AmRoutes.test.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.test.tsx
@@ -27,8 +27,9 @@ const mocks = {
   },
 };
 
-const renderAmRoutes = () => {
+const renderAmRoutes = (location = '') => {
   const store = configureStore();
+  locationService.push(location);
 
   return render(
     <Provider store={store}>
@@ -390,6 +391,73 @@ describe('AmRoutes', () => {
                 ['hello', '=', 'world'],
                 ['foo', '!=', 'bar'],
               ],
+              receiver: 'simple-receiver',
+              routes: [],
+            },
+          ],
+        },
+        templates: [],
+      },
+      template_files: {},
+    });
+  });
+
+  it('Keeps matchers for non-grafana alertmanager sources', async () => {
+    const defaultConfig: AlertManagerCortexConfig = {
+      alertmanager_config: {
+        receivers: [{ name: 'default' }, { name: 'critical' }],
+        route: {
+          continue: false,
+          receiver: 'default',
+          group_by: ['alertname'],
+          routes: [simpleRoute],
+          group_interval: '4m',
+          group_wait: '1m',
+          repeat_interval: '5h',
+        },
+        templates: [],
+      },
+      template_files: {},
+    };
+
+    const currentConfig = { current: defaultConfig };
+    mocks.api.updateAlertManagerConfig.mockImplementation((amSourceName, newConfig) => {
+      currentConfig.current = newConfig;
+      return Promise.resolve();
+    });
+
+    mocks.api.fetchAlertManagerConfig.mockImplementation(() => {
+      return Promise.resolve(currentConfig.current);
+    });
+
+    await renderAmRoutes(`?alertmanager=${dataSources.am.name}`);
+    expect(await ui.rootReceiver.find()).toHaveTextContent('default');
+    expect(mocks.api.fetchAlertManagerConfig).toHaveBeenCalled();
+
+    // Toggle a save to test new object_matchers
+    const rootRouteContainer = await ui.rootRouteContainer.find();
+    userEvent.click(ui.editButton.get(rootRouteContainer));
+    userEvent.click(ui.saveButton.get(rootRouteContainer));
+
+    await waitFor(() => expect(ui.editButton.query(rootRouteContainer)).not.toBeInTheDocument());
+
+    expect(mocks.api.updateAlertManagerConfig).toHaveBeenCalled();
+    expect(mocks.api.updateAlertManagerConfig).toHaveBeenCalledWith(dataSources.am.name, {
+      alertmanager_config: {
+        receivers: [{ name: 'default' }, { name: 'critical' }],
+        route: {
+          continue: false,
+          group_by: ['alertname'],
+          group_interval: '4m',
+          group_wait: '1m',
+          matchers: [],
+          receiver: 'default',
+          repeat_interval: '5h',
+          routes: [
+            {
+              continue: false,
+              group_by: [],
+              matchers: ['hello=world', 'foo!=bar'],
               receiver: 'simple-receiver',
               routes: [],
             },

--- a/public/app/features/alerting/unified/AmRoutes.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.tsx
@@ -56,6 +56,7 @@ const AmRoutes: FC = () => {
   useCleanup((state) => state.unifiedAlerting.saveAMConfig);
   const handleSave = (data: Partial<FormAmRoute>) => {
     const newData = formAmRouteToAmRoute(
+      alertManagerSourceName,
       {
         ...rootRoute,
         ...data,

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -87,12 +87,18 @@ export type Receiver = {
   [key: string]: any;
 };
 
+type ObjectMatcher = [name: string, operator: MatcherOperator, value: string];
+
 export type Route = {
   receiver?: string;
   group_by?: string[];
   continue?: boolean;
-  object_matchers?: string[][];
+  object_matchers?: ObjectMatcher[];
+  /** @deprecated use `object_matchers` for matcher namespaces support */
+  matchers?: string[];
+  /** @deprecated use `object_matchers` */
   match?: Record<string, string>;
+  /** @deprecated use `object_matchers` */
   match_re?: Record<string, string>;
   group_wait?: string;
   group_interval?: string;

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -94,7 +94,6 @@ export type Route = {
   group_by?: string[];
   continue?: boolean;
   object_matchers?: ObjectMatcher[];
-  /** @deprecated use `object_matchers` for matcher namespaces support */
   matchers?: string[];
   /** @deprecated use `object_matchers` */
   match?: Record<string, string>;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is related to: https://github.com/grafana/grafana/pull/38629

- Converts existing `matchers` to `object_matchers`
- Add tuple type for `object_matchers` and deprecation flag to `matchers` in types.

**Special notes for your reviewer**:

