### PR TITLE
Graphite: Ensure only valid queries are used for interpolation

### DIFF
--- a/public/app/plugins/datasource/graphite/state/helpers.ts
+++ b/public/app/plugins/datasource/graphite/state/helpers.ts
@@ -4,7 +4,7 @@ import { dispatch } from '../../../../store/store';
 import { notifyApp } from '../../../../core/reducers/appNotification';
 import { createErrorNotification } from '../../../../core/copy/appNotification';
 import { FuncInstance } from '../gfunc';
-import { GraphiteTagOperator } from '../types';
+import { GraphiteQuery, GraphiteTagOperator } from '../types';
 
 /**
  * Helpers used by reducers and providers. They modify state object directly so should operate on a copy of the state.
@@ -152,7 +152,13 @@ export function handleTargetChanged(state: GraphiteQueryEditorState): void {
   }
 
   const oldTarget = state.queryModel.target.target;
-  state.queryModel.updateModelTarget(state.queries);
+  // Interpolate from other queries:
+  // Because of mixed data sources the list may contain queries for non-Graphite data sources. To ensure a valid query
+  // is used for interpolation we should check required properties are passed though in theory it allows to interpolate
+  // with queries that contain "target" property as well.
+  state.queryModel.updateModelTarget(
+    (state.queries || []).filter((query) => 'target' in query && typeof (query as GraphiteQuery).target === 'string')
+  );
 
   if (state.queryModel.target.target !== oldTarget && !state.paused) {
     state.refresh(state.target.target);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is to fix Graphite query interpolation in mixed data sources and new alerting. Graphite uses queries from other query rows for interpolation, e.g. having a query `sum(#B)`, `#B` is replaced with a query from `#B` query row. It's all good if such query is a Graphite query, but if it's not then the interpolation logic still attempts to read `target` property (valid in Graphite queries) and throws an error.

The fix is to ensure only valid queries are taken into consideration when interpolating the query.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #36572

**Special notes for your reviewer**:

To reproduce the error: 
* add a mixed data source in dashboards
* add a graphite data source
* add another non-graphite data source

cc: @peterholmberg 

