### PR TITLE
Folders: Prevents deletion of General folder

### DIFF
--- a/public/app/features/search/hooks/useManageDashboards.test.ts
+++ b/public/app/features/search/hooks/useManageDashboards.test.ts
@@ -53,12 +53,83 @@ describe('useManageDashboards', () => {
   });
 
   describe('when called and General folder and another folder are selected', () => {
-    it('then canDelete should be true', () => {
+    it('then canDelete should be false', () => {
       const results: DashboardSection[] = [
-        { id: 1, checked: true, items: [], title: 'One', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+        {
+          id: 1,
+          checked: true,
+          items: [
+            {
+              id: 11,
+              checked: true,
+              title: 'Eleven',
+              type: DashboardSearchItemType.DashDB,
+              url: '/',
+              isStarred: false,
+              tags: [],
+              uri: '',
+            },
+          ],
+          title: 'One',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
         {
           id: GENERAL_FOLDER_ID,
           checked: true,
+          items: [
+            {
+              id: 10,
+              checked: true,
+              title: 'Ten',
+              type: DashboardSearchItemType.DashDB,
+              url: '/',
+              isStarred: false,
+              tags: [],
+              uri: '',
+            },
+          ],
+          title: 'General',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
+        { id: 2, checked: false, items: [], title: 'Two', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+      ];
+
+      const { result } = setupTestContext({ results });
+
+      expect(result.current.canDelete).toBe(false);
+    });
+  });
+
+  describe('when called on an empty General folder that is not selected but another folder is selected', () => {
+    it('then canDelete should be true', () => {
+      const results: DashboardSection[] = [
+        {
+          id: 1,
+          checked: true,
+          items: [
+            {
+              id: 11,
+              checked: true,
+              title: 'Eleven',
+              type: DashboardSearchItemType.DashDB,
+              url: '/',
+              isStarred: false,
+              tags: [],
+              uri: '',
+            },
+          ],
+          title: 'One',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
+        {
+          id: GENERAL_FOLDER_ID,
+          checked: false,
           items: [],
           title: 'General',
           type: DashboardSearchItemType.DashFolder,
@@ -66,6 +137,37 @@ describe('useManageDashboards', () => {
           url: '/',
         },
         { id: 2, checked: false, items: [], title: 'Two', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+      ];
+
+      const { result } = setupTestContext({ results });
+
+      expect(result.current.canDelete).toBe(true);
+    });
+  });
+
+  describe('when called on a non empty General folder that is not selected dashboard in General folder is selected', () => {
+    it('then canDelete should be true', () => {
+      const results: DashboardSection[] = [
+        {
+          id: GENERAL_FOLDER_ID,
+          checked: false,
+          items: [
+            {
+              id: 10,
+              checked: true,
+              title: 'Ten',
+              type: DashboardSearchItemType.DashDB,
+              url: '/',
+              isStarred: false,
+              tags: [],
+              uri: '',
+            },
+          ],
+          title: 'General',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
       ];
 
       const { result } = setupTestContext({ results });

--- a/public/app/features/search/hooks/useManageDashboards.ts
+++ b/public/app/features/search/hooks/useManageDashboards.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useReducer } from 'react';
 import { FolderDTO } from 'app/types';
 import { contextSrv } from 'app/core/services/context_srv';
-import { DashboardQuery, DashboardSection, OnDeleteItems, OnMoveItems, OnToggleChecked } from '../types';
+import { DashboardQuery, OnDeleteItems, OnMoveItems, OnToggleChecked } from '../types';
 import { DELETE_ITEMS, MOVE_ITEMS, TOGGLE_ALL_CHECKED, TOGGLE_CHECKED } from '../reducers/actionTypes';
 import { manageDashboardsReducer, manageDashboardsState, ManageDashboardsState } from '../reducers/manageDashboards';
 import { useSearch } from './useSearch';
@@ -42,14 +42,14 @@ export const useManageDashboards = (
     dispatch({ type: MOVE_ITEMS, payload: { dashboards: selectedDashboards, folder } });
   };
 
-  const canMove = useMemo(
-    () => results.some((result: DashboardSection) => result.items && result.items.some((item) => item.checked)),
-    [results]
-  );
-  const canDelete = useMemo(
-    () => canMove || results.some((result: DashboardSection) => result.checked && result.id !== GENERAL_FOLDER_ID),
-    [canMove, results]
-  );
+  const canMove = useMemo(() => results.some((result) => result.items && result.items.some((item) => item.checked)), [
+    results,
+  ]);
+
+  const canDelete = useMemo(() => {
+    const includesGeneralFolder = results.find((result) => result.checked && result.id === GENERAL_FOLDER_ID);
+    return canMove && !includesGeneralFolder;
+  }, [canMove, results]);
 
   const canSave = folder?.canSave;
   const hasEditPermissionInFolders = folder ? canSave : contextSrv.hasEditPermissionInFolders;


### PR DESCRIPTION
**What this PR does / why we need it**:
When you move the last dashboard from the `General` folder to another folder, the `General` folder is "empty". The problem arises when the user clicks the "empty" General folder. Instead of receiving an empty result, the backend api returns all folders. This PR prevents any selection that includes the General folder from activating the `Delete` button.

Another solution would be to reload the page when there are no dashboards left in the `General` folder, because then the `General` folder would not be part of the search result at all.

**Before moving the last dashboard from General folder**
![image](https://user-images.githubusercontent.com/562238/136515688-9092bdd4-42f7-439e-abf4-2d4279be94fb.png)

**After moving the last dashboard from General folder and toggling the General folder**
![image](https://user-images.githubusercontent.com/562238/136516213-fb7d029a-f7d4-4695-90bc-0960cc3e6db1.png)

**Which issue(s) this PR fixes**:
Fixes #40029

**Special notes for your reviewer**:

