### PR TITLE
CI: Run builds on single-build agents

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -227,6 +227,9 @@ services:
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
 
+node:
+  type: no-parallel
+
 trigger:
   event:
   - pull_request
@@ -550,6 +553,9 @@ services:
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
 
+node:
+  type: no-parallel
+
 trigger:
   branch:
   - main
@@ -649,6 +655,9 @@ steps:
       from_secret: grafana_api_key
   depends_on:
   - initialize
+
+node:
+  type: no-parallel
 
 trigger:
   branch:
@@ -985,6 +994,9 @@ services:
     MYSQL_PASSWORD: password
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
+
+node:
+  type: no-parallel
 
 trigger:
   ref:
@@ -1450,6 +1462,9 @@ services:
 image_pull_secrets:
 - dockerconfigjson
 
+node:
+  type: no-parallel
+
 trigger:
   ref:
   - refs/tags/v*
@@ -1589,6 +1604,9 @@ steps:
       from_secret: grafana_api_key
   depends_on:
   - initialize
+
+node:
+  type: no-parallel
 
 trigger:
   ref:
@@ -1914,6 +1932,9 @@ services:
     MYSQL_PASSWORD: password
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
+
+node:
+  type: no-parallel
 
 trigger:
   event:
@@ -2373,6 +2394,9 @@ services:
 image_pull_secrets:
 - dockerconfigjson
 
+node:
+  type: no-parallel
+
 trigger:
   event:
   - custom
@@ -2512,6 +2536,9 @@ steps:
       from_secret: grafana_api_key
   depends_on:
   - initialize
+
+node:
+  type: no-parallel
 
 trigger:
   event:
@@ -2812,6 +2839,9 @@ services:
     MYSQL_PASSWORD: password
     MYSQL_ROOT_PASSWORD: rootpass
     MYSQL_USER: grafana
+
+node:
+  type: no-parallel
 
 trigger:
   ref:
@@ -3270,6 +3300,9 @@ services:
 image_pull_secrets:
 - dockerconfigjson
 
+node:
+  type: no-parallel
+
 trigger:
   ref:
   - refs/heads/v[0-9]*
@@ -3441,6 +3474,6 @@ get:
 
 ---
 kind: signature
-hmac: 344cd4f6925147cee6a32670a128e7633afb6f0df83e61f0464a03deaac7ec55
+hmac: 879a81aca1cb7a901b878e031ce0894fc756f97e4ca2ec89cde757b4878d0fd2
 
 ...

--- a/scripts/lib.star
+++ b/scripts/lib.star
@@ -17,14 +17,23 @@ def pipeline(
     ):
     if platform != 'windows':
         platform_conf = {
-            'os': 'linux',
-            'arch': 'amd64',
+            'platform': {
+                'os': 'linux',
+                'arch': 'amd64'
+            },
+            # A shared cache is used on the host
+            # To avoid issues with parallel builds, we run this repo on single build agents
+            'node': {
+                'type': 'no-parallel'
+            }
         }
     else:
         platform_conf = {
-            'os': 'windows',
-            'arch': 'amd64',
-            'version': '1809',
+            'platform': {
+                'os': 'windows',
+                'arch': 'amd64',
+                'version': '1809',
+            }
         }
 
     pipeline = {
@@ -39,6 +48,7 @@ def pipeline(
         ) + steps,
         'depends_on': depends_on,
     }
+    pipeline.update(platform_conf)
 
     if edition in ('enterprise', 'enterprise2'):
         pipeline['image_pull_secrets'] = [pull_secret]


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an effort to reduce cache errors when multiple agents try to build the yarn cache at the same time
grafana/deployment_tools#13329

Reopened from #36809

Backport of #37702