### PR TITLE
AccessControl: Resolve `attribute` based scopes to `id` based scopes

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -20,9 +20,13 @@ type AccessControl interface {
 	//IsDisabled returns if access control is enabled or not
 	IsDisabled() bool
 
-	// DeclareFixedRoles allow the caller to declare, to the service, fixed roles and their
+	// DeclareFixedRoles allows the caller to declare, to the service, fixed roles and their
 	// assignments to organization roles ("Viewer", "Editor", "Admin") or "Grafana Admin"
 	DeclareFixedRoles(...RoleRegistration) error
+
+	// RegisterAttributeScopeResolver allows the caller to register a scope resolver for a
+	// specific scope prefix (ex: datasources:name:)
+	RegisterAttributeScopeResolver(scopePrefix string, resolver AttributeScopeResolveFunc)
 }
 
 type PermissionsProvider interface {

--- a/pkg/services/accesscontrol/errors.go
+++ b/pkg/services/accesscontrol/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	ErrFixedRolePrefixMissing = errors.New("fixed role should be prefixed with '" + FixedRolePrefix + "'")
 	ErrInvalidBuiltinRole     = errors.New("built-in role is not valid")
+	ErrInvalidScope           = errors.New("invalid scope")
 )

--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -1,6 +1,7 @@
 package accesscontrol
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,7 +121,7 @@ func TestPermission_Inject(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			injected, err := test.evaluator.Inject(test.params)
+			injected, err := test.evaluator.MutateScopes(context.TODO(), ScopeInjector(test.params))
 			assert.NoError(t, err)
 			ok, err := injected.Evaluate(test.permissions)
 			assert.NoError(t, err)
@@ -233,7 +234,7 @@ func TestAll_Inject(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			injected, err := test.evaluator.Inject(test.params)
+			injected, err := test.evaluator.MutateScopes(context.TODO(), ScopeInjector(test.params))
 			assert.NoError(t, err)
 			ok, err := injected.Evaluate(test.permissions)
 			assert.NoError(t, err)
@@ -344,7 +345,7 @@ func TestAny_Inject(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			injected, err := test.evaluator.Inject(test.params)
+			injected, err := test.evaluator.MutateScopes(context.TODO(), ScopeInjector(test.params))
 			assert.NoError(t, err)
 			ok, err := injected.Evaluate(test.permissions)
 			assert.NoError(t, err)

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -15,7 +15,7 @@ import (
 )
 
 func authorize(c *models.ReqContext, ac accesscontrol.AccessControl, user *models.SignedInUser, evaluator accesscontrol.Evaluator) {
-	injected, err := evaluator.Inject(buildScopeParams(c))
+	injected, err := evaluator.MutateScopes(c.Req.Context(), accesscontrol.ScopeInjector(buildScopeParams(c)))
 	if err != nil {
 		c.JsonApiErr(http.StatusInternalServerError, "Internal server error", err)
 		return

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -14,13 +14,14 @@ type fullAccessControl interface {
 }
 
 type Calls struct {
-	Evaluate            []interface{}
-	GetUserPermissions  []interface{}
-	GetUserRoles        []interface{}
-	IsDisabled          []interface{}
-	DeclareFixedRoles   []interface{}
-	GetUserBuiltInRoles []interface{}
-	RegisterFixedRoles  []interface{}
+	Evaluate                       []interface{}
+	GetUserPermissions             []interface{}
+	GetUserRoles                   []interface{}
+	IsDisabled                     []interface{}
+	DeclareFixedRoles              []interface{}
+	GetUserBuiltInRoles            []interface{}
+	RegisterFixedRoles             []interface{}
+	RegisterAttributeScopeResolver []interface{}
 }
 
 type Mock struct {
@@ -37,13 +38,14 @@ type Mock struct {
 	Calls Calls
 
 	// Override functions
-	EvaluateFunc            func(context.Context, *models.SignedInUser, accesscontrol.Evaluator) (bool, error)
-	GetUserPermissionsFunc  func(context.Context, *models.SignedInUser) ([]*accesscontrol.Permission, error)
-	GetUserRolesFunc        func(context.Context, *models.SignedInUser) ([]*accesscontrol.RoleDTO, error)
-	IsDisabledFunc          func() bool
-	DeclareFixedRolesFunc   func(...accesscontrol.RoleRegistration) error
-	GetUserBuiltInRolesFunc func(user *models.SignedInUser) []string
-	RegisterFixedRolesFunc  func() error
+	EvaluateFunc                       func(context.Context, *models.SignedInUser, accesscontrol.Evaluator) (bool, error)
+	GetUserPermissionsFunc             func(context.Context, *models.SignedInUser) ([]*accesscontrol.Permission, error)
+	GetUserRolesFunc                   func(context.Context, *models.SignedInUser) ([]*accesscontrol.RoleDTO, error)
+	IsDisabledFunc                     func() bool
+	DeclareFixedRolesFunc              func(...accesscontrol.RoleRegistration) error
+	GetUserBuiltInRolesFunc            func(user *models.SignedInUser) []string
+	RegisterFixedRolesFunc             func() error
+	RegisterAttributeScopeResolverFunc func(string, accesscontrol.AttributeScopeResolveFunc)
 }
 
 // Ensure the mock stays in line with the interface
@@ -161,4 +163,14 @@ func (m *Mock) RegisterFixedRoles() error {
 		return m.RegisterFixedRolesFunc()
 	}
 	return nil
+}
+
+// RegisterAttributeScopeResolver allows the caller to register a scope resolver for a
+// specific scope prefix (ex: datasources:name:)
+func (m *Mock) RegisterAttributeScopeResolver(scopePrefix string, resolver accesscontrol.AttributeScopeResolveFunc) {
+	m.Calls.RegisterAttributeScopeResolver = append(m.Calls.RegisterAttributeScopeResolver, []struct{}{})
+	// Use override if provided
+	if m.RegisterAttributeScopeResolverFunc != nil {
+		m.RegisterAttributeScopeResolverFunc(scopePrefix, resolver)
+	}
 }

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -210,3 +210,9 @@ func (ac *OSSAccessControlService) DeclareFixedRoles(registrations ...accesscont
 
 	return nil
 }
+
+// RegisterAttributeScopeResolver allows the caller to register scope resolvers for a
+// specific scope prefix (ex: datasources:name:)
+func (ac *OSSAccessControlService) RegisterAttributeScopeResolver(scopePrefix string, resolver accesscontrol.AttributeScopeResolveFunc) {
+	ac.scopeResolver.AddAttributeResolver(scopePrefix, resolver)
+}

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -18,7 +18,7 @@ func ProvideService(cfg *setting.Cfg, usageStats usagestats.Service) *OSSAccessC
 		Cfg:           cfg,
 		UsageStats:    usageStats,
 		Log:           log.New("accesscontrol"),
-		scopeResolver: accesscontrol.NewScopeResolver(),
+		ScopeResolver: accesscontrol.NewScopeResolver(),
 	}
 	s.registerUsageMetrics()
 	return s
@@ -30,7 +30,7 @@ type OSSAccessControlService struct {
 	UsageStats    usagestats.Service
 	Log           log.Logger
 	registrations accesscontrol.RegistrationList
-	scopeResolver accesscontrol.ScopeResolver
+	ScopeResolver accesscontrol.ScopeResolver
 }
 
 func (ac *OSSAccessControlService) IsDisabled() bool {
@@ -74,7 +74,7 @@ func (ac *OSSAccessControlService) Evaluate(ctx context.Context, user *models.Si
 		user.Permissions[user.OrgId] = accesscontrol.GroupScopesByAction(permissions)
 	}
 
-	attributeMutator := ac.scopeResolver.GetResolveAttributeScopeMutator(user.OrgId)
+	attributeMutator := ac.ScopeResolver.GetResolveAttributeScopeMutator(user.OrgId)
 	resolvedEvaluator, err := evaluator.MutateScopes(ctx, attributeMutator)
 	if err != nil {
 		return false, err
@@ -93,7 +93,7 @@ func (ac *OSSAccessControlService) GetUserPermissions(ctx context.Context, user 
 	defer timer.ObserveDuration()
 
 	var err error
-	keywordMutator := ac.scopeResolver.GetResolveKeywordScopeMutator(user)
+	keywordMutator := ac.ScopeResolver.GetResolveKeywordScopeMutator(user)
 
 	builtinRoles := ac.GetUserBuiltInRoles(user)
 	permissions := make([]*accesscontrol.Permission, 0)
@@ -214,5 +214,5 @@ func (ac *OSSAccessControlService) DeclareFixedRoles(registrations ...accesscont
 // RegisterAttributeScopeResolver allows the caller to register scope resolvers for a
 // specific scope prefix (ex: datasources:name:)
 func (ac *OSSAccessControlService) RegisterAttributeScopeResolver(scopePrefix string, resolver accesscontrol.AttributeScopeResolveFunc) {
-	ac.scopeResolver.AddAttributeResolver(scopePrefix, resolver)
+	ac.ScopeResolver.AddAttributeResolver(scopePrefix, resolver)
 }

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func setupTestEnv(t testing.TB) *OSSAccessControlService {
@@ -573,6 +572,90 @@ func TestOSSAccessControlService_GetUserPermissions(t *testing.T) {
 
 			assert.Contains(t, rawUserPerms, &tt.wantPerm, "Expected resolution of raw permission")
 			assert.NotContains(t, rawUserPerms, &tt.rawPerm, "Expected raw permission to have been resolved")
+		})
+	}
+}
+
+func TestOSSAccessControlService_Evaluate(t *testing.T) {
+	testUser := models.SignedInUser{
+		UserId:  2,
+		OrgId:   3,
+		OrgName: "TestOrg",
+		OrgRole: models.ROLE_VIEWER,
+		Login:   "testUser",
+		Name:    "Test User",
+		Email:   "testuser@example.org",
+	}
+	registration := accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Version:     1,
+			UID:         "fixed:test:test",
+			Name:        "fixed:test:test",
+			Description: "Test role",
+			Permissions: []accesscontrol.Permission{},
+		},
+		Grants: []string{"Viewer"},
+	}
+	userLoginScopeSolver := func(ctx context.Context, orgID int64, initialScope string) (string, error) {
+		if initialScope == "users:login:testUser" {
+			return "users:id:2", nil
+		}
+		return initialScope, nil
+	}
+
+	tests := []struct {
+		name       string
+		user       models.SignedInUser
+		rawPerm    accesscontrol.Permission
+		evaluator  accesscontrol.Evaluator
+		wantAccess bool
+		wantErr    bool
+	}{
+		{
+			name:       "Should translate users:self",
+			user:       testUser,
+			rawPerm:    accesscontrol.Permission{Action: "users:read", Scope: "users:self"},
+			evaluator:  accesscontrol.EvalPermission("users:read", "users:id:2"),
+			wantAccess: true,
+			wantErr:    false,
+		},
+		{
+			name:       "Should translate users:login:testUser",
+			user:       testUser,
+			rawPerm:    accesscontrol.Permission{Action: "users:read", Scope: "users:id:2"},
+			evaluator:  accesscontrol.EvalPermission("users:read", "users:login:testUser"),
+			wantAccess: true,
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Remove any inserted role after the test case has been run
+			t.Cleanup(func() {
+				removeRoleHelper(registration.Role.Name)
+			})
+
+			// Setup
+			ac := setupTestEnv(t)
+			ac.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
+			ac.RegisterAttributeScopeResolver("users:login:", userLoginScopeSolver)
+
+			registration.Role.Permissions = []accesscontrol.Permission{tt.rawPerm}
+			err := ac.DeclareFixedRoles(registration)
+			require.NoError(t, err)
+
+			err = ac.RegisterFixedRoles()
+			require.NoError(t, err)
+
+			// Test
+			hasAccess, err := ac.Evaluate(context.TODO(), &tt.user, tt.evaluator)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wantAccess, hasAccess)
 		})
 	}
 }

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func setupTestEnv(t testing.TB) *OSSAccessControlService {

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -26,7 +26,7 @@ func setupTestEnv(t testing.TB) *OSSAccessControlService {
 		UsageStats:    &usagestats.UsageStatsMock{T: t},
 		Log:           log.New("accesscontrol"),
 		registrations: accesscontrol.RegistrationList{},
-		scopeResolver: accesscontrol.NewScopeResolver(),
+		ScopeResolver: accesscontrol.NewScopeResolver(),
 	}
 	return ac
 }

--- a/pkg/services/accesscontrol/scope.go
+++ b/pkg/services/accesscontrol/scope.go
@@ -1,10 +1,21 @@
 package accesscontrol
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"html/template"
 	"strings"
+	"time"
 
+	"github.com/grafana/grafana/pkg/infra/localcache"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+)
+
+const (
+	ttl           = 30 * time.Second
+	cleanInterval = 2 * time.Minute
 )
 
 func GetResourceScope(resource string, resourceID string) string {
@@ -44,11 +55,17 @@ func Field(key string) string {
 	return fmt.Sprintf(`{{ .%s }}`, key)
 }
 
+// ScopeMutator alters a Scope to return a new modified Scope
+type ScopeMutator func(context.Context, string) (string, error)
+
 type KeywordScopeResolveFunc func(*models.SignedInUser) (string, error)
 
-// ScopeResolver contains a map of functions to resolve scope keywords such as `self` or `current` into `id` based scopes
+// ScopeResolver is used to resolve scope keywords such as `self` or `current` into `id` based scopes and scope attributes such as `name` or `uid` into `id` based scopes.
 type ScopeResolver struct {
-	keywordResolvers map[string]KeywordScopeResolveFunc
+	keywordResolvers   map[string]KeywordScopeResolveFunc
+	attributeResolvers map[string]AttributeScopeResolveFunc
+	cache              *localcache.CacheService
+	log                log.Logger
 }
 
 func NewScopeResolver() ScopeResolver {
@@ -56,21 +73,95 @@ func NewScopeResolver() ScopeResolver {
 		keywordResolvers: map[string]KeywordScopeResolveFunc{
 			"users:self": resolveUserSelf,
 		},
+		attributeResolvers: map[string]AttributeScopeResolveFunc{},
+		cache:              localcache.New(ttl, cleanInterval),
+		log:                log.New("accesscontrol.scoperesolution"),
 	}
+}
+
+func (s *ScopeResolver) AddKeywordResolver(keyword string, fn KeywordScopeResolveFunc) {
+	s.log.Debug("adding keyword resolution for '%v'", keyword)
+	s.keywordResolvers[keyword] = fn
+}
+
+func (s *ScopeResolver) AddAttributeResolver(prefix string, fn AttributeScopeResolveFunc) {
+	s.log.Debug("adding attribute resolution for '%v'", prefix)
+	s.attributeResolvers[prefix] = fn
 }
 
 func resolveUserSelf(u *models.SignedInUser) (string, error) {
 	return Scope("users", "id", fmt.Sprintf("%v", u.UserId)), nil
 }
 
-// ResolveKeyword resolves scope with keywords such as `self` or `current` into `id` based scopes
-func (s *ScopeResolver) ResolveKeyword(user *models.SignedInUser, permission Permission) (*Permission, error) {
-	if fn, ok := s.keywordResolvers[permission.Scope]; ok {
-		resolvedScope, err := fn(user)
-		if err != nil {
-			return nil, fmt.Errorf("could not resolve %v: %v", permission.Scope, err)
+// GetResolveKeywordScopeMutator returns a function to resolve scope with keywords such as `self` or `current` into `id` based scopes
+func (s *ScopeResolver) GetResolveKeywordScopeMutator(user *models.SignedInUser) ScopeMutator {
+	return func(_ context.Context, scope string) (string, error) {
+		var err error
+		// By default the scope remains unchanged
+		resolvedScope := scope
+		if fn, ok := s.keywordResolvers[scope]; ok {
+			resolvedScope, err = fn(user)
+			if err != nil {
+				return "", fmt.Errorf("could not resolve %v: %w", scope, err)
+			}
+			s.log.Debug("resolved '%v' to '%v'", scope, resolvedScope)
 		}
-		permission.Scope = resolvedScope
+		return resolvedScope, nil
 	}
-	return &permission, nil
+}
+
+type AttributeScopeResolveFunc func(ctx context.Context, orgID int64, initialScope string) (string, error)
+
+// getCacheKey creates an identifier to fetch and store resolution of scopes in the cache
+func getCacheKey(orgID int64, scope string) string {
+	return fmt.Sprintf("%s-%v", scope, orgID)
+}
+
+// GetResolveAttributeScopeMutator returns a function to resolve scopes with attributes such as `name` or `uid` into `id` based scopes
+func (s *ScopeResolver) GetResolveAttributeScopeMutator(orgID int64) ScopeMutator {
+	return func(ctx context.Context, scope string) (string, error) {
+		// Check cache before computing the scope
+		if cachedScope, ok := s.cache.Get(getCacheKey(orgID, scope)); ok {
+			resolvedScope := cachedScope.(string)
+			s.log.Debug("used cache to resolve '%v' to '%v'", scope, resolvedScope)
+			return resolvedScope, nil
+		}
+
+		var err error
+		// By default the scope remains unchanged
+		resolvedScope := scope
+		prefix := scopePrefix(scope)
+		if fn, ok := s.attributeResolvers[prefix]; ok {
+			resolvedScope, err = fn(ctx, orgID, scope)
+			if err != nil {
+				return "", fmt.Errorf("could not resolve %v: %w", scope, err)
+			}
+			// Cache result
+			s.cache.Set(getCacheKey(orgID, scope), resolvedScope, ttl)
+			s.log.Debug("resolved '%v' to '%v'", scope, resolvedScope)
+		}
+		return resolvedScope, nil
+	}
+}
+
+func scopePrefix(scope string) string {
+	parts := strings.Split(scope, ":")
+	n := len(parts) - 1
+	parts[n] = ""
+	return strings.Join(parts, ":")
+}
+
+//Inject params into the evaluator's templated scopes. e.g. "settings:" + eval.Parameters(":id")
+func ScopeInjector(params ScopeParams) ScopeMutator {
+	return func(_ context.Context, scope string) (string, error) {
+		tmpl, err := template.New("scope").Parse(scope)
+		if err != nil {
+			return "", err
+		}
+		var buf bytes.Buffer
+		if err = tmpl.Execute(&buf, params); err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	}
 }

--- a/pkg/services/accesscontrol/scope_test.go
+++ b/pkg/services/accesscontrol/scope_test.go
@@ -1,6 +1,7 @@
 package accesscontrol
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -22,34 +23,156 @@ func TestResolveKeywordedScope(t *testing.T) {
 		name       string
 		user       *models.SignedInUser
 		permission Permission
-		want       *Permission
+		want       Permission
 		wantErr    bool
 	}{
 		{
 			name:       "no scope",
 			user:       testUser,
 			permission: Permission{Action: "users:read"},
-			want:       &Permission{Action: "users:read"},
+			want:       Permission{Action: "users:read"},
 			wantErr:    false,
 		},
 		{
 			name:       "user if resolution",
 			user:       testUser,
 			permission: Permission{Action: "users:read", Scope: "users:self"},
-			want:       &Permission{Action: "users:read", Scope: "users:id:2"},
+			want:       Permission{Action: "users:read", Scope: "users:id:2"},
 			wantErr:    false,
 		},
 	}
 	for _, tt := range tests {
+		var err error
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := NewScopeResolver()
-			resolved, err := resolver.ResolveKeyword(tt.user, tt.permission)
+			scopeModifier := resolver.GetResolveKeywordScopeMutator(tt.user)
+			tt.permission.Scope, err = scopeModifier(context.TODO(), tt.permission.Scope)
 			if tt.wantErr {
 				assert.Error(t, err, "expected an error during the resolution of the scope")
 				return
 			}
 			assert.NoError(t, err)
-			assert.EqualValues(t, tt.want, resolved, "permission did not match expected resolution")
+			assert.EqualValues(t, tt.want, tt.permission, "permission did not match expected resolution")
+		})
+	}
+}
+
+func TestScopeResolver_ResolveAttribute(t *testing.T) {
+	// Calls allow us to see how many times the fakeDataSourceResolution has been called
+	calls := 0
+	fakeDataSourceResolution := func(ctx context.Context, orgID int64, initialScope string) (string, error) {
+		calls++
+		if initialScope == "datasources:name:testds" {
+			return Scope("datasources", "id", "1"), nil
+		} else if initialScope == "datasources:name:testds2" {
+			return Scope("datasources", "id", "2"), nil
+		} else {
+			return "", models.ErrDataSourceNotFound
+		}
+	}
+
+	tests := []struct {
+		name          string
+		orgID         int64
+		evaluator     Evaluator
+		wantEvaluator Evaluator
+		wantCalls     int
+		wantErr       error
+	}{
+		{
+			name:          "should work with scope less permissions",
+			evaluator:     EvalPermission("datasources:read"),
+			wantEvaluator: EvalPermission("datasources:read"),
+			wantCalls:     0,
+		},
+		{
+			name:      "should handle an error",
+			orgID:     1,
+			evaluator: EvalPermission("datasources:read", Scope("datasources", "name", "testds3")),
+			wantErr:   models.ErrDataSourceNotFound,
+			wantCalls: 1,
+		},
+		{
+			name:          "should resolve a scope",
+			orgID:         1,
+			evaluator:     EvalPermission("datasources:read", Scope("datasources", "name", "testds")),
+			wantEvaluator: EvalPermission("datasources:read", Scope("datasources", "id", "1")),
+			wantCalls:     1,
+		},
+		{
+			name:  "should resolve nested scopes with cache",
+			orgID: 1,
+			evaluator: EvalAll(
+				EvalPermission("datasources:read", Scope("datasources", "name", "testds")),
+				EvalAny(
+					EvalPermission("datasources:read", Scope("datasources", "name", "testds")),
+					EvalPermission("datasources:read", Scope("datasources", "name", "testds2")),
+				),
+			),
+			wantEvaluator: EvalAll(
+				EvalPermission("datasources:read", Scope("datasources", "id", "1")),
+				EvalAny(
+					EvalPermission("datasources:read", Scope("datasources", "id", "1")),
+					EvalPermission("datasources:read", Scope("datasources", "id", "2")),
+				),
+			),
+			wantCalls: 2,
+		},
+	}
+	for _, tt := range tests {
+		resolver := NewScopeResolver()
+
+		// Reset calls counter
+		calls = 0
+		// Register a resolution method
+		resolver.AddAttributeResolver("datasources:name:", fakeDataSourceResolution)
+
+		// Test
+		scopeModifier := resolver.GetResolveAttributeScopeMutator(tt.orgID)
+		resolvedEvaluator, err := tt.evaluator.MutateScopes(context.TODO(), scopeModifier)
+		if tt.wantErr != nil {
+			assert.ErrorAs(t, err, &tt.wantErr, "expected an error during the resolution of the scope")
+			return
+		}
+		assert.NoError(t, err)
+		assert.EqualValues(t, tt.wantEvaluator, resolvedEvaluator, "permission did not match expected resolution")
+
+		assert.Equal(t, tt.wantCalls, calls, "cache has not been used")
+	}
+}
+
+func Test_scopePrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope string
+		want  string
+	}{
+		{
+			name:  "empty",
+			scope: "",
+			want:  "",
+		},
+		{
+			name:  "minimal",
+			scope: ":",
+			want:  ":",
+		},
+		{
+			name:  "datasources",
+			scope: "datasources:",
+			want:  "datasources:",
+		},
+		{
+			name:  "datasources name",
+			scope: "datasources:name:testds",
+			want:  "datasources:name:",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix := scopePrefix(tt.scope)
+
+			assert.Equal(t, tt.want, prefix)
 		})
 	}
 }

--- a/pkg/services/datasources/service.go
+++ b/pkg/services/datasources/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
@@ -49,7 +51,7 @@ type cachedDecryptedJSON struct {
 	json    map[string]string
 }
 
-func ProvideService(bus bus.Bus, store *sqlstore.SQLStore, secretsService secrets.Service) *Service {
+func ProvideService(bus bus.Bus, store *sqlstore.SQLStore, secretsService secrets.Service, ac accesscontrol.AccessControl) *Service {
 	s := &Service{
 		Bus:            bus,
 		SQLStore:       store,
@@ -70,7 +72,26 @@ func ProvideService(bus bus.Bus, store *sqlstore.SQLStore, secretsService secret
 	s.Bus.AddHandler(s.UpdateDataSource)
 	s.Bus.AddHandler(s.GetDefaultDataSource)
 
+	ac.RegisterAttributeScopeResolver(NewDatasourceNameScopeResolver(store))
+
 	return s
+}
+
+// NewDatasourceNameScopeResolver provides an AttributeScopeResolver able to
+// translate a scope prefixed with "datasources:name:" into an id based scope.
+func NewDatasourceNameScopeResolver(db *sqlstore.SQLStore) (string, accesscontrol.AttributeScopeResolveFunc) {
+	dsNameResolver := func(ctx context.Context, orgID int64, initialScope string) (string, error) {
+		dsName := strings.Split(initialScope, ":")[2]
+
+		query := models.GetDataSourceQuery{Name: dsName, OrgId: orgID}
+		if err := db.GetDataSource(ctx, &query); err != nil {
+			return "", err
+		}
+
+		return accesscontrol.Scope("datasources", "id", fmt.Sprintf("%v", query.Result.Id)), nil
+	}
+
+	return "datasources:name:", dsNameResolver
 }
 
 func (s *Service) GetDataSource(ctx context.Context, query *models.GetDataSourceQuery) error {

--- a/pkg/services/datasources/service_test.go
+++ b/pkg/services/datasources/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/models"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/secrets/database"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
@@ -34,7 +35,7 @@ func TestService(t *testing.T) {
 	})
 
 	secretsService := secretsManager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
-	s := ProvideService(bus.New(), sqlStore, secretsService)
+	s := ProvideService(bus.New(), sqlStore, secretsService, &acmock.Mock{})
 
 	var ds *models.DataSource
 
@@ -83,7 +84,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		}
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		rt1, err := dsService.GetHTTPTransport(&ds, provider)
 		require.NoError(t, err)
@@ -116,7 +117,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		json.Set("tlsAuthWithCACert", true)
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		tlsCaCert, err := secretsService.Encrypt(context.Background(), []byte(caCert), secrets.WithoutScope())
 		require.NoError(t, err)
@@ -166,7 +167,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		json.Set("tlsAuth", true)
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		tlsClientCert, err := secretsService.Encrypt(context.Background(), []byte(clientCert), secrets.WithoutScope())
 		require.NoError(t, err)
@@ -209,7 +210,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		json.Set("serverName", "server-name")
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		tlsCaCert, err := secretsService.Encrypt(context.Background(), []byte(caCert), secrets.WithoutScope())
 		require.NoError(t, err)
@@ -246,7 +247,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		json.Set("tlsSkipVerify", true)
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		ds := models.DataSource{
 			Id:       1,
@@ -277,7 +278,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		})
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		encryptedData, err := secretsService.Encrypt(context.Background(), []byte(`Bearer xf5yhfkpsnmgo`), secrets.WithoutScope())
 		require.NoError(t, err)
@@ -336,7 +337,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		})
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		ds := models.DataSource{
 			Id:       1,
@@ -369,7 +370,7 @@ func TestService_GetHttpTransport(t *testing.T) {
 		require.NoError(t, err)
 
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		ds := models.DataSource{
 			Type:     models.DS_ES,
@@ -403,7 +404,7 @@ func TestService_getTimeout(t *testing.T) {
 	}
 
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-	dsService := ProvideService(bus.New(), nil, secretsService)
+	dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 	for _, tc := range testCases {
 		ds := &models.DataSource{
@@ -416,7 +417,7 @@ func TestService_getTimeout(t *testing.T) {
 func TestService_DecryptedValue(t *testing.T) {
 	t.Run("When datasource hasn't been updated, encrypted JSON should be fetched from cache", func(t *testing.T) {
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		encryptedJsonData, err := secretsService.EncryptJsonData(
 			context.Background(),
@@ -470,7 +471,7 @@ func TestService_DecryptedValue(t *testing.T) {
 			SecureJsonData: encryptedJsonData,
 		}
 
-		dsService := ProvideService(bus.New(), nil, secretsService)
+		dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 		// Populate cache
 		password, ok := dsService.DecryptedValue(&ds, "password")
@@ -506,7 +507,7 @@ func TestService_HTTPClientOptions(t *testing.T) {
 			t.Cleanup(func() { ds.JsonData = emptyJsonData; ds.SecureJsonData = emptySecureJsonData })
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-			dsService := ProvideService(bus.New(), nil, secretsService)
+			dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 			opts, err := dsService.httpClientOptions(&ds)
 			require.NoError(t, err)
@@ -523,7 +524,7 @@ func TestService_HTTPClientOptions(t *testing.T) {
 			})
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-			dsService := ProvideService(bus.New(), nil, secretsService)
+			dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 			opts, err := dsService.httpClientOptions(&ds)
 			require.NoError(t, err)
@@ -543,7 +544,7 @@ func TestService_HTTPClientOptions(t *testing.T) {
 			})
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-			dsService := ProvideService(bus.New(), nil, secretsService)
+			dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 			opts, err := dsService.httpClientOptions(&ds)
 			require.NoError(t, err)
@@ -567,7 +568,7 @@ func TestService_HTTPClientOptions(t *testing.T) {
 			})
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-			dsService := ProvideService(bus.New(), nil, secretsService)
+			dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 			opts, err := dsService.httpClientOptions(&ds)
 			require.NoError(t, err)
@@ -585,7 +586,7 @@ func TestService_HTTPClientOptions(t *testing.T) {
 			})
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-			dsService := ProvideService(bus.New(), nil, secretsService)
+			dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 			_, err := dsService.httpClientOptions(&ds)
 			assert.Error(t, err)
@@ -599,7 +600,7 @@ func TestService_HTTPClientOptions(t *testing.T) {
 			})
 
 			secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-			dsService := ProvideService(bus.New(), nil, secretsService)
+			dsService := ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 
 			opts, err := dsService.httpClientOptions(&ds)
 			require.NoError(t, err)

--- a/pkg/services/datasources/service_test.go
+++ b/pkg/services/datasources/service_test.go
@@ -126,7 +126,6 @@ func TestService_DatasourceNameScopeResolver(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 //nolint:goconst

--- a/pkg/services/datasources/service_test.go
+++ b/pkg/services/datasources/service_test.go
@@ -81,7 +81,7 @@ func (d *dataSourceMockRetriever) GetDataSource(ctx context.Context, query *mode
 	return models.ErrDataSourceNotFound
 }
 
-func TestService_DatasourceNameScopeResolver(t *testing.T) {
+func TestService_NameScopeResolver(t *testing.T) {
 	type testCaseResolver struct {
 		desc    string
 		given   string
@@ -94,6 +94,12 @@ func TestService_DatasourceNameScopeResolver(t *testing.T) {
 			desc:    "correct",
 			given:   "datasources:name:test-datasource",
 			want:    "datasources:id:1",
+			wantErr: nil,
+		},
+		{
+			desc:    "correct",
+			given:   "datasources:name:*",
+			want:    "datasources:id:*",
 			wantErr: nil,
 		},
 		{
@@ -111,7 +117,7 @@ func TestService_DatasourceNameScopeResolver(t *testing.T) {
 	}
 
 	testDataSource := &models.DataSource{Id: 1, Name: "test-datasource"}
-	prefix, resolver := NewDatasourceNameScopeResolver(&dataSourceMockRetriever{testDataSource})
+	prefix, resolver := NewNameScopeResolver(&dataSourceMockRetriever{testDataSource})
 	require.Equal(t, "datasources:name:", prefix)
 
 	for _, tc := range testCases {

--- a/pkg/tsdb/legacydata/service/service_test.go
+++ b/pkg/tsdb/legacydata/service/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
@@ -35,7 +36,7 @@ func TestHandleRequest(t *testing.T) {
 			return backend.NewQueryDataResponse(), nil
 		}
 		secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-		dsService := datasources.ProvideService(bus.New(), nil, secretsService)
+		dsService := datasources.ProvideService(bus.New(), nil, secretsService, &acmock.Mock{})
 		s := ProvideService(client, nil, dsService)
 
 		ds := &models.DataSource{Id: 12, Type: "unregisteredType", JsonData: simplejson.New()}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Some of our endpoints are protected with scopes in the form of: `resource:name:name`. We need a way to translate such a scope to an id based one:  `resource:id:id` for user permissions to be matched.
Ex: `datasources:name:testDs` -> `datasources:id:3`

This work takes as an assumption that at first, user permissions will be ID based.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partly fixes #https://github.com/grafana/grafana-enterprise/issues/1849

**Special notes for your reviewer**:
