### PR TITLE
CodeEditor: change so the code comments are aligned with our defaults

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/types.ts
+++ b/packages/grafana-ui/src/components/Monaco/types.ts
@@ -7,7 +7,7 @@ export type CodeEditorSuggestionProvider = () => CodeEditorSuggestionItem[];
 export type { monacoType as monacoTypes };
 export type Monaco = typeof monacoType;
 export type MonacoEditor = monacoType.editor.IStandaloneCodeEditor;
-export type MonacoOptions = monacoType.editor.IStandaloneEditorConstructionOptions;
+export type MonacoOptions = MonacoOptionsWithGrafanaDefaults;
 
 export interface CodeEditorProps {
   value: string;
@@ -86,4 +86,51 @@ export interface CodeEditorSuggestionItem {
    * this completion. When `falsy` the `label` is used.
    */
   insertText?: string;
+}
+
+/**
+ * This interface will extend the original Monaco editor options interface
+ * but changing the code comments to contain the proper default values to
+ * prevent the consumer of the CodeEditor to get incorrect documentation in editor.
+ */
+export interface MonacoOptionsWithGrafanaDefaults extends monacoType.editor.IStandaloneEditorConstructionOptions {
+  /**
+   * Enable custom contextmenu.
+   * Defaults to false.
+   */
+  contextmenu?: boolean;
+  /**
+   * The number of spaces a tab is equal to.
+   * This setting is overridden based on the file contents when `detectIndentation` is on.
+   * Defaults to 4.
+   */
+  tabSize?: number;
+  /**
+   * Show code lens
+   * Defaults to false.
+   */
+  codeLens?: boolean;
+  /**
+   * Control the width of line numbers, by reserving horizontal space for rendering at least an amount of digits.
+   * Defaults to 4.
+   */
+  lineNumbersMinChars?: number;
+  /**
+   * The width reserved for line decorations (in px).
+   * Line decorations are placed between line numbers and the editor content.
+   * You can pass in a string in the format floating point followed by "ch". e.g. 1.3ch.
+   * Defaults to 1 * theme.spacing.gridSize.
+   */
+  lineDecorationsWidth?: number | string;
+  /**
+   * Controls if a border should be drawn around the overview ruler.
+   * Defaults to `false`.
+   */
+  overviewRulerBorder?: boolean;
+  /**
+   * Enable that the editor will install an interval to check if its container dom node size has changed.
+   * Enabling this might have a severe performance impact.
+   * Defaults to true.
+   */
+  automaticLayout?: boolean;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm note sure this is needed since I think we decided to do some refactoring of this component. But I got a suggestion from the author of this issue on how to resolve it so I gave it a try.

**Which issue(s) this PR fixes**:
Fixes #40210

**Special notes for your reviewer**:
What did we end up deciding regarding exposing the monaco options? Is this PR needed?
