### PR TITLE
BarGauge: Improved handling of  streaming data.

### DIFF
--- a/packages/grafana-data/src/types/constants.ts
+++ b/packages/grafana-data/src/types/constants.ts
@@ -1,0 +1,2 @@
+export const GAUGE_DEFAULT_MINIMUM = 0;
+export const GAUGE_DEFAULT_MAXIMUM = 100;

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './data';
 export * from './dataFrame';
 export * from './dataFrameTypes';

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -132,8 +132,8 @@ export class BarGauge extends PureComponent<Props> {
       wrapperWidth,
       wrapperHeight,
     } = calculateBarAndValueDimensions(this.props);
-    const minValue = field.min!;
-    const maxValue = field.max!;
+    const minValue = field.min ?? 0;
+    const maxValue = field.max ?? 100;
 
     const isVert = isVertical(orientation);
     const valueRange = maxValue - minValue;
@@ -439,7 +439,9 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
   const { displayMode, field, value, alignmentFactors, orientation, theme, text } = props;
   const { valueWidth, valueHeight, maxBarHeight, maxBarWidth } = calculateBarAndValueDimensions(props);
 
-  const valuePercent = getValuePercent(value.numeric, field.min!, field.max!);
+  const minValue = field.min ?? 0;
+  const maxValue = field.max ?? 100;
+  const valuePercent = getValuePercent(value.numeric, minValue, maxValue);
   const valueColor = getValueColor(props);
 
   const valueToBaseSizeOn = alignmentFactors ? alignmentFactors : value;

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -6,6 +6,8 @@ import {
   DisplayValue,
   formattedValueToString,
   FormattedValue,
+  GAUGE_DEFAULT_MAXIMUM,
+  GAUGE_DEFAULT_MINIMUM,
   DisplayValueAlignmentFactors,
   ThresholdsMode,
   DisplayProcessor,
@@ -132,8 +134,8 @@ export class BarGauge extends PureComponent<Props> {
       wrapperWidth,
       wrapperHeight,
     } = calculateBarAndValueDimensions(this.props);
-    const minValue = field.min ?? 0;
-    const maxValue = field.max ?? 100;
+    const minValue = field.min ?? GAUGE_DEFAULT_MINIMUM;
+    const maxValue = field.max ?? GAUGE_DEFAULT_MAXIMUM;
 
     const isVert = isVertical(orientation);
     const valueRange = maxValue - minValue;
@@ -439,8 +441,8 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
   const { displayMode, field, value, alignmentFactors, orientation, theme, text } = props;
   const { valueWidth, valueHeight, maxBarHeight, maxBarWidth } = calculateBarAndValueDimensions(props);
 
-  const minValue = field.min ?? 0;
-  const maxValue = field.max ?? 100;
+  const minValue = field.min ?? GAUGE_DEFAULT_MINIMUM;
+  const maxValue = field.max ?? GAUGE_DEFAULT_MAXIMUM;
   const valuePercent = getValuePercent(value.numeric, minValue, maxValue);
   const valueColor = getValueColor(props);
 

--- a/packages/grafana-ui/src/components/Gauge/Gauge.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.tsx
@@ -5,6 +5,8 @@ import {
   formattedValueToString,
   FieldConfig,
   ThresholdsMode,
+  GAUGE_DEFAULT_MAXIMUM,
+  GAUGE_DEFAULT_MINIMUM,
   getActiveThreshold,
   Threshold,
   getColorForTheme,
@@ -58,15 +60,15 @@ export class Gauge extends PureComponent<Props> {
     const { field, theme, value } = this.props;
 
     if (field.color?.mode !== FieldColorModeId.Thresholds) {
-      return [{ value: field.min ?? 0, color: value.color ?? FALLBACK_COLOR }];
+      return [{ value: field.min ?? GAUGE_DEFAULT_MINIMUM, color: value.color ?? FALLBACK_COLOR }];
     }
 
     const thresholds = field.thresholds ?? Gauge.defaultProps.field?.thresholds!;
     const isPercent = thresholds.mode === ThresholdsMode.Percentage;
     const steps = thresholds.steps;
 
-    let min = field.min ?? 0;
-    let max = field.max ?? 100;
+    let min = field.min ?? GAUGE_DEFAULT_MINIMUM;
+    let max = field.max ?? GAUGE_DEFAULT_MAXIMUM;
 
     if (isPercent) {
       min = 0;
@@ -116,8 +118,8 @@ export class Gauge extends PureComponent<Props> {
     const fontSize = this.props.text?.valueSize ?? calculateFontSize(text, valueWidth, dimension, 1, gaugeWidth * 1.7);
     const thresholdLabelFontSize = Math.max(fontSize / 2.5, 12);
 
-    let min = field.min ?? 0;
-    let max = field.max ?? 100;
+    let min = field.min ?? GAUGE_DEFAULT_MINIMUM;
+    let max = field.max ?? GAUGE_DEFAULT_MAXIMUM;
     let numeric = value.numeric;
 
     if (field.thresholds?.mode === ThresholdsMode.Percentage) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- `BarGauge` doesn't really work when streaming data at the moment unless you set an explicit minimum and maximum because we don't have a default min/max value when the `field.min`/`field.max` values aren't set
- compare this to `Gauge` where we do: https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Gauge/Gauge.tsx#L119
- this PR matches `Gauge`'s behaviour

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/37952

**Special notes for your reviewer**:

