### PR TITLE
Alerting: rule evaluation loop to not access multiorg Alertmanager if no alerts to add

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -478,7 +478,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key models.AlertRul
 				alerts := FromAlertStateToPostableAlerts(sch.log, processedStates, sch.stateManager, sch.appURL)
 
 				if len(alerts.PostableAlerts) == 0 {
-					sch.log.Debug("no alerts to send to Alertmanager. Exiting", "org", alertRule.OrgID)
+					sch.log.Debug("no alerts to put in the notifier", "org", alertRule.OrgID)
 					return nil
 				}
 

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -477,6 +477,11 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key models.AlertRul
 				sch.saveAlertStates(processedStates)
 				alerts := FromAlertStateToPostableAlerts(sch.log, processedStates, sch.stateManager, sch.appURL)
 
+				if len(alerts.PostableAlerts) == 0 {
+					sch.log.Debug("no alerts to send to Alertmanager. Exiting", "org", alertRule.OrgID)
+					return nil
+				}
+
 				sch.log.Debug("sending alerts to notifier", "count", len(alerts.PostableAlerts), "alerts", alerts.PostableAlerts, "org", alertRule.OrgID)
 				n, err := sch.multiOrgNotifier.AlertmanagerFor(alertRule.OrgID)
 				if err == nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When the scheduler's evaluation loop got alert states it converts them to the Alertmanager's alerts. However, if the alert is not firing, the resulting list of the alerts is empty. After the conversion, the procedure gets Alertmanager from the MultiorgAlertManager which uses RO mutex to access the list as well as Sender, which also puts lock on the map. This happens even if the list of alerts is empty, which is effectively useless. 
This PR updates the evaluation procedure to exit if there are no alerts to send to Alertmanager. This should reduce contention while accessing the alertmanager's map and sender's map.


