### PR TITLE
DashboardList/AlertList: Fix for missing All folder value

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -200,6 +200,9 @@ export const Components = {
   FolderPicker: {
     container: 'Folder picker select container',
   },
+  ReadonlyFolderPicker: {
+    container: 'data-testid Readonly folder picker select container',
+  },
   DataSourcePicker: {
     container: 'Data source picker select container',
   },

--- a/public/app/core/components/Select/ReadonlyFolderPicker/ReadonlyFolderPicker.test.tsx
+++ b/public/app/core/components/Select/ReadonlyFolderPicker/ReadonlyFolderPicker.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { SelectableValue } from '@grafana/data';
+import { render, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { byTestId } from 'testing-library-selector';
+
+import * as api from './api';
+import { FolderInfo, PermissionLevelString } from '../../../../types';
+import { ALL_FOLDER, GENERAL_FOLDER, ReadonlyFolderPicker, ReadonlyFolderPickerProps } from './ReadonlyFolderPicker';
+import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
+
+async function getTestContext(
+  propOverrides: Partial<ReadonlyFolderPickerProps> = {},
+  folders: Array<SelectableValue<FolderInfo>> = []
+) {
+  jest.clearAllMocks();
+  const selectors = {
+    container: byTestId(e2eSelectors.components.ReadonlyFolderPicker.container),
+  };
+  const getFoldersAsOptionsSpy = jest.spyOn(api, 'getFoldersAsOptions').mockResolvedValue(folders);
+  const props: ReadonlyFolderPickerProps = {
+    onChange: jest.fn(),
+  };
+
+  Object.assign(props, propOverrides);
+
+  render(<ReadonlyFolderPicker {...props} />);
+  await waitFor(() => expect(getFoldersAsOptionsSpy).toHaveBeenCalledTimes(1));
+
+  return { getFoldersAsOptionsSpy, selectors };
+}
+
+describe('ReadonlyFolderPicker', () => {
+  describe('when there are no folders', () => {
+    it('then the no folder should be selected and Choose should appear', async () => {
+      const { selectors } = await getTestContext();
+
+      expect(within(selectors.container.get()).getByText('Choose')).toBeInTheDocument();
+    });
+  });
+
+  describe('when permissionLevel is set', () => {
+    it('then permissionLevel is passed correctly to getFoldersAsOptions', async () => {
+      const { getFoldersAsOptionsSpy } = await getTestContext({ permissionLevel: PermissionLevelString.Edit });
+
+      expect(getFoldersAsOptionsSpy).toHaveBeenCalledWith({
+        query: '',
+        permissionLevel: 'Edit',
+        extraFolders: [],
+      });
+    });
+  });
+
+  describe('when extraFolders is set', () => {
+    it('then extraFolders is passed correctly to getFoldersAsOptions', async () => {
+      const { getFoldersAsOptionsSpy } = await getTestContext({ extraFolders: [ALL_FOLDER] });
+
+      expect(getFoldersAsOptionsSpy).toHaveBeenCalledWith({
+        query: '',
+        permissionLevel: 'View',
+        extraFolders: [{ id: undefined, title: 'All' }],
+      });
+    });
+  });
+
+  describe('when entering a query in the input', () => {
+    it('then query is passed correctly to getFoldersAsOptions', async () => {
+      const { getFoldersAsOptionsSpy, selectors } = await getTestContext();
+
+      expect(within(selectors.container.get()).getByRole('textbox')).toBeInTheDocument();
+      getFoldersAsOptionsSpy.mockClear();
+      await userEvent.type(within(selectors.container.get()).getByRole('textbox'), 'A');
+      await waitFor(() => expect(getFoldersAsOptionsSpy).toHaveBeenCalledTimes(1));
+
+      expect(getFoldersAsOptionsSpy).toHaveBeenCalledWith({
+        query: 'A',
+        permissionLevel: 'View',
+        extraFolders: [],
+      });
+    });
+  });
+
+  describe('when there are folders', () => {
+    it('then the first folder in all folders should be selected', async () => {
+      const { selectors } = await getTestContext({}, [
+        { value: GENERAL_FOLDER, label: GENERAL_FOLDER.title },
+        { value: { id: 1, title: 'Test' }, label: 'Test' },
+      ]);
+
+      expect(within(selectors.container.get()).getByText(GENERAL_FOLDER.title!)).toBeInTheDocument();
+    });
+
+    describe('and initialFolderId is passed in props and it matches an existing folder', () => {
+      it('then the folder with an id equal to initialFolderId should be selected', async () => {
+        const { selectors } = await getTestContext({ initialFolderId: 1 }, [
+          { value: GENERAL_FOLDER, label: GENERAL_FOLDER.title },
+          { value: { id: 1, title: 'Test' }, label: 'Test' },
+        ]);
+
+        expect(within(selectors.container.get()).getByText('Test')).toBeInTheDocument();
+      });
+    });
+
+    describe('and initialFolderId is passed in props and it does not match an existing folder', () => {
+      it('then the first folder in all folders should be selected', async () => {
+        const { selectors } = await getTestContext({ initialFolderId: 2 }, [
+          { value: GENERAL_FOLDER, label: GENERAL_FOLDER.title },
+          { value: { id: 1, title: 'Test' }, label: 'Test' },
+        ]);
+
+        expect(within(selectors.container.get()).getByText(GENERAL_FOLDER.title!)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/public/app/core/components/Select/ReadonlyFolderPicker/ReadonlyFolderPicker.tsx
+++ b/public/app/core/components/Select/ReadonlyFolderPicker/ReadonlyFolderPicker.tsx
@@ -1,0 +1,83 @@
+import React, { ReactElement, useCallback, useState } from 'react';
+import debouncePromise from 'debounce-promise';
+import { SelectableValue } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { AsyncSelect } from '@grafana/ui';
+
+import { FolderInfo, PermissionLevelString } from '../../../../types';
+import { findOptionWithId, getFoldersAsOptions } from './api';
+import { PermissionLevel } from './types';
+import { GENERAL_FOLDER_ID, GENERAL_FOLDER_TITLE } from '../../../../features/search/constants';
+
+export const ALL_FOLDER: FolderInfo = { id: undefined, title: 'All' };
+export const GENERAL_FOLDER: FolderInfo = { id: GENERAL_FOLDER_ID, title: GENERAL_FOLDER_TITLE };
+
+export interface ReadonlyFolderPickerProps {
+  onChange: (folder?: FolderInfo) => void;
+  initialFolderId?: number;
+  /**
+   * By default the folders API doesn't include the General folder because it doesn't exist
+   * Add any extra folders you need to appear in the folder picker with the extraFolders property
+   */
+  extraFolders?: FolderInfo[];
+  permissionLevel?: PermissionLevel;
+}
+
+export function ReadonlyFolderPicker({
+  onChange: propsOnChange,
+  extraFolders = [],
+  initialFolderId,
+  permissionLevel = PermissionLevelString.View,
+}: ReadonlyFolderPickerProps): ReactElement {
+  const [initialized, setInitialized] = useState(false);
+  const [option, setOption] = useState<SelectableValue<FolderInfo> | undefined>(undefined);
+  const [options, setOptions] = useState<Array<SelectableValue<FolderInfo>> | undefined>(undefined);
+  const initialize = useCallback(
+    (options: Array<SelectableValue<FolderInfo>>) => {
+      let option = findOptionWithId(options, initialFolderId);
+      if (!option) {
+        // we didn't find the option with the initialFolderId, select the first item in the options and call propsOnChange
+        option = options[0];
+        propsOnChange(option.value);
+      }
+
+      setInitialized(true);
+      setOptions(options);
+      setOption(option);
+    },
+    [initialFolderId, propsOnChange]
+  );
+  const loadOptions = useCallback(
+    async (query: string) => {
+      const options = await getFoldersAsOptions({ query, permissionLevel, extraFolders });
+      if (!initialized) {
+        initialize(options);
+      }
+      return options;
+    },
+    [permissionLevel, extraFolders, initialized, initialize]
+  );
+  const debouncedLoadOptions = debouncePromise(loadOptions, 300, { leading: true });
+  const onChange = useCallback(
+    ({ value }: SelectableValue<FolderInfo>) => {
+      const option = findOptionWithId(options, value?.id);
+      setOption(option);
+      propsOnChange(value);
+    },
+    [options, propsOnChange]
+  );
+
+  return (
+    <div data-testid={selectors.components.ReadonlyFolderPicker.container}>
+      <AsyncSelect
+        menuShouldPortal
+        loadingMessage="Loading folders..."
+        defaultOptions
+        defaultValue={option}
+        value={option}
+        loadOptions={debouncedLoadOptions}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/public/app/core/components/Select/ReadonlyFolderPicker/api.test.ts
+++ b/public/app/core/components/Select/ReadonlyFolderPicker/api.test.ts
@@ -1,0 +1,76 @@
+import * as api from '../../../../features/manage-dashboards/state/actions';
+import { getFoldersAsOptions } from './api';
+import { DashboardSearchHit } from '../../../../features/search/types';
+import { PermissionLevelString } from '../../../../types';
+import { ALL_FOLDER, GENERAL_FOLDER } from './ReadonlyFolderPicker';
+
+function getTestContext(searchHits: DashboardSearchHit[] = []) {
+  jest.clearAllMocks();
+  const searchFoldersSpy = jest.spyOn(api, 'searchFolders').mockResolvedValue(searchHits);
+
+  return { searchFoldersSpy };
+}
+
+describe('getFoldersAsOptions', () => {
+  describe('when called without permissionLevel and query', () => {
+    it('then the correct defaults are passed to the api', async () => {
+      const { searchFoldersSpy } = getTestContext();
+
+      await getFoldersAsOptions({ query: '' });
+
+      expect(searchFoldersSpy).toHaveBeenCalledTimes(1);
+      expect(searchFoldersSpy).toHaveBeenCalledWith('', 'View');
+    });
+
+    describe('and extra folders are passed', () => {
+      it('then extra folders should all appear first in the result', async () => {
+        const args = { query: '', extraFolders: [ALL_FOLDER, GENERAL_FOLDER] };
+        const searchHits: any[] = [{ id: 1, title: 'Folder 1' }];
+        getTestContext(searchHits);
+
+        const result = await getFoldersAsOptions(args);
+        expect(result).toEqual([
+          { value: { id: undefined, title: 'All' }, label: 'All' },
+          { value: { id: 0, title: 'General' }, label: 'General' },
+          { value: { id: 1, title: 'Folder 1' }, label: 'Folder 1' },
+        ]);
+      });
+    });
+  });
+
+  describe('when called with permissionLevel and query', () => {
+    it('then the correct values are passed to the api', async () => {
+      const { searchFoldersSpy } = getTestContext();
+
+      await getFoldersAsOptions({ query: 'Folder1', permissionLevel: PermissionLevelString.Edit });
+
+      expect(searchFoldersSpy).toHaveBeenCalledTimes(1);
+      expect(searchFoldersSpy).toHaveBeenCalledWith('Folder1', 'Edit');
+    });
+
+    describe('and extra folders are passed and extra folders contain query', () => {
+      it('then correct extra folders should all appear first in the result', async () => {
+        const args = { query: 'er', extraFolders: [ALL_FOLDER, GENERAL_FOLDER] };
+        const searchHits: any[] = [{ id: 1, title: 'Folder 1' }];
+        getTestContext(searchHits);
+
+        const result = await getFoldersAsOptions(args);
+        expect(result).toEqual([
+          { value: { id: 0, title: 'General' }, label: 'General' },
+          { value: { id: 1, title: 'Folder 1' }, label: 'Folder 1' },
+        ]);
+      });
+    });
+
+    describe('and extra folders are passed and extra folders do not contain query', () => {
+      it('then no extra folders should appear first in the result', async () => {
+        const args = { query: '1', extraFolders: [ALL_FOLDER, GENERAL_FOLDER] };
+        const searchHits: any[] = [{ id: 1, title: 'Folder 1' }];
+        getTestContext(searchHits);
+
+        const result = await getFoldersAsOptions(args);
+        expect(result).toEqual([{ value: { id: 1, title: 'Folder 1' }, label: 'Folder 1' }]);
+      });
+    });
+  });
+});

--- a/public/app/core/components/Select/ReadonlyFolderPicker/api.ts
+++ b/public/app/core/components/Select/ReadonlyFolderPicker/api.ts
@@ -1,7 +1,7 @@
 import { SelectableValue } from '@grafana/data';
 
 import { FolderInfo, PermissionLevelString } from '../../../../types';
-import { searchFolders } from '../../../../features/manage-dashboards/state/actions';
+import { getFolderById, searchFolders } from '../../../../features/manage-dashboards/state/actions';
 import { PermissionLevel } from './types';
 
 interface GetFoldersArgs {
@@ -51,13 +51,24 @@ export async function getFoldersAsOptions({
   });
 }
 
-function isValidFolderId(id?: number) {
-  return id !== undefined && id !== null && id >= 0;
-}
-
 export function findOptionWithId(
   options?: Array<SelectableValue<FolderInfo>>,
   id?: number
 ): SelectableValue<FolderInfo> | undefined {
-  return options?.find((o) => isValidFolderId(o.value?.id) && isValidFolderId(id) && o.value?.id === id);
+  return options?.find((o) => o.value?.id === id);
+}
+
+export async function getFolderAsOption(folderId?: number): Promise<SelectableValue<FolderInfo> | undefined> {
+  if (folderId === undefined || folderId === null) {
+    return;
+  }
+
+  try {
+    const { id, title } = await getFolderById(folderId);
+    return { value: { id, title }, label: title };
+  } catch (err) {
+    console.error(`Could not find folder with id:${folderId}`);
+  }
+
+  return;
 }

--- a/public/app/core/components/Select/ReadonlyFolderPicker/api.ts
+++ b/public/app/core/components/Select/ReadonlyFolderPicker/api.ts
@@ -1,0 +1,63 @@
+import { SelectableValue } from '@grafana/data';
+
+import { FolderInfo, PermissionLevelString } from '../../../../types';
+import { searchFolders } from '../../../../features/manage-dashboards/state/actions';
+import { PermissionLevel } from './types';
+
+interface GetFoldersArgs {
+  query: string;
+  permissionLevel?: PermissionLevel;
+}
+
+async function getFolders({ query, permissionLevel }: GetFoldersArgs): Promise<FolderInfo[]> {
+  const searchHits = await searchFolders(query, permissionLevel);
+  const folders: FolderInfo[] = searchHits.map((searchHit) => ({
+    id: searchHit.id,
+    title: searchHit.title,
+    url: searchHit.url,
+  }));
+
+  return folders;
+}
+
+export interface GetFoldersWithEntriesArgs extends GetFoldersArgs {
+  extraFolders?: FolderInfo[];
+}
+
+async function getFoldersWithEntries({
+  query,
+  permissionLevel,
+  extraFolders,
+}: GetFoldersWithEntriesArgs): Promise<FolderInfo[]> {
+  const folders = await getFolders({ query, permissionLevel });
+  const extra: FolderInfo[] = extraFolders ?? [];
+  const filteredExtra = query ? extra.filter((f) => f.title?.toLowerCase().includes(query.toLowerCase())) : extra;
+  if (folders) {
+    return filteredExtra.concat(folders);
+  }
+
+  return filteredExtra;
+}
+
+export async function getFoldersAsOptions({
+  query,
+  permissionLevel = PermissionLevelString.View,
+  extraFolders = [],
+}: GetFoldersWithEntriesArgs) {
+  const folders = await getFoldersWithEntries({ query, permissionLevel, extraFolders });
+  return folders.map((value) => {
+    const option: SelectableValue<FolderInfo> = { value, label: value.title };
+    return option;
+  });
+}
+
+function isValidFolderId(id?: number) {
+  return id !== undefined && id !== null && id >= 0;
+}
+
+export function findOptionWithId(
+  options?: Array<SelectableValue<FolderInfo>>,
+  id?: number
+): SelectableValue<FolderInfo> | undefined {
+  return options?.find((o) => isValidFolderId(o.value?.id) && isValidFolderId(id) && o.value?.id === id);
+}

--- a/public/app/core/components/Select/ReadonlyFolderPicker/types.ts
+++ b/public/app/core/components/Select/ReadonlyFolderPicker/types.ts
@@ -1,0 +1,3 @@
+import { PermissionLevelString } from '../../../../types';
+
+export type PermissionLevel = Exclude<PermissionLevelString, PermissionLevelString.Admin>;

--- a/public/app/features/search/constants.ts
+++ b/public/app/features/search/constants.ts
@@ -5,3 +5,4 @@ export const SEARCH_ITEM_MARGIN = 8;
 export const DEFAULT_SORT = { label: 'A\u2013Z', value: 'alpha-asc' };
 export const SECTION_STORAGE_KEY = 'search.sections';
 export const GENERAL_FOLDER_ID = 0;
+export const GENERAL_FOLDER_TITLE = 'General';

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -3,11 +3,15 @@ import { PanelPlugin } from '@grafana/data';
 import { TagsInput } from '@grafana/ui';
 import { AlertList } from './AlertList';
 import { UnifiedAlertList } from './UnifiedAlertList';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
-import { AlertListOptions, UnifiedAlertListOptions, ShowOption, SortOrder } from './types';
+import { AlertListOptions, ShowOption, SortOrder, UnifiedAlertListOptions } from './types';
 import { alertListPanelMigrationHandler } from './AlertListMigrationHandler';
 import { config } from '@grafana/runtime';
 import { RuleFolderPicker } from 'app/features/alerting/unified/components/rule-editor/RuleFolderPicker';
+import {
+  ALL_FOLDER,
+  GENERAL_FOLDER,
+  ReadonlyFolderPicker,
+} from '../../../core/components/Select/ReadonlyFolderPicker/ReadonlyFolderPicker';
 
 function showIfCurrentState(options: AlertListOptions) {
   return options.showOptions === ShowOption.Current;
@@ -74,13 +78,12 @@ const alertList = new PanelPlugin<AlertListOptions>(AlertList)
         name: 'Folder',
         id: 'folderId',
         defaultValue: null,
-        editor: function RenderFolderPicker(props) {
+        editor: function RenderFolderPicker({ value, onChange }) {
           return (
-            <FolderPicker
-              initialFolderId={props.value}
-              initialTitle="All"
-              enableReset={true}
-              onChange={({ id }) => props.onChange(id)}
+            <ReadonlyFolderPicker
+              initialFolderId={value}
+              onChange={(folder) => onChange(folder?.id)}
+              extraFolders={[ALL_FOLDER, GENERAL_FOLDER]}
             />
           );
         },

--- a/public/app/plugins/panel/dashlist/module.tsx
+++ b/public/app/plugins/panel/dashlist/module.tsx
@@ -1,10 +1,13 @@
 import { PanelModel, PanelPlugin } from '@grafana/data';
 import { DashList } from './DashList';
 import { DashListOptions } from './types';
-import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import React from 'react';
 import { TagsInput } from '@grafana/ui';
-import { PermissionLevelString } from '../../../types';
+import {
+  ALL_FOLDER,
+  GENERAL_FOLDER,
+  ReadonlyFolderPicker,
+} from '../../../core/components/Select/ReadonlyFolderPicker/ReadonlyFolderPicker';
 
 export const plugin = new PanelPlugin<DashListOptions>(DashList)
   .setPanelOptions((builder) => {
@@ -43,15 +46,13 @@ export const plugin = new PanelPlugin<DashListOptions>(DashList)
         path: 'folderId',
         name: 'Folder',
         id: 'folderId',
-        defaultValue: null,
-        editor: function RenderFolderPicker(props) {
+        defaultValue: undefined,
+        editor: function RenderFolderPicker({ value, onChange }) {
           return (
-            <FolderPicker
-              initialFolderId={props.value}
-              initialTitle="All"
-              enableReset={true}
-              permissionLevel={PermissionLevelString.View}
-              onChange={({ id }) => props.onChange(id)}
+            <ReadonlyFolderPicker
+              initialFolderId={value}
+              onChange={(folder) => onChange(folder?.id)}
+              extraFolders={[ALL_FOLDER, GENERAL_FOLDER]}
             />
           );
         },


### PR DESCRIPTION
**What this PR does / why we need it**:
I couldn't find yet another `hack` in the FolderPicker that would solve this issue so I took the time to create another one, yeah I know :( I called it `ReadOnlyFolderPicker` because you can't create new folders with this one. 

But you can add your own `extra folders` with the `extraFolders` property. Not super happy with the naming of that property, so please leave some feedback on that and on the rest. 

**Which issue(s) this PR fixes**:
Fixes #39454
Related #38102

**Special notes for your reviewer**:
I deliberately put this for 8.2.0 milestone because beta2 goes out tomorrow and not sure if we have time to review and merge it before that.

