### PR TITLE
Alerting: Stop firing of alert when it is updated

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -90,7 +90,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterRulerApiEndpoints(NewForkedRuler(
 		api.DatasourceCache,
 		NewLotexRuler(proxy, logger),
-		RulerSrv{DatasourceCache: api.DatasourceCache, QuotaService: api.QuotaService, manager: api.StateManager, store: api.RuleStore, log: logger},
+		RulerSrv{DatasourceCache: api.DatasourceCache, QuotaService: api.QuotaService, scheduleService: api.Schedule, store: api.RuleStore, log: logger},
 	), m)
 	api.RegisterTestingApiEndpoints(NewForkedTestingApi(
 		TestingApiSrv{

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/go-openapi/strfmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/prometheus/alertmanager/api/v2/models"
@@ -123,5 +124,21 @@ func FromAlertStateToPostableAlerts(firingStates []*state.State, stateManager *s
 		sentAlerts = append(sentAlerts, alertState)
 	}
 	stateManager.Put(sentAlerts)
+	return alerts
+}
+
+// FromAlertsStateToStoppedAlert converts firingStates that have evaluation state eval.Alerting to models.PostableAlert that are accepted by notifiers.
+// Returns a list of alert instances that have expiration time.Now
+func FromAlertsStateToStoppedAlert(firingStates []*state.State, appURL *url.URL, clock clock.Clock) apimodels.PostableAlerts {
+	alerts := apimodels.PostableAlerts{PostableAlerts: make([]models.PostableAlert, 0, len(firingStates))}
+	ts := clock.Now()
+	for _, alertState := range firingStates {
+		if alertState.State == eval.Normal || alertState.State == eval.Pending {
+			continue
+		}
+		postableAlert := stateToPostableAlert(alertState, appURL)
+		postableAlert.EndsAt = strfmt.DateTime(ts)
+		alerts.PostableAlerts = append(alerts.PostableAlerts, *postableAlert)
+	}
 	return alerts
 }

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -127,7 +127,7 @@ func FromAlertStateToPostableAlerts(firingStates []*state.State, stateManager *s
 	return alerts
 }
 
-// FromAlertsStateToStoppedAlert converts firingStates that have evaluation state eval.Alerting to models.PostableAlert that are accepted by notifiers.
+// FromAlertsStateToStoppedAlert converts firingStates that have evaluation state either eval.Alerting or eval.NoData or eval.Error to models.PostableAlert that are accepted by notifiers.
 // Returns a list of alert instances that have expiration time.Now
 func FromAlertsStateToStoppedAlert(firingStates []*state.State, appURL *url.URL, clock clock.Clock) apimodels.PostableAlerts {
 	alerts := apimodels.PostableAlerts{PostableAlerts: make([]models.PostableAlert, 0, len(firingStates))}

--- a/pkg/services/ngalert/schedule/compat_test.go
+++ b/pkg/services/ngalert/schedule/compat_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/common/model"
@@ -191,6 +192,37 @@ func Test_stateToPostableAlert(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_FromAlertsStateToStoppedAlert(t *testing.T) {
+	appURL := &url.URL{
+		Scheme: "http:",
+		Host:   fmt.Sprintf("host-%d", rand.Int()),
+		Path:   fmt.Sprintf("path-%d", rand.Int()),
+	}
+
+	evalStates := [...]eval.State{eval.Normal, eval.Alerting, eval.Pending, eval.Error, eval.NoData}
+	states := make([]*state.State, 0, len(evalStates))
+	for _, s := range evalStates {
+		states = append(states, randomState(s))
+	}
+
+	clk := clock.NewMock()
+	clk.Set(time.Now())
+
+	expected := make([]models.PostableAlert, 0, len(states))
+	for _, s := range states {
+		if !(s.State == eval.Alerting || s.State == eval.Error || s.State == eval.NoData) {
+			continue
+		}
+		alert := stateToPostableAlert(s, appURL)
+		alert.EndsAt = strfmt.DateTime(clk.Now())
+		expected = append(expected, *alert)
+	}
+
+	result := FromAlertsStateToStoppedAlert(states, appURL, clk)
+
+	require.Equal(t, expected, result.PostableAlerts)
 }
 
 func randomMapOfStrings() map[string]string {

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -604,6 +604,7 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key models.AlertRul
 				}
 			}()
 		case <-grafanaCtx.Done():
+			clearState()
 			logger.Debug("stopping alert rule routine")
 			return nil
 		}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -324,7 +324,7 @@ func (sch *schedule) UpdateAlertRule(key models.AlertRuleKey) {
 func (sch *schedule) DeleteAlertRule(key models.AlertRuleKey) {
 	ruleInfo, ok := sch.registry.del(key)
 	if !ok {
-		sch.log.Info("unable to get alert rule routine information by key", "uid", key.UID, "org_id", key.OrgID)
+		sch.log.Info("unable to delete alert rule routine information by key", "uid", key.UID, "org_id", key.OrgID)
 		return
 	}
 	// stop rule evaluation

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -607,6 +607,27 @@ func (r *alertRuleRegistry) getOrCreateInfo(context context.Context, key models.
 	return info, !ok
 }
 
+// get returns the channel for the specific alert rule
+// if the key does not exist returns an error
+func (r *alertRuleRegistry) get(key models.AlertRuleKey) (*alertRuleInfo, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	info, ok := r.alertRuleInfo[key]
+	if !ok {
+		return nil, fmt.Errorf("%v key not found", key)
+	}
+	return info, nil
+}
+
+func (r *alertRuleRegistry) exists(key models.AlertRuleKey) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, ok := r.alertRuleInfo[key]
+	return ok
+}
+
 // del removes pair that has specific key from alertRuleInfo.
 // Returns 2-tuple where the first element is value of the removed pair
 // and the second element indicates whether element with the specified key existed.

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -276,7 +276,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			go func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				t.Cleanup(cancel)
-				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan)
+				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan struct{}))
 			}()
 
 			expectedTime := time.UnixMicro(rand.Int63())
@@ -373,7 +373,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
-				err := sch.ruleRoutine(ctx, models.AlertRuleKey{}, make(chan *evalContext))
+				err := sch.ruleRoutine(ctx, models.AlertRuleKey{}, make(chan *evalContext), make(chan struct{}))
 				stoppedChan <- err
 			}()
 
@@ -394,7 +394,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
-			_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan)
+			_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan struct{}))
 		}()
 
 		expectedTime := time.UnixMicro(rand.Int63())
@@ -446,7 +446,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
-			_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan)
+			_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan struct{}))
 		}()
 
 		expectedTime := time.UnixMicro(rand.Int63())
@@ -529,7 +529,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			go func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				t.Cleanup(cancel)
-				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan)
+				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, make(chan struct{}))
 			}()
 
 			evalChan <- &evalContext{

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -833,7 +833,7 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 func TestSchedule_UpdateAlertRule(t *testing.T) {
 	t.Run("when rule exists", func(t *testing.T) {
 		t.Run("it should call Update", func(t *testing.T) {
-			sch := createMockedScheduler(t)
+			sch := setupSchedulerWithFakeStores(t)
 			key := generateRuleKey()
 			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
 			go func() {
@@ -847,7 +847,7 @@ func TestSchedule_UpdateAlertRule(t *testing.T) {
 			}
 		})
 		t.Run("should exit if it is closed", func(t *testing.T) {
-			sch := createMockedScheduler(t)
+			sch := setupSchedulerWithFakeStores(t)
 			key := generateRuleKey()
 			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
 			info.stop()
@@ -856,7 +856,7 @@ func TestSchedule_UpdateAlertRule(t *testing.T) {
 	})
 	t.Run("when rule does not exist", func(t *testing.T) {
 		t.Run("should exit", func(t *testing.T) {
-			sch := createMockedScheduler(t)
+			sch := setupSchedulerWithFakeStores(t)
 			key := generateRuleKey()
 			sch.UpdateAlertRule(key)
 		})
@@ -866,7 +866,7 @@ func TestSchedule_UpdateAlertRule(t *testing.T) {
 func TestSchedule_DeleteAlertRule(t *testing.T) {
 	t.Run("when rule exists", func(t *testing.T) {
 		t.Run("it should stop evaluation loop and remove the controller from registry", func(t *testing.T) {
-			sch := createMockedScheduler(t)
+			sch := setupSchedulerWithFakeStores(t)
 			key := generateRuleKey()
 			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
 			sch.DeleteAlertRule(key)
@@ -875,7 +875,7 @@ func TestSchedule_DeleteAlertRule(t *testing.T) {
 			require.False(t, sch.registry.exists(key))
 		})
 		t.Run("should remove controller from registry", func(t *testing.T) {
-			sch := createMockedScheduler(t)
+			sch := setupSchedulerWithFakeStores(t)
 			key := generateRuleKey()
 			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
 			info.stop()
@@ -887,7 +887,7 @@ func TestSchedule_DeleteAlertRule(t *testing.T) {
 	})
 	t.Run("when rule does not exist", func(t *testing.T) {
 		t.Run("should exit", func(t *testing.T) {
-			sch := createMockedScheduler(t)
+			sch := setupSchedulerWithFakeStores(t)
 			key := generateRuleKey()
 			sch.DeleteAlertRule(key)
 		})
@@ -901,7 +901,7 @@ func generateRuleKey() models.AlertRuleKey {
 	}
 }
 
-func createMockedScheduler(t *testing.T) *schedule {
+func setupSchedulerWithFakeStores(t *testing.T) *schedule {
 	t.Helper()
 	ruleStore := newFakeRuleStore(t)
 	instanceStore := &FakeInstanceStore{}

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -33,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestSendingToExternalAlertmanager(t *testing.T) {
@@ -259,6 +261,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 	// normal states do not include NoData and Error because currently it is not possible to perform any sensible test
 	normalStates := []eval.State{eval.Normal, eval.Alerting, eval.Pending}
+	allStates := [...]eval.State{eval.Normal, eval.Alerting, eval.Pending, eval.NoData, eval.Error}
 	randomNormalState := func() eval.State {
 		// pick only supported cases
 		return normalStates[rand.Intn(3)]
@@ -485,6 +488,175 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		require.Len(t, queries, 1, "Expected exactly one request of %T", models.GetAlertRuleByUIDQuery{})
 	})
 
+	t.Run("when update channel is not empty", func(t *testing.T) {
+		t.Run("should fetch the alert rule from database", func(t *testing.T) {
+			evalChan := make(chan *evalContext)
+			evalAppliedChan := make(chan time.Time)
+			updateChan := make(chan struct{})
+
+			sch, ruleStore, _, _, _ := createSchedule(evalAppliedChan)
+
+			rule := CreateTestAlertRule(t, ruleStore, 10, rand.Int63(), eval.Alerting) // we want the alert to fire
+
+			go func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, updateChan)
+			}()
+			updateChan <- struct{}{}
+
+			// wait for command to be executed
+			var queries []interface{}
+			require.Eventuallyf(t, func() bool {
+				queries = ruleStore.getRecordedCommands(func(cmd interface{}) (interface{}, bool) {
+					c, ok := cmd.(models.GetAlertRuleByUIDQuery)
+					return c, ok
+				})
+				return len(queries) == 1
+			}, 5*time.Second, 100*time.Millisecond, "Expected command a single %T to be recorded. All recordings: %#v", models.GetAlertRuleByUIDQuery{}, ruleStore.recordedOps)
+
+			m := queries[0].(models.GetAlertRuleByUIDQuery)
+			require.Equal(t, rule.UID, m.UID)
+			require.Equal(t, rule.OrgID, m.OrgID)
+
+			// now call evaluation loop to make sure that the rule was persisted
+			evalChan <- &evalContext{
+				now:     time.UnixMicro(rand.Int63()),
+				version: rule.Version,
+			}
+			waitForTimeChannel(t, evalAppliedChan)
+
+			queries = ruleStore.getRecordedCommands(func(cmd interface{}) (interface{}, bool) {
+				c, ok := cmd.(models.GetAlertRuleByUIDQuery)
+				return c, ok
+			})
+			require.Lenf(t, queries, 1, "evaluation loop requested a rule from database but it should not be")
+		})
+
+		t.Run("should retry when database fails", func(t *testing.T) {
+			evalAppliedChan := make(chan time.Time)
+			updateChan := make(chan struct{})
+
+			sch, ruleStore, _, _, _ := createSchedule(evalAppliedChan)
+			sch.maxAttempts = rand.Int63n(4) + 1
+
+			rule := CreateTestAlertRule(t, ruleStore, 10, rand.Int63(), randomNormalState())
+
+			go func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+				_ = sch.ruleRoutine(ctx, rule.GetKey(), make(chan *evalContext), updateChan)
+			}()
+
+			ruleStore.hook = func(cmd interface{}) error {
+				if _, ok := cmd.(models.GetAlertRuleByUIDQuery); !ok {
+					return nil
+				}
+				return errors.New("TEST")
+			}
+			updateChan <- struct{}{}
+
+			var queries []interface{}
+			require.Eventuallyf(t, func() bool {
+				queries = ruleStore.getRecordedCommands(func(cmd interface{}) (interface{}, bool) {
+					c, ok := cmd.(models.GetAlertRuleByUIDQuery)
+					return c, ok
+				})
+				return int64(len(queries)) == sch.maxAttempts
+			}, 5*time.Second, 100*time.Millisecond, "Expected exactly two request of %T. All recordings: %#v", models.GetAlertRuleByUIDQuery{}, ruleStore.recordedOps)
+		})
+	})
+
+	t.Run("when rule version is updated", func(t *testing.T) {
+		t.Run("should clear the state and expire firing alerts", func(t *testing.T) {
+			fakeAM := NewFakeExternalAlertmanager(t)
+			defer fakeAM.Close()
+
+			orgID := rand.Int63()
+			s, err := sender.New(nil)
+			require.NoError(t, err)
+			adminConfig := &models.AdminConfiguration{OrgID: orgID, Alertmanagers: []string{fakeAM.server.URL}}
+			err = s.ApplyConfig(adminConfig)
+			require.NoError(t, err)
+			s.Run()
+			defer s.Stop()
+
+			require.Eventuallyf(t, func() bool {
+				return len(s.Alertmanagers()) == 1
+			}, 20*time.Second, 200*time.Millisecond, "external Alertmanager was not discovered.")
+
+			evalChan := make(chan *evalContext)
+			evalAppliedChan := make(chan time.Time)
+			updateChan := make(chan struct{})
+
+			sch, ruleStore, _, _, _ := createSchedule(evalAppliedChan)
+			sch.senders[orgID] = s
+
+			var rulePtr = CreateTestAlertRule(t, ruleStore, 10, orgID, eval.Alerting) // we want the alert to fire
+			var rule = *rulePtr
+
+			// define some state
+			states := make([]*state.State, 0, len(allStates))
+			for _, s := range allStates {
+				for i := 0; i < 2; i++ {
+					states = append(states, &state.State{
+						AlertRuleUID: rule.UID,
+						CacheId:      util.GenerateShortUID(),
+						OrgID:        rule.OrgID,
+						State:        s,
+						StartsAt:     sch.clock.Now(),
+						EndsAt:       sch.clock.Now().Add(time.Duration(rand.Intn(25)+5) * time.Second),
+						Labels:       rule.Labels,
+					})
+				}
+			}
+			sch.stateManager.Put(states)
+			states = sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
+			expectedToBeSent := FromAlertsStateToStoppedAlert(states, sch.appURL, sch.clock)
+			require.NotEmptyf(t, expectedToBeSent.PostableAlerts, "State manger was expected to return at least one state that can be expired")
+
+			go func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+				_ = sch.ruleRoutine(ctx, rule.GetKey(), evalChan, updateChan)
+			}()
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			ruleStore.hook = func(cmd interface{}) error {
+				_, ok := cmd.(models.GetAlertRuleByUIDQuery)
+				if ok {
+					wg.Done() // add synchronization.
+				}
+				return nil
+			}
+
+			updateChan <- struct{}{}
+
+			wg.Wait()
+			newRule := rule
+			newRule.Version++
+			ruleStore.putRule(&newRule)
+			wg.Add(1)
+			updateChan <- struct{}{}
+			wg.Wait()
+
+			require.Eventually(t, func() bool {
+				return len(sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)) == 0
+			}, 5*time.Second, 100*time.Millisecond)
+
+			var count int
+			require.Eventuallyf(t, func() bool {
+				count = fakeAM.AlertsCount()
+				return count == len(expectedToBeSent.PostableAlerts)
+			}, 20*time.Second, 200*time.Millisecond, "Alertmanager was expected to receive %d alerts, but received only %d", len(expectedToBeSent.PostableAlerts), count)
+
+			for _, alert := range fakeAM.alerts {
+				require.Equalf(t, sch.clock.Now().UTC(), time.Time(alert.EndsAt).UTC(), "Alert received by Alertmanager should be expired as of now")
+			}
+		})
+	})
+
 	t.Run("when evaluation fails", func(t *testing.T) {
 		t.Run("it should increase failure counter", func(t *testing.T) {
 			t.Skip()
@@ -554,6 +726,19 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 func TestSchedule_alertRuleInfo(t *testing.T) {
 	t.Run("when rule evaluation is not stopped", func(t *testing.T) {
+		t.Run("Update should send to updateCh", func(t *testing.T) {
+			r := newAlertRuleInfo(context.Background())
+			resultCh := make(chan bool)
+			go func() {
+				resultCh <- r.update()
+			}()
+			select {
+			case <-r.updateCh:
+				require.True(t, <-resultCh)
+			case <-time.After(5 * time.Second):
+				t.Fatal("No message was received on update channel")
+			}
+		})
 		t.Run("eval should send to evalCh", func(t *testing.T) {
 			r := newAlertRuleInfo(context.Background())
 			expected := time.Now()
@@ -588,6 +773,11 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 		})
 	})
 	t.Run("when rule evaluation is stopped", func(t *testing.T) {
+		t.Run("Update should do nothing", func(t *testing.T) {
+			r := newAlertRuleInfo(context.Background())
+			r.stop()
+			require.False(t, r.update())
+		})
 		t.Run("eval should do nothing", func(t *testing.T) {
 			r := newAlertRuleInfo(context.Background())
 			r.stop()
@@ -606,7 +796,9 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 			for {
 				select {
 				case <-r.evalCh:
-					time.Sleep(time.Millisecond)
+					time.Sleep(time.Microsecond)
+				case <-r.updateCh:
+					time.Sleep(time.Microsecond)
 				case <-r.ctx.Done():
 					return
 				}
@@ -617,14 +809,16 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				for i := 0; i < 20; i++ {
-					max := 2
+					max := 3
 					if i <= 10 {
-						max = 1
+						max = 2
 					}
 					switch rand.Intn(max) + 1 {
 					case 1:
-						r.eval(time.Now(), rand.Int63())
+						r.update()
 					case 2:
+						r.eval(time.Now(), rand.Int63())
+					case 3:
 						r.stop()
 					}
 				}
@@ -634,6 +828,86 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 
 		wg.Wait()
 	})
+}
+
+func TestSchedule_UpdateAlertRule(t *testing.T) {
+	t.Run("when rule exists", func(t *testing.T) {
+		t.Run("it should call Update", func(t *testing.T) {
+			sch := createMockedScheduler(t)
+			key := generateRuleKey()
+			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
+			go func() {
+				sch.UpdateAlertRule(key)
+			}()
+
+			select {
+			case <-info.updateCh:
+			case <-time.After(5 * time.Second):
+				t.Fatal("No message was received on update channel")
+			}
+		})
+		t.Run("should exit if it is closed", func(t *testing.T) {
+			sch := createMockedScheduler(t)
+			key := generateRuleKey()
+			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
+			info.stop()
+			sch.UpdateAlertRule(key)
+		})
+	})
+	t.Run("when rule does not exist", func(t *testing.T) {
+		t.Run("should exit", func(t *testing.T) {
+			sch := createMockedScheduler(t)
+			key := generateRuleKey()
+			sch.UpdateAlertRule(key)
+		})
+	})
+}
+
+func TestSchedule_DeleteAlertRule(t *testing.T) {
+	t.Run("when rule exists", func(t *testing.T) {
+		t.Run("it should stop evaluation loop and remove the controller from registry", func(t *testing.T) {
+			sch := createMockedScheduler(t)
+			key := generateRuleKey()
+			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
+			sch.DeleteAlertRule(key)
+			require.False(t, info.update())
+			require.False(t, info.eval(time.Now(), 1))
+			require.False(t, sch.registry.exists(key))
+		})
+		t.Run("should remove controller from registry", func(t *testing.T) {
+			sch := createMockedScheduler(t)
+			key := generateRuleKey()
+			info, _ := sch.registry.getOrCreateInfo(context.Background(), key)
+			info.stop()
+			sch.DeleteAlertRule(key)
+			require.False(t, info.update())
+			require.False(t, info.eval(time.Now(), 1))
+			require.False(t, sch.registry.exists(key))
+		})
+	})
+	t.Run("when rule does not exist", func(t *testing.T) {
+		t.Run("should exit", func(t *testing.T) {
+			sch := createMockedScheduler(t)
+			key := generateRuleKey()
+			sch.DeleteAlertRule(key)
+		})
+	})
+}
+
+func generateRuleKey() models.AlertRuleKey {
+	return models.AlertRuleKey{
+		OrgID: rand.Int63(),
+		UID:   util.GenerateShortUID(),
+	}
+}
+
+func createMockedScheduler(t *testing.T) *schedule {
+	t.Helper()
+	ruleStore := newFakeRuleStore(t)
+	instanceStore := &FakeInstanceStore{}
+	adminConfigStore := newFakeAdminConfigStore(t)
+	sch, _ := setupScheduler(t, ruleStore, instanceStore, adminConfigStore, nil)
+	return sch
 }
 
 func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, acs store.AdminConfigurationStore, registry *prometheus.Registry) (*schedule, *clock.Mock) {

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -51,7 +51,13 @@ func waitForErrChannel(t *testing.T, ch chan error) error {
 }
 
 func newFakeRuleStore(t *testing.T) *fakeRuleStore {
-	return &fakeRuleStore{t: t, rules: map[int64]map[string]map[string][]*models.AlertRule{}}
+	return &fakeRuleStore{
+		t:     t,
+		rules: map[int64]map[string]map[string][]*models.AlertRule{},
+		hook: func(interface{}) error {
+			return nil
+		},
+	}
 }
 
 // FakeRuleStore mocks the RuleStore of the scheduler.
@@ -59,6 +65,7 @@ type fakeRuleStore struct {
 	t           *testing.T
 	mtx         sync.Mutex
 	rules       map[int64]map[string]map[string][]*models.AlertRule
+	hook        func(cmd interface{}) error // use hook if you need to intercept some query and return an error
 	recordedOps []interface{}
 }
 
@@ -69,6 +76,22 @@ func (f *fakeRuleStore) putRule(r *models.AlertRule) {
 	f.rules[r.OrgID][r.RuleGroup][r.NamespaceUID] = []*models.AlertRule{
 		r,
 	}
+}
+
+// getRecordedCommands filters recorded commands using predicate function. Returns the subset of the recorded commands that meet the predicate
+func (f *fakeRuleStore) getRecordedCommands(predicate func(cmd interface{}) (interface{}, bool)) []interface{} {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	result := make([]interface{}, 0, len(f.recordedOps))
+	for _, op := range f.recordedOps {
+		cmd, ok := predicate(op)
+		if !ok {
+			continue
+		}
+		result = append(result, cmd)
+	}
+	return result
 }
 
 func (f *fakeRuleStore) DeleteAlertRuleByUID(_ int64, _ string) error { return nil }
@@ -83,6 +106,9 @@ func (f *fakeRuleStore) GetAlertRuleByUID(q *models.GetAlertRuleByUIDQuery) erro
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
+	if err := f.hook(*q); err != nil {
+		return err
+	}
 	rgs, ok := f.rules[q.OrgID]
 	if !ok {
 		return nil
@@ -107,6 +133,9 @@ func (f *fakeRuleStore) GetAlertRulesForScheduling(q *models.ListAlertRulesQuery
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
+	if err := f.hook(*q); err != nil {
+		return err
+	}
 	for _, rg := range f.rules {
 		for _, n := range rg {
 			for _, r := range n {
@@ -133,6 +162,9 @@ func (f *fakeRuleStore) GetRuleGroupAlertRules(q *models.ListRuleGroupAlertRules
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
+	if err := f.hook(*q); err != nil {
+		return err
+	}
 	rgs, ok := f.rules[q.OrgID]
 	if !ok {
 		return nil
@@ -168,6 +200,9 @@ func (f *fakeRuleStore) GetOrgRuleGroups(q *models.ListOrgRuleGroupsQuery) error
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
+	if err := f.hook(*q); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -175,12 +210,18 @@ func (f *fakeRuleStore) UpsertAlertRules(q []store.UpsertRule) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, q)
+	if err := f.hook(q); err != nil {
+		return err
+	}
 	return nil
 }
 func (f *fakeRuleStore) UpdateRuleGroup(cmd store.UpdateRuleGroupCmd) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, cmd)
+	if err := f.hook(cmd); err != nil {
+		return err
+	}
 	rgs, ok := f.rules[cmd.OrgID]
 	if !ok {
 		f.rules[cmd.OrgID] = map[string]map[string][]*models.AlertRule{}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, when a user creates an alert (Grafana hosted), the alert starts firing, and then the user modifies it by changing labels, the user can see two firing alerts at the same time: 
- the previous alert is still firing because its end time is set to 2 evaluation intervals in the future (but not less than 30 seconds)
- depending on the configuration, the new version of the alert is promoted from pending to firing and starts firing alongside with the old one. 

Same situation happens when user deletes an alert rule that has firing instances. The alertmanager keeps firing the alert until it expires.

Current implementation, cleans up alert state but does not expire alerts in Alertmanager: when user submits update or delete request, API just cleans up the state manager.

This PR changes the behavior. When alert rule is changed or deleted, all firing instances are immediately expired along with state. This is done by moving the responsibility to clean up state and update Alertmanager to scheduler. 

- Scheduler is updated to expose two new public functions `UpdateAlertRule` and `DeleteAlertRule`. 
- Rule evaluation routine is updated to read a new channel `updateCh` which is used by the functions to let know the routine loop to update the rule. 
- rule evaluation routine is updated to reset state and send expired alert instances to Alertmanager every time version of alert changes.

**Which issue(s) this PR fixes**:
Related https://github.com/grafana/grafana/issues/39154
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:
- The PR does not fix the issue above. It addresses only clearing up alerts. There is one thing that is missing: when a user updates an alert rule, API should check whether there are any changes and do not do anything if the rule is not changed. This will be addressed in another PR.