### PR TITLE
AccessControl: Add FGAC permissions to org update endpoint

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -207,8 +207,8 @@ func (hs *HTTPServer) registerRoutes() {
 		// current org
 		apiRoute.Group("/org", func(orgRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
-			orgRoute.Put("/", reqOrgAdmin, bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrgCurrent))
-			orgRoute.Put("/address", reqOrgAdmin, bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddressCurrent))
+			orgRoute.Put("/", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgCurrentID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateCurrentOrg))
+			orgRoute.Put("/address", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgCurrentID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateCurrentOrgAddress))
 			orgRoute.Get("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsersForCurrentOrg))
 			orgRoute.Get("/users/search", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.SearchOrgUsersWithPaging))
 			orgRoute.Post("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), quota("user"), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUserToCurrentOrg))
@@ -222,7 +222,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 			// prefs
 			orgRoute.Get("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesRead, ScopeOrgCurrentID)), routing.Wrap(GetOrgPreferences))
-			orgRoute.Put("/preferences", reqOrgAdmin, bind(dtos.UpdatePrefsCmd{}), routing.Wrap(UpdateOrgPreferences))
+			orgRoute.Put("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesWrite, ScopeOrgCurrentID)), bind(dtos.UpdatePrefsCmd{}), routing.Wrap(UpdateOrgPreferences))
 		})
 
 		// current org without requirement of user to be org admin
@@ -240,15 +240,15 @@ func (hs *HTTPServer) registerRoutes() {
 		apiRoute.Group("/orgs/:orgId", func(orgsRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
 			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgID)), routing.Wrap(GetOrgByID))
-			orgsRoute.Put("/", reqGrafanaAdmin, bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
-			orgsRoute.Put("/address", reqGrafanaAdmin, bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
+			orgsRoute.Put("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
+			orgsRoute.Put("/address", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
 			orgsRoute.Delete("/", reqGrafanaAdmin, routing.Wrap(DeleteOrgByID))
 			orgsRoute.Get("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsers))
 			orgsRoute.Post("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
 			orgsRoute.Patch("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))
 			orgsRoute.Delete("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUser))
 			orgsRoute.Get("/quotas", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsQuotasRead, ScopeOrgID)), routing.Wrap(hs.GetOrgQuotas))
-			orgsRoute.Put("/quotas/:target", reqGrafanaAdmin, bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(UpdateOrgQuota))
+			orgsRoute.Put("/quotas/:target", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsQuotasWrite, ScopeOrgID)), bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(hs.UpdateOrgQuota))
 		})
 
 		// orgs (admin routes)

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -101,7 +101,7 @@ func CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Respo
 }
 
 // PUT /api/org
-func UpdateOrgCurrent(c *models.ReqContext, form dtos.UpdateOrgForm) response.Response {
+func UpdateCurrentOrg(c *models.ReqContext, form dtos.UpdateOrgForm) response.Response {
 	return updateOrgHelper(form, c.OrgId)
 }
 
@@ -112,7 +112,7 @@ func UpdateOrg(c *models.ReqContext, form dtos.UpdateOrgForm) response.Response 
 
 func updateOrgHelper(form dtos.UpdateOrgForm, orgID int64) response.Response {
 	cmd := models.UpdateOrgCommand{Name: form.Name, OrgId: orgID}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := sqlstore.UpdateOrg(&cmd); err != nil {
 		if errors.Is(err, models.ErrOrgNameTaken) {
 			return response.Error(400, "Organization name taken", err)
 		}
@@ -123,7 +123,7 @@ func updateOrgHelper(form dtos.UpdateOrgForm, orgID int64) response.Response {
 }
 
 // PUT /api/org/address
-func UpdateOrgAddressCurrent(c *models.ReqContext, form dtos.UpdateOrgAddressForm) response.Response {
+func UpdateCurrentOrgAddress(c *models.ReqContext, form dtos.UpdateOrgAddressForm) response.Response {
 	return updateOrgAddressHelper(form, c.OrgId)
 }
 
@@ -145,7 +145,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgID int64) respons
 		},
 	}
 
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := sqlstore.UpdateOrgAddress(&cmd); err != nil {
 		return response.Error(500, "Failed to update org address", err)
 	}
 

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,10 +13,22 @@ import (
 )
 
 var (
-	searchOrgsURL    = "/api/orgs/"
-	getCurrentOrgURL = "/api/org/"
-	getOrgsURL       = "/api/orgs/%v"
-	getOrgsByNameURL = "/api/orgs/name/%v"
+	searchOrgsURL           = "/api/orgs/"
+	getCurrentOrgURL        = "/api/org/"
+	getOrgsURL              = "/api/orgs/%v"
+	getOrgsByNameURL        = "/api/orgs/name/%v"
+	putCurrentOrgURL        = "/api/org/"
+	putOrgsURL              = "/api/orgs/%v"
+	putCurrentOrgAddressURL = "/api/org/address"
+	putOrgsAddressURL       = "/api/orgs/%v/address"
+
+	testUpdateOrgNameForm    = `{ "name": "TestOrgChanged" }`
+	testUpdateOrgAddressForm = `{ "address1": "1 test road",
+	"address2": "2 test road",
+	"city": "TestCity",
+	"ZipCode": "TESTZIPCODE",
+	"State": "TestState",
+	"Country": "TestCountry" }`
 )
 
 func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
@@ -214,6 +227,214 @@ func TestAPIEndpoint_GetOrgByName_AccessControl(t *testing.T) {
 	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
 		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	t.Run("Viewer cannot update current org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	t.Run("Admin can update current org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating current org with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating current org with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrg_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+
+	t.Run("Viewer cannot update another org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana Admin can update another org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrg_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating another org with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl prevents updating another org with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating another org with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	t.Run("Viewer cannot update current org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	t.Run("Admin can update current org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl allows updating current org address with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl allows updating current org address with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org address with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrgAddress_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+
+	t.Run("Viewer cannot update another org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana Admin can update another org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutOrgAddress_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs, to update another one than the logged in one
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl allows updating another org address with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl prevents updating another org address with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating another org address with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -67,7 +67,7 @@ func updatePreferencesFor(orgID, userID, teamId int64, dtoCmd *dtos.UpdatePrefsC
 		HomeDashboardId: dtoCmd.HomeDashboardID,
 	}
 
-	if err := bus.Dispatch(&saveCmd); err != nil {
+	if err := sqlstore.SavePreferences(&saveCmd); err != nil {
 		return response.Error(500, "Failed to save preferences", err)
 	}
 

--- a/pkg/api/preferences_test.go
+++ b/pkg/api/preferences_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -11,6 +12,9 @@ import (
 
 var (
 	getOrgPreferencesURL = "/api/org/preferences/"
+	putOrgPreferencesURL = "/api/org/preferences/"
+
+	testUpdateOrgPreferencesCmd = `{ "theme": "light", "homeDashboardId": 1 }`
 )
 
 func TestAPIEndpoint_GetCurrentOrgPreferences_LegacyAccessControl(t *testing.T) {
@@ -52,6 +56,56 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_AccessControl(t *testing.T) {
 	t.Run("AccessControl prevents getting org preferences with incorrect permissions", func(t *testing.T) {
 		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
 		response := callAPI(sc.server, http.MethodGet, getOrgPreferencesURL, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgPreferences_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	input := strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("Viewer cannot update org preferences", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	input = strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("Org Admin can update org preferences", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgPreferences_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("AccessControl allows updating org preferences with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsPreferencesWrite, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("AccessControl allows updating org preferences with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsPreferencesWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgPreferencesCmd)
+	t.Run("AccessControl prevents updating org preferences with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPut, putOrgPreferencesURL, input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -29,18 +29,18 @@ func (hs *HTTPServer) getOrgQuotasHelper(c *models.ReqContext, orgID int64) resp
 	return response.JSON(200, query.Result)
 }
 
-func UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response.Response {
-	if !setting.Quota.Enabled {
+func (hs *HTTPServer) UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response.Response {
+	if !hs.Cfg.Quota.Enabled {
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.OrgId = c.ParamsInt64(":orgId")
 	cmd.Target = web.Params(c.Req)[":target"]
 
-	if _, ok := setting.Quota.Org.ToMap()[cmd.Target]; !ok {
+	if _, ok := hs.Cfg.Quota.Org.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)
 	}
 
-	if err := bus.DispatchCtx(c.Req.Context(), &cmd); err != nil {
+	if err := hs.SQLStore.UpdateOrgQuota(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to update org quotas", err)
 	}
 	return response.Success("Organization quota updated")

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -16,9 +16,12 @@ const (
 	ActionDatasourcesDelete = "datasources:delete"
 	ActionDatasourcesIDRead = "datasources.id:read"
 
-	ActionOrgsRead            = "orgs:read"
-	ActionOrgsPreferencesRead = "orgs.preferences:read"
-	ActionOrgsQuotasRead      = "orgs.quotas:read"
+	ActionOrgsRead             = "orgs:read"
+	ActionOrgsPreferencesRead  = "orgs.preferences:read"
+	ActionOrgsQuotasRead       = "orgs.quotas:read"
+	ActionOrgsWrite            = "orgs:write"
+	ActionOrgsPreferencesWrite = "orgs.preferences:write"
+	ActionOrgsQuotasWrite      = "orgs.quotas:write"
 )
 
 // API related scopes


### PR DESCRIPTION
**What this PR does / why we need it**:

> While in the first milestone we covered mostly all organization relevant endpoints with fine-grained permissions, there are few still missing the construction blocks.

In this PR, I cover the endpoints:
| Method | Url                             | Legacy AC       | Action                   | Scope              |
|--------|---------------------------------|-----------------|--------------------------|--------------------|
| PUT    | /api/org/                       | reqOrgAdmin     | `orgs:write`             | `orgs:id:{OrgID}`  |
| PUT    | /api/org/address                | reqOrgAdmin     | `orgs:write`             | `orgs:id:{OrgID}`  |
| PUT    | /api/org/preferences            | reqOrgAdmin     | `orgs.preferences:write` | `orgs:id:{OrgID}`  |
| PUT    | /api/orgs/:orgId/               | reqGrafanaAdmin | `orgs:write`             | `orgs:id:{:orgId}` |
| PUT    | /api/orgs/:orgId/address        | reqGrafanaAdmin | `orgs:write`             | `orgs:id:{:orgId}` |
| PUT    | /api/orgs/:orgId/quotas/:target | reqGrafanaAdmin | `orgs.quotas:write`      | `orgs:id:{:orgId}` |

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana-enterprise/issues/1550

**Special notes for your reviewer**:
I won't merge this until I create the associated roles