### PR TITLE
Prometheus: Remove limits on metrics, labels, and values in Metrics Browser

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PrometheusMetricsBrowser.tsx
@@ -17,8 +17,6 @@ import { FixedSizeList } from 'react-window';
 import { GrafanaTheme } from '@grafana/data';
 
 // Hard limit on labels to render
-const MAX_LABEL_COUNT = 10000;
-const MAX_VALUE_COUNT = 50000;
 const EMPTY_SELECTOR = '{}';
 const METRIC_LABEL = '__name__';
 const LIST_ITEM_SIZE = 25;
@@ -321,12 +319,6 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
       const selectedLabels: string[] = lastUsedLabels;
       languageProvider.start().then(() => {
         let rawLabels: string[] = languageProvider.getLabelKeys();
-        // TODO too-many-metrics
-        if (rawLabels.length > MAX_LABEL_COUNT) {
-          const error = `Too many labels found (showing only ${MAX_LABEL_COUNT} of ${rawLabels.length})`;
-          rawLabels = rawLabels.slice(0, MAX_LABEL_COUNT);
-          this.setState({ error });
-        }
         // Get metrics
         this.fetchValues(METRIC_LABEL, EMPTY_SELECTOR);
         // Auto-select previously selected labels
@@ -393,11 +385,6 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
       if (selector !== buildSelector(this.state.labels)) {
         this.updateLabelState(name, { loading: false });
         return;
-      }
-      if (rawValues.length > MAX_VALUE_COUNT) {
-        const error = `Too many values for ${name} (showing only ${MAX_VALUE_COUNT} of ${rawValues.length})`;
-        rawValues = rawValues.slice(0, MAX_VALUE_COUNT);
-        this.setState({ error });
       }
       const values: FacettableValue[] = [];
       const { metricsMetadata } = languageProvider;


### PR DESCRIPTION
**What this PR does / why we need it**:

The Prometheus Metrics Browser limits metrics to the first 50k. If a deployment has greater than 50k metrics, the additional metrics cannot be discovered or selected from the Metrics Browser.

This PR removes these hardcoded limits. The Metrics Browser will now display all metrics, labels, and values returned from the Prometheus api.

**Which issue(s) this PR fixes**:

Fixes #40479

**Special notes for your reviewer**:

I see the main concern here would be a performance regression, but I think it is low risk. For references our cortex deployment is at ~165k metrics and I don't see any noticeable performance hit.

- The prometheus api doesn't support pagination or querying based on a search string - it just dumps the complete list of all values (see [docs for querying labels](https://prometheus.io/docs/prometheus/latest/querying/api/#getting-label-names), [docs for querying values](https://prometheus.io/docs/prometheus/latest/querying/api/#querying-label-values)). So a deployment with really high cardinality is going to pay the cost of downloading, json parsing, allocating an array, regardless of these limits. In other words, if they have so many metrics / labels / values that the browser will choke, then it is already doing that today.
- The metrics and values are rendered into a react-window FixedSizeList, so they are virtualized in the DOM. Only labels are not virtualized.