### PR TITLE
Query execution: allow empty datasource ref with multiple queries

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -37,7 +37,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricReq
 		if dsType == expr.DatasourceName {
 			return hs.handleExpressions(c, reqDTO)
 		}
-		if prevType != "" && prevType != dsType {
+		if prevType != "" && prevType != dsType && dsType != "" {
 			// For mixed datasource case, each data source is sent in a single request.
 			// So only the datasource from the first query is needed. As all requests
 			// should be the same data source.


### PR DESCRIPTION
In #38571, we cleaned up the query cycle so that if the requested datasource in each query does not match the previous one it will fail.  Previously it happily executed all queries against the original datasource.

In addition, the front end code recently changed so it saves the datasource on each query item, but this has a side effect that items with multiple queries now fail with the "All queries must use the same datasource" 

In explore with multiple queries, only the first has the data source set.  I think this can be half the solution, but we should also fix explore to send the data source on every query
