### PR TITLE
Call plugin healthchecks on startup

### DIFF
--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/live/pushhttp"
 	"github.com/grafana/grafana/pkg/services/ngalert"
@@ -43,6 +44,7 @@ func ProvideBackgroundServiceRegistry(
 	backendPM *backendmanager.Manager, metrics *metrics.InternalMetricsService,
 	usageStats *usagestats.UsageStatsService, tracing *tracing.TracingService, remoteCache *remotecache.RemoteCache,
 	// Need to make sure these are initialized, is there a better place to put them?
+	datasourceInitializer *datasources.DataSourceInitializerService,
 	_ *azuremonitor.Service, _ *cloudwatch.CloudWatchService, _ *elasticsearch.Service, _ *graphite.Service,
 	_ *influxdb.Service, _ *loki.Service, _ *opentsdb.Service, _ *prometheus.Service, _ *tempo.Service,
 	_ *testdatasource.TestDataPlugin, _ *plugindashboards.Service, _ *dashboardsnapshots.Service,
@@ -65,7 +67,8 @@ func ProvideBackgroundServiceRegistry(
 		metrics,
 		usageStats,
 		tracing,
-		remoteCache)
+		remoteCache,
+		datasourceInitializer)
 }
 
 // BackgroundServiceRegistry provides background services.

--- a/pkg/server/backgroundsvcs/background_services.go
+++ b/pkg/server/backgroundsvcs/background_services.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
-	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/services/live/pushhttp"
 	"github.com/grafana/grafana/pkg/services/ngalert"
@@ -44,7 +43,6 @@ func ProvideBackgroundServiceRegistry(
 	backendPM *backendmanager.Manager, metrics *metrics.InternalMetricsService,
 	usageStats *usagestats.UsageStatsService, tracing *tracing.TracingService, remoteCache *remotecache.RemoteCache,
 	// Need to make sure these are initialized, is there a better place to put them?
-	datasourceInitializer *datasources.DataSourceInitializerService,
 	_ *azuremonitor.Service, _ *cloudwatch.CloudWatchService, _ *elasticsearch.Service, _ *graphite.Service,
 	_ *influxdb.Service, _ *loki.Service, _ *opentsdb.Service, _ *prometheus.Service, _ *tempo.Service,
 	_ *testdatasource.TestDataPlugin, _ *plugindashboards.Service, _ *dashboardsnapshots.Service,
@@ -67,8 +65,7 @@ func ProvideBackgroundServiceRegistry(
 		metrics,
 		usageStats,
 		tracing,
-		remoteCache,
-		datasourceInitializer)
+		remoteCache)
 }
 
 // BackgroundServiceRegistry provides background services.

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -33,6 +33,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/datasourceproxy"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/services/librarypanels"
@@ -111,6 +112,7 @@ var wireBasicSet = wire.NewSet(
 	wire.Bind(new(login.Service), new(*loginservice.Implementation)),
 	authinfoservice.ProvideAuthInfoService,
 	wire.Bind(new(login.AuthInfoService), new(*authinfoservice.Implementation)),
+	datasources.ProvideInitializerService,
 	datasourceproxy.ProvideService,
 	search.ProvideService,
 	live.ProvideService,

--- a/pkg/services/datasources/datasource_initializer.go
+++ b/pkg/services/datasources/datasource_initializer.go
@@ -1,0 +1,101 @@
+package datasources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/adapters"
+	"github.com/grafana/grafana/pkg/plugins/manager"
+)
+
+const (
+	adminUserID = 1
+	orgID       = 1
+)
+
+var logger = log.New("datasource_initializer")
+
+func ProvideInitializerService(dataSourceCache CacheService, plugReqValidator models.PluginRequestValidator,
+	pm plugins.Manager,
+	pluginManager *manager.PluginManager) *DataSourceInitializerService {
+	return &DataSourceInitializerService{
+		DataSourceCache:    dataSourceCache,
+		PluginManager:      pm,
+		OtherPluginManager: pluginManager,
+	}
+}
+
+type DataSourceInitializerService struct {
+	DataSourceCache    CacheService
+	PluginManager      plugins.Manager
+	OtherPluginManager *manager.PluginManager
+}
+
+func (di *DataSourceInitializerService) Run(ctx context.Context) error {
+	query := models.GetDataSourcesQuery{OrgId: orgID, DataSourceLimit: -1}
+
+	if err := bus.Dispatch(&query); err != nil {
+		return fmt.Errorf("failed to query datasources: %v", err)
+	}
+
+	for _, ds := range query.Result {
+		err := di.CheckDatasourceHealth(ds.Id, ds.Name)
+		if err != nil {
+			logger.Error("error checking datasource: %v", err)
+		}
+	}
+	return nil
+}
+
+// CheckDatasourceHealth sends a health check request to the plugin datasource
+func (di *DataSourceInitializerService) CheckDatasourceHealth(datasourceID int64, datasourceName string) error {
+	adminUser := models.SignedInUser{
+		UserId:  adminUserID,
+		Name:    "admin",
+		OrgId:   orgID,
+		OrgRole: "admin",
+	}
+
+	ds, err := di.DataSourceCache.GetDatasource(datasourceID, &adminUser, true)
+	if err != nil {
+		if errors.Is(err, models.ErrDataSourceAccessDenied) {
+			return fmt.Errorf("access denied to datasource: %v", err)
+		}
+		return fmt.Errorf("unable to load datasource metadata: %v", err)
+	}
+
+	plugin := di.PluginManager.GetDataSource(ds.Type)
+	if plugin == nil {
+		return fmt.Errorf("unable to find datasource plugin: %v", err)
+	}
+
+	dsInstanceSettings, err := adapters.ModelToInstanceSettings(ds)
+	if err != nil {
+		return fmt.Errorf("unable to get datasource model: %v", err)
+	}
+	pCtx := backend.PluginContext{
+		User:                       adapters.BackendUserFromSignedInUser(&adminUser),
+		OrgID:                      adminUser.OrgId,
+		PluginID:                   plugin.Id,
+		DataSourceInstanceSettings: dsInstanceSettings,
+	}
+
+	ctx := context.Background()
+	resp, err := di.OtherPluginManager.BackendPluginManager.CheckHealth(ctx, pCtx)
+	if err != nil {
+		return err
+	}
+
+	if resp.Status != backend.HealthStatusOk {
+		logger.Error("Plugin %s responded %s to initialize", datasourceName, resp.Status.String())
+	} else {
+		logger.Info("Plugin %s responded %s to initialize", datasourceName, resp.Status.String())
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Plugins are currently stateless - they only respond to requests that include the
full context for the request.

This PR adds a service that pings the healthcheck for each plugin on startup.
This hack allows the plugin to initialise itself when its Grafana instance
starts.
