### PR TITLE
Bug: packages/grafana-ui and public/app use different instances of react-hook-form

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -42,6 +42,7 @@ module.exports = {
       // problems with @grafana/ui
       'react-router': require.resolve('react-router'),
       'react-router-dom': require.resolve('react-router-dom'),
+      'react-hook-form': require.resolve('react-hook-form'),
       jquery: require.resolve('jquery'),
       // some of data source pluginis use global Prism object to add the language definition
       // we want to have same Prism object in core and in grafana/ui


### PR DESCRIPTION
**What this PR does / why we need it**:

It appears that after [yarn 2 migration](https://github.com/grafana/grafana/pull/39082) code in `package/grafana-ui` and in `public/app` import different instances of `react-hook-form`, which causes form react context provided by one to not be found by the other. Nefariously, this is not picked up by jest tests, as appraently they compile things different :)

 Fixed by aliasing the import in webpack config, same as with `react-router`

