### PR TITLE
E2E: improvements to the importDashboard flow

### DIFF
--- a/e2e/suite1/dashboards/TestDashboard.json
+++ b/e2e/suite1/dashboards/TestDashboard.json
@@ -1,0 +1,210 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 321,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.3.0-pre",
+      "title": "Gauge Example",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.0-pre",
+      "title": "Stat",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "title": "Time series example",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 31,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2021-09-01T04:00:00.000Z",
+    "to": "2021-09-15T04:00:00.000Z"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "E2E Test - Import Dashboard",
+  "uid": "kquZN5H7k",
+  "version": 4
+}

--- a/e2e/suite1/specs/import-dashboard.spec.ts
+++ b/e2e/suite1/specs/import-dashboard.spec.ts
@@ -1,122 +1,14 @@
 import { e2e } from '@grafana/e2e';
 
+const PATH_TO_TEST_DASHBOARD_DIRECTORY = '../../../../e2e/suite1/dashboards';
+
 e2e.scenario({
-  describeName: 'Import Dashboard Test',
-  itName: 'Ensure you can import a dashboard',
+  describeName: 'Import Dashboards Test',
+  itName: 'Ensure you can import a number of json test dashboards from a specific test directory',
   addScenarioDataSource: false,
   addScenarioDashBoard: false,
   skipScenario: false,
   scenario: () => {
-    e2e.flows.importDashboard(TEST_DASHBOARD);
+    e2e.flows.importDashboards(PATH_TO_TEST_DASHBOARD_DIRECTORY, 1000);
   },
 });
-
-const TEST_DASHBOARD = {
-  annotations: {
-    list: [
-      {
-        builtIn: 1,
-        datasource: '-- Grafana --',
-        enable: true,
-        hide: true,
-        iconColor: 'rgba(0, 211, 255, 1)',
-        name: 'Annotations & Alerts',
-        type: 'dashboard',
-      },
-    ],
-  },
-  editable: true,
-  gnetId: null,
-  graphTooltip: 0,
-  id: 74,
-  links: [],
-  panels: [
-    {
-      datasource: null,
-      fieldConfig: {
-        defaults: {
-          color: {
-            mode: 'palette-classic',
-          },
-          custom: {
-            axisLabel: '',
-            axisPlacement: 'auto',
-            barAlignment: 0,
-            drawStyle: 'line',
-            fillOpacity: 0,
-            gradientMode: 'none',
-            hideFrom: {
-              legend: false,
-              tooltip: false,
-              viz: false,
-            },
-            lineInterpolation: 'linear',
-            lineWidth: 1,
-            pointSize: 5,
-            scaleDistribution: {
-              type: 'linear',
-            },
-            showPoints: 'auto',
-            spanNulls: false,
-            stacking: {
-              group: 'A',
-              mode: 'none',
-            },
-            thresholdsStyle: {
-              mode: 'off',
-            },
-          },
-          mappings: [],
-          thresholds: {
-            mode: 'absolute',
-            steps: [
-              {
-                color: 'green',
-                value: null,
-              },
-              {
-                color: 'red',
-                value: 80,
-              },
-            ],
-          },
-        },
-        overrides: [],
-      },
-      gridPos: {
-        h: 9,
-        w: 12,
-        x: 0,
-        y: 0,
-      },
-      id: 2,
-      options: {
-        legend: {
-          calcs: [],
-          displayMode: 'list',
-          placement: 'bottom',
-        },
-        tooltip: {
-          mode: 'single',
-        },
-      },
-      title: 'Panel Title',
-      type: 'timeseries',
-    },
-  ],
-  schemaVersion: 30,
-  style: 'dark',
-  tags: [],
-  templating: {
-    list: [],
-  },
-  time: {
-    from: '2021-06-30T04:00:00.000Z',
-    to: '2021-07-02T03:59:59.000Z',
-  },
-  timepicker: {},
-  timezone: '',
-  title: 'An imported dashboard for e2e tests',
-  uid: '6V0Nzyz7k',
-  version: 1,
-};

--- a/e2e/suite1/specs/import-dashboard.spec.ts
+++ b/e2e/suite1/specs/import-dashboard.spec.ts
@@ -1,7 +1,5 @@
 import { e2e } from '@grafana/e2e';
 
-const PATH_TO_TEST_DASHBOARD_DIRECTORY = '../../../../e2e/suite1/dashboards';
-
 e2e.scenario({
   describeName: 'Import Dashboards Test',
   itName: 'Ensure you can import a number of json test dashboards from a specific test directory',
@@ -9,6 +7,6 @@ e2e.scenario({
   addScenarioDashBoard: false,
   skipScenario: false,
   scenario: () => {
-    e2e.flows.importDashboards(PATH_TO_TEST_DASHBOARD_DIRECTORY, 1000);
+    e2e.flows.importDashboards('/dashboards', 1000);
   },
 });

--- a/e2e/suite1/tsconfig.json
+++ b/e2e/suite1/tsconfig.json
@@ -3,5 +3,6 @@
     "types": ["cypress"]
   },
   "extends": "../../tsconfig.json",
-  "include": ["**/*.ts", "../../packages/grafana-e2e/cypress/support/index.d.ts"]
+  "include": ["**/*.ts", "../../packages/grafana-e2e/cypress/support/index.d.ts"],
+  "resolveJsonModule": true
 }

--- a/packages/grafana-e2e/cypress/plugins/index.js
+++ b/packages/grafana-e2e/cypress/plugins/index.js
@@ -20,16 +20,11 @@ module.exports = (on, config) => {
       const directoryPath = path.join(projectPath, relativePath);
       const jsonFiles = fs.readdirSync(directoryPath);
       return jsonFiles
+        .filter((fileName) => /.json$/i.test(fileName))
         .map((fileName) => {
-          try {
-            const fileBuffer = fs.readFileSync(path.join(directoryPath, fileName));
-            return JSON.parse(fileBuffer);
-          } catch (err) {
-            console.error(`Could not read and parse: ${fileName}`);
-            return null;
-          }
-        })
-        .filter((fileWasParsedSuccessfully) => !!fileWasParsedSuccessfully);
+          const fileBuffer = fs.readFileSync(path.join(directoryPath, fileName));
+          return JSON.parse(fileBuffer);
+        });
     },
   });
 

--- a/packages/grafana-e2e/cypress/plugins/index.js
+++ b/packages/grafana-e2e/cypress/plugins/index.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 const compareScreenshots = require('./compareScreenshots');
 const extendConfig = require('./extendConfig');
 const readProvisions = require('./readProvisions');
@@ -10,6 +13,17 @@ module.exports = (on, config) => {
     log({ message, optional }) {
       optional ? console.log(message, optional) : console.log(message);
       return null;
+    },
+  });
+  on('task', {
+    getJSONFiles: async ({ dirPath }) => {
+      const directoryPath = path.join(__dirname, dirPath);
+      console.log(`Attempting to read contents of directory: ${directoryPath}`);
+      const jsonFiles = fs.readdirSync(directoryPath);
+      return jsonFiles.map((fileName) => {
+        const fileBuffer = fs.readFileSync(path.join(directoryPath, fileName));
+        return JSON.parse(fileBuffer);
+      });
     },
   });
 

--- a/packages/grafana-e2e/cypress/plugins/index.js
+++ b/packages/grafana-e2e/cypress/plugins/index.js
@@ -16,14 +16,20 @@ module.exports = (on, config) => {
     },
   });
   on('task', {
-    getJSONFiles: async ({ dirPath }) => {
-      const directoryPath = path.join(__dirname, dirPath);
-      console.log(`Attempting to read contents of directory: ${directoryPath}`);
+    getJSONFilesFromDir: async ({ projectPath, relativePath }) => {
+      const directoryPath = path.join(projectPath, relativePath);
       const jsonFiles = fs.readdirSync(directoryPath);
-      return jsonFiles.map((fileName) => {
-        const fileBuffer = fs.readFileSync(path.join(directoryPath, fileName));
-        return JSON.parse(fileBuffer);
-      });
+      return jsonFiles
+        .map((fileName) => {
+          try {
+            const fileBuffer = fs.readFileSync(path.join(directoryPath, fileName));
+            return JSON.parse(fileBuffer);
+          } catch (err) {
+            console.error(`Could not read and parse: ${fileName}`);
+            return null;
+          }
+        })
+        .filter((fileWasParsedSuccessfully) => !!fileWasParsedSuccessfully);
     },
   });
 

--- a/packages/grafana-e2e/cypress/support/commands.ts
+++ b/packages/grafana-e2e/cypress/support/commands.ts
@@ -23,3 +23,10 @@ Cypress.Commands.add('readProvisions', (filePaths: string[]) => {
     filePaths,
   });
 });
+
+Cypress.Commands.add('getJSONFilesFromDir', (dirPath: string) => {
+  return cy.task('getJSONFilesFromDir', {
+    projectPath: Cypress.config().parentTestsFolder,
+    relativePath: dirPath,
+  });
+});

--- a/packages/grafana-e2e/cypress/support/index.d.ts
+++ b/packages/grafana-e2e/cypress/support/index.d.ts
@@ -5,5 +5,6 @@ declare namespace Cypress {
     compareScreenshots(config: CompareScreenshotsConfig | string): Chainable;
     logToConsole(message: string, optional?: any): void;
     readProvisions(filePaths: string[]): Chainable;
+    getJSONFilesFromDir(dirPath: string): Chainable;
   }
 }

--- a/packages/grafana-e2e/src/flows/importDashboards.ts
+++ b/packages/grafana-e2e/src/flows/importDashboards.ts
@@ -1,0 +1,26 @@
+import { importDashboard, Dashboard } from './importDashboard';
+import { e2e } from '../index';
+
+/**
+ * Smoke test several dashboard json files from a test directory
+ * and validate that all the panels in each import finish loading their queries
+ * @param dirPath the path to a directory which contains json files representing dashboards.
+ * A note that due this directory must be relative to `node_modules/@grafana/e2e/cypress/plugins`
+ * so an example path might be something like `../../../../../cypress/fixtures/testDashboards`
+ * @param queryTimeout a number of ms to wait for the imported dashboard to finish loading
+ */
+export const importDashboards = async (dirPath: string, queryTimeout?: number) => {
+  /* 
+    Why not just use fs.readDir? 
+    Because Cypress runs this file in a (headless) browser, not in node 
+    so we don't have access to fs. Fortunately cypress offers a workaround:
+    ".task" which lets us run node like readDir in a separate process 
+  */
+  e2e()
+    .task<Dashboard[]>('getJSONFiles', { dirPath })
+    .then((jsonFiles) => {
+      jsonFiles.forEach((file) => {
+        importDashboard(file, queryTimeout || 6000);
+      });
+    });
+};

--- a/packages/grafana-e2e/src/flows/importDashboards.ts
+++ b/packages/grafana-e2e/src/flows/importDashboards.ts
@@ -4,21 +4,14 @@ import { e2e } from '../index';
 /**
  * Smoke test several dashboard json files from a test directory
  * and validate that all the panels in each import finish loading their queries
- * @param dirPath the path to a directory which contains json files representing dashboards.
- * A note that due this directory must be relative to `node_modules/@grafana/e2e/cypress/plugins`
- * so an example path might be something like `../../../../../cypress/fixtures/testDashboards`
+ * @param dirPath the relative path to a directory which contains json files representing dashboards,
+ * for example if your dashboards live in `cypress/testDashboards` you can pass `/testDashboards`
  * @param queryTimeout a number of ms to wait for the imported dashboard to finish loading
  */
 export const importDashboards = async (dirPath: string, queryTimeout?: number) => {
-  /* 
-    Why not just use fs.readDir? 
-    Because Cypress runs this file in a (headless) browser, not in node 
-    so we don't have access to fs. Fortunately cypress offers a workaround:
-    ".task" which lets us run node like readDir in a separate process 
-  */
   e2e()
-    .task<Dashboard[]>('getJSONFiles', { dirPath })
-    .then((jsonFiles) => {
+    .getJSONFilesFromDir(dirPath)
+    .then((jsonFiles: Dashboard[]) => {
       jsonFiles.forEach((file) => {
         importDashboard(file, queryTimeout || 6000);
       });

--- a/packages/grafana-e2e/src/flows/index.ts
+++ b/packages/grafana-e2e/src/flows/index.ts
@@ -13,6 +13,7 @@ export * from './revertAllChanges';
 export * from './saveDashboard';
 export * from './selectOption';
 export * from './importDashboard';
+export * from './importDashboards';
 
 export {
   VISUALIZATION_ALERT_LIST,


### PR DESCRIPTION
**What this PR does / why we need it**:

Several improvements to the importDashboard e2e flow
- removes .waits and replaces it with an optionally customizable query wait time, to ensure that queries load within a particular amount of time.
- validates every panel in a dashboard loads successfully and not just the first panel
- adds a new flow importDashboards which uses the original importDashboard to all test dashboards in a particular test directory that the user specifies. The goal here is to make it easy for datasource developers to add several dashboards with lots of different queries to ensure they've successfully connected to their backend datasource. 

**Special notes for reviewer**
While the existing importDashboard flow is not particularly difficult to write code for, we thought it might be nice to improve this process particularly for external contributors and stakeholders. The idea is if that we would write the code to hook up importDashboards to a particular test directory and then anyone can make a pr with a dashboard json file without ever having to necessarily write code to run it as part of our e2e testing suite. 

The most difficult part of this was that it's not really possible to run fs.readDir from a cypress test file which means it's a bit hard to test a whole directory with an unknown number of files or names of files. There were several other options I considered:
- creating some sort of index file that imports all of json files and then using [cypress.readFile](https://docs.cypress.io/api/commands/readfile#Syntax) to parse it. This seemed easiest but also seemed like it was missing the point. The whole idea behind this was that setting up an e2e flow for an external datasource should be very set-it-and-forget-it, where there's some initial set up work, but then adding new tests is as easy as adding one file to one folder. 
- writing some sort of script that had a hardcoded path that it would look for and generating that index file dynamically. This seemed potentially promising, but seemed like a fair bit of work and maybe a bit brittle. 
-  the choice I ended up taking was to use [Cypress.task](https://docs.cypress.io/api/commands/task) to run node. I believe this is the recommended path for this sort of thing. The only downside to this approach was that when I run readDir, all the calls are being made from within node_modules so whatever directory path we pass to it needs to be relative to the file in node_modules. I don't love this, but I think it should work. I've tried to provide an example in the typescript comments. So hopefully that's sufficient. Let me know though if there's something obvious I missed!
