### PR TITLE
TimePicker: fix console error on time picker open

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.tsx
@@ -14,7 +14,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 import { Icon, Tooltip } from '../..';
-import { stylesFactory, useStyles2 } from '../../..';
+import { useStyles2 } from '../../..';
 import { Button } from '../../Button';
 import { Field } from '../../Forms/Field';
 import { Input } from '../../Input/Input';

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeForm.tsx
@@ -14,7 +14,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 import { Icon, Tooltip } from '../..';
-import { useStyles2 } from '../../..';
+import { stylesFactory, useStyles2 } from '../../..';
 import { Button } from '../../Button';
 import { Field } from '../../Forms/Field';
 import { Input } from '../../Input/Input';
@@ -115,8 +115,8 @@ export const TimeRangeForm: React.FC<Props> = (props) => {
 
   return (
     <div aria-label="Absolute time ranges">
-      <Field label="From" invalid={from.invalid} error={from.errorMessage}>
-        <div className={style.fieldContainer}>
+      <div className={style.fieldContainer}>
+        <Field label="From" invalid={from.invalid} error={from.errorMessage}>
           <Input
             onClick={(event) => event.stopPropagation()}
             onFocus={onFocus}
@@ -125,11 +125,11 @@ export const TimeRangeForm: React.FC<Props> = (props) => {
             aria-label={selectors.components.TimePicker.fromField}
             value={from.value}
           />
-          {fyTooltip}
-        </div>
-      </Field>
-      <Field label="To" invalid={to.invalid} error={to.errorMessage}>
-        <div className={style.fieldContainer}>
+        </Field>
+        {fyTooltip}
+      </div>
+      <div className={style.fieldContainer}>
+        <Field label="To" invalid={to.invalid} error={to.errorMessage}>
           <Input
             onClick={(event) => event.stopPropagation()}
             onFocus={onFocus}
@@ -138,9 +138,9 @@ export const TimeRangeForm: React.FC<Props> = (props) => {
             aria-label={selectors.components.TimePicker.toField}
             value={to.value}
           />
-          {fyTooltip}
-        </div>
-      </Field>
+        </Field>
+        {fyTooltip}
+      </div>
       <Button data-testid={selectors.components.TimePicker.applyTimeRange} onClick={onApply}>
         Apply time range
       </Button>
@@ -217,7 +217,7 @@ function getStyles(theme: GrafanaTheme2) {
     `,
     tooltip: css`
       padding-left: ${theme.spacing(1)};
-      padding-top: ${theme.spacing(0.5)};
+      padding-top: ${theme.spacing(3)};
     `,
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
a div as the first element in a Field component does not work. This moves the styling div outside the field component to make the styling on the input when invalid work again. Also fixes the associated console error.