### PR TITLE
Datasources: Fix deletion of data source if plugin is not found 

### DIFF
--- a/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
+++ b/public/app/features/datasources/settings/DataSourceSettingsPage.test.tsx
@@ -44,6 +44,7 @@ const getProps = (): Props => ({
   page: null,
   plugin: null,
   loadError: null,
+  loading: false,
   testingStatus: {},
 });
 
@@ -57,6 +58,7 @@ describe('Render', () => {
   it('should render loading if datasource is not ready', () => {
     const mockProps = getProps();
     mockProps.dataSource.id = 0;
+    mockProps.loading = true;
 
     render(<DataSourceSettingsPage {...mockProps} />);
 

--- a/public/app/features/datasources/state/actions.test.ts
+++ b/public/app/features/datasources/state/actions.test.ts
@@ -114,7 +114,7 @@ describe('getDataSourceUsingUidOrId', () => {
   it('should return empty response data', async () => {
     // @ts-ignore
     delete window.location;
-    window.location = {} as any;
+    window.location = {} as Location;
 
     const uidResponse = {
       ok: false,
@@ -190,11 +190,11 @@ describe('initDataSourceSettings', () => {
 
   describe('when pageId is a valid', () => {
     it('then initDataSourceSettingsSucceeded should be dispatched', async () => {
-      const thunkMock = (): ThunkResult<void> => (dispatch: ThunkDispatch, getState) => {};
       const dataSource = { type: 'app' };
       const dataSourceMeta = { id: 'some id' };
       const dependencies: InitDataSourceSettingDependencies = {
-        loadDataSource: jest.fn(thunkMock) as any,
+        loadDataSource: jest.fn((): ThunkResult<void> => (dispatch: ThunkDispatch, getState) => dataSource) as any,
+        loadDataSourceMeta: jest.fn((): ThunkResult<void> => (dispatch: ThunkDispatch, getState) => {}),
         getDataSource: jest.fn().mockReturnValue(dataSource),
         getDataSourceMeta: jest.fn().mockReturnValue(dataSourceMeta),
         importDataSourcePlugin: jest.fn().mockReturnValue({} as GenericDataSourcePlugin),
@@ -211,6 +211,9 @@ describe('initDataSourceSettings', () => {
       expect(dependencies.loadDataSource).toHaveBeenCalledTimes(1);
       expect(dependencies.loadDataSource).toHaveBeenCalledWith(256);
 
+      expect(dependencies.loadDataSourceMeta).toHaveBeenCalledTimes(1);
+      expect(dependencies.loadDataSourceMeta).toHaveBeenCalledWith(dataSource);
+
       expect(dependencies.getDataSource).toHaveBeenCalledTimes(1);
       expect(dependencies.getDataSource).toHaveBeenCalledWith({}, 256);
 
@@ -224,8 +227,10 @@ describe('initDataSourceSettings', () => {
 
   describe('when plugin loading fails', () => {
     it('then initDataSourceSettingsFailed should be dispatched', async () => {
+      const dataSource = { type: 'app' };
       const dependencies: InitDataSourceSettingDependencies = {
-        loadDataSource: jest.fn().mockImplementation(() => {
+        loadDataSource: jest.fn((): ThunkResult<void> => (dispatch: ThunkDispatch, getState) => dataSource) as any,
+        loadDataSourceMeta: jest.fn().mockImplementation(() => {
           throw new Error('Error loading plugin');
         }),
         getDataSource: jest.fn(),
@@ -243,6 +248,9 @@ describe('initDataSourceSettings', () => {
       expect(dispatchedActions).toEqual([initDataSourceSettingsFailed(new Error('Error loading plugin'))]);
       expect(dependencies.loadDataSource).toHaveBeenCalledTimes(1);
       expect(dependencies.loadDataSource).toHaveBeenCalledWith(301);
+
+      expect(dependencies.loadDataSourceMeta).toHaveBeenCalledTimes(1);
+      expect(dependencies.loadDataSourceMeta).toHaveBeenCalledWith(dataSource);
     });
   });
 });

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -33,6 +33,7 @@ export interface DataSourceTypesLoadedPayload {
 
 export interface InitDataSourceSettingDependencies {
   loadDataSource: typeof loadDataSource;
+  loadDataSourceMeta: typeof loadDataSourceMeta;
   getDataSource: typeof getDataSource;
   getDataSourceMeta: typeof getDataSourceMeta;
   importDataSourcePlugin: typeof importDataSourcePlugin;
@@ -47,6 +48,7 @@ export const initDataSourceSettings = (
   pageId: string,
   dependencies: InitDataSourceSettingDependencies = {
     loadDataSource,
+    loadDataSourceMeta,
     getDataSource,
     getDataSourceMeta,
     importDataSourcePlugin,
@@ -59,7 +61,8 @@ export const initDataSourceSettings = (
     }
 
     try {
-      await dispatch(dependencies.loadDataSource(pageId));
+      const loadedDataSource = await dispatch(dependencies.loadDataSource(pageId));
+      await dispatch(dependencies.loadDataSourceMeta(loadedDataSource));
 
       // have we already loaded the plugin then we can skip the steps below?
       if (getState().dataSourceSettings.plugin) {
@@ -72,7 +75,7 @@ export const initDataSourceSettings = (
 
       dispatch(initDataSourceSettingsSucceeded(importedPlugin));
     } catch (err) {
-      console.error('Failed to import plugin module', err);
+      // console.error('Failed to import plugin module', err);
       dispatch(initDataSourceSettingsFailed(err));
     }
   };
@@ -117,9 +120,17 @@ export function loadDataSources(): ThunkResult<void> {
   };
 }
 
-export function loadDataSource(uid: string): ThunkResult<void> {
+export function loadDataSource(uid: string): ThunkResult<Promise<DataSourceSettings>> {
   return async (dispatch) => {
     const dataSource = await getDataSourceUsingUidOrId(uid);
+
+    dispatch(dataSourceLoaded(dataSource));
+    return dataSource;
+  };
+}
+
+export function loadDataSourceMeta(dataSource: DataSourceSettings): ThunkResult<void> {
+  return async (dispatch) => {
     const pluginInfo = (await getPluginSettings(dataSource.type)) as DataSourcePluginMeta;
     const plugin = await importDataSourcePlugin(pluginInfo);
     const isBackend = plugin.DataSourceClass.prototype instanceof DataSourceWithBackend;
@@ -127,7 +138,7 @@ export function loadDataSource(uid: string): ThunkResult<void> {
       ...pluginInfo,
       isBackend: isBackend,
     };
-    dispatch(dataSourceLoaded(dataSource));
+
     dispatch(dataSourceMetaLoaded(meta));
 
     plugin.meta = meta;

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -75,7 +75,6 @@ export const initDataSourceSettings = (
 
       dispatch(initDataSourceSettingsSucceeded(importedPlugin));
     } catch (err) {
-      // console.error('Failed to import plugin module', err);
       dispatch(initDataSourceSettingsFailed(err));
     }
   };

--- a/public/app/features/datasources/state/reducers.test.ts
+++ b/public/app/features/datasources/state/reducers.test.ts
@@ -150,7 +150,7 @@ describe('dataSourceSettingsReducer', () => {
         .thenStateShouldEqual({
           ...initialDataSourceSettingsState,
           plugin: {} as GenericDataSourcePlugin,
-          loadError: null,
+          loading: false,
         });
     });
   });
@@ -164,8 +164,12 @@ describe('dataSourceSettingsReducer', () => {
         })
         .whenActionIsDispatched(initDataSourceSettingsFailed(new Error('Some error')))
         .thenStatePredicateShouldEqual((resultingState) => {
-          expect(resultingState.plugin).toEqual(null);
-          expect(resultingState.loadError).toEqual('Some error');
+          expect(resultingState).toEqual({
+            testingStatus: {},
+            loadError: 'Some error',
+            loading: false,
+            plugin: null,
+          });
           return true;
         });
     });

--- a/public/app/features/datasources/state/reducers.ts
+++ b/public/app/features/datasources/state/reducers.ts
@@ -97,6 +97,7 @@ export const dataSourcesReducer = (state: DataSourcesState = initialState, actio
 export const initialDataSourceSettingsState: DataSourceSettingsState = {
   testingStatus: {},
   loadError: null,
+  loading: true,
   plugin: null,
 };
 
@@ -117,11 +118,11 @@ export const dataSourceSettingsReducer = (
   action: AnyAction
 ): DataSourceSettingsState => {
   if (initDataSourceSettingsSucceeded.match(action)) {
-    return { ...state, plugin: action.payload, loadError: null };
+    return { ...state, plugin: action.payload, loadError: null, loading: false };
   }
 
   if (initDataSourceSettingsFailed.match(action)) {
-    return { ...state, plugin: null, loadError: action.payload.message };
+    return { ...state, plugin: null, loadError: action.payload.message, loading: false };
   }
 
   if (testDataSourceStarting.match(action)) {

--- a/public/app/features/plugins/PluginPage.tsx
+++ b/public/app/features/plugins/PluginPage.tsx
@@ -62,33 +62,29 @@ class PluginPage extends PureComponent<Props, State> {
   }
 
   async componentDidMount() {
-    const { location, queryParams } = this.props;
-    const { appSubUrl } = config;
-
-    const plugin = await loadPlugin(this.props.match.params.pluginId);
-
-    if (!plugin) {
+    try {
+      const { location, queryParams } = this.props;
+      const { appSubUrl } = config;
+      const plugin = await loadPlugin(this.props.match.params.pluginId);
+      const { defaultPage, nav } = getPluginTabsNav(
+        plugin,
+        appSubUrl,
+        location.pathname,
+        queryParams,
+        contextSrv.hasRole('Admin')
+      );
+      this.setState({
+        loading: false,
+        plugin,
+        defaultPage,
+        nav,
+      });
+    } catch {
       this.setState({
         loading: false,
         nav: getNotFoundNav(),
       });
-      return; // 404
     }
-
-    const { defaultPage, nav } = getPluginTabsNav(
-      plugin,
-      appSubUrl,
-      location.pathname,
-      queryParams,
-      contextSrv.hasRole('Admin')
-    );
-
-    this.setState({
-      loading: false,
-      plugin,
-      defaultPage,
-      nav,
-    });
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/public/app/features/plugins/PluginSettingsCache.ts
+++ b/public/app/features/plugins/PluginSettingsCache.ts
@@ -19,7 +19,6 @@ export function getPluginSettings(pluginId: string): Promise<PluginMeta> {
       return settings;
     })
     .catch((err: any) => {
-      // err.isHandled = true;
-      return Promise.reject('Unknown Plugin');
+      return Promise.reject(new Error('Unknown Plugin'));
     });
 }

--- a/public/app/types/datasources.ts
+++ b/public/app/types/datasources.ts
@@ -26,6 +26,7 @@ export interface DataSourceSettingsState {
   plugin?: GenericDataSourcePlugin | null;
   testingStatus?: TestingStatus;
   loadError?: string | null;
+  loading: boolean;
 }
 
 export interface DataSourcePluginCategory {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR makes it possible to delete a datasource if the plugin cannot be found / has been uninstalled. Most of the code already existed but an unhandled error prevented it from rendering. After handling the plugin loading error it revealed a second issue where the delete functionality either didn’t work (due to missing redux state) or allowed a user to delete the wrong datasource (due to out of sync redux state).

Thanks to @mckn & @leventebalogh for taking the time to help me understand the code and bounce ideas around on how to fix it. 🥇 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #37650

**Special notes for your reviewer**:
