### PR TITLE
Panel ID annotation cannot be set without Dashboard UID

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -503,6 +503,10 @@ func (st DBstore) validateAlertRule(alertRule ngmodels.AlertRule) error {
 		return fmt.Errorf("%w: no organisation is found", ngmodels.ErrAlertRuleFailedValidation)
 	}
 
+	if alertRule.DashboardUID == nil && alertRule.PanelID != nil {
+		return fmt.Errorf("%w: cannot have Panel ID without a Dashboard UID", ngmodels.ErrAlertRuleFailedValidation)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request checks that the Panel ID annotation cannot be set without the Dashboard UID annotation. It also checks that previous alert rules where the Panel ID annotation has been set without the Dashboard UID annotation are ignored in the `updateDashboardUIDPanelIDMigration` migration.

**Special notes for your reviewer**:

