### PR TITLE
Logging: improve frontend logging behaviour with high volume of errors

### DIFF
--- a/public/app/core/services/echo/backends/sentry/SentryBackend.test.ts
+++ b/public/app/core/services/echo/backends/sentry/SentryBackend.test.ts
@@ -66,6 +66,11 @@ describe('SentryEchoBackend', () => {
       dsn: options.dsn,
       sampleRate: options.sampleRate,
       transport: EchoSrvTransport,
+      ignoreErrors: [
+        'ResizeObserver loop limit exceeded',
+        'ResizeObserver loop completed',
+        'Non-Error exception captured with keys',
+      ],
     });
     expect(sentrySetUser).toHaveBeenCalledWith({
       email: options.user?.email,

--- a/public/app/core/services/echo/backends/sentry/SentryBackend.ts
+++ b/public/app/core/services/echo/backends/sentry/SentryBackend.ts
@@ -35,6 +35,11 @@ export class SentryEchoBackend implements EchoBackend<SentryEchoEvent, SentryEch
       dsn: options.dsn || 'https://examplePublicKey@o0.ingest.sentry.io/0',
       sampleRate: options.sampleRate,
       transport: EchoSrvTransport, // will dump errors to EchoSrv
+      ignoreErrors: [
+        'ResizeObserver loop limit exceeded',
+        'ResizeObserver loop completed',
+        'Non-Error exception captured with keys',
+      ],
     };
 
     if (options.user) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Several fixes to frontend logging behaviour spotted in https://drive.google.com/file/d/18LUHIPoN_-PqoYLLVd8qjHPkfV0RqwMp/view

* Limit concurrent log requests to 3 at a time. Excess events are dropped
* Fix problem where rate limiting rejection is reported itself as error, causing high volume of error logs in browser console
* Add "ResizeObserver" and "Non-Error exception" errors to ignore list. These are frequent and benign 


