### PR TITLE
Tempo: Change t/min to r/sec in service map

### DIFF
--- a/public/app/plugins/datasource/tempo/graphTransform.test.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.test.ts
@@ -73,7 +73,7 @@ describe('mapPromMetricsToServiceMap', () => {
       { name: 'id', values: new ArrayVector(['db', 'app', 'lb']) },
       { name: 'title', values: new ArrayVector(['db', 'app', 'lb']) },
       { name: 'mainStat', values: new ArrayVector([1000, 2000, NaN]) },
-      { name: 'secondaryStat', values: new ArrayVector([10, 20, NaN]) },
+      { name: 'secondaryStat', values: new ArrayVector([0.17, 0.33, NaN]) },
     ]);
     expect(edges.fields).toMatchObject([
       { name: 'id', values: new ArrayVector(['app_db', 'lb_app']) },

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -170,7 +170,7 @@ function createServiceMapDataFrames() {
     { name: Fields.mainStat, config: { unit: 'ms/r', displayName: 'Average response time' } },
     {
       name: Fields.secondaryStat,
-      config: { unit: 'r/sec', displayName: 'Request per second' },
+      config: { unit: 'r/sec', displayName: 'Requests per second' },
     },
   ]);
   const edges = createDF('Edges', [

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -167,7 +167,7 @@ function createServiceMapDataFrames() {
   const nodes = createDF('Nodes', [
     { name: Fields.id },
     { name: Fields.title },
-    { name: Fields.mainStat, config: { unit: 'ms/t', displayName: 'Average response time' } },
+    { name: Fields.mainStat, config: { unit: 'ms/r', displayName: 'Average response time' } },
     {
       name: Fields.secondaryStat,
       config: { unit: 'r/sec', displayName: 'Request per second' },
@@ -178,7 +178,7 @@ function createServiceMapDataFrames() {
     { name: Fields.source },
     { name: Fields.target },
     { name: Fields.mainStat, config: { unit: 'r', displayName: 'Requests' } },
-    { name: Fields.secondaryStat, config: { unit: 'ms/t', displayName: 'Average response time' } },
+    { name: Fields.secondaryStat, config: { unit: 'ms/r', displayName: 'Average response time' } },
   ]);
 
   return [nodes, edges];

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -257,8 +257,8 @@ function convertToDataFrames(
       title: nodeId,
       // NaN will not be shown in the node graph. This happens for a root client node which did not process
       // any requests itself.
-      mainStat: node.total ? (node.seconds / node.total) * 1000 : Number.NaN, // Average response time (ms/t)
-      secondaryStat: node.total ? Math.round((node.total / (rangeMs / 1000)) * 100) / 100 : Number.NaN, // Request per second (r/sec to 2 decimals)
+      mainStat: node.total ? (node.seconds / node.total) * 1000 : Number.NaN, // Average response time
+      secondaryStat: node.total ? Math.round((node.total / (rangeMs / 1000)) * 100) / 100 : Number.NaN, // Request per second (to 2 decimals)
     });
   }
   for (const edgeId of Object.keys(edgesMap)) {
@@ -267,8 +267,8 @@ function convertToDataFrames(
       id: edgeId,
       source: edge.source,
       target: edge.target,
-      mainStat: edge.total, // Requests (r)
-      secondaryStat: edge.total ? (edge.seconds / edge.total) * 1000 : Number.NaN, // Average response time (ms/t)
+      mainStat: edge.total, // Requests
+      secondaryStat: edge.total ? (edge.seconds / edge.total) * 1000 : Number.NaN, // Average response time
     });
   }
 

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -170,14 +170,14 @@ function createServiceMapDataFrames() {
     { name: Fields.mainStat, config: { unit: 'ms/t', displayName: 'Average response time' } },
     {
       name: Fields.secondaryStat,
-      config: { unit: 't/min', displayName: 'Transactions per minute' },
+      config: { unit: 'r/sec', displayName: 'Request per second' },
     },
   ]);
   const edges = createDF('Edges', [
     { name: Fields.id },
     { name: Fields.source },
     { name: Fields.target },
-    { name: Fields.mainStat, config: { unit: 't', displayName: 'Transactions' } },
+    { name: Fields.mainStat, config: { unit: 'r', displayName: 'Requests' } },
     { name: Fields.secondaryStat, config: { unit: 'ms/t', displayName: 'Average response time' } },
   ]);
 
@@ -257,8 +257,8 @@ function convertToDataFrames(
       title: nodeId,
       // NaN will not be shown in the node graph. This happens for a root client node which did not process
       // any requests itself.
-      mainStat: node.total ? (node.seconds / node.total) * 1000 : Number.NaN,
-      secondaryStat: node.total ? node.total / (rangeMs / (1000 * 60)) : Number.NaN,
+      mainStat: node.total ? (node.seconds / node.total) * 1000 : Number.NaN, // Average response time (ms/t)
+      secondaryStat: node.total ? Math.round((node.total / (rangeMs / 1000)) * 100) / 100 : Number.NaN, // Request per second (r/sec to 2 decimals)
     });
   }
   for (const edgeId of Object.keys(edgesMap)) {
@@ -267,8 +267,8 @@ function convertToDataFrames(
       id: edgeId,
       source: edge.source,
       target: edge.target,
-      mainStat: edge.total,
-      secondaryStat: edge.total ? (edge.seconds / edge.total) * 1000 : Number.NaN,
+      mainStat: edge.total, // Requests (r)
+      secondaryStat: edge.total ? (edge.seconds / edge.total) * 1000 : Number.NaN, // Average response time (ms/t)
     });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes `transactions` to `requests` and changes secondary stat `transactions per minute` to `requests per second`.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/39879
