### PR TITLE
Docs: Add docs for Redis cluster caching backend configuration

### DIFF
--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -403,9 +403,9 @@ The default is `"redis://localhost:6379"`.
 
 ### cluster
 
-A comma separated list of Redis cluster members in `host:port` format. Example: `localhost:7000, localhost: 7001, localhost:7002`.
+A comma-separated list of Redis cluster members in `host:port` format. For example, `localhost:7000, localhost: 7001, localhost:7002`.
 
-> **Note:** The value for `url` will be ignored if `cluster` is specified.
+> **Note:** If you have specify `cluster`, the value for `url` is ignored.
 
 ### prefix
 

--- a/docs/sources/enterprise/enterprise-configuration.md
+++ b/docs/sources/enterprise/enterprise-configuration.md
@@ -401,6 +401,12 @@ The full Redis URL of your Redis server. Example: `redis://localhost:6739/0`.
 
 The default is `"redis://localhost:6379"`.
 
+### cluster
+
+A comma separated list of Redis cluster members in `host:port` format. Example: `localhost:7000, localhost: 7001, localhost:7002`.
+
+> **Note:** The value for `url` will be ignored if `cluster` is specified.
+
 ### prefix
 
 A string that prefixes all Redis keys. This value must be set if using a shared database in Redis. If `prefix` is empty, then one will not be used.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This adds documentation for the new `cluster` option in the redis caching backend.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Adds documentation for:
* https://github.com/grafana/grafana-enterprise/issues/1959

**Special notes for your reviewer**: