### PR TITLE
Chore: Add `/packaging/**/*.tar.gz.sha256` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ debug.test
 /packaging/**/*.rpm
 /packaging/**/*.deb
 /packaging/**/*.tar.gz
+/packaging/**/*.tar.gz.sha256
 
 # Ignore OSX indexing
 .DS_Store


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `/packaging/**/*.tar.gz.sha256` to `.gitignore` file.