### PR TITLE
grafana-ui: explicitly mention dependency in package.json

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -43,6 +43,7 @@
     "@sentry/browser": "5.25.0",
     "ansicolor": "1.1.95",
     "classnames": "2.2.6",
+    "csstype": "2.6.8",
     "d3": "5.15.0",
     "hoist-non-react-statics": "3.3.2",
     "immutable": "3.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9477,7 +9477,7 @@ cssstyle@^2.0.0, cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
+csstype@2.6.8, csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==


### PR DESCRIPTION
the package `@grafana/ui` uses the package `csstypes`, but does not mention it in it's `package.json`. this PR fixes it.

NOTE: i did not pick the newest version of `csstype` (3.0.x), because that has a changed API, and i tried to quickly fix our code too, but failed 😄 . so for now, i chose a version that is is already referenced in our `yarn.lock` (2.6.8).