### PR TITLE
Use sentence case for consistency

### DIFF
--- a/docs/sources/http_api/_index.md
+++ b/docs/sources/http_api/_index.md
@@ -6,27 +6,27 @@ aliases = ["/docs/grafana/latest/overview"]
 weight = 170
 +++
 
-# HTTP API Reference
+# HTTP API reference
 
-The Grafana backend exposes an HTTP API, the same API is used by the frontend to do everything from saving
-dashboards, creating users and updating data sources.
+The Grafana backend exposes an HTTP API, which is the same API that is used by the frontend to do everything from saving
+dashboards, creating users, and updating data sources.
 
 ## HTTP APIs
 
 - [Authentication API]({{< relref "auth.md" >}})
 - [Dashboard API]({{< relref "dashboard.md" >}})
-- [Dashboard Versions API]({{< relref "dashboard_versions.md" >}})
-- [Dashboard Permissions API]({{< relref "dashboard_permissions.md" >}})
+- [Dashboard versions API]({{< relref "dashboard_versions.md" >}})
+- [Dashboard permissions API]({{< relref "dashboard_permissions.md" >}})
 - [Folder API]({{< relref "folder.md" >}})
-- [Folder Permissions API]({{< relref "folder_permissions.md" >}})
+- [Folder permissions API]({{< relref "folder_permissions.md" >}})
 - [Folder/dashboard search API]({{< relref "folder_dashboard_search.md" >}})
-- [Data Source API]({{< relref "data_source.md" >}})
+- [Data source API]({{< relref "data_source.md" >}})
 - [Organization API]({{< relref "org.md" >}})
 - [Snapshot API]({{< relref "snapshot.md" >}})
 - [Annotations API]({{< relref "annotations.md" >}})
 - [Playlists API]({{< relref "playlist.md" >}})
 - [Alerting API]({{< relref "alerting.md" >}})
-- [Alert Notification Channels API]({{< relref "alerting_notification_channels.md" >}})
+- [Alert notification channels API]({{< relref "alerting_notification_channels.md" >}})
 - [User API]({{< relref "user.md" >}})
 - [Team API]({{< relref "team.md" >}})
 - [Admin API]({{< relref "admin.md" >}})
@@ -37,8 +37,8 @@ dashboards, creating users and updating data sources.
 
 Grafana Enterprise includes all of the Grafana OSS APIs as well as those that follow:
 
-- [Fine-Grained Access Control API]({{< relref "access_control.md" >}})
-- [Data Source Permissions API]({{< relref "datasource_permissions.md" >}})
-- [External Group Sync API]({{< relref "external_group_sync.md" >}})
+- [Fine-grained access control API]({{< relref "access_control.md" >}})
+- [Data source permissions API]({{< relref "datasource_permissions.md" >}})
+- [External group sync API]({{< relref "external_group_sync.md" >}})
 - [License API]({{< relref "licensing.md" >}})
 - [Reporting API]({{< relref "reporting.md" >}})


### PR DESCRIPTION
For example, https://grafana.com/docs/grafana/next/http_api/access_control/ uses sentence case and the link text is inconsistent.

For more information, see https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings.