### PR TITLE
Prometheus: Change condition to evaulate exemplars availability

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -813,7 +813,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
   async areExemplarsAvailable() {
     try {
       const res = await this.metadataRequest('/api/v1/query_exemplars', { query: 'test' });
-      if (res.statusText === 'OK') {
+      if (res.data.status === 'success') {
         return true;
       }
       return false;


### PR DESCRIPTION
**What this PR does / why we need it**:

Change condition to evaulate exemplars availability from `res.statusText` to `res.data.status` based on https://prometheus.io/docs/prometheus/latest/querying/api/#querying-exemplars. 

**About the issue:**
The issue is kind of weird because I am not able to reproduce it locally. When I test prometheus instance that supports exemplars, it correctly works locally, but on hosted grafana it shows unavailable exemplars. I am not sure we can test if this is correct solution before merging it, but it is also more correct solution because we rely on Prometheus data source. 