### PR TITLE
Explore: simplify URL generation logic

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -236,11 +236,8 @@ export class KeybindingSrv {
     if (contextSrv.hasAccessToExplore()) {
       this.bindWithPanelId('x', async (panelId) => {
         const panel = dashboard.getPanelById(panelId)!;
-        const datasource = await getDatasourceSrv().get(panel.datasource);
         const url = await getExploreUrl({
           panel,
-          panelTargets: panel.targets,
-          panelDatasource: datasource,
           datasourceSrv: getDatasourceSrv(),
           timeSrv: getTimeSrv(),
         });

--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -194,16 +194,12 @@ describe('getExploreUrl', () => {
   const args = ({
     panel: {
       getSavedId: () => 1,
-    },
-    panelTargets: [{ refId: 'A', expr: 'query1', legendFormat: 'legendFormat1' }],
-    panelDatasource: {
-      name: 'testDataSource',
-      meta: {
-        id: '1',
-      },
+      targets: [{ refId: 'A', expr: 'query1', legendFormat: 'legendFormat1' }],
     },
     datasourceSrv: {
-      get: jest.fn(),
+      get() {
+        return {};
+      },
       getDataSourceById: jest.fn(),
     },
     timeSrv: {

--- a/public/app/features/explore/state/main.test.ts
+++ b/public/app/features/explore/state/main.test.ts
@@ -27,7 +27,6 @@ const getNavigateToExploreContext = async (openInNewWindow?: (url: string) => vo
   return {
     url,
     panel,
-    datasource,
     get,
     getDataSourceSrv,
     getTimeSrv,
@@ -51,13 +50,6 @@ describe('navigateToExplore', () => {
         expect(getDataSourceSrv).toHaveBeenCalledTimes(1);
       });
 
-      it('then getDataSourceSrv.get should have been called with correct arguments', async () => {
-        const { get, panel } = await getNavigateToExploreContext(openInNewWindow);
-
-        expect(get).toHaveBeenCalledTimes(1);
-        expect(get).toHaveBeenCalledWith(panel.datasource);
-      });
-
       it('then getTimeSrv should have been called once', async () => {
         const { getTimeSrv } = await getNavigateToExploreContext(openInNewWindow);
 
@@ -65,15 +57,13 @@ describe('navigateToExplore', () => {
       });
 
       it('then getExploreUrl should have been called with correct arguments', async () => {
-        const { getExploreUrl, panel, datasource, getDataSourceSrv, getTimeSrv } = await getNavigateToExploreContext(
+        const { getExploreUrl, panel, getDataSourceSrv, getTimeSrv } = await getNavigateToExploreContext(
           openInNewWindow
         );
 
         expect(getExploreUrl).toHaveBeenCalledTimes(1);
         expect(getExploreUrl).toHaveBeenCalledWith({
           panel,
-          panelTargets: panel.targets,
-          panelDatasource: datasource,
           datasourceSrv: getDataSourceSrv(),
           timeSrv: getTimeSrv(),
         });
@@ -94,13 +84,6 @@ describe('navigateToExplore', () => {
         expect(getDataSourceSrv).toHaveBeenCalledTimes(1);
       });
 
-      it('then getDataSourceSrv.get should have been called with correct arguments', async () => {
-        const { get, panel } = await getNavigateToExploreContext(openInNewWindow);
-
-        expect(get).toHaveBeenCalledTimes(1);
-        expect(get).toHaveBeenCalledWith(panel.datasource);
-      });
-
       it('then getTimeSrv should have been called once', async () => {
         const { getTimeSrv } = await getNavigateToExploreContext(openInNewWindow);
 
@@ -108,15 +91,13 @@ describe('navigateToExplore', () => {
       });
 
       it('then getExploreUrl should have been called with correct arguments', async () => {
-        const { getExploreUrl, panel, datasource, getDataSourceSrv, getTimeSrv } = await getNavigateToExploreContext(
+        const { getExploreUrl, panel, getDataSourceSrv, getTimeSrv } = await getNavigateToExploreContext(
           openInNewWindow
         );
 
         expect(getExploreUrl).toHaveBeenCalledTimes(1);
         expect(getExploreUrl).toHaveBeenCalledWith({
           panel,
-          panelTargets: panel.targets,
-          panelDatasource: datasource,
           datasourceSrv: getDataSourceSrv(),
           timeSrv: getTimeSrv(),
         });

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -145,11 +145,8 @@ export const navigateToExplore = (
   return async (dispatch) => {
     const { getDataSourceSrv, getTimeSrv, getExploreUrl, openInNewWindow } = dependencies;
     const datasourceSrv = getDataSourceSrv();
-    const datasource = await datasourceSrv.get(panel.datasource);
     const path = await getExploreUrl({
       panel,
-      panelTargets: panel.targets,
-      panelDatasource: datasource,
       datasourceSrv,
       timeSrv: getTimeSrv(),
     });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
`getExploreUrl` is getting passed 2 arguments that chan be easily calculated from other args:
- `panelDatasource`
  - we already pass `panel` and `datasourceSrv`.  `panelDatasource` can be `datasourceSrv.get(panel.datasource)`
  - **NOTE**: once explore will start supporting mixed datasource, we can remove the dependency from `datasourceSrv` and directly pass the datasource in. this will allow the function to not be async anymore.
- `panelTargets` is simply `panel.targets`

