### PR TITLE
AccessControl: Add FGAC permissions to create and delete orgs

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -231,7 +231,7 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		// create new org
-		apiRoute.Post("/orgs", quota("org"), bind(models.CreateOrgCommand{}), routing.Wrap(CreateOrg))
+		apiRoute.Post("/orgs", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsCreate)), quota("org"), bind(models.CreateOrgCommand{}), routing.Wrap(hs.CreateOrg))
 
 		// search all orgs
 		apiRoute.Get("/orgs", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsAll)), routing.Wrap(SearchOrgs))
@@ -242,7 +242,7 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgID)), routing.Wrap(GetOrgByID))
 			orgsRoute.Put("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
 			orgsRoute.Put("/address", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
-			orgsRoute.Delete("/", reqGrafanaAdmin, routing.Wrap(DeleteOrgByID))
+			orgsRoute.Delete("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsDelete, ScopeOrgID)), routing.Wrap(DeleteOrgByID))
 			orgsRoute.Get("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsers))
 			orgsRoute.Post("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
 			orgsRoute.Patch("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -80,7 +80,7 @@ func getOrgHelper(orgID int64) response.Response {
 
 // POST /api/orgs
 func (hs *HTTPServer) CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Response {
-	_, acEnabled := hs.Cfg.FeatureToggles["accesscontrol"]
+	acEnabled := hs.Cfg.FeatureToggles["accesscontrol"]
 	if !acEnabled && !(setting.AllowUserOrgCreate || c.IsGrafanaAdmin) {
 		return response.Error(403, "Ac!cess denied", nil)
 	}

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -82,7 +82,7 @@ func getOrgHelper(orgID int64) response.Response {
 func (hs *HTTPServer) CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Response {
 	acEnabled := hs.Cfg.FeatureToggles["accesscontrol"]
 	if !acEnabled && !(setting.AllowUserOrgCreate || c.IsGrafanaAdmin) {
-		return response.Error(403, "Ac!cess denied", nil)
+		return response.Error(403, "Access denied", nil)
 	}
 
 	cmd.UserId = c.UserId

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -79,13 +79,14 @@ func getOrgHelper(orgID int64) response.Response {
 }
 
 // POST /api/orgs
-func CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Response {
-	if !c.IsSignedIn || (!setting.AllowUserOrgCreate && !c.IsGrafanaAdmin) {
-		return response.Error(403, "Access denied", nil)
+func (hs *HTTPServer) CreateOrg(c *models.ReqContext, cmd models.CreateOrgCommand) response.Response {
+	_, acEnabled := hs.Cfg.FeatureToggles["accesscontrol"]
+	if !acEnabled && !(setting.AllowUserOrgCreate || c.IsGrafanaAdmin) {
+		return response.Error(403, "Ac!cess denied", nil)
 	}
 
 	cmd.UserId = c.UserId
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := sqlstore.CreateOrg(&cmd); err != nil {
 		if errors.Is(err, models.ErrOrgNameTaken) {
 			return response.Error(409, "Organization name taken", err)
 		}
@@ -152,7 +153,7 @@ func updateOrgAddressHelper(form dtos.UpdateOrgAddressForm, orgID int64) respons
 	return response.Success("Address updated")
 }
 
-// GET /api/orgs/:orgId
+// DELETE /api/orgs/:orgId
 func DeleteOrgByID(c *models.ReqContext) response.Response {
 	orgID := c.ParamsInt64(":orgId")
 	// before deleting an org, check if user does not belong to the current org
@@ -160,7 +161,7 @@ func DeleteOrgByID(c *models.ReqContext) response.Response {
 		return response.Error(400, "Can not delete org for current user", nil)
 	}
 
-	if err := bus.Dispatch(&models.DeleteOrgCommand{Id: orgID}); err != nil {
+	if err := sqlstore.DeleteOrg(&models.DeleteOrgCommand{Id: orgID}); err != nil {
 		if errors.Is(err, models.ErrOrgNotFound) {
 			return response.Error(404, "Failed to delete organization. ID not found", nil)
 		}

--- a/pkg/api/org.go
+++ b/pkg/api/org.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
-	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -64,7 +64,6 @@ func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
 		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-
 }
 
 func TestAPIEndpoint_CreateOrgs_AccessControl(t *testing.T) {

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -128,7 +128,7 @@ func TestAPIEndpoint_DeleteOrgs_AccessControl(t *testing.T) {
 		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-	t.Run("AccessControl prevents deleting Orgs with exact permissions", func(t *testing.T) {
+	t.Run("AccessControl allows deleting Orgs with exact permissions", func(t *testing.T) {
 		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: accesscontrol.Scope("orgs", "id", "3")}})
 		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 3), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var (
@@ -29,7 +30,120 @@ var (
 	"ZipCode": "TESTZIPCODE",
 	"State": "TestState",
 	"Country": "TestCountry" }`
+
+	deleteOrgsURL = "/api/orgs/%v"
+
+	createOrgsURL    = "/api/orgs/"
+	testCreateOrgCmd = `{ "name": "TestOrg%v"}`
 )
+
+func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	setting.AllowUserOrgCreate = false
+	input := strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 2))
+	t.Run("Viewer cannot create Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 3))
+	t.Run("Grafana Admin viewer can create Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	setting.AllowUserOrgCreate = true
+	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 4))
+	t.Run("User viewer can create Orgs when AllowUserOrgCreate setting is true", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+}
+
+func TestAPIEndpoint_CreateOrgs_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 2))
+	t.Run("AccessControl allows creating Orgs with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsCreate}})
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 3))
+	t.Run("AccessControl prevents creating Orgs with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_DeleteOrgs_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create two orgs
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+
+	t.Run("Viewer cannot delete Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = true
+	t.Run("Grafana Admin viewer can delete Orgs", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_DeleteOrgs_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	// Create three orgs (to delete org2 then org3)
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
+	require.NoError(t, err)
+	_, err = sc.db.CreateOrgWithMember("TestOrg3", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows deleting Orgs with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: ScopeOrgsAll}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents deleting Orgs with exact permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: accesscontrol.Scope("orgs", "id", "3")}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 3), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents deleting Orgs with too narrow permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents deleting Orgs with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
 
 func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, false)

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -58,6 +58,7 @@ func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 
+	sc.initCtx.SignedInUser.IsGrafanaAdmin = false
 	setting.AllowUserOrgCreate = true
 	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 4))
 	t.Run("User viewer can create Orgs when AllowUserOrgCreate setting is true", func(t *testing.T) {

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -22,6 +22,8 @@ const (
 	ActionOrgsWrite            = "orgs:write"
 	ActionOrgsPreferencesWrite = "orgs.preferences:write"
 	ActionOrgsQuotasWrite      = "orgs.quotas:write"
+	ActionOrgsDelete           = "orgs:delete"
+	ActionOrgsCreate           = "orgs:create"
 )
 
 // API related scopes


### PR DESCRIPTION

**What this PR does / why we need it**:

> While in the first milestone we covered mostly all organization relevant endpoints with fine-grained permissions, there are few still missing the construction blocks.

In this PR, I cover the endpoints:
| Method | Url              | Legacy AC       | Action        | Scope              |
|--------|------------------|-----------------|---------------|--------------------|
| DELETE | /api/orgs/:orgId | reqGrafanaAdmin | `orgs:delete` | `orgs:id:{:orgId}` |
| POST   | /api/orgs        | reqSignedIn     | `orgs:create` | n/a                |

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana-enterprise/issues/1550

**Special notes for your reviewer**:
I won't merge this until I create the associated roles


