### PR TITLE
CodeEditor: Ensure that we trigger the latest onSave callback provided to the component.

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -86,6 +86,13 @@ class UnthemedCodeEditor extends React.PureComponent<Props> {
     }
   };
 
+  onSave = () => {
+    const { onSave } = this.props;
+    if (onSave) {
+      onSave(this.getEditorValue());
+    }
+  };
+
   handleBeforeMount = (monaco: Monaco) => {
     this.monaco = monaco;
     const { language, theme, getSuggestions, onBeforeEditorMount } = this.props;
@@ -99,15 +106,10 @@ class UnthemedCodeEditor extends React.PureComponent<Props> {
   };
 
   handleOnMount = (editor: MonacoEditorType, monaco: Monaco) => {
-    const { onSave, onEditorDidMount } = this.props;
+    const { onEditorDidMount } = this.props;
     this.getEditorValue = () => editor.getValue();
 
-    if (onSave) {
-      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, () => {
-        onSave(this.getEditorValue());
-      });
-    }
-
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, this.onSave);
     const languagePromise = this.loadCustomLanguage();
 
     if (onEditorDidMount) {


### PR DESCRIPTION
**What this PR does / why we need it**:
As described in the linked issue. The `onBlur` and `onSave` callbacks currently work differently. The `onBlur` will always trigger the the latest "version" of the callback passed to the component. The `onSave` however will always trigger the first "version" of the callback passed to the component.

The reason for this is that when we mount the underlying Monaco editor will will wire up the save events in the Monaco editor to the callback `onSave` being passed initially. So this PR will wire an internal function, with access to the latest version of the props, in the CodeEditor to the Monaco editor which then always will trigger the latest version.

**Which issue(s) this PR fixes**:
Fixes #39264
