### PR TITLE
Variables: Improve display when selecting variables with the same value

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -138,7 +138,7 @@ const optionsPickerSlice = createSlice({
       const { multi, selectedValues } = state;
 
       if (option) {
-        const selected = !selectedValues.find((o) => o.value === option.value);
+        const selected = !selectedValues.find((o) => o.value === option.value && o.text === option.text);
 
         if (option.value === ALL_VARIABLE_VALUE || !multi || clearOthers) {
           if (selected || forceSelect) {
@@ -153,7 +153,7 @@ const optionsPickerSlice = createSlice({
           return applyStateChanges(state, updateDefaultSelection, updateAllSelection, updateOptions);
         }
 
-        state.selectedValues = selectedValues.filter((o) => o.value !== option.value);
+        state.selectedValues = selectedValues.filter((o) => o.value !== option.value && o.text !== option.text);
       } else {
         state.selectedValues = [];
       }

--- a/public/app/features/variables/pickers/shared/VariableOptions.tsx
+++ b/public/app/features/variables/pickers/shared/VariableOptions.tsx
@@ -61,7 +61,7 @@ export class VariableOptions extends PureComponent<Props> {
     const highlightClass = index === highlightIndex ? `${selectClass} highlighted` : selectClass;
 
     return (
-      <li key={`${option.text}-${option.value}`}>
+      <li key={`${option.value}`}>
         <a role="checkbox" aria-checked={option.selected} className={highlightClass} onClick={this.onToggle(option)}>
           <span className="variable-option-icon"></span>
           <span data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownOptionTexts(`${option.text}`)}>

--- a/public/app/features/variables/pickers/shared/VariableOptions.tsx
+++ b/public/app/features/variables/pickers/shared/VariableOptions.tsx
@@ -61,7 +61,7 @@ export class VariableOptions extends PureComponent<Props> {
     const highlightClass = index === highlightIndex ? `${selectClass} highlighted` : selectClass;
 
     return (
-      <li key={`${option.value}`}>
+      <li key={`${option.text}-${option.value}`}>
         <a role="checkbox" aria-checked={option.selected} className={highlightClass} onClick={this.onToggle(option)}>
           <span className="variable-option-icon"></span>
           <span data-testid={selectors.pages.Dashboard.SubMenu.submenuItemValueDropDownOptionTexts(`${option.text}`)}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

there are some scenarios where having variables with different labels but the same underlying value could make sense. e.g. if the variables are key=location, value=hostname. you may have a server that is responsible for asia + australia for example. in which case you might have 2 different variables, `asia=<hostname>` and `australia=<hostname>` where `hostname` are the same value.

i don't think we can ever fully support this use case without a significant amount of refactoring. for example, the current variable value is stored in the query parameter, but if there are 2 variables with the same value we have no way of knowing which variable was actually selected.

the confusion happens when you select one of these options from the variable picker. because they share the same value, when you select one of these variables it displays the first option matching the value as selected. this may or may not be the actual option you selected. by introducing a check on the label as well, we at least ensure that the option you selected is then displayed in the variable picker.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/40414

**Special notes for your reviewer**:

