### PR TITLE
OrgPage: Minor typo fix

### DIFF
--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -137,7 +137,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                 label={
                   <Label>
                     <span className={styles.labelText}>Home Dashboard</span>
-                    <Tooltip content="Not finding dashboard you want? Star it first, then it should appear in this select box.">
+                    <Tooltip content="Not finding the dashboard you want? Star it first, then it should appear in this select box.">
                       <Icon name="info-circle" />
                     </Tooltip>
                   </Label>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes minor typo in the org preferences page 
![image](https://user-images.githubusercontent.com/468940/135238464-935769ea-701a-4599-8838-15c02100f195.png)
