### PR TITLE
Docs: Fix 404 link to time series doc

### DIFF
--- a/docs/sources/visualizations/graph-panel.md
+++ b/docs/sources/visualizations/graph-panel.md
@@ -7,7 +7,7 @@ weight = 500
 
 # Graph panel (old)
 
-> **Note:** [Time series panel](time-series/) visualization is going to replace the Graph panel visualization in a future release.
+> **Note:** [Time series panel]({{< relref "./time-series/_index.md" >}}) visualization is going to replace the Graph panel visualization in a future release.
 
 The graph panel can render metrics as a line, a path of dots, or a series of bars. This type of graph is versatile enough to display almost any time-series data.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Link to time series panel on old graph panel doc links to a 404
https://grafana.com/docs/grafana/latest/visualizations/graph-panel/ 

**Special notes for your reviewer**:
Tested by building local

