### PR TITLE
FluxQuery/InfluxDB: Fix spelling - "Chronograf" rather than "Chronograph"

### DIFF
--- a/docs/sources/datasources/influxdb/influxdb-flux.md
+++ b/docs/sources/datasources/influxdb/influxdb-flux.md
@@ -40,7 +40,7 @@ You can use the [Flux query and scripting language](https://www.influxdata.com/p
 
 ## Supported macros
 
-The macros support copying and pasting from [Chronograph](https://www.influxdata.com/time-series-platform/chronograf/).
+The macros support copying and pasting from [Chronograf](https://www.influxdata.com/time-series-platform/chronograf/).
 
 | Macro example      | Description                                                                                                                                                                             |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/public/app/plugins/datasource/influxdb/components/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/FluxQueryEditor.tsx
@@ -167,7 +167,7 @@ export class FluxQueryEditor extends PureComponent<Props> {
     const helpTooltip = (
       <div>
         Type: <i>ctrl+space</i> to show template variable suggestions <br />
-        Many queries can be copied from chronograph
+        Many queries can be copied from Chronograf
       </div>
     );
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor change to tooltip and documentation - fixes spelling of the product it refers to



