### PR TITLE
Plugins Catalog: Make the catalog the default way to interact with plugins

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -965,7 +965,7 @@ app_tls_skip_verify_insecure = false
 # Enter a comma-separated list of plugin identifiers to identify plugins to load even if they are unsigned. Plugins with modified signatures are never loaded.
 allow_loading_unsigned_plugins =
 # Enable or disable installing plugins directly from within Grafana.
-plugin_admin_enabled = false
+plugin_admin_enabled = true
 plugin_admin_external_manage_enabled = false
 plugin_catalog_url = https://grafana.com/grafana/plugins/
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -80,7 +80,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     sampleRate: 1,
   };
   pluginCatalogURL = 'https://grafana.com/grafana/plugins/';
-  pluginAdminEnabled = false;
+  pluginAdminEnabled = true;
   pluginAdminExternalManageEnabled = false;
   expressionsEnabled = false;
   customTheme?: any;

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -930,7 +930,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 		cfg.PluginsAllowUnsigned = append(cfg.PluginsAllowUnsigned, plug)
 	}
 	cfg.PluginCatalogURL = pluginsSection.Key("plugin_catalog_url").MustString("https://grafana.com/grafana/plugins/")
-	cfg.PluginAdminEnabled = pluginsSection.Key("plugin_admin_enabled").MustBool(false)
+	cfg.PluginAdminEnabled = pluginsSection.Key("plugin_admin_enabled").MustBool(true)
 	cfg.PluginAdminExternalManageEnabled = pluginsSection.Key("plugin_admin_external_manage_enabled").MustBool(false)
 
 	if err := cfg.readFeatureToggles(iniFile); err != nil {

--- a/public/app/features/plugins/PluginListPage.test.tsx
+++ b/public/app/features/plugins/PluginListPage.test.tsx
@@ -11,14 +11,21 @@ import { afterEach } from '../../../test/lib/common';
 
 let errorsReturnMock: any = [];
 
-jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as object),
-  getBackendSrv: () => ({
-    get: () => {
-      return errorsReturnMock as any;
-    },
-  }),
-}));
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  const mockedRuntime = {
+    ...original,
+    getBackendSrv: () => ({
+      get: () => {
+        return errorsReturnMock as any;
+      },
+    }),
+  };
+
+  mockedRuntime.config.pluginAdminEnabled = false;
+
+  return mockedRuntime;
+});
 
 const setup = (propOverrides?: object) => {
   const store = configureStore();

--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -12,14 +12,12 @@ import { PluginAdminRoutes, CatalogPlugin, ReducerState, RequestStatus } from '.
 import { getCatalogPluginMock, getPluginsStateMock } from '../__mocks__';
 import BrowsePage from './Browse';
 
-// Mock the config to enable the plugin catalog
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
   const mockedRuntime = { ...original };
 
   mockedRuntime.config.bootData.user.isGrafanaAdmin = true;
   mockedRuntime.config.buildInfo.version = 'v8.1.0';
-  mockedRuntime.config.pluginAdminEnabled = true;
 
   return mockedRuntime;
 });

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -14,14 +14,12 @@ import { mockPluginApis, getCatalogPluginMock, getPluginsStateMock } from '../__
 import { PluginErrorCode, PluginSignatureStatus } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
-// Mock the config to enable the plugin catalog
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
   const mockedRuntime = { ...original };
 
   mockedRuntime.config.bootData.user.isGrafanaAdmin = true;
   mockedRuntime.config.buildInfo.version = 'v8.1.0';
-  mockedRuntime.config.pluginAdminEnabled = true;
 
   return mockedRuntime;
 });

--- a/public/app/features/plugins/state/reducers.test.ts
+++ b/public/app/features/plugins/state/reducers.test.ts
@@ -11,6 +11,16 @@ import {
 } from './reducers';
 import { PluginMetaInfo, PluginType } from '@grafana/data';
 
+// Mock the config to enable the old version of the plugins page
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  const mockedRuntime = { ...original };
+
+  mockedRuntime.config.pluginAdminEnabled = false;
+
+  return mockedRuntime;
+});
+
 describe('pluginsReducer', () => {
   describe('when pluginsLoaded is dispatched', () => {
     it('then state should be correct', () => {


### PR DESCRIPTION
Fixes #38717 

**What this PR does / why we need it**:
We would like to "turn on" the Plugins Catalog for the second beta of Grafana 8.2.0.
