### PR TITLE
Plugins: Create a mock icon component to prevent console errors

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/toolkit.build.ts
@@ -58,6 +58,7 @@ const copyFiles = () => {
     'src/config/styles.mock.js',
     'src/config/jest.plugin.config.local.js',
     'src/config/matchMedia.js',
+    'src/config/react-inlinesvg.tsx',
   ];
 
   return useSpinner(`Moving ${files.join(', ')} files`, async () => {

--- a/packages/grafana-toolkit/src/config/jest.plugin.config.test.ts
+++ b/packages/grafana-toolkit/src/config/jest.plugin.config.test.ts
@@ -26,7 +26,6 @@ describe('Jest config', () => {
     it('should preserve mapping for stylesheets when moduleNameMapper overrides provided', () => {
       const config = jestConfig(`${__dirname}/mocks/jestSetup/overrides`);
       expect(config.moduleNameMapper).toBeDefined();
-      expect(Object.keys(config.moduleNameMapper)).toHaveLength(2);
       expect(Object.keys(config.moduleNameMapper)).toContain('\\.(css|sass|scss)$');
       expect(Object.keys(config.moduleNameMapper)).toContain('someOverride');
     });

--- a/packages/grafana-toolkit/src/config/jest.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/jest.plugin.config.ts
@@ -44,6 +44,7 @@ export const jestConfig = (baseDir: string = process.cwd()) => {
   const { moduleNameMapper, ...otherOverrides } = jestConfigOverrides;
   const moduleNameMapperConfig = {
     '\\.(css|sass|scss)$': `${__dirname}/styles.mock.js`,
+    'react-inlinesvg': `${__dirname}/react-inlinesvg.tsx`,
     ...moduleNameMapper,
   };
 

--- a/packages/grafana-toolkit/src/config/react-inlinesvg.tsx
+++ b/packages/grafana-toolkit/src/config/react-inlinesvg.tsx
@@ -14,8 +14,12 @@ export interface StorageItem {
 
 export const cacheStore: { [key: string]: StorageItem } = Object.create(null);
 
+const SVG_FILE_NAME_REGEX = /(.+)\/(.+)\.svg$/;
+
 const InlineSVG = ({ src }: { src: string }) => {
-  return <svg xmlns="http://www.w3.org/2000/svg" data-testid={src} viewBox="0 0 24 24" />;
+  // testId will be the file name without extension (e.g. `public/img/icons/angle-double-down.svg` -> `angle-double-down`)
+  const testId = src.replace(SVG_FILE_NAME_REGEX, '$2');
+  return <svg xmlns="http://www.w3.org/2000/svg" data-testid={testId} viewBox="0 0 24 24" />;
 };
 
 export default InlineSVG;

--- a/packages/grafana-toolkit/src/config/react-inlinesvg.tsx
+++ b/packages/grafana-toolkit/src/config/react-inlinesvg.tsx
@@ -1,0 +1,21 @@
+// Due to the grafana/ui Icon component making fetch requests to
+// `/public/img/icon/<icon_name>.svg` we need to mock react-inlinesvg to prevent
+// the failed fetch requests from displaying errors in console.
+
+import React from 'react';
+
+type Callback = (...args: any[]) => void;
+
+export interface StorageItem {
+  content: string;
+  queue: Callback[];
+  status: string;
+}
+
+export const cacheStore: { [key: string]: StorageItem } = Object.create(null);
+
+const InlineSVG = ({ src }: { src: string }) => {
+  return <svg xmlns="http://www.w3.org/2000/svg" data-testid={src} viewBox="0 0 24 24" />;
+};
+
+export default InlineSVG;

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -34,6 +34,7 @@ const buildCjsPackage = ({ env }) => {
       '@grafana/e2e-selectors',
       'moment',
       'jquery', // required to use jquery.plot, which is assigned externally
+      'react-inlinesvg', // required to mock Icon svg loading in tests
     ],
     plugins: [
       commonjs({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR mocks the grafana-ui `Icon` components SVG loading to prevent errors appearing in console when running plugin tests.

| Before | After |
| --- | --- |
| <img width="800" alt="before" src="https://user-images.githubusercontent.com/73201/135594587-9b75a76c-f00d-4f43-967c-b9c200fa26c7.png"> | <img width="800" alt="after" src="https://user-images.githubusercontent.com/73201/135619285-12b03cca-9206-4dd5-9457-54f6ac0e255a.png"> |

_Note: the errors caused by the failed SVG fetching don't cause tests to fail._


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37052

**Special notes for your reviewer**:
I've made the mock return a `data-testid` that matches the Icon component `name` prop. In doing so a developer that uses `<Icon name="angle-double-down" />` can get hold of it in tests with `screen.getByTestId('angle-double-down')`. 
