### PR TITLE
Explore: Prevent empty Elasticsearch logs query responses from hiding the logs panel

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -501,64 +501,67 @@ export class ElasticResponse {
         throw this.getErrorFromElasticResponse(this.response, response.error);
       }
 
-      if (response.hits && response.hits.hits.length > 0) {
+      if (response.hits) {
         const { propNames, docs } = flattenHits(response.hits.hits);
-        if (docs.length > 0) {
-          let series = createEmptyDataFrame(
-            propNames.map(toNameTypePair(docs)),
-            this.targets[0].timeField!,
-            isLogsRequest,
-            logMessageField,
-            logLevelField
-          );
 
-          // Add a row for each document
-          for (const doc of docs) {
-            if (logLevelField) {
-              // Remap level field based on the datasource config. This field is
-              // then used in explore to figure out the log level. We may rewrite
-              // some actual data in the level field if they are different.
-              doc['level'] = doc[logLevelField];
-            }
-            // When highlighting exists, we need to collect all the highlighted
-            // phrases and add them to the DataFrame's meta.searchWords array.
-            if (doc.highlight) {
-              // There might be multiple words so we need two versions of the
-              // regular expression. One to match gobally, when used with part.match,
-              // it returns and array of matches. The second one is used to capture the
-              // values between the tags.
-              const globalHighlightWordRegex = new RegExp(HIGHLIGHT_TAGS_EXP, 'g');
-              const highlightWordRegex = new RegExp(HIGHLIGHT_TAGS_EXP);
-              const newSearchWords = Object.keys(doc.highlight)
-                .flatMap((key) => {
-                  return doc.highlight[key].flatMap((line: string) => {
-                    const matchedPhrases = line.match(globalHighlightWordRegex);
-                    if (!matchedPhrases) {
-                      return [];
-                    }
-                    return matchedPhrases.map((part) => {
-                      const matches = part.match(highlightWordRegex);
-                      return (matches && matches[1]) || null;
-                    });
-                  });
-                })
-                .filter(identity);
-              // If meta and searchWords already exists, add the words and
-              // deduplicate otherwise create a new set of search words.
-              const searchWords = series.meta?.searchWords
-                ? uniq([...series.meta.searchWords, ...newSearchWords])
-                : [...newSearchWords];
-              series.meta = series.meta ? { ...series.meta, searchWords } : { searchWords };
-            }
-            series.add(doc);
-          }
-          if (isLogsRequest) {
-            addPreferredVisualisationType(series, 'logs');
-          }
-          const target = this.targets[n];
-          series.refId = target.refId;
-          dataFrame.push(series);
+        const series = docs.length
+          ? createEmptyDataFrame(
+              propNames.map(toNameTypePair(docs)),
+              isLogsRequest,
+              this.targets[0].timeField,
+              logMessageField,
+              logLevelField
+            )
+          : createEmptyDataFrame([], isLogsRequest);
+
+        if (isLogsRequest) {
+          addPreferredVisualisationType(series, 'logs');
         }
+
+        // Add a row for each document
+        for (const doc of docs) {
+          if (logLevelField) {
+            // Remap level field based on the datasource config. This field is
+            // then used in explore to figure out the log level. We may rewrite
+            // some actual data in the level field if they are different.
+            doc['level'] = doc[logLevelField];
+          }
+          // When highlighting exists, we need to collect all the highlighted
+          // phrases and add them to the DataFrame's meta.searchWords array.
+          if (doc.highlight) {
+            // There might be multiple words so we need two versions of the
+            // regular expression. One to match gobally, when used with part.match,
+            // it returns and array of matches. The second one is used to capture the
+            // values between the tags.
+            const globalHighlightWordRegex = new RegExp(HIGHLIGHT_TAGS_EXP, 'g');
+            const highlightWordRegex = new RegExp(HIGHLIGHT_TAGS_EXP);
+            const newSearchWords = Object.keys(doc.highlight)
+              .flatMap((key) => {
+                return doc.highlight[key].flatMap((line: string) => {
+                  const matchedPhrases = line.match(globalHighlightWordRegex);
+                  if (!matchedPhrases) {
+                    return [];
+                  }
+                  return matchedPhrases.map((part) => {
+                    const matches = part.match(highlightWordRegex);
+                    return (matches && matches[1]) || null;
+                  });
+                });
+              })
+              .filter(identity);
+            // If meta and searchWords already exists, add the words and
+            // deduplicate otherwise create a new set of search words.
+            const searchWords = series.meta?.searchWords
+              ? uniq([...series.meta.searchWords, ...newSearchWords])
+              : [...newSearchWords];
+            series.meta = series.meta ? { ...series.meta, searchWords } : { searchWords };
+          }
+          series.add(doc);
+        }
+
+        const target = this.targets[n];
+        series.refId = target.refId;
+        dataFrame.push(series);
       }
 
       if (response.aggregations) {
@@ -690,20 +693,22 @@ const flattenHits = (hits: Doc[]): { docs: Array<Record<string, any>>; propNames
  */
 const createEmptyDataFrame = (
   props: Array<[string, FieldType]>,
-  timeField: string,
   isLogsRequest: boolean,
+  timeField?: string,
   logMessageField?: string,
   logLevelField?: string
 ): MutableDataFrame => {
   const series = new MutableDataFrame({ fields: [] });
 
-  series.addField({
-    config: {
-      filterable: true,
-    },
-    name: timeField,
-    type: FieldType.time,
-  });
+  if (timeField) {
+    series.addField({
+      config: {
+        filterable: true,
+      },
+      name: timeField,
+      type: FieldType.time,
+    });
+  }
 
   if (logMessageField) {
     series.addField({

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -489,7 +489,7 @@ export class ElasticResponse {
     return this.processResponseToDataFrames(true, logMessageField, logLevelField);
   }
 
-  processResponseToDataFrames(
+  private processResponseToDataFrames(
     isLogsRequest: boolean,
     logMessageField?: string,
     logLevelField?: string
@@ -553,7 +553,7 @@ export class ElasticResponse {
             series.add(doc);
           }
           if (isLogsRequest) {
-            series = addPreferredVisualisationType(series, 'logs');
+            addPreferredVisualisationType(series, 'logs');
           }
           const target = this.targets[n];
           series.refId = target.refId;
@@ -582,7 +582,7 @@ export class ElasticResponse {
 
           // When log results, show aggregations only in graph. Log fields are then going to be shown in table.
           if (isLogsRequest) {
-            series = addPreferredVisualisationType(series, 'graph');
+            addPreferredVisualisationType(series, 'graph');
           }
 
           series.refId = target.refId;
@@ -756,8 +756,6 @@ const addPreferredVisualisationType = (series: any, type: PreferredVisualisation
     : (s.meta = {
         preferredVisualisationType: type,
       });
-
-  return s;
 };
 
 const toNameTypePair = (docs: Array<Record<string, any>>) => (propName: string): [string, FieldType] => [

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1432,4 +1432,39 @@ describe('ElasticResponse', () => {
       expect(fields).toContainEqual({ name: 'message', type: 'string' });
     });
   });
+
+  describe('logs query with empty response', () => {
+    const targets: ElasticsearchQuery[] = [
+      {
+        refId: 'A',
+        metrics: [{ type: 'logs', id: '2' }],
+        bucketAggs: [{ type: 'date_histogram', settings: { interval: 'auto' }, id: '1' }],
+        key: 'Q-1561369883389-0.7611823271062786-0',
+        query: 'hello AND message',
+        timeField: '@timestamp',
+      },
+    ];
+    const response = {
+      responses: [
+        {
+          hits: { hits: [] },
+          aggregations: {
+            '1': {
+              buckets: [
+                { key_as_string: '1633676760000', key: 1633676760000, doc_count: 0 },
+                { key_as_string: '1633676770000', key: 1633676770000, doc_count: 0 },
+                { key_as_string: '1633676780000', key: 1633676780000, doc_count: 0 },
+              ],
+            },
+          },
+          status: 200,
+        },
+      ],
+    };
+
+    it('should return histogram aggregation and documents', () => {
+      const result = new ElasticResponse(targets, response).getLogs('message', 'level');
+      expect(result.data.length).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When issuing logs queries, it may happen that for a given time range there are no entries. Instead of returning nothing, we should return an empty series to prevent the logs panel from disappearing in explore, especially when using logs pagination since it would force users to manually change the time range from the topo-level time picker.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #38679

**Special notes for your reviewer**:


