### PR TITLE
Alerting: specify Prometheus implementation in YAML example (docs)

### DIFF
--- a/docs/sources/datasources/alertmanager.md
+++ b/docs/sources/datasources/alertmanager.md
@@ -26,6 +26,8 @@ datasources:
     type: alertmanager
     url: http://localhost:9090
     access: proxy
+    jsonData:
+      implementation: 'prometheus'
     # optionally
     basicAuth: true
     basicAuthUser: my_user


### PR DESCRIPTION
**What this PR does / why we need it**:

It updates the [Alertmanager data source docs](https://grafana.com/docs/grafana/latest/datasources/alertmanager/).

**Which issue(s) this PR fixes**:

https://github.com/grafana/alerting-squad/issues/184