### PR TITLE
TimePicker: Close timepicker with esc

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -66,6 +66,20 @@ export class UnthemedTimeRangePicker extends PureComponent<TimeRangePickerProps,
     this.setState({ isOpen: !isOpen });
   };
 
+  componentDidMount() {
+    window.addEventListener('keyup', this.onKeyUp);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keyup', this.onKeyUp);
+  }
+
+  onKeyUp = (event: KeyboardEvent) => {
+    if (event.code === 'Escape') {
+      this.onClose();
+    }
+  };
+
   onClose = () => {
     this.setState({ isOpen: false });
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
Enabled closing the Time Picker with escape (again)

**Which issue(s) this PR fixes**:

Fixes #39806