### PR TITLE
Tempo: Decrease the default Tempo Search limit to 20

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -12,7 +12,7 @@ import {
 
 import { createFetchResponse } from 'test/helpers/createFetchResponse';
 import { BackendDataSourceResponse, FetchResponse, setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
-import { TempoDatasource, TempoQuery } from './datasource';
+import { DEFAULT_LIMIT, TempoDatasource, TempoQuery } from './datasource';
 import mockJson from './mockJsonResponse.json';
 
 describe('Tempo data source', () => {
@@ -155,7 +155,7 @@ describe('Tempo data source', () => {
     });
   });
 
-  it('should include a default limit of 100', () => {
+  it('should include a default limit', () => {
     const ds = new TempoDatasource(defaultSettings);
     const tempoQuery: TempoQuery = {
       queryType: 'search',
@@ -165,7 +165,7 @@ describe('Tempo data source', () => {
     };
     const builtQuery = ds.buildSearchQuery(tempoQuery);
     expect(builtQuery).toStrictEqual({
-      limit: 100,
+      limit: DEFAULT_LIMIT,
     });
   });
 
@@ -179,7 +179,7 @@ describe('Tempo data source', () => {
     };
     const builtQuery = ds.buildSearchQuery(tempoQuery);
     expect(builtQuery).toStrictEqual({
-      limit: 100,
+      limit: DEFAULT_LIMIT,
       'root.http.status_code': '500',
     });
   });

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -54,6 +54,8 @@ export type TempoQuery = {
   limit?: number;
 } & DataQuery;
 
+export const DEFAULT_LIMIT = 20;
+
 export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJsonData> {
   tracesToLogs?: TraceToLogsOptions;
   serviceMap?: {
@@ -238,7 +240,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
     // Set default limit
     if (!tempoQuery.limit) {
-      tempoQuery.limit = 100;
+      tempoQuery.limit = DEFAULT_LIMIT;
     }
 
     // Validate query inputs and remove spaces if valid


### PR DESCRIPTION
**What this PR does / why we need it**:
Decrease default limit to 20. The original limit of 100 was a bit too high after testing for a while in ops.