### PR TITLE
Dep: Ignore ora lib bump for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: "slate-plain-serializer"
       - dependency-name: "systemjs"
       - dependency-name: "ts-loader" # we should remove ts-loader and use babel-loader instead
+      - dependency-name: "ora" # we should bump this once we move to esm modules
     reviewers:
       - "grafana/frontend-ops"
     versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds ora to ignore list as we need to have esm modules bundling in toolkit. https://github.com/grafana/grafana/pull/39656

