### PR TITLE
live: local subscribers data output

### DIFF
--- a/pkg/services/live/pipeline/config.go
+++ b/pkg/services/live/pipeline/config.go
@@ -413,6 +413,8 @@ func (f *StorageRuleBuilder) extractDataOutputter(config *DataOutputterConfig) (
 		return NewRedirectDataOutput(*config.RedirectDataOutputConfig), nil
 	case DataOutputTypeBuiltin:
 		return NewBuiltinDataOutput(f.ChannelHandlerGetter), nil
+	case DataOutputTypeLocalSubscribers:
+		return NewLocalSubscribersDataOutput(f.Node), nil
 	default:
 		return nil, fmt.Errorf("unknown data output type: %s", config.Type)
 	}

--- a/pkg/services/live/pipeline/data_output_local_subscribers.go
+++ b/pkg/services/live/pipeline/data_output_local_subscribers.go
@@ -1,0 +1,38 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/services/live/orgchannel"
+
+	"github.com/centrifugal/centrifuge"
+)
+
+type LocalSubscribersDataOutput struct {
+	// TODO: refactor to depend on interface (avoid Centrifuge dependency here).
+	node *centrifuge.Node
+}
+
+func NewLocalSubscribersDataOutput(node *centrifuge.Node) *LocalSubscribersDataOutput {
+	return &LocalSubscribersDataOutput{node: node}
+}
+
+const DataOutputTypeLocalSubscribers = "localSubscribers"
+
+func (out *LocalSubscribersDataOutput) Type() string {
+	return DataOutputTypeLocalSubscribers
+}
+
+func (out *LocalSubscribersDataOutput) OutputData(_ context.Context, vars Vars, data []byte) ([]*ChannelData, error) {
+	channelID := vars.Channel
+	channel := orgchannel.PrependOrgID(vars.OrgID, channelID)
+	pub := &centrifuge.Publication{
+		Data: data,
+	}
+	err := out.node.Hub().BroadcastPublication(channel, pub, centrifuge.StreamPosition{})
+	if err != nil {
+		return nil, fmt.Errorf("error publishing %s: %w", string(data), err)
+	}
+	return nil, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

While trying to mimic Signal Datasource behavior over channel rules I realized that we don't need conversion to a frame there if we just want to proxy data as we usually do for datasource plugins. Thus a new type of data outputter: `localSubscribers` added.

For example with rule like this:

```json
{
  "rules": [
    {
      "pattern": "ds/*rest",
      "settings": {
        "dataOutputs": [
          {
            "type": "localSubscribers"
          }
        ],
        "subscribers": [
          {
            "type": "builtin"
          }
        ]
      }
    }
  ]
}
```

We inherit existing subscribe feature and whenever plugin publishes data we proxy it to Live channel.