### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,12 +4,12 @@ on:
     inputs:
       version:
         required: true
-        default: '7.x.x'
+        default: "7.x.x"
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    # This is a basic workflow to help you get started with Actions
+      # This is a basic workflow to help you get started with Actions
       - uses: actions-ecosystem/action-regex-match@v2.0.2
         id: regex-match
         with:
@@ -24,7 +24,6 @@ jobs:
           example: 7.4.3 or 7.4.3-beta.1"
           exit 1
       - uses: actions/checkout@v2
-
       - name: Set intermedia variables
         id: intermedia
         run: |
@@ -55,7 +54,8 @@ jobs:
           ref: main
       - uses: actions/setup-node@v2.4.1
         with:
-          node-version: '14'
+          node-version: "14"
+          cache: npm
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run bump version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,47 +3,47 @@ name: publish_docs
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-    - 'docs/sources/**'
-    - 'packages/grafana-*/**'
+      - "docs/sources/**"
+      - "packages/grafana-*/**"
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
-    - name: generate-packages-docs
-      uses: actions/setup-node@v2.4.1
-      id: generate-docs
-      with:
-        node-version: '14'
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-    - uses: actions/cache@v2.1.6
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
+      - uses: actions/checkout@v1
+      - run: git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync
+      - name: generate-packages-docs
+        uses: actions/setup-node@v2.4.1
+        id: generate-docs
+        with:
+          node-version: "14"
+          cache: npm
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
             yarn-
-    - run: yarn install --immutable
-    - run: ./scripts/ci-reference-docs-build.sh
-    - name: publish-to-git
-      uses: ./.github/actions/website-sync
-      id: publish
-      with:
-        repository: grafana/website
-        branch: master
-        host: github.com
-        github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
-        source_folder: docs/sources
-        target_folder: content/docs/grafana/next
-        allow_no_changes: 'true'
-    - shell: bash
-      run: |
-        test -n "${{ steps.publish.outputs.commit_hash }}"
-        test -n "${{ steps.publish.outputs.working_directory }}"
+      - run: yarn install --immutable
+      - run: ./scripts/ci-reference-docs-build.sh
+      - name: publish-to-git
+        uses: ./.github/actions/website-sync
+        id: publish
+        with:
+          repository: grafana/website
+          branch: master
+          host: github.com
+          github_pat: "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
+          source_folder: docs/sources
+          target_folder: content/docs/grafana/next
+          allow_no_changes: "true"
+      - shell: bash
+        run: |
+          test -n "${{ steps.publish.outputs.commit_hash }}"
+          test -n "${{ steps.publish.outputs.working_directory }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         id: generate-docs
         with:
           node-version: "14"
-          cache: npm
+          cache: yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,6 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2.1.6
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-
       - run: yarn install --immutable
       - run: ./scripts/ci-reference-docs-build.sh
       - name: publish-to-git


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
