### PR TITLE
Chore: replace macaron with web package

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/search"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func ValidateOrgAlert(c *models.ReqContext) {
@@ -258,7 +258,7 @@ func GetAlertNotificationByID(c *models.ReqContext) response.Response {
 func GetAlertNotificationByUID(c *models.ReqContext) response.Response {
 	query := &models.GetAlertNotificationsWithUidQuery{
 		OrgId: c.OrgId,
-		Uid:   macaron.Params(c.Req)[":uid"],
+		Uid:   web.Params(c.Req)[":uid"],
 	}
 
 	if query.Uid == "" {
@@ -318,7 +318,7 @@ func (hs *HTTPServer) UpdateAlertNotification(c *models.ReqContext, cmd models.U
 
 func (hs *HTTPServer) UpdateAlertNotificationByUID(c *models.ReqContext, cmd models.UpdateAlertNotificationWithUidCommand) response.Response {
 	cmd.OrgId = c.OrgId
-	cmd.Uid = macaron.Params(c.Req)[":uid"]
+	cmd.Uid = web.Params(c.Req)[":uid"]
 
 	err := hs.fillWithSecureSettingsDataByUID(c.Req.Context(), &cmd)
 	if err != nil {
@@ -419,7 +419,7 @@ func DeleteAlertNotification(c *models.ReqContext) response.Response {
 func DeleteAlertNotificationByUID(c *models.ReqContext) response.Response {
 	cmd := models.DeleteAlertNotificationWithUidCommand{
 		OrgId: c.OrgId,
-		Uid:   macaron.Params(c.Req)[":uid"],
+		Uid:   web.Params(c.Req)[":uid"],
 	}
 
 	if err := bus.Dispatch(&cmd); err != nil {

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -13,12 +13,12 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var pluginProxyTransport *http.Transport
 
-func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
+func (hs *HTTPServer) initAppPluginRoutes(r *web.Mux) {
 	pluginProxyTransport = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: hs.Cfg.PluginsAppsSkipVerifyTLS,
@@ -35,7 +35,7 @@ func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
 	for _, plugin := range hs.PluginManager.Apps() {
 		for _, route := range plugin.Routes {
 			url := util.JoinURLFragments("/api/plugin-proxy/"+plugin.Id, route.Path)
-			handlers := make([]macaron.Handler, 0)
+			handlers := make([]web.Handler, 0)
 			handlers = append(handlers, middleware.Auth(&middleware.AuthOptions{
 				ReqSignedIn: true,
 			}))
@@ -56,9 +56,9 @@ func (hs *HTTPServer) initAppPluginRoutes(r *macaron.Macaron) {
 	}
 }
 
-func AppPluginRoute(route *plugins.AppPluginRoute, appID string, hs *HTTPServer) macaron.Handler {
+func AppPluginRoute(route *plugins.AppPluginRoute, appID string, hs *HTTPServer) web.Handler {
 	return func(c *models.ReqContext) {
-		path := macaron.Params(c.Req)["*"]
+		path := web.Params(c.Req)["*"]
 
 		proxy := pluginproxy.NewApiPluginProxy(c, path, route, appID, hs.Cfg, hs.EncryptionService)
 		proxy.Transport = pluginProxyTransport

--- a/pkg/api/avatar/avatar.go
+++ b/pkg/api/avatar/avatar.go
@@ -23,8 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	"gopkg.in/macaron.v1"
-
+	"github.com/grafana/grafana/pkg/web"
 	gocache "github.com/patrickmn/go-cache"
 )
 
@@ -78,7 +77,7 @@ type CacheServer struct {
 var validMD5 = regexp.MustCompile("^[a-fA-F0-9]{32}$")
 
 func (a *CacheServer) Handler(ctx *models.ReqContext) {
-	hash := macaron.Params(ctx.Req)[":hash"]
+	hash := web.Params(ctx.Req)[":hash"]
 
 	if len(hash) != 32 || !validMD5.MatchString(hash) {
 		ctx.JsonApiErr(404, "Avatar not found", nil)

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -12,9 +12,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/searchusers"
 
-	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
@@ -29,6 +26,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/require"
 )
 
 func loggedInUserScenario(t *testing.T, desc string, url string, fn scenarioFunc) {
@@ -148,12 +147,12 @@ func (sc *scenarioContext) fakeReqNoAssertionsWithCookie(method, url string, coo
 type scenarioContext struct {
 	t                    *testing.T
 	cfg                  *setting.Cfg
-	m                    *macaron.Macaron
+	m                    *web.Mux
 	context              *models.ReqContext
 	resp                 *httptest.ResponseRecorder
 	handlerFunc          handlerFunc
 	handlerFuncCtx       handlerFuncCtx
-	defaultHandler       macaron.Handler
+	defaultHandler       web.Handler
 	req                  *http.Request
 	url                  string
 	userAuthTokenService *auth.FakeUserAuthTokenService
@@ -200,8 +199,8 @@ func setupScenarioContext(t *testing.T, url string) *scenarioContext {
 	require.NoError(t, err)
 	require.Truef(t, exists, "Views should be in %q", viewsPath)
 
-	sc.m = macaron.New()
-	sc.m.UseMiddleware(macaron.Renderer(viewsPath, "[[", "]]"))
+	sc.m = web.New()
+	sc.m.UseMiddleware(web.Renderer(viewsPath, "[[", "]]"))
 	sc.m.Use(getContextHandler(t, cfg).Middleware)
 
 	return sc

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -8,19 +8,18 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/alerting"
-	"github.com/grafana/grafana/pkg/services/dashboards"
-	macaron "gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/dashdiffs"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 const (
@@ -71,7 +70,7 @@ func (hs *HTTPServer) TrimDashboard(c *models.ReqContext, cmd models.TrimDashboa
 }
 
 func (hs *HTTPServer) GetDashboard(c *models.ReqContext) response.Response {
-	uid := macaron.Params(c.Req)[":uid"]
+	uid := web.Params(c.Req)[":uid"]
 	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, uid)
 	if rsp != nil {
 		return rsp
@@ -215,7 +214,7 @@ func getDashboardHelper(ctx context.Context, orgID int64, id int64, uid string) 
 }
 
 func (hs *HTTPServer) DeleteDashboardBySlug(c *models.ReqContext) response.Response {
-	query := models.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: macaron.Params(c.Req)[":slug"]}
+	query := models.GetDashboardsBySlugQuery{OrgId: c.OrgId, Slug: web.Params(c.Req)[":slug"]}
 
 	if err := bus.Dispatch(&query); err != nil {
 		return response.Error(500, "Failed to retrieve dashboards by slug", err)
@@ -233,7 +232,7 @@ func (hs *HTTPServer) DeleteDashboardByUID(c *models.ReqContext) response.Respon
 }
 
 func (hs *HTTPServer) deleteDashboard(c *models.ReqContext) response.Response {
-	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, macaron.Params(c.Req)[":uid"])
+	dash, rsp := getDashboardHelper(c.Req.Context(), c.OrgId, 0, web.Params(c.Req)[":uid"])
 	if rsp != nil {
 		return rsp
 	}

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var client = &http.Client{
@@ -146,7 +146,7 @@ func CreateDashboardSnapshot(c *models.ReqContext, cmd models.CreateDashboardSna
 
 // GET /api/snapshots/:key
 func GetDashboardSnapshot(c *models.ReqContext) response.Response {
-	key := macaron.Params(c.Req)[":key"]
+	key := web.Params(c.Req)[":key"]
 	if len(key) == 0 {
 		return response.Error(404, "Snapshot not found", nil)
 	}
@@ -214,7 +214,7 @@ func deleteExternalDashboardSnapshot(externalUrl string) error {
 
 // GET /api/snapshots-delete/:deleteKey
 func DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) response.Response {
-	key := macaron.Params(c.Req)[":deleteKey"]
+	key := web.Params(c.Req)[":deleteKey"]
 	if len(key) == 0 {
 		return response.Error(404, "Snapshot not found", nil)
 	}
@@ -247,7 +247,7 @@ func DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) response.Response 
 
 // DELETE /api/snapshots/:key
 func DeleteDashboardSnapshot(c *models.ReqContext) response.Response {
-	key := macaron.Params(c.Req)[":key"]
+	key := web.Params(c.Req)[":key"]
 	if len(key) == 0 {
 		return response.Error(404, "Snapshot not found", nil)
 	}

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -26,15 +26,15 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
 )
 
 func TestGetHomeDashboard(t *testing.T) {
 	httpReq, err := http.NewRequest(http.MethodGet, "", nil)
 	require.NoError(t, err)
-	req := &models.ReqContext{SignedInUser: &models.SignedInUser{}, Context: &macaron.Context{Req: httpReq}}
+	req := &models.ReqContext{SignedInUser: &models.SignedInUser{}, Context: &web.Context{Req: httpReq}}
 	cfg := setting.NewCfg()
 	cfg.StaticRootPath = "../../public/"
 

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -17,7 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/adapters"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var datasourcesLogger = log.New("datasources")
@@ -119,7 +119,7 @@ func (hs *HTTPServer) DeleteDataSourceById(c *models.ReqContext) response.Respon
 
 // GET /api/datasources/uid/:uid
 func GetDataSourceByUID(c *models.ReqContext) response.Response {
-	ds, err := getRawDataSourceByUID(macaron.Params(c.Req)[":uid"], c.OrgId)
+	ds, err := getRawDataSourceByUID(web.Params(c.Req)[":uid"], c.OrgId)
 
 	if err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -134,7 +134,7 @@ func GetDataSourceByUID(c *models.ReqContext) response.Response {
 
 // DELETE /api/datasources/uid/:uid
 func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Response {
-	uid := macaron.Params(c.Req)[":uid"]
+	uid := web.Params(c.Req)[":uid"]
 
 	if uid == "" {
 		return response.Error(400, "Missing datasource uid", nil)
@@ -165,7 +165,7 @@ func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Respo
 }
 
 func (hs *HTTPServer) DeleteDataSourceByName(c *models.ReqContext) response.Response {
-	name := macaron.Params(c.Req)[":name"]
+	name := web.Params(c.Req)[":name"]
 
 	if name == "" {
 		return response.Error(400, "Missing valid datasource name", nil)
@@ -334,7 +334,7 @@ func getRawDataSourceByUID(uid string, orgID int64) (*models.DataSource, error) 
 
 // Get /api/datasources/name/:name
 func GetDataSourceByName(c *models.ReqContext) response.Response {
-	query := models.GetDataSourceQuery{Name: macaron.Params(c.Req)[":name"], OrgId: c.OrgId}
+	query := models.GetDataSourceQuery{Name: web.Params(c.Req)[":name"], OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -349,7 +349,7 @@ func GetDataSourceByName(c *models.ReqContext) response.Response {
 
 // Get /api/datasources/id/:name
 func GetDataSourceIdByName(c *models.ReqContext) response.Response {
-	query := models.GetDataSourceQuery{Name: macaron.Params(c.Req)[":name"], OrgId: c.OrgId}
+	query := models.GetDataSourceQuery{Name: web.Params(c.Req)[":name"], OrgId: c.OrgId}
 
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrDataSourceNotFound) {
@@ -397,7 +397,7 @@ func (hs *HTTPServer) CallDatasourceResource(c *models.ReqContext) {
 		PluginID:                   plugin.Id,
 		DataSourceInstanceSettings: dsInstanceSettings,
 	}
-	hs.BackendPluginManager.CallResource(pCtx, c, macaron.Params(c.Req)["*"])
+	hs.BackendPluginManager.CallResource(pCtx, c, web.Params(c.Req)["*"])
 }
 
 func convertModelToDtos(ds *models.DataSource) dtos.DataSource {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func (hs *HTTPServer) GetFolders(c *models.ReqContext) response.Response {
@@ -39,7 +39,7 @@ func (hs *HTTPServer) GetFolders(c *models.ReqContext) response.Response {
 
 func (hs *HTTPServer) GetFolderByUID(c *models.ReqContext) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Params(c.Req)[":uid"])
+	folder, err := s.GetFolderByUID(c.Req.Context(), web.Params(c.Req)[":uid"])
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -79,7 +79,7 @@ func (hs *HTTPServer) CreateFolder(c *models.ReqContext, cmd models.CreateFolder
 
 func (hs *HTTPServer) UpdateFolder(c *models.ReqContext, cmd models.UpdateFolderCommand) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	err := s.UpdateFolder(c.Req.Context(), macaron.Params(c.Req)[":uid"], &cmd)
+	err := s.UpdateFolder(c.Req.Context(), web.Params(c.Req)[":uid"], &cmd)
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}
@@ -90,7 +90,7 @@ func (hs *HTTPServer) UpdateFolder(c *models.ReqContext, cmd models.UpdateFolder
 
 func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // temporarily adding this function to HTTPServer, will be removed from HTTPServer when librarypanels featuretoggle is removed
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	err := hs.LibraryElementService.DeleteLibraryElementsInFolder(c.Req.Context(), c.SignedInUser, macaron.Params(c.Req)[":uid"])
+	err := hs.LibraryElementService.DeleteLibraryElementsInFolder(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":uid"])
 	if err != nil {
 		if errors.Is(err, libraryelements.ErrFolderHasConnectedLibraryElements) {
 			return response.Error(403, "Folder could not be deleted because it contains library elements in use", err)
@@ -98,7 +98,7 @@ func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // 
 		return apierrors.ToFolderErrorResponse(err)
 	}
 
-	f, err := s.DeleteFolder(c.Req.Context(), macaron.Params(c.Req)[":uid"], c.QueryBool("forceDeleteRules"))
+	f, err := s.DeleteFolder(c.Req.Context(), web.Params(c.Req)[":uid"], c.QueryBool("forceDeleteRules"))
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}

--- a/pkg/api/folder_permission.go
+++ b/pkg/api/folder_permission.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"time"
 
-	macaron "gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/api/apierrors"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -13,11 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func (hs *HTTPServer) GetFolderPermissionList(c *models.ReqContext) response.Response {
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Params(c.Req)[":uid"])
+	folder, err := s.GetFolderByUID(c.Req.Context(), web.Params(c.Req)[":uid"])
 
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
@@ -65,7 +64,7 @@ func (hs *HTTPServer) UpdateFolderPermissions(c *models.ReqContext, apiCmd dtos.
 	}
 
 	s := dashboards.NewFolderService(c.OrgId, c.SignedInUser, hs.SQLStore)
-	folder, err := s.GetFolderByUID(c.Req.Context(), macaron.Params(c.Req)[":uid"])
+	folder, err := s.GetFolderByUID(c.Req.Context(), web.Params(c.Req)[":uid"])
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -7,10 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/plugins/manager"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
@@ -18,9 +14,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) (*macaron.Macaron, *HTTPServer) {
+func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) (*web.Mux, *HTTPServer) {
 	t.Helper()
 	sqlstore.InitTestDB(t)
 
@@ -53,9 +52,9 @@ func setupTestEnvironment(t *testing.T, cfg *setting.Cfg) (*macaron.Macaron, *HT
 		AccessControl: accesscontrolmock.New().WithDisabled(),
 	}
 
-	m := macaron.New()
+	m := web.New()
 	m.Use(getContextHandler(t, cfg).Middleware)
-	m.UseMiddleware(macaron.Renderer(filepath.Join(setting.StaticRootPath, "views"), "[[", "]]"))
+	m.UseMiddleware(web.Renderer(filepath.Join(setting.StaticRootPath, "views"), "[[", "]]"))
 	m.Get("/api/frontend/settings/", hs.GetFrontendSettings)
 
 	return m, hs

--- a/pkg/api/grafana_com_proxy.go
+++ b/pkg/api/grafana_com_proxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var grafanaComProxyTransport = &http.Transport{
@@ -42,7 +42,7 @@ func ReverseProxyGnetReq(proxyPath string) *httputil.ReverseProxy {
 }
 
 func ProxyGnetRequest(c *models.ReqContext) {
-	proxyPath := macaron.Params(c.Req)["*"]
+	proxyPath := web.Params(c.Req)["*"]
 	proxy := ReverseProxyGnetReq(proxyPath)
 	proxy.Transport = grafanaComProxyTransport
 	proxy.ServeHTTP(c.Resp, c.Req)

--- a/pkg/api/health_test.go
+++ b/pkg/api/health_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
-	macaron "gopkg.in/macaron.v1"
 )
 
 func TestHealthAPI_Version(t *testing.T) {
@@ -167,13 +167,13 @@ func TestHealthAPI_DatabaseHealthCached(t *testing.T) {
 	require.True(t, healthy.(bool))
 }
 
-func setupHealthAPITestEnvironment(t *testing.T, cbs ...func(*setting.Cfg)) (*macaron.Macaron, *HTTPServer) {
+func setupHealthAPITestEnvironment(t *testing.T, cbs ...func(*setting.Cfg)) (*web.Mux, *HTTPServer) {
 	t.Helper()
 
 	bus.ClearBusHandlers()
 	t.Cleanup(bus.ClearBusHandlers)
 
-	m := macaron.New()
+	m := web.New()
 	cfg := setting.NewCfg()
 	for _, cb := range cbs {
 		cb(cfg)

--- a/pkg/api/ldap_debug.go
+++ b/pkg/api/ldap_debug.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/multildap"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var (
@@ -239,7 +239,7 @@ func (hs *HTTPServer) GetUserFromLDAP(c *models.ReqContext) response.Response {
 
 	ldap := newLDAP(ldapConfig.Servers)
 
-	username := macaron.Params(c.Req)[":username"]
+	username := web.Params(c.Req)[":username"]
 
 	if len(username) == 0 {
 		return response.Error(http.StatusBadRequest, "Validation error. You must specify an username", nil)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -19,7 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 const (
@@ -173,7 +173,7 @@ func (hs *HTTPServer) LoginAPIPing(c *models.ReqContext) response.Response {
 
 func (hs *HTTPServer) LoginPost(c *models.ReqContext) response.Response {
 	cmd := dtos.LoginCommand{}
-	if err := macaron.Bind(c.Req, &cmd); err != nil {
+	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad login data", err)
 	}
 	authModule := ""

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -11,9 +11,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"golang.org/x/oauth2"
-	macaron "gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -22,6 +19,8 @@ import (
 	"github.com/grafana/grafana/pkg/middleware/cookies"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -42,7 +41,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	loginInfo := models.LoginInfo{
 		AuthModule: "oauth",
 	}
-	name := macaron.Params(ctx.Req)[":name"]
+	name := web.Params(ctx.Req)[":name"]
 	loginInfo.AuthModule = name
 	provider := hs.SocialService.GetOAuthInfoProvider(name)
 	if provider == nil {

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // GET /api/org
@@ -25,7 +25,7 @@ func GetOrgByID(c *models.ReqContext) response.Response {
 
 // Get /api/orgs/name/:name
 func (hs *HTTPServer) GetOrgByName(c *models.ReqContext) response.Response {
-	org, err := hs.SQLStore.GetOrgByName(macaron.Params(c.Req)[":name"])
+	org, err := hs.SQLStore.GetOrgByName(web.Params(c.Req)[":name"])
 	if err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
 			return response.Error(404, "Organization not found", err)

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func GetPendingOrgInvites(c *models.ReqContext) response.Response {
@@ -132,7 +132,7 @@ func inviteExistingUserToOrg(c *models.ReqContext, user *models.User, inviteDto 
 }
 
 func RevokeInvite(c *models.ReqContext) response.Response {
-	if ok, rsp := updateTempUserStatus(macaron.Params(c.Req)[":code"], models.TmpUserRevoked); !ok {
+	if ok, rsp := updateTempUserStatus(web.Params(c.Req)[":code"], models.TmpUserRevoked); !ok {
 		return rsp
 	}
 
@@ -143,7 +143,7 @@ func RevokeInvite(c *models.ReqContext) response.Response {
 // A response containing an InviteInfo object is returned if the invite is found.
 // If a (pending) invite is not found, 404 is returned.
 func GetInviteInfoByCode(c *models.ReqContext) response.Response {
-	query := models.GetTempUserByCodeQuery{Code: macaron.Params(c.Req)[":code"]}
+	query := models.GetTempUserByCodeQuery{Code: web.Params(c.Req)[":code"]}
 	if err := bus.Dispatch(&query); err != nil {
 		if errors.Is(err, models.ErrTempUserNotFound) {
 			return response.Error(404, "Invite not found", nil)

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/encryption/ossencryption"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
-	"gopkg.in/macaron.v1"
 )
 
 func TestDataSourceProxy_routeRule(t *testing.T) {
@@ -114,7 +114,7 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 			req, err := http.NewRequest("GET", "http://localhost/asd", nil)
 			require.NoError(t, err)
 			ctx := &models.ReqContext{
-				Context:      &macaron.Context{Req: req},
+				Context:      &web.Context{Req: req},
 				SignedInUser: &models.SignedInUser{OrgRole: models.ROLE_EDITOR},
 			}
 			return ctx, req
@@ -255,7 +255,7 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://localhost/asd", nil)
 		require.NoError(t, err)
 		ctx := &models.ReqContext{
-			Context:      &macaron.Context{Req: req},
+			Context:      &web.Context{Req: req},
 			SignedInUser: &models.SignedInUser{OrgRole: models.ROLE_EDITOR},
 		}
 
@@ -483,7 +483,7 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 		require.NoError(t, err)
 		ctx := &models.ReqContext{
 			SignedInUser: &models.SignedInUser{UserId: 1},
-			Context:      &macaron.Context{Req: req},
+			Context:      &web.Context{Req: req},
 		}
 		mockAuthToken := mockOAuthTokenService{
 			token: &oauth2.Token{
@@ -600,7 +600,7 @@ func TestDataSourceProxy_requestHandling(t *testing.T) {
 
 		ds := &models.DataSource{Url: backend.URL, Type: models.DS_GRAPHITE}
 
-		responseWriter := macaron.NewResponseWriter("GET", httptest.NewRecorder())
+		responseWriter := web.NewResponseWriter("GET", httptest.NewRecorder())
 
 		// XXX: Really unsure why, but setting headers within the HTTP handler function doesn't stick,
 		// so doing it here instead
@@ -612,7 +612,7 @@ func TestDataSourceProxy_requestHandling(t *testing.T) {
 
 		return &models.ReqContext{
 			SignedInUser: &models.SignedInUser{},
-			Context: &macaron.Context{
+			Context: &web.Context{
 				Req:  httptest.NewRequest("GET", "/render", nil),
 				Resp: responseWriter,
 			},
@@ -694,7 +694,7 @@ func TestDataSourceProxy_requestHandling(t *testing.T) {
 
 func TestNewDataSourceProxy_InvalidURL(t *testing.T) {
 	ctx := models.ReqContext{
-		Context:      &macaron.Context{},
+		Context:      &web.Context{},
 		SignedInUser: &models.SignedInUser{OrgRole: models.ROLE_EDITOR},
 	}
 	ds := models.DataSource{
@@ -711,7 +711,7 @@ func TestNewDataSourceProxy_InvalidURL(t *testing.T) {
 
 func TestNewDataSourceProxy_ProtocolLessURL(t *testing.T) {
 	ctx := models.ReqContext{
-		Context:      &macaron.Context{},
+		Context:      &web.Context{},
 		SignedInUser: &models.SignedInUser{OrgRole: models.ROLE_EDITOR},
 	}
 	ds := models.DataSource{
@@ -730,7 +730,7 @@ func TestNewDataSourceProxy_ProtocolLessURL(t *testing.T) {
 // Test wth MSSQL type data sources.
 func TestNewDataSourceProxy_MSSQL(t *testing.T) {
 	ctx := models.ReqContext{
-		Context:      &macaron.Context{},
+		Context:      &web.Context{},
 		SignedInUser: &models.SignedInUser{OrgRole: models.ROLE_EDITOR},
 	}
 	tcs := []struct {
@@ -939,7 +939,7 @@ func Test_PathCheck(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://localhost/asd", nil)
 		require.NoError(t, err)
 		ctx := &models.ReqContext{
-			Context:      &macaron.Context{Req: req},
+			Context:      &web.Context{Req: req},
 			SignedInUser: &models.SignedInUser{OrgRole: models.ROLE_VIEWER},
 		}
 		return ctx, req

--- a/pkg/api/quota.go
+++ b/pkg/api/quota.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func GetOrgQuotas(c *models.ReqContext) response.Response {
@@ -26,7 +26,7 @@ func UpdateOrgQuota(c *models.ReqContext, cmd models.UpdateOrgQuotaCmd) response
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.OrgId = c.ParamsInt64(":orgId")
-	cmd.Target = macaron.Params(c.Req)[":target"]
+	cmd.Target = web.Params(c.Req)[":target"]
 
 	if _, ok := setting.Quota.Org.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)
@@ -56,7 +56,7 @@ func UpdateUserQuota(c *models.ReqContext, cmd models.UpdateUserQuotaCmd) respon
 		return response.Error(404, "Quotas not enabled", nil)
 	}
 	cmd.UserId = c.ParamsInt64(":id")
-	cmd.Target = macaron.Params(c.Req)[":target"]
+	cmd.Target = web.Params(c.Req)[":target"]
 
 	if _, ok := setting.Quota.User.ToMap()[cmd.Target]; !ok {
 		return response.Error(404, "Invalid quota target", nil)

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func (hs *HTTPServer) RenderToPng(c *models.ReqContext) {
@@ -59,7 +59,7 @@ func (hs *HTTPServer) RenderToPng(c *models.ReqContext) {
 		OrgID:             c.OrgId,
 		UserID:            c.UserId,
 		OrgRole:           c.OrgRole,
-		Path:              macaron.Params(c.Req)["*"] + queryParams,
+		Path:              web.Params(c.Req)["*"] + queryParams,
 		Timezone:          queryReader.Get("tz", ""),
 		Encoding:          queryReader.Get("encoding", ""),
 		ConcurrentLimit:   hs.Cfg.RendererConcurrentRequestLimit,

--- a/pkg/api/routing/route_register_test.go
+++ b/pkg/api/routing/route_register_test.go
@@ -5,14 +5,14 @@ import (
 	"strconv"
 	"testing"
 
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 type fakeRouter struct {
 	route []route
 }
 
-func (fr *fakeRouter) Handle(method, pattern string, handlers []macaron.Handler) {
+func (fr *fakeRouter) Handle(method, pattern string, handlers []web.Handler) {
 	fr.route = append(fr.route, route{
 		pattern:  pattern,
 		method:   method,
@@ -20,7 +20,7 @@ func (fr *fakeRouter) Handle(method, pattern string, handlers []macaron.Handler)
 	})
 }
 
-func (fr *fakeRouter) Get(pattern string, handlers ...macaron.Handler) {
+func (fr *fakeRouter) Get(pattern string, handlers ...web.Handler) {
 	fr.route = append(fr.route, route{
 		pattern:  pattern,
 		method:   http.MethodGet,
@@ -28,15 +28,15 @@ func (fr *fakeRouter) Get(pattern string, handlers ...macaron.Handler) {
 	})
 }
 
-func emptyHandlers(n int) []macaron.Handler {
-	var res []macaron.Handler
+func emptyHandlers(n int) []web.Handler {
+	var res []web.Handler
 	for i := 1; n >= i; i++ {
 		res = append(res, emptyHandler(strconv.Itoa(i)))
 	}
 	return res
 }
 
-func emptyHandler(name string) macaron.Handler {
+func emptyHandler(name string) web.Handler {
 	return struct{ name string }{name: name}
 }
 
@@ -212,7 +212,7 @@ func TestNamedMiddlewareRouteRegister(t *testing.T) {
 
 	namedMiddlewares := map[string]bool{}
 	// Setup
-	rr := NewRouteRegister(func(name string) macaron.Handler {
+	rr := NewRouteRegister(func(name string) web.Handler {
 		namedMiddlewares[name] = true
 
 		return struct{ name string }{name: name}

--- a/pkg/api/routing/routing.go
+++ b/pkg/api/routing/routing.go
@@ -3,7 +3,7 @@ package routing
 import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var (
@@ -12,7 +12,7 @@ var (
 	}
 )
 
-func Wrap(action interface{}) macaron.Handler {
+func Wrap(action interface{}) web.Handler {
 	return func(c *models.ReqContext) {
 		var res response.Response
 		val, err := c.Invoke(action)

--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // createShortURL handles requests to create short URLs.
@@ -46,7 +46,7 @@ func (hs *HTTPServer) createShortURL(c *models.ReqContext, cmd dtos.CreateShortU
 }
 
 func (hs *HTTPServer) redirectFromShortURL(c *models.ReqContext) {
-	shortURLUID := macaron.Params(c.Req)[":uid"]
+	shortURLUID := web.Params(c.Req)[":uid"]
 
 	if !util.IsValidShortUID(shortURLUID) {
 		return

--- a/pkg/api/static/static.go
+++ b/pkg/api/static/static.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var Root string
@@ -39,7 +39,7 @@ func init() {
 	}
 }
 
-// StaticOptions is a struct for specifying configuration options for the macaron.Static middleware.
+// StaticOptions is a struct for specifying configuration options for the web.Static middleware.
 type StaticOptions struct {
 	// Prefix is the optional prefix used to serve the static directory content
 	Prefix string
@@ -49,7 +49,7 @@ type StaticOptions struct {
 	IndexFile string
 	// Expires defines which user-defined function to use for producing a HTTP Expires Header
 	// https://developers.google.com/speed/docs/insights/LeverageBrowserCaching
-	AddHeaders func(ctx *macaron.Context)
+	AddHeaders func(ctx *web.Context)
 	// FileSystem is the interface for supporting any implementation of file system.
 	FileSystem http.FileSystem
 }
@@ -115,7 +115,7 @@ func prepareStaticOptions(dir string, options []StaticOptions) StaticOptions {
 	return prepareStaticOption(dir, opt)
 }
 
-func staticHandler(ctx *macaron.Context, log log.Logger, opt StaticOptions) bool {
+func staticHandler(ctx *web.Context, log log.Logger, opt StaticOptions) bool {
 	if ctx.Req.Method != "GET" && ctx.Req.Method != "HEAD" {
 		return false
 	}
@@ -195,11 +195,11 @@ func staticHandler(ctx *macaron.Context, log log.Logger, opt StaticOptions) bool
 }
 
 // Static returns a middleware handler that serves static files in the given directory.
-func Static(directory string, staticOpt ...StaticOptions) macaron.Handler {
+func Static(directory string, staticOpt ...StaticOptions) web.Handler {
 	opt := prepareStaticOptions(directory, staticOpt)
 
 	logger := log.New("static")
-	return func(ctx *macaron.Context) {
+	return func(ctx *web.Context) {
 		staticHandler(ctx, logger, opt)
 	}
 }

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -3,13 +3,12 @@ package api
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
-	macaron "gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 
 	"net/http"
 
@@ -126,7 +125,7 @@ func TestTeamAPIEndpoint(t *testing.T) {
 		t.Run("with no real signed in user", func(t *testing.T) {
 			stub := &testLogger{}
 			c := &models.ReqContext{
-				Context:      &macaron.Context{Req: req},
+				Context:      &web.Context{Req: req},
 				SignedInUser: &models.SignedInUser{},
 				Logger:       stub,
 			}
@@ -142,7 +141,7 @@ func TestTeamAPIEndpoint(t *testing.T) {
 		t.Run("with real signed in user", func(t *testing.T) {
 			stub := &testLogger{}
 			c := &models.ReqContext{
-				Context:      &macaron.Context{Req: req},
+				Context:      &web.Context{Req: req},
 				SignedInUser: &models.SignedInUser{UserId: 42},
 				Logger:       stub,
 			}

--- a/pkg/macaron/macaron.go
+++ b/pkg/macaron/macaron.go
@@ -16,7 +16,7 @@
 // under the License.
 
 // Package macaron is a high productive and modular web framework in Go.
-package macaron // import "gopkg.in/macaron.v1"
+package macaron // import "gopkg.in/web.v1"
 
 import (
 	"context"
@@ -107,7 +107,7 @@ func New() *Macaron {
 // Macaron stops future process when it returns true.
 type BeforeHandler func(rw http.ResponseWriter, req *http.Request) bool
 
-// macaronContextKey is used to store/fetch macaron.Context inside context.Context
+// macaronContextKey is used to store/fetch web.Context inside context.Context
 type macaronContextKey struct{}
 
 // FromContext returns the macaron context stored in a context.Context, if any.
@@ -137,7 +137,7 @@ func SetURLParams(r *http.Request, vars map[string]string) *http.Request {
 // A middleware is a function that has a reference to the next handler in the chain
 // and returns the actual middleware handler, that may do its job and optionally
 // call next.
-// Due to how Macaron handles/injects requests and responses we patch the macaron.Context
+// Due to how Macaron handles/injects requests and responses we patch the web.Context
 // to use the new ResponseWriter and http.Request here. The caller may only call
 // `next.ServeHTTP(rw, req)` to pass a modified response writer and/or a request to the
 // further middlewares in the chain.

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -7,12 +7,11 @@ import (
 	"strconv"
 	"strings"
 
-	macaron "gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/middleware/cookies"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 type AuthOptions struct {
@@ -80,7 +79,7 @@ func EnsureEditorOrViewerCanEdit(c *models.ReqContext) {
 	}
 }
 
-func RoleAuth(roles ...models.RoleType) macaron.Handler {
+func RoleAuth(roles ...models.RoleType) web.Handler {
 	return func(c *models.ReqContext) {
 		ok := false
 		for _, role := range roles {
@@ -95,7 +94,7 @@ func RoleAuth(roles ...models.RoleType) macaron.Handler {
 	}
 }
 
-func Auth(options *AuthOptions) macaron.Handler {
+func Auth(options *AuthOptions) web.Handler {
 	return func(c *models.ReqContext) {
 		forceLogin := false
 		if c.AllowAnonymous {
@@ -134,7 +133,7 @@ func Auth(options *AuthOptions) macaron.Handler {
 // feature flag is enabled.
 // Intended for when feature flags open up access to APIs that
 // are otherwise only available to admins.
-func AdminOrFeatureEnabled(enabled bool) macaron.Handler {
+func AdminOrFeatureEnabled(enabled bool) web.Handler {
 	return func(c *models.ReqContext) {
 		if c.OrgRole == models.ROLE_ADMIN {
 			return
@@ -148,7 +147,7 @@ func AdminOrFeatureEnabled(enabled bool) macaron.Handler {
 
 // SnapshotPublicModeOrSignedIn creates a middleware that allows access
 // if snapshot public mode is enabled or if user is signed in.
-func SnapshotPublicModeOrSignedIn(cfg *setting.Cfg) macaron.Handler {
+func SnapshotPublicModeOrSignedIn(cfg *setting.Cfg) web.Handler {
 	return func(c *models.ReqContext) {
 		if cfg.SnapshotPublicMode {
 			return
@@ -169,7 +168,7 @@ func ReqNotSignedIn(c *models.ReqContext) {
 
 // NoAuth creates a middleware that doesn't require any authentication.
 // If forceLogin param is set it will redirect the user to the login page.
-func NoAuth() macaron.Handler {
+func NoAuth() web.Handler {
 	return func(c *models.ReqContext) {
 		if shouldForceLogin(c) {
 			notAuthorized(c)

--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 	"strings"
 
-	macaron "gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 type gzipResponseWriter struct {
 	w *gzip.Writer
-	macaron.ResponseWriter
+	web.ResponseWriter
 }
 
 func (grw *gzipResponseWriter) WriteHeader(c int) {
@@ -68,7 +68,7 @@ func Gziper() func(http.Handler) http.Handler {
 				return
 			}
 
-			grw := &gzipResponseWriter{gzip.NewWriter(rw), rw.(macaron.ResponseWriter)}
+			grw := &gzipResponseWriter{gzip.NewWriter(rw), rw.(web.ResponseWriter)}
 			grw.Header().Set("Content-Encoding", "gzip")
 			grw.Header().Set("Vary", "Accept-Encoding")
 

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -21,15 +21,15 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	cw "github.com/weaveworks/common/middleware"
-	"gopkg.in/macaron.v1"
 )
 
-func Logger(cfg *setting.Cfg) macaron.Handler {
-	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
+func Logger(cfg *setting.Cfg) web.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c *web.Context) {
 		start := time.Now()
 
-		rw := res.(macaron.ResponseWriter)
+		rw := res.(web.ResponseWriter)
 		c.Next()
 
 		timeTaken := time.Since(start) / time.Millisecond

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	macaron "gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var (
@@ -25,9 +24,9 @@ func HandleNoCacheHeader(ctx *models.ReqContext) {
 	ctx.SkipCache = ctx.Req.Header.Get("X-Grafana-NoCache") == "true"
 }
 
-func AddDefaultResponseHeaders(cfg *setting.Cfg) macaron.Handler {
-	return func(c *macaron.Context) {
-		c.Resp.Before(func(w macaron.ResponseWriter) {
+func AddDefaultResponseHeaders(cfg *setting.Cfg) web.Handler {
+	return func(c *web.Context) {
+		c.Resp.Before(func(w web.ResponseWriter) {
 			// if response has already been written, skip.
 			if w.Written() {
 				return
@@ -47,7 +46,7 @@ func AddDefaultResponseHeaders(cfg *setting.Cfg) macaron.Handler {
 }
 
 // addSecurityHeaders adds HTTP(S) response headers that enable various security protections in the client's browser.
-func addSecurityHeaders(w macaron.ResponseWriter, cfg *setting.Cfg) {
+func addSecurityHeaders(w web.ResponseWriter, cfg *setting.Cfg) {
 	if (cfg.Protocol == setting.HTTPSScheme || cfg.Protocol == setting.HTTP2Scheme) && cfg.StrictTransportSecurity {
 		strictHeaderValues := []string{fmt.Sprintf("max-age=%v", cfg.StrictTransportSecurityMaxAge)}
 		if cfg.StrictTransportSecurityPreload {
@@ -68,12 +67,12 @@ func addSecurityHeaders(w macaron.ResponseWriter, cfg *setting.Cfg) {
 	}
 }
 
-func addNoCacheHeaders(w macaron.ResponseWriter) {
+func addNoCacheHeaders(w web.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "-1")
 }
 
-func addXFrameOptionsDenyHeader(w macaron.ResponseWriter) {
+func addXFrameOptionsDenyHeader(w web.ResponseWriter) {
 	w.Header().Set("X-Frame-Options", "deny")
 }

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -11,10 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/bus"
@@ -30,6 +26,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func fakeGetTime() func() time.Time {
@@ -628,10 +627,10 @@ func middlewareScenario(t *testing.T, desc string, fn scenarioFunc, cbs ...func(
 		require.NoError(t, err)
 		require.Truef(t, exists, "Views directory should exist at %q", viewsPath)
 
-		sc.m = macaron.New()
+		sc.m = web.New()
 		sc.m.Use(AddDefaultResponseHeaders(cfg))
 		sc.m.UseMiddleware(AddCSPHeader(cfg, logger))
-		sc.m.UseMiddleware(macaron.Renderer(viewsPath, "[[", "]]"))
+		sc.m.UseMiddleware(web.Renderer(viewsPath, "[[", "]]"))
 
 		ctxHdlr := getContextHandler(t, cfg)
 		sc.sqlStore = ctxHdlr.SQLStore

--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -10,13 +10,13 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/setting"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // OrgRedirect changes org and redirects users if the
 // querystring `orgId` doesn't match the active org.
-func OrgRedirect(cfg *setting.Cfg) macaron.Handler {
-	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
+func OrgRedirect(cfg *setting.Cfg) web.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c *web.Context) {
 		orgIdValue := req.URL.Query().Get("orgId")
 		orgId, err := strconv.ParseInt(orgIdValue, 10, 64)
 

--- a/pkg/middleware/quota.go
+++ b/pkg/middleware/quota.go
@@ -3,19 +3,18 @@ package middleware
 import (
 	"fmt"
 
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/quota"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 // Quota returns a function that returns a function used to call quotaservice based on target name
-func Quota(quotaService *quota.QuotaService) func(string) macaron.Handler {
+func Quota(quotaService *quota.QuotaService) func(string) web.Handler {
 	if quotaService == nil {
 		panic("quotaService is nil")
 	}
 	//https://open.spotify.com/track/7bZSoBEAEEUsGEuLOf94Jm?si=T1Tdju5qRSmmR0zph_6RBw fuuuuunky
-	return func(target string) macaron.Handler {
+	return func(target string) web.Handler {
 		return func(c *models.ReqContext) {
 			limitReached, err := quotaService.QuotaReached(c, target)
 			if err != nil {

--- a/pkg/middleware/quota_test.go
+++ b/pkg/middleware/quota_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
-	macaron "gopkg.in/macaron.v1"
 )
 
 func TestMiddlewareQuota(t *testing.T) {
@@ -266,7 +266,7 @@ func TestMiddlewareQuota(t *testing.T) {
 	})
 }
 
-func getQuotaHandler(sc *scenarioContext, target string) macaron.Handler {
+func getQuotaHandler(sc *scenarioContext, target string) web.Handler {
 	fakeAuthTokenService := auth.NewFakeUserAuthTokenService()
 	qs := &quota.QuotaService{
 		AuthTokenService: fakeAuthTokenService,

--- a/pkg/middleware/rate_limit.go
+++ b/pkg/middleware/rate_limit.go
@@ -3,10 +3,9 @@ package middleware
 import (
 	"time"
 
-	"golang.org/x/time/rate"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/web"
+	"golang.org/x/time/rate"
 )
 
 type getTimeFn func() time.Time
@@ -14,7 +13,7 @@ type getTimeFn func() time.Time
 // RateLimit is a very basic rate limiter.
 // Will allow average of "rps" requests per second over an extended period of time, with max "burst" requests at the same time.
 // getTime should return the current time. For non-testing purposes use time.Now
-func RateLimit(rps, burst int, getTime getTimeFn) macaron.Handler {
+func RateLimit(rps, burst int, getTime getTimeFn) web.Handler {
 	l := rate.NewLimiter(rate.Limit(rps), burst)
 	return func(c *models.ReqContext) {
 		if !l.AllowN(getTime(), 1) {

--- a/pkg/middleware/rate_limit_test.go
+++ b/pkg/middleware/rate_limit_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
 
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
 )
 
 type execFunc func() *httptest.ResponseRecorder
@@ -31,8 +31,8 @@ func rateLimiterScenario(t *testing.T, desc string, rps int, burst int, fn rateL
 
 		cfg := setting.NewCfg()
 
-		m := macaron.New()
-		m.UseMiddleware(macaron.Renderer("../../public/views", "[[", "]]"))
+		m := web.New()
+		m.UseMiddleware(web.Renderer("../../public/views", "[[", "]]"))
 		m.Use(getContextHandler(t, cfg).Middleware)
 		m.Get("/foo", RateLimit(rps, burst, func() time.Time { return currentTime }), defaultHandler)
 

--- a/pkg/middleware/recovery.go
+++ b/pkg/middleware/recovery.go
@@ -23,11 +23,10 @@ import (
 	"net/http"
 	"runtime"
 
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var (
@@ -103,8 +102,8 @@ func function(pc uintptr) []byte {
 
 // Recovery returns a middleware that recovers from any panics and writes a 500 if there was one.
 // While Martini is in development mode, Recovery will also output the panic as HTML.
-func Recovery(cfg *setting.Cfg) macaron.Handler {
-	return func(c *macaron.Context) {
+func Recovery(cfg *setting.Cfg) web.Handler {
+	return func(c *web.Context) {
 		defer func() {
 			if r := recover(); r != nil {
 				panicLogger := log.Root

--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	macaron "gopkg.in/macaron.v1"
 )
 
 func TestRecoveryMiddleware(t *testing.T) {
@@ -61,11 +61,11 @@ func recoveryScenario(t *testing.T, desc string, url string, fn scenarioFunc) {
 		viewsPath, err := filepath.Abs("../../public/views")
 		require.NoError(t, err)
 
-		sc.m = macaron.New()
+		sc.m = web.New()
 		sc.m.Use(Recovery(cfg))
 
 		sc.m.Use(AddDefaultResponseHeaders(cfg))
-		sc.m.UseMiddleware(macaron.Renderer(viewsPath, "[[", "]]"))
+		sc.m.UseMiddleware(web.Renderer(viewsPath, "[[", "]]"))
 
 		sc.userAuthTokenService = auth.NewFakeUserAuthTokenService()
 		sc.remoteCacheService = remotecache.NewFakeStore(t)

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/prometheus/client_golang/prometheus"
 	cw "github.com/weaveworks/common/middleware"
-	"gopkg.in/macaron.v1"
 )
 
 var (
@@ -45,10 +45,10 @@ func init() {
 }
 
 // RequestMetrics is a middleware handler that instruments the request.
-func RequestMetrics(cfg *setting.Cfg) func(handler string) macaron.Handler {
-	return func(handler string) macaron.Handler {
-		return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
-			rw := res.(macaron.ResponseWriter)
+func RequestMetrics(cfg *setting.Cfg) func(handler string) web.Handler {
+	return func(handler string) web.Handler {
+		return func(res http.ResponseWriter, req *http.Request, c *web.Context) {
+			rw := res.(web.ResponseWriter)
 			now := time.Now()
 			httpRequestsInFlight.Inc()
 			defer httpRequestsInFlight.Dec()

--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -9,7 +9,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 type contextKey struct{}
@@ -19,8 +19,8 @@ var routeOperationNameKey = contextKey{}
 // ProvideRouteOperationName creates a named middleware responsible for populating
 // the context with the route operation name that can be used later in the request pipeline.
 // Implements routing.RegisterNamedMiddleware.
-func ProvideRouteOperationName(name string) macaron.Handler {
-	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
+func ProvideRouteOperationName(name string) web.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c *web.Context) {
 		ctx := context.WithValue(c.Req.Context(), routeOperationNameKey, name)
 		c.Req = c.Req.WithContext(ctx)
 	}
@@ -36,15 +36,15 @@ func RouteOperationNameFromContext(ctx context.Context) (string, bool) {
 	return "", false
 }
 
-func RequestTracing() macaron.Handler {
-	return func(res http.ResponseWriter, req *http.Request, c *macaron.Context) {
+func RequestTracing() web.Handler {
+	return func(res http.ResponseWriter, req *http.Request, c *web.Context) {
 		if strings.HasPrefix(c.Req.URL.Path, "/public/") ||
 			c.Req.URL.Path == "robots.txt" {
 			c.Next()
 			return
 		}
 
-		rw := res.(macaron.ResponseWriter)
+		rw := res.(web.ResponseWriter)
 
 		tracer := opentracing.GlobalTracer()
 		wireContext, _ := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))

--- a/pkg/middleware/testing.go
+++ b/pkg/middleware/testing.go
@@ -6,20 +6,19 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
 )
 
 type scenarioContext struct {
 	t                    *testing.T
-	m                    *macaron.Macaron
+	m                    *web.Mux
 	context              *models.ReqContext
 	resp                 *httptest.ResponseRecorder
 	apiKey               string
@@ -28,7 +27,7 @@ type scenarioContext struct {
 	tokenSessionCookie   string
 	respJson             map[string]interface{}
 	handlerFunc          handlerFunc
-	defaultHandler       macaron.Handler
+	defaultHandler       web.Handler
 	url                  string
 	userAuthTokenService *auth.FakeUserAuthTokenService
 	jwtAuthService       *models.FakeJWTService

--- a/pkg/middleware/validate_host.go
+++ b/pkg/middleware/validate_host.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
-func ValidateHostHeader(cfg *setting.Cfg) macaron.Handler {
+func ValidateHostHeader(cfg *setting.Cfg) web.Handler {
 	return func(c *models.ReqContext) {
 		// ignore local render calls
 		if c.IsRenderCall {

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/prometheus/client_golang/prometheus"
-	"gopkg.in/macaron.v1"
 )
 
 type ReqContext struct {
-	*macaron.Context
+	*web.Context
 	*SignedInUser
 	UserToken *UserToken
 

--- a/pkg/models/context_test.go
+++ b/pkg/models/context_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
 )
 
 func TestQueryBoolWithDefault(t *testing.T) {
@@ -31,7 +31,7 @@ func TestQueryBoolWithDefault(t *testing.T) {
 			req, err := http.NewRequest("GET", tt.url, nil)
 			require.NoError(t, err)
 			r := ReqContext{
-				Context: &macaron.Context{Req: req},
+				Context: &web.Context{Req: req},
 			}
 			require.Equal(t, tt.expected, r.QueryBoolWithDefault("silenced", tt.defaultValue))
 		})

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -5,15 +5,14 @@ import (
 	"net/http"
 	"time"
 
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 )
 
-func Middleware(ac accesscontrol.AccessControl) func(macaron.Handler, accesscontrol.Evaluator) macaron.Handler {
-	return func(fallback macaron.Handler, evaluator accesscontrol.Evaluator) macaron.Handler {
+func Middleware(ac accesscontrol.AccessControl) func(web.Handler, accesscontrol.Evaluator) web.Handler {
+	return func(fallback web.Handler, evaluator accesscontrol.Evaluator) web.Handler {
 		if ac.IsDisabled() {
 			return fallback
 		}
@@ -73,6 +72,6 @@ func newID() string {
 func buildScopeParams(c *models.ReqContext) accesscontrol.ScopeParams {
 	return accesscontrol.ScopeParams{
 		OrgID:     c.OrgId,
-		URLParams: macaron.Params(c.Req),
+		URLParams: web.Params(c.Req),
 	}
 }

--- a/pkg/services/accesscontrol/middleware/middleware_test.go
+++ b/pkg/services/accesscontrol/middleware/middleware_test.go
@@ -5,8 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"gopkg.in/macaron.v1"
-
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -58,8 +57,8 @@ func TestMiddleware(t *testing.T) {
 				fallbackCalled = true
 			}
 
-			server := macaron.New()
-			server.UseMiddleware(macaron.Renderer("../../public/views", "[[", "]]"))
+			server := web.New()
+			server.UseMiddleware(web.Renderer("../../public/views", "[[", "]]"))
 
 			server.Use(contextProvider())
 			server.Use(Middleware(test.ac)(fallback, test.evaluator))
@@ -81,8 +80,8 @@ func TestMiddleware(t *testing.T) {
 	}
 }
 
-func contextProvider() macaron.Handler {
-	return func(c *macaron.Context) {
+func contextProvider() web.Handler {
+	return func(c *web.Context) {
 		reqCtx := &models.ReqContext{
 			Context:      c,
 			Logger:       log.New(""),

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
-	macaron "gopkg.in/macaron.v1"
 )
 
 // Test initContextWithAuthProxy with a cached user ID that is no longer valid.
@@ -58,7 +58,7 @@ func TestInitContextWithAuthProxy_CachedInvalidUserID(t *testing.T) {
 	req, err := http.NewRequest("POST", "http://example.com", nil)
 	require.NoError(t, err)
 	ctx := &models.ReqContext{
-		Context: &macaron.Context{Req: req},
+		Context: &web.Context{Req: req},
 		Logger:  log.New("Test"),
 	}
 	req.Header.Set(svc.Cfg.AuthProxyHeaderName, name)

--- a/pkg/services/contexthandler/authproxy/authproxy_test.go
+++ b/pkg/services/contexthandler/authproxy/authproxy_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/ldap"
 	"github.com/grafana/grafana/pkg/services/multildap"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
 )
 
 type fakeMultiLDAP struct {
@@ -64,7 +64,7 @@ func prepareMiddleware(t *testing.T, remoteCache *remotecache.RemoteCache, cb fu
 	}
 
 	ctx := &models.ReqContext{
-		Context: &macaron.Context{Req: req},
+		Context: &web.Context{Req: req},
 	}
 
 	auth := New(cfg, &Options{

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -21,10 +21,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/opentracing/opentracing-go"
 	ol "github.com/opentracing/opentracing-go/log"
 	cw "github.com/weaveworks/common/middleware"
-	"gopkg.in/macaron.v1"
 )
 
 const (
@@ -71,7 +71,7 @@ func FromContext(c context.Context) *models.ReqContext {
 }
 
 // Middleware provides a middleware to initialize the Macaron context.
-func (h *ContextHandler) Middleware(mContext *macaron.Context) {
+func (h *ContextHandler) Middleware(mContext *web.Context) {
 	span, _ := opentracing.StartSpanFromContext(mContext.Req.Context(), "Auth - Middleware")
 	defer span.Finish()
 
@@ -320,8 +320,8 @@ func (h *ContextHandler) initContextWithToken(reqContext *models.ReqContext, org
 }
 
 func (h *ContextHandler) rotateEndOfRequestFunc(reqContext *models.ReqContext, authTokenService models.UserTokenService,
-	token *models.UserToken) macaron.BeforeFunc {
-	return func(w macaron.ResponseWriter) {
+	token *models.UserToken) web.BeforeFunc {
+	return func(w web.ResponseWriter) {
 		// if response has already been written, skip.
 		if w.Written() {
 			return

--- a/pkg/services/contexthandler/contexthandler_test.go
+++ b/pkg/services/contexthandler/contexthandler_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	macaron "gopkg.in/macaron.v1"
 )
 
 func TestDontRotateTokensOnCancelledRequests(t *testing.T) {
@@ -96,7 +96,7 @@ func initTokenRotationScenario(ctx context.Context, t *testing.T, ctxHdlr *Conte
 		return nil, nil, err
 	}
 	reqContext := &models.ReqContext{
-		Context: &macaron.Context{Req: req},
+		Context: &web.Context{Req: req},
 		Logger:  log.New("testlogger"),
 	}
 
@@ -110,11 +110,11 @@ type mockWriter struct {
 	*httptest.ResponseRecorder
 }
 
-func (mw mockWriter) Flush()                    {}
-func (mw mockWriter) Status() int               { return 0 }
-func (mw mockWriter) Size() int                 { return 0 }
-func (mw mockWriter) Written() bool             { return false }
-func (mw mockWriter) Before(macaron.BeforeFunc) {}
+func (mw mockWriter) Flush()                {}
+func (mw mockWriter) Status() int           { return 0 }
+func (mw mockWriter) Size() int             { return 0 }
+func (mw mockWriter) Written() bool         { return false }
+func (mw mockWriter) Before(web.BeforeFunc) {}
 func (mw mockWriter) Push(target string, opts *http.PushOptions) error {
 	return nil
 }

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -4,12 +4,11 @@ import (
 	"errors"
 
 	"github.com/go-macaron/binding"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func (l *LibraryElementService) registerAPIEndpoints() {
@@ -36,7 +35,7 @@ func (l *LibraryElementService) createHandler(c *models.ReqContext, cmd CreateLi
 
 // deleteHandler handles DELETE /api/library-elements/:uid.
 func (l *LibraryElementService) deleteHandler(c *models.ReqContext) response.Response {
-	err := l.deleteLibraryElement(c.Req.Context(), c.SignedInUser, macaron.Params(c.Req)[":uid"])
+	err := l.deleteLibraryElement(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to delete library element")
 	}
@@ -46,7 +45,7 @@ func (l *LibraryElementService) deleteHandler(c *models.ReqContext) response.Res
 
 // getHandler handles GET  /api/library-elements/:uid.
 func (l *LibraryElementService) getHandler(c *models.ReqContext) response.Response {
-	element, err := l.getLibraryElementByUid(c.Req.Context(), c.SignedInUser, macaron.Params(c.Req)[":uid"])
+	element, err := l.getLibraryElementByUid(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to get library element")
 	}
@@ -76,7 +75,7 @@ func (l *LibraryElementService) getAllHandler(c *models.ReqContext) response.Res
 
 // patchHandler handles PATCH /api/library-elements/:uid
 func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibraryElementCommand) response.Response {
-	element, err := l.patchLibraryElement(c.Req.Context(), c.SignedInUser, cmd, macaron.Params(c.Req)[":uid"])
+	element, err := l.patchLibraryElement(c.Req.Context(), c.SignedInUser, cmd, web.Params(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to update library element")
 	}
@@ -86,7 +85,7 @@ func (l *LibraryElementService) patchHandler(c *models.ReqContext, cmd patchLibr
 
 // getConnectionsHandler handles GET /api/library-panels/:uid/connections/.
 func (l *LibraryElementService) getConnectionsHandler(c *models.ReqContext) response.Response {
-	connections, err := l.getConnections(c.Req.Context(), c.SignedInUser, macaron.Params(c.Req)[":uid"])
+	connections, err := l.getConnections(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":uid"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to get connections")
 	}
@@ -96,7 +95,7 @@ func (l *LibraryElementService) getConnectionsHandler(c *models.ReqContext) resp
 
 // getByNameHandler handles GET /api/library-elements/name/:name/.
 func (l *LibraryElementService) getByNameHandler(c *models.ReqContext) response.Response {
-	elements, err := l.getLibraryElementsByName(c.Req.Context(), c.SignedInUser, macaron.Params(c.Req)[":name"])
+	elements, err := l.getLibraryElementsByName(c.Req.Context(), c.SignedInUser, web.Params(c.Req)[":name"])
 	if err != nil {
 		return toLibraryElementError(err, "Failed to get library element")
 	}

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -4,8 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"gopkg.in/macaron.v1"
-
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -20,14 +19,14 @@ func TestDeleteLibraryElement(t *testing.T) {
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel that exists, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 		})
 
 	scenarioWithPanel(t, "When an admin tries to delete a library panel in another org, it should fail",
 		func(t *testing.T, sc scenarioContext) {
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.reqContext.SignedInUser.OrgId = 2
 			sc.reqContext.SignedInUser.OrgRole = models.ROLE_ADMIN
 			resp := sc.service.deleteHandler(sc.reqContext)
@@ -70,7 +69,7 @@ func TestDeleteLibraryElement(t *testing.T) {
 			err := sc.service.ConnectElementsToDashboard(sc.reqContext.Req.Context(), sc.reqContext.SignedInUser, []string{sc.initialResult.Result.UID}, dashInDB.Id)
 			require.NoError(t, err)
 
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.deleteHandler(sc.reqContext)
 			require.Equal(t, 403, resp.Status())
 		})

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -3,10 +3,9 @@ package libraryelements
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"gopkg.in/macaron.v1"
-
 	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -16,12 +15,12 @@ func TestGetLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to get a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// by uid
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": "unknown"})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": "unknown"})
 			resp := sc.service.getHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 
 			// by name
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": "unknown"})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":name": "unknown"})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -69,7 +68,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by uid
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			var result = validateAndUnMarshalResponse(t, resp)
 
@@ -78,7 +77,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by name
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			arrayResult := validateAndUnMarshalArrayResponse(t, resp)
 
@@ -164,7 +163,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by uid
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			result := validateAndUnMarshalResponse(t, resp)
 
@@ -173,7 +172,7 @@ func TestGetLibraryElement(t *testing.T) {
 			}
 
 			// by name
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			arrayResult := validateAndUnMarshalArrayResponse(t, resp)
 			if diff := cmp.Diff(libraryElementArrayResult{Result: []libraryElement{expected(result).Result}}, arrayResult, getCompareOptions()...); diff != "" {
@@ -187,12 +186,12 @@ func TestGetLibraryElement(t *testing.T) {
 			sc.reqContext.SignedInUser.OrgRole = models.ROLE_ADMIN
 
 			// by uid
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.getHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 
 			// by name
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":name": sc.initialResult.Result.Name})
 			resp = sc.service.getByNameHandler(sc.reqContext)
 			require.Equal(t, 404, resp.Status())
 		})

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -6,17 +6,16 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPatchLibraryElement(t *testing.T) {
 	scenarioWithPanel(t, "When an admin tries to patch a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := patchLibraryElementCommand{Kind: int64(models.PanelElement)}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": "unknown"})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": "unknown"})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -39,7 +38,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:    int64(models.PanelElement),
 				Version: 1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -91,7 +90,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)
@@ -112,7 +111,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Name = "New Name"
@@ -133,7 +132,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.UID = cmd.UID
@@ -154,7 +153,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -167,7 +166,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -184,7 +183,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -197,7 +196,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "graph"
@@ -224,7 +223,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "text"
@@ -249,7 +248,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 				Version:  1,
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Type = "graph"
@@ -270,7 +269,7 @@ func TestPatchLibraryElement(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			cmd := patchLibraryElementCommand{FolderID: -1, Version: 1, Kind: int64(models.PanelElement)}
 			sc.reqContext.UserId = 2
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			var result = validateAndUnMarshalResponse(t, resp)
 			sc.initialResult.Result.Meta.UpdatedBy.ID = int64(2)
@@ -292,7 +291,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version: 1,
 				Kind:    int64(models.PanelElement),
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -308,7 +307,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.PanelElement),
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 400, resp.Status())
 		})
@@ -321,7 +320,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Kind:     int64(models.PanelElement),
 			}
 			sc.reqContext.OrgId = 2
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 404, resp.Status())
 		})
@@ -333,7 +332,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.PanelElement),
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			resp = sc.service.patchHandler(sc.reqContext, cmd)
@@ -347,7 +346,7 @@ func TestPatchLibraryElement(t *testing.T) {
 				Version:  1,
 				Kind:     int64(models.VariableElement),
 			}
-			sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			resp := sc.service.patchHandler(sc.reqContext, cmd)
 			require.Equal(t, 200, resp.Status())
 			var result = validateAndUnMarshalResponse(t, resp)

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLibraryElementPermissions(t *testing.T) {
@@ -86,7 +85,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: toFolder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -101,7 +100,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: toFolder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -114,7 +113,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result := validateAndUnMarshalResponse(t, resp)
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.deleteHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -148,7 +147,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: 0, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -162,7 +161,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: folder.Id, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -174,7 +173,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result := validateAndUnMarshalResponse(t, resp)
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.deleteHandler(sc.reqContext)
 				require.Equal(t, testCase.status, resp.Status())
 			})
@@ -207,7 +206,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				cmd := patchLibraryElementCommand{FolderID: -100, Version: 1, Kind: int64(models.PanelElement)}
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.patchHandler(sc.reqContext, cmd)
 				require.Equal(t, 404, resp.Status())
 			})
@@ -242,7 +241,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				for i, result := range results {
-					sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.UID})
+					sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.UID})
 					resp := sc.service.getHandler(sc.reqContext)
 					require.Equal(t, testCase.statuses[i], resp.Status())
 				}
@@ -261,7 +260,7 @@ func TestLibraryElementPermissions(t *testing.T) {
 				result.Result.Meta.FolderUID = ""
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
-				sc.ctx.Req = macaron.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
+				sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result.Result.UID})
 				resp = sc.service.getHandler(sc.reqContext)
 				require.Equal(t, 200, resp.Status())
 				var actual libraryElementResult

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -12,14 +12,13 @@ import (
 	dboards "github.com/grafana/grafana/pkg/dashboards"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+	"github.com/stretchr/testify/require"
 )
 
 const userInDbName = "user_in_db"
@@ -163,7 +162,7 @@ func getCreateCommandWithModel(folderID int64, name string, kind models.LibraryE
 }
 
 type scenarioContext struct {
-	ctx           *macaron.Context
+	ctx           *web.Context
 	service       *LibraryElementService
 	reqContext    *models.ReqContext
 	user          models.SignedInUser
@@ -280,7 +279,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 	t.Helper()
 
 	t.Run(desc, func(t *testing.T) {
-		ctx := macaron.Context{Req: &http.Request{}}
+		ctx := web.Context{Req: &http.Request{}}
 		orgID := int64(1)
 		role := models.ROLE_ADMIN
 		sqlStore := sqlstore.InitTestDB(t)

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -43,8 +43,8 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/macaron.v1"
 )
 
 var (
@@ -333,7 +333,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	g.pushWebsocketHandler = func(ctx *models.ReqContext) {
 		user := ctx.SignedInUser
 		newCtx := livecontext.SetContextSignedUser(ctx.Req.Context(), user)
-		newCtx = livecontext.SetContextStreamID(newCtx, macaron.Params(ctx.Req)[":streamId"])
+		newCtx = livecontext.SetContextStreamID(newCtx, web.Params(ctx.Req)[":streamId"])
 		r := ctx.Req.WithContext(newCtx)
 		pushWSHandler.ServeHTTP(ctx.Resp, r)
 	}
@@ -968,7 +968,7 @@ func (g *GrafanaLive) HandleListHTTP(c *models.ReqContext) response.Response {
 
 // HandleInfoHTTP special http response for
 func (g *GrafanaLive) HandleInfoHTTP(ctx *models.ReqContext) response.Response {
-	path := macaron.Params(ctx.Req)["*"]
+	path := web.Params(ctx.Req)["*"]
 	if path == "grafana/dashboards/gitops" {
 		return response.JSON(200, util.DynMap{
 			"active": g.GrafanaScope.Dashboards.HasGitOpsObserver(ctx.SignedInUser.OrgId),

--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 
 	liveDto "github.com/grafana/grafana-plugin-sdk-go/live"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var (
@@ -46,7 +46,7 @@ func (g *Gateway) Run(ctx context.Context) error {
 }
 
 func (g *Gateway) Handle(ctx *models.ReqContext) {
-	streamID := macaron.Params(ctx.Req)[":streamId"]
+	streamID := web.Params(ctx.Req)[":streamId"]
 
 	stream, err := g.GrafanaLive.ManagedStreamRunner.GetOrCreateStream(ctx.SignedInUser.OrgId, liveDto.ScopeStream, streamID)
 	if err != nil {
@@ -97,8 +97,8 @@ func (g *Gateway) Handle(ctx *models.ReqContext) {
 }
 
 func (g *Gateway) HandlePath(ctx *models.ReqContext) {
-	streamID := macaron.Params(ctx.Req)[":streamId"]
-	path := macaron.Params(ctx.Req)[":path"]
+	streamID := web.Params(ctx.Req)[":streamId"]
+	path := web.Params(ctx.Req)[":path"]
 
 	body, err := io.ReadAll(ctx.Req.Body)
 	if err != nil {

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 const (
@@ -178,7 +178,7 @@ func (srv AlertmanagerSrv) RouteDeleteSilence(c *models.ReqContext) response.Res
 		return errResp
 	}
 
-	silenceID := macaron.Params(c.Req)[":SilenceId"]
+	silenceID := web.Params(c.Req)[":SilenceId"]
 	if err := am.DeleteSilence(silenceID); err != nil {
 		if errors.Is(err, notifier.ErrSilenceNotFound) {
 			return ErrResp(http.StatusNotFound, err, "")
@@ -305,7 +305,7 @@ func (srv AlertmanagerSrv) RouteGetSilence(c *models.ReqContext) response.Respon
 		return errResp
 	}
 
-	silenceID := macaron.Params(c.Req)[":SilenceId"]
+	silenceID := web.Params(c.Req)[":SilenceId"]
 	gettableSilence, err := am.GetSilence(silenceID)
 	if err != nil {
 		if errors.Is(err, notifier.ErrSilenceNotFound) {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -6,19 +6,18 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/grafana/grafana/pkg/services/ngalert/state"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
-	"github.com/grafana/grafana/pkg/services/quota"
-	"gopkg.in/macaron.v1"
-
 	"github.com/grafana/grafana/pkg/api/apierrors"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/prometheus/common/model"
 )
 
@@ -31,7 +30,7 @@ type RulerSrv struct {
 }
 
 func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
+	namespaceTitle := web.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -50,12 +49,12 @@ func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) respon
 }
 
 func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
+	namespaceTitle := web.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
 	}
-	ruleGroup := macaron.Params(c.Req)[":Groupname"]
+	ruleGroup := web.Params(c.Req)[":Groupname"]
 	uids, err := srv.store.DeleteRuleGroupAlertRules(c.SignedInUser.OrgId, namespace.Uid, ruleGroup)
 
 	if err != nil {
@@ -73,7 +72,7 @@ func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Re
 }
 
 func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
+	namespaceTitle := web.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, false)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
@@ -114,13 +113,13 @@ func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.
 }
 
 func (srv RulerSrv) RouteGetRulegGroupConfig(c *models.ReqContext) response.Response {
-	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
+	namespaceTitle := web.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, false)
 	if err != nil {
 		return toNamespaceErrorResponse(err)
 	}
 
-	ruleGroup := macaron.Params(c.Req)[":Groupname"]
+	ruleGroup := web.Params(c.Req)[":Groupname"]
 	q := ngmodels.ListRuleGroupAlertRulesQuery{
 		OrgID:        c.SignedInUser.OrgId,
 		NamespaceUID: namespace.Uid,
@@ -225,7 +224,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response 
 }
 
 func (srv RulerSrv) RoutePostNameRulesConfig(c *models.ReqContext, ruleGroupConfig apimodels.PostableRuleGroupConfig) response.Response {
-	namespaceTitle := macaron.Params(c.Req)[":Namespace"]
+	namespaceTitle := web.Params(c.Req)[":Namespace"]
 	namespace, err := srv.store.GetNamespaceByTitle(c.Req.Context(), namespaceTitle, c.SignedInUser.OrgId, c.SignedInUser, true)
 	if err != nil {
 		return toNamespaceErrorResponse(err)

--- a/pkg/services/ngalert/api/api_testing.go
+++ b/pkg/services/ngalert/api/api_testing.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 type TestingApiSrv struct {
@@ -27,7 +27,7 @@ type TestingApiSrv struct {
 }
 
 func (srv TestingApiSrv) RouteTestRuleConfig(c *models.ReqContext, body apimodels.TestRulePayload) response.Response {
-	recipient := macaron.Params(c.Req)[":Recipient"]
+	recipient := web.Params(c.Req)[":Recipient"]
 	if recipient == apimodels.GrafanaBackend.String() {
 		if body.Type() != apimodels.GrafanaBackend || body.GrafanaManagedCondition == nil {
 			return ErrResp(http.StatusBadRequest, errors.New("unexpected payload"), "")

--- a/pkg/services/ngalert/api/lotex_am.go
+++ b/pkg/services/ngalert/api/lotex_am.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 	"gopkg.in/yaml.v3"
 )
 
@@ -140,7 +140,7 @@ func (am *LotexAM) RouteDeleteSilence(ctx *models.ReqContext) response.Response 
 		ctx,
 		http.MethodDelete,
 		"silence",
-		[]string{macaron.Params(ctx.Req)[":SilenceId"]},
+		[]string{web.Params(ctx.Req)[":SilenceId"]},
 		nil,
 		messageExtractor,
 		nil,
@@ -188,7 +188,7 @@ func (am *LotexAM) RouteGetSilence(ctx *models.ReqContext) response.Response {
 		ctx,
 		http.MethodGet,
 		"silence",
-		[]string{macaron.Params(ctx.Req)[":SilenceId"]},
+		[]string{web.Params(ctx.Req)[":SilenceId"]},
 		nil,
 		jsonExtractor(&apimodels.GettableSilence{}),
 		nil,

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
-	"gopkg.in/macaron.v1"
+	"github.com/grafana/grafana/pkg/web"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -42,7 +42,7 @@ func (r *LotexRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) res
 		http.MethodDelete,
 		withPath(
 			*ctx.Req.URL,
-			fmt.Sprintf("%s/%s", legacyRulerPrefix, macaron.Params(ctx.Req)[":Namespace"]),
+			fmt.Sprintf("%s/%s", legacyRulerPrefix, web.Params(ctx.Req)[":Namespace"]),
 		),
 		nil,
 		messageExtractor,
@@ -63,8 +63,8 @@ func (r *LotexRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				macaron.Params(ctx.Req)[":Namespace"],
-				macaron.Params(ctx.Req)[":Groupname"],
+				web.Params(ctx.Req)[":Namespace"],
+				web.Params(ctx.Req)[":Groupname"],
 			),
 		),
 		nil,
@@ -86,7 +86,7 @@ func (r *LotexRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respon
 			fmt.Sprintf(
 				"%s/%s",
 				legacyRulerPrefix,
-				macaron.Params(ctx.Req)[":Namespace"],
+				web.Params(ctx.Req)[":Namespace"],
 			),
 		),
 		nil,
@@ -108,8 +108,8 @@ func (r *LotexRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.R
 			fmt.Sprintf(
 				"%s/%s/%s",
 				legacyRulerPrefix,
-				macaron.Params(ctx.Req)[":Namespace"],
-				macaron.Params(ctx.Req)[":Groupname"],
+				web.Params(ctx.Req)[":Namespace"],
+				web.Params(ctx.Req)[":Groupname"],
 			),
 		),
 		nil,
@@ -145,7 +145,7 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 	if err != nil {
 		return ErrResp(500, err, "Failed marshal rule group")
 	}
-	ns := macaron.Params(ctx.Req)[":Namespace"]
+	ns := web.Params(ctx.Req)[":Namespace"]
 	u := withPath(*ctx.Req.URL, fmt.Sprintf("%s/%s", legacyRulerPrefix, ns))
 	return r.withReq(ctx, http.MethodPost, u, bytes.NewBuffer(yml), jsonExtractor(nil), nil)
 }

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -23,8 +23,8 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/pkg/errors"
-	"gopkg.in/macaron.v1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -40,7 +40,7 @@ func toMacaronPath(path string) string {
 }
 
 func backendType(ctx *models.ReqContext, cache datasources.CacheService) (apimodels.Backend, error) {
-	recipient := macaron.Params(ctx.Req)[":Recipient"]
+	recipient := web.Params(ctx.Req)[":Recipient"]
 	if recipient == apimodels.GrafanaBackend.String() {
 		return apimodels.GrafanaBackend, nil
 	}
@@ -77,7 +77,7 @@ func replacedResponseWriter(ctx *models.ReqContext) (*models.ReqContext, *respon
 	resp := response.CreateNormalResponse(make(http.Header), nil, 0)
 	cpy := *ctx
 	cpyMCtx := *cpy.Context
-	cpyMCtx.Resp = macaron.NewResponseWriter(ctx.Req.Method, &safeMacaronWrapper{resp})
+	cpyMCtx.Resp = web.NewResponseWriter(ctx.Req.Method, &safeMacaronWrapper{resp})
 	cpy.Context = &cpyMCtx
 	return &cpy, resp
 }

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -12,10 +12,10 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/prometheus/alertmanager/api/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"gopkg.in/macaron.v1"
 )
 
 const (
@@ -250,7 +250,7 @@ func Instrument(
 	path string,
 	action interface{},
 	metrics *API,
-) macaron.Handler {
+) web.Handler {
 	normalizedPath := MakeLabelValue(path)
 
 	return func(c *models.ReqContext) {
@@ -265,7 +265,7 @@ func Instrument(
 
 		// TODO: We could look up the datasource type via our datasource service
 		var backend string
-		recipient := macaron.Params(c.Req)[":Recipient"]
+		recipient := web.Params(c.Req)[":Recipient"]
 		if recipient == apimodels.GrafanaBackend.String() || recipient == "" {
 			backend = GrafanaBackend
 		} else {

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -1,0 +1,17 @@
+package web
+
+import "gopkg.in/macaron.v1"
+
+type Context = macaron.Context
+type Handler = macaron.Handler
+type BeforeFunc = macaron.BeforeFunc
+type ResponseWriter = macaron.ResponseWriter
+type Mux = macaron.Macaron
+
+var Params = macaron.Params
+var SetURLParams = macaron.SetURLParams
+var NewResponseWriter = macaron.NewResponseWriter
+var New = macaron.New
+var Env = macaron.Env
+var Renderer = macaron.Renderer
+var Bind = macaron.Bind


### PR DESCRIPTION
As many other massive PRs, this one is relateed to https://github.com/grafana/grafana/issues/31071
It replaces the imports all around grafana to use `pkg/web` instead of `pkg.in/macaron.v1`.

Also it adds `pkg/web/web.go` - the only hand-written change in this PR, the rest was generated.

Web package, in its turn, currently is just an alias for what's left of Macaron in `pkg/macaron` submodule.
Luckily, we only have a few APIs of Macaron left and even those would be reduced.

Once this PR is merged and all dependent code is also migrated to `pkg/web` - we can finally remove `pkg/macaron` and its submodules.