### PR TITLE
prometheus: monaco query editor: handle ctrl+enter

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -144,13 +144,17 @@ const MonacoQueryField = (props: Props) => {
           editor.onDidContentSizeChange(updateElementHeight);
           updateElementHeight();
 
-          // handle: shift + enter
-          // FIXME: maybe move this functionality into CodeEditor?
-          editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
+          const keyboardShortcutSubmit = () => {
             const text = editor.getValue();
             props.onChange(text);
             props.onRunQuery();
-          });
+          };
+
+          // handle: shift + enter
+          editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, keyboardShortcutSubmit);
+
+          // handle: ctrl + enter
+          editor.addCommand(monaco.KeyMod.WinCtrl | monaco.KeyCode.Enter, keyboardShortcutSubmit);
         }}
       />
     </div>


### PR DESCRIPTION
in the old (non-monaco) query-editor, control+enter submits the query the same way as shift+enter. this pull-request implements this in the monaco-version too.