### PR TITLE
Alerting: Fix rule form crash when there are extra query actions defined

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -3,6 +3,7 @@ import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
 import {
   DataQuery,
   DataSourceInstanceSettings,
+  LoadingState,
   PanelData,
   RelativeTimeRange,
   ThresholdsConfig,
@@ -230,13 +231,15 @@ export class QueryRows extends PureComponent<Props, State> {
             return (
               <div ref={provided.innerRef} {...provided.droppableProps}>
                 {queries.map((query, index) => {
-                  const data = this.props.data ? this.props.data[query.refId] : ({} as PanelData);
+                  const data: PanelData = this.props.data?.[query.refId] ?? {
+                    series: [],
+                    state: LoadingState.NotStarted,
+                  };
                   const dsSettings = this.getDataSourceSettings(query);
 
                   if (!dsSettings) {
                     return null;
                   }
-
                   return (
                     <QueryWrapper
                       index={index}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -6,6 +6,7 @@ import {
   DataSourceInstanceSettings,
   getDefaultRelativeTimeRange,
   GrafanaTheme2,
+  LoadingState,
   PanelData,
   RelativeTimeRange,
   ThresholdsConfig,
@@ -83,7 +84,7 @@ export const QueryWrapper: FC<Props> = ({
         queries={queries}
         renderHeaderExtras={() => renderTimePicker(query, index)}
         visualization={
-          data ? (
+          data.state !== LoadingState.NotStarted ? (
             <VizWrapper
               data={data}
               changePanel={changePluginId}


### PR DESCRIPTION
**What this PR does / why we need it**:

Problem: Grafana 8 alerting rule editor crashes if there are extra query editor actions provided via `QueryActionComponents.addExtraRenderAction`. OSS version does not define any, but pro/enerprise do, triggering the bug

Cause: Until queries are run, rule editor provides `undefined` typecast to `PanelData`. `QueryEditorRow` however expects it to be well defined and tries to read `timeRange` off it [here](https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryEditorRow.tsx#L312), causing an error

Solution: initialize empty but well defined `PanelData`

