### PR TITLE
CI Build: update the grafana/build-container image

### DIFF
--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update && \
         cmake           \
         libssl-dev      \
         xz-utils        \
-        lzma-dev
+        lzma-dev        \
+        libgnutls30
 RUN git clone https://github.com/tpoechtrager/osxcross.git /tmp/osxcross && \
       cd /tmp/osxcross && git reset --hard $OSX_CROSS_REV
 COPY MacOSX10.15.sdk.tar.xz /tmp/osxcross/tarballs/

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.4.3"
+_version="1.4.4"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
**What this PR does / why we need it**:
There is an issue started happening yesterday (2021-09-30) with the builds due to (possibly) the certificate for deb.nodesource seems to be expired. 

[Example failing pull request](https://github.com/grafana/grafana/pull/39866)
[Example failing build step](https://drone.grafana.net/grafana/grafana/35886/1/25)

[1. Related issue on github.com/nodesource](https://github.com/nodesource/distributions/issues/1266)
[2. Related issue on github.com/nodesource](https://github.com/nodesource/distributions/issues/1267)

**TL;DR**
To me it seems that there is no permanent solution to the problem yet, but one of the suggestion seemed to me like an ok temporary one. Maybe I was wrong, let me know.