### PR TITLE
Dev: Add debug jest test to vscode launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,15 @@
       "program": "${workspaceFolder}/pkg/cmd/grafana-server/",
       "env": {},
       "args": ["--homepath", "${workspaceFolder}", "--packaging", "dev"]
+    },
+    {
+      "name": "Debug Jest test",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "${file}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I often find myself that I want to debug a test and need to find the config for vscode because we have launch.json so I thought  that maybe we can add that as well.

