### PR TITLE
Prometheus: Fix interpolation of legendFormat

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -606,7 +606,7 @@ describe('PrometheusDatasource', () => {
       templateSrvStub.replace.mockReturnValue(interval);
 
       const interpolatedQuery = ds.applyTemplateVariables(query, { interval: { text: interval, value: interval } });
-      expect(interpolatedQuery.expr).toBe(interval);
+      expect(interpolatedQuery.interval).not.toBe(interval);
     });
   });
   describe('metricFindQuery', () => {

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -570,6 +570,45 @@ describe('PrometheusDatasource', () => {
     });
   });
 
+  describe('applyTemplateVariables', () => {
+    it('should call replace function for legendFormat', () => {
+      const query = {
+        expr: 'test{job="bar"}',
+        legendFormat: '$legend',
+        refId: 'A',
+      };
+      const legend = 'baz';
+      templateSrvStub.replace.mockReturnValue(legend);
+
+      const interpolatedQuery = ds.applyTemplateVariables(query, { legend: { text: legend, value: legend } });
+      expect(interpolatedQuery.legendFormat).toBe(legend);
+    });
+
+    it('should call replace function for expr', () => {
+      const query = {
+        expr: 'test{job="$job"}',
+        refId: 'A',
+      };
+      const job = 'bar';
+      templateSrvStub.replace.mockReturnValue(job);
+
+      const interpolatedQuery = ds.applyTemplateVariables(query, { job: { text: job, value: job } });
+      expect(interpolatedQuery.expr).toBe(job);
+    });
+
+    it('should not call replace function for interval', () => {
+      const query = {
+        expr: 'test{job="bar"}',
+        interval: '$interval',
+        refId: 'A',
+      };
+      const interval = '10s';
+      templateSrvStub.replace.mockReturnValue(interval);
+
+      const interpolatedQuery = ds.applyTemplateVariables(query, { interval: { text: interval, value: interval } });
+      expect(interpolatedQuery.expr).toBe(interval);
+    });
+  });
   describe('metricFindQuery', () => {
     beforeEach(() => {
       const query = 'query_result(topk(5,rate(http_request_duration_microseconds_count[$__interval])))';

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -894,6 +894,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
 
     return {
       ...target,
+      legendFormat: this.templateSrv.replace(target.legendFormat, variables),
       expr: this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr),
     };
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
During Prometheus backend migration I have forgotten to interpolate `legendFormat` which we were doing before the migration. This PR fixes it. 

To test the PR, you can import [this dashboard from play](https://play.grafana.org/d/000000063/prometheus-templating?orgId=1&editPanel=6)and change legend to `$jobs`. The legend in graph should be interpolated.  
![image](https://user-images.githubusercontent.com/30407135/137924583-87cc4199-93bf-4939-aeb1-c0245559be1f.png)

