### PR TITLE
Table: We improved the styling of the type icons to make them more distinct from column / field name.

### DIFF
--- a/packages/grafana-ui/src/components/Table/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/HeaderRow.tsx
@@ -61,7 +61,7 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, field?: Field, 
             title={column.render('Header')}
           >
             {showTypeIcons && (
-              <Icon name={getFieldTypeIcon(field)} title={field?.type} size="sm" style={{ marginRight: '8px' }} />
+              <Icon name={getFieldTypeIcon(field)} title={field?.type} size="sm" className={tableStyles.typeIcon} />
             )}
             <div>{column.render('Header')}</div>
             <div>

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -170,6 +170,10 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       cursor: pointer;
       padding: 0 ${theme.spacing(0.025)};
     `,
+    typeIcon: css`
+      margin-right: ${theme.spacing(1)};
+      color: ${theme.colors.text.secondary};
+    `,
     noData: css`
       align-items: center;
       display: flex;


### PR DESCRIPTION
When using the table view and seeing the type icons I felt it hard to distinguish the type from the name especially in scenarios like this:

![Screenshot from 2021-10-19 07-20-04](https://user-images.githubusercontent.com/10999/137848408-9e93942f-d03d-4089-826a-944ddb2be53d.png)

So propose coloring the type icon in secondary color so it's separate from the field name 
![Screenshot from 2021-10-19 07-17-02](https://user-images.githubusercontent.com/10999/137848418-0ce2d2a8-4996-490c-88ff-4d07eb7bcf08.png)


![Screenshot from 2021-10-19 07-16-40](https://user-images.githubusercontent.com/10999/137848443-26bd75e3-1f3a-4e67-8c1d-1ae7c52c8c47.png)


