### PR TITLE
Auth: add name parameter to auth.saml

### DIFF
--- a/packages/grafana-data/src/types/constants.ts
+++ b/packages/grafana-data/src/types/constants.ts
@@ -1,2 +1,3 @@
 export const GAUGE_DEFAULT_MINIMUM = 0;
 export const GAUGE_DEFAULT_MAXIMUM = 100;
+export const DEFAULT_SAML_NAME = 'SAML';

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -44,7 +44,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   ldapEnabled = false;
   sigV4AuthEnabled = false;
   samlEnabled = false;
-  samlName = 'SAML';
+  samlName = '';
   autoAssignOrg = true;
   verifyEmailEnabled = false;
   oauth: any;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -44,6 +44,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   ldapEnabled = false;
   sigV4AuthEnabled = false;
   samlEnabled = false;
+  samlName = 'SAML';
   autoAssignOrg = true;
   verifyEmailEnabled = false;
   oauth: any;

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -97,6 +97,7 @@ func (hs *HTTPServer) LoginView(c *models.ReqContext) {
 
 	viewData.Settings["oauth"] = enabledOAuths
 	viewData.Settings["samlEnabled"] = hs.samlEnabled()
+	viewData.Settings["samlName"] = hs.samlName()
 
 	if loginError, ok := hs.tryGetEncryptedCookie(c, loginErrorCookieName); ok {
 		// this cookie is only set whenever an OAuth login fails
@@ -344,6 +345,10 @@ func (hs *HTTPServer) RedirectResponseWithError(ctx *models.ReqContext, err erro
 
 func (hs *HTTPServer) samlEnabled() bool {
 	return hs.SettingsProvider.KeyValue("auth.saml", "enabled").MustBool(false) && hs.License.HasValidLicense()
+}
+
+func (hs *HTTPServer) samlName() string {
+	return hs.SettingsProvider.KeyValue("auth.saml", "name").MustString("SAML")
 }
 
 func (hs *HTTPServer) samlSingleLogoutEnabled() bool {

--- a/public/app/core/components/Login/LoginServiceButtons.tsx
+++ b/public/app/core/components/Login/LoginServiceButtons.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import config from 'app/core/config';
 import { css, cx } from '@emotion/css';
 import { Icon, IconName, LinkButton, useStyles, useTheme2, VerticalGroup } from '@grafana/ui';
-import { GrafanaTheme, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme, GrafanaTheme2, DEFAULT_SAML_NAME } from '@grafana/data';
 import { pickBy } from 'lodash';
 
 export interface LoginService {
@@ -24,7 +24,7 @@ const loginServices: () => LoginServices = () => {
     saml: {
       bgColor: '#464646',
       enabled: config.samlEnabled,
-      name: config.samlName || 'SAML',
+      name: config.samlName || DEFAULT_SAML_NAME,
       icon: 'key-skeleton-alt',
     },
     google: {

--- a/public/app/core/components/Login/LoginServiceButtons.tsx
+++ b/public/app/core/components/Login/LoginServiceButtons.tsx
@@ -24,7 +24,7 @@ const loginServices: () => LoginServices = () => {
     saml: {
       bgColor: '#464646',
       enabled: config.samlEnabled,
-      name: 'SAML',
+      name: config.samlName || 'SAML',
       icon: 'key-skeleton-alt',
     },
     google: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds the optional parameter `name` to the `[auth.saml]` configuration, allowing the user to set a custom name on the button "Sign in with SAML" so it can say "Sign in with <user_defined_name>".

We need this to support changing "Sign in with SAML" to "Sign in with SSO".
For all the other auth providers, this name can be overridden, but not `[auth.saml]`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/grafana-enterprise#985

**Special notes for your reviewer**:

I'm not sure if this is the best way to solve this, it seems like the simplest way, since it would be a bigger change to include SAML on the `settings.oauth` object. Not sure why SAML was the only provider not included on the `settings.oauth`. It would be nice to change that so SAML would follow the same pattern as other providers but it would make the PR unnecessarily complex.