### PR TITLE
Prometheus: Transform NaN values from matrix response to null on backend

### DIFF
--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -181,7 +181,6 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 			if err != nil {
 				plog.Error("Exemplar query", query.Expr, "failed with", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
-				continue
 			}
 			response[ExemplarQueryType] = exemplarResponse
 		}
@@ -408,11 +407,18 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery) data.Frames
 		}
 
 		timeField := data.NewFieldFromFieldType(data.FieldTypeTime, len(v.Values))
-		valueField := data.NewFieldFromFieldType(data.FieldTypeFloat64, len(v.Values))
+		valueField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, len(v.Values))
 
 		for i, k := range v.Values {
 			timeField.Set(i, time.Unix(k.Timestamp.Unix(), 0).UTC())
-			valueField.Set(i, float64(k.Value))
+
+			// We are replacing all NaN values with nil
+			var pointer *float64
+			value := float64(k.Value)
+			if !math.IsNaN(value) {
+				pointer = &value
+			}
+			valueField.Set(i, pointer)
 		}
 
 		name := formatLegend(v.Metric, query)

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -181,8 +181,9 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 			if err != nil {
 				plog.Error("Exemplar query", query.Expr, "failed with", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
+			} else {
+				response[ExemplarQueryType] = exemplarResponse
 			}
-			response[ExemplarQueryType] = exemplarResponse
 		}
 
 		frames, err := parseResponse(response, query)

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -411,14 +411,10 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery) data.Frames
 
 		for i, k := range v.Values {
 			timeField.Set(i, time.Unix(k.Timestamp.Unix(), 0).UTC())
-
-			// We are replacing all NaN values with nil
-			var pointer *float64
 			value := float64(k.Value)
 			if !math.IsNaN(value) {
-				pointer = &value
+				valueField.Set(i, &value)
 			}
-			valueField.Set(i, pointer)
 		}
 
 		name := formatLegend(v.Metric, query)

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -419,6 +419,7 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery) data.Frames
 		timeField.Name = data.TimeSeriesTimeFieldName
 		valueField.Name = data.TimeSeriesValueFieldName
 		valueField.Config = &data.FieldConfig{DisplayNameFromDS: name}
+		valueField.Labels = tags
 
 		frame := data.NewFrame(name, timeField, valueField)
 		frame.Meta = &data.FrameMeta{

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -434,6 +435,31 @@ func TestPrometheus_parseResponse(t *testing.T) {
 		require.Equal(t, res[0].Fields[1].Labels.String(), "app=Application, tag2=tag2")
 		require.Equal(t, res[0].Fields[1].Name, "Value")
 		require.Equal(t, res[0].Fields[1].Config.DisplayNameFromDS, "legend Application")
+
+		// Ensure the timestamps are UTC zoned
+		testValue := res[0].Fields[0].At(0)
+		require.Equal(t, "UTC", testValue.(time.Time).Location().String())
+	})
+
+	t.Run("matrix response with NaN value should be changed to null", func(t *testing.T) {
+		value := make(map[PrometheusQueryType]interface{})
+		value[RangeQueryType] = p.Matrix{
+			&p.SampleStream{
+				Metric: p.Metric{"app": "Application"},
+				Values: []p.SamplePair{
+					{Value: p.SampleValue(math.NaN()), Timestamp: 1000},
+				},
+			},
+		}
+		query := &PrometheusQuery{
+			LegendFormat: "",
+		}
+		res, err := parseResponse(value, query)
+		require.NoError(t, err)
+		var nilPointer *float64
+
+		require.Equal(t, res[0].Fields[1].Name, "Value")
+		require.Equal(t, res[0].Fields[1].At(0), nilPointer)
 
 		// Ensure the timestamps are UTC zoned
 		testValue := res[0].Fields[0].At(0)

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -456,14 +456,10 @@ func TestPrometheus_parseResponse(t *testing.T) {
 		}
 		res, err := parseResponse(value, query)
 		require.NoError(t, err)
-		var nilPointer *float64
 
+		var nilPointer *float64
 		require.Equal(t, res[0].Fields[1].Name, "Value")
 		require.Equal(t, res[0].Fields[1].At(0), nilPointer)
-
-		// Ensure the timestamps are UTC zoned
-		testValue := res[0].Fields[0].At(0)
-		require.Equal(t, "UTC", testValue.(time.Time).Location().String())
 	})
 
 	t.Run("vector response should be parsed normally", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When running queries and processing results through frontend, we always change NaN to null for matrix values. We missed this when working no backend migration for Prometheus. This PR fixes it. 

How to test, run range query such as `histogram_quantile(0.99,rate(prometheus_http_response_size_bytes_bucket{handler="/api/v1/metadata"}[$__rate_interval]))` with Robust perception data source and then open inspector -> data. There shouldn't be any NaN and. there should be `null` values. 

Moreover, Ryan refactored how we create dataFrames to make it more performant! 🚀 
