### PR TITLE
Stat: Fixes an issue that could lead to browser crash with specific values 

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -92,6 +92,15 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
   getYRange(field: Field) {
     let { min, max } = this.state.alignedDataFrame.fields[1].state?.range!;
 
+    if (min === max) {
+      if (min === 0) {
+        max = 100;
+      } else {
+        min = 0;
+        max! *= 2;
+      }
+    }
+
     return [
       Math.max(min!, field.config.min ?? -Infinity),
       Math.min(max!, field.config.max ?? Infinity),


### PR DESCRIPTION
Fixes #40411.

this adds a guard against returning the same min and max in sparkline, which happens with a single value.

not sure yet why uPlot only crashes for values like `48.44` or `50.44` but not `1` (i would have expected a crash for all of them).