### PR TITLE
Scale: We fixed how the system handles NaN percent when data min = data max.

### DIFF
--- a/packages/grafana-data/src/field/scale.test.ts
+++ b/packages/grafana-data/src/field/scale.test.ts
@@ -1,4 +1,4 @@
-import { ThresholdsMode, Field, FieldType } from '../types';
+import { ThresholdsMode, Field, FieldType, FieldColorModeId } from '../types';
 import { sortThresholds } from './thresholds';
 import { ArrayVector } from '../vector/ArrayVector';
 import { getScaleCalculator } from './scale';
@@ -48,5 +48,19 @@ describe('getScaleCalculator', () => {
       color: getColorForTheme('red', theme.v1),
       threshold: undefined,
     });
+  });
+
+  it('should handle min = max', () => {
+    const field: Field = {
+      name: 'test',
+      config: { color: { mode: FieldColorModeId.ContinuousGrYlRd } },
+      type: FieldType.number,
+      values: new ArrayVector([1]),
+    };
+
+    const theme = createTheme();
+    const calc = getScaleCalculator(field, theme);
+
+    expect(calc(1).color).toEqual('rgb(115, 191, 105)');
   });
 });

--- a/packages/grafana-data/src/field/scale.ts
+++ b/packages/grafana-data/src/field/scale.ts
@@ -27,6 +27,10 @@ export function getScaleCalculator(field: Field, theme: GrafanaTheme2): ScaleCal
 
     if (value !== -Infinity) {
       percent = (value - info.min!) / info.delta;
+
+      if (Number.isNaN(percent)) {
+        percent = 0;
+      }
     }
 
     const threshold = getActiveThresholdForValue(field, value, percent);


### PR DESCRIPTION
When we only have one value percent became NaN and color became black. This fixes handling of this so this scenario is treated as percent 0
