### PR TITLE
AccessControl: Extend scope parameters with extra params from context

### DIFF
--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -17,17 +17,17 @@ const (
 )
 
 // API related scopes
-const (
-	ScopeProvisionersAll           = "provisioners:*"
-	ScopeProvisionersDashboards    = "provisioners:dashboards"
-	ScopeProvisionersPlugins       = "provisioners:plugins"
-	ScopeProvisionersDatasources   = "provisioners:datasources"
-	ScopeProvisionersNotifications = "provisioners:notifications"
+var (
+	ScopeProvisionersAll           = accesscontrol.Scope("provisioners", "*")
+	ScopeProvisionersDashboards    = accesscontrol.Scope("provisioners", "dashboards")
+	ScopeProvisionersPlugins       = accesscontrol.Scope("provisioners", "plugins")
+	ScopeProvisionersDatasources   = accesscontrol.Scope("provisioners", "datasources")
+	ScopeProvisionersNotifications = accesscontrol.Scope("provisioners", "notifications")
 
-	ScopeDatasourcesAll = `datasources:*`
-	ScopeDatasourceID   = `datasources:id:{{ index . ":id" }}`
-	ScopeDatasourceUID  = `datasources:uid:{{ index . ":uid" }}`
-	ScopeDatasourceName = `datasources:name:{{ index . ":name" }}`
+	ScopeDatasourcesAll = accesscontrol.Scope("datasources", "*")
+	ScopeDatasourceID   = accesscontrol.Scope("datasources", "id", accesscontrol.Parameter(":id"))
+	ScopeDatasourceUID  = accesscontrol.Scope("datasources", "uid", accesscontrol.Parameter(":uid"))
+	ScopeDatasourceName = accesscontrol.Scope("datasources", "name", accesscontrol.Parameter(":name"))
 )
 
 // declareFixedRoles declares to the AccessControl service fixed roles and their

--- a/pkg/services/accesscontrol/evaluator.go
+++ b/pkg/services/accesscontrol/evaluator.go
@@ -15,7 +15,7 @@ type Evaluator interface {
 	// Evaluate permissions that are grouped by action
 	Evaluate(permissions map[string]map[string]struct{}) (bool, error)
 	// Inject params into the evaluator's templated scopes. e.g. "settings:" + eval.Parameters(":id") and returns a new Evaluator
-	Inject(params map[string]string) (Evaluator, error)
+	Inject(params ScopeParams) (Evaluator, error)
 	// String returns a string representation of permission required by the evaluator
 	String() string
 }
@@ -89,7 +89,7 @@ func match(scope, target string) (bool, error) {
 	return scope == target, nil
 }
 
-func (p permissionEvaluator) Inject(params map[string]string) (Evaluator, error) {
+func (p permissionEvaluator) Inject(params ScopeParams) (Evaluator, error) {
 	scopes := make([]string, 0, len(p.Scopes))
 	for _, scope := range p.Scopes {
 		tmpl, err := template.New("scope").Parse(scope)
@@ -129,7 +129,7 @@ func (a allEvaluator) Evaluate(permissions map[string]map[string]struct{}) (bool
 	return true, nil
 }
 
-func (a allEvaluator) Inject(params map[string]string) (Evaluator, error) {
+func (a allEvaluator) Inject(params ScopeParams) (Evaluator, error) {
 	var injected []Evaluator
 	for _, e := range a.allOf {
 		i, err := e.Inject(params)
@@ -173,7 +173,7 @@ func (a anyEvaluator) Evaluate(permissions map[string]map[string]struct{}) (bool
 	return false, nil
 }
 
-func (a anyEvaluator) Inject(params map[string]string) (Evaluator, error) {
+func (a anyEvaluator) Inject(params ScopeParams) (Evaluator, error) {
 	var injected []Evaluator
 	for _, e := range a.anyOf {
 		i, err := e.Inject(params)

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -343,6 +343,26 @@ func TestAny_Inject(t *testing.T) {
 			},
 		},
 		{
+			desc:     "should inject extra and url param",
+			expected: true,
+			evaluator: EvalAny(
+				EvalPermission("orgs:read", Scope("orgs", ExtraParameter("OrgID"))),
+				EvalPermission("orgs:read", Scope("orgs", Parameter(":orgId"))),
+			),
+			params: ScopeParams{
+				OrgID: 3,
+				UrlParams: map[string]string{
+					":orgId": "4",
+				},
+			},
+			permissions: map[string]map[string]struct{}{
+				"orgs:read": {
+					"orgs:3": struct{}{},
+					"orgs:4": struct{}{},
+				},
+			},
+		},
+		{
 			desc:     "should fail for nil params",
 			expected: false,
 			evaluator: EvalAny(

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -17,7 +17,7 @@ type injectTestCase struct {
 	desc        string
 	expected    bool
 	evaluator   Evaluator
-	params      map[string]string
+	params      ScopeParams
 	permissions map[string]map[string]struct{}
 }
 
@@ -81,9 +81,11 @@ func TestPermission_Inject(t *testing.T) {
 			desc:      "should inject correct param",
 			expected:  true,
 			evaluator: EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
-			params: map[string]string{
-				":id":       "10",
-				":reportId": "1",
+			params: ScopeParams{
+				UrlParams: map[string]string{
+					":id":       "10",
+					":reportId": "1",
+				},
 			},
 			permissions: map[string]map[string]struct{}{
 				"reports:read": {
@@ -95,7 +97,7 @@ func TestPermission_Inject(t *testing.T) {
 			desc:      "should fail for nil params",
 			expected:  false,
 			evaluator: EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
-			params:    nil,
+			params:    ScopeParams{},
 			permissions: map[string]map[string]struct{}{
 				"reports:read": {
 					"reports:1": struct{}{},
@@ -106,9 +108,11 @@ func TestPermission_Inject(t *testing.T) {
 			desc:      "should inject several parameters to one permission",
 			expected:  true,
 			evaluator: EvalPermission("reports:read", Scope("reports", Parameter(":reportId"), Parameter(":reportId2"))),
-			params: map[string]string{
-				":reportId":  "report",
-				":reportId2": "report2",
+			params: ScopeParams{
+				UrlParams: map[string]string{
+					":reportId":  "report",
+					":reportId2": "report2",
+				},
 			},
 			permissions: map[string]map[string]struct{}{
 				"reports:read": {
@@ -187,10 +191,12 @@ func TestAll_Inject(t *testing.T) {
 				EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
 				EvalPermission("settings:read", Scope("settings", Parameter(":settingsId"))),
 			),
-			params: map[string]string{
-				":id":         "10",
-				":settingsId": "3",
-				":reportId":   "1",
+			params: ScopeParams{
+				UrlParams: map[string]string{
+					":id":         "10",
+					":settingsId": "3",
+					":reportId":   "1",
+				},
 			},
 			permissions: map[string]map[string]struct{}{
 				"reports:read": {
@@ -208,7 +214,7 @@ func TestAll_Inject(t *testing.T) {
 				EvalPermission("settings:read", Scope("reports", Parameter(":settingsId"))),
 				EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
 			),
-			params: nil,
+			params: ScopeParams{},
 			permissions: map[string]map[string]struct{}{
 				"reports:read": {
 					"reports:1": struct{}{},
@@ -287,10 +293,12 @@ func TestAny_Inject(t *testing.T) {
 				EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
 				EvalPermission("settings:read", Scope("settings", Parameter(":settingsId"))),
 			),
-			params: map[string]string{
-				":id":         "10",
-				":settingsId": "3",
-				":reportId":   "1",
+			params: ScopeParams{
+				UrlParams: map[string]string{
+					":id":         "10",
+					":settingsId": "3",
+					":reportId":   "1",
+				},
 			},
 			permissions: map[string]map[string]struct{}{
 				"reports:read": {
@@ -308,7 +316,7 @@ func TestAny_Inject(t *testing.T) {
 				EvalPermission("settings:read", Scope("reports", Parameter(":settingsId"))),
 				EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
 			),
-			params: nil,
+			params: ScopeParams{},
 			permissions: map[string]map[string]struct{}{
 				"reports:read": {
 					"reports:1": struct{}{},

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -78,6 +78,19 @@ func TestPermission_Evaluate(t *testing.T) {
 func TestPermission_Inject(t *testing.T) {
 	tests := []injectTestCase{
 		{
+			desc:      "should inject extra param",
+			expected:  true,
+			evaluator: EvalPermission("orgs:read", Scope("orgs", ExtraParameter("OrgID"))),
+			params: ScopeParams{
+				OrgID: 3,
+			},
+			permissions: map[string]map[string]struct{}{
+				"orgs:read": {
+					"orgs:3": struct{}{},
+				},
+			},
+		},
+		{
 			desc:      "should inject correct param",
 			expected:  true,
 			evaluator: EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
@@ -204,6 +217,26 @@ func TestAll_Inject(t *testing.T) {
 				},
 				"settings:read": {
 					"settings:3": struct{}{},
+				},
+			},
+		},
+		{
+			desc:     "should inject extra and url param",
+			expected: true,
+			evaluator: EvalAll(
+				EvalPermission("orgs:read", Scope("orgs", ExtraParameter("OrgID"))),
+				EvalPermission("orgs:read", Scope("orgs", Parameter(":orgId"))),
+			),
+			params: ScopeParams{
+				OrgID: 3,
+				UrlParams: map[string]string{
+					":orgId": "4",
+				},
+			},
+			permissions: map[string]map[string]struct{}{
+				"orgs:read": {
+					"orgs:3": struct{}{},
+					"orgs:4": struct{}{},
 				},
 			},
 		},

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -80,7 +80,7 @@ func TestPermission_Inject(t *testing.T) {
 		{
 			desc:      "should inject extra param",
 			expected:  true,
-			evaluator: EvalPermission("orgs:read", Scope("orgs", ExtraParameter("OrgID"))),
+			evaluator: EvalPermission("orgs:read", Scope("orgs", Field("OrgID"))),
 			params: ScopeParams{
 				OrgID: 3,
 			},
@@ -95,7 +95,7 @@ func TestPermission_Inject(t *testing.T) {
 			expected:  true,
 			evaluator: EvalPermission("reports:read", Scope("reports", Parameter(":reportId"))),
 			params: ScopeParams{
-				UrlParams: map[string]string{
+				URLParams: map[string]string{
 					":id":       "10",
 					":reportId": "1",
 				},
@@ -122,7 +122,7 @@ func TestPermission_Inject(t *testing.T) {
 			expected:  true,
 			evaluator: EvalPermission("reports:read", Scope("reports", Parameter(":reportId"), Parameter(":reportId2"))),
 			params: ScopeParams{
-				UrlParams: map[string]string{
+				URLParams: map[string]string{
 					":reportId":  "report",
 					":reportId2": "report2",
 				},
@@ -205,7 +205,7 @@ func TestAll_Inject(t *testing.T) {
 				EvalPermission("settings:read", Scope("settings", Parameter(":settingsId"))),
 			),
 			params: ScopeParams{
-				UrlParams: map[string]string{
+				URLParams: map[string]string{
 					":id":         "10",
 					":settingsId": "3",
 					":reportId":   "1",
@@ -224,12 +224,12 @@ func TestAll_Inject(t *testing.T) {
 			desc:     "should inject extra and url param",
 			expected: true,
 			evaluator: EvalAll(
-				EvalPermission("orgs:read", Scope("orgs", ExtraParameter("OrgID"))),
+				EvalPermission("orgs:read", Scope("orgs", Field("OrgID"))),
 				EvalPermission("orgs:read", Scope("orgs", Parameter(":orgId"))),
 			),
 			params: ScopeParams{
 				OrgID: 3,
-				UrlParams: map[string]string{
+				URLParams: map[string]string{
 					":orgId": "4",
 				},
 			},
@@ -327,7 +327,7 @@ func TestAny_Inject(t *testing.T) {
 				EvalPermission("settings:read", Scope("settings", Parameter(":settingsId"))),
 			),
 			params: ScopeParams{
-				UrlParams: map[string]string{
+				URLParams: map[string]string{
 					":id":         "10",
 					":settingsId": "3",
 					":reportId":   "1",
@@ -346,12 +346,12 @@ func TestAny_Inject(t *testing.T) {
 			desc:     "should inject extra and url param",
 			expected: true,
 			evaluator: EvalAny(
-				EvalPermission("orgs:read", Scope("orgs", ExtraParameter("OrgID"))),
+				EvalPermission("orgs:read", Scope("orgs", Field("OrgID"))),
 				EvalPermission("orgs:read", Scope("orgs", Parameter(":orgId"))),
 			),
 			params: ScopeParams{
 				OrgID: 3,
-				UrlParams: map[string]string{
+				URLParams: map[string]string{
 					":orgId": "4",
 				},
 			},

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -78,7 +78,7 @@ func TestPermission_Evaluate(t *testing.T) {
 func TestPermission_Inject(t *testing.T) {
 	tests := []injectTestCase{
 		{
-			desc:      "should inject extra param",
+			desc:      "should inject field",
 			expected:  true,
 			evaluator: EvalPermission("orgs:read", Scope("orgs", Field("OrgID"))),
 			params: ScopeParams{
@@ -221,7 +221,7 @@ func TestAll_Inject(t *testing.T) {
 			},
 		},
 		{
-			desc:     "should inject extra and url param",
+			desc:     "should inject field and URL param",
 			expected: true,
 			evaluator: EvalAll(
 				EvalPermission("orgs:read", Scope("orgs", Field("OrgID"))),
@@ -343,7 +343,7 @@ func TestAny_Inject(t *testing.T) {
 			},
 		},
 		{
-			desc:     "should inject extra and url param",
+			desc:     "should inject field and URL param",
 			expected: true,
 			evaluator: EvalAny(
 				EvalPermission("orgs:read", Scope("orgs", Field("OrgID"))),

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -19,7 +19,7 @@ func Middleware(ac accesscontrol.AccessControl) func(macaron.Handler, accesscont
 		}
 
 		return func(c *models.ReqContext) {
-			injected, err := evaluator.Inject(macaron.Params(c.Req))
+			injected, err := evaluator.Inject(buildScopeParams(c))
 			if err != nil {
 				c.JsonApiErr(http.StatusInternalServerError, "Internal server error", err)
 				return
@@ -68,4 +68,11 @@ func newID() string {
 		id = fmt.Sprintf("%d", time.Now().UnixNano())
 	}
 	return "ACE" + id
+}
+
+func buildScopeParams(c *models.ReqContext) accesscontrol.ScopeParams {
+	return accesscontrol.ScopeParams{
+		OrgID:     c.OrgId,
+		UrlParams: macaron.Params(c.Req),
+	}
 }

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -73,6 +73,6 @@ func newID() string {
 func buildScopeParams(c *models.ReqContext) accesscontrol.ScopeParams {
 	return accesscontrol.ScopeParams{
 		OrgID:     c.OrgId,
-		UrlParams: macaron.Params(c.Req),
+		URLParams: macaron.Params(c.Req),
 	}
 }

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -140,6 +140,12 @@ func (p Permission) OSSPermission() Permission {
 	}
 }
 
+// ScopeParams holds the parameters used to fill in scope templates
+type ScopeParams struct {
+	OrgID     int64
+	UrlParams map[string]string
+}
+
 const (
 	GlobalOrgID = 0
 	// Permission actions

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -143,7 +143,7 @@ func (p Permission) OSSPermission() Permission {
 // ScopeParams holds the parameters used to fill in scope templates
 type ScopeParams struct {
 	OrgID     int64
-	UrlParams map[string]string
+	URLParams map[string]string
 }
 
 const (

--- a/pkg/services/accesscontrol/scope.go
+++ b/pkg/services/accesscontrol/scope.go
@@ -18,8 +18,14 @@ func Scope(parts ...string) string {
 	return b.String()
 }
 
-// Parameter returns injectable scope part
+// Parameter returns injectable scope part, based on the URL parameter
 // e.g. Scope("users", Parameter(":id")) or "users:" + Parameter(":id")
 func Parameter(key string) string {
-	return fmt.Sprintf(`{{ index . "%s" }}`, key)
+	return fmt.Sprintf(`{{ index .UrlParams "%s" }}`, key)
+}
+
+// ExtraParameter returns injectable scope part, based on ScopeParams fields
+// e.g. Scope("orgs", Parameter("OrgID")) or "orgs:" + Parameter("OrgID")
+func ExtraParameter(key string) string {
+	return fmt.Sprintf(`{{ .%s }}`, key)
 }

--- a/pkg/services/accesscontrol/scope.go
+++ b/pkg/services/accesscontrol/scope.go
@@ -18,7 +18,7 @@ func Scope(parts ...string) string {
 	return b.String()
 }
 
-// Parameter returns injectable scope part, based on the URL parameter
+// Parameter returns injectable scope part, based on URL parameters.
 // e.g. Scope("users", Parameter(":id")) or "users:" + Parameter(":id")
 func Parameter(key string) string {
 	return fmt.Sprintf(`{{ index .UrlParams "%s" }}`, key)

--- a/pkg/services/accesscontrol/scope.go
+++ b/pkg/services/accesscontrol/scope.go
@@ -21,11 +21,11 @@ func Scope(parts ...string) string {
 // Parameter returns injectable scope part, based on URL parameters.
 // e.g. Scope("users", Parameter(":id")) or "users:" + Parameter(":id")
 func Parameter(key string) string {
-	return fmt.Sprintf(`{{ index .UrlParams "%s" }}`, key)
+	return fmt.Sprintf(`{{ index .URLParams "%s" }}`, key)
 }
 
-// ExtraParameter returns an injectable scope part for selected fields from the request's context available in accesscontrol.ScopeParams.
+// Field returns an injectable scope part for selected fields from the request's context available in accesscontrol.ScopeParams.
 // e.g. Scope("orgs", Parameter("OrgID")) or "orgs:" + Parameter("OrgID")
-func ExtraParameter(key string) string {
+func Field(key string) string {
 	return fmt.Sprintf(`{{ .%s }}`, key)
 }

--- a/pkg/services/accesscontrol/scope.go
+++ b/pkg/services/accesscontrol/scope.go
@@ -24,7 +24,7 @@ func Parameter(key string) string {
 	return fmt.Sprintf(`{{ index .UrlParams "%s" }}`, key)
 }
 
-// ExtraParameter returns injectable scope part, based on ScopeParams fields
+// ExtraParameter returns an injectable scope part for selected fields from the request's context available in accesscontrol.ScopeParams.
 // e.g. Scope("orgs", Parameter("OrgID")) or "orgs:" + Parameter("OrgID")
 func ExtraParameter(key string) string {
 	return fmt.Sprintf(`{{ .%s }}`, key)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
To protect `"/api/org"` endpoints with FGAC permissions we need to use a scope with the `OrgID`. However, the `OrgID` is provided by the context, not the url parameters. This PR adds a new `ScopeParams` struct that will allow us to easily fix this kind of problem in the future.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana-enterprise/issues/1550

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

