### PR TITLE
Alerting: Fix folder icons for alert rules

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -87,7 +87,7 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace }) => {
           onToggle={setIsCollapsed}
           data-testid="group-collapse-toggle"
         />
-        <Icon name={isCollapsed ? 'folder-open' : 'folder'} />
+        <Icon name={isCollapsed ? 'folder' : 'folder-open'} />
         {isCloudRulesSource(rulesSource) && (
           <Tooltip content={rulesSource.name} placement="top">
             <img className={styles.dataSourceIcon} src={rulesSource.meta.info.logos.small} />


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes folder icons for alert rules showing up as opened when collapsed and as closed when expanded.

Fixes #39830.

