### PR TITLE
Geomap: avoid exceptions when missing data and values (heatmap and zoom settings)

### DIFF
--- a/public/app/plugins/panel/geomap/editor/MapViewEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/MapViewEditor.tsx
@@ -49,9 +49,9 @@ export const MapViewEditor: FC<StandardEditorProps<MapViewConfig, any, GeomapPan
         onChange({
           ...value,
           id: v.id,
-          lat: v.lat ?? value.lat,
-          lon: v.lon ?? value.lon,
-          zoom: v.zoom ?? value.zoom,
+          lat: v.lat ?? value?.lat,
+          lon: v.lon ?? value?.lon,
+          zoom: v.zoom ?? value?.zoom,
         });
       }
     },
@@ -99,7 +99,7 @@ export const MapViewEditor: FC<StandardEditorProps<MapViewConfig, any, GeomapPan
       <InlineFieldRow>
         <InlineField label="Zoom" labelWidth={labelWidth} grow={true}>
           <NumberInput
-            value={value.zoom ?? 1}
+            value={value?.zoom ?? 1}
             min={1}
             max={18}
             step={0.01}

--- a/public/app/plugins/panel/geomap/layers/data/heatMap.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/heatMap.tsx
@@ -74,6 +74,9 @@ export const heatmapLayer: MapLayerRegistryItem<HeatmapConfig> = {
           vectorLayer.getSource().removeFeature(feature);
         });
 
+        if (!frame) {
+          return;
+        }
         // Get data points (latitude and longitude coordinates)
         const info = dataFrameToPoints(frame, matchers);
         if (info.warning) {


### PR DESCRIPTION
**What this PR does / why we need it**:
- checks if there is no frame in heatmap
- check if there is no value for setting zoom in the mapview editor
**Which issue(s) this PR fixes**:

Fixes #37911

**Special notes for your reviewer**:

