### PR TITLE
explore: rich-history: add test for old-mode conversion code

### DIFF
--- a/public/app/core/utils/richHistory.test.ts
+++ b/public/app/core/utils/richHistory.test.ts
@@ -1,5 +1,6 @@
 import {
   addToRichHistory,
+  getRichHistory,
   updateStarredInRichHistory,
   updateCommentInRichHistory,
   mapNumbertoTimeInSlider,
@@ -272,6 +273,37 @@ describe('richHistory', () => {
     it('should correctly create heading for queries when sort order is datasourceAZ ', () => {
       const heading = createQueryHeading(mock.storedHistory[0], SortOrder.DatasourceAZ);
       expect(heading).toEqual(mock.storedHistory[0].datasourceName);
+    });
+  });
+
+  describe('getRichHistory', () => {
+    afterEach(() => {
+      deleteAllFromRichHistory();
+      expect(store.exists(key)).toBeFalsy();
+    });
+    it('should load from localStorage data in old format', () => {
+      const oldHistoryItem = { ...mock.storedHistory[0], queries: ['test query 1', 'test query 2', 'test query 3'] };
+      store.setObject(key, [oldHistoryItem]);
+      const expectedHistoryItem = {
+        ...mock.storedHistory[0],
+        queries: [
+          {
+            expr: 'test query 1',
+            refId: 'A',
+          },
+          {
+            expr: 'test query 2',
+            refId: 'B',
+          },
+          {
+            expr: 'test query 3',
+            refId: 'C',
+          },
+        ],
+      };
+
+      const result = getRichHistory();
+      expect(result).toStrictEqual([expectedHistoryItem]);
     });
   });
 });

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -394,7 +394,6 @@ export function filterAndSortQueries(
   return sortQueries(filteredQueriesToBeSorted, sortOrder);
 }
 
-/* These functions are created to migrate string queries (from 6.7 release) to DataQueries. They can be removed after 7.1 release. */
 function migrateRichHistory(richHistory: RichHistoryQuery[]) {
   const transformedRichHistory = richHistory.map((query) => {
     const transformedQueries: DataQuery[] = query.queries.map((q, index) => createDataQuery(query, q, index));


### PR DESCRIPTION
in explore, in rich-history, we have code that supports loading data from localStorage that is stored in an old format. this PR adds a unit-test to cover that case.

also, it removes a comment saying we should remove the conversion code, because we want to keep the conversion code.