### PR TITLE
Prometheus: We fixed the issue where the system did not reuse TCP connections when querying from Grafana alerting.

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -97,18 +97,17 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			}
 		}
 
-		client, err := getClient(settings.URL, httpCliOpts, httpClientProvider)
+		client, err := createClient(settings.URL, httpCliOpts, httpClientProvider)
 		if err != nil {
 			return nil, err
 		}
 
 		mdl := DatasourceInfo{
-			ID:             settings.ID,
-			URL:            settings.URL,
-			HTTPClientOpts: httpCliOpts,
-			HTTPMethod:     httpMethod,
-			TimeInterval:   timeInterval,
-			promClient:     client,
+			ID:           settings.ID,
+			URL:          settings.URL,
+			HTTPMethod:   httpMethod,
+			TimeInterval: timeInterval,
+			promClient:   client,
 		}
 
 		return mdl, nil
@@ -193,7 +192,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	return &result, nil
 }
 
-func getClient(url string, httpOpts sdkhttpclient.Options, clientProvider httpclient.Provider) (apiv1.API, error) {
+func createClient(url string, httpOpts sdkhttpclient.Options, clientProvider httpclient.Provider) (apiv1.API, error) {
 	customMiddlewares := customQueryParametersMiddleware(plog)
 	httpOpts.Middlewares = []sdkhttpclient.Middleware{customMiddlewares}
 

--- a/pkg/tsdb/prometheus/types.go
+++ b/pkg/tsdb/prometheus/types.go
@@ -1,9 +1,11 @@
 package prometheus
 
 import (
+	"sync"
 	"time"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 type DatasourceInfo struct {
@@ -12,6 +14,23 @@ type DatasourceInfo struct {
 	URL            string
 	HTTPMethod     string
 	TimeInterval   string
+
+	client apiv1.API
+	cmtx   sync.RWMutex
+}
+
+func (s *DatasourceInfo) Client() apiv1.API {
+	s.cmtx.RLock()
+	defer s.cmtx.RUnlock()
+
+	return s.client
+}
+
+func (s *DatasourceInfo) SetClient(client apiv1.API) {
+	s.cmtx.Lock()
+	defer s.cmtx.Unlock()
+
+	s.client = client
 }
 
 type PrometheusQuery struct {

--- a/pkg/tsdb/prometheus/types.go
+++ b/pkg/tsdb/prometheus/types.go
@@ -15,22 +15,22 @@ type DatasourceInfo struct {
 	HTTPMethod     string
 	TimeInterval   string
 
-	client apiv1.API
-	cmtx   sync.RWMutex
+	promClient apiv1.API
+	cmtx       *sync.RWMutex
 }
 
-func (s *DatasourceInfo) Client() apiv1.API {
+func (s *DatasourceInfo) client() apiv1.API {
 	s.cmtx.RLock()
 	defer s.cmtx.RUnlock()
 
-	return s.client
+	return s.promClient
 }
 
-func (s *DatasourceInfo) SetClient(client apiv1.API) {
+func (s *DatasourceInfo) setClient(client apiv1.API) {
 	s.cmtx.Lock()
 	defer s.cmtx.Unlock()
 
-	s.client = client
+	s.promClient = client
 }
 
 type PrometheusQuery struct {

--- a/pkg/tsdb/prometheus/types.go
+++ b/pkg/tsdb/prometheus/types.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"sync"
 	"time"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
@@ -16,21 +15,6 @@ type DatasourceInfo struct {
 	TimeInterval   string
 
 	promClient apiv1.API
-	cmtx       *sync.RWMutex
-}
-
-func (s *DatasourceInfo) client() apiv1.API {
-	s.cmtx.RLock()
-	defer s.cmtx.RUnlock()
-
-	return s.promClient
-}
-
-func (s *DatasourceInfo) setClient(client apiv1.API) {
-	s.cmtx.Lock()
-	defer s.cmtx.Unlock()
-
-	s.promClient = client
 }
 
 type PrometheusQuery struct {

--- a/pkg/tsdb/prometheus/types.go
+++ b/pkg/tsdb/prometheus/types.go
@@ -3,16 +3,14 @@ package prometheus
 import (
 	"time"
 
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 type DatasourceInfo struct {
-	ID             int64
-	HTTPClientOpts sdkhttpclient.Options
-	URL            string
-	HTTPMethod     string
-	TimeInterval   string
+	ID           int64
+	URL          string
+	HTTPMethod   string
+	TimeInterval string
 
 	promClient apiv1.API
 }


### PR DESCRIPTION
The function returned by `newInstanceSettings` is ran every time the data source is saved. Instead of initializing the client on every request, we initialize the client in this function, and simply fetch the initialized client whenever we need it.

Fixes #40366 