### PR TITLE
DashboardRow: Prevent unintended editing of DashboardRow with keyboar…

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -766,6 +766,64 @@ describe('DashboardModel', () => {
       }
     );
   });
+
+  describe('canEditPanel', () => {
+    it('returns false if the dashboard cannot be edited', () => {
+      const dashboard = new DashboardModel({
+        panels: [
+          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
+        ],
+      });
+      dashboard.meta.canEdit = false;
+      const panel = dashboard.getPanelById(2);
+      expect(dashboard.canEditPanel(panel)).toBe(false);
+    });
+
+    it('returns false if no panel is passed in', () => {
+      const dashboard = new DashboardModel({
+        panels: [
+          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
+        ],
+      });
+      expect(dashboard.canEditPanel()).toBe(false);
+    });
+
+    it('returns false if the panel is a repeat', () => {
+      const dashboard = new DashboardModel({
+        panels: [
+          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
+          { id: 3, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 }, repeatPanelId: 2 },
+        ],
+      });
+      const panel = dashboard.getPanelById(3);
+      expect(dashboard.canEditPanel(panel)).toBe(false);
+    });
+
+    it('returns false if the panel is a row', () => {
+      const dashboard = new DashboardModel({
+        panels: [
+          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
+        ],
+      });
+      const panel = dashboard.getPanelById(1);
+      expect(dashboard.canEditPanel(panel)).toBe(false);
+    });
+
+    it('returns true otherwise', () => {
+      const dashboard = new DashboardModel({
+        panels: [
+          { id: 1, type: 'row', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          { id: 2, type: 'graph', gridPos: { x: 0, y: 7, w: 12, h: 2 } },
+        ],
+      });
+      const panel = dashboard.getPanelById(2);
+      expect(dashboard.canEditPanel(panel)).toBe(true);
+    });
+  });
 });
 
 describe('exitViewPanel', () => {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -470,7 +470,7 @@ export class DashboardModel {
   }
 
   canEditPanel(panel?: PanelModel | null): boolean | undefined | null {
-    return this.meta.canEdit && panel && !panel.repeatPanelId;
+    return Boolean(this.meta.canEdit && panel && !panel.repeatPanelId && panel.type !== 'row');
   }
 
   canEditPanelById(id: number): boolean | undefined | null {


### PR DESCRIPTION
…d shortcut 'e'

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- pressing 'e' whilst hovering a `DashboardRow` takes you to the edit view for this panel
- `DashboardRow`s are not meant to be edited in this way, so let's disable the keybinding if the panel is a row for now.
- adds unit tests for `canEditPanel`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/39732

**Special notes for your reviewer**:

