### PR TITLE
Forbid creation of dashboard permissions with both a user and a team

### DIFF
--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -112,6 +112,10 @@ func (hs *HTTPServer) UpdateDashboardPermissions(c *models.ReqContext, apiCmd dt
 
 func validatePermissionsUpdate(apiCmd dtos.UpdateDashboardAclCommand) error {
 	for _, item := range apiCmd.Items {
+		if item.UserID > 0 && item.TeamID > 0 {
+			return models.ErrPermissionsWithUserAndTeamNotAllowed
+		}
+
 		if (item.UserID > 0 || item.TeamID > 0) && item.Role != nil {
 			return models.ErrPermissionsWithRoleNotAllowed
 		}

--- a/pkg/models/dashboard_acl.go
+++ b/pkg/models/dashboard_acl.go
@@ -24,11 +24,12 @@ func (p PermissionType) String() string {
 
 // Typed errors
 var (
-	ErrDashboardAclInfoMissing           = errors.New("user id and team id cannot both be empty for a dashboard permission")
-	ErrDashboardPermissionDashboardEmpty = errors.New("dashboard id must be greater than zero for a dashboard permission")
-	ErrFolderAclInfoMissing              = errors.New("user id and team id cannot both be empty for a folder permission")
-	ErrFolderPermissionFolderEmpty       = errors.New("folder id must be greater than zero for a folder permission")
-	ErrPermissionsWithRoleNotAllowed     = errors.New("team and user permissions cannot have an associated role")
+	ErrDashboardAclInfoMissing              = errors.New("user id and team id cannot both be empty for a dashboard permission")
+	ErrDashboardPermissionDashboardEmpty    = errors.New("dashboard id must be greater than zero for a dashboard permission")
+	ErrFolderAclInfoMissing                 = errors.New("user id and team id cannot both be empty for a folder permission")
+	ErrFolderPermissionFolderEmpty          = errors.New("folder id must be greater than zero for a folder permission")
+	ErrPermissionsWithRoleNotAllowed        = errors.New("permissions cannot have both a user and team")
+	ErrPermissionsWithUserAndTeamNotAllowed = errors.New("team and user permissions cannot have an associated role")
 )
 
 // Dashboard ACL model


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Forbids creation of dashboard permissions with both a user and team ID. This is impossible in the UI, but has been done through the API, and these dual permissions show incorrectly in the UI.

