### PR TITLE
grafana-ui: simplify and centralize monaco-theme-handling

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -10,7 +10,6 @@ import { Themeable2 } from '../../types';
 
 import { CodeEditorProps, Monaco, MonacoEditor as MonacoEditorType, MonacoOptions } from './types';
 import { registerSuggestions } from './suggestions';
-import defineThemes from './theme';
 
 type Props = CodeEditorProps & Themeable2;
 
@@ -85,8 +84,7 @@ class UnthemedCodeEditor extends React.PureComponent<Props> {
 
   handleBeforeMount = (monaco: Monaco) => {
     this.monaco = monaco;
-    const { language, theme, getSuggestions, onBeforeEditorMount } = this.props;
-    defineThemes(monaco, theme);
+    const { language, getSuggestions, onBeforeEditorMount } = this.props;
 
     if (getSuggestions) {
       this.completionCancel = registerSuggestions(monaco, language, getSuggestions);
@@ -148,7 +146,6 @@ class UnthemedCodeEditor extends React.PureComponent<Props> {
           width={width}
           height={height}
           language={language}
-          theme={theme.isDark ? 'grafana-dark' : 'grafana-light'}
           value={value}
           options={{
             ...options,

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import MonacoEditor, { loader as monacoEditorLoader, EditorProps as MonacoEditorProps } from '@monaco-editor/react';
+import MonacoEditor, { loader as monacoEditorLoader } from '@monaco-editor/react';
+import defineThemes from './theme';
+import { useTheme2 } from '../../themes';
+import { Monaco } from './types';
+import type { Props } from './reactMonacoEditorProps';
 
 let initalized = false;
 function initMonaco() {
@@ -15,7 +19,18 @@ function initMonaco() {
   initalized = true;
 }
 
-export const ReactMonacoEditor = (props: MonacoEditorProps) => {
+export const ReactMonacoEditor = (props: Props) => {
+  const theme = useTheme2();
   initMonaco();
-  return <MonacoEditor {...props} />;
+  const { beforeMount, ...rest } = props;
+
+  const handleBeforeMount = (monaco: Monaco) => {
+    defineThemes(monaco, theme);
+
+    // call user-speficied `beforeMount` if it exists
+    beforeMount?.(monaco);
+  };
+  const monacoTheme = theme.isDark ? 'grafana-dark' : 'grafana-light';
+
+  return <MonacoEditor theme={monacoTheme} beforeMount={handleBeforeMount} {...rest} />;
 };

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
@@ -35,7 +35,7 @@ export const ReactMonacoEditor = (props: ReactMonacoEditorProps) => {
     if (monaco !== null) {
       defineThemes(monaco, theme);
     }
-  }, [monaco]);
+  }, [monaco, theme]);
 
   initMonaco();
 

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import MonacoEditor, { loader as monacoEditorLoader, useMonaco } from '@monaco-editor/react';
 import defineThemes from './theme';
 import { useTheme2 } from '../../themes';
-import type { Monaco, ReactMonacoEditorProps } from './types';
+import type { ReactMonacoEditorProps } from './types';
 
 let initalized = false;
 function initMonaco() {

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditor.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import MonacoEditor, { loader as monacoEditorLoader } from '@monaco-editor/react';
 import defineThemes from './theme';
 import { useTheme2 } from '../../themes';
-import { Monaco } from './types';
-import type { Props } from './reactMonacoEditorProps';
+import type { Monaco, ReactMonacoEditorProps } from './types';
 
 let initalized = false;
 function initMonaco() {
@@ -19,7 +18,7 @@ function initMonaco() {
   initalized = true;
 }
 
-export const ReactMonacoEditor = (props: Props) => {
+export const ReactMonacoEditor = (props: ReactMonacoEditorProps) => {
   const theme = useTheme2();
   initMonaco();
   const { beforeMount, ...rest } = props;

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { useAsyncDependency } from '../../utils/useAsyncDependency';
 import { ErrorWithStack, LoadingPlaceholder } from '..';
 // we only use import type so it will not be included in the bundle
-import type { EditorProps } from '@monaco-editor/react';
+import type { Props } from './reactMonacoEditorProps';
 
 /**
  * @internal
  * Experimental export
  **/
-export const ReactMonacoEditorLazy = (props: EditorProps) => {
+export const ReactMonacoEditorLazy = (props: Props) => {
   const { loading, error, dependency } = useAsyncDependency(
     import(/* webpackChunkName: "react-monaco-editor" */ './ReactMonacoEditor')
   );

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { useAsyncDependency } from '../../utils/useAsyncDependency';
 import { ErrorWithStack, LoadingPlaceholder } from '..';
 // we only use import type so it will not be included in the bundle
-import type { Props } from './reactMonacoEditorProps';
+import type { ReactMonacoEditorProps } from './types';
 
 /**
  * @internal
  * Experimental export
  **/
-export const ReactMonacoEditorLazy = (props: Props) => {
+export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   const { loading, error, dependency } = useAsyncDependency(
     import(/* webpackChunkName: "react-monaco-editor" */ './ReactMonacoEditor')
   );

--- a/packages/grafana-ui/src/components/Monaco/reactMonacoEditorProps.ts
+++ b/packages/grafana-ui/src/components/Monaco/reactMonacoEditorProps.ts
@@ -1,0 +1,9 @@
+import type { EditorProps } from '@monaco-editor/react';
+
+// we do not allow customizing the theme.
+// (theme is complicated in Monaco, right now there is
+// a limitation where all monaco editors must have
+// the same theme, see
+// https://github.com/microsoft/monaco-editor/issues/338#issuecomment-274837186
+// )
+export type Props = Omit<EditorProps, 'theme'>;

--- a/packages/grafana-ui/src/components/Monaco/reactMonacoEditorProps.ts
+++ b/packages/grafana-ui/src/components/Monaco/reactMonacoEditorProps.ts
@@ -1,9 +1,0 @@
-import type { EditorProps } from '@monaco-editor/react';
-
-// we do not allow customizing the theme.
-// (theme is complicated in Monaco, right now there is
-// a limitation where all monaco editors must have
-// the same theme, see
-// https://github.com/microsoft/monaco-editor/issues/338#issuecomment-274837186
-// )
-export type Props = Omit<EditorProps, 'theme'>;

--- a/packages/grafana-ui/src/components/Monaco/theme.ts
+++ b/packages/grafana-ui/src/components/Monaco/theme.ts
@@ -1,12 +1,22 @@
 import { GrafanaTheme2 } from '@grafana/data';
-import { Monaco } from './types';
+import { Monaco, monacoTypes } from './types';
 
-export default function defineThemes(monaco: Monaco, theme: GrafanaTheme2) {
+function getColors(theme?: GrafanaTheme2): monacoTypes.editor.IColors {
+  if (theme === undefined) {
+    return {};
+  } else {
+    return {
+      'editor.background': theme.components.input.background,
+      'minimap.background': theme.colors.background.secondary,
+    };
+  }
+}
+
+// we support calling this without a theme, it will make sure the themes
+// are registered in monaco, even if the colors are not perfect.
+export default function defineThemes(monaco: Monaco, theme?: GrafanaTheme2) {
   // color tokens are defined here https://github.com/microsoft/vscode/blob/main/src/vs/platform/theme/common/colorRegistry.ts#L174
-  const colors = {
-    'editor.background': theme.components.input.background,
-    'minimap.background': theme.colors.background.secondary,
-  };
+  const colors = getColors(theme);
 
   monaco.editor.defineTheme('grafana-dark', {
     base: 'vs-dark',

--- a/packages/grafana-ui/src/components/Monaco/types.ts
+++ b/packages/grafana-ui/src/components/Monaco/types.ts
@@ -1,5 +1,14 @@
 // We use `import type` to guarantee it'll be erased from the JS and it doesnt accidently bundle monaco
 import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
+import type { EditorProps } from '@monaco-editor/react';
+
+// we do not allow customizing the theme.
+// (theme is complicated in Monaco, right now there is
+// a limitation where all monaco editors must have
+// the same theme, see
+// https://github.com/microsoft/monaco-editor/issues/338#issuecomment-274837186
+// )
+export type ReactMonacoEditorProps = Omit<EditorProps, 'theme'>;
 
 export type CodeEditorChangeHandler = (value: string) => void;
 export type CodeEditorSuggestionProvider = () => CodeEditorSuggestionItem[];

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -51,23 +51,6 @@ function ensurePromQL(monaco: Monaco) {
   }
 }
 
-const THEME_NAME = 'grafana-prometheus-query-field';
-
-let MONACO_THEME_SETUP_STARTED = false;
-function ensureMonacoTheme(monaco: Monaco, theme: GrafanaTheme2) {
-  if (MONACO_THEME_SETUP_STARTED === false) {
-    MONACO_THEME_SETUP_STARTED = true;
-    monaco.editor.defineTheme(THEME_NAME, {
-      base: theme.isDark ? 'vs-dark' : 'vs',
-      inherit: true,
-      colors: {
-        'editor.background': theme.components.input.background,
-      },
-      rules: [],
-    });
-  }
-}
-
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     container: css`
@@ -106,11 +89,9 @@ const MonacoQueryField = (props: Props) => {
       <ReactMonacoEditor
         options={options}
         language="promql"
-        theme={THEME_NAME}
         value={initialValue}
         beforeMount={(monaco) => {
           ensurePromQL(monaco);
-          ensureMonacoTheme(monaco, theme);
         }}
         onMount={(editor, monaco) => {
           // we setup on-blur


### PR DESCRIPTION
setting up a theme in Monaco has certain complications, for example, every monaco editor must use the same theme. so, while you can assign different themes to different monaco editors, it is not supported (see microsoft/monaco-editor#338 (comment)).

so it makes sense to somehow "centralize" the theme-handling code.

this pull-request is an attempt to do so.

from grafana-ui we export a very thin wrapper around `@monaco-editor/react` , we only do lazy-loading as extra, and we provide the exact same Props as `@monaco-editor/react`.

but, as i wrote above, themeing is complicated, so in this PR:
- we remove the `theme` prop from the Props, so you cannot customize it
- we automatically setup the monaco-theme correctly (light vs dark etc.)

we loose a little simplicity by not being an exact API copy of `@monaco-editor/react`, but we assume that everyone will need to handle the themeing and anyway having multiple differently themed monaco-editors is not possible, so this approach is perhaps the right way to go.