### PR TITLE
WIP: grafana-ui: export monaco-theme helper function

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -10,7 +10,7 @@ import { Themeable2 } from '../../types';
 
 import { CodeEditorProps, Monaco, MonacoEditor as MonacoEditorType, MonacoOptions } from './types';
 import { registerSuggestions } from './suggestions';
-import defineThemes from './theme';
+import { ensureGrafanaMonacoThemes } from './theme';
 
 type Props = CodeEditorProps & Themeable2;
 

--- a/packages/grafana-ui/src/components/Monaco/theme.ts
+++ b/packages/grafana-ui/src/components/Monaco/theme.ts
@@ -1,12 +1,22 @@
 import { GrafanaTheme2 } from '@grafana/data';
 import { Monaco } from './types';
 
-export default function defineThemes(monaco: Monaco, theme: GrafanaTheme2) {
+/**
+ * @internal
+ * Experimental export
+ **/
+export function ensureGrafanaMonacoThemes(monaco: Monaco, theme: GrafanaTheme2) {
   // color tokens are defined here https://github.com/microsoft/vscode/blob/main/src/vs/platform/theme/common/colorRegistry.ts#L174
   const colors = {
     'editor.background': theme.components.input.background,
     'minimap.background': theme.colors.background.secondary,
   };
+
+  // we create the themes if they do not exist, or update the themes
+  // if they already exist.
+  // NOTE: we should optimize this code to only run once,
+  // or to only run when the theme-colors change. we should not run this
+  // too often, for example, we should not run this on every render.
 
   monaco.editor.defineTheme('grafana-dark', {
     base: 'vs-dark',

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -45,6 +45,7 @@ export { QueryField } from './QueryField/QueryField';
 export { CodeEditor } from './Monaco/CodeEditor';
 
 export { ReactMonacoEditorLazy as ReactMonacoEditor } from './Monaco/ReactMonacoEditorLazy';
+export { ensureGrafanaMonacoThemes } from './Monaco/theme';
 
 export {
   Monaco,

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-import { useTheme2, ReactMonacoEditor, Monaco, monacoTypes } from '@grafana/ui';
+import { useTheme2, ReactMonacoEditor, ensureGrafanaMonacoThemes, Monaco, monacoTypes } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useLatest } from 'react-use';
@@ -51,23 +51,6 @@ function ensurePromQL(monaco: Monaco) {
   }
 }
 
-const THEME_NAME = 'grafana-prometheus-query-field';
-
-let MONACO_THEME_SETUP_STARTED = false;
-function ensureMonacoTheme(monaco: Monaco, theme: GrafanaTheme2) {
-  if (MONACO_THEME_SETUP_STARTED === false) {
-    MONACO_THEME_SETUP_STARTED = true;
-    monaco.editor.defineTheme(THEME_NAME, {
-      base: theme.isDark ? 'vs-dark' : 'vs',
-      inherit: true,
-      colors: {
-        'editor.background': theme.components.input.background,
-      },
-      rules: [],
-    });
-  }
-}
-
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     container: css`
@@ -106,11 +89,11 @@ const MonacoQueryField = (props: Props) => {
       <ReactMonacoEditor
         options={options}
         language="promql"
-        theme={THEME_NAME}
+        theme={theme.isDark ? 'grafana-dark' : 'grafana-light'}
         value={initialValue}
         beforeMount={(monaco) => {
           ensurePromQL(monaco);
-          ensureMonacoTheme(monaco, theme);
+          ensureGrafanaMonacoThemes(monaco, theme);
         }}
         onMount={(editor, monaco) => {
           // we setup on-blur


### PR DESCRIPTION
(NOTE: this is approach 1. approach 2 is https://github.com/grafana/grafana/pull/40643)

setting up a theme in Monaco has certain complications, for example, every monaco editor must use the same theme. so, while you can assign different themes to different monaco editors, it is not supported (see https://github.com/microsoft/monaco-editor/issues/338#issuecomment-274837186).

so it makes sense to somehow "centralize" the theme-handling code.

this pull-request is an attempt to do so.
the problem is, if we want to centralize it, it has to live in `@grafana/ui`, so i added a new marked_as_internal export, `ensureGrafanaMonacoThemes`. when called, it makes sure the monaco-theme is set up. it is probably safe to call this multiple times (we are doing that in `<CodeEditor/>` after all), but we probably should not call this more often than needed.

i am not 100% happy with this approach, because the user still has to do multiple things:
- use `useTheme`
- import the `ensureGrafanaMonacoThemes` function and call it at a good time
- based on `theme.isDark` choose `grafana-dark` or `grafana-light`

but still, it is better than the current situation.

there is an alternative approach:
- we take our extremely thing `@monaco-editor/react` wrapper, and modify it so that:
  - it calls `useTheme` and `ensureGrafanaMonacoThemes` itself
  - it sets the `theme` attribute on` @monaco-editor/react` itself
  - it's Prop-type will differ from `@monaco-editor/react` by not having `theme` as a prop (we will not allow `theme` as a prop there)

but i'm not a fan of that approach because we are then again starting to modify the offered monaco-editor and not providing the "original" experience. 

i prefer the offer-helper-function approach more.

NOTE: i don't like the name `ensureGrafanaMonacoThemes`, if you have a better idea please tell me 😄 