### PR TITLE
Chore/Nit: Fix minor alignment issue in panel editor

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -173,6 +173,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding: ${theme.spacing(1)};
     background: ${theme.colors.background.primary};
     border: 1px solid ${theme.components.panel.borderColor};
+    border-top-left-radius: ${theme.shape.borderRadius(1.5)};
     border-bottom: none;
   `,
   closeButton: css`

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -507,7 +507,6 @@ export const getStyles = stylesFactory((theme: GrafanaTheme, props: Props) => {
       min-height: 0;
       width: 100%;
       padding-left: ${paneSpacing};
-      padding-right: 2px;
     `,
     tabsWrapper: css`
       height: 100%;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -38,7 +38,7 @@ export const PanelEditorTabs: FC<PanelEditorTabsProps> = React.memo(({ panel, da
 
   return (
     <div className={styles.wrapper}>
-      <TabsBar className={styles.tabBar}>
+      <TabsBar className={styles.tabBar} hideBorder>
         {tabs.map((tab) => {
           if (config.unifiedAlertingEnabled && tab.id === PanelEditorTabId.Alert) {
             return (
@@ -107,7 +107,10 @@ const getStyles = (theme: GrafanaTheme2) => {
       flex-grow: 1;
       min-height: 0;
       background: ${theme.colors.background.primary};
-      border-right: 1px solid ${theme.components.panel.borderColor};
+      border: 1px solid ${theme.components.panel.borderColor};
+      border-left: none;
+      border-bottom: none;
+      border-top-right-radius: ${theme.shape.borderRadius(1.5)};
     `,
   };
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a very minor alignment issue to line up the right edge of the refresh button with the right edge of the visualization.
Also adds a radius to the top left of the drawer, and top right of the query editor contents.

Before / After:
![image](https://user-images.githubusercontent.com/45561153/136589370-e3d4ffe4-50da-4485-83cd-42929797098b.png)
