### PR TITLE
influxdb: config page: typescript-fix for strict-mode

### DIFF
--- a/public/app/plugins/datasource/influxdb/types.ts
+++ b/public/app/plugins/datasource/influxdb/types.ts
@@ -8,8 +8,8 @@ export enum InfluxVersion {
 export interface InfluxOptions extends DataSourceJsonData {
   version?: InfluxVersion;
 
-  timeInterval: string;
-  httpMode: string;
+  timeInterval?: string;
+  httpMode?: string;
 
   // With Flux
   organization?: string;

--- a/scripts/ci-check-strict.sh
+++ b/scripts/ci-check-strict.sh
@@ -3,7 +3,7 @@ set -e
 
 echo -e "Collecting code stats (typescript errors & more)"
 
-ERROR_COUNT_LIMIT=24
+ERROR_COUNT_LIMIT=19
 ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --strict true | grep -oP 'Found \K(\d+)')"
 
 if [ "$ERROR_COUNT" -gt $ERROR_COUNT_LIMIT ]; then


### PR DESCRIPTION
this change makes 2 confg-page attributes optional. with this change, we eliminate typescript-strict-mode errors, and do not cause any new errors.

this is only a typescript-change, no functional changes.

i debugged the running code, and those 2 attributes are unset at the beginning in the json-object, so this change makes the type more correct.

relates to https://github.com/grafana/grafana/issues/40461