### PR TITLE
Improve handling of old/slow-to-start remote renderer

### DIFF
--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -212,7 +212,10 @@ func (rs *RenderingService) getRemotePluginVersion() (string, error) {
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode == http.StatusNotFound {
+		// Old versions of the renderer lacked the version endpoint
+		return "1.0.0", nil
+	} else if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("remote rendering request to get version failed, status code: %d, status: %s", resp.StatusCode,
 			resp.Status)
 	}

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -194,6 +194,31 @@ func (rs *RenderingService) readFileResponse(ctx context.Context, resp *http.Res
 	return nil
 }
 
+func (rs *RenderingService) getRemotePluginVersionWithRetry(retryInterval time.Duration, numRetries uint, callback func(string, error)) {
+	version, err := rs.getRemotePluginVersion()
+	if err == nil {
+		callback(version, err)
+		return
+	}
+	rs.log.Info("Couldn't get remote renderer version, retrying", "err", err)
+
+	go func() {
+		var err error
+		for try := uint(0); try < numRetries; try++ {
+			version, err := rs.getRemotePluginVersion()
+			if err == nil {
+				callback(version, err)
+				return
+			}
+			rs.log.Info("Couldn't get remote renderer version on retry, retrying", "err", err, "try", try)
+
+			time.Sleep(retryInterval)
+		}
+
+		callback("", err)
+	}()
+}
+
 func (rs *RenderingService) getRemotePluginVersion() (string, error) {
 	rendererURL, err := url.Parse(rs.Cfg.RendererUrl + "/version")
 	if err != nil {

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -195,22 +195,15 @@ func (rs *RenderingService) readFileResponse(ctx context.Context, resp *http.Res
 }
 
 func (rs *RenderingService) getRemotePluginVersionWithRetry(retryInterval time.Duration, numRetries uint, callback func(string, error)) {
-	version, err := rs.getRemotePluginVersion()
-	if err == nil {
-		callback(version, err)
-		return
-	}
-	rs.log.Info("Couldn't get remote renderer version, retrying", "err", err)
-
 	go func() {
 		var err error
-		for try := uint(0); try < numRetries; try++ {
+		for try := uint(0); try <= numRetries; try++ {
 			version, err := rs.getRemotePluginVersion()
 			if err == nil {
 				callback(version, err)
 				return
 			}
-			rs.log.Info("Couldn't get remote renderer version on retry, retrying", "err", err, "try", try)
+			rs.log.Info("Couldn't get remote renderer version, retrying", "err", err, "try", try)
 
 			time.Sleep(retryInterval)
 		}

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -37,16 +37,14 @@ type RenderUser struct {
 }
 
 type RenderingService struct {
-	log                        log.Logger
-	pluginInfo                 *plugins.Plugin
-	renderAction               renderFunc
-	renderCSVAction            renderCSVFunc
-	domain                     string
-	inProgressCount            int32
-	version                    string
-	versionMutex               sync.RWMutex
-	remoteVersionFetchInterval time.Duration
-	remoteVersionFetchRetries  uint
+	log             log.Logger
+	pluginInfo      *plugins.Plugin
+	renderAction    renderFunc
+	renderCSVAction renderCSVFunc
+	domain          string
+	inProgressCount int32
+	version         string
+	versionMutex    sync.RWMutex
 
 	Cfg                   *setting.Cfg
 	RemoteCacheService    *remotecache.RemoteCache
@@ -84,13 +82,11 @@ func ProvideService(cfg *setting.Cfg, remoteCache *remotecache.RemoteCache, rm p
 	}
 
 	s := &RenderingService{
-		Cfg:                        cfg,
-		RemoteCacheService:         remoteCache,
-		RendererPluginManager:      rm,
-		log:                        log.New("rendering"),
-		domain:                     domain,
-		remoteVersionFetchInterval: time.Second * 15,
-		remoteVersionFetchRetries:  4,
+		Cfg:                   cfg,
+		RemoteCacheService:    remoteCache,
+		RendererPluginManager: rm,
+		log:                   log.New("rendering"),
+		domain:                domain,
 	}
 	return s, nil
 }
@@ -99,7 +95,7 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 	if rs.remoteAvailable() {
 		rs.log = rs.log.New("renderer", "http")
 
-		rs.getRemotePluginVersionWithRetry(rs.remoteVersionFetchInterval, rs.remoteVersionFetchRetries, func(version string, err error) {
+		rs.getRemotePluginVersionWithRetry(func(version string, err error) {
 			if err != nil {
 				rs.log.Info("Couldn't get remote renderer version", "err", err)
 			}

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -186,7 +186,7 @@ func TestRenderingServiceGetRemotePluginVersion(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			tries++
 
-			if tries < rs.remoteVersionFetchRetries {
+			if tries < remoteVersionFetchRetries {
 				w.WriteHeader(http.StatusInternalServerError)
 			} else {
 				w.Header().Set("Content-Type", "application/json")
@@ -199,8 +199,8 @@ func TestRenderingServiceGetRemotePluginVersion(t *testing.T) {
 		defer server.Close()
 
 		rs.Cfg.RendererUrl = server.URL + "/render"
-		rs.remoteVersionFetchInterval = time.Millisecond
-		rs.remoteVersionFetchRetries = 5
+		remoteVersionFetchInterval = time.Millisecond
+		remoteVersionFetchRetries = 5
 		go func() {
 			require.NoError(t, rs.Run(ctx))
 		}()

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -144,7 +144,7 @@ func TestRenderLimitImage(t *testing.T) {
 	}
 }
 
-func TestRenderingServiceVersionFail(t *testing.T) {
+func TestRenderingServiceGetRemotePluginVersion(t *testing.T) {
 	cfg := setting.NewCfg()
 	rs := &RenderingService{
 		Cfg: cfg,
@@ -164,7 +164,7 @@ func TestRenderingServiceVersionFail(t *testing.T) {
 		version, err := rs.getRemotePluginVersion()
 
 		require.NoError(t, err)
-		require.Equal(t, version, "2.7.1828")
+		require.Equal(t, "2.7.1828", version)
 	})
 
 	t.Run("When renderer responds with 404 should assume a valid but old version", func(t *testing.T) {

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -155,7 +155,8 @@ func TestRenderingServiceVersionFail(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("{\"version\":\"2.7.1828\"}"))
+			_, err := w.Write([]byte("{\"version\":\"2.7.1828\"}"))
+			require.NoError(t, err)
 		}))
 		defer server.Close()
 
@@ -191,7 +192,8 @@ func TestRenderingServiceVersionFail(t *testing.T) {
 			} else {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("{\"version\":\"3.1.4159\"}"))
+				_, err := w.Write([]byte("{\"version\":\"3.1.4159\"}"))
+				require.NoError(t, err)
 				cancel()
 				lastRetryHit <- struct{}{}
 			}
@@ -201,7 +203,9 @@ func TestRenderingServiceVersionFail(t *testing.T) {
 		rs.Cfg.RendererUrl = server.URL + "/render"
 		rs.remoteVersionFetchInterval = time.Millisecond
 		rs.remoteVersionFetchRetries = 5
-		go rs.Run(ctx)
+		go func() {
+			require.NoError(t, rs.Run(ctx))
+		}()
 
 		select {
 		case <-time.After(time.Second):


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

If Grafana tries to fetch the remote renderer version before the renderer has started, it will permanently believe the renderer is out of date. This PR:
* improves the handling of old remote renderers (which returned 404 to a version request)
* tries 5 times, spaced 15 seconds apart, to fetch the remote renderer's version

**Special notes for your reviewer**:
The retry logic is a touch fiddly, would appreciate a close look there.

