### PR TITLE
prometheus metrics browser: remove autocompletion limits

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
@@ -17,8 +17,6 @@ import { FixedSizeList } from 'react-window';
 import { GrafanaTheme } from '@grafana/data';
 
 // Hard limit on labels to render
-const MAX_LABEL_COUNT = 10000;
-const MAX_VALUE_COUNT = 50000;
 const EMPTY_SELECTOR = '{}';
 const METRIC_LABEL = '__name__';
 const LIST_ITEM_SIZE = 25;
@@ -321,12 +319,6 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
       const selectedLabels: string[] = lastUsedLabels;
       languageProvider.start().then(() => {
         let rawLabels: string[] = languageProvider.getLabelKeys();
-        // TODO too-many-metrics
-        if (rawLabels.length > MAX_LABEL_COUNT) {
-          const error = `Too many labels found (showing only ${MAX_LABEL_COUNT} of ${rawLabels.length})`;
-          rawLabels = rawLabels.slice(0, MAX_LABEL_COUNT);
-          this.setState({ error });
-        }
         // Get metrics
         this.fetchValues(METRIC_LABEL, EMPTY_SELECTOR);
         // Auto-select previously selected labels
@@ -393,11 +385,6 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
       if (selector !== buildSelector(this.state.labels)) {
         this.updateLabelState(name, { loading: false });
         return;
-      }
-      if (rawValues.length > MAX_VALUE_COUNT) {
-        const error = `Too many values for ${name} (showing only ${MAX_VALUE_COUNT} of ${rawValues.length})`;
-        rawValues = rawValues.slice(0, MAX_VALUE_COUNT);
-        this.setState({ error });
       }
       const values: FacettableValue[] = [];
       const { metricsMetadata } = languageProvider;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

A recent PR removed autocompletion limits for the autocompletion bar: https://github.com/grafana/grafana/pull/39363.
Can we remove limits in the metric browser as well? For large number of metrics, this makes the metric browser much more usable compared to truncating the list.

I tested it with 500K metric names and performance was satisfactory.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/40416

**Special notes for your reviewer**:
If we are not ready to remove limits entirely, can we at least raise the limits to >1M or be able to configure it?

