### PR TITLE
AzureMonitor: Prevent incomplete Logs queries from running

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -1,7 +1,8 @@
 import AzureMonitorDatasource from '../datasource';
+import AzureLogAnalyticsDatasource from './azure_log_analytics_datasource';
 import FakeSchemaData from './__mocks__/schema';
 import { TemplateSrv } from 'app/features/templating/template_srv';
-import { AzureLogsVariable, DatasourceValidationResult } from '../types';
+import { AzureLogsVariable, AzureMonitorQuery, DatasourceValidationResult } from '../types';
 import { toUtc } from '@grafana/data';
 
 const templateSrv = new TemplateSrv();
@@ -374,6 +375,62 @@ describe('AzureLogAnalyticsDatasource', () => {
     it('should return the first workspace', async () => {
       const workspace = await ctx.ds.azureLogAnalyticsDatasource.getFirstWorkspace();
       expect(workspace).toEqual('foo');
+    });
+  });
+
+  describe('When performing filterQuery', () => {
+    const ctx: any = {};
+    let laDatasource: AzureLogAnalyticsDatasource;
+
+    beforeEach(() => {
+      ctx.instanceSettings = {
+        jsonData: { subscriptionId: 'xxx' },
+        url: 'http://azureloganalyticsapi',
+      };
+
+      laDatasource = new AzureLogAnalyticsDatasource(ctx.instanceSettings);
+    });
+
+    it('should run complete queries', () => {
+      const query: AzureMonitorQuery = {
+        refId: 'A',
+        azureLogAnalytics: {
+          resource: '/sub/124/rg/cloud/vm/server',
+          query: 'perf | take 100',
+        },
+      };
+
+      expect(laDatasource.filterQuery(query)).toBeTruthy();
+    });
+
+    it('should not run empty queries', () => {
+      const query: AzureMonitorQuery = {
+        refId: 'A',
+      };
+
+      expect(laDatasource.filterQuery(query)).toBeFalsy();
+    });
+
+    it('should not run queries missing a kusto query', () => {
+      const query: AzureMonitorQuery = {
+        refId: 'A',
+        azureLogAnalytics: {
+          resource: '/sub/124/rg/cloud/vm/server',
+        },
+      };
+
+      expect(laDatasource.filterQuery(query)).toBeFalsy();
+    });
+
+    it('should not run queries missing a resource', () => {
+      const query: AzureMonitorQuery = {
+        refId: 'A',
+        azureLogAnalytics: {
+          query: 'perf | take 100',
+        },
+      };
+
+      expect(laDatasource.filterQuery(query)).toBeFalsy();
     });
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -411,6 +411,19 @@ describe('AzureLogAnalyticsDatasource', () => {
       expect(laDatasource.filterQuery(query)).toBeFalsy();
     });
 
+    it('should not run hidden queries', () => {
+      const query: AzureMonitorQuery = {
+        refId: 'A',
+        hide: true,
+        azureLogAnalytics: {
+          resource: '/sub/124/rg/cloud/vm/server',
+          query: 'perf | take 100',
+        },
+      };
+
+      expect(laDatasource.filterQuery(query)).toBeFalsy();
+    });
+
     it('should not run queries missing a kusto query', () => {
       const query: AzureMonitorQuery = {
         refId: 'A',

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -59,6 +59,10 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
     return !this.validateDatasource();
   }
 
+  filterQuery(item: AzureMonitorQuery): boolean {
+    return !!(item.hide !== true && !!item.azureLogAnalytics?.query && !!item.azureLogAnalytics?.resource);
+  }
+
   async getSubscriptions(): Promise<Array<{ text: string; value: string }>> {
     if (!this.isConfigured()) {
       return [];

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -60,7 +60,7 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
   }
 
   filterQuery(item: AzureMonitorQuery): boolean {
-    return !!(item.hide !== true && !!item.azureLogAnalytics?.query && !!item.azureLogAnalytics?.resource);
+    return item.hide !== true && !!item.azureLogAnalytics?.query && !!item.azureLogAnalytics.resource;
   }
 
   async getSubscriptions(): Promise<Array<{ text: string; value: string }>> {


### PR DESCRIPTION
**What this PR does / why we need it**:

Azure Monitor Logs queries did not implement filterQuery, so the query would be executed as soon as the user selected a resource, which resulted in confusing and unhelpful error message

![image](https://user-images.githubusercontent.com/46142/137477311-94857ad5-018e-49f1-a9ca-5018bb995af4.png)

**Which issue(s) this PR fixes**:

Fixes an issue mentioned in #40511
