### PR TITLE
Alerting: Prevent alerting routes from working if alerting is not enabled

### DIFF
--- a/public/app/features/alerting/FeatureTogglePage.tsx
+++ b/public/app/features/alerting/FeatureTogglePage.tsx
@@ -3,7 +3,7 @@ import Page from 'app/core/components/Page/Page';
 import { useNavModel } from 'app/core/hooks/useNavModel';
 
 export default function FeatureTogglePage() {
-  const navModel = useNavModel('alerting');
+  const navModel = useNavModel('alert-list');
 
   return (
     <Page navModel={navModel}>

--- a/public/app/features/alerting/FeatureTogglePage.tsx
+++ b/public/app/features/alerting/FeatureTogglePage.tsx
@@ -9,12 +9,22 @@ export default function FeatureTogglePage() {
     <Page navModel={navModel}>
       <Page.Contents>
         <h1>Alerting is not enabled</h1>
-        To enable alerting, enable it in the server config:
-        <pre>
-          {`[alerting]
+        To enable alerting, enable it in the Grafana config:
+        <div>
+          <pre>
+            {`[unified_alerting]
 enable = true
 `}
-        </pre>
+          </pre>
+        </div>
+        <div>
+          For legacy alerting
+          <pre>
+            {`[alerting]
+enable = true
+`}
+          </pre>
+        </div>
       </Page.Contents>
     </Page>
   );

--- a/public/app/features/alerting/FeatureTogglePage.tsx
+++ b/public/app/features/alerting/FeatureTogglePage.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Page from 'app/core/components/Page/Page';
+import { useNavModel } from 'app/core/hooks/useNavModel';
+
+export default function FeatureTogglePage() {
+  const navModel = useNavModel('alerting');
+
+  return (
+    <Page navModel={navModel}>
+      <Page.Contents>
+        <h1>Alerting is not enabled</h1>
+        To enable alerting, enable it in the server config:
+        <pre>
+          {`[alerting]
+enable = true
+`}
+        </pre>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -147,7 +147,7 @@ const alertingRoutes = [
 ];
 
 export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
-  if (cfg.featureToggles['alerting']) {
+  if (cfg.alertingEnabled || cfg.unifiedAlertingEnabled) {
     return alertingRoutes;
   }
 

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
+import { config } from 'app/core/config';
+import { RouteDescriptor } from 'app/core/navigation/types';
+
+const alertingRoutes = [
+  {
+    path: '/alerting',
+    // eslint-disable-next-line react/display-name
+    component: () => <Redirect to="/alerting/list" />,
+  },
+  {
+    path: '/alerting/list',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertRuleListIndex" */ 'app/features/alerting/AlertRuleListIndex')
+    ),
+  },
+  {
+    path: '/alerting/ng/list',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertRuleList" */ 'app/features/alerting/AlertRuleList')
+    ),
+  },
+  {
+    path: '/alerting/routes',
+    roles: () => ['Admin', 'Editor'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertAmRoutes" */ 'app/features/alerting/unified/AmRoutes')
+    ),
+  },
+  {
+    path: '/alerting/silences',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertSilences" */ 'app/features/alerting/unified/Silences')
+    ),
+  },
+  {
+    path: '/alerting/silence/new',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertSilences" */ 'app/features/alerting/unified/Silences')
+    ),
+  },
+  {
+    path: '/alerting/silence/:id/edit',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertSilences" */ 'app/features/alerting/unified/Silences')
+    ),
+  },
+  {
+    path: '/alerting/notifications',
+    roles: config.unifiedAlertingEnabled ? () => ['Editor', 'Admin'] : undefined,
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+    ),
+  },
+  {
+    path: '/alerting/notifications/templates/new',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+    ),
+  },
+  {
+    path: '/alerting/notifications/templates/:id/edit',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+    ),
+  },
+  {
+    path: '/alerting/notifications/receivers/new',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+    ),
+  },
+  {
+    path: '/alerting/notifications/receivers/:id/edit',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+    ),
+  },
+  {
+    path: '/alerting/notifications/global-config',
+    roles: () => ['Admin', 'Editor'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+    ),
+  },
+  {
+    path: '/alerting/notification/new',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NewNotificationChannel" */ 'app/features/alerting/NewNotificationChannelPage')
+    ),
+  },
+  {
+    path: '/alerting/notification/:id/edit',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "EditNotificationChannel"*/ 'app/features/alerting/EditNotificationChannelPage')
+    ),
+  },
+  {
+    path: '/alerting/groups/',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertGroups" */ 'app/features/alerting/unified/AlertGroups')
+    ),
+  },
+  {
+    path: '/alerting/new',
+    pageClass: 'page-alerting',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertingRuleForm"*/ 'app/features/alerting/unified/RuleEditor')
+    ),
+  },
+  {
+    path: '/alerting/:id/edit',
+    pageClass: 'page-alerting',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertingRuleForm"*/ 'app/features/alerting/unified/RuleEditor')
+    ),
+  },
+  {
+    path: '/alerting/:sourceName/:id/view',
+    pageClass: 'page-alerting',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertingRule"*/ 'app/features/alerting/unified/RuleViewer')
+    ),
+  },
+  {
+    path: '/alerting/:sourceName/:name/find',
+    pageClass: 'page-alerting',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertingRedirectToRule"*/ 'app/features/alerting/unified/RedirectToRuleViewer')
+    ),
+  },
+  {
+    path: '/alerting/admin',
+    roles: () => ['Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertingAdmin" */ 'app/features/alerting/unified/Admin')
+    ),
+  },
+];
+
+export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
+  if (cfg.featureToggles['alerting']) {
+    return alertingRoutes;
+  }
+
+  return alertingRoutes.map((route) => ({
+    ...route,
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "Alerting feature toggle page"*/ 'app/features/alerting/FeatureTogglePage')
+    ),
+  }));
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -11,6 +11,7 @@ import ErrorPage from 'app/core/components/ErrorPage/ErrorPage';
 import { getPluginsAdminRoutes } from 'app/features/plugins/routes';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getLiveRoutes } from 'app/features/live/pages/routes';
+import { getAlertingRoutes } from 'app/features/alerting/routes';
 
 export const extraRoutes: RouteDescriptor[] = [];
 
@@ -331,148 +332,6 @@ export function getAppRoutes(): RouteDescriptor[] {
     //   controllerAs: 'ctrl',
     // },
     {
-      path: '/alerting',
-      // eslint-disable-next-line react/display-name
-      component: () => <Redirect to="/alerting/list" />,
-    },
-    {
-      path: '/alerting/list',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertRuleListIndex" */ 'app/features/alerting/AlertRuleListIndex')
-      ),
-    },
-    {
-      path: '/alerting/ng/list',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertRuleList" */ 'app/features/alerting/AlertRuleList')
-      ),
-    },
-    {
-      path: '/alerting/routes',
-      roles: () => ['Admin', 'Editor'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertAmRoutes" */ 'app/features/alerting/unified/AmRoutes')
-      ),
-    },
-    {
-      path: '/alerting/silences',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertSilences" */ 'app/features/alerting/unified/Silences')
-      ),
-    },
-    {
-      path: '/alerting/silence/new',
-      roles: () => ['Editor', 'Admin'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertSilences" */ 'app/features/alerting/unified/Silences')
-      ),
-    },
-    {
-      path: '/alerting/silence/:id/edit',
-      roles: () => ['Editor', 'Admin'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertSilences" */ 'app/features/alerting/unified/Silences')
-      ),
-    },
-    {
-      path: '/alerting/notifications',
-      roles: config.unifiedAlertingEnabled ? () => ['Editor', 'Admin'] : undefined,
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
-      ),
-    },
-    {
-      path: '/alerting/notifications/templates/new',
-      roles: () => ['Editor', 'Admin'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
-      ),
-    },
-    {
-      path: '/alerting/notifications/templates/:id/edit',
-      roles: () => ['Editor', 'Admin'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
-      ),
-    },
-    {
-      path: '/alerting/notifications/receivers/new',
-      roles: () => ['Editor', 'Admin'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
-      ),
-    },
-    {
-      path: '/alerting/notifications/receivers/:id/edit',
-      roles: () => ['Editor', 'Admin'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
-      ),
-    },
-    {
-      path: '/alerting/notifications/global-config',
-      roles: () => ['Admin', 'Editor'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
-      ),
-    },
-    {
-      path: '/alerting/notification/new',
-      component: SafeDynamicImport(
-        () =>
-          import(/* webpackChunkName: "NewNotificationChannel" */ 'app/features/alerting/NewNotificationChannelPage')
-      ),
-    },
-    {
-      path: '/alerting/notification/:id/edit',
-      component: SafeDynamicImport(
-        () =>
-          import(/* webpackChunkName: "EditNotificationChannel"*/ 'app/features/alerting/EditNotificationChannelPage')
-      ),
-    },
-    {
-      path: '/alerting/groups/',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertGroups" */ 'app/features/alerting/unified/AlertGroups')
-      ),
-    },
-    {
-      path: '/alerting/new',
-      pageClass: 'page-alerting',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertingRuleForm"*/ 'app/features/alerting/unified/RuleEditor')
-      ),
-    },
-    {
-      path: '/alerting/:id/edit',
-      pageClass: 'page-alerting',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertingRuleForm"*/ 'app/features/alerting/unified/RuleEditor')
-      ),
-    },
-    {
-      path: '/alerting/:sourceName/:id/view',
-      pageClass: 'page-alerting',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertingRule"*/ 'app/features/alerting/unified/RuleViewer')
-      ),
-    },
-    {
-      path: '/alerting/:sourceName/:name/find',
-      pageClass: 'page-alerting',
-      component: SafeDynamicImport(
-        () =>
-          import(/* webpackChunkName: "AlertingRedirectToRule"*/ 'app/features/alerting/unified/RedirectToRuleViewer')
-      ),
-    },
-    {
-      path: '/alerting/admin',
-      roles: () => ['Admin'],
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "AlertingAdmin" */ 'app/features/alerting/unified/Admin')
-      ),
-    },
-    {
       path: '/playlists',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "PlaylistPage"*/ 'app/features/playlist/PlaylistPage')
@@ -516,6 +375,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     ...getPluginsAdminRoutes(),
     ...getLiveRoutes(),
+    ...getAlertingRoutes(),
     ...extraRoutes,
     {
       path: '/*',


### PR DESCRIPTION
**What this PR does / why we need it**:
If you had disabled alerting in the server config you could still reach the alerting pages by going directly to an alerting route. 

**Which issue(s) this PR fixes**:

Fixes #39956

**Special notes for your reviewer**:
Not sure if we want to show more information on the page. Don't know if it's enabled by default in cloud etc?
