### PR TITLE
Live: Unsubscribe all users from channel when RunStream returns

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -217,7 +217,8 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	g.contextGetter = liveplugin.NewContextGetter(g.PluginContextProvider)
 	pipelinedChannelLocalPublisher := liveplugin.NewChannelLocalPublisher(node, g.Pipeline)
 	numLocalSubscribersGetter := liveplugin.NewNumLocalSubscribersGetter(node)
-	g.runStreamManager = runstream.NewManager(pipelinedChannelLocalPublisher, numLocalSubscribersGetter, g.contextGetter)
+	channelUnsubscriber := liveplugin.NewChannelUnsubscriber(node)
+	g.runStreamManager = runstream.NewManager(pipelinedChannelLocalPublisher, numLocalSubscribersGetter, channelUnsubscriber, g.contextGetter)
 
 	// Initialize the main features
 	dash := &features.DashboardHandler{

--- a/pkg/services/live/liveplugin/plugin.go
+++ b/pkg/services/live/liveplugin/plugin.go
@@ -59,6 +59,27 @@ func (p *NumLocalSubscribersGetter) GetNumLocalSubscribers(channelID string) (in
 	return p.node.Hub().NumSubscribers(channelID), nil
 }
 
+type ChannelUnsubscriber struct {
+	node *centrifuge.Node
+}
+
+func NewChannelUnsubscriber(node *centrifuge.Node) *ChannelUnsubscriber {
+	return &ChannelUnsubscriber{node: node}
+}
+
+func (c *ChannelUnsubscriber) Unsubscribe(channelID string) error {
+	p, err := c.node.Presence(channelID)
+	if err != nil {
+		return err
+	}
+	for _, v := range p.Presence {
+		if err = c.node.Unsubscribe(v.UserID, channelID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type ContextGetter struct {
 	PluginContextProvider *plugincontext.Provider
 }

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -296,6 +296,15 @@ export class CentrifugeSrv implements GrafanaLiveSrv {
                 process(evt.message);
               }
               return;
+            } else if (evt.state === LiveChannelConnectionState.Disconnected) {
+              console.log('LiveQuery [complete]', options.addr);
+              if (state !== LoadingState.Error) {
+                state = LoadingState.Done;
+              }
+              subscriber.next({ state, data: [data], key });
+              subscriber.complete();
+              sub.unsubscribe();
+              return;
             }
             console.log('ignore state', evt);
           }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When `RunStream` cleanly exits, the subscribed clients are not unsubscribed from the channel. This can result in strange behavior where the received data is held in a buffer and not rendered. This is easiest to reproduce when there are multiple queries in a single panel.

For example, the results in the panel below should always equal `10000` and `50000`, but the results are very inconsistent:

https://user-images.githubusercontent.com/360020/137183456-2329c5c5-94df-4ca9-b81f-656cbc77ae1e.mp4

Another side effect of this issue is that to the user it looks like the query hasn't completed, even though `RunStream` has returned and will no longer be sending data to the channel:

![image](https://user-images.githubusercontent.com/360020/137183831-4116b78e-9ae4-419b-8929-d24e8d8fb625.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

