### PR TITLE
Prometheus: We fixed the problem that resulted in an error when a user created a  query with a $__interval min step.

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromLink.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromLink.test.tsx
@@ -5,9 +5,17 @@ import { PromQuery } from '../types';
 import { PrometheusDatasource } from '../datasource';
 import PromLink from './PromLink';
 
+jest.mock('@grafana/data', () => ({
+  ...(jest.requireActual('@grafana/data') as any),
+  rangeUtil: {
+    intervalToSeconds: jest.fn(() => 15),
+  },
+}));
+
 const getPanelData = (panelDataOverrides?: Partial<PanelData>) => {
   const panelData = {
     request: {
+      scopedVars: [{ __interval: { text: '15s', value: '15s' } }],
       targets: [
         { refId: 'A', datasource: 'prom1' },
         { refId: 'B', datasource: 'prom2' },
@@ -30,6 +38,7 @@ const getDataSource = (datasourceOverrides?: Partial<PrometheusDatasource>) => {
     getPrometheusTime: () => 123,
     createQuery: () => ({ expr: 'up', step: 15 }),
     directUrl: 'prom1',
+    getRateIntervalScopedVariable: jest.fn(() => ({ __rate_interval: { text: '60s', value: '60s' } })),
   };
 
   return (Object.assign(datasource, datasourceOverrides) as unknown) as PrometheusDatasource;


### PR DESCRIPTION
**What this PR does / why we need it**:
We weren't passing scoped vars from panel data and therefore when creating query with `$__interval` min step, createQuery threw error. Moreover, as we support also  `$__rate_interval`, we need to create and pass rate interval variable that is calculated from interval and scrape interval (set on data source level)

I was also considering to use the last run query params in PromLink, but this is currently more complicated as we are creating, running and processing browser and server queries at different places.  We can revisit when we remove browser mode and therefore createQuery will be removed as well. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/40326

**How to test/reproduce:**

When running Prometheus query with min interval set to `$__interval` or `$__rate_interval`. The PromLink component shouldn't throw error and should create correct query.