### PR TITLE
Packaging: We removed the ProcSubset option in systemd. This option prevented Grafana from starting in LXC environments.

### DIFF
--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -34,7 +34,6 @@ NoNewPrivileges=true
 PrivateDevices=true
 PrivateTmp=true
 PrivateUsers=true
-ProcSubset=pid
 ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -33,7 +33,6 @@ NoNewPrivileges=true
 PrivateDevices=true
 PrivateTmp=true
 PrivateUsers=true
-ProcSubset=pid
 ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true


### PR DESCRIPTION
What is `ProcSubset`?

Basically it limits what folders in the `/proc` directory the program can access. In LXC environments [this option can prevent Grafana from starting](https://github.com/grafana/grafana/issues/40240), though in other environments this is a pretty benign option.