### PR TITLE
Chore: Move Grafana version generator in initialize step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -291,7 +291,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -623,7 +623,7 @@ steps:
   name: identify-runner
 - commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/windows/grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/windows/grabpl.exe
     -OutFile grabpl.exe
   image: grafana/ci-wix:0.1.1
   name: initialize
@@ -670,7 +670,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -758,7 +758,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -1055,7 +1055,7 @@ steps:
   name: identify-runner
 - commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/windows/grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/windows/grabpl.exe
     -OutFile grabpl.exe
   image: grafana/ci-wix:0.1.1
   name: initialize
@@ -1122,7 +1122,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -1530,7 +1530,7 @@ steps:
   name: identify-runner
 - commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/windows/grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/windows/grabpl.exe
     -OutFile grabpl.exe
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -1595,7 +1595,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -1702,7 +1702,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -1987,7 +1987,7 @@ steps:
   name: identify-runner
 - commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/windows/grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/windows/grabpl.exe
     -OutFile grabpl.exe
   image: grafana/ci-wix:0.1.1
   name: initialize
@@ -2055,7 +2055,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -2455,7 +2455,7 @@ steps:
   name: identify-runner
 - commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/windows/grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/windows/grabpl.exe
     -OutFile grabpl.exe
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -2521,7 +2521,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -2633,7 +2633,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
@@ -2895,7 +2895,7 @@ steps:
   name: identify-runner
 - commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/windows/grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/windows/grabpl.exe
     -OutFile grabpl.exe
   image: grafana/ci-wix:0.1.1
   name: initialize
@@ -2958,7 +2958,7 @@ steps:
   name: identify-runner
 - commands:
   - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/grabpl
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
   - chmod +x bin/grabpl
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -3362,7 +3362,7 @@ steps:
   name: identify-runner
 - commands:
   - $$ProgressPreference = "SilentlyContinue"
-  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.2/windows/grabpl.exe
+  - Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/windows/grabpl.exe
     -OutFile grabpl.exe
   - git clone "https://$$env:GITHUB_TOKEN@github.com/grafana/grafana-enterprise.git"
   - cd grafana-enterprise
@@ -3485,6 +3485,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: e9840e1a4ba7a76a431ea51f37d3ead1d94e099d3057891b8a2dc8dac4c7c284
+hmac: 0d26eda19dc6e530d02c734704c8a9d01beb5082c7e14b2609577b8695ed06f5
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,7 @@ steps:
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
+  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
   image: grafana/build-container:1.4.3
   name: initialize
@@ -145,20 +146,14 @@ steps:
   image: grafana/build-container:1.4.3
   name: ensure-cuetsified
 - commands:
-  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
+  - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
+    --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64,armv6
   depends_on:
   - build-plugins
   - build-backend
   - build-frontend
   - codespell
   - shellcheck
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
-    --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise --variants linux-x64,linux-x64-musl,osx64,win64,armv6
-  depends_on:
-  - gen-version
   environment: null
   image: grafana/build-container:1.4.3
   name: package
@@ -184,7 +179,7 @@ steps:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
   depends_on:
-  - package
+  - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.4.3
@@ -302,6 +297,7 @@ steps:
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
+  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
   image: grafana/build-container:1.4.3
   name: initialize
@@ -428,20 +424,14 @@ steps:
   image: grafana/build-container:1.4.3
   name: ensure-cuetsified
 - commands:
-  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
+  - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
+    --sign
   depends_on:
   - build-plugins
   - build-backend
   - build-frontend
   - codespell
   - shellcheck
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
-    --sign
-  depends_on:
-  - gen-version
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -477,7 +467,7 @@ steps:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
   depends_on:
-  - package
+  - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.4.3
@@ -777,6 +767,7 @@ steps:
   - ./bin/grabpl verify-drone
   - make gen-go
   - ./bin/grabpl verify-version ${DRONE_TAG}
+  - ./bin/grabpl gen-version ${DRONE_TAG}
   - yarn install --immutable
   image: grafana/build-container:1.4.3
   name: initialize
@@ -894,20 +885,14 @@ steps:
   image: grafana/build-container:1.4.3
   name: ensure-cuetsified
 - commands:
-  - ./bin/grabpl gen-version ${DRONE_TAG}
+  - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
+    --sign ${DRONE_TAG}
   depends_on:
   - build-plugins
   - build-backend
   - build-frontend
   - codespell
   - shellcheck
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
-    --sign ${DRONE_TAG}
-  depends_on:
-  - gen-version
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1006,7 +991,7 @@ steps:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
   depends_on:
-  - package
+  - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.4.3
@@ -1164,6 +1149,7 @@ steps:
   - ./bin/grabpl verify-drone
   - make gen-go
   - ./bin/grabpl verify-version ${DRONE_TAG}
+  - ./bin/grabpl gen-version ${DRONE_TAG}
   - yarn install --immutable
   depends_on:
   - clone
@@ -1315,7 +1301,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: build-backend-enterprise2
 - commands:
-  - ./bin/grabpl gen-version ${DRONE_TAG}
+  - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
+    --no-pull-enterprise --sign ${DRONE_TAG}
   depends_on:
   - build-plugins
   - build-backend
@@ -1324,13 +1311,6 @@ steps:
   - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
-    --no-pull-enterprise --sign ${DRONE_TAG}
-  depends_on:
-  - gen-version
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1473,7 +1453,13 @@ steps:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise --sign ${DRONE_TAG}
   depends_on:
-  - gen-version
+  - build-plugins
+  - build-backend
+  - build-frontend
+  - codespell
+  - shellcheck
+  - build-backend-enterprise2
+  - test-backend-enterprise2
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1731,6 +1717,7 @@ steps:
   - ./bin/grabpl verify-drone
   - make gen-go
   - ./bin/grabpl verify-version v7.3.0-test
+  - ./bin/grabpl gen-version v7.3.0-test
   - yarn install --immutable
   image: grafana/build-container:1.4.3
   name: initialize
@@ -1848,20 +1835,14 @@ steps:
   image: grafana/build-container:1.4.3
   name: ensure-cuetsified
 - commands:
-  - ./bin/grabpl gen-version v7.3.0-test
+  - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
+    --sign v7.3.0-test
   depends_on:
   - build-plugins
   - build-backend
   - build-frontend
   - codespell
   - shellcheck
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
-    --sign v7.3.0-test
-  depends_on:
-  - gen-version
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1952,7 +1933,7 @@ steps:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
   depends_on:
-  - package
+  - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.4.3
@@ -2107,6 +2088,7 @@ steps:
   - ./bin/grabpl verify-drone
   - make gen-go
   - ./bin/grabpl verify-version v7.3.0-test
+  - ./bin/grabpl gen-version v7.3.0-test
   - yarn install --immutable
   depends_on:
   - clone
@@ -2258,7 +2240,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: build-backend-enterprise2
 - commands:
-  - ./bin/grabpl gen-version v7.3.0-test
+  - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
+    --no-pull-enterprise --sign v7.3.0-test
   depends_on:
   - build-plugins
   - build-backend
@@ -2267,13 +2250,6 @@ steps:
   - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
-    --no-pull-enterprise --sign v7.3.0-test
-  depends_on:
-  - gen-version
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2408,7 +2384,13 @@ steps:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise --sign v7.3.0-test
   depends_on:
-  - gen-version
+  - build-plugins
+  - build-backend
+  - build-frontend
+  - codespell
+  - shellcheck
+  - build-backend-enterprise2
+  - test-backend-enterprise2
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2671,6 +2653,7 @@ steps:
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
+  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
   image: grafana/build-container:1.4.3
   name: initialize
@@ -2786,20 +2769,14 @@ steps:
   image: grafana/build-container:1.4.3
   name: ensure-cuetsified
 - commands:
-  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
+  - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
+    --sign
   depends_on:
   - build-plugins
   - build-backend
   - build-frontend
   - codespell
   - shellcheck
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
-    --sign
-  depends_on:
-  - gen-version
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2890,7 +2867,7 @@ steps:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
   depends_on:
-  - package
+  - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.4.3
@@ -3019,6 +2996,7 @@ steps:
   - mv /tmp/grabpl bin/
   - ./bin/grabpl verify-drone
   - make gen-go
+  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
   depends_on:
   - clone
@@ -3166,7 +3144,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: build-backend-enterprise2
 - commands:
-  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
+  - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
+    --no-pull-enterprise --sign
   depends_on:
   - build-plugins
   - build-backend
@@ -3175,13 +3154,6 @@ steps:
   - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
-  image: grafana/build-container:1.4.3
-  name: gen-version
-- commands:
-  - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
-    --no-pull-enterprise --sign
-  depends_on:
-  - gen-version
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -3274,7 +3246,7 @@ steps:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
   depends_on:
-  - package
+  - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.4.3
@@ -3325,7 +3297,13 @@ steps:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
     --no-pull-enterprise --variants linux-x64 --sign
   depends_on:
-  - gen-version
+  - build-plugins
+  - build-backend
+  - build-frontend
+  - codespell
+  - shellcheck
+  - build-backend-enterprise2
+  - test-backend-enterprise2
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -3529,6 +3507,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 96d23b144a0a27bce871f7faf782827c17cc132492fe058a7c56768c543078c9
+hmac: 2e6faca0cb0dbf3c14bf3a589a1ffefb0fc50ada0e3adfc10436030d72dae97a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -152,8 +152,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   environment: null
   image: grafana/build-container:1.4.3
   name: package
@@ -215,7 +213,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -430,8 +428,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -517,7 +513,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -891,8 +887,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -928,7 +922,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -1307,8 +1301,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
   environment:
@@ -1348,7 +1340,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -1456,8 +1448,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
   environment:
@@ -1841,8 +1831,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1878,7 +1866,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -2246,8 +2234,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
   environment:
@@ -2287,7 +2273,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -2387,8 +2373,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
   environment:
@@ -2775,8 +2759,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2812,7 +2794,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -3150,8 +3132,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
   environment:
@@ -3191,7 +3171,7 @@ steps:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
-  - end-to-end-tests-server
+  - package
   image: grafana/build-container:1.4.3
   name: copy-packages-for-docker
 - depends_on:
@@ -3300,8 +3280,6 @@ steps:
   - build-plugins
   - build-backend
   - build-frontend
-  - codespell
-  - shellcheck
   - build-backend-enterprise2
   - test-backend-enterprise2
   environment:
@@ -3507,6 +3485,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 2e6faca0cb0dbf3c14bf3a589a1ffefb0fc50ada0e3adfc10436030d72dae97a
+hmac: e9840e1a4ba7a76a431ea51f37d3ead1d94e099d3057891b8a2dc8dac4c7c284
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -10,7 +10,6 @@ load(
     'build_backend_step',
     'build_frontend_step',
     'build_plugins_step',
-    'gen_version_step',
     'package_step',
     'e2e_tests_server_step',
     'e2e_tests_step',
@@ -69,7 +68,6 @@ def get_steps(edition, is_downstream=False):
         ensure_cuetsified_step(),
     ]
 
-    # Have to insert Enterprise2 steps before they're depended on (in the gen-version step)
     if include_enterprise2:
         edition2 = 'enterprise2'
         steps.extend([
@@ -81,8 +79,7 @@ def get_steps(edition, is_downstream=False):
 
     # Insert remaining steps
     steps.extend([
-        gen_version_step(ver_mode=ver_mode, is_downstream=is_downstream, include_enterprise2=include_enterprise2),
-        package_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),
         e2e_tests_server_step(edition=edition),
         e2e_tests_step(edition=edition),
         build_storybook_step(edition=edition, ver_mode=ver_mode),
@@ -109,7 +106,7 @@ def get_steps(edition, is_downstream=False):
     if include_enterprise2:
         edition2 = 'enterprise2'
         steps.extend([
-            package_step(edition=edition2, ver_mode=ver_mode, variants=['linux-x64'], is_downstream=is_downstream),
+            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=['linux-x64'], is_downstream=is_downstream),
             e2e_tests_server_step(edition=edition2, port=3002),
             e2e_tests_step(edition=edition2, port=3002),
             upload_packages_step(edition=edition2, ver_mode=ver_mode, is_downstream=is_downstream),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -10,7 +10,6 @@ load(
     'test_backend_step',
     'test_backend_integration_step',
     'test_frontend_step',
-    'gen_version_step',
     'package_step',
     'e2e_tests_server_step',
     'e2e_tests_step',
@@ -61,7 +60,6 @@ def pr_pipelines(edition):
         ensure_cuetsified_step(),
     ]
 
-    # Have to insert Enterprise2 steps before they're depended on (in the gen-version step)
     if include_enterprise2:
         edition2 = 'enterprise2'
         steps.append(benchmark_ldap_step())
@@ -75,8 +73,7 @@ def pr_pipelines(edition):
 
     # Insert remaining steps
     steps.extend([
-        gen_version_step(ver_mode=ver_mode, include_enterprise2=include_enterprise2),
-        package_step(edition=edition, ver_mode=ver_mode, variants=variants),
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=variants),
         e2e_tests_server_step(edition=edition),
         e2e_tests_step(edition=edition),
         build_storybook_step(edition=edition, ver_mode=ver_mode),
@@ -93,7 +90,7 @@ def pr_pipelines(edition):
         steps.extend([
             redis_integration_tests_step(),
             memcached_integration_tests_step(),
-            package_step(edition=edition2, ver_mode=ver_mode, variants=['linux-x64']),
+            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=['linux-x64']),
             e2e_tests_server_step(edition=edition2, port=3002),
             e2e_tests_step(edition=edition2, port=3002),
         ])

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -13,7 +13,6 @@ load(
     'build_backend_step',
     'build_frontend_step',
     'build_plugins_step',
-    'gen_version_step',
     'package_step',
     'e2e_tests_server_step',
     'e2e_tests_step',
@@ -97,7 +96,6 @@ def get_steps(edition, ver_mode):
         ensure_cuetsified_step(),
     ]
 
-    # Have to insert Enterprise2 steps before they're depended on (in the gen-version step)
     if include_enterprise2:
         edition2 = 'enterprise2'
         steps.extend([
@@ -109,8 +107,7 @@ def get_steps(edition, ver_mode):
 
     # Insert remaining steps
     steps.extend([
-        gen_version_step(ver_mode=ver_mode, include_enterprise2=include_enterprise2),
-        package_step(edition=edition, ver_mode=ver_mode),
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2),
         e2e_tests_server_step(edition=edition),
         e2e_tests_step(edition=edition, tries=3),
         copy_packages_for_docker_step(),
@@ -142,7 +139,7 @@ def get_steps(edition, ver_mode):
     if include_enterprise2:
         edition2 = 'enterprise2'
         steps.extend([
-            package_step(edition=edition2, ver_mode=ver_mode, variants=['linux-x64']),
+            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=['linux-x64']),
             e2e_tests_server_step(edition=edition2, port=3002),
             e2e_tests_step(edition=edition2, port=3002, tries=3),
             upload_cdn_step(edition=edition2),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,6 +1,6 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token')
 
-grabpl_version = '2.5.2'
+grabpl_version = '2.5.5'
 build_image = 'grafana/build-container:1.4.3'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -514,8 +514,6 @@ def package_step(edition, ver_mode, include_enterprise2=False, variants=None, is
         'build-plugins',
         'build-backend',
         'build-frontend',
-        'codespell',
-        'shellcheck',
     ]
     if include_enterprise2:
         sfx = '-enterprise2'
@@ -644,7 +642,7 @@ def copy_packages_for_docker_step():
         'name': 'copy-packages-for-docker',
         'image': build_image,
         'depends_on': [
-            'end-to-end-tests-server',
+            'package',
         ],
         'commands': [
             'ls dist/*.tar.gz*',


### PR DESCRIPTION
**What this PR does / why we need it**:

Simplifies the pipeline dependencies. `gen-version` step should export the Grafana version early in the pipeline for other steps to grab it.

