### PR TITLE
AccessControl: Create FGAC roles for orgs

### DIFF
--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -123,7 +123,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Role: accesscontrol.RoleDTO{
 				Version:     1,
 				Name:        "fixed:current:org:reader",
-				Description: "Read current org and its quotas.",
+				Description: "Read current organization and its quotas.",
 				Permissions: []accesscontrol.Permission{
 					{
 						Action: ActionOrgsRead,

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -171,7 +171,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Role: accesscontrol.RoleDTO{
 				Version:     1,
 				Name:        "fixed:orgs:writer",
-				Description: "Create, Read, Write, Delete orgs. Read, Write orgs' quotas.",
+				Description: "Create, read, write, or delete an organization. Read or write an organization's quotas.",
 				Permissions: []accesscontrol.Permission{
 					{Action: ActionOrgsCreate},
 					{

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -15,6 +15,15 @@ const (
 	ActionDatasourcesWrite  = "datasources:write"
 	ActionDatasourcesDelete = "datasources:delete"
 	ActionDatasourcesIDRead = "datasources.id:read"
+
+	ActionOrgsRead             = "orgs:read"
+	ActionOrgsPreferencesRead  = "orgs.preferences:read"
+	ActionOrgsQuotasRead       = "orgs.quotas:read"
+	ActionOrgsWrite            = "orgs:write"
+	ActionOrgsPreferencesWrite = "orgs.preferences:write"
+	ActionOrgsQuotasWrite      = "orgs.quotas:write"
+	ActionOrgsDelete           = "orgs:delete"
+	ActionOrgsCreate           = "orgs:create"
 )
 
 // API related scopes
@@ -29,6 +38,12 @@ var (
 	ScopeDatasourceID   = accesscontrol.Scope("datasources", "id", accesscontrol.Parameter(":id"))
 	ScopeDatasourceUID  = accesscontrol.Scope("datasources", "uid", accesscontrol.Parameter(":uid"))
 	ScopeDatasourceName = accesscontrol.Scope("datasources", "name", accesscontrol.Parameter(":name"))
+
+	ScopeOrgsAll      = accesscontrol.Scope("orgs", "*")
+	ScopeOrgID        = accesscontrol.Scope("orgs", "id", accesscontrol.Parameter(":orgId"))
+	ScopeOrgCurrentID = accesscontrol.Scope("orgs", "id", accesscontrol.Field("OrgID"))
+	ScopeOrgName      = accesscontrol.Scope("orgs", "name", accesscontrol.Parameter(":name"))
+	ScopeOrgCurrent   = accesscontrol.Scope("orgs", "current")
 )
 
 // declareFixedRoles declares to the AccessControl service fixed roles and their
@@ -103,6 +118,87 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				},
 			},
 			Grants: []string{string(models.ROLE_VIEWER)},
+		},
+		// TODO should I add display names
+		// TODO work on the name and descriptions
+		{
+			Role: accesscontrol.RoleDTO{
+				Version:     1,
+				Name:        "fixed:current:org:reader",
+				Description: "Read current org and its quotas.",
+				Permissions: []accesscontrol.Permission{
+					{
+						Action: ActionOrgsRead,
+						Scope:  ScopeOrgCurrent,
+					},
+					{
+						Action: ActionOrgsQuotasRead,
+						Scope:  ScopeOrgCurrent,
+					},
+				},
+			},
+			Grants: []string{string(models.ROLE_VIEWER)},
+		},
+		{
+			Role: accesscontrol.RoleDTO{
+				Version:     1,
+				Name:        "fixed:current:org:writer",
+				Description: "Read current org, its quotas, its preferences. Write current org and its preferences.",
+				Permissions: []accesscontrol.Permission{
+					{
+						Action: ActionOrgsRead,
+						Scope:  ScopeOrgCurrent,
+					},
+					{
+						Action: ActionOrgsQuotasRead,
+						Scope:  ScopeOrgCurrent,
+					},
+					{
+						Action: ActionOrgsPreferencesRead,
+						Scope:  ScopeOrgCurrent,
+					},
+					{
+						Action: ActionOrgsWrite,
+						Scope:  ScopeOrgCurrent,
+					},
+					{
+						Action: ActionOrgsPreferencesWrite,
+						Scope:  ScopeOrgCurrent,
+					},
+				},
+			},
+			Grants: []string{string(models.ROLE_ADMIN)},
+		},
+		{
+			Role: accesscontrol.RoleDTO{
+				Version:     1,
+				Name:        "fixed:orgs:writer",
+				Description: "Create, Read, Write, Delete orgs. Read, Write orgs' quotas.",
+				Permissions: []accesscontrol.Permission{
+					{Action: ActionOrgsCreate},
+					{
+						Action: ActionOrgsRead,
+						Scope:  ScopeOrgsAll,
+					},
+					{
+						Action: ActionOrgsWrite,
+						Scope:  ScopeOrgsAll,
+					},
+					{
+						Action: ActionOrgsDelete,
+						Scope:  ScopeOrgsAll,
+					},
+					{
+						Action: ActionOrgsQuotasRead,
+						Scope:  ScopeOrgsAll,
+					},
+					{
+						Action: ActionOrgsQuotasWrite,
+						Scope:  ScopeOrgsAll,
+					},
+				},
+			},
+			Grants: []string{string(accesscontrol.RoleGrafanaAdmin)},
 		},
 	}
 

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -119,8 +119,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			},
 			Grants: []string{string(models.ROLE_VIEWER)},
 		},
-		// TODO should I add display names
-		// TODO work on the name and descriptions
 		{
 			Role: accesscontrol.RoleDTO{
 				Version:     1,

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -141,7 +141,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Role: accesscontrol.RoleDTO{
 				Version:     1,
 				Name:        "fixed:current:org:writer",
-				Description: "Read current org, its quotas, its preferences. Write current org and its preferences.",
+				Description: "Read current organization, its quotas, and its preferences. Write current organization and its preferences.",
 				Permissions: []accesscontrol.Permission{
 					{
 						Action: ActionOrgsRead,


### PR DESCRIPTION

**What this PR does / why we need it**:

> While in the first milestone we covered mostly all organization relevant endpoints with fine-grained permissions, there are few still missing the construction blocks.

In the other PRs (#39579 #39699 #40156), I protected the following endpoints:
| Method | Url                             | Legacy AC                                      | Action                   | Scope                  |
|--------|---------------------------------|------------------------------------------------|--------------------------|------------------------|
| GET    | /api/org/                       | reqSignedIn                                    | `orgs:read`              | `orgs:id:{OrgID}`      |
| GET    | /api/org/quotas                 | reqSignedIn                                    | `orgs.quotas:read`       | `orgs:id:{OrgID}`      |
| PUT    | /api/org/                       | reqOrgAdmin                                    | `orgs:write`             | `orgs:id:{OrgID}`      |
| PUT    | /api/org/address                | reqOrgAdmin                                    | `orgs:write`             | `orgs:id:{OrgID}`      |
| PUT    | /api/org/preferences            | reqOrgAdmin                                    | `orgs.preferences:write` | `orgs:id:{OrgID}`      |
| GET    | /api/org/preferences            | reqOrgAdmin                                    | `orgs.preferences:read`  | `orgs:id:{OrgID}`      |
| GET    | /api/orgs/:orgId                | reqGrafanaAdmin                                | `orgs:read`              | `orgs:id:{:orgId}`     |
| GET    | /api/orgs/:orgId/quotas         | reqGrafanaAdmin                                | `orgs.quotas:read`       | `orgs:id:{:orgId}`     |
| GET    | /api/orgs?perpage=x&page=y      | reqGrafanaAdmin                                | `orgs:read`              | `orgs:*`               |
| GET    | /api/orgs/name/:orgName         | reqGrafanaAdmin                                | `orgs:read`              | `orgs:name:{:orgName}` |
| PUT    | /api/orgs/:orgId/               | reqGrafanaAdmin                                | `orgs:write`             | `orgs:id:{:orgId}`     |
| PUT    | /api/orgs/:orgId/address        | reqGrafanaAdmin                                | `orgs:write`             | `orgs:id:{:orgId}`     |
| PUT    | /api/orgs/:orgId/quotas/:target | reqGrafanaAdmin                                | `orgs.quotas:write`      | `orgs:id:{:orgId}`     |
| POST   | /api/orgs                       | setting.AllowUserOrgCreate<br/>reqGrafanaAdmin | `orgs:create`            | n/a                    |
| DELETE | /api/orgs/:orgId                | reqGrafanaAdmin                                | `orgs:delete`            | `orgs:id:{:orgId}`     |

In this PR, I'll define the required roles to migrate seamlessly to FGAC:
| Role                     | Permissions                                                                                                                                                                                | Grant        |
|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
| fixed:current:org:reader | {`orgs:read`, `orgs:current`}, {`orgs.quotas:read`, `orgs:current`}                                                                                                                        | Viewer       |
| fixed:current:org:writer | {`orgs:read`, `orgs:current`}, {`orgs.quotas:read`, `orgs:current`}, {`orgs:write`, `orgs:current`}, {`orgs.preferences:read`, `orgs:current`}, {`orgs.preferences:write`, `orgs:current`} | Admin        |
| fixed:orgs:writer        | {`orgs:create`}, {`orgs:read`, `orgs:*`}, {`orgs:write`, `orgs:*`}, {`orgs:delete`, `orgs:*`}, {`orgs.quotas:read`, `orgs:*`}, {`orgs.quotas:write`, `orgs:*`}                             | GrafanaAdmin |

**Remarks:**
Switching to FGAC would change the following:
1. OrgAdmins and Viewers can use `GET /api/orgs/:orgId` `GET /api/orgs/:orgId/quotas` when `orgId = current` and even `GET /api/orgs/name/:orgName` once attribute resolution is implemented
2. OrgAdmins can use `PUT /api/orgs/:orgId/` `PUT /api/orgs/:orgId/address` when `orgId = current`
3. GrafanaAdmins can use `/api/org/` endpoints (except the `/api/org/preferences` ones)

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana-enterprise/issues/1550

**Special notes for your reviewer**:
This PR depends on scope resolution (#40229, grafana/grafana-enterprise/pull/2074). I won't merge it until scope resolution has been merged