### PR TITLE
Transformers: Fix Labels to fields duplicates

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/labelsToFields.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/labelsToFields.test.ts
@@ -145,6 +145,68 @@ describe('Labels as Columns', () => {
       `);
     });
   });
+
+  it('data frame with labels and multiple fields', async () => {
+    const cfg: DataTransformerConfig<LabelsToFieldsOptions> = {
+      id: DataTransformerID.labelsToFields,
+      options: {},
+    };
+
+    const source = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'a', type: FieldType.number, values: [1, 3], labels: { name: 'thing' } },
+        { name: 'b', type: FieldType.number, values: [2, 4], labels: { name: 'thing' } },
+      ],
+    });
+
+    await expect(transformDataFrame([cfg], [source])).toEmitValuesWith((received) => {
+      const data = received[0];
+      const result = toDataFrameDTO(data[0]);
+
+      const expected: FieldDTO[] = [
+        { name: 'time', type: FieldType.time, values: [1000, 2000], config: {} },
+        { name: 'a', type: FieldType.number, values: [1, 3], config: {} },
+        { name: 'b', type: FieldType.number, values: [2, 4], config: {} },
+        { name: 'name', type: FieldType.string, values: ['thing', 'thing'], config: {} },
+      ];
+
+      expect(result.fields).toEqual(expected);
+    });
+  });
+
+  it('data frame with labels and multiple fields with different labels', async () => {
+    const cfg: DataTransformerConfig<LabelsToFieldsOptions> = {
+      id: DataTransformerID.labelsToFields,
+      options: {},
+    };
+
+    const source = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'a', type: FieldType.number, values: [1, 3], labels: { name: 'thing', field: 'a' } },
+        { name: 'b', type: FieldType.number, values: [2, 4], labels: { name: 'thing', field: 'b' } },
+      ],
+    });
+
+    await expect(transformDataFrame([cfg], [source])).toEmitValuesWith((received) => {
+      const data = received[0];
+      const result = toDataFrameDTO(data[0]);
+
+      const expected: FieldDTO[] = [
+        { name: 'time', type: FieldType.time, values: [1000, 2000], config: {} },
+        { name: 'a', type: FieldType.number, values: [1, 3], config: {} },
+        { name: 'b', type: FieldType.number, values: [2, 4], config: {} },
+        { name: 'name', type: FieldType.string, values: ['thing', 'thing'], config: {} },
+        { name: 'field', type: FieldType.string, values: ['a', 'a'], config: {} },
+        { name: 'field', type: FieldType.string, values: ['b', 'b'], config: {} },
+      ];
+
+      expect(result.fields).toEqual(expected);
+    });
+  });
 });
 
 function toSimpleObject(frame: DataFrame) {

--- a/packages/grafana-data/src/transformations/transformers/labelsToFields.ts
+++ b/packages/grafana-data/src/transformations/transformers/labelsToFields.ts
@@ -24,6 +24,7 @@ export const labelsToFieldsTransformer: SynchronousDataTransformerInfo<LabelsToF
 
     for (const frame of data) {
       const newFields: Field[] = [];
+      const uniqueLabels: Record<string, Set<string>> = {};
 
       for (const field of frame.fields) {
         if (!field.labels) {
@@ -50,9 +51,16 @@ export const labelsToFieldsTransformer: SynchronousDataTransformerInfo<LabelsToF
             continue;
           }
 
-          const values = new Array(frame.length).fill(field.labels[labelName]);
+          const uniqueValues = (uniqueLabels[labelName] ||= new Set());
+          uniqueValues.add(field.labels[labelName]);
+        }
+      }
+
+      for (const name in uniqueLabels) {
+        for (const value of uniqueLabels[name]) {
+          const values = new Array(frame.length).fill(value);
           newFields.push({
-            name: labelName,
+            name: name,
             type: FieldType.string,
             values: new ArrayVector(values),
             config: {},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Labels to fields was creating duplicate fields for data frames with multiple fields because the labels are found on each field. This could be worked around with a Merge, but Merge does not do anything if there is only a single data frame.

Given a data frame with two or more non-time fields that have labels, such as:

| Time | A {region: US} | B {region: US} |
| ---- | -------------- | -------------- |
| 1000 | 1              | 2              |
| 2000 | 3              | 4              |

What seems to have been happening since Grafana 8.1.x when using the Labels to fields transformation, you get a new field for the same labels in each existing field (while Grafana's display adds the number suffixes, the actual data frame fields just have duplicate names):

| Time | A | Region 1 | B | Region 2 |
| ---- | - | -------- | - | -------- |
| 1000 | 1 | US       | 2 | US       |
| 2000 | 3 | US       | 4 | US       |

With my change, the behavior that I believe works the same as <=8.0.x had is restored:

| Time | A | B | Region |
| ---- | - | - | ------ |
| 1000 | 1 | 2 | US     |
| 2000 | 3 | 4 | US     |

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

~~Fixes #~~

**Special notes for your reviewer**:

The pre-existing functionality seems to allow for individual data frames having fields with different sets of label values, so my change still supports that case as well in case it is needed. From my experience I believe that usually data frames with differing labels are separate, but perhaps there are further use-cases.