### PR TITLE
CloudMonitoring: Allow to manually set filters

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.tsx
@@ -77,9 +77,9 @@ export const LabelFilter: FunctionComponent<Props> = ({
       <VerticalGroup spacing="xs" width="auto">
         {filters.map(({ key, operator, value, condition }, index) => {
           // Add the current key and value as options if they are manually entered
-          const keyPresent = options.find((op) => {
+          const keyPresent = options.some((op) => {
             if (op.options) {
-              return options.find((opp) => opp.label === key);
+              return options.some((opp) => opp.label === key);
             }
             return op.label === key;
           });
@@ -90,7 +90,7 @@ export const LabelFilter: FunctionComponent<Props> = ({
           const valueOptions = labels.hasOwnProperty(key)
             ? [variableOptionGroup, ...labels[key].map(toOption)]
             : [variableOptionGroup];
-          const valuePresent = valueOptions.find((op) => {
+          const valuePresent = valueOptions.some((op) => {
             return op.label === value;
           });
           if (!valuePresent) {

--- a/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.tsx
@@ -75,57 +75,78 @@ export const LabelFilter: FunctionComponent<Props> = ({
       noFillEnd={filters.length > 1}
     >
       <VerticalGroup spacing="xs" width="auto">
-        {filters.map(({ key, operator, value, condition }, index) => (
-          <HorizontalGroup key={index} spacing="xs" width="auto">
-            <Select
-              menuShouldPortal
-              width={SELECT_WIDTH}
-              allowCustomValue
-              formatCreateLabel={(v) => `Use label key: ${v}`}
-              value={key}
-              options={options}
-              onChange={({ value: key = '' }) => {
-                onChange(
-                  filtersToStringArray(
-                    filters.map((f, i) => (i === index ? { key, operator, condition, value: '' } : f))
-                  )
-                );
-              }}
-            />
-            <Select
-              menuShouldPortal
-              value={operator}
-              options={operators.map(toOption)}
-              onChange={({ value: operator = '=' }) =>
-                onChange(filtersToStringArray(filters.map((f, i) => (i === index ? { ...f, operator } : f))))
-              }
-              menuPlacement="bottom"
-              renderControl={OperatorButton}
-            />
-            <Select
-              menuShouldPortal
-              width={SELECT_WIDTH}
-              formatCreateLabel={(v) => `Use label value: ${v}`}
-              allowCustomValue
-              value={value}
-              placeholder="add filter value"
-              options={
-                labels.hasOwnProperty(key) ? [variableOptionGroup, ...labels[key].map(toOption)] : [variableOptionGroup]
-              }
-              onChange={({ value = '' }) =>
-                onChange(filtersToStringArray(filters.map((f, i) => (i === index ? { ...f, value } : f))))
-              }
-            />
-            <Button
-              variant="secondary"
-              size="md"
-              icon="trash-alt"
-              aria-label="Remove"
-              onClick={() => onChange(filtersToStringArray(filters.filter((_, i) => i !== index)))}
-            ></Button>
-            {index + 1 === filters.length && Object.values(filters).every(({ value }) => value) && <AddFilter />}
-          </HorizontalGroup>
-        ))}
+        {filters.map(({ key, operator, value, condition }, index) => {
+          // Add the current key and value as options if they are manually entered
+          const keyPresent = options.find((op) => {
+            if (op.options) {
+              return options.find((opp) => opp.label === key);
+            }
+            return op.label === key;
+          });
+          if (!keyPresent) {
+            options.push({ label: key, value: key });
+          }
+
+          const valueOptions = labels.hasOwnProperty(key)
+            ? [variableOptionGroup, ...labels[key].map(toOption)]
+            : [variableOptionGroup];
+          const valuePresent = valueOptions.find((op) => {
+            return op.label === value;
+          });
+          if (!valuePresent) {
+            valueOptions.push({ label: value, value });
+          }
+
+          return (
+            <HorizontalGroup key={index} spacing="xs" width="auto">
+              <Select
+                menuShouldPortal
+                width={SELECT_WIDTH}
+                allowCustomValue
+                formatCreateLabel={(v) => `Use label key: ${v}`}
+                value={key}
+                options={options}
+                onChange={({ value: key = '' }) => {
+                  onChange(
+                    filtersToStringArray(
+                      filters.map((f, i) => (i === index ? { key, operator, condition, value: '' } : f))
+                    )
+                  );
+                }}
+              />
+              <Select
+                menuShouldPortal
+                value={operator}
+                options={operators.map(toOption)}
+                onChange={({ value: operator = '=' }) =>
+                  onChange(filtersToStringArray(filters.map((f, i) => (i === index ? { ...f, operator } : f))))
+                }
+                menuPlacement="bottom"
+                renderControl={OperatorButton}
+              />
+              <Select
+                menuShouldPortal
+                width={SELECT_WIDTH}
+                formatCreateLabel={(v) => `Use label value: ${v}`}
+                allowCustomValue
+                value={value}
+                placeholder="add filter value"
+                options={valueOptions}
+                onChange={({ value = '' }) =>
+                  onChange(filtersToStringArray(filters.map((f, i) => (i === index ? { ...f, value } : f))))
+                }
+              />
+              <Button
+                variant="secondary"
+                size="md"
+                icon="trash-alt"
+                aria-label="Remove"
+                onClick={() => onChange(filtersToStringArray(filters.filter((_, i) => i !== index)))}
+              ></Button>
+              {index + 1 === filters.length && Object.values(filters).every(({ value }) => value) && <AddFilter />}
+            </HorizontalGroup>
+          );
+        })}
         {!filters.length && <AddFilter />}
       </VerticalGroup>
     </QueryEditorRow>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

It's possible to manually enter a label or a value as a filter in a Cloud Monitoring filter but if that's done, the values are no longer shown in the query editor since they are not part of the predefined options. This PR adds the manual value to the options so it's rendered:

![Screenshot from 2021-10-19 11-23-14](https://user-images.githubusercontent.com/4025665/137882284-a1ca046f-fa8b-43b5-9c01-e38c4a0b5ea8.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #36811

**Special notes for your reviewer**:

