### PR TITLE
Analytics: Fixed an issue related to interaction event propagation in Azure Application Insights.

### DIFF
--- a/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/ApplicationInsightsBackend.ts
@@ -1,5 +1,12 @@
 import $ from 'jquery';
-import { EchoBackend, EchoEventType, isInteractionEvent, isPageviewEvent, PageviewEchoEvent } from '@grafana/runtime';
+import {
+  EchoBackend,
+  EchoEventType,
+  InteractionEchoEvent,
+  isInteractionEvent,
+  isPageviewEvent,
+  PageviewEchoEvent,
+} from '@grafana/runtime';
 
 export interface ApplicationInsightsBackendOptions {
   connectionString: string;
@@ -7,7 +14,7 @@ export interface ApplicationInsightsBackendOptions {
 }
 
 export class ApplicationInsightsBackend implements EchoBackend<PageviewEchoEvent, ApplicationInsightsBackendOptions> {
-  supportedEvents = [EchoEventType.Pageview];
+  supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction];
 
   constructor(public options: ApplicationInsightsBackendOptions) {
     $.ajax({
@@ -26,7 +33,7 @@ export class ApplicationInsightsBackend implements EchoBackend<PageviewEchoEvent
     });
   }
 
-  addEvent = (e: PageviewEchoEvent) => {
+  addEvent = (e: PageviewEchoEvent | InteractionEchoEvent) => {
     if (!(window as any).applicationInsights) {
       return;
     }
@@ -36,7 +43,7 @@ export class ApplicationInsightsBackend implements EchoBackend<PageviewEchoEvent
     }
 
     if (isInteractionEvent(e)) {
-      (window as any).applicationInsights.trackPageView({
+      (window as any).applicationInsights.trackEvent({
         name: e.payload.interactionName,
         properties: e.payload.properties,
       });


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure the `trackEvent` action is triggered when an interaction event is triggered in the Grafana EchoSrv. 

I've verified that interaction events are passed to Application Insights. 

![Screenshot from 2021-09-28 20-38-44](https://user-images.githubusercontent.com/2388950/135146337-9b657276-3828-4c50-aece-5f62b5bd380c.png)

**Which issue(s) this PR fixes**:

Fixes #39751
Related to #38553
