### PR TITLE
prometheus: more correct jsonData typescript type

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -56,7 +56,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
   withCredentials: any;
   metricsNameCache = new LRU<string, string[]>(10);
   interval: string;
-  queryTimeout: string;
+  queryTimeout: string | undefined;
   httpMethod: string;
   languageProvider: PrometheusLanguageProvider;
   exemplarTraceIdDestinations: ExemplarTraceIdDestination[] | undefined;
@@ -80,7 +80,9 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
     this.queryTimeout = instanceSettings.jsonData.queryTimeout;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'POST';
-    this.directUrl = instanceSettings.jsonData.directUrl;
+    // `directUrl` is never undefined, we set it at https://github.com/grafana/grafana/blob/main/pkg/api/frontendsettings.go#L108
+    // here we "fall back" to this.url to make typescript happy, but it should never happen
+    this.directUrl = instanceSettings.jsonData.directUrl ?? this.url;
     this.exemplarTraceIdDestinations = instanceSettings.jsonData.exemplarTraceIdDestinations;
     this.ruleMappings = {};
     this.languageProvider = new PrometheusLanguageProvider(this);

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -20,10 +20,10 @@ export interface PromQuery extends DataQuery {
 }
 
 export interface PromOptions extends DataSourceJsonData {
-  timeInterval: string;
-  queryTimeout: string;
-  httpMethod: string;
-  directUrl: string;
+  timeInterval?: string;
+  queryTimeout?: string;
+  httpMethod?: string;
+  directUrl?: string;
   customQueryParameters?: string;
   disableMetricsLookup?: boolean;
   exemplarTraceIdDestinations?: ExemplarTraceIdDestination[];

--- a/scripts/ci-check-strict.sh
+++ b/scripts/ci-check-strict.sh
@@ -3,7 +3,7 @@ set -e
 
 echo -e "Collecting code stats (typescript errors & more)"
 
-ERROR_COUNT_LIMIT=12
+ERROR_COUNT_LIMIT=13
 ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --strict true | grep -oP 'Found \K(\d+)')"
 
 if [ "$ERROR_COUNT" -gt $ERROR_COUNT_LIMIT ]; then

--- a/scripts/ci-check-strict.sh
+++ b/scripts/ci-check-strict.sh
@@ -3,7 +3,7 @@ set -e
 
 echo -e "Collecting code stats (typescript errors & more)"
 
-ERROR_COUNT_LIMIT=17
+ERROR_COUNT_LIMIT=16
 ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --strict true | grep -oP 'Found \K(\d+)')"
 
 if [ "$ERROR_COUNT" -gt $ERROR_COUNT_LIMIT ]; then


### PR DESCRIPTION
This PR changes typescript types to be more correct (it makes fields that can be undefined in runtime optional in typescript)
i verified it by debugging the code that these field are optional, they are empty when unset. so the new code is more correct than the old code.

there is one complication with the `directUrl` field. it is not stored in the JSON structure, it is used to deliver extra info from the backend-code (the real URL of the prometheus server), so in some places it is undefined, and other places it is a string.

for now, i added a fallback to `instanceSettings.url`, but that fallback should never happen, because at that place `directUrl` is always a string. but this makes typescript happy.