### PR TITLE
Add vim undo files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ public/css/*.min.css
 # Editor junk
 *.sublime-workspace
 *.swp
+[._]*.un~
 .idea/
 *.iml
 *.tmp


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
I noticed that vim `.swp` files are in the `.gitignore`, but not the persistent undo files.

The vim persistent undo files look like this: `.filename.un~` . 

This is a minor change.
