### PR TITLE
Add onDataSourceChange to optional components

### DIFF
--- a/public/app/features/query/components/QueryActionComponent.ts
+++ b/public/app/features/query/components/QueryActionComponent.ts
@@ -4,6 +4,7 @@ interface ActionComponentProps {
   query?: DataQuery;
   queries?: Array<Partial<DataQuery>>;
   onAddQuery?: (q: DataQuery) => void;
+  onChangeDataSource?: (newSettings: DataSourceInstanceSettings) => void;
   timeRange?: TimeRange;
   dataSource?: DataSourceInstanceSettings;
 }

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, { PureComponent, ReactNode } from 'react';
 import classNames from 'classnames';
-import { has, cloneDeep } from 'lodash';
+import { cloneDeep, has } from 'lodash';
 // Utils & Services
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { AngularComponent, getAngularLoader } from '@grafana/runtime';
@@ -41,6 +41,7 @@ interface Props<TQuery extends DataQuery> {
   index: number;
   dataSource: DataSourceInstanceSettings;
   onChangeDataSource?: (dsSettings: DataSourceInstanceSettings) => void;
+  onChangeParentDataSource?: (dsSettings: DataSourceInstanceSettings) => void;
   renderHeaderExtras?: () => ReactNode;
   onAddQuery: (query: TQuery) => void;
   onRemoveQuery: (query: TQuery) => void;
@@ -304,7 +305,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   }
 
   renderExtraActions = () => {
-    const { query, queries, data, onAddQuery, dataSource } = this.props;
+    const { query, queries, data, onAddQuery, dataSource, onChangeParentDataSource } = this.props;
     return RowActionComponents.getAllExtraRenderAction().map((c, index) => {
       return React.createElement(c, {
         query,
@@ -313,6 +314,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         onAddQuery: onAddQuery as (query: DataQuery) => void,
         dataSource: dataSource,
         key: index,
+        onChangeDataSource: onChangeParentDataSource,
       });
     });
   };

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -31,6 +31,7 @@ interface Props {
   app?: CoreApp;
   history?: Array<HistoryItem<DataQuery>>;
   eventBus?: EventBusExtended;
+  onChangeParentDataSource?: (ds: DataSourceInstanceSettings) => void;
 }
 
 export class QueryEditorRows extends PureComponent<Props> {
@@ -101,7 +102,7 @@ export class QueryEditorRows extends PureComponent<Props> {
   };
 
   render() {
-    const { dsSettings, data, queries, app, history, eventBus } = this.props;
+    const { dsSettings, data, queries, app, history, eventBus, onChangeParentDataSource } = this.props;
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
@@ -124,6 +125,7 @@ export class QueryEditorRows extends PureComponent<Props> {
                       query={query}
                       dataSource={dataSourceSettings}
                       onChangeDataSource={onChangeDataSourceSettings}
+                      onChangeParentDataSource={onChangeParentDataSource}
                       onChange={(query) => this.onChangeQuery(query, index)}
                       onRemoveQuery={this.onRemoveQuery}
                       onAddQuery={this.props.onAddQuery}

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -12,7 +12,7 @@ import {
   stylesFactory,
   Tooltip,
 } from '@grafana/ui';
-import { getDataSourceSrv, DataSourcePicker } from '@grafana/runtime';
+import { DataSourcePicker, getDataSourceSrv } from '@grafana/runtime';
 import { QueryEditorRows } from './QueryEditorRows';
 // Services
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -115,11 +115,15 @@ export class QueryGroup extends PureComponent<Props, State> {
 
     // switching to mixed
     if (newSettings.meta.mixed) {
-      for (const query of queries) {
-        if (query.datasource !== ExpressionDatasourceID) {
-          query.datasource = dsSettings?.name;
-          if (!query.datasource) {
-            query.datasource = config.defaultDatasource;
+      const isCurrentMixed = dsSettings?.meta?.mixed || false;
+      if (!isCurrentMixed) {
+        // Only update if mixed hasn't already been selected
+        for (const query of queries) {
+          if (query.datasource !== ExpressionDatasourceID) {
+            query.datasource = dsSettings?.name;
+            if (!query.datasource) {
+              query.datasource = config.defaultDatasource;
+            }
           }
         }
       }
@@ -318,6 +322,7 @@ export class QueryGroup extends PureComponent<Props, State> {
           onQueriesChange={this.onQueriesChange}
           onAddQuery={this.onAddQuery}
           onRunQueries={onRunQueries}
+          onChangeParentDataSource={this.onChangeDataSource}
           data={data}
         />
       </div>
@@ -330,7 +335,7 @@ export class QueryGroup extends PureComponent<Props, State> {
 
   renderExtraActions() {
     return GroupActionComponents.getAllExtraRenderAction().map((c) => {
-      return React.createElement(c, { onAddQuery: this.onAddQuery });
+      return React.createElement(c, { onAddQuery: this.onAddQuery, onChangeDataSource: this.onChangeDataSource });
     });
   }
 


### PR DESCRIPTION
Enterprise work on recorded queries requires components from to be able to control the main data source dropdown in the query editor. Recording expressions requires the editor to be in mixed mode so that all queries have the appropriate datasource information before they are recorded.

As part of this work, we also discovered a bug where a user could select `-- Mixed --` twice by typing it into the dropdown after selecting it. This caused all child queries to also be set as `-- Mixed --` and broke everything. We've fixed that issue in this PR by only accepting a change to the `-- Mixed --` datasource if the current datasource isn't already `-- Mixed --`.

