### PR TITLE
Loki: fix typescript-strict-mode error

### DIFF
--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -38,12 +38,8 @@ export class LiveStreams {
     data.meta = { ...data.meta, preferredVisualisationType: 'logs' };
     data.refId = target.refId;
 
-    stream = webSocket(target.url).pipe(
-      map((unknownResponse: unknown) => {
-        // we need to cast response to `LokiTailResponse`.
-        // we need to cast it first to unknown, to make typescript happy.
-        const anyResponse: any = unknownResponse;
-        const response: LokiTailResponse = anyResponse;
+    stream = webSocket<LokiTailResponse>(target.url).pipe(
+      map((response: LokiTailResponse) => {
         appendResponseToBufferedData(response, data);
         return [data];
       }),

--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -39,7 +39,11 @@ export class LiveStreams {
     data.refId = target.refId;
 
     stream = webSocket(target.url).pipe(
-      map((response: LokiTailResponse) => {
+      map((unknownResponse: unknown) => {
+        // we need to cast response to `LokiTailResponse`.
+        // we need to cast it first to unknown, to make typescript happy.
+        const anyResponse: any = unknownResponse;
+        const response: LokiTailResponse = anyResponse;
         appendResponseToBufferedData(response, data);
         return [data];
       }),

--- a/scripts/ci-check-strict.sh
+++ b/scripts/ci-check-strict.sh
@@ -3,7 +3,7 @@ set -e
 
 echo -e "Collecting code stats (typescript errors & more)"
 
-ERROR_COUNT_LIMIT=13
+ERROR_COUNT_LIMIT=12
 ERROR_COUNT="$(./node_modules/.bin/tsc --project tsconfig.json --noEmit --strict true | grep -oP 'Found \K(\d+)')"
 
 if [ "$ERROR_COUNT" -gt $ERROR_COUNT_LIMIT ]; then


### PR DESCRIPTION
fix an error that appears when running typescript in strict-mode. relates to https://github.com/grafana/grafana/issues/40461