### PR TITLE
Tempo / Trace Viewer: Support deep linking to spans

### DIFF
--- a/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
@@ -261,7 +261,7 @@ export default function TracePageHeader(props: TracePageHeaderEmbedProps) {
       <small className={cx(styles.TracePageHeaderTraceId, uTxMuted)}>{trace.traceID}</small>{' '}
       {focusedSpanId == null ? null : (
         <Button fill="text" size="sm" onClick={() => setFocusedSpanId()}>
-          View full trace
+          View complete trace
         </Button>
       )}
     </h1>

--- a/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
@@ -20,7 +20,15 @@ import cx from 'classnames';
 
 import SpanGraph from './SpanGraph';
 import TracePageSearchBar from './TracePageSearchBar';
-import { autoColor, Theme, TUpdateViewRangeTimeFunction, useTheme, ViewRange, ViewRangeTimeUpdate } from '..';
+import {
+  autoColor,
+  Theme,
+  TUpdateViewRangeTimeFunction,
+  useFocusedSpanContext,
+  useTheme,
+  ViewRange,
+  ViewRangeTimeUpdate,
+} from '..';
 import LabeledList from '../common/LabeledList';
 import TraceName from '../common/TraceName';
 import { getTraceName } from '../model/trace-viewer';
@@ -33,6 +41,7 @@ import ExternalLinks from '../common/ExternalLinks';
 import { createStyle } from '../Theme';
 import { uTxMuted } from '../uberUtilityStyles';
 import { dateTimeFormat, TimeZone } from '@grafana/data';
+import { Button } from '@grafana/ui';
 
 const getStyles = createStyle((theme: Theme) => {
   return {
@@ -224,6 +233,7 @@ export default function TracePageHeader(props: TracePageHeaderEmbedProps) {
     hideSearchButtons,
     timeZone,
   } = props;
+  const { focusedSpanId, setFocusedSpanId } = useFocusedSpanContext();
 
   const styles = getStyles(useTheme());
   const links = React.useMemo(() => {
@@ -248,7 +258,12 @@ export default function TracePageHeader(props: TracePageHeaderEmbedProps) {
   const title = (
     <h1 className={cx(styles.TracePageHeaderTitle, canCollapse && styles.TracePageHeaderTitleCollapsible)}>
       <TraceName traceName={getTraceName(trace.spans)} />{' '}
-      <small className={cx(styles.TracePageHeaderTraceId, uTxMuted)}>{trace.traceID}</small>
+      <small className={cx(styles.TracePageHeaderTraceId, uTxMuted)}>{trace.traceID}</small>{' '}
+      {focusedSpanId == null ? null : (
+        <Button fill="text" size="sm" onClick={() => setFocusedSpanId()}>
+          View full trace
+        </Button>
+      )}
     </h1>
   );
 

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/FocusedSpanContext.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/FocusedSpanContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+export interface FocusedSpanContextValue {
+  focusedSpanId?: string;
+  setFocusedSpanId: (val?: string) => void;
+}
+
+const FocusedSpanContext = createContext<FocusedSpanContextValue | null>(null);
+
+export const FocusedSpanContextProvider: React.FC<{ focusedSpanId?: string }> = ({
+  children,
+  focusedSpanId: initalValue,
+}) => {
+  const [focusedSpanId, setFocusedSpanId] = useState(initalValue);
+
+  const value = useMemo(() => ({ focusedSpanId, setFocusedSpanId }), [focusedSpanId, setFocusedSpanId]);
+
+  return <FocusedSpanContext.Provider value={value}>{children}</FocusedSpanContext.Provider>;
+};
+
+export const useFocusedSpanContext = () => {
+  const ctx = useContext(FocusedSpanContext);
+  if (ctx == null) {
+    throw new Error('Must provide FocusedSpanContextProvider');
+  }
+  return ctx;
+};
+
+export const withFocusedSpanContext = (
+  WrappedComponent: React.ComponentType<{ focusedSpanContext: FocusedSpanContextValue }>
+) => {
+  const HOC: React.FC = (props) => {
+    const context = useFocusedSpanContext();
+
+    return <WrappedComponent focusedSpanContext={context} {...props} />;
+  };
+
+  return HOC;
+};

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/index.tsx
@@ -30,8 +30,9 @@ import AccordianReferences from './AccordianReferences';
 import { autoColor, createStyle, Theme, useTheme } from '../../Theme';
 import { UIDivider } from '../../uiElementsContext';
 import { ubFlex, ubFlexAuto, ubItemsCenter, ubM0, ubMb1, ubMy1, ubTxRightAlign } from '../../uberUtilityStyles';
-import { DataLinkButton, TextArea } from '@grafana/ui';
+import { DataLinkButton, IconButton, TextArea } from '@grafana/ui';
 import { CreateSpanLink } from '../types';
+import { useFocusedSpanContext } from '../FocusedSpanContext';
 
 const getStyles = createStyle((theme: Theme) => {
   return {
@@ -175,11 +176,21 @@ export default function SpanDetail(props: SpanDetailProps) {
   const deepLinkCopyText = `${window.location.origin}${window.location.pathname}?uiFind=${spanID}`;
   const styles = getStyles(useTheme());
   const link = createSpanLink?.(span);
+  const { setFocusedSpanId, focusedSpanId } = useFocusedSpanContext();
+  const isFocused = focusedSpanId === spanID;
 
   return (
     <div>
       <div className={cx(ubFlex, ubItemsCenter, ubMb1)}>
-        <h2 className={cx(ubFlexAuto, ubM0)}>{operationName}</h2>
+        <h2 className={cx(ubFlexAuto, ubM0)}>
+          {operationName}{' '}
+          <IconButton
+            style={{ marginLeft: 4 }}
+            onClick={() => setFocusedSpanId(isFocused ? undefined : spanID)}
+            name={isFocused ? 'eye-slash' : 'eye'}
+            title={isFocused ? 'View entire trace' : 'Focus on this span'}
+          ></IconButton>
+        </h2>{' '}
         <LabeledList className={ubTxRightAlign} dividerClassName={styles.divider} items={overviewItems} />
       </div>
       {link ? (

--- a/packages/jaeger-ui-components/src/index.ts
+++ b/packages/jaeger-ui-components/src/index.ts
@@ -4,6 +4,7 @@ export { default as UIElementsContext } from './uiElementsContext';
 export * from './uiElementsContext';
 export * from './types';
 export * from './TraceTimelineViewer/types';
+export * from './TraceTimelineViewer/FocusedSpanContext';
 export { default as DetailState } from './TraceTimelineViewer/SpanDetail/DetailState';
 export { default as transformTraceData } from './model/transform-trace-data';
 export { default as filterSpans } from './utils/filter-spans';

--- a/packages/jaeger-ui-components/src/model/trace-viewer.ts
+++ b/packages/jaeger-ui-components/src/model/trace-viewer.ts
@@ -53,5 +53,5 @@ export const getTraceName = memoize(_getTraceNameImpl, (spans: TraceSpan[]) => {
   if (!spans.length) {
     return 0;
   }
-  return spans[0].traceID;
+  return spans[0].spanID;
 });

--- a/packages/jaeger-ui-components/src/model/transform-trace-data.tsx
+++ b/packages/jaeger-ui-components/src/model/transform-trace-data.tsx
@@ -72,7 +72,7 @@ export function orderTags(spanTags: TraceKeyValuePair[], topPrefixes?: string[])
  * NOTE: Mutates `data` - Transform the HTTP response data into the form the app
  * generally requires.
  */
-export default function transformTraceData(data: TraceResponse | undefined): Trace | null {
+export default function transformTraceData(data: TraceResponse | undefined, focusedSpanId?: string): Trace | null {
   if (!data?.traceID) {
     return null;
   }

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -29,6 +29,7 @@ import { ResponseErrorContainer } from './ResponseErrorContainer';
 import { TraceViewContainer } from './TraceView/TraceViewContainer';
 import { ExploreGraph } from './ExploreGraph';
 import { LogsVolumePanel } from './LogsVolumePanel';
+import { TempoQuery, TempoQueryType } from 'app/plugins/datasource/tempo/datasource';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
@@ -274,9 +275,19 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     const { queryResponse, splitOpen, exploreId } = this.props;
     const dataFrames = queryResponse.series.filter((series) => series.meta?.preferredVisualisationType === 'trace');
 
+    // TODO: hack
+    const { focusedSpanId } = queryResponse.request?.targets.find((t) => t.refId === dataFrames[0].refId) as TempoQuery;
+
     return (
       // If there is no data (like 404) we show a separate error so no need to show anything here
-      dataFrames.length && <TraceViewContainer exploreId={exploreId} dataFrames={dataFrames} splitOpenFn={splitOpen} />
+      dataFrames.length && (
+        <TraceViewContainer
+          exploreId={exploreId}
+          dataFrames={dataFrames}
+          splitOpenFn={splitOpen}
+          focusedSpanId={focusedSpanId}
+        />
+      )
     );
   }
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -29,7 +29,6 @@ import { ResponseErrorContainer } from './ResponseErrorContainer';
 import { TraceViewContainer } from './TraceView/TraceViewContainer';
 import { ExploreGraph } from './ExploreGraph';
 import { LogsVolumePanel } from './LogsVolumePanel';
-import { TempoQuery, TempoQueryType } from 'app/plugins/datasource/tempo/datasource';
 import { FocusedSpanContextProvider } from '@jaegertracing/jaeger-ui-components';
 
 const getStyles = (theme: GrafanaTheme2) => {

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -12,6 +12,7 @@ import {
   transformTraceData,
   TTraceTimeline,
   UIElementsContext,
+  useFocusedSpanContext,
 } from '@jaegertracing/jaeger-ui-components';
 import { TraceToLogsData } from 'app/core/components/TraceToLogsSettings';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -36,7 +37,6 @@ type Props = {
   dataFrames: DataFrame[];
   splitOpenFn: SplitOpen;
   exploreId: ExploreId;
-  focusedSpanId?: string;
 };
 
 export function TraceView(props: Props) {
@@ -63,10 +63,11 @@ export function TraceView(props: Props) {
    * State of the top minimap, slim means it is collapsed.
    */
   const [slim, setSlim] = useState(false);
+  const { focusedSpanId } = useFocusedSpanContext();
 
-  const traceProp = useMemo(() => transformDataFrames(props.dataFrames, props.focusedSpanId), [
+  const traceProp = useMemo(() => transformDataFrames(props.dataFrames, focusedSpanId), [
     props.dataFrames,
-    props.focusedSpanId,
+    focusedSpanId,
   ]);
   const { search, setSearch, spanFindMatches } = useSearch(traceProp?.spans);
   const dataSourceName = useSelector((state: StoreState) => state.explore[props.exploreId]?.datasourceInstance?.name);
@@ -191,7 +192,7 @@ function transformDataFrames(frames: DataFrame[], focusedSpanId?: string): Trace
   return transformTraceData(data, focusedSpanId);
 }
 
-function transformTraceDataFrame(frame: DataFrame, focusedSpanId?: string): TraceResponse {
+function transformTraceDataFrame(frame: DataFrame): TraceResponse {
   const view = new DataFrameView<TraceSpanRow>(frame);
   const processes: Record<string, TraceProcess> = {};
   for (let i = 0; i < view.length; i++) {

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -36,6 +36,7 @@ type Props = {
   dataFrames: DataFrame[];
   splitOpenFn: SplitOpen;
   exploreId: ExploreId;
+  focusedSpanId?: string;
 };
 
 export function TraceView(props: Props) {
@@ -63,7 +64,10 @@ export function TraceView(props: Props) {
    */
   const [slim, setSlim] = useState(false);
 
-  const traceProp = useMemo(() => transformDataFrames(props.dataFrames), [props.dataFrames]);
+  const traceProp = useMemo(() => transformDataFrames(props.dataFrames, props.focusedSpanId), [
+    props.dataFrames,
+    props.focusedSpanId,
+  ]);
   const { search, setSearch, spanFindMatches } = useSearch(traceProp?.spans);
   const dataSourceName = useSelector((state: StoreState) => state.explore[props.exploreId]?.datasourceInstance?.name);
   const traceToLogsOptions = (getDatasourceSrv().getInstanceSettings(dataSourceName)?.jsonData as TraceToLogsData)
@@ -173,7 +177,7 @@ export function TraceView(props: Props) {
   );
 }
 
-function transformDataFrames(frames: DataFrame[]): Trace | null {
+function transformDataFrames(frames: DataFrame[], focusedSpanId?: string): Trace | null {
   // At this point we only show single trace.
   const frame = frames[0];
   if (!frame) {
@@ -184,10 +188,10 @@ function transformDataFrames(frames: DataFrame[]): Trace | null {
       ? // For backward compatibility when we sent whole json response in a single field/value
         frame.fields[0].values.get(0)
       : transformTraceDataFrame(frame);
-  return transformTraceData(data);
+  return transformTraceData(data, focusedSpanId);
 }
 
-function transformTraceDataFrame(frame: DataFrame): TraceResponse {
+function transformTraceDataFrame(frame: DataFrame, focusedSpanId?: string): TraceResponse {
   const view = new DataFrameView<TraceSpanRow>(frame);
   const processes: Record<string, TraceProcess> = {};
   for (let i = 0; i < view.length; i++) {

--- a/public/app/features/explore/TraceView/TraceViewContainer.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.tsx
@@ -8,19 +8,13 @@ interface Props {
   dataFrames: DataFrame[];
   splitOpenFn: SplitOpen;
   exploreId: ExploreId;
-  focusedSpanId?: string;
 }
 export function TraceViewContainer(props: Props) {
-  const { dataFrames, splitOpenFn, exploreId, focusedSpanId } = props;
+  const { dataFrames, splitOpenFn, exploreId } = props;
 
   return (
     <Collapse label="Trace View" isOpen>
-      <TraceView
-        exploreId={exploreId}
-        dataFrames={dataFrames}
-        splitOpenFn={splitOpenFn}
-        focusedSpanId={focusedSpanId}
-      />
+      <TraceView exploreId={exploreId} dataFrames={dataFrames} splitOpenFn={splitOpenFn} />
     </Collapse>
   );
 }

--- a/public/app/features/explore/TraceView/TraceViewContainer.tsx
+++ b/public/app/features/explore/TraceView/TraceViewContainer.tsx
@@ -8,13 +8,19 @@ interface Props {
   dataFrames: DataFrame[];
   splitOpenFn: SplitOpen;
   exploreId: ExploreId;
+  focusedSpanId?: string;
 }
 export function TraceViewContainer(props: Props) {
-  const { dataFrames, splitOpenFn, exploreId } = props;
+  const { dataFrames, splitOpenFn, exploreId, focusedSpanId } = props;
 
   return (
     <Collapse label="Trace View" isOpen>
-      <TraceView exploreId={exploreId} dataFrames={dataFrames} splitOpenFn={splitOpenFn} />
+      <TraceView
+        exploreId={exploreId}
+        dataFrames={dataFrames}
+        splitOpenFn={splitOpenFn}
+        focusedSpanId={focusedSpanId}
+      />
     </Collapse>
   );
 }

--- a/public/app/plugins/datasource/tempo/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryField.tsx
@@ -183,25 +183,46 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
           </div>
         )}
         {query.queryType === 'traceId' && (
-          <InlineFieldRow>
-            <InlineField label="Trace ID" labelWidth={14} grow>
-              <QueryField
-                query={query.query}
-                onChange={(val) => {
-                  onChange({
-                    ...query,
-                    query: val,
-                    queryType: 'traceId',
-                    linkedQuery: undefined,
-                  });
-                }}
-                onBlur={this.props.onBlur}
-                onRunQuery={this.props.onRunQuery}
-                placeholder={'Enter a Trace ID (run with Shift+Enter)'}
-                portalOrigin="tempo"
-              />
-            </InlineField>
-          </InlineFieldRow>
+          <>
+            <InlineFieldRow>
+              <InlineField label="Trace ID" labelWidth={14} grow>
+                <QueryField
+                  query={query.query}
+                  onChange={(val) => {
+                    onChange({
+                      ...query,
+                      query: val,
+                      queryType: 'traceId',
+                      linkedQuery: undefined,
+                    });
+                  }}
+                  onBlur={this.props.onBlur}
+                  onRunQuery={this.props.onRunQuery}
+                  placeholder={'Enter a Trace ID (run with Shift+Enter)'}
+                  portalOrigin="tempo"
+                />
+              </InlineField>
+            </InlineFieldRow>
+            <InlineFieldRow>
+              <InlineField label="Span ID" labelWidth={14} grow>
+                <QueryField
+                  query={query.focusedSpanId}
+                  onChange={(val) => {
+                    onChange({
+                      ...query,
+                      focusedSpanId: val,
+                      queryType: 'traceId',
+                      linkedQuery: undefined,
+                    });
+                  }}
+                  onBlur={this.props.onBlur}
+                  onRunQuery={this.props.onRunQuery}
+                  placeholder={'Enter a Span ID'}
+                  portalOrigin="tempo"
+                />
+              </InlineField>
+            </InlineFieldRow>
+          </>
         )}
         {query.queryType === 'serviceMap' && <ServiceGraphSection graphDatasourceUid={graphDatasourceUid} />}
       </>

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -45,7 +45,7 @@ export interface TempoJsonData extends DataSourceJsonData {
 
 export type TempoQuery = {
   query: string;
-  focusedSpanId: string;
+  focusedSpanId?: string;
   // Query to find list of traces, e.g., via Loki
   linkedQuery?: LokiQuery;
   search: string;

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -45,6 +45,7 @@ export interface TempoJsonData extends DataSourceJsonData {
 
 export type TempoQuery = {
   query: string;
+  focusedSpanId: string;
   // Query to find list of traces, e.g., via Loki
   linkedQuery?: LokiQuery;
   search: string;


### PR DESCRIPTION
**What this PR does / why we need it**:

- Updates the Tempo datasource so that traceId queries can optionally include a `focusedSpanId` query param.
- Updates the Explore Trace Viewer & underlying components to support a "focused span". When viewing a trace with a focused span, parent & sibling spans are hidden. The trace viewer effectively displays the focused span as though it were the root span of its own trace.
- Updates the Explore Trace Viewer & underlying components with UI elements to focus on a span and to clear the focus (ie, view the entire trace).
- Creates a React Context `FocusedSpanContext` to connect the Tempo data source to the Explore Trace viewer, so that focusing/unfocusing a span in the Explore Trace Viewer updates the query (and url), and updating the query (and url) updates the focused span in the explorer.

Taken together, these changes allow for deep linking to spans from the Tempo datasource. Use cases are outlined in #40720.

https://user-images.githubusercontent.com/918178/138150030-cfa97eaa-4551-4100-a84e-117c14147cab.mp4

**Which issue(s) this PR fixes**:

Fixes #40720

**Special notes for your reviewer**:

This is a draft PR. I want guidance in a couple areas:

- UX. Right now I have pretty ugly UX just to get an e2e solution and show it's possible. I have some ideas for improvement, but wanted to open up discussion to the grafana team.
- Architecture. There are some challenges in connecting span focusing (essentially a frontend concern of the trace viewer) to the url (owned by datasource query builder and fully decoupled from the results view). I have a few ideas here that I can share in a follow up comment.