### PR TITLE
Explore: Fix displaying rich history saving error message

### DIFF
--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -75,17 +75,6 @@ export function addToRichHistory(
     ];
 
     try {
-      for (let i = 0; i < 1000; i++) {
-        updatedHistory = updatedHistory.concat({
-          queries: newQueriesToSave,
-          ts,
-          datasourceId,
-          datasourceName,
-          starred,
-          comment,
-          sessionName,
-        });
-      }
       store.setObject(RICH_HISTORY_KEY, updatedHistory);
       return updatedHistory;
     } catch (error) {

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -14,6 +14,8 @@ import { serializeStateToUrlParam } from '@grafana/data/src/utils/url';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 const RICH_HISTORY_KEY = 'grafana.explore.richHistory';
+const RICH_HISTORY_SAVE_ERROR_TITLE = 'Saving rich history failed';
+const RICH_HISTORY_SAVE_ERROR_MESSAGE = 'Please clear query history to save new items.';
 
 export const RICH_HISTORY_SETTING_KEYS = {
   retentionPeriod: 'grafana.explore.richHistory.retentionPeriod',
@@ -78,7 +80,7 @@ export function addToRichHistory(
       store.setObject(RICH_HISTORY_KEY, updatedHistory);
       return updatedHistory;
     } catch (error) {
-      dispatch(notifyApp(createErrorNotification(error)));
+      dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
       return richHistory;
     }
   }
@@ -111,7 +113,7 @@ export function updateStarredInRichHistory(richHistory: RichHistoryQuery[], ts: 
     store.setObject(RICH_HISTORY_KEY, updatedHistory);
     return updatedHistory;
   } catch (error) {
-    dispatch(notifyApp(createErrorNotification(error)));
+    dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
     return richHistory;
   }
 }
@@ -133,7 +135,7 @@ export function updateCommentInRichHistory(
     store.setObject(RICH_HISTORY_KEY, updatedHistory);
     return updatedHistory;
   } catch (error) {
-    dispatch(notifyApp(createErrorNotification(error)));
+    dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
     return richHistory;
   }
 }
@@ -144,7 +146,7 @@ export function deleteQueryInRichHistory(richHistory: RichHistoryQuery[], ts: nu
     store.setObject(RICH_HISTORY_KEY, updatedHistory);
     return updatedHistory;
   } catch (error) {
-    dispatch(notifyApp(createErrorNotification(error)));
+    dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
     return richHistory;
   }
 }

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -14,8 +14,6 @@ import { serializeStateToUrlParam } from '@grafana/data/src/utils/url';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 const RICH_HISTORY_KEY = 'grafana.explore.richHistory';
-const RICH_HISTORY_SAVE_ERROR_TITLE = 'Saving rich history failed';
-const RICH_HISTORY_SAVE_ERROR_MESSAGE = 'Please clear query history to save new items.';
 
 export const RICH_HISTORY_SETTING_KEYS = {
   retentionPeriod: 'grafana.explore.richHistory.retentionPeriod',
@@ -77,10 +75,21 @@ export function addToRichHistory(
     ];
 
     try {
+      for (let i = 0; i < 1000; i++) {
+        updatedHistory = updatedHistory.concat({
+          queries: newQueriesToSave,
+          ts,
+          datasourceId,
+          datasourceName,
+          starred,
+          comment,
+          sessionName,
+        });
+      }
       store.setObject(RICH_HISTORY_KEY, updatedHistory);
       return updatedHistory;
     } catch (error) {
-      dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
+      dispatch(notifyApp(createErrorNotification('Saving rich history failed', error.message)));
       return richHistory;
     }
   }
@@ -113,7 +122,7 @@ export function updateStarredInRichHistory(richHistory: RichHistoryQuery[], ts: 
     store.setObject(RICH_HISTORY_KEY, updatedHistory);
     return updatedHistory;
   } catch (error) {
-    dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
+    dispatch(notifyApp(createErrorNotification('Saving rich history failed', error.message)));
     return richHistory;
   }
 }
@@ -135,7 +144,7 @@ export function updateCommentInRichHistory(
     store.setObject(RICH_HISTORY_KEY, updatedHistory);
     return updatedHistory;
   } catch (error) {
-    dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
+    dispatch(notifyApp(createErrorNotification('Saving rich history failed', error.message)));
     return richHistory;
   }
 }
@@ -146,7 +155,7 @@ export function deleteQueryInRichHistory(richHistory: RichHistoryQuery[], ts: nu
     store.setObject(RICH_HISTORY_KEY, updatedHistory);
     return updatedHistory;
   } catch (error) {
-    dispatch(notifyApp(createErrorNotification(RICH_HISTORY_SAVE_ERROR_TITLE, RICH_HISTORY_SAVE_ERROR_MESSAGE)));
+    dispatch(notifyApp(createErrorNotification('Saving rich history failed', error.message)));
     return richHistory;
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is to mitigate the problem with saving rich history mentioned in #38814.

We are using `dispatch(notifyApp(createErrorNotification(...` incorrectly by passing full `Error` object as a parameter instead of a string for the error message. This causes React trying to render error object and throwing a full-page error (see #38814). With this change this error should be shown instead:

<img width="1464" alt="Screen Shot 2021-09-29 at 13 18 25" src="https://user-images.githubusercontent.com/745532/135258507-d3bb72d7-3091-49d3-bddd-83dae32b4e4d.png">



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Not a proper fix yet but shouldn't break running queries Explore anymore.

**Special notes for your reviewer**:

