### PR TITLE
backendSrv: allow delete request to accept body

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -140,7 +140,7 @@ export interface FetchError<T extends FetchErrorDataProps = any> {
  */
 export interface BackendSrv {
   get(url: string, params?: any, requestId?: string): Promise<any>;
-  delete(url: string): Promise<any>;
+  delete(url: string, data?: any): Promise<any>;
   post(url: string, data?: any): Promise<any>;
   patch(url: string, data?: any): Promise<any>;
   put(url: string, data?: any): Promise<any>;

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -385,8 +385,8 @@ export class BackendSrv implements BackendService {
     return await this.request({ method: 'GET', url, params, requestId });
   }
 
-  async delete(url: string) {
-    return await this.request({ method: 'DELETE', url });
+  async delete(url: string, data?: any) {
+    return await this.request({ method: 'DELETE', url, data });
   }
 
   async post(url: string, data?: any) {


### PR DESCRIPTION
For live CRUD, we need to pass a payload to delete a certain rule. This allows `getBackendSrv()` call to accept a body with the delete call.

