### PR TITLE
Slider: Adjusts input to enforce min/max values on blur

### DIFF
--- a/packages/grafana-ui/src/components/Slider/Slider.test.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.test.tsx
@@ -26,4 +26,14 @@ describe('Slider', () => {
     expect(wrapper.html()).not.toContain('aria-valuenow="20"');
     expect(wrapper.html()).not.toContain('aria-valuenow="10"');
   });
+
+  it('allows for custom values to be set in the input', () => {
+    console.log('something');
+    const wrapper = mount(<Slider {...sliderProps} value={10} min={10} max={100} />);
+    const sliderInput = wrapper.find('input');
+    sliderInput.simulate('focus');
+    sliderInput.simulate('change', { target: { value: 50 } });
+    sliderInput.simulate('blur');
+    expect(wrapper.html()).toContain('aria-valuenow="50"');
+  });
 });

--- a/packages/grafana-ui/src/components/Slider/Slider.test.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.test.tsx
@@ -28,12 +28,27 @@ describe('Slider', () => {
   });
 
   it('allows for custom values to be set in the input', () => {
-    console.log('something');
     const wrapper = mount(<Slider {...sliderProps} value={10} min={10} max={100} />);
     const sliderInput = wrapper.find('input');
     sliderInput.simulate('focus');
     sliderInput.simulate('change', { target: { value: 50 } });
     sliderInput.simulate('blur');
     expect(wrapper.html()).toContain('aria-valuenow="50"');
+  });
+
+  it('defaults after blur if input value is outside of range', () => {
+    const wrapper = mount(<Slider {...sliderProps} value={10} min={10} max={100} />);
+    const sliderInput = wrapper.find('input');
+    sliderInput.simulate('focus');
+    sliderInput.simulate('change', { target: { value: 200 } });
+    // re-grab to check value is out of range before blur
+    const sliderInputIncorrect = wrapper.find('input');
+    expect(sliderInputIncorrect.get(0).props.value).toEqual('200');
+
+    sliderInput.simulate('blur');
+    expect(wrapper.html()).toContain('aria-valuenow="100"');
+    // re-grab to check value is back inside range
+    const sliderInputCorrect = wrapper.find('input');
+    expect(sliderInputCorrect.get(0).props.value).toEqual('100');
   });
 });

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, ChangeEvent, FunctionComponent } from 'react';
+import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent } from 'react';
 import SliderComponent from 'rc-slider';
 import { cx } from '@emotion/css';
 import { Global } from '@emotion/react';
@@ -46,9 +46,6 @@ export const Slider: FunctionComponent<SliderProps> = ({
         v = 0;
       }
 
-      v > max && (v = max);
-      v < min && (v = min);
-
       setSliderValue(v);
 
       if (onChange) {
@@ -59,7 +56,21 @@ export const Slider: FunctionComponent<SliderProps> = ({
         onAfterChange(v);
       }
     },
-    [max, min, onChange, onAfterChange]
+    [onChange, onAfterChange]
+  );
+
+  // Check for min/max on input blur so user is able to enter
+  // custom values that might seem above/below min/max on first keystroke
+  const onSliderInputBlur = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      let v = +e.target.value;
+
+      v > max && (v = max);
+      v < min && (v = min);
+
+      setSliderValue(v);
+    },
+    [max, min]
   );
 
   const sliderInputClassNames = !isHorizontal ? [styles.sliderInputVertical] : [];
@@ -88,6 +99,7 @@ export const Slider: FunctionComponent<SliderProps> = ({
           className={cx(styles.sliderInputField, ...sliderInputFieldClassNames)}
           value={`${sliderValue}`} // to fix the react leading zero issue
           onChange={onSliderInputChange}
+          onBlur={onSliderInputBlur}
           min={min}
           max={max}
         />

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -63,12 +63,13 @@ export const Slider: FunctionComponent<SliderProps> = ({
   // custom values that might seem above/below min/max on first keystroke
   const onSliderInputBlur = useCallback(
     (e: FocusEvent<HTMLInputElement>) => {
-      let v = +e.target.value;
+      const v = +e.target.value;
 
-      v > max && (v = max);
-      v < min && (v = min);
-
-      setSliderValue(v);
+      if (v > max) {
+        setSliderValue(max);
+      } else if (v < min) {
+        setSliderValue(min);
+      }
     },
     [max, min]
   );


### PR DESCRIPTION
**What this PR does / why we need it**:
We've had a couple Synthetic Monitoring users reach out about undesirable behavior with the input on the `<Slider />` component. When entering custom values and the slider has a set `min/max`, on first keystroke the component thinks you're going above/below the allowed values and defaults to either `min` or `max` values.

See [editing probe frequency on our SM instance for an example](https://syntheticmonitoring.grafana.net/a/grafana-synthetic-monitoring-app/?page=checks&id=47). 

This PR changes the enforcing of min/max on input blur, so that users can enter values freely until leaving.

**Special notes for your reviewer**:
First time contributing to Grafana, let me know if I missed anything :) 
