### PR TITLE
E2E: Fix path for importDashboards

### DIFF
--- a/packages/grafana-e2e/cypress/support/commands.ts
+++ b/packages/grafana-e2e/cypress/support/commands.ts
@@ -26,7 +26,7 @@ Cypress.Commands.add('readProvisions', (filePaths: string[]) => {
 
 Cypress.Commands.add('getJSONFilesFromDir', (dirPath: string) => {
   return cy.task('getJSONFilesFromDir', {
-    projectPath: Cypress.config().parentTestsFolder,
+    projectPath: Cypress.env('CWD') || Cypress.config().parentTestsFolder,
     relativePath: dirPath,
   });
 });

--- a/packages/grafana-e2e/cypress/support/commands.ts
+++ b/packages/grafana-e2e/cypress/support/commands.ts
@@ -26,6 +26,7 @@ Cypress.Commands.add('readProvisions', (filePaths: string[]) => {
 
 Cypress.Commands.add('getJSONFilesFromDir', (dirPath: string) => {
   return cy.task('getJSONFilesFromDir', {
+    // CWD is set for plugins in the cli but not for the main grafana repo: https://github.com/grafana/grafana/blob/main/packages/grafana-e2e/cli.js#L12
     projectPath: Cypress.env('CWD') || Cypress.config().parentTestsFolder,
     relativePath: dirPath,
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
While testing out the new importDashboards flow I added in #39693 I noticed that Cypress.config().parentTestsFolder was a different path than what I expected when using this in an external datasource. It seems to be a path from within node_modules. I think using CWD like we do in the task above makes the most sense, but it seems to be undefined when we run the e2e tests in the main grafana repo. So my proposal is that we use CWD if it exists otherwise we use this parentTestsFolder function.
