### PR TITLE
dependabot: ignore ts-loader

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       - dependency-name: "slate"
       - dependency-name: "slate-plain-serializer"
       - dependency-name: "systemjs"
+      - dependency-name: "ts-loader" # we should remove ts-loader and use babel-loader instead
     reviewers:
       - "grafana/frontend-ops"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
we do not need `ts-loader` anymore, `babel-loader` can do it's job, so it makes no sense to spend resources updating this.