### PR TITLE
Chore: update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,32 +48,60 @@ go.sum @grafana/backend-platform
 /pkg/services/ngalert @grafana/alerting-squad
 /pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad
 
+# Library Services
+/pkg/services/libraryelements @grafana/user-essentials
+/pkg/services/librarypanels @grafana/user-essentials
+
 # Backend code docs
 /contribute/style-guides/backend.md @grafana/backend-platform
 /contribute/architecture/backend @grafana/backend-platform
 /contribute/engineering/backend @grafana/backend-platform
 
-/e2e @grafana/grafana-frontend-platform
-/packages @grafana/grafana-frontend-platform
-/plugins-bundled @grafana/grafana-frontend-platform
-/public @grafana/grafana-frontend-platform
-/scripts/build/release-packages.sh @grafana/grafana-frontend-platform
-/scripts/circle-release-next-packages.sh @grafana/grafana-frontend-platform
-/scripts/ci-frontend-metrics.sh @grafana/grafana-frontend-platform
-/scripts/grunt @grafana/grafana-frontend-platform
-/scripts/webpack @grafana/grafana-frontend-platform
+/e2e @grafana/user-essentials
+/packages @grafana/user-essentials @grafana/plugins-platform @grafana/grafana-bi-squad
+/packages/grafana-e2e-selectors @grafana/user-essentials
+/packages/grafana-e2e @grafana/user-essentials
+/packages/grafana-toolkit @grafana/plugins-platform
+/packages/grafana-ui/.storybook @grafana/plugins-platform
+/packages/grafana-ui/src/components/DateTimePickers @grafana/grafana-bi-squad
+/packages/grafana-ui/src/components/GraphNG @grafana/grafana-bi-squad
+/packages/grafana-ui/src/components/Table @grafana/grafana-bi-squad
+/packages/grafana-ui/src/components/TimeSeries @grafana/grafana-bi-squad
+/packages/grafana-ui/src/components/uPlot @grafana/grafana-bi-squad
+/packages/grafana-ui/src/utils/storybook @grafana/plugins-platform
+/packages/jaeger-ui-components/ @grafana/observability-squad
+/plugins-bundled @grafana/plugins-platform
+/public @grafana/user-essentials
+/public/app/core/components/TimePicker @grafana/grafana-bi-squad
+/public/app/features/explore/ @grafana/observability-squad
+/public/app/plugins/panel/alertlist @grafana/alerting-squad
+/public/app/plugins/panel/barchart @grafana/grafana-bi-squad
+/public/app/plugins/panel/heatmap @grafana/grafana-bi-squad
+/public/app/plugins/panel/histogram @grafana/grafana-bi-squad
+/public/app/plugins/panel/piechart @grafana/grafana-bi-squad
+/public/app/plugins/panel/state-timeline @grafana/grafana-bi-squad
+/public/app/plugins/panel/status-history @grafana/grafana-bi-squad
+/public/app/plugins/panel/table @grafana/grafana-bi-squad
+/public/app/plugins/panel/timeseries @grafana/grafana-bi-squad
+/scripts/build/release-packages.sh @grafana/plugins-platform
+/scripts/circle-release-next-packages.sh @grafana/plugins-platform
+/scripts/ci-frontend-metrics.sh @grafana/user-essentials @grafana/plugins-platform @grafana/grafana-bi-squad
+/scripts/ci-reference-docs-build.sh @grafana/plugins-platform
+/scripts/ci-reference-docs-lint.sh @grafana/plugins-platform
+/scripts/grunt @grafana/frontend-ops
+/scripts/webpack @grafana/frontend-ops
+/scripts/generate-a11y-report.sh @grafana/user-essentials
 package.json @grafana/frontend-ops
-tsconfig.json @grafana/grafana-frontend-platform
-lerna.json @grafana/grafana-frontend-platform
-.babelrc @grafana/grafana-frontend-platform
-.prettierrc.js @grafana/grafana-frontend-platform
-.eslintrc @grafana/grafana-frontend-platform
+tsconfig.json @grafana/frontend-ops
+lerna.json @grafana/frontend-ops
+.babelrc @grafana/frontend-ops
+.prettierrc.js @grafana/frontend-ops
+.eslintrc @grafana/frontend-ops
+.pa11yci.conf.js @grafana/user-essentials
+.pa11yci-pr.conf.js @grafana/user-essentials
 
 # @grafana/ui component documentation
-*.mdx @marcusolsson @jessover9000 @grafana/grafana-frontend-platform
-
-/public/app/features/explore/ @grafana/observability-squad
-/packages/jaeger-ui-components/ @grafana/observability-squad
+*.mdx @marcusolsson @jessover9000 @grafana/plugins-platform
 
 # Core datasources
 /public/app/plugins/datasource/cloudwatch @grafana/cloud-datasources @grafana/observability-squad


### PR DESCRIPTION
**What this PR does / why we need it**:
The frontend platform squad has split into 3 separate squads. This change to the CODEOWNERS should represent that change. Also, I moved some paths to keep them together.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Pinging all the squads: @grafana/grafana-bi-squad @grafana/user-essentials @grafana/plugins-platform @grafana/frontend-ops 

