### PR TITLE
IntervalV2: Fix parsing of Grafana specific durations in interval

### DIFF
--- a/pkg/tsdb/intervalv2/intervalv2.go
+++ b/pkg/tsdb/intervalv2/intervalv2.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/tsdb/interval"
 )
 
@@ -120,7 +121,7 @@ func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
 	if isPureNum {
 		formattedInterval += "s"
 	}
-	parsedInterval, err := time.ParseDuration(formattedInterval)
+	parsedInterval, err := gtime.ParseDuration(formattedInterval)
 	if err != nil {
 		return time.Duration(0), err
 	}

--- a/pkg/tsdb/intervalv2/intervalv2_test.go
+++ b/pkg/tsdb/intervalv2/intervalv2_test.go
@@ -112,6 +112,7 @@ func TestGetIntervalFrom(t *testing.T) {
 		{"45s", nil, "45s", 0, time.Second * 15, time.Second * 45},
 		{"45", nil, "45", 0, time.Second * 15, time.Second * 45},
 		{"2m", nil, "2m", 0, time.Second * 15, time.Minute * 2},
+		{"1d", nil, "1d", 0, time.Second * 15, time.Hour * 24},
 		{"intervalMs", nil, "", 45000, time.Second * 15, time.Second * 45},
 		{"intervalMs sub-seconds", nil, "", 45200, time.Second * 15, time.Millisecond * 45200},
 		{"defaultInterval when interval empty", nil, "", 0, time.Second * 15, time.Second * 15},


### PR DESCRIPTION
**What this PR does / why we need it**:
When using interval such as `1d` `time.ParseDuration` threw error. We want to use `gtime.ParseDuration` that parses a duration with support for all units that Grafana uses https://github.com/grafana/grafana-plugin-sdk-go/blob/5169c0aeb8a09cd9eadcfeb1368129847d60a09d/backend/gtime/gtime.go#L74