### PR TITLE
Chore: Remove refs to deprecated Yarn install --pure-lockfile option

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -48,7 +48,7 @@ Grafana consists of two components; the _frontend_, and the _backend_.
 Before we can build the frontend assets, we need to install the dependencies:
 
 ```
-yarn install --pure-lockfile
+yarn install --immutable
 ```
 
 After the command has finished, we can start building our source code:

--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -309,7 +309,7 @@ You can contribute to grafana-toolkit by helping develop it or by debugging it.
 Typically plugins should be developed using the `@grafana/toolkit` installed from npm. However, when working on the toolkit, you might want to use the local version. Follow the steps below to develop with a local version:
 
 1. Clone [Grafana repository](https://github.com/grafana/grafana).
-2. Navigate to the directory you have cloned Grafana repo to and then run `yarn install --pure-lockfile`.
+2. Navigate to the directory you have cloned Grafana repo to and then run `yarn install --immutable`.
 3. Navigate to `<GRAFANA_DIR>/packages/grafana-toolkit` and then run `yarn link`.
 4. Navigate to the directory where your plugin code is and then run `npx grafana-toolkit plugin:dev --yarnlink`. This adds all dependencies required by grafana-toolkit to your project, as well as link your local grafana-toolkit version to be used by the plugin.
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
With the upgrade to Yarn V2, `--pure-lockfile` is no longer a valid argument.

```
Unknown Syntax Error: Unsupported option name ("--pure-lockfile").

$ yarn install [--json] [--immutable] [--immutable-cache] [--check-cache] [--inline-builds] [--mode #0]
```

Note: Not sure if the most correct is to replace with `--immutable` - let me know if there's a more appropriate option

PS there are likely places in actual source where this change is required - for example Dockerfiles https://github.com/grafana/grafana/blob/main/Dockerfile.ubuntu#L9 https://github.com/grafana/grafana/blob/main/Dockerfile#L9
