### PR TITLE
QueryEditor: Add missing keys to extra action components

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -138,7 +138,7 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
       }
     `,
     dragIcon: css`
-      cursor: drag;
+      cursor: grab;
       color: ${theme.colors.textWeak};
       &:hover {
         color: ${theme.colors.text};

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -100,10 +100,10 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       dashboard: dashboard,
       refresh: () => {
         // Old angular editors modify the query model and just call refresh
-        // Important that this use this.props here so that as this fuction is only created on mount and it's
+        // Important that this use this.props here so that as this function is only created on mount and it's
         // important not to capture old prop functions in this closure
 
-        // the "hide" attribute of the quries can be changed from the "outside",
+        // the "hide" attribute of the queries can be changed from the "outside",
         // it will be applied to "this.props.query.hide", but not to "query.hide".
         // so we have to apply it.
         if (query.hide !== me.props.query.hide) {
@@ -304,13 +304,14 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
   renderExtraActions = () => {
     const { query, queries, data, onAddQuery, dataSource } = this.props;
-    return RowActionComponents.getAllExtraRenderAction().map((c) => {
+    return RowActionComponents.getAllExtraRenderAction().map((c, index) => {
       return React.createElement(c, {
         query,
         queries,
         timeRange: data.timeRange,
         onAddQuery: onAddQuery as (query: DataQuery) => void,
         dataSource: dataSource,
+        key: index,
       });
     });
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Extra action components in `QueryEditorRow` were missing required `key` prop, resulting in an error shown in console. This PR fixes that, also changes cursor `drag`, which is not a valid cursor type to `grab`. 

