### PR TITLE
Fix: prevent queryDisplyText in QueryRowHeader from overflowing

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -75,21 +75,26 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
 
   const rowHeader = (
     <div className={styles.header}>
-      <Icon
-        name={isContentVisible ? 'angle-down' : 'angle-right'}
-        className={styles.collapseIcon}
-        onClick={onRowToggle}
-      />
-      {title && (
-        <div className={styles.titleWrapper} onClick={onRowToggle} aria-label="Query operation row title">
-          <div className={cx(styles.title, disabled && styles.disabled)}>{titleElement}</div>
-        </div>
-      )}
-      {headerElementRendered}
-      {actions && <div>{actionsElement}</div>}
-      {draggable && (
-        <Icon title="Drag and drop to reorder" name="draggabledots" size="lg" className={styles.dragIcon} />
-      )}
+      <div className={styles.column}>
+        <Icon
+          name={isContentVisible ? 'angle-down' : 'angle-right'}
+          className={styles.collapseIcon}
+          onClick={onRowToggle}
+        />
+        {title && (
+          <div className={styles.titleWrapper} onClick={onRowToggle} aria-label="Query operation row title">
+            <div className={cx(styles.title, disabled && styles.disabled)}>{titleElement}</div>
+          </div>
+        )}
+        {headerElementRendered}
+      </div>
+
+      <div className={styles.column}>
+        {actionsElement}
+        {draggable && (
+          <Icon title="Drag and drop to reorder" name="draggabledots" size="lg" className={styles.dragIcon} />
+        )}
+      </div>
     </div>
   );
 
@@ -124,11 +129,13 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
       margin-bottom: ${theme.spacing.md};
     `,
     header: css`
+      label: Header;
       padding: ${theme.spacing.xs} ${theme.spacing.sm};
       border-radius: ${theme.border.radius.sm};
       background: ${theme.colors.bg2};
       min-height: ${theme.spacing.formInputHeight}px;
-      display: flex;
+      display: grid;
+      grid-template-columns: minmax(100px, max-content) min-content;
       align-items: center;
       justify-content: space-between;
       white-space: nowrap;
@@ -136,6 +143,11 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
       &:focus {
         outline: none;
       }
+    `,
+    column: css`
+      label: Column;
+      display: flex;
+      align-items: center;
     `,
     dragIcon: css`
       cursor: grab;
@@ -164,6 +176,7 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
       color: ${theme.colors.textBlue};
       margin-left: ${theme.spacing.sm};
       overflow: hidden;
+      text-overflow: ellipsis;
     `,
     content: css`
       margin-top: ${theme.spacing.inlineFormMargin};

--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -80,46 +80,49 @@ export const QueryEditorRowHeader = <TQuery extends DataQuery>(props: Props<TQue
   };
 
   return (
-    <div className={styles.wrapper}>
-      {!isEditing && (
-        <button
-          className={styles.queryNameWrapper}
-          aria-label={selectors.components.QueryEditorRow.title(query.refId)}
-          title="Edit query name"
-          onClick={onEditQuery}
-          data-testid="query-name-div"
-        >
-          <span className={styles.queryName}>{query.refId}</span>
-          <Icon name="pen" className={styles.queryEditIcon} size="sm" />
-        </button>
-      )}
-      {isEditing && (
-        <>
-          <Input
-            type="text"
-            defaultValue={query.refId}
-            onBlur={onEditQueryBlur}
-            autoFocus
-            onKeyDown={onKeyDown}
-            onFocus={onFocus}
-            invalid={validationError !== null}
-            onChange={onInputChange}
-            className={styles.queryNameInput}
-            data-testid="query-name-input"
-          />
-          {validationError && <FieldValidationMessage horizontal>{validationError}</FieldValidationMessage>}
-        </>
-      )}
-      {renderDataSource(props, styles)}
-      {renderExtras && <div className={styles.itemWrapper}>{renderExtras()}</div>}
-      {disabled && <em className={styles.contextInfo}>Disabled</em>}
+    <>
+      <div className={styles.wrapper}>
+        {!isEditing && (
+          <button
+            className={styles.queryNameWrapper}
+            aria-label={selectors.components.QueryEditorRow.title(query.refId)}
+            title="Edit query name"
+            onClick={onEditQuery}
+            data-testid="query-name-div"
+          >
+            <span className={styles.queryName}>{query.refId}</span>
+            <Icon name="pen" className={styles.queryEditIcon} size="sm" />
+          </button>
+        )}
+
+        {isEditing && (
+          <>
+            <Input
+              type="text"
+              defaultValue={query.refId}
+              onBlur={onEditQueryBlur}
+              autoFocus
+              onKeyDown={onKeyDown}
+              onFocus={onFocus}
+              invalid={validationError !== null}
+              onChange={onInputChange}
+              className={styles.queryNameInput}
+              data-testid="query-name-input"
+            />
+            {validationError && <FieldValidationMessage horizontal>{validationError}</FieldValidationMessage>}
+          </>
+        )}
+        {renderDataSource(props, styles)}
+        {renderExtras && <div className={styles.itemWrapper}>{renderExtras()}</div>}
+        {disabled && <em className={styles.contextInfo}>Disabled</em>}
+      </div>
 
       {collapsedText && (
         <div className={styles.collapsedText} onClick={onClick}>
           {collapsedText}
         </div>
       )}
-    </div>
+    </>
   );
 };
 
@@ -143,43 +146,37 @@ const renderDataSource = <TQuery extends DataQuery>(
 const getStyles = (theme: GrafanaTheme) => {
   return {
     wrapper: css`
+      label: Wrapper;
       display: flex;
       align-items: center;
-      flex-grow: 1;
       margin-left: ${theme.spacing.xs};
+    `,
+    queryNameWrapper: css`
+      display: flex;
+      cursor: pointer;
+      border: 1px solid transparent;
+      border-radius: ${theme.border.radius.md};
+      align-items: center;
+      padding: 0 0 0 ${theme.spacing.xs};
+      margin: 0;
+      background: transparent;
 
       &:hover {
-        .query-name-wrapper {
-          background: ${theme.colors.bg3};
-          border: 1px dashed ${theme.colors.border3};
-        }
+        background: ${theme.colors.bg3};
+        border: 1px dashed ${theme.colors.border3};
+      }
 
+      &:focus {
+        border: 2px solid ${theme.colors.formInputBorderActive};
+      }
+
+      &:hover,
+      &:focus {
         .query-name-edit-icon {
           visibility: visible;
         }
       }
     `,
-    queryNameWrapper: cx(
-      css`
-        display: flex;
-        cursor: pointer;
-        border: 1px solid transparent;
-        border-radius: ${theme.border.radius.md};
-        align-items: center;
-        padding: 0 0 0 ${theme.spacing.xs};
-        margin: 0;
-        background: transparent;
-
-        &:focus {
-          border: 2px solid ${theme.colors.formInputBorderActive};
-
-          .query-name-edit-icon {
-            visibility: visible;
-          }
-        }
-      `,
-      'query-name-wrapper'
-    ),
     queryName: css`
       font-weight: ${theme.typography.weight.semibold};
       color: ${theme.colors.textBlue};
@@ -206,10 +203,8 @@ const getStyles = (theme: GrafanaTheme) => {
       align-items: center;
       overflow: hidden;
       font-style: italic;
-      overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      min-width: 0;
     `,
     contextInfo: css`
       font-size: ${theme.typography.size.sm};

--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -147,7 +147,6 @@ const getStyles = (theme: GrafanaTheme) => {
       align-items: center;
       flex-grow: 1;
       margin-left: ${theme.spacing.xs};
-      overflow: hidden;
 
       &:hover {
         .query-name-wrapper {

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -141,7 +141,6 @@
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  width: 100%;
 }
 
 .explore.explore-live {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

prevents `collapsedText` from overflowing horizontally. This is an alternative approach to https://github.com/grafana/grafana/pull/39419 (reverted in this PR) to avoid an issue when, in alerting UI, the timepicker was not being shown anymore.

### Alerting UI
![Screenshot 2021-10-06 at 16 38 00](https://user-images.githubusercontent.com/1170767/136237356-666bce57-3580-478e-a283-ac50340b4bd2.png)

### Dashboard edit
![Screenshot 2021-10-06 at 16 37 16](https://user-images.githubusercontent.com/1170767/136237362-a5b6d695-6279-491f-ac8a-c6f9a6c42bb2.png)

### Explore
![Screenshot 2021-10-06 at 16 36 42](https://user-images.githubusercontent.com/1170767/136237536-9194dcd5-a930-4422-97f0-e75b820b51d6.png)

