### PR TITLE
Chore: add codeowners for edge squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,7 @@ go.sum @grafana/backend-platform
 /public @grafana/user-essentials
 /public/app/core/components/TimePicker @grafana/grafana-bi-squad
 /public/app/features/canvas/ @grafana/grafana-edge-squad
+/public/app/features/dimensions/ @grafana/grafana-edge-squad
 /public/app/features/live/ @grafana/grafana-edge-squad
 /public/app/features/explore/ @grafana/observability-squad
 /public/app/plugins/panel/alertlist @grafana/alerting-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,9 @@ go.sum @grafana/backend-platform
 /pkg/services/sqlstore/migrations @grafana/backend-platform @grafana/hosted-grafana-team
 *_mig.go @grafana/backend-platform @grafana/hosted-grafana-team
 
+# Grafana live
+/pkg/service/live/ @grafana/grafana-edge-squad
+
 # Unified Alerting
 /pkg/services/ngalert @grafana/alerting-squad
 /pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad
@@ -73,6 +76,8 @@ go.sum @grafana/backend-platform
 /plugins-bundled @grafana/plugins-platform
 /public @grafana/user-essentials
 /public/app/core/components/TimePicker @grafana/grafana-bi-squad
+/public/app/features/canvas/ @grafana/grafana-edge-squad
+/public/app/features/live/ @grafana/grafana-edge-squad
 /public/app/features/explore/ @grafana/observability-squad
 /public/app/plugins/panel/alertlist @grafana/alerting-squad
 /public/app/plugins/panel/barchart @grafana/grafana-bi-squad
@@ -83,6 +88,8 @@ go.sum @grafana/backend-platform
 /public/app/plugins/panel/status-history @grafana/grafana-bi-squad
 /public/app/plugins/panel/table @grafana/grafana-bi-squad
 /public/app/plugins/panel/timeseries @grafana/grafana-bi-squad
+/public/app/plugins/panel/geomap @grafana/grafana-edge-squad
+/public/app/plugins/panel/canvas @grafana/grafana-edge-squad
 /scripts/build/release-packages.sh @grafana/plugins-platform
 /scripts/circle-release-next-packages.sh @grafana/plugins-platform
 /scripts/ci-frontend-metrics.sh @grafana/user-essentials @grafana/plugins-platform @grafana/grafana-bi-squad


### PR DESCRIPTION
add the edge squad links

https://github.com/orgs/grafana/teams/grafana-edge-squad/members