### PR TITLE
Docs: Add missing comma in AWS IAM policy

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -66,7 +66,7 @@ Here is a minimal policy example:
         "cloudwatch:DescribeAlarms",
         "cloudwatch:ListMetrics",
         "cloudwatch:GetMetricStatistics",
-        "cloudwatch:GetMetricData"
+        "cloudwatch:GetMetricData",
         "cloudwatch:GetInsightRuleReport"
       ],
       "Resource": "*"


### PR DESCRIPTION
**What this PR does / why we need it**:

The AWS IAM policy in the cloudwatch datasource documentation was missing a comma, making it invalid json.