### PR TITLE
Alerting: Parse App URL only once

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -2,6 +2,7 @@ package ngalert
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -125,11 +126,17 @@ func (ng *AlertNG) init() error {
 		DisabledOrgs:            ng.Cfg.UnifiedAlerting.DisabledOrgs,
 		MinRuleInterval:         ng.getRuleMinInterval(),
 	}
+
+	appUrl, err := url.Parse(ng.Cfg.AppURL)
+	if err != nil {
+		ng.Log.Error("Failed to parse application URL. Continue without it.", "error", err)
+		appUrl = nil
+	}
 	stateManager := state.NewManager(ng.Log, ng.Metrics.GetStateMetrics(), store, store)
-	schedule := schedule.NewScheduler(schedCfg, ng.DataService, ng.Cfg.AppURL, stateManager)
+	scheduler := schedule.NewScheduler(schedCfg, ng.DataService, appUrl, stateManager)
 
 	ng.stateManager = stateManager
-	ng.schedule = schedule
+	ng.schedule = scheduler
 
 	api := api.API{
 		Cfg:                  ng.Cfg,

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -11,21 +11,14 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/prometheus/alertmanager/api/v2/models"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 )
 
-func FromAlertStateToPostableAlerts(logger log.Logger, firingStates []*state.State, stateManager *state.Manager, appURL string) apimodels.PostableAlerts {
+func FromAlertStateToPostableAlerts(firingStates []*state.State, stateManager *state.Manager, appURL *url.URL) apimodels.PostableAlerts {
 	alerts := apimodels.PostableAlerts{PostableAlerts: make([]models.PostableAlert, 0, len(firingStates))}
 	var sentAlerts []*state.State
 	ts := time.Now()
-
-	u, err := url.Parse(appURL)
-	if err != nil {
-		logger.Debug("failed to parse URL while joining URL", "url", appURL, "err", err.Error())
-		u = nil
-	}
 
 	for _, alertState := range firingStates {
 		if !alertState.NeedsSending(stateManager.ResendDelay) {
@@ -38,12 +31,15 @@ func FromAlertStateToPostableAlerts(logger log.Logger, firingStates []*state.Sta
 			nA["__value_string__"] = alertState.Results[0].EvaluationString
 		}
 
-		genURL := appURL
-		if uid := nL[ngModels.RuleUIDLabel]; len(uid) > 0 && u != nil {
-			oldPath := u.Path
+		var urlStr string
+		if uid := nL[ngModels.RuleUIDLabel]; len(uid) > 0 && appURL != nil {
+			u := *appURL
 			u.Path = path.Join(u.Path, fmt.Sprintf("/alerting/%s/edit", uid))
-			genURL = u.String()
-			u.Path = oldPath
+			urlStr = u.String()
+		} else if appURL != nil {
+			urlStr = appURL.String()
+		} else {
+			urlStr = ""
 		}
 
 		alerts.PostableAlerts = append(alerts.PostableAlerts, models.PostableAlert{
@@ -52,7 +48,7 @@ func FromAlertStateToPostableAlerts(logger log.Logger, firingStates []*state.Sta
 			EndsAt:      strfmt.DateTime(alertState.EndsAt),
 			Alert: models.Alert{
 				Labels:       models.LabelSet(nL),
-				GeneratorURL: strfmt.URI(genURL),
+				GeneratorURL: strfmt.URI(urlStr),
 			},
 		})
 		alertState.LastSentAt = ts

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -109,13 +109,8 @@ type SchedulerCfg struct {
 }
 
 // NewScheduler returns a new schedule.
-func NewScheduler(cfg SchedulerCfg, dataService *tsdb.Service, appURL string, stateManager *state.Manager) *schedule {
+func NewScheduler(cfg SchedulerCfg, dataService *tsdb.Service, appURL *url.URL, stateManager *state.Manager) *schedule {
 	ticker := alerting.NewTicker(cfg.C.Now(), time.Second*0, cfg.C, int64(cfg.BaseInterval.Seconds()))
-	appUrl, err := url.Parse(appURL)
-	if err != nil {
-		cfg.Logger.Error("Failed to parse app URL. Continue without it.", "error", err)
-		appUrl = nil
-	}
 
 	sch := schedule{
 
@@ -135,7 +130,7 @@ func NewScheduler(cfg SchedulerCfg, dataService *tsdb.Service, appURL string, st
 		adminConfigStore:        cfg.AdminConfigStore,
 		multiOrgNotifier:        cfg.MultiOrgNotifier,
 		metrics:                 cfg.Metrics,
-		appURL:                  appUrl,
+		appURL:                  appURL,
 		stateManager:            stateManager,
 		senders:                 map[int64]*sender.Sender{},
 		sendersCfgHash:          map[int64]string{},

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -3,6 +3,7 @@ package schedule_test
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"runtime"
 	"strings"
 	"testing"
@@ -155,7 +156,11 @@ func TestAlertingTicker(t *testing.T) {
 		},
 	}
 	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), dbstore, dbstore)
-	sched := schedule.NewScheduler(schedCfg, nil, "http://localhost", st)
+	appUrl := &url.URL{
+		Scheme: "http",
+		Host:   "localhost",
+	}
+	sched := schedule.NewScheduler(schedCfg, nil, appUrl, st)
 
 	ctx := context.Background()
 

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"testing"
 	"time"
 
@@ -247,7 +248,11 @@ func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, ac
 		AdminConfigPollInterval: 10 * time.Minute, // do not poll in unit tests.
 	}
 	st := state.NewManager(schedCfg.Logger, m.GetStateMetrics(), rs, is)
-	return NewScheduler(schedCfg, nil, "http://localhost", st), mockedClock
+	appUrl := &url.URL{
+		Scheme: "http",
+		Host:   "localhost",
+	}
+	return NewScheduler(schedCfg, nil, appUrl, st), mockedClock
 }
 
 // createTestAlertRule creates a dummy alert definition to be used by the tests.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
the function [FromAlertStateToPostableAlerts](https://github.com/grafana/grafana/blob/79ae97ed802824b714d9fed8fe45f2c843d4a300/pkg/services/ngalert/schedule/compat.go#L18) converts alerting state to a model for Alertmanager. It is called quite often (every time the alert rule is evaluated), and every time it is called it parses the application URL that comes from the static configuration file. This PR moves the parsing to the constructor function of the Scheduler to avoid parsing the URL over and over.


