### PR TITLE
Chore: Remove unused `push_to_deployment_tools` step

### DIFF
--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -29,7 +29,6 @@ load(
     'publish_storybook_step',
     'release_canary_npm_packages_step',
     'upload_packages_step',
-    'push_to_deployment_tools_step',
     'publish_packages_step',
     'upload_cdn_step',
     'validate_scuemata_step',
@@ -104,7 +103,6 @@ def get_steps(edition, is_downstream=False):
     steps.extend([
         release_canary_npm_packages_step(edition),
         upload_packages_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
-        push_to_deployment_tools_step(edition=edition, is_downstream=is_downstream),
         upload_cdn_step(edition=edition)
     ])
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -795,26 +795,6 @@ def release_canary_npm_packages_step(edition):
         ],
     }
 
-def push_to_deployment_tools_step(edition, is_downstream=False):
-    if edition != 'enterprise' or not is_downstream:
-        return None
-
-    return {
-        'name': 'push-to-deployment_tools',
-        'image': deploy_docker_image,
-        'depends_on': [
-            'build-docker-images',
-            # This step should have all the dependencies required for packaging, and should generate
-            # dist/grafana.version
-            'gen-version',
-        ],
-        'settings': {
-            'github_token': from_secret(github_token),
-            'images_file': './deployment_tools_config.json',
-            'docker_tag_file': './dist/grafana.version'
-        },
-    }
-
 def enterprise2_suffix(edition):
     if edition == 'enterprise2':
         return '-{}'.format(edition)


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleanup - this step is now moved to another repo, and wasn't used at all in the first place.