### PR TITLE
Bra: Run wire re-gen on code change

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -15,6 +15,7 @@ watch_dirs = [
 watch_exts = [".go", ".ini", ".toml", ".template.html"]
 build_delay = 1500
 cmds = [
+  ["make", "gen-go"],
   ["go", "run", "build.go", "-dev", "build-server"],
   ["./bin/grafana-server", "-packaging=dev", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
Find having to constantly kill and restart bra many times a day when I find the backend no longer to be running to be a bit annoying.

I understand always doing wire code gen will make it a bit slower when doing small backend changes that do not require wire re-gen, but I cannot measure any noticable difference. But if there is a small difference
then maybe a new separate bra config command `[run-go]` or something could be added that only had wire re-gen on startup.
