### PR TITLE
CloudWatch Logs: Skip caching for log queries

### DIFF
--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -31,7 +31,7 @@ You can make a panel retrieve fresh data more frequently by increasing the **Max
 
 Query caching works for all [Enterprise data sources](https://grafana.com/grafana/plugins/?type=datasource&enterprise=1), and it works for the following [built-in data sources]({{< relref "../datasources/_index.md" >}}):
 
-- CloudWatch
+- CloudWatch Metrics
 - Google Cloud Monitoring
 - InfluxDB
 - Microsoft SQL Server

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -159,7 +159,10 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
     }));
 
     // This first starts the query which returns queryId which can be used to retrieve results.
-    return this.makeLogActionRequest('StartQuery', queryParams, options.scopedVars).pipe(
+    return this.makeLogActionRequest('StartQuery', queryParams, {
+      scopedVars: options.scopedVars,
+      skipCache: true,
+    }).pipe(
       mergeMap((dataFrames) =>
         // This queries for the results
         this.logsQuery(
@@ -258,7 +261,7 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
     });
 
     const dataFrames = increasingInterval({ startPeriod: 100, endPeriod: 1000, step: 300 }).pipe(
-      concatMap((_) => this.makeLogActionRequest('GetQueryResults', queryParams)),
+      concatMap((_) => this.makeLogActionRequest('GetQueryResults', queryParams, { skipCache: true })),
       repeat(),
       share()
     );
@@ -337,8 +340,10 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
       this.makeLogActionRequest(
         'StopQuery',
         Object.values(this.logQueries).map((logQuery) => ({ queryId: logQuery.id, region: logQuery.region })),
-        undefined,
-        false
+        {
+          makeReplacements: false,
+          skipCache: true,
+        }
       ).pipe(
         finalize(() => {
           this.logQueries = {};
@@ -511,8 +516,14 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
   makeLogActionRequest(
     subtype: LogAction,
     queryParams: any[],
-    scopedVars?: ScopedVars,
-    makeReplacements = true
+    options: {
+      scopedVars?: ScopedVars;
+      makeReplacements?: boolean;
+      skipCache?: boolean;
+    } = {
+      makeReplacements: true,
+      skipCache: false,
+    }
   ): Observable<DataFrame[]> {
     const range = this.timeSrv.timeRange();
 
@@ -530,26 +541,32 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
       })),
     };
 
-    if (makeReplacements) {
+    if (options.makeReplacements) {
       requestParams.queries.forEach((query) => {
         if (query.hasOwnProperty('queryString')) {
-          query.queryString = this.replace(query.queryString, scopedVars, true);
+          query.queryString = this.replace(query.queryString, options.scopedVars, true);
         }
-        query.region = this.replace(query.region, scopedVars, true, 'region');
+        query.region = this.replace(query.region, options.scopedVars, true, 'region');
         query.region = this.getActualRegion(query.region);
 
         // interpolate log groups
         if (query.logGroupNames) {
           query.logGroupNames = query.logGroupNames.map((logGroup: string) =>
-            this.replace(logGroup, scopedVars, true, 'log groups')
+            this.replace(logGroup, options.scopedVars, true, 'log groups')
           );
         }
       });
     }
 
     const resultsToDataFrames = (val: any): DataFrame[] => toDataQueryResponse(val).data || [];
+    let headers = {};
+    if (options.skipCache) {
+      headers = {
+        'X-Cache-Skip': true,
+      };
+    }
 
-    return this.awsRequest(DS_QUERY_ENDPOINT, requestParams).pipe(
+    return this.awsRequest(DS_QUERY_ENDPOINT, requestParams, headers).pipe(
       map((response) => resultsToDataFrames({ data: response })),
       catchError((err) => {
         if (err.data?.error) {
@@ -794,11 +811,12 @@ export class CloudWatchDatasource extends DataSourceWithBackend<CloudWatchQuery,
     }
   }
 
-  awsRequest(url: string, data: MetricRequest): Observable<TSDBResponse> {
+  awsRequest(url: string, data: MetricRequest, headers: Record<string, any> = {}): Observable<TSDBResponse> {
     const options = {
       method: 'POST',
       url,
       data,
+      headers,
     };
 
     return getBackendSrv()


### PR DESCRIPTION
Because of how CloudWatch logs queries work they are not cacheable by default and caching resulted in errors due to too many retries.

This adds x-skip-cache header to log queries which means caching is always skipped.