### PR TITLE
Explore: rich history: add more tests

### DIFF
--- a/public/app/core/utils/richHistory.test.ts
+++ b/public/app/core/utils/richHistory.test.ts
@@ -281,55 +281,57 @@ describe('richHistory', () => {
       deleteAllFromRichHistory();
       expect(store.exists(key)).toBeFalsy();
     });
-    it('should load from localStorage data in old format #1', () => {
-      const oldHistoryItem = { ...mock.storedHistory[0], queries: ['test query 1', 'test query 2', 'test query 3'] };
-      store.setObject(key, [oldHistoryItem]);
-      const expectedHistoryItem = {
-        ...mock.storedHistory[0],
-        queries: [
-          {
-            expr: 'test query 1',
-            refId: 'A',
-          },
-          {
-            expr: 'test query 2',
-            refId: 'B',
-          },
-          {
-            expr: 'test query 3',
-            refId: 'C',
-          },
-        ],
-      };
+    describe('should load from localStorage data in old formats', () => {
+      it('should load when queries are strings', () => {
+        const oldHistoryItem = { ...mock.storedHistory[0], queries: ['test query 1', 'test query 2', 'test query 3'] };
+        store.setObject(key, [oldHistoryItem]);
+        const expectedHistoryItem = {
+          ...mock.storedHistory[0],
+          queries: [
+            {
+              expr: 'test query 1',
+              refId: 'A',
+            },
+            {
+              expr: 'test query 2',
+              refId: 'B',
+            },
+            {
+              expr: 'test query 3',
+              refId: 'C',
+            },
+          ],
+        };
 
-      const result = getRichHistory();
-      expect(result).toStrictEqual([expectedHistoryItem]);
-    });
+        const result = getRichHistory();
+        expect(result).toStrictEqual([expectedHistoryItem]);
+      });
 
-    it('should load from localStorage data in old format #2', () => {
-      const oldHistoryItem = {
-        ...mock.storedHistory[0],
-        queries: ['{"refId":"A","key":"key1","metrics":[]}', '{"refId":"B","key":"key2","metrics":[]}'],
-      };
-      store.setObject(key, [oldHistoryItem]);
-      const expectedHistoryItem = {
-        ...mock.storedHistory[0],
-        queries: [
-          {
-            refId: 'A',
-            key: 'key1',
-            metrics: [],
-          },
-          {
-            refId: 'B',
-            key: 'key2',
-            metrics: [],
-          },
-        ],
-      };
+      it('should load when queries are json-encoded strings', () => {
+        const oldHistoryItem = {
+          ...mock.storedHistory[0],
+          queries: ['{"refId":"A","key":"key1","metrics":[]}', '{"refId":"B","key":"key2","metrics":[]}'],
+        };
+        store.setObject(key, [oldHistoryItem]);
+        const expectedHistoryItem = {
+          ...mock.storedHistory[0],
+          queries: [
+            {
+              refId: 'A',
+              key: 'key1',
+              metrics: [],
+            },
+            {
+              refId: 'B',
+              key: 'key2',
+              metrics: [],
+            },
+          ],
+        };
 
-      const result = getRichHistory();
-      expect(result).toStrictEqual([expectedHistoryItem]);
+        const result = getRichHistory();
+        expect(result).toStrictEqual([expectedHistoryItem]);
+      });
     });
   });
 });

--- a/public/app/core/utils/richHistory.test.ts
+++ b/public/app/core/utils/richHistory.test.ts
@@ -281,7 +281,7 @@ describe('richHistory', () => {
       deleteAllFromRichHistory();
       expect(store.exists(key)).toBeFalsy();
     });
-    it('should load from localStorage data in old format', () => {
+    it('should load from localStorage data in old format #1', () => {
       const oldHistoryItem = { ...mock.storedHistory[0], queries: ['test query 1', 'test query 2', 'test query 3'] };
       store.setObject(key, [oldHistoryItem]);
       const expectedHistoryItem = {
@@ -298,6 +298,32 @@ describe('richHistory', () => {
           {
             expr: 'test query 3',
             refId: 'C',
+          },
+        ],
+      };
+
+      const result = getRichHistory();
+      expect(result).toStrictEqual([expectedHistoryItem]);
+    });
+
+    it('should load from localStorage data in old format #2', () => {
+      const oldHistoryItem = {
+        ...mock.storedHistory[0],
+        queries: ['{"refId":"A","key":"key1","metrics":[]}', '{"refId":"B","key":"key2","metrics":[]}'],
+      };
+      store.setObject(key, [oldHistoryItem]);
+      const expectedHistoryItem = {
+        ...mock.storedHistory[0],
+        queries: [
+          {
+            refId: 'A',
+            key: 'key1',
+            metrics: [],
+          },
+          {
+            refId: 'B',
+            key: 'key2',
+            metrics: [],
           },
         ],
       };

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -409,10 +409,10 @@ function createDataQuery(query: RichHistoryQuery, individualQuery: DataQuery | s
     // the current format
     return individualQuery;
   } else if (isParsable(individualQuery)) {
-    // ElasticSearch (maybe other datasoures too) queries before grafana7
+    // ElasticSearch (maybe other datasoures too) before grafana7
     return JSON.parse(individualQuery);
   }
-  // prometehus (maybe other datasources too) queries before grafana7
+  // prometehus (maybe other datasources too) before grafana7
   return { expr: individualQuery, refId: letters[index] };
 }
 

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -406,10 +406,13 @@ function migrateRichHistory(richHistory: RichHistoryQuery[]) {
 function createDataQuery(query: RichHistoryQuery, individualQuery: DataQuery | string, index: number) {
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVXYZ';
   if (typeof individualQuery === 'object') {
+    // the current format
     return individualQuery;
   } else if (isParsable(individualQuery)) {
+    // ElasticSearch (maybe other datasoures too) queries before grafana7
     return JSON.parse(individualQuery);
   }
+  // prometehus (maybe other datasources too) queries before grafana7
   return { expr: individualQuery, refId: letters[index] };
 }
 


### PR DESCRIPTION
i added a test for handling an old rich-history local-storage format. also added comments explaining which old-format was produced by what datasource.