### PR TITLE
AccessControl: keyword scope resolution

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -84,6 +84,7 @@ func (ac *OSSAccessControlService) GetUserPermissions(ctx context.Context, user 
 					continue
 				}
 				for _, p := range role.Permissions {
+					// if the permission has a keyword in its scope it will be resolved
 					permission, err := accesscontrol.ResolveKeywordScope(user, p)
 					if err != nil {
 						return nil, err

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -69,7 +69,7 @@ func (ac *OSSAccessControlService) Evaluate(ctx context.Context, user *models.Si
 	groupedPermissions := accesscontrol.GroupScopesByAction(permissions)
 
 	// TODO would it be better to work inside GetUserPermissions instead?
-	resolvedPermissions, err := accesscontrol.ResolveGroupedPermissions(user, groupedPermissions)
+	resolvedPermissions, err := accesscontrol.ResolvePermissionsKeywordedScopes(user, groupedPermissions)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -65,7 +65,16 @@ func (ac *OSSAccessControlService) Evaluate(ctx context.Context, user *models.Si
 	if err != nil {
 		return false, err
 	}
-	return evaluator.Evaluate(accesscontrol.GroupScopesByAction(permissions))
+
+	groupedPermissions := accesscontrol.GroupScopesByAction(permissions)
+
+	// TODO would it be better to work inside GetUserPermissions instead?
+	resolvedPermissions, err := accesscontrol.ResolveGroupedPermissions(user, groupedPermissions)
+	if err != nil {
+		return false, err
+	}
+
+	return evaluator.Evaluate(resolvedPermissions)
 }
 
 // GetUserPermissions returns user permissions based on built-in roles

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -555,6 +555,7 @@ func TestOSSAccessControlService_ScopeResolution(t *testing.T) {
 				UsageStats:    &usagestats.UsageStatsMock{T: t},
 				Log:           log.New("accesscontrol-test"),
 				registrations: accesscontrol.RegistrationList{},
+				scopeResolver: accesscontrol.NewScopeResolver(),
 			}
 			ac.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -500,7 +500,7 @@ func TestOSSAccessControlService_RegisterFixedRoles(t *testing.T) {
 	}
 }
 
-func TestOSSAccessControlService_ScopeResolution(t *testing.T) {
+func TestOSSAccessControlService_GetUserPermissions(t *testing.T) {
 	testUser := &models.SignedInUser{
 		UserId:  2,
 		OrgId:   3,

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -45,7 +45,7 @@ func removeRoleHelper(role string) {
 	}
 }
 
-// extractRawPermissions extracts action and scope fields only from a permission slice
+// extractRawPermissionsHelper extracts action and scope fields only from a permission slice
 func extractRawPermissionsHelper(perms []*accesscontrol.Permission) []*accesscontrol.Permission {
 	res := make([]*accesscontrol.Permission, len(perms))
 	for i, p := range perms {

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -531,14 +531,14 @@ func TestOSSAccessControlService_ScopeResolution(t *testing.T) {
 			name:     "Translate orgs:current",
 			user:     testUser,
 			rawPerm:  accesscontrol.Permission{Action: "orgs:read", Scope: "orgs:current"},
-			wantPerm: accesscontrol.Permission{Action: "orgs:read", Scope: "orgs:3"},
+			wantPerm: accesscontrol.Permission{Action: "orgs:read", Scope: "orgs:id:3"},
 			wantErr:  false,
 		},
 		{
 			name:     "Translate users:self",
 			user:     testUser,
 			rawPerm:  accesscontrol.Permission{Action: "users:read", Scope: "users:self"},
-			wantPerm: accesscontrol.Permission{Action: "users:read", Scope: "users:2"},
+			wantPerm: accesscontrol.Permission{Action: "users:read", Scope: "users:id:2"},
 			wantErr:  false,
 		},
 	}
@@ -569,8 +569,9 @@ func TestOSSAccessControlService_ScopeResolution(t *testing.T) {
 			userPerms, err := ac.GetUserPermissions(context.TODO(), tt.user)
 			if tt.wantErr {
 				assert.Error(t, err, "Expected an error with GetUserPermissions.")
+				return
 			}
-			assert.NoError(t, err, "Did not expect an error with GetUserPermissions.")
+			require.NoError(t, err, "Did not expect an error with GetUserPermissions.")
 
 			rawUserPerms := extractRawPermissionsHelper(userPerms)
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -45,6 +45,15 @@ func removeRoleHelper(role string) {
 	}
 }
 
+// extractRawPermissions extracts action and scope fields only from a permission slice
+func extractRawPermissionsHelper(perms []*accesscontrol.Permission) []*accesscontrol.Permission {
+	res := make([]*accesscontrol.Permission, len(perms))
+	for i, p := range perms {
+		res[i] = &accesscontrol.Permission{Action: p.Action, Scope: p.Scope}
+	}
+	return res
+}
+
 type evaluatingPermissionsTestCase struct {
 	desc       string
 	user       userTestCase
@@ -487,6 +496,86 @@ func TestOSSAccessControlService_RegisterFixedRoles(t *testing.T) {
 						fmt.Sprintf("role %s should have been assigned to %s", registration.Role.Name, br))
 				}
 			}
+		})
+	}
+}
+
+func TestOSSAccessControlService_ScopeResolution(t *testing.T) {
+	testUser := &models.SignedInUser{
+		UserId:  2,
+		OrgId:   3,
+		OrgName: "TestOrg",
+		OrgRole: models.ROLE_VIEWER,
+		Login:   "testUser",
+		Name:    "Test User",
+		Email:   "testuser@example.org",
+	}
+	registration := accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Version:     1,
+			UID:         "fixed:test:test",
+			Name:        "fixed:test:test",
+			Description: "Test role",
+			Permissions: []accesscontrol.Permission{},
+		},
+		Grants: []string{"Viewer"},
+	}
+	tests := []struct {
+		name     string
+		user     *models.SignedInUser
+		rawPerm  accesscontrol.Permission
+		wantPerm accesscontrol.Permission
+		wantErr  bool
+	}{
+		{
+			name:     "Translate orgs:current",
+			user:     testUser,
+			rawPerm:  accesscontrol.Permission{Action: "orgs:read", Scope: "orgs:current"},
+			wantPerm: accesscontrol.Permission{Action: "orgs:read", Scope: "orgs:3"},
+			wantErr:  false,
+		},
+		{
+			name:     "Translate users:self",
+			user:     testUser,
+			rawPerm:  accesscontrol.Permission{Action: "users:read", Scope: "users:self"},
+			wantPerm: accesscontrol.Permission{Action: "users:read", Scope: "users:2"},
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Remove any inserted role after the test case has been run
+			t.Cleanup(func() {
+				removeRoleHelper(registration.Role.Name)
+			})
+
+			// Setup
+			ac := &OSSAccessControlService{
+				Cfg:           setting.NewCfg(),
+				UsageStats:    &usagestats.UsageStatsMock{T: t},
+				Log:           log.New("accesscontrol-test"),
+				registrations: accesscontrol.RegistrationList{},
+			}
+			ac.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
+
+			registration.Role.Permissions = []accesscontrol.Permission{tt.rawPerm}
+			err := ac.DeclareFixedRoles(registration)
+			require.NoError(t, err)
+
+			err = ac.RegisterFixedRoles()
+			require.NoError(t, err)
+
+			// Test
+			userPerms, err := ac.GetUserPermissions(context.TODO(), tt.user)
+			if tt.wantErr {
+				assert.Error(t, err, "Expected an error with GetUserPermissions.")
+			}
+			assert.NoError(t, err, "Did not expect an error with GetUserPermissions.")
+
+			rawUserPerms := extractRawPermissionsHelper(userPerms)
+
+			assert.Contains(t, rawUserPerms, &tt.wantPerm, "Expected resolution of raw permission")
+			assert.NotContains(t, rawUserPerms, &tt.rawPerm, "Expected raw permission to have been resolved")
 		})
 	}
 }

--- a/pkg/services/accesscontrol/scoperesolution.go
+++ b/pkg/services/accesscontrol/scoperesolution.go
@@ -6,9 +6,9 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 )
 
-type ScopeResolveFunc func(*models.SignedInUser) (string, error)
+type KeywordedScopeResolveFunc func(*models.SignedInUser) (string, error)
 
-var ScopeResolutions = map[string]ScopeResolveFunc{
+var KeywordedScopeResolutions = map[string]KeywordedScopeResolveFunc{
 	"orgs:current": resolveCurrentOrg,
 	"users:self":   resolveUserSelf,
 }
@@ -22,9 +22,9 @@ func resolveUserSelf(u *models.SignedInUser) (string, error) {
 }
 
 // TODO: This is destructive for the input map, double check if that's ok.
-func ResolveGroupedPermissions(u *models.SignedInUser, permissions map[string]map[string]struct{}) (map[string]map[string]struct{}, error) {
+func ResolvePermissionsKeywordedScopes(u *models.SignedInUser, permissions map[string]map[string]struct{}) (map[string]map[string]struct{}, error) {
 	for action, scopes := range permissions {
-		resolvedScopes, err := resolveScopes(u, scopes)
+		resolvedScopes, err := resolveKeywordedScopes(u, scopes)
 		if err != nil {
 			return nil, err
 		}
@@ -34,9 +34,9 @@ func ResolveGroupedPermissions(u *models.SignedInUser, permissions map[string]ma
 }
 
 // TODO: This is destructive for the input map, double check if that's ok.
-func resolveScopes(u *models.SignedInUser, scopes map[string]struct{}) (map[string]struct{}, error) {
+func resolveKeywordedScopes(u *models.SignedInUser, scopes map[string]struct{}) (map[string]struct{}, error) {
 	for scope := range scopes {
-		if fn, ok := ScopeResolutions[scope]; ok {
+		if fn, ok := KeywordedScopeResolutions[scope]; ok {
 			res, err := fn(u)
 			if err != nil {
 				return nil, fmt.Errorf("Could not resolve %v: %v", scope, err)

--- a/pkg/services/accesscontrol/scoperesolution.go
+++ b/pkg/services/accesscontrol/scoperesolution.go
@@ -1,0 +1,49 @@
+package accesscontrol
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/models"
+)
+
+type ScopeResolveFunc func(*models.SignedInUser) (string, error)
+
+var ScopeResolutions = map[string]ScopeResolveFunc{
+	"orgs:current": resolveCurrentOrg,
+	"users:self":   resolveUserSelf,
+}
+
+func resolveCurrentOrg(u *models.SignedInUser) (string, error) {
+	return fmt.Sprintf("orgs:%v", u.OrgId), nil
+}
+
+func resolveUserSelf(u *models.SignedInUser) (string, error) {
+	return fmt.Sprintf("users:%v", u.UserId), nil
+}
+
+// TODO: This is destructive for the input map, double check if that's ok.
+func ResolveGroupedPermissions(u *models.SignedInUser, permissions map[string]map[string]struct{}) (map[string]map[string]struct{}, error) {
+	for action, scopes := range permissions {
+		resolvedScopes, err := resolveScopes(u, scopes)
+		if err != nil {
+			return nil, err
+		}
+		permissions[action] = resolvedScopes
+	}
+	return permissions, nil
+}
+
+// TODO: This is destructive for the input map, double check if that's ok.
+func resolveScopes(u *models.SignedInUser, scopes map[string]struct{}) (map[string]struct{}, error) {
+	for scope := range scopes {
+		if fn, ok := ScopeResolutions[scope]; ok {
+			res, err := fn(u)
+			if err != nil {
+				return nil, fmt.Errorf("Could not resolve %v: %v", scope, err)
+			}
+			delete(scopes, scope)
+			scopes[res] = struct{}{}
+		}
+	}
+	return scopes, nil
+}

--- a/pkg/services/accesscontrol/scoperesolution.go
+++ b/pkg/services/accesscontrol/scoperesolution.go
@@ -8,20 +8,21 @@ import (
 
 type KeywordScopeResolveFunc func(*models.SignedInUser) (string, error)
 
-// TODO should I encapsulate this map in an object not to have a package variable
+// TODO should I encapsulate this map in an object not to have a package variable?
 var keywordScopeResolutions = map[string]KeywordScopeResolveFunc{
 	"orgs:current": resolveCurrentOrg,
 	"users:self":   resolveUserSelf,
 }
 
 func resolveCurrentOrg(u *models.SignedInUser) (string, error) {
-	return fmt.Sprintf("orgs:%v", u.OrgId), nil
+	return Scope("orgs", "id", fmt.Sprintf("%v", u.OrgId)), nil
 }
 
 func resolveUserSelf(u *models.SignedInUser) (string, error) {
-	return fmt.Sprintf("users:%v", u.UserId), nil
+	return Scope("users", "id", fmt.Sprintf("%v", u.UserId)), nil
 }
 
+// ResolveKeywordScope resolves scope with keywords such as `self` or `current` for instance into `id` based scopes
 func ResolveKeywordScope(user *models.SignedInUser, permission Permission) (*Permission, error) {
 	if fn, ok := keywordScopeResolutions[permission.Scope]; ok {
 		resolvedScope, err := fn(user)

--- a/pkg/services/accesscontrol/scoperesolution_test.go
+++ b/pkg/services/accesscontrol/scoperesolution_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var testUser = &models.SignedInUser{
@@ -18,130 +17,38 @@ var testUser = &models.SignedInUser{
 	Email:   "testuser@example.org",
 }
 
-func Test_resolveKeywordedScopes(t *testing.T) {
+func TestResolveKeywordedScope(t *testing.T) {
 	tests := []struct {
-		name    string
-		u       *models.SignedInUser
-		scopes  map[string]struct{}
-		want    map[string]struct{}
-		wantErr bool
+		name       string
+		user       *models.SignedInUser
+		permission Permission
+		want       *Permission
+		wantErr    bool
 	}{
 		{
-			name:    "empty test",
-			u:       testUser,
-			scopes:  nil,
-			want:    nil,
-			wantErr: false,
+			name:       "no scope",
+			user:       testUser,
+			permission: Permission{Action: "users:read"},
+			want:       &Permission{Action: "users:read"},
+			wantErr:    false,
 		},
 		{
-			name:    "no translation test",
-			u:       testUser,
-			scopes:  map[string]struct{}{"users:1": {}},
-			want:    map[string]struct{}{"users:1": {}},
-			wantErr: false,
-		},
-		{
-			name:    "multiple translation test",
-			u:       testUser,
-			scopes:  map[string]struct{}{"users:self": {}, "orgs:current": {}},
-			want:    map[string]struct{}{"users:2": {}, "orgs:3": {}},
-			wantErr: false,
+			name:       "user if resolution",
+			user:       testUser,
+			permission: Permission{Action: "users:read", Scope: "users:self"},
+			want:       &Permission{Action: "users:read", Scope: "users:2"},
+			wantErr:    false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolved, err := resolveKeywordedScopes(tt.u, tt.scopes)
+			resolved, err := ResolveKeywordScope(tt.user, tt.permission)
 			if tt.wantErr {
-				require.Error(t, err)
+				assert.Error(t, err, "expected an error during the resolution of the scope")
 				return
 			}
-			require.NoError(t, err)
-
-			assert.EqualValues(t, resolved, tt.want)
-		})
-	}
-}
-
-func TestResolvePermissionsKeywordedScopes(t *testing.T) {
-	tests := []struct {
-		name        string
-		u           *models.SignedInUser
-		permissions map[string]map[string]struct{}
-		want        map[string]map[string]struct{}
-		wantErr     bool
-	}{
-		{
-			name:        "empty test",
-			u:           testUser,
-			permissions: nil,
-			want:        nil,
-			wantErr:     false,
-		},
-		{
-			name: "no translation test",
-			u:    testUser,
-			permissions: map[string]map[string]struct{}{
-				"users:read": {"users:1": {}},
-				"orgs:read":  {"orgs:1": {}},
-			},
-			want: map[string]map[string]struct{}{
-				"users:read": {"users:1": {}},
-				"orgs:read":  {"orgs:1": {}},
-			},
-			wantErr: false,
-		},
-		{
-			name: "multiple translation test",
-			u:    testUser,
-			permissions: map[string]map[string]struct{}{
-				"users:read": {"users:self": {}},
-				"orgs:read":  {"orgs:current": {}},
-				"orgs:write": {"orgs:current": {}},
-			},
-			want: map[string]map[string]struct{}{
-				"users:read": {"users:2": {}},
-				"orgs:read":  {"orgs:3": {}},
-				"orgs:write": {"orgs:3": {}},
-			},
-			wantErr: false,
-		},
-		{
-			name: "slightly more complex translation test",
-			u:    testUser,
-			permissions: map[string]map[string]struct{}{
-				"users:read": {"users:self": {}},
-				"orgs:read":  {"orgs:1": {}, "orgs:5": {}, "orgs:current": {}},
-				"orgs:write": {"orgs:1": {}, "orgs:5": {}, "orgs:current": {}},
-			},
-			want: map[string]map[string]struct{}{
-				"users:read": {"users:2": {}},
-				"orgs:read":  {"orgs:1": {}, "orgs:5": {}, "orgs:3": {}},
-				"orgs:write": {"orgs:1": {}, "orgs:5": {}, "orgs:3": {}},
-			},
-			wantErr: false,
-		},
-		{
-			name: "conflicting translations test",
-			u:    testUser,
-			permissions: map[string]map[string]struct{}{
-				"users:read": {"users:2": {}, "users:self": {}},
-			},
-			want: map[string]map[string]struct{}{
-				"users:read": {"users:2": {}},
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resolved, err := ResolvePermissionsKeywordedScopes(tt.u, tt.permissions)
-			if tt.wantErr {
-				require.Error(t, err, "expected an error during the grouped permissions resolution")
-				return
-			}
-			require.NoError(t, err, "did not expect an error during the grouped permissions resolution")
-
-			assert.EqualValues(t, resolved, tt.want, "resolution of grouped permissions did not end with expected result")
+			assert.NoError(t, err)
+			assert.EqualValues(t, tt.want, resolved, "permission did not match expected resolution")
 		})
 	}
 }

--- a/pkg/services/accesscontrol/scoperesolution_test.go
+++ b/pkg/services/accesscontrol/scoperesolution_test.go
@@ -1,0 +1,147 @@
+package accesscontrol
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testUser = &models.SignedInUser{
+	UserId:  2,
+	OrgId:   3,
+	OrgName: "TestOrg",
+	OrgRole: models.ROLE_VIEWER,
+	Login:   "testUser",
+	Name:    "Test User",
+	Email:   "testuser@example.org",
+}
+
+func Test_resolveScopes(t *testing.T) {
+	tests := []struct {
+		name    string
+		u       *models.SignedInUser
+		scopes  map[string]struct{}
+		want    map[string]struct{}
+		wantErr bool
+	}{
+		{
+			name:    "empty test",
+			u:       testUser,
+			scopes:  nil,
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "no translation test",
+			u:       testUser,
+			scopes:  map[string]struct{}{"users:1": {}},
+			want:    map[string]struct{}{"users:1": {}},
+			wantErr: false,
+		},
+		{
+			name:    "multiple translation test",
+			u:       testUser,
+			scopes:  map[string]struct{}{"users:self": {}, "orgs:current": {}},
+			want:    map[string]struct{}{"users:2": {}, "orgs:3": {}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, err := resolveScopes(tt.u, tt.scopes)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.EqualValues(t, resolved, tt.want)
+		})
+	}
+}
+
+func TestResolveGroupedPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		u           *models.SignedInUser
+		permissions map[string]map[string]struct{}
+		want        map[string]map[string]struct{}
+		wantErr     bool
+	}{
+		{
+			name:        "empty test",
+			u:           testUser,
+			permissions: nil,
+			want:        nil,
+			wantErr:     false,
+		},
+		{
+			name: "no translation test",
+			u:    testUser,
+			permissions: map[string]map[string]struct{}{
+				"users:read": {"users:1": {}},
+				"orgs:read":  {"orgs:1": {}},
+			},
+			want: map[string]map[string]struct{}{
+				"users:read": {"users:1": {}},
+				"orgs:read":  {"orgs:1": {}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple translation test",
+			u:    testUser,
+			permissions: map[string]map[string]struct{}{
+				"users:read": {"users:self": {}},
+				"orgs:read":  {"orgs:current": {}},
+				"orgs:write": {"orgs:current": {}},
+			},
+			want: map[string]map[string]struct{}{
+				"users:read": {"users:2": {}},
+				"orgs:read":  {"orgs:3": {}},
+				"orgs:write": {"orgs:3": {}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "slightly more complex translation test",
+			u:    testUser,
+			permissions: map[string]map[string]struct{}{
+				"users:read": {"users:self": {}},
+				"orgs:read":  {"orgs:1": {}, "orgs:5": {}, "orgs:current": {}},
+				"orgs:write": {"orgs:1": {}, "orgs:5": {}, "orgs:current": {}},
+			},
+			want: map[string]map[string]struct{}{
+				"users:read": {"users:2": {}},
+				"orgs:read":  {"orgs:1": {}, "orgs:5": {}, "orgs:3": {}},
+				"orgs:write": {"orgs:1": {}, "orgs:5": {}, "orgs:3": {}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "conflicting translations test",
+			u:    testUser,
+			permissions: map[string]map[string]struct{}{
+				"users:read": {"users:2": {}, "users:self": {}},
+			},
+			want: map[string]map[string]struct{}{
+				"users:read": {"users:2": {}},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, err := ResolveGroupedPermissions(tt.u, tt.permissions)
+			if tt.wantErr {
+				require.Error(t, err, "expected an error during the grouped permissions resolution")
+				return
+			}
+			require.NoError(t, err, "expected an error during the grouped permissions resolution")
+
+			assert.EqualValues(t, resolved, tt.want, "resolution of grouped permissions did not end with expected result")
+		})
+	}
+}

--- a/pkg/services/accesscontrol/scoperesolution_test.go
+++ b/pkg/services/accesscontrol/scoperesolution_test.go
@@ -36,7 +36,7 @@ func TestResolveKeywordedScope(t *testing.T) {
 			name:       "user if resolution",
 			user:       testUser,
 			permission: Permission{Action: "users:read", Scope: "users:self"},
-			want:       &Permission{Action: "users:read", Scope: "users:2"},
+			want:       &Permission{Action: "users:read", Scope: "users:id:2"},
 			wantErr:    false,
 		},
 	}

--- a/pkg/services/accesscontrol/scoperesolution_test.go
+++ b/pkg/services/accesscontrol/scoperesolution_test.go
@@ -42,7 +42,8 @@ func TestResolveKeywordedScope(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolved, err := ResolveKeywordScope(tt.user, tt.permission)
+			resolver := NewScopeResolver()
+			resolved, err := resolver.ResolveKeyword(tt.user, tt.permission)
 			if tt.wantErr {
 				assert.Error(t, err, "expected an error during the resolution of the scope")
 				return

--- a/pkg/services/accesscontrol/scoperesolution_test.go
+++ b/pkg/services/accesscontrol/scoperesolution_test.go
@@ -18,7 +18,7 @@ var testUser = &models.SignedInUser{
 	Email:   "testuser@example.org",
 }
 
-func Test_resolveScopes(t *testing.T) {
+func Test_resolveKeywordedScopes(t *testing.T) {
 	tests := []struct {
 		name    string
 		u       *models.SignedInUser
@@ -50,7 +50,7 @@ func Test_resolveScopes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolved, err := resolveScopes(tt.u, tt.scopes)
+			resolved, err := resolveKeywordedScopes(tt.u, tt.scopes)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -62,7 +62,7 @@ func Test_resolveScopes(t *testing.T) {
 	}
 }
 
-func TestResolveGroupedPermissions(t *testing.T) {
+func TestResolvePermissionsKeywordedScopes(t *testing.T) {
 	tests := []struct {
 		name        string
 		u           *models.SignedInUser
@@ -134,12 +134,12 @@ func TestResolveGroupedPermissions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolved, err := ResolveGroupedPermissions(tt.u, tt.permissions)
+			resolved, err := ResolvePermissionsKeywordedScopes(tt.u, tt.permissions)
 			if tt.wantErr {
 				require.Error(t, err, "expected an error during the grouped permissions resolution")
 				return
 			}
-			require.NoError(t, err, "expected an error during the grouped permissions resolution")
+			require.NoError(t, err, "did not expect an error during the grouped permissions resolution")
 
 			assert.EqualValues(t, resolved, tt.want, "resolution of grouped permissions did not end with expected result")
 		})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In some context, we would like to grant viewers with the ability to `"users:read"` `"users:self"` for instance. At the moment this is not possible. This PR intends to see if we can have something efficient working to solve this problem.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/grafana-enterprise#1849

**Special notes for your reviewer**:
Handling Attribute resolution will be done in another PR.
