### PR TITLE
Explore: fix history settings tab padding

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistorySettings.tsx
+++ b/public/app/features/explore/RichHistory/RichHistorySettings.tsx
@@ -22,7 +22,6 @@ export interface RichHistorySettingsProps {
 const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
     container: css`
-      padding-left: ${theme.spacing.sm};
       font-size: ${theme.typography.size.sm};
       .space-between {
         margin-bottom: ${theme.spacing.lg};


### PR DESCRIPTION
There's an extra tiny padding in rich history settings that shouldn't be there 🧐. This PR removes it. 

<img width="396" alt="Screenshot 2021-10-21 at 10 23 36" src="https://user-images.githubusercontent.com/1170767/138249795-19777d15-3f1c-4e04-a0a6-61f63565e41b.png">
<img width="329" alt="Screenshot 2021-10-21 at 10 24 22" src="https://user-images.githubusercontent.com/1170767/138249805-23466e7b-aef8-4ab3-a97e-6b0acf1788fa.png">
