### PR TITLE
Prometheus: Add Headers to HTTP client options

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -185,6 +185,7 @@ func getClient(dsInfo *DatasourceInfo, s *Service) (apiv1.API, error) {
 		Timeouts:  dsInfo.HTTPClientOpts.Timeouts,
 		TLS:       dsInfo.HTTPClientOpts.TLS,
 		BasicAuth: dsInfo.HTTPClientOpts.BasicAuth,
+		Headers:   dsInfo.HTTPClientOpts.Headers,
 	}
 
 	customMiddlewares := customQueryParametersMiddleware(plog)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Custom HTTP Headers to client options when setting up Prometheus client.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/40170

