### PR TITLE
Docs: Updated docker image names for consistency

### DIFF
--- a/docs/sources/administration/configure-docker.md
+++ b/docs/sources/administration/configure-docker.md
@@ -10,6 +10,8 @@ weight = 200
 
 If you are running Grafana in a Docker image, then you configure Grafana using [environment variables]({{< relref "../administration/configuration.md#configure-with-environment-variables" >}}) rather than directly editing the configuration file. If you want to save your data, then you also need to designate persistent storage or bind mounts for the Grafana container.
 
+> **Note:** These examples use the Grafana Enterprise docker image. You can use the Grafana Open Source edition by changing the docker image to `grafana/grafana-oss`.
+
 ## Save your Grafana data
 
 If you do not designate a location for information storage, then all your Grafana data disappears as soon as you stop your container. To save your data, you need to set up persistent storage or bind mounts for your container.
@@ -21,7 +23,7 @@ If you do not designate a location for information storage, then all your Grafan
 docker volume create grafana-storage
 
 # start grafana
-docker run -d -p 3000:3000 --name=grafana -v grafana-storage:/var/lib/grafana grafana/grafana
+docker run -d -p 3000:3000 --name=grafana -v grafana-storage:/var/lib/grafana grafana/grafana-enterprise
 ```
 
 ### Run Grafana container using bind mounts
@@ -33,7 +35,7 @@ mkdir data # creates a folder for your data
 ID=$(id -u) # saves your user id in the ID variable
 
 # starts grafana with your user id and using the data folder
-docker run -d --user $ID --volume "$PWD/data:/var/lib/grafana" -p 3000:3000 grafana/grafana:7.2.1
+docker run -d --user $ID --volume "$PWD/data:/var/lib/grafana" -p 3000:3000 grafana/grafana-enterprise:7.2.1
 ```
 
 ## Default paths
@@ -57,7 +59,7 @@ Example:
 
 ```bash
 # Run Grafana while logging to both standard out and /var/log/grafana/grafana.log
-docker run -p 3000:3000 -e "GF_LOG_MODE=console file" grafana/grafana
+docker run -p 3000:3000 -e "GF_LOG_MODE=console file" grafana/grafana-enterprise
 ```
 
 ## Configure Grafana with Docker Secrets
@@ -83,7 +85,7 @@ docker run -d \
 -e "GF_AWS_default_ACCESS_KEY_ID=YOUR_ACCESS_KEY" \
 -e "GF_AWS_default_SECRET_ACCESS_KEY=YOUR_SECRET_KEY" \
 -e "GF_AWS_default_REGION=us-east-1" \
-grafana/grafana
+grafana/grafana-enterprise
 ```
 
 You may also specify multiple profiles to `GF_AWS_PROFILES` (e.g.

--- a/docs/sources/administration/configure-docker.md
+++ b/docs/sources/administration/configure-docker.md
@@ -35,7 +35,7 @@ mkdir data # creates a folder for your data
 ID=$(id -u) # saves your user id in the ID variable
 
 # starts grafana with your user id and using the data folder
-docker run -d --user $ID --volume "$PWD/data:/var/lib/grafana" -p 3000:3000 grafana/grafana-enterprise:7.2.1
+docker run -d --user $ID --volume "$PWD/data:/var/lib/grafana" -p 3000:3000 grafana/grafana-enterprise:8.2.1
 ```
 
 ## Default paths

--- a/docs/sources/installation/docker.md
+++ b/docs/sources/installation/docker.md
@@ -48,7 +48,7 @@ You can run the latest Grafana version, run a specific version, or run an unstab
 
 ### Run the latest stable version of Grafana
 
-> **Note:** If you are on a Linux system, you might need to add `sudo` before the command.
+> **Note:** If you are on a Linux system, you might need to add `sudo` before the command or add your user to the `docker` group.
 
 ```bash
 docker run -d -p 3000:3000 grafana/grafana-enterprise
@@ -56,7 +56,7 @@ docker run -d -p 3000:3000 grafana/grafana-enterprise
 
 ### Run a specific version of Grafana
 
-> **Note:** If you are on a Linux system, you might need to add `sudo` before the command.
+> **Note:** If you are on a Linux system, you might need to add `sudo` before the command add your user to the `docker` group.
 
 ```bash
 docker run -d -p 3000:3000 --name grafana grafana/grafana-enterprise:<version number>


### PR DESCRIPTION
This is a minor addition which follows on from a change during the 8.2 beta cycle. It changes the documented docker image examples on the `Configuring Docker` page to match the docker getting started guide.

It also adds a note that you may want to add your user to the `docker` group on Linux (instead of only recommending `sudo`). 