### PR TITLE
Alerting: Provide alert state to template data + migration of KeepLastState to unified alerting

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -113,10 +113,6 @@ func (a *State) resultNoData(alertRule *ngModels.AlertRule, result eval.Result) 
 }
 
 func (a *State) NeedsSending(resendDelay time.Duration) bool {
-	if a.State != eval.Alerting && a.State != eval.Normal {
-		return false
-	}
-
 	if a.State == eval.Normal && !a.Resolved {
 		return false
 	}

--- a/pkg/services/ngalert/state/template.go
+++ b/pkg/services/ngalert/state/template.go
@@ -36,10 +36,12 @@ func expandTemplate(name, text string, labels map[string]string, alertInstance e
 		Labels map[string]string
 		Values map[string]templateCaptureValue
 		Value  string
+		State  string
 	}{
 		Labels: labels,
 		Values: newTemplateCaptureValues(alertInstance.Values),
 		Value:  alertInstance.EvaluationString,
+		State:  alertInstance.State.String(),
 	}
 
 	expander := template.NewTemplateExpander(

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -95,6 +95,13 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 	lbls, annotations := addMigrationInfo(&da)
 	lbls["alertname"] = da.Name
 	annotations["message"] = da.Message
+	if da.ParsedSettings.NoDataState == "keep_state" {
+		lbls["alertstate"] = " {{ .State }}"
+		err := m.addNoDataSilence(da.OrgId)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	ar := &alertRule{
 		OrgID:           da.OrgId,

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -201,7 +201,7 @@ func transNoData(s string) (string, error) {
 	case "alerting":
 		return "Alerting", nil
 	case "keep_state":
-		return "Alerting", nil
+		return "NoData", nil
 	}
 	return "", fmt.Errorf("unrecognized No Data setting %v", s)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This is a proof of concept for an alternative approach for the option "Keep Last State" in the legacy alerting system. 
- Add evaluation state (Normal, Error, NoData, Alerting) to template data. This allows the user to use the evaluation state in the labels\annotations.
- Remove the block that prevents evaluation results with states other than Normal or Alerting from firing.
- Update migrator to handle alert rules with option KeepLastState for state NoData the following way:
1. Change the status from Alerting to NoData.
2. Add a label `alertstatus` with template `{{ .Status }}` in the value 
3. Add silence with 1-year expiration and matcher `alertstatus=NoData`

![image](https://user-images.githubusercontent.com/25988953/138774681-e8fec94a-3885-4d40-88e0-d529600a469c.png)
![image](https://user-images.githubusercontent.com/25988953/138774691-a20999b5-de78-48f9-89e9-65c0a93130bc.png)


This is an alternative solution to https://github.com/grafana/grafana/pull/40540

**Which issue(s) this PR fixes**:
Related: https://github.com/grafana/alerting-squad/issues/178

**Special notes for your reviewer**: