### PR TITLE
Alerting: Remove invalid Slack URL as we migrate notification channels

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/channel.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel.go
@@ -138,6 +138,7 @@ func (m *migration) makeReceiverAndRoute(ruleUid string, orgID int64, channelUid
 			if ok {
 				_, err := url.Parse(u)
 				if err != nil {
+					m.mg.Logger.Warn("slack notification channel had invalid URL, removing", "name", c.Name, "uid", c.Uid, "org", c.OrgID)
 					delete(decryptedSecureSettings, "url")
 				}
 			}

--- a/pkg/services/sqlstore/migrations/ualert/channel.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -127,6 +128,21 @@ func (m *migration) makeReceiverAndRoute(ruleUid string, orgID int64, channelUid
 		if err != nil {
 			return err
 		}
+
+		// Grafana accepts any type of string as a URL for the Slack notification channel.
+		// However, the Alertmanager will fail if provided with an invalid URL we have two options at this point:
+		// Either we fail the migration or remove the URL, we've chosen the latter and assume that the notification
+		// channel was broken to begin with.
+		if c.Type == "slack" {
+			u, ok := decryptedSecureSettings["url"]
+			if ok {
+				_, err := url.Parse(u)
+				if err != nil {
+					delete(decryptedSecureSettings, "url")
+				}
+			}
+		}
+
 		portedChannels = append(portedChannels, &PostableGrafanaReceiver{
 			UID:                   uid,
 			Name:                  c.Name,

--- a/pkg/services/sqlstore/migrations/ualert/channel_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel_test.go
@@ -1,0 +1,118 @@
+package ualert
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+func Test_makeReceiverAndRoute(t *testing.T) {
+	emptyMigration := func() *migration {
+		return &migration{
+			mg: &migrator.Migrator{
+				Logger: log.New("test"),
+			},
+			migratedChannelsPerOrg:    make(map[int64]map[*notificationChannel]struct{}),
+			portedChannelGroupsPerOrg: make(map[int64]map[string]string),
+			seenChannelUIDs:           make(map[string]struct{}),
+			// lastReceiverID: 0,
+		}
+	}
+
+	generateChannel := func(channelType string, settings map[string]interface{}, secureSettings map[string]string) *notificationChannel {
+		uid := util.GenerateShortUID()
+		return &notificationChannel{
+			ID:                    rand.Int63(),
+			OrgID:                 rand.Int63(),
+			Uid:                   uid,
+			Name:                  fmt.Sprintf("Test-%s", uid),
+			Type:                  channelType,
+			DisableResolveMessage: rand.Int63()%2 == 0,
+			IsDefault:             rand.Int63()%2 == 0,
+			Settings:              simplejson.NewFromAny(settings),
+			SecureSettings:        GetEncryptedJsonData(secureSettings),
+		}
+	}
+
+	t.Run("Slack channel is migrated", func(t *testing.T) {
+		t.Run("url is removed if it is invalid (secure settings)", func(t *testing.T) {
+			secureSettings := map[string]string{
+				"url": "�6�M��)uk譹1(�h`$�o�N>mĕ����cS2�dh![ę�	���`csB�!��OSxP�{�",
+				"token": util.GenerateShortUID(),
+			}
+			settings := map[string]interface{}{
+				"test": "data",
+				"some_map": map[string]interface{}{
+					"test": rand.Int63(),
+				},
+			}
+
+			channel := generateChannel("slack", settings, secureSettings)
+			channelsUid := []interface{}{
+				channel.Uid,
+			}
+			defaultChannels := make([]*notificationChannel, 0)
+			allChannels := map[interface{}]*notificationChannel{
+				channel.Uid: channel,
+			}
+
+			apiReceiver, _, err := emptyMigration().makeReceiverAndRoute(util.GenerateShortUID(), channel.OrgID, channelsUid, defaultChannels, allChannels)
+			require.NoError(t, err)
+
+			require.Len(t, apiReceiver.GrafanaManagedReceivers, 1)
+
+			receiver := apiReceiver.GrafanaManagedReceivers[0]
+
+			require.NotContains(t, receiver.SecureSettings, "url")
+			require.Contains(t, receiver.SecureSettings, "token")
+			require.Equal(t, secureSettings["token"], receiver.SecureSettings["token"])
+			actualSettings, err := receiver.Settings.Map()
+			require.NoError(t, err)
+			require.Equal(t, settings, actualSettings)
+		})
+
+		t.Run("url is removed if it is invalid (settings)", func(t *testing.T) {
+			secureSettings := map[string]string{
+				"token": util.GenerateShortUID(),
+			}
+			settings := map[string]interface{}{
+				"url": "�6�M��)uk譹1(�h`$�o�N>mĕ����cS2�dh![ę�	���`csB�!��OSxP�{�",
+				"test": "data",
+				"some_map": map[string]interface{}{
+					"test": rand.Int63(),
+				},
+			}
+
+			channel := generateChannel("slack", settings, secureSettings)
+			channelsUid := []interface{}{
+				channel.Uid,
+			}
+			defaultChannels := make([]*notificationChannel, 0)
+			allChannels := map[interface{}]*notificationChannel{
+				channel.Uid: channel,
+			}
+
+			apiReceiver, _, err := emptyMigration().makeReceiverAndRoute(util.GenerateShortUID(), channel.OrgID, channelsUid, defaultChannels, allChannels)
+			require.NoError(t, err)
+
+			require.Len(t, apiReceiver.GrafanaManagedReceivers, 1)
+
+			receiver := apiReceiver.GrafanaManagedReceivers[0]
+
+			require.NotContains(t, receiver.SecureSettings, "url")
+			require.Contains(t, receiver.SecureSettings, "token")
+			require.Equal(t, secureSettings["token"], receiver.SecureSettings["token"])
+			actualSettings, err := receiver.Settings.Map()
+			require.NoError(t, err)
+			delete(settings, "url")
+			require.Equal(t, settings, actualSettings)
+		})
+	})
+}

--- a/pkg/services/sqlstore/migrations/ualert/channel_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/channel_test.go
@@ -22,7 +22,6 @@ func Test_makeReceiverAndRoute(t *testing.T) {
 			migratedChannelsPerOrg:    make(map[int64]map[*notificationChannel]struct{}),
 			portedChannelGroupsPerOrg: make(map[int64]map[string]string),
 			seenChannelUIDs:           make(map[string]struct{}),
-			// lastReceiverID: 0,
 		}
 	}
 
@@ -44,7 +43,7 @@ func Test_makeReceiverAndRoute(t *testing.T) {
 	t.Run("Slack channel is migrated", func(t *testing.T) {
 		t.Run("url is removed if it is invalid (secure settings)", func(t *testing.T) {
 			secureSettings := map[string]string{
-				"url": "�6�M��)uk譹1(�h`$�o�N>mĕ����cS2�dh![ę�	���`csB�!��OSxP�{�",
+				"url":   invalidUri,
 				"token": util.GenerateShortUID(),
 			}
 			settings := map[string]interface{}{
@@ -83,7 +82,7 @@ func Test_makeReceiverAndRoute(t *testing.T) {
 				"token": util.GenerateShortUID(),
 			}
 			settings := map[string]interface{}{
-				"url": "�6�M��)uk譹1(�h`$�o�N>mĕ����cS2�dh![ę�	���`csB�!��OSxP�{�",
+				"url":  invalidUri,
 				"test": "data",
 				"some_map": map[string]interface{}{
 					"test": rand.Int63(),
@@ -116,3 +115,5 @@ func Test_makeReceiverAndRoute(t *testing.T) {
 		})
 	})
 }
+
+const invalidUri = "�6�M��)uk譹1(�h`$�o�N>mĕ����cS2�dh![ę�	���`csB�!��OSxP�{�"


### PR DESCRIPTION
Grafana will accept any type of utf8 valid string as the Slack URL and will simply fail as we try to deliver the notification of the channel. The Alertmanager will fail to apply a configuration if the URL of the Slack Receiver is invalid.

This change takes that into account by removing the URL for the receiver as we migrate notification channels that do not pass the url validation. As we assume the notification was not being delivered to being with.