### PR TITLE
Prometheus: Send errors from backend in response

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -175,7 +175,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		}
 
 		if query.ExemplarQuery {
-			exemplarResponse, err := client.QueryExemplars(ctx, "}", timeRange.Start, timeRange.End)
+			exemplarResponse, err := client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
 			if err != nil {
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -159,6 +159,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		if query.RangeQuery {
 			rangeResponse, _, err := client.QueryRange(ctx, query.Expr, timeRange)
 			if err != nil {
+				plog.Error("Range query", query.Expr, "failed with", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue
 			}
@@ -168,6 +169,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		if query.InstantQuery {
 			instantResponse, _, err := client.Query(ctx, query.Expr, query.End)
 			if err != nil {
+				plog.Error("Instant query", query.Expr, "failed with", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue
 			}
@@ -177,6 +179,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		if query.ExemplarQuery {
 			exemplarResponse, err := client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
 			if err != nil {
+				plog.Error("Exemplar query", query.Expr, "failed with", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue
 			}

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -159,7 +159,8 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		if query.RangeQuery {
 			rangeResponse, _, err := client.QueryRange(ctx, query.Expr, timeRange)
 			if err != nil {
-				return &result, fmt.Errorf("query: %s failed with: %v", query.Expr, err)
+				result.Responses[query.RefId] = backend.DataResponse{Error: err}
+				continue
 			}
 			response[RangeQueryType] = rangeResponse
 		}
@@ -167,16 +168,17 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		if query.InstantQuery {
 			instantResponse, _, err := client.Query(ctx, query.Expr, query.End)
 			if err != nil {
-				return &result, fmt.Errorf("query: %s failed with: %v", query.Expr, err)
+				result.Responses[query.RefId] = backend.DataResponse{Error: err}
+				continue
 			}
 			response[InstantQueryType] = instantResponse
 		}
-		// For now, we ignore exemplar errors and continue with processing of other results
+
 		if query.ExemplarQuery {
-			exemplarResponse, err := client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
+			exemplarResponse, err := client.QueryExemplars(ctx, "}", timeRange.Start, timeRange.End)
 			if err != nil {
-				exemplarResponse = nil
-				plog.Error("Exemplar query", query.Expr, "failed with", err)
+				result.Responses[query.RefId] = backend.DataResponse{Error: err}
+				continue
 			}
 			response[ExemplarQueryType] = exemplarResponse
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Since [Prometheus backend migration](https://github.com/issues), **a lot of people** were bringing to our attention the fact, that they don't see actual errors and just `Metric request error` with no information what is the error about. Before backend migration, we were always showing all information on error. 

There is an ongoing discussion about security & error propagation here: https://github.com/grafana/grafana/discussions/40444

For now, I think it makes no sense to introduce error propagation regression, as it will probably be a huge pain point for our users. In proxy mode, we were already doing it and therefore this is not a regression/introduction of something new. We are also doing this for azure data source in https://github.com/grafana/grafana/blob/main/pkg/tsdb/azuremonitor/azure-resource-graph-datasource.go#L110 and in flux https://github.com/grafana/grafana/blob/main/pkg/tsdb/influxdb/flux/executor.go#L28.


