### PR TITLE
Alerting: add ability to specify thread_ts for slack notifier

### DIFF
--- a/public/app/features/alerting/unified/mocks/grafana-notifiers.ts
+++ b/public/app/features/alerting/unified/mocks/grafana-notifiers.ts
@@ -972,6 +972,20 @@ export const grafanaNotifiersMock: NotifierDTO[] = [
       {
         element: 'input',
         inputType: 'text',
+        label: 'Thread',
+        description:
+          'Specify a thread ID for all notifications to be sent as a reply to that thread instead of individual messages',
+        placeholder: '',
+        propertyName: 'threadTS',
+        selectOptions: null,
+        showWhen: { field: '', is: '' },
+        required: false,
+        validationRule: '',
+        secure: false,
+      },
+      {
+        element: 'input',
+        inputType: 'text',
         label: 'Token',
         description: 'Provide a Slack API token (starts with "xoxb") - required unless you provide a webhook',
         placeholder: '',


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an option to specify `thread_ts` for Slack notifier if one would want all notifications to appear in a specific Slack thread instead of brand new messages, which could be desirable in certain situations.