### PR TITLE
Add on datasource change to optional components -- alt --

### DIFF
--- a/public/app/core/utils/query.ts
+++ b/public/app/core/utils/query.ts
@@ -1,4 +1,4 @@
-import { DataQuery } from '@grafana/data';
+import { DataQuery, DataSourceInstanceSettings } from '@grafana/data';
 
 export const getNextRefIdChar = (queries: DataQuery[]): string => {
   for (let num = 0; ; num++) {
@@ -9,11 +9,37 @@ export const getNextRefIdChar = (queries: DataQuery[]): string => {
   }
 };
 
-export function addQuery(queries: DataQuery[], query?: Partial<DataQuery>): DataQuery[] {
+export function addQuery(queries: DataQuery[], query?: Partial<DataQuery>, datasource?: string): DataQuery[] {
   const q = query || {};
   q.refId = getNextRefIdChar(queries);
   q.hide = false;
+
+  if (!q.datasource && datasource) {
+    q.datasource = datasource;
+  }
+
   return [...queries, q as DataQuery];
+}
+
+export function updateQueries(
+  newSettings: DataSourceInstanceSettings,
+  queries: DataQuery[],
+  extensionID: string, // pass this in because importing it creates a circular dependency
+  dsSettings?: DataSourceInstanceSettings
+): DataQuery[] {
+  if (!newSettings.meta.mixed && dsSettings?.meta.mixed) {
+    return queries.map((q) => {
+      if (q.datasource !== extensionID) {
+        q.datasource = newSettings.name;
+      }
+      return q;
+    });
+  } else if (!newSettings.meta.mixed && dsSettings?.meta.id !== newSettings.meta.id) {
+    // we are changing data source type, clear queries
+    return [{ refId: 'A', datasource: newSettings.name }];
+  }
+
+  return queries;
 }
 
 export function isDataQuery(url: string): boolean {

--- a/public/app/features/query/components/QueryActionComponent.ts
+++ b/public/app/features/query/components/QueryActionComponent.ts
@@ -4,7 +4,7 @@ interface ActionComponentProps {
   query?: DataQuery;
   queries?: Array<Partial<DataQuery>>;
   onAddQuery?: (q: DataQuery) => void;
-  onChangeDataSource?: (newSettings: DataSourceInstanceSettings) => void;
+  onChangeDataSource?: (ds: DataSourceInstanceSettings) => void;
   timeRange?: TimeRange;
   dataSource?: DataSourceInstanceSettings;
 }

--- a/public/app/features/query/components/QueryActionComponent.ts
+++ b/public/app/features/query/components/QueryActionComponent.ts
@@ -4,6 +4,7 @@ interface ActionComponentProps {
   query?: DataQuery;
   queries?: Array<Partial<DataQuery>>;
   onAddQuery?: (q: DataQuery) => void;
+  onChangeDataSource?: (newSettings: DataSourceInstanceSettings) => void;
   timeRange?: TimeRange;
   dataSource?: DataSourceInstanceSettings;
 }

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React, { PureComponent, ReactNode } from 'react';
 import classNames from 'classnames';
-import { has, cloneDeep } from 'lodash';
+import { cloneDeep, has } from 'lodash';
 // Utils & Services
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { AngularComponent, getAngularLoader } from '@grafana/runtime';
@@ -41,6 +41,7 @@ interface Props<TQuery extends DataQuery> {
   index: number;
   dataSource: DataSourceInstanceSettings;
   onChangeDataSource?: (dsSettings: DataSourceInstanceSettings) => void;
+  onChangeParentDataSource?: (dsSettings: DataSourceInstanceSettings) => void;
   renderHeaderExtras?: () => ReactNode;
   onAddQuery: (query: TQuery) => void;
   onRemoveQuery: (query: TQuery) => void;
@@ -304,7 +305,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   }
 
   renderExtraActions = () => {
-    const { query, queries, data, onAddQuery, dataSource } = this.props;
+    const { query, queries, data, onAddQuery, dataSource, onChangeParentDataSource } = this.props;
     return RowActionComponents.getAllExtraRenderAction().map((c, index) => {
       return React.createElement(c, {
         query,
@@ -313,6 +314,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         onAddQuery: onAddQuery as (query: DataQuery) => void,
         dataSource: dataSource,
         key: index,
+        onChangeDataSource: onChangeParentDataSource,
       });
     });
   };

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -41,7 +41,6 @@ interface Props<TQuery extends DataQuery> {
   index: number;
   dataSource: DataSourceInstanceSettings;
   onChangeDataSource?: (dsSettings: DataSourceInstanceSettings) => void;
-  onChangeParentDataSource?: (dsSettings: DataSourceInstanceSettings) => void;
   renderHeaderExtras?: () => ReactNode;
   onAddQuery: (query: TQuery) => void;
   onRemoveQuery: (query: TQuery) => void;
@@ -305,7 +304,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   }
 
   renderExtraActions = () => {
-    const { query, queries, data, onAddQuery, dataSource, onChangeParentDataSource } = this.props;
+    const { query, queries, data, onAddQuery, dataSource } = this.props;
     return RowActionComponents.getAllExtraRenderAction().map((c, index) => {
       return React.createElement(c, {
         query,
@@ -314,7 +313,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         onAddQuery: onAddQuery as (query: DataQuery) => void,
         dataSource: dataSource,
         key: index,
-        onChangeDataSource: onChangeParentDataSource,
       });
     });
   };

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -31,6 +31,7 @@ interface Props {
   app?: CoreApp;
   history?: Array<HistoryItem<DataQuery>>;
   eventBus?: EventBusExtended;
+  onChangeParentDataSource?: (ds: DataSourceInstanceSettings) => void;
 }
 
 export class QueryEditorRows extends PureComponent<Props> {
@@ -101,7 +102,7 @@ export class QueryEditorRows extends PureComponent<Props> {
   };
 
   render() {
-    const { dsSettings, data, queries, app, history, eventBus } = this.props;
+    const { dsSettings, data, queries, app, history, eventBus, onChangeParentDataSource } = this.props;
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
@@ -124,6 +125,7 @@ export class QueryEditorRows extends PureComponent<Props> {
                       query={query}
                       dataSource={dataSourceSettings}
                       onChangeDataSource={onChangeDataSourceSettings}
+                      onChangeParentDataSource={onChangeParentDataSource}
                       onChange={(query) => this.onChangeQuery(query, index)}
                       onRemoveQuery={this.onRemoveQuery}
                       onAddQuery={this.props.onAddQuery}

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -31,7 +31,6 @@ interface Props {
   app?: CoreApp;
   history?: Array<HistoryItem<DataQuery>>;
   eventBus?: EventBusExtended;
-  onChangeParentDataSource?: (ds: DataSourceInstanceSettings) => void;
 }
 
 export class QueryEditorRows extends PureComponent<Props> {
@@ -102,7 +101,7 @@ export class QueryEditorRows extends PureComponent<Props> {
   };
 
   render() {
-    const { dsSettings, data, queries, app, history, eventBus, onChangeParentDataSource } = this.props;
+    const { dsSettings, data, queries, app, history, eventBus } = this.props;
 
     return (
       <DragDropContext onDragEnd={this.onDragEnd}>
@@ -125,7 +124,6 @@ export class QueryEditorRows extends PureComponent<Props> {
                       query={query}
                       dataSource={dataSourceSettings}
                       onChangeDataSource={onChangeDataSourceSettings}
-                      onChangeParentDataSource={onChangeParentDataSource}
                       onChange={(query) => this.onChangeQuery(query, index)}
                       onRemoveQuery={this.onRemoveQuery}
                       onAddQuery={this.props.onAddQuery}

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -12,7 +12,7 @@ import {
   stylesFactory,
   Tooltip,
 } from '@grafana/ui';
-import { getDataSourceSrv, DataSourcePicker } from '@grafana/runtime';
+import { DataSourcePicker, getDataSourceSrv } from '@grafana/runtime';
 import { QueryEditorRows } from './QueryEditorRows';
 // Services
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -115,11 +115,15 @@ export class QueryGroup extends PureComponent<Props, State> {
 
     // switching to mixed
     if (newSettings.meta.mixed) {
-      for (const query of queries) {
-        if (query.datasource !== ExpressionDatasourceID) {
-          query.datasource = dsSettings?.name;
-          if (!query.datasource) {
-            query.datasource = config.defaultDatasource;
+      const isCurrentMixed = dsSettings?.meta?.mixed || false;
+      if (!isCurrentMixed) {
+        // Only update if mixed hasn't already been selected
+        for (const query of queries) {
+          if (query.datasource !== ExpressionDatasourceID) {
+            query.datasource = dsSettings?.name;
+            if (!query.datasource) {
+              query.datasource = config.defaultDatasource;
+            }
           }
         }
       }
@@ -320,6 +324,7 @@ export class QueryGroup extends PureComponent<Props, State> {
           onQueriesChange={this.onQueriesChange}
           onAddQuery={this.onAddQuery}
           onRunQueries={onRunQueries}
+          onChangeParentDataSource={this.onChangeDataSource}
           data={data}
         />
       </div>
@@ -332,7 +337,7 @@ export class QueryGroup extends PureComponent<Props, State> {
 
   renderExtraActions() {
     return GroupActionComponents.getAllExtraRenderAction().map((c) => {
-      return React.createElement(c, { onAddQuery: this.onAddQuery });
+      return React.createElement(c, { onAddQuery: this.onAddQuery, onChangeDataSource: this.onChangeDataSource });
     });
   }
 

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -27,12 +27,9 @@ import {
   PanelData,
 } from '@grafana/data';
 import { PluginHelp } from 'app/core/components/PluginHelp/PluginHelp';
-import { addQuery } from 'app/core/utils/query';
+import { addQuery, updateQueries } from 'app/core/utils/query';
 import { Unsubscribable } from 'rxjs';
-import {
-  dataSource as expressionDatasource,
-  ExpressionDatasourceID,
-} from 'app/features/expressions/ExpressionDatasource';
+import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { selectors } from '@grafana/e2e-selectors';
 import { PanelQueryRunner } from '../state/PanelQueryRunner';
 import { QueryGroupOptionsEditor } from './QueryGroupOptions';
@@ -52,6 +49,7 @@ interface Props {
 interface State {
   dataSource?: DataSourceApi;
   dsSettings?: DataSourceInstanceSettings;
+  queries: DataQuery[];
   helpContent: React.ReactNode;
   isLoadingHelp: boolean;
   isPickerOpen: boolean;
@@ -74,6 +72,7 @@ export class QueryGroup extends PureComponent<Props, State> {
     isAddingMixed: false,
     isHelpOpen: false,
     scrollTop: 0,
+    queries: [],
     data: {
       state: LoadingState.NotStarted,
       series: [],
@@ -92,7 +91,8 @@ export class QueryGroup extends PureComponent<Props, State> {
       const ds = await this.dataSourceSrv.get(options.dataSource.name);
       const dsSettings = this.dataSourceSrv.getInstanceSettings(options.dataSource.name);
       const defaultDataSource = await this.dataSourceSrv.get();
-      this.setState({ dataSource: ds, dsSettings, defaultDataSource });
+      const queries = options.queries.map((q) => (q.datasource ? q : { ...q, datasource: dsSettings?.name }));
+      this.setState({ queries, dataSource: ds, dsSettings, defaultDataSource });
     } catch (error) {
       console.log('failed to load data source', error);
     }
@@ -110,40 +110,10 @@ export class QueryGroup extends PureComponent<Props, State> {
   }
 
   onChangeDataSource = async (newSettings: DataSourceInstanceSettings) => {
-    let { queries } = this.props.options;
     const { dsSettings } = this.state;
-
-    // switching to mixed
-    if (newSettings.meta.mixed) {
-      const isCurrentMixed = dsSettings?.meta?.mixed || false;
-      if (!isCurrentMixed) {
-        // Only update if mixed hasn't already been selected
-        for (const query of queries) {
-          if (query.datasource !== ExpressionDatasourceID) {
-            query.datasource = dsSettings?.name;
-            if (!query.datasource) {
-              query.datasource = config.defaultDatasource;
-            }
-          }
-        }
-      }
-    } else if (dsSettings) {
-      // if switching from mixed
-      if (dsSettings.meta.mixed) {
-        // Remove the explicit datasource
-        for (const query of queries) {
-          if (query.datasource !== ExpressionDatasourceID) {
-            delete query.datasource;
-          }
-        }
-      } else if (dsSettings.meta.id !== newSettings.meta.id) {
-        // we are changing data source type, clear queries
-        queries = [{ refId: 'A' }];
-      }
-    }
+    const queries = updateQueries(newSettings, this.state.queries, expressionDatasource.name, dsSettings);
 
     const dataSource = await this.dataSourceSrv.get(newSettings.name);
-
     this.onChange({
       queries,
       dataSource: {
@@ -154,14 +124,15 @@ export class QueryGroup extends PureComponent<Props, State> {
     });
 
     this.setState({
+      queries,
       dataSource: dataSource,
       dsSettings: newSettings,
     });
   };
 
   onAddQueryClick = () => {
-    const { options } = this.props;
-    this.onChange({ queries: addQuery(options.queries, this.newQuery()) });
+    const { queries } = this.state;
+    this.onQueriesChange(addQuery(queries, this.newQuery()));
     this.onScrollBottom();
   };
 
@@ -169,7 +140,7 @@ export class QueryGroup extends PureComponent<Props, State> {
     const { dsSettings, defaultDataSource } = this.state;
 
     if (!dsSettings?.meta.mixed) {
-      return {};
+      return { datasource: dsSettings?.name };
     }
 
     return {
@@ -185,9 +156,7 @@ export class QueryGroup extends PureComponent<Props, State> {
   }
 
   onAddExpressionClick = () => {
-    this.onChange({
-      queries: addQuery(this.props.options.queries, expressionDatasource.newQuery()),
-    });
+    this.onQueriesChange(addQuery(this.state.queries, expressionDatasource.newQuery()));
     this.onScrollBottom();
   };
 
@@ -288,8 +257,8 @@ export class QueryGroup extends PureComponent<Props, State> {
   };
 
   onAddQuery = (query: Partial<DataQuery>) => {
-    const { queries } = this.props.options;
-    this.onChange({ queries: addQuery(queries, query) });
+    const { dsSettings, queries } = this.state;
+    this.onQueriesChange(addQuery(queries, query, dsSettings?.name));
     this.onScrollBottom();
   };
 
@@ -299,16 +268,17 @@ export class QueryGroup extends PureComponent<Props, State> {
 
   onQueriesChange = (queries: DataQuery[]) => {
     this.onChange({ queries });
+    this.setState({ queries });
   };
 
   renderQueries(dsSettings: DataSourceInstanceSettings) {
-    const { options, onRunQueries } = this.props;
-    const { data } = this.state;
+    const { onRunQueries } = this.props;
+    const { data, queries } = this.state;
 
     if (isSharedDashboardQuery(dsSettings.name)) {
       return (
         <DashboardQueryEditor
-          queries={options.queries}
+          queries={queries}
           panelData={data}
           onChange={this.onQueriesChange}
           onRunQueries={onRunQueries}
@@ -319,12 +289,11 @@ export class QueryGroup extends PureComponent<Props, State> {
     return (
       <div aria-label={selectors.components.QueryTab.content}>
         <QueryEditorRows
-          queries={options.queries}
+          queries={queries}
           dsSettings={dsSettings}
           onQueriesChange={this.onQueriesChange}
           onAddQuery={this.onAddQuery}
           onRunQueries={onRunQueries}
-          onChangeParentDataSource={this.onChangeDataSource}
           data={data}
         />
       </div>


### PR DESCRIPTION
This is an alternative approach to #40164. In this approach, the `QueryGroup` keeps track of the queries it is responsibe for and makes sure they all have a datasource. As a result, the `create recorded query modal` no longer has to take `onChangeDataSource`

This PR still passes `onChangeDataSource` to the `add recorded query modal` because this modal actually adds a query to the group and should be mixed.

An interesing result of the PR is that the logic inside `onDataSourceChange` has become simpler because we don't repeatedly add and remove the datasource name.

What are folks thoughts on this approach?