### PR TITLE
Live: pipeline DataOutputter interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,10 @@ require (
 	github.com/yudai/gojsondiff v1.0.0
 	go.opentelemetry.io/collector v0.31.0
 	go.opentelemetry.io/collector/model v0.31.0
+	go.opentelemetry.io/otel v1.0.0
+	go.opentelemetry.io/otel/exporters/jaeger v1.0.0
+	go.opentelemetry.io/otel/sdk v1.0.0
+	go.opentelemetry.io/otel/trace v1.0.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/exp v0.0.0-20210220032938-85be41e4509f // indirect
 	golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f

--- a/go.sum
+++ b/go.sum
@@ -2416,11 +2416,19 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.21.0/go.mod h1:
 go.opentelemetry.io/contrib/zpages v0.0.0-20210722161726-7668016acb73/go.mod h1:NAkejuYm41lpyL43Fu1XdnCOYxN5NVV80/MJ03JQ/X8=
 go.opentelemetry.io/otel v0.11.0/go.mod h1:G8UCk+KooF2HLkgo8RHX9epABH/aRGYET7gQOqBVdB0=
 go.opentelemetry.io/otel v1.0.0-RC1/go.mod h1:x9tRa9HK4hSSq7jf2TKbqFbtt58/TGk0f9XiEYISI1I=
+go.opentelemetry.io/otel v1.0.0 h1:qTTn6x71GVBvoafHK/yaRUmFzI4LcONZD0/kXxl5PHI=
+go.opentelemetry.io/otel v1.0.0/go.mod h1:AjRVh9A5/5DE7S+mZtTR6t8vpKKryam+0lREnfmS4cg=
+go.opentelemetry.io/otel/exporters/jaeger v1.0.0 h1:cLhx8llHw02h5JTqGqaRbYn+QVKHmrzD9vEbKnSPk5U=
+go.opentelemetry.io/otel/exporters/jaeger v1.0.0/go.mod h1:q10N1AolE1JjqKrFJK2tYw0iZpmX+HBaXBtuCzRnBGQ=
 go.opentelemetry.io/otel/internal/metric v0.21.0/go.mod h1:iOfAaY2YycsXfYD4kaRSbLx2LKmfpKObWBEv9QK5zFo=
 go.opentelemetry.io/otel/metric v0.21.0/go.mod h1:JWCt1bjivC4iCrz/aCrM1GSw+ZcvY44KCbaeeRhzHnc=
 go.opentelemetry.io/otel/oteltest v1.0.0-RC1/go.mod h1:+eoIG0gdEOaPNftuy1YScLr1Gb4mL/9lpDkZ0JjMRq4=
 go.opentelemetry.io/otel/sdk v1.0.0-RC1/go.mod h1:kj6yPn7Pgt5ByRuwesbaWcRLA+V7BSDg3Hf8xRvsvf8=
+go.opentelemetry.io/otel/sdk v1.0.0 h1:BNPMYUONPNbLneMttKSjQhOTlFLOD9U22HNG1KrIN2Y=
+go.opentelemetry.io/otel/sdk v1.0.0/go.mod h1:PCrDHlSy5x1kjezSdL37PhbFUMjrsLRshJ2zCzeXwbM=
 go.opentelemetry.io/otel/trace v1.0.0-RC1/go.mod h1:86UHmyHWFEtWjfWPSbu0+d0Pf9Q6e1U+3ViBOc+NXAg=
+go.opentelemetry.io/otel/trace v1.0.0 h1:TSBr8GTEtKevYMG/2d21M989r5WJYVimhTHBKVEZuh4=
+go.opentelemetry.io/otel/trace v1.0.0/go.mod h1:PXTWqayeFUlJV1YDNhsJYB184+IvAH814St6o6ajzIs=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.starlark.net v0.0.0-20200901195727-6e684ef5eeee/go.mod h1:f0znQkUKRrkk36XxWbGjMqQM8wGv/xHBVE2qc3B5oFU=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -2806,6 +2814,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/services/live/pipeline/data_output_builtin.go
+++ b/pkg/services/live/pipeline/data_output_builtin.go
@@ -1,0 +1,47 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/live/livecontext"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+type BuiltinDataOutput struct {
+	channelHandlerGetter ChannelHandlerGetter
+}
+
+const DataOutputTypeBuiltin = "builtin"
+
+func NewBuiltinDataOutput(channelHandlerGetter ChannelHandlerGetter) *BuiltinDataOutput {
+	return &BuiltinDataOutput{channelHandlerGetter: channelHandlerGetter}
+}
+
+func (s *BuiltinDataOutput) Type() string {
+	return DataOutputTypeBuiltin
+}
+
+func (s *BuiltinDataOutput) OutputData(ctx context.Context, vars Vars, data []byte) ([]*ChannelData, error) {
+	u, ok := livecontext.GetContextSignedUser(ctx)
+	if !ok {
+		return nil, errors.New("user not found in context")
+	}
+	handler, _, err := s.channelHandlerGetter.GetChannelHandler(u, vars.Channel)
+	if err != nil {
+		return nil, err
+	}
+	_, status, err := handler.OnPublish(ctx, u, models.PublishEvent{
+		Channel: vars.Channel,
+		Data:    data,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if status != backend.PublishStreamStatusOK {
+		return nil, errors.New("unauthorized publish")
+	}
+	return nil, nil
+}

--- a/pkg/services/live/pipeline/data_output_redirect.go
+++ b/pkg/services/live/pipeline/data_output_redirect.go
@@ -1,0 +1,37 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+)
+
+// RedirectDataOutputConfig ...
+type RedirectDataOutputConfig struct {
+	Channel string `json:"channel"`
+}
+
+// RedirectDataOutput passes processing control to the rule defined
+// for a configured channel.
+type RedirectDataOutput struct {
+	config RedirectDataOutputConfig
+}
+
+func NewRedirectDataOutput(config RedirectDataOutputConfig) *RedirectDataOutput {
+	return &RedirectDataOutput{config: config}
+}
+
+const DataOutputTypeRedirect = "redirect"
+
+func (out *RedirectDataOutput) Type() string {
+	return DataOutputTypeRedirect
+}
+
+func (out *RedirectDataOutput) OutputData(_ context.Context, vars Vars, data []byte) ([]*ChannelData, error) {
+	if vars.Channel == out.config.Channel {
+		return nil, fmt.Errorf("redirect to the same channel: %s", out.config.Channel)
+	}
+	return []*ChannelData{{
+		Channel: out.config.Channel,
+		Data:    data,
+	}}, nil
+}

--- a/pkg/services/live/pipeline/pipeline.go
+++ b/pkg/services/live/pipeline/pipeline.go
@@ -13,11 +13,33 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/live"
 )
 
+// TODO: some things to implement and ideas to consider.
+// * Can return ChannelData from Frame Outputter – thus starting corresponding rule from processing input step.
+// * Better error communication with WS/HTTP? Currently we can't return nothing beyond InternalError.
+// * Better copy data and Frame on redirects? (at least for safety, but no real problem exists yet).
+// * How to deal with auth on redirects? What if publish auth configured for a rule in redirect? Currently auth skipped.
+// * Avoid ProcessorVars, OutputVars – use Vars everywhere.
+// * Rename:
+//		* Converter => FrameConverter
+//		* Outputter => FrameOutputter
+//		* Processor => FrameProcessor
+//		* ConditionChecker => FrameConditionChecker.
+// * Put SignedInUser into Vars.
+// * Distributed tracing to visualize pipeline path
+
+// ChannelData is a wrapper over raw data with additional channel information.
+// Channel is used for rule routing, if the channel is empty then data processing
+// stops. If channel is not empty then data processing will be redirected to a
+// corresponding channel rule.
+type ChannelData struct {
+	Channel string
+	Data    []byte
+}
+
 // ChannelFrame is a wrapper over data.Frame with additional channel information.
 // Channel is used for rule routing, if the channel is empty then frame processing
 // will try to take current rule Processor and Outputter. If channel is not empty
 // then frame processing will be redirected to a corresponding channel rule.
-// TODO: avoid recursion, increment a counter while frame travels over pipeline steps, make it configurable.
 type ChannelFrame struct {
 	Channel string
 	Frame   *data.Frame
@@ -40,6 +62,12 @@ type ProcessorVars struct {
 // OutputVars has some helpful things Outputter entities could use.
 type OutputVars struct {
 	ProcessorVars
+}
+
+// DataOutputter can output incoming data before conversion to frames.
+type DataOutputter interface {
+	Type() string
+	OutputData(ctx context.Context, vars Vars, data []byte) ([]*ChannelData, error)
 }
 
 // Converter converts raw bytes to slice of ChannelFrame. Each element
@@ -82,14 +110,15 @@ type SubscribeAuthChecker interface {
 // LiveChannelRule is an in-memory representation of each specific rule, with Converter, Processor
 // and Outputter to be executed by Pipeline.
 type LiveChannelRule struct {
-	OrgId         int64
-	Pattern       string
-	PublishAuth   PublishAuthChecker
-	SubscribeAuth SubscribeAuthChecker
-	Converter     Converter
-	Processors    []Processor
-	Outputters    []Outputter
-	Subscribers   []Subscriber
+	OrgId          int64
+	Pattern        string
+	PublishAuth    PublishAuthChecker
+	SubscribeAuth  SubscribeAuthChecker
+	DataOutputters []DataOutputter
+	Converter      Converter
+	Processors     []Processor
+	Outputters     []Outputter
+	Subscribers    []Subscriber
 }
 
 // Label ...
@@ -137,12 +166,26 @@ func (p *Pipeline) Get(orgID int64, channel string) (*LiveChannelRule, bool, err
 }
 
 func (p *Pipeline) ProcessInput(ctx context.Context, orgID int64, channelID string, body []byte) (bool, error) {
+	return p.processInput(ctx, orgID, channelID, body, nil)
+}
+
+func (p *Pipeline) processInput(ctx context.Context, orgID int64, channelID string, body []byte, visitedChannels map[string]struct{}) (bool, error) {
 	rule, ok, err := p.ruleGetter.Get(orgID, channelID)
 	if err != nil {
 		return false, err
 	}
 	if !ok {
 		return false, nil
+	}
+	if visitedChannels == nil {
+		visitedChannels = map[string]struct{}{}
+	}
+	if len(rule.DataOutputters) > 0 {
+		channelDataList := []*ChannelData{{Channel: channelID, Data: body}}
+		err = p.processChannelDataList(ctx, orgID, channelID, channelDataList, visitedChannels)
+		if err != nil {
+			return false, err
+		}
 	}
 	channelFrames, ok, err := p.dataToChannelFrames(ctx, *rule, orgID, channelID, body)
 	if err != nil {
@@ -187,6 +230,32 @@ func (p *Pipeline) dataToChannelFrames(ctx context.Context, rule LiveChannelRule
 }
 
 var errChannelRecursion = errors.New("channel recursion")
+
+func (p *Pipeline) processChannelDataList(ctx context.Context, orgID int64, channelID string, channelDataList []*ChannelData, visitedChannels map[string]struct{}) error {
+	for _, channelData := range channelDataList {
+		var nextChannel = channelID
+		if channelData.Channel != "" {
+			nextChannel = channelData.Channel
+		}
+		if _, ok := visitedChannels[nextChannel]; ok {
+			return fmt.Errorf("%w: %s", errChannelRecursion, nextChannel)
+		}
+		visitedChannels[nextChannel] = struct{}{}
+		newChannelDataList, err := p.processData(ctx, orgID, nextChannel, channelData.Data)
+		if err != nil {
+			return err
+		}
+		if len(newChannelDataList) > 0 {
+			for _, cd := range newChannelDataList {
+				_, err := p.processInput(ctx, orgID, cd.Channel, cd.Data, visitedChannels)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
 
 func (p *Pipeline) processChannelFrames(ctx context.Context, orgID int64, channelID string, channelFrames []*ChannelFrame, visitedChannels map[string]struct{}) error {
 	if visitedChannels == nil {
@@ -270,6 +339,47 @@ func (p *Pipeline) processFrame(ctx context.Context, orgID int64, channelID stri
 			resultingFrames = append(resultingFrames, frames...)
 		}
 		return resultingFrames, nil
+	}
+
+	return nil, nil
+}
+
+func (p *Pipeline) processData(ctx context.Context, orgID int64, channelID string, data []byte) ([]*ChannelData, error) {
+	rule, ruleOk, err := p.ruleGetter.Get(orgID, channelID)
+	if err != nil {
+		logger.Error("Error getting rule", "error", err)
+		return nil, err
+	}
+	if !ruleOk {
+		logger.Debug("Rule not found", "channel", channelID)
+		return nil, err
+	}
+
+	ch, err := live.ParseChannel(channelID)
+	if err != nil {
+		logger.Error("Error parsing channel", "error", err, "channel", channelID)
+		return nil, err
+	}
+
+	vars := Vars{
+		OrgID:     orgID,
+		Channel:   channelID,
+		Scope:     ch.Scope,
+		Namespace: ch.Namespace,
+		Path:      ch.Path,
+	}
+
+	if len(rule.DataOutputters) > 0 {
+		var resultingChannelDataList []*ChannelData
+		for _, out := range rule.DataOutputters {
+			channelDataList, err := out.OutputData(ctx, vars, data)
+			if err != nil {
+				logger.Error("Error outputting frame", "error", err)
+				return nil, err
+			}
+			resultingChannelDataList = append(resultingChannelDataList, channelDataList...)
+		}
+		return resultingChannelDataList, nil
 	}
 
 	return nil, nil

--- a/pkg/services/live/pipeline/pipeline.go
+++ b/pkg/services/live/pipeline/pipeline.go
@@ -11,7 +11,44 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/live"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/jaeger"
+	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"go.opentelemetry.io/otel/trace"
 )
+
+const (
+	service     = "grafana"
+	environment = "dev"
+	id          = 1
+)
+
+// tracerProvider returns an OpenTelemetry TracerProvider configured to use
+// the Jaeger exporter that will send spans to the provided url. The returned
+// TracerProvider will also use a Resource configured with all the information
+// about the application.
+func tracerProvider(url string) (*tracesdk.TracerProvider, error) {
+	// Create the Jaeger exporter
+	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
+	if err != nil {
+		return nil, err
+	}
+	tp := tracesdk.NewTracerProvider(
+		// Always be sure to batch in production.
+		tracesdk.WithBatcher(exp),
+		// Record information about this application in an Resource.
+		tracesdk.WithResource(resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String(service),
+			attribute.String("environment", environment),
+			attribute.Int64("ID", id),
+		)),
+	)
+	return tp, nil
+}
 
 // TODO: some things to implement and ideas to consider.
 // * Can return ChannelData from Frame Outputter – thus starting corresponding rule from processing input step.
@@ -25,7 +62,6 @@ import (
 //		* Processor => FrameProcessor
 //		* ConditionChecker => FrameConditionChecker.
 // * Put SignedInUser into Vars.
-// * Distributed tracing to visualize pipeline path
 
 // ChannelData is a wrapper over raw data with additional channel information.
 // Channel is used for rule routing, if the channel is empty then data processing
@@ -147,6 +183,7 @@ type ChannelRuleGetter interface {
 // * output resulting frames to various destinations.
 type Pipeline struct {
 	ruleGetter ChannelRuleGetter
+	tracer     trace.Tracer
 }
 
 // New creates new Pipeline.
@@ -155,9 +192,24 @@ func New(ruleGetter ChannelRuleGetter) (*Pipeline, error) {
 	p := &Pipeline{
 		ruleGetter: ruleGetter,
 	}
+
+	if os.Getenv("GF_LIVE_PIPELINE_TRACE") != "" {
+		// Traces for development only at the moment.
+		// Start local Jaeger and then run Grafana with GF_LIVE_PIPELINE_TRACE:
+		// docker run --rm -it --name jaeger -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 -p 5775:5775/udp -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 14268:14268 -p 14250:14250 -p 9411:9411 jaegertracing/all-in-one:1.26
+		// Then visit http://localhost:16686/ where Jaeger UI is served.
+		tp, err := tracerProvider("http://localhost:14268/api/traces")
+		if err != nil {
+			return nil, err
+		}
+		tracer := tp.Tracer("gf.live.pipeline")
+		p.tracer = tracer
+	}
+
 	if os.Getenv("GF_LIVE_PIPELINE_DEV") != "" {
 		go postTestData() // TODO: temporary for development, remove before merge.
 	}
+
 	return p, nil
 }
 
@@ -166,10 +218,37 @@ func (p *Pipeline) Get(orgID int64, channel string) (*LiveChannelRule, bool, err
 }
 
 func (p *Pipeline) ProcessInput(ctx context.Context, orgID int64, channelID string, body []byte) (bool, error) {
-	return p.processInput(ctx, orgID, channelID, body, nil)
+	var span trace.Span
+	if p.tracer != nil {
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.process_input")
+		span.SetAttributes(
+			attribute.Int64("orgId", orgID),
+			attribute.String("channel", channelID),
+			attribute.String("body", string(body)),
+		)
+		defer span.End()
+	}
+	ok, err := p.processInput(ctx, orgID, channelID, body, nil)
+	if err != nil {
+		if p.tracer != nil && span != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		return ok, err
+	}
+	return ok, err
 }
 
 func (p *Pipeline) processInput(ctx context.Context, orgID int64, channelID string, body []byte, visitedChannels map[string]struct{}) (bool, error) {
+	var span trace.Span
+	if p.tracer != nil {
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.process_input_"+channelID)
+		span.SetAttributes(
+			attribute.Int64("orgId", orgID),
+			attribute.String("channel", channelID),
+			attribute.String("body", string(body)),
+		)
+		defer span.End()
+	}
 	rule, ok, err := p.ruleGetter.Get(orgID, channelID)
 	if err != nil {
 		return false, err
@@ -187,12 +266,12 @@ func (p *Pipeline) processInput(ctx context.Context, orgID int64, channelID stri
 			return false, err
 		}
 	}
-	channelFrames, ok, err := p.dataToChannelFrames(ctx, *rule, orgID, channelID, body)
+	if rule.Converter == nil {
+		return false, nil
+	}
+	channelFrames, err := p.dataToChannelFrames(ctx, *rule, orgID, channelID, body)
 	if err != nil {
 		return false, err
-	}
-	if !ok {
-		return false, nil
 	}
 	err = p.processChannelFrames(ctx, orgID, channelID, channelFrames, nil)
 	if err != nil {
@@ -201,15 +280,21 @@ func (p *Pipeline) processInput(ctx context.Context, orgID int64, channelID stri
 	return true, nil
 }
 
-func (p *Pipeline) dataToChannelFrames(ctx context.Context, rule LiveChannelRule, orgID int64, channelID string, body []byte) ([]*ChannelFrame, bool, error) {
-	if rule.Converter == nil {
-		return nil, false, nil
+func (p *Pipeline) dataToChannelFrames(ctx context.Context, rule LiveChannelRule, orgID int64, channelID string, body []byte) ([]*ChannelFrame, error) {
+	var span trace.Span
+	if p.tracer != nil {
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.convert_"+rule.Converter.Type())
+		span.SetAttributes(
+			attribute.Int64("orgId", orgID),
+			attribute.String("channel", channelID),
+		)
+		defer span.End()
 	}
 
 	channel, err := live.ParseChannel(channelID)
 	if err != nil {
 		logger.Error("Error parsing channel", "error", err, "channel", channelID)
-		return nil, false, err
+		return nil, err
 	}
 
 	vars := Vars{
@@ -223,10 +308,10 @@ func (p *Pipeline) dataToChannelFrames(ctx context.Context, rule LiveChannelRule
 	frames, err := rule.Converter.Convert(ctx, vars, body)
 	if err != nil {
 		logger.Error("Error converting data", "error", err)
-		return nil, false, err
+		return nil, err
 	}
 
-	return frames, true, nil
+	return frames, nil
 }
 
 var errChannelRecursion = errors.New("channel recursion")
@@ -285,6 +370,20 @@ func (p *Pipeline) processChannelFrames(ctx context.Context, orgID int64, channe
 }
 
 func (p *Pipeline) processFrame(ctx context.Context, orgID int64, channelID string, frame *data.Frame) ([]*ChannelFrame, error) {
+	var span trace.Span
+	if p.tracer != nil {
+		table, err := frame.StringTable(32, 32)
+		if err != nil {
+			return nil, err
+		}
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.process_frame_"+channelID)
+		span.SetAttributes(
+			attribute.Int64("orgId", orgID),
+			attribute.String("channel", channelID),
+			attribute.String("frame", table),
+		)
+		defer span.End()
+	}
 	rule, ruleOk, err := p.ruleGetter.Get(orgID, channelID)
 	if err != nil {
 		logger.Error("Error getting rule", "error", err)
@@ -313,7 +412,7 @@ func (p *Pipeline) processFrame(ctx context.Context, orgID int64, channelID stri
 
 	if len(rule.Processors) > 0 {
 		for _, proc := range rule.Processors {
-			frame, err = proc.Process(ctx, vars, frame)
+			frame, err = p.execProcessor(ctx, proc, vars, frame)
 			if err != nil {
 				logger.Error("Error processing frame", "error", err)
 				return nil, err
@@ -331,7 +430,7 @@ func (p *Pipeline) processFrame(ctx context.Context, orgID int64, channelID stri
 	if len(rule.Outputters) > 0 {
 		var resultingFrames []*ChannelFrame
 		for _, out := range rule.Outputters {
-			frames, err := out.Output(ctx, outputVars, frame)
+			frames, err := p.processFrameOutput(ctx, out, outputVars, frame)
 			if err != nil {
 				logger.Error("Error outputting frame", "error", err)
 				return nil, err
@@ -344,7 +443,56 @@ func (p *Pipeline) processFrame(ctx context.Context, orgID int64, channelID stri
 	return nil, nil
 }
 
+func (p *Pipeline) execProcessor(ctx context.Context, proc Processor, vars ProcessorVars, frame *data.Frame) (*data.Frame, error) {
+	var span trace.Span
+	if p.tracer != nil {
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.apply_processor_"+proc.Type())
+		table, err := frame.StringTable(32, 32)
+		if err != nil {
+			return nil, err
+		}
+		span.SetAttributes(
+			attribute.Int64("orgId", vars.OrgID),
+			attribute.String("channel", vars.Channel),
+			attribute.String("frame", table),
+			attribute.String("processor", proc.Type()),
+		)
+		// Note: we can also visualize resulting frame here.
+		defer span.End()
+	}
+	return proc.Process(ctx, vars, frame)
+}
+
+func (p *Pipeline) processFrameOutput(ctx context.Context, out Outputter, vars OutputVars, frame *data.Frame) ([]*ChannelFrame, error) {
+	var span trace.Span
+	if p.tracer != nil {
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.frame_output_"+out.Type())
+		table, err := frame.StringTable(32, 32)
+		if err != nil {
+			return nil, err
+		}
+		span.SetAttributes(
+			attribute.Int64("orgId", vars.OrgID),
+			attribute.String("channel", vars.Channel),
+			attribute.String("frame", table),
+			attribute.String("output", out.Type()),
+		)
+		defer span.End()
+	}
+	return out.Output(ctx, vars, frame)
+}
+
 func (p *Pipeline) processData(ctx context.Context, orgID int64, channelID string, data []byte) ([]*ChannelData, error) {
+	var span trace.Span
+	if p.tracer != nil {
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.process_data_"+channelID)
+		span.SetAttributes(
+			attribute.Int64("orgId", orgID),
+			attribute.String("channel", channelID),
+			attribute.String("data", string(data)),
+		)
+		defer span.End()
+	}
 	rule, ruleOk, err := p.ruleGetter.Get(orgID, channelID)
 	if err != nil {
 		logger.Error("Error getting rule", "error", err)
@@ -372,7 +520,7 @@ func (p *Pipeline) processData(ctx context.Context, orgID int64, channelID strin
 	if len(rule.DataOutputters) > 0 {
 		var resultingChannelDataList []*ChannelData
 		for _, out := range rule.DataOutputters {
-			channelDataList, err := out.OutputData(ctx, vars, data)
+			channelDataList, err := p.processDataOutput(ctx, out, vars, data)
 			if err != nil {
 				logger.Error("Error outputting frame", "error", err)
 				return nil, err
@@ -383,4 +531,19 @@ func (p *Pipeline) processData(ctx context.Context, orgID int64, channelID strin
 	}
 
 	return nil, nil
+}
+
+func (p *Pipeline) processDataOutput(ctx context.Context, out DataOutputter, vars Vars, data []byte) ([]*ChannelData, error) {
+	var span trace.Span
+	if p.tracer != nil {
+		ctx, span = p.tracer.Start(ctx, "live.pipeline.data_output_"+out.Type())
+		span.SetAttributes(
+			attribute.Int64("orgId", vars.OrgID),
+			attribute.String("channel", vars.Channel),
+			attribute.String("data", string(data)),
+			attribute.String("output", out.Type()),
+		)
+		defer span.End()
+	}
+	return out.OutputData(ctx, vars, data)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

To support built-in features like Broadcast with channel rules we need a path that does not convert data to data.Frames. This pr adds `DataOutputter` interface which allows handling this scenario.