### PR TITLE
Toolkit: Prevent toolkit from crashing when an error occur

### DIFF
--- a/packages/grafana-toolkit/src/plugins/manifest.ts
+++ b/packages/grafana-toolkit/src/plugins/manifest.ts
@@ -76,7 +76,7 @@ export async function signManifest(manifest: ManifestInfo): Promise<string> {
 
     return info.data;
   } catch (err: any) {
-    if ((err.response && err.response.data) || err.response.data.message) {
+    if (err.response?.data?.message) {
       throw new Error('Error signing manifest: ' + err.response.data.message);
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This will prevent the toolkit from crashing when throwing an error during plugin signing. Currently we are trying to print an error message to the console from an error that we have not verified exists.

**Which issue(s) this PR fixes**:
Fixes #40243
