### PR TITLE
Alerting: Update remaining occurrences of checking "ngalert" flag in frontend

### DIFF
--- a/public/app/features/alerting/state/ThresholdMapper.ts
+++ b/public/app/features/alerting/state/ThresholdMapper.ts
@@ -4,7 +4,7 @@ import { PanelModel } from 'app/features/dashboard/state';
 export const hiddenReducerTypes = ['percent_diff', 'percent_diff_abs'];
 export class ThresholdMapper {
   static alertToGraphThresholds(panel: PanelModel) {
-    if (!panel.alert || config.featureToggles.ngalert) {
+    if (!panel.alert || config.unifiedAlertingEnabled) {
       return false; // no update when no alerts
     }
 

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -42,7 +42,7 @@ export const DeleteDashboardModal: React.FC<DeleteDashboardModalProps> = ({ hide
 
 const getModalBody = (panels: PanelModel[], title: string) => {
   const totalAlerts = sumBy(panels, (panel) => (panel.alert ? 1 : 0));
-  return totalAlerts > 0 && !config.featureToggles.ngalert ? (
+  return totalAlerts > 0 && !config.unifiedAlertingEnabled ? (
     <>
       <p>Do you want to delete this dashboard?</p>
       <p>

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -26,7 +26,7 @@ export const removePanel = (dashboard: DashboardModel, panel: PanelModel, ask: b
   // confirm deletion
   if (ask !== false) {
     const text2 =
-      panel.alert && !config.featureToggles.ngalert
+      panel.alert && !config.unifiedAlertingEnabled
         ? 'Panel includes an alert rule. removing the panel will also remove the alert rule'
         : undefined;
     const confirmText = panel.alert ? 'YES' : undefined;

--- a/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
@@ -31,7 +31,7 @@ class DashboardQueryRunnerImpl implements DashboardQueryRunner {
     private readonly dashboard: DashboardModel,
     private readonly timeSrv: TimeSrv = getTimeSrv(),
     private readonly workers: DashboardQueryRunnerWorker[] = [
-      config.featureToggles.ngalert ? new UnifiedAlertStatesWorker() : new AlertStatesWorker(),
+      config.unifiedAlertingEnabled ? new UnifiedAlertStatesWorker() : new AlertStatesWorker(),
       new SnapshotWorker(),
       new AnnotationsWorker(),
     ]

--- a/public/app/plugins/panel/graph/thresholds_form.ts
+++ b/public/app/plugins/panel/graph/thresholds_form.ts
@@ -12,7 +12,7 @@ export class ThresholdFormCtrl {
   $onInit() {
     this.panel = this.panelCtrl.panel;
 
-    if (this.panel.alert && !config.featureToggles.ngalert) {
+    if (this.panel.alert && !config.unifiedAlertingEnabled) {
       this.disabled = true;
     }
 


### PR DESCRIPTION
There's still some leftover checks of `ngalert` flag in frontend, but this flag is deprecated. Updates to check `config.unifiedAlertingEnabled` instead.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

