### PR TITLE
Docs: Improved documentation markdown guide and docs readme.

### DIFF
--- a/contribute/style-guides/documentation-markdown-guide.md
+++ b/contribute/style-guides/documentation-markdown-guide.md
@@ -121,15 +121,15 @@ _Do not_ use image shortcodes at this time.
 Include images in a document using the following syntax:
 
 ```
-![Alt text](link to image, starting with /img/docs/ if it is to an internal image "Title of image in sentence case")
+![Alt text](link to image, starting with /static/img/docs/ if it is to an internal image "Title of image in sentence case")
 ```
 
 > **Note:** Alt text does not appear when the user hovers the mouse over the image, but title text does.
 
 **Examples:** 
 
-- \!\[Grafana logo](/link/to/grafanalogo/logo.png)
-- \!\[Example](/img/docs/folder_name/alert_test_rule.png)
+- \!\[Grafana logo](/link/to/grafanalogo/logo.png "Grafana logo")
+- \!\[Example](/static/img/docs/folder_name/alert_test_rule.png "Example title")
 
 This follows the format of "!", alt text wrapped in "[]" and the link URL wrapped in "()".
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ If you have the grafana/website repo checked out in the same directory as the gr
 
 Edit content in the `sources` directory.
 
+### [Contributing](https://github.com/grafana/grafana/blob/main/contribute/documentation.md)
+
 ### Using `relref` for internal links
 
 Use the Hugo shortcode [relref](https://gohugo.io/content-management/cross-references/#use-ref-and-relref) any time you are linking to other internal docs pages.


### PR DESCRIPTION
Adding link from docs/README to contributing doc for quicker navigation.

Improved the examples about how to add images. Seems like `/static/img/docs` is the correct prefix for adding internal images.