### PR TITLE
Chore: Make test-frontend step depend on initialize step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,7 +64,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -79,13 +82,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -198,7 +201,7 @@ steps:
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
-  - lint-frontend
+  - build-frontend
   image: grafana/build-container:1.4.3
   name: build-frontend-docs
 - commands:
@@ -338,7 +341,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -353,13 +359,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -506,7 +512,7 @@ steps:
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
-  - lint-frontend
+  - build-frontend
   image: grafana/build-container:1.4.3
   name: build-frontend-docs
 - commands:
@@ -795,7 +801,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -810,13 +819,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -1177,7 +1186,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -1192,13 +1204,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -1271,7 +1283,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend-enterprise2
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
@@ -1735,7 +1747,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -1750,13 +1765,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -2106,7 +2121,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -2121,13 +2139,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -2200,7 +2218,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend-enterprise2
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
@@ -2661,7 +2679,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -2676,13 +2697,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -3004,7 +3025,10 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - echo skip
+  - yarn run prettier:check
+  - yarn run lint
+  - yarn run typecheck
+  - yarn run check-strict
   depends_on:
   - initialize
   environment:
@@ -3019,13 +3043,13 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - echo skip
+  - yarn run ci:test-frontend
   depends_on:
   - initialize
   environment:
@@ -3096,7 +3120,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend-enterprise2
 - commands:
-  - echo skip
+  - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
@@ -3473,6 +3497,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 545c17474588c3e4c797cd8b84069d9e3b20ee6b2cab7aaa141c4c35a45597af
+hmac: a6afb9baae7ecf011d368d43870c625c727d8604563a6daae0c76fac94762886
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -64,10 +64,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -82,15 +79,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition oss
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -124,6 +121,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -339,10 +338,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -357,15 +353,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition oss
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -401,6 +397,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -797,10 +795,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -815,15 +810,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition oss
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -861,6 +856,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -1180,10 +1177,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -1198,15 +1192,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition enterprise
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -1245,6 +1239,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -1275,7 +1271,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend-enterprise2
 - commands:
-  - ./bin/grabpl integration-tests --edition enterprise2
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
@@ -1739,10 +1735,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -1757,15 +1750,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition oss
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -1803,6 +1796,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -2111,10 +2106,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -2129,15 +2121,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition enterprise
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -2176,6 +2168,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -2206,7 +2200,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend-enterprise2
 - commands:
-  - ./bin/grabpl integration-tests --edition enterprise2
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
@@ -2667,10 +2661,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -2685,15 +2676,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition oss
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -2729,6 +2720,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -3011,10 +3004,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: lint-backend
 - commands:
-  - yarn run prettier:check
-  - yarn run lint
-  - yarn run typecheck
-  - yarn run check-strict
+  - echo skip
   depends_on:
   - initialize
   environment:
@@ -3029,15 +3019,15 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend
 - commands:
-  - ./bin/grabpl integration-tests --edition enterprise
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
   name: test-backend-integration
 - commands:
-  - yarn run ci:test-frontend
+  - echo skip
   depends_on:
-  - lint-frontend
+  - initialize
   environment:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.3
@@ -3074,6 +3064,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
+  - pwd
+  - ls -a bin/linux-amd64
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -3104,7 +3096,7 @@ steps:
   image: grafana/build-container:1.4.3
   name: test-backend-enterprise2
 - commands:
-  - ./bin/grabpl integration-tests --edition enterprise2
+  - echo skip
   depends_on:
   - lint-backend
   image: grafana/build-container:1.4.3
@@ -3481,6 +3473,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 914bf2e3e06c65f7bc587a77e72e773858e864b4f0636d00f0edf6ede3f6d54d
+hmac: 485001e8ea52089210dbdaada0a9045e63e2fd693258a205c1bd1d182e6888df
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -198,7 +198,7 @@ steps:
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
-  - build-frontend
+  - lint-frontend
   image: grafana/build-container:1.4.3
   name: build-frontend-docs
 - commands:
@@ -506,7 +506,7 @@ steps:
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
-  - build-frontend
+  - lint-frontend
   image: grafana/build-container:1.4.3
   name: build-frontend-docs
 - commands:
@@ -3473,6 +3473,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: fb7a82e73f8507d43feff402273291d13c55dfcf2e9c9af5595c6c4a79f450dd
+hmac: 545c17474588c3e4c797cd8b84069d9e3b20ee6b2cab7aaa141c4c35a45597af
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,8 +121,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -397,8 +397,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -856,8 +856,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -1239,8 +1239,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -1796,8 +1796,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -2168,8 +2168,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -2720,8 +2720,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -3064,8 +3064,8 @@ steps:
   image: grafana/build-container:1.4.3
   name: validate-scuemata
 - commands:
-  - pwd
-  - ls -a bin/linux-amd64
+  - '# Make sure the git tree is clean.'
+  - git reset --hard
   - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .
   - '# The above command generates Typescript files (*.gen.ts) from all appropriate
     .cue files.'
@@ -3473,6 +3473,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 485001e8ea52089210dbdaada0a9045e63e2fd693258a205c1bd1d182e6888df
+hmac: fb7a82e73f8507d43feff402273291d13c55dfcf2e9c9af5595c6c4a79f450dd
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -328,7 +328,7 @@ def build_frontend_docs_step(edition):
         'name': 'build-frontend-docs',
         'image': build_image,
         'depends_on': [
-            'lint-frontend'
+            'build-frontend'
         ],
         'commands': [
             './scripts/ci-reference-docs-lint.sh ci',
@@ -379,7 +379,7 @@ def test_backend_integration_step(edition):
             'lint-backend',
         ],
         'commands': [
-            'echo skip',
+            './bin/grabpl integration-tests --edition {}'.format(edition),
         ],
     }
 
@@ -394,7 +394,7 @@ def test_frontend_step():
             'TEST_MAX_WORKERS': '50%',
         },
         'commands': [
-            'echo skip',
+            'yarn run ci:test-frontend',
         ],
     }
 
@@ -409,7 +409,10 @@ def lint_frontend_step():
             'TEST_MAX_WORKERS': '50%',
         },
         'commands': [
-            'echo skip',
+            'yarn run prettier:check',
+            'yarn run lint',
+            'yarn run typecheck',
+            'yarn run check-strict',
         ],
     }
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -328,7 +328,7 @@ def build_frontend_docs_step(edition):
         'name': 'build-frontend-docs',
         'image': build_image,
         'depends_on': [
-            'build-frontend'
+            'lint-frontend'
         ],
         'commands': [
             './scripts/ci-reference-docs-lint.sh ci',

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -379,7 +379,7 @@ def test_backend_integration_step(edition):
             'lint-backend',
         ],
         'commands': [
-            './bin/grabpl integration-tests --edition {}'.format(edition),
+            'echo skip',
         ],
     }
 
@@ -388,13 +388,13 @@ def test_frontend_step():
         'name': 'test-frontend',
         'image': build_image,
         'depends_on': [
-            'lint-frontend',
+            'initialize',
         ],
         'environment': {
             'TEST_MAX_WORKERS': '50%',
         },
         'commands': [
-            'yarn run ci:test-frontend',
+            'echo skip',
         ],
     }
 
@@ -409,10 +409,7 @@ def lint_frontend_step():
             'TEST_MAX_WORKERS': '50%',
         },
         'commands': [
-            'yarn run prettier:check',
-            'yarn run lint',
-            'yarn run typecheck',
-            'yarn run check-strict',
+            'echo skip',
         ],
     }
 
@@ -1010,6 +1007,8 @@ def ensure_cuetsified_step():
             'validate-scuemata',
         ],
         'commands': [
+            'pwd',
+            'ls -a bin/linux-amd64',
             './bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .',
             '# The above command generates Typescript files (*.gen.ts) from all appropriate .cue files.',
             '# It is required that the generated Typescript be in sync with the input CUE files.',

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1007,8 +1007,8 @@ def ensure_cuetsified_step():
             'validate-scuemata',
         ],
         'commands': [
-            'pwd',
-            'ls -a bin/linux-amd64',
+            '# Make sure the git tree is clean.',
+            'git reset --hard',
             './bin/linux-amd64/grafana-cli cue gen-ts --grafana-root .',
             '# The above command generates Typescript files (*.gen.ts) from all appropriate .cue files.',
             '# It is required that the generated Typescript be in sync with the input CUE files.',


### PR DESCRIPTION
**What this PR does / why we need it**:

Run frontend tests after the project has been initialized, and remove dependency on `lint-backend` step since it's really time consuming. This reordering will save ~5mins in the pipeline cycle.

