### PR TITLE
Chore: Add @grafana/grafana-release-eng to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,8 +23,9 @@ go.mod @grafana/backend-platform
 go.sum @grafana/backend-platform
 
 # Continuous Integration
-.drone.yml @malcolmholmes @dsotirakis @kminehart
-/scripts/drone/ @malcolmholmes @dsotirakis @kminehart
+.drone.yml @grafana/grafana-release-eng
+.drone.star @grafana/grafana-release-eng
+/scripts/drone/ @grafana/grafana-release-eng
 
 # Cloud Datasources backend code
 /pkg/tsdb/cloudwatch @grafana/cloud-datasources @grafana/observability-squad


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces certain individuals with `@grafana/grafana-release-eng` GH group