### PR TITLE
Dashboard: Show logs on time series when hovering

### DIFF
--- a/packages/grafana-data/src/events/common.ts
+++ b/packages/grafana-data/src/events/common.ts
@@ -1,5 +1,5 @@
 import { AnnotationEvent, DataFrame } from '../types';
-import { BusEventWithPayload } from './types';
+import { BusEventBase, BusEventWithPayload } from './types';
 
 /**
  * When hovering over an element this will identify
@@ -26,7 +26,7 @@ export class DataHoverEvent extends BusEventWithPayload<DataHoverPayload> {
 }
 
 /** @alpha */
-export class DataHoverClearEvent extends BusEventWithPayload<DataHoverPayload> {
+export class DataHoverClearEvent extends BusEventBase {
   static type = 'data-hover-clear';
 }
 

--- a/packages/grafana-data/src/types/legacyEvents.ts
+++ b/packages/grafana-data/src/types/legacyEvents.ts
@@ -28,7 +28,9 @@ export const PanelEvents = {
   render: eventFactory<any>('render'),
 };
 
-/** @public */
+/**
+ * @deprecated It will be removed with the old graph. For setting cursor on GraphNG please check GraphNG/events.
+ */
 export interface LegacyGraphHoverEventPayload extends DataHoverPayload {
   pos: any;
   panel: {
@@ -36,12 +38,16 @@ export interface LegacyGraphHoverEventPayload extends DataHoverPayload {
   };
 }
 
-/** @alpha */
+/**
+ * @deprecated It will be removed with the old graph. For setting cursor on GraphNG please check GraphNG/events.
+ */
 export class LegacyGraphHoverEvent extends BusEventWithPayload<LegacyGraphHoverEventPayload> {
   static type = 'graph-hover';
 }
 
-/** @alpha */
+/**
+ * @deprecated It will be removed with the old graph. For setting cursor on GraphNG please check GraphNG/events.
+ */
 export class LegacyGraphHoverClearEvent extends BusEventBase {
   static type = 'graph-hover-clear';
   payload: DataHoverPayload = { point: {} };

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -2,15 +2,7 @@ import React from 'react';
 import { AlignedData } from 'uplot';
 import { Themeable2 } from '../../types';
 import { findMidPointYPosition, pluginLog } from '../uPlot/utils';
-import {
-  DataFrame,
-  FieldMatcherID,
-  fieldMatchers,
-  LegacyGraphHoverClearEvent,
-  LegacyGraphHoverEvent,
-  TimeRange,
-  TimeZone,
-} from '@grafana/data';
+import { DataFrame, FieldMatcherID, fieldMatchers, TimeRange, TimeZone } from '@grafana/data';
 import { preparePlotFrame as defaultPreparePlotFrame } from './utils';
 import { VizLegendOptions } from '@grafana/schema';
 import { PanelContext, PanelContextRoot } from '../PanelChrome/PanelContext';
@@ -20,6 +12,7 @@ import { GraphNGLegendEvent, XYFieldMatchers } from './types';
 import { UPlotConfigBuilder } from '../uPlot/config/UPlotConfigBuilder';
 import { VizLayout } from '../VizLayout/VizLayout';
 import { UPlotChart } from '../uPlot/Plot';
+import { ClearGraphNGCursorEvent, SetGraphNGCursorEvent } from './events';
 
 /**
  * @internal -- not a public API
@@ -131,7 +124,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
 
     this.subscription.add(
       eventBus
-        .getStream(LegacyGraphHoverEvent)
+        .getStream(SetGraphNGCursorEvent)
         .pipe(throttleTime(50))
         .subscribe({
           next: (evt) => {
@@ -160,7 +153,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
 
     this.subscription.add(
       eventBus
-        .getStream(LegacyGraphHoverClearEvent)
+        .getStream(ClearGraphNGCursorEvent)
         .pipe(throttleTime(50))
         .subscribe({
           next: () => {

--- a/packages/grafana-ui/src/components/GraphNG/events.ts
+++ b/packages/grafana-ui/src/components/GraphNG/events.ts
@@ -1,0 +1,19 @@
+import { BusEventBase, BusEventWithPayload } from '@grafana/data';
+
+/** @alpha */
+export interface SetGraphCursorEventPayload {
+  point: { time: number };
+}
+
+/**
+ * Event used for one-way communication to set cursor at all time series panel at given time
+ * @alpha
+ */
+export class SetGraphNGCursorEvent extends BusEventWithPayload<SetGraphCursorEventPayload> {
+  static type = 'graph-ng-set-cursor';
+}
+
+/** @alpha */
+export class ClearGraphNGCursorEvent extends BusEventBase {
+  static type = 'graph-ng-clear-cursor';
+}

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -53,6 +53,7 @@ interface Props extends Themeable2 {
   showContextToggle?: (row?: LogRowModel) => boolean;
   onClickShowDetectedField?: (key: string) => void;
   onClickHideDetectedField?: (key: string) => void;
+  onLogRowHover?: (row?: LogRowModel) => void;
 }
 
 interface State {
@@ -141,6 +142,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       theme,
       getFieldLinks,
       forceEscape,
+      onLogRowHover,
     } = this.props;
     const { showDetails, showContext } = this.state;
     const style = getLogRowStyles(theme, row.logLevel);
@@ -157,7 +159,16 @@ class UnThemedLogRow extends PureComponent<Props, State> {
 
     return (
       <>
-        <tr className={logRowBackground} onClick={this.toggleDetails}>
+        <tr
+          className={logRowBackground}
+          onClick={this.toggleDetails}
+          onMouseEnter={() => {
+            onLogRowHover && onLogRowHover(row);
+          }}
+          onMouseLeave={() => {
+            onLogRowHover && onLogRowHover(undefined);
+          }}
+        >
           {showDuplicates && (
             <td className={style.logsRowDuplicates}>
               {processedRow.duplicates && processedRow.duplicates > 0 ? `${processedRow.duplicates + 1}x` : null}

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -33,6 +33,7 @@ export interface Props extends Themeable2 {
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
   onClickShowDetectedField?: (key: string) => void;
   onClickHideDetectedField?: (key: string) => void;
+  onLogRowHover?: (row?: LogRowModel) => void;
 }
 
 interface State {
@@ -99,6 +100,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       onClickShowDetectedField,
       onClickHideDetectedField,
       forceEscape,
+      onLogRowHover,
     } = this.props;
     const { renderAll } = this.state;
     const { logsRowsTable } = getLogRowStyles(theme);
@@ -144,6 +146,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                 getFieldLinks={getFieldLinks}
                 logsSortOrder={logsSortOrder}
                 forceEscape={forceEscape}
+                onLogRowHover={onLogRowHover}
               />
             ))}
           {hasData &&

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -173,6 +173,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                 getFieldLinks={getFieldLinks}
                 logsSortOrder={logsSortOrder}
                 forceEscape={forceEscape}
+                onLogRowHover={onLogRowHover}
               />
             ))}
           {hasData && !renderAll && (

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -343,9 +343,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
         pub: (type: string, src: uPlot, x: number, y: number, w: number, h: number, dataIdx: number) => {
           payload.rowIndex = dataIdx;
           if (x < 0 && y < 0) {
-            payload.point[xScaleUnit] = null;
-            payload.point[yScaleKey] = null;
-            eventBus.publish(new DataHoverClearEvent(payload));
+            eventBus.publish(new DataHoverClearEvent());
           } else {
             // convert the points
             payload.point[xScaleUnit] = src.posToVal(x, xScaleKey);

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -259,6 +259,7 @@ export { TimeSeries } from './TimeSeries/TimeSeries';
 export { useGraphNGContext } from './GraphNG/hooks';
 export { preparePlotFrame } from './GraphNG/utils';
 export { GraphNGLegendEvent } from './GraphNG/types';
+export { SetGraphNGCursorEvent, ClearGraphNGCursorEvent } from './GraphNG/events';
 export * from './PanelChrome/types';
 export { EmotionPerfTest } from './ThemeDemos/EmotionPerfTest';
 export { Label as BrowserLabel } from './BrowserLabel/Label';

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -1,6 +1,6 @@
 import Mousetrap from 'mousetrap';
 import 'mousetrap-global-bind';
-import { LegacyGraphHoverClearEvent, locationUtil } from '@grafana/data';
+import { locationUtil } from '@grafana/data';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import { DashboardModel } from 'app/features/dashboard/state';
@@ -23,6 +23,7 @@ import { getTimeSrv } from '../../features/dashboard/services/TimeSrv';
 import { toggleTheme } from './toggleTheme';
 import { withFocusedPanel } from './withFocusedPanelId';
 import { HelpModal } from '../components/help/HelpModal';
+import { ClearGraphNGCursorEvent } from '@grafana/ui';
 
 export class KeybindingSrv {
   modalOpen = false;
@@ -183,7 +184,7 @@ export class KeybindingSrv {
   setupDashboardBindings(dashboard: DashboardModel) {
     this.bind('mod+o', () => {
       dashboard.graphTooltip = (dashboard.graphTooltip + 1) % 3;
-      dashboard.events.publish(new LegacyGraphHoverClearEvent());
+      dashboard.events.publish(new ClearGraphNGCursorEvent());
       dashboard.startRefresh();
     });
 

--- a/public/app/plugins/panel/debug/CursorView.tsx
+++ b/public/app/plugins/panel/debug/CursorView.tsx
@@ -5,8 +5,7 @@ import {
   LegacyGraphHoverClearEvent,
   DataHoverEvent,
   DataHoverClearEvent,
-  DataHoverPayload,
-  BusEventWithPayload,
+  BusEventBase,
 } from '@grafana/data';
 import { Subscription } from 'rxjs';
 import { CustomScrollbar } from '@grafana/ui';
@@ -17,7 +16,7 @@ interface Props {
 }
 
 interface State {
-  event?: BusEventWithPayload<DataHoverPayload>;
+  event?: BusEventBase;
 }
 export class CursorView extends Component<Props, State> {
   subscription = new Subscription();

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -171,7 +171,7 @@ export class GeomapPanel extends Component<Props, State> {
     // Tooltip listener
     this.map.on('pointermove', this.pointerMoveListener);
     this.map.getViewport().addEventListener('mouseout', (evt) => {
-      this.props.eventBus.publish(new DataHoverClearEvent({ point: {} }));
+      this.props.eventBus.publish(new DataHoverClearEvent());
     });
   };
 

--- a/public/app/plugins/panel/graph/graph_tooltip.ts
+++ b/public/app/plugins/panel/graph/graph_tooltip.ts
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import { appEvents } from 'app/core/core';
 import { CoreEvents } from 'app/types';
 import { textUtil, systemDateFormats, LegacyGraphHoverClearEvent, LegacyGraphHoverEvent } from '@grafana/data';
+import { ClearGraphNGCursorEvent, SetGraphNGCursorEvent } from '@grafana/ui';
 
 export default function GraphTooltip(this: any, elem: any, dashboard: any, scope: any, getSeriesFn: any) {
   const self = this;
@@ -153,6 +154,7 @@ export default function GraphTooltip(this: any, elem: any, dashboard: any, scope
       }
     }
     dashboard.events.publish(new LegacyGraphHoverClearEvent());
+    dashboard.events.publish(new ClearGraphNGCursorEvent());
   });
 
   elem.bind('plothover', (event: any, pos: { panelRelY: number; pageY: number }, item: any) => {
@@ -164,6 +166,13 @@ export default function GraphTooltip(this: any, elem: any, dashboard: any, scope
     hoverEvent.payload.panel = panel;
     hoverEvent.payload.point['time'] = (pos as any).x;
     dashboard.events.publish(hoverEvent);
+    dashboard.events.publish(
+      new SetGraphNGCursorEvent({
+        point: {
+          time: (pos as any).x,
+        },
+      })
+    );
   });
 
   elem.bind('plotclick', (event: any, pos: any, item: any) => {

--- a/public/app/plugins/panel/heatmap/rendering.ts
+++ b/public/app/plugins/panel/heatmap/rendering.ts
@@ -16,7 +16,7 @@ import {
   PanelEvents,
   toUtc,
 } from '@grafana/data';
-import { graphTimeFormat } from '@grafana/ui';
+import { graphTimeFormat, SetGraphNGCursorEvent, ClearGraphNGCursorEvent } from '@grafana/ui';
 import { config } from 'app/core/config';
 
 const MIN_CARD_SIZE = 1,
@@ -712,6 +712,7 @@ export class HeatmapRenderer {
 
   onMouseLeave() {
     this.ctrl.dashboard.events.publish(new LegacyGraphHoverClearEvent());
+    this.ctrl.dashboard.events.publish(new ClearGraphNGCursorEvent());
     this.clearCrosshair();
   }
 
@@ -760,7 +761,10 @@ export class HeatmapRenderer {
     this.hoverEvent.payload.pos = pos;
     this.hoverEvent.payload.panel = this.panel;
     this.hoverEvent.payload.point['time'] = (pos as any).x;
+    // for compatibility with panels synchronizing from the old graph panel
     this.ctrl.dashboard.events.publish(this.hoverEvent);
+    // for synchronizing cursor between the old graph panel and GraphNG
+    this.ctrl.dashboard.events.publish(new SetGraphNGCursorEvent({ point: { time: (pos as any).x } }));
   }
 
   limitSelection(x2: number) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is to show cursor on Time Series panel when hovering over logs panel:

https://user-images.githubusercontent.com/745532/136019289-06b314ca-8b7f-4133-9754-6d8a2dc8fd1d.mov

As shown above this works only with new Time Series panel (not the old graph or heatmap).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to #29231 (one way synchronization)
Fixes https://github.com/grafana/grafana/issues/33952

**Special notes for your reviewer**:

⚠️ I tried to re-use existing `DataHoverEvent` ([PR](https://github.com/grafana/grafana/pull/40005)) but the problem is that a panel dispatches and listens to the same event. Not sure what would be the best approach (introduce `source`)? This PR adds a separate event just for setting the cursor on Time Series panel, but feels a bit too complex (?). 

I could also simply re-use `LegacyGraphHoverClearEvent` -> [diff](https://github.com/grafana/grafana/compare/ifrost/logs-time-series-sync?expand=1). However this makes logs panel coupled with old graph api/event. I guess what we could do in this case is to simply rename `LegacyGraphHoverEvent` when old graph is removed and keep using this event to set the cursor on time series panel. That would eventually lead to the same solution as this PR (with the only difference is that with this PR a new event is added now and the old one could be removed when old graph is removed). 