### PR TITLE
CI: Make build, test and integration tests steps run in parallel

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -132,6 +132,37 @@ steps:
     MYSQL_HOST: mysql
   image: grafana/build-container:1.4.5
   name: mysql-integration-tests
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+depends_on: []
+kind: pipeline
+name: build-pr
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.14.2
+  name: identify-runner
+- commands:
+  - make gen-go
+  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
+  - yarn install --immutable
+  image: grafana/build-container:1.4.5
+  name: initialize
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
     --variants linux-x64,linux-x64-musl,osx64,win64,armv6 --no-pull-enterprise
@@ -150,7 +181,7 @@ steps:
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
-  - lint-backend
+  - initialize
   environment: null
   image: grafana/build-container:1.4.5
   name: build-plugins
@@ -428,7 +459,7 @@ steps:
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   depends_on:
-  - lint-backend
+  - initialize
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
@@ -891,7 +922,7 @@ steps:
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   depends_on:
-  - lint-backend
+  - initialize
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
@@ -1276,7 +1307,7 @@ steps:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
     --signing-admin
   depends_on:
-  - lint-backend
+  - initialize
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
@@ -1838,7 +1869,7 @@ steps:
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   depends_on:
-  - lint-backend
+  - initialize
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
@@ -2212,7 +2243,7 @@ steps:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
     --signing-admin
   depends_on:
-  - lint-backend
+  - initialize
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
@@ -2769,7 +2800,7 @@ steps:
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
   depends_on:
-  - lint-backend
+  - initialize
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
@@ -3115,7 +3146,7 @@ steps:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
     --signing-admin
   depends_on:
-  - lint-backend
+  - initialize
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
@@ -3500,6 +3531,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 9437ec89add3c810b1e32d0d5c1f32b0e771c4555f6d0bb60d7031f7afd6b5b5
+hmac: e6086427a556519668fd021b26de88a44597486e05ea57ccf9d3c6291dbbe64f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 depends_on: []
 kind: pipeline
-name: test-pr
+name: pr-test
 node:
   type: no-parallel
 platform:
@@ -139,7 +139,7 @@ type: docker
 ---
 depends_on: []
 kind: pipeline
-name: build-pr
+name: pr-build-e2e
 node:
   type: no-parallel
 platform:
@@ -3531,6 +3531,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 8dc023cfdfedfbef48a3cfbaa7f80a502de2c9abf684e07c3ea726525707c993
+hmac: 0e3e2c1fb43055cd1b7d45dcfa6b5bdf7d90ebdc690aef3cb5b92822a388e688
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,20 +7,7 @@ node:
 platform:
   arch: amd64
   os: linux
-services:
-- environment:
-    POSTGRES_DB: grafanatest
-    POSTGRES_PASSWORD: grafanatest
-    POSTGRES_USER: grafanatest
-  image: postgres:12.3-alpine
-  name: postgres
-- environment:
-    MYSQL_DATABASE: grafana_tests
-    MYSQL_PASSWORD: password
-    MYSQL_ROOT_PASSWORD: rootpass
-    MYSQL_USER: grafana
-  image: mysql:5.6.48
-  name: mysql
+services: []
 steps:
 - commands:
   - mkdir -p bin
@@ -102,36 +89,6 @@ steps:
     TEST_MAX_WORKERS: 50%
   image: grafana/build-container:1.4.5
   name: test-frontend
-- commands:
-  - apt-get update
-  - apt-get install -yq postgresql-client
-  - dockerize -wait tcp://postgres:5432 -timeout 120s
-  - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
-  - go clean -testcache
-  - ./bin/grabpl integration-tests --database postgres
-  depends_on:
-  - initialize
-  environment:
-    GRAFANA_TEST_DB: postgres
-    PGPASSWORD: grafanatest
-    POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
-  name: postgres-integration-tests
-- commands:
-  - apt-get update
-  - apt-get install -yq default-mysql-client
-  - dockerize -wait tcp://mysql:3306 -timeout 120s
-  - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
-    -prootpass
-  - go clean -testcache
-  - ./bin/grabpl integration-tests --database mysql
-  depends_on:
-  - initialize
-  environment:
-    GRAFANA_TEST_DB: mysql
-    MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
-  name: mysql-integration-tests
 trigger:
   event:
   - pull_request
@@ -299,6 +256,70 @@ type: docker
 ---
 depends_on: []
 kind: pipeline
+name: pr-integration-tests
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services:
+- environment:
+    POSTGRES_DB: grafanatest
+    POSTGRES_PASSWORD: grafanatest
+    POSTGRES_USER: grafanatest
+  image: postgres:12.3-alpine
+  name: postgres
+- environment:
+    MYSQL_DATABASE: grafana_tests
+    MYSQL_PASSWORD: password
+    MYSQL_ROOT_PASSWORD: rootpass
+    MYSQL_USER: grafana
+  image: mysql:5.6.48
+  name: mysql
+steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
+  - apt-get update
+  - apt-get install -yq postgresql-client
+  - dockerize -wait tcp://postgres:5432 -timeout 120s
+  - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
+  - go clean -testcache
+  - ./bin/grabpl integration-tests --database postgres
+  depends_on:
+  - grabpl
+  environment:
+    GRAFANA_TEST_DB: postgres
+    PGPASSWORD: grafanatest
+    POSTGRES_HOST: postgres
+  image: grafana/build-container:1.4.5
+  name: postgres-integration-tests
+- commands:
+  - apt-get update
+  - apt-get install -yq default-mysql-client
+  - dockerize -wait tcp://mysql:3306 -timeout 120s
+  - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
+    -prootpass
+  - go clean -testcache
+  - ./bin/grabpl integration-tests --database mysql
+  depends_on:
+  - grabpl
+  environment:
+    GRAFANA_TEST_DB: mysql
+    MYSQL_HOST: mysql
+  image: grafana/build-container:1.4.5
+  name: mysql-integration-tests
+trigger:
+  event:
+  - pull_request
+type: docker
+---
+depends_on: []
+kind: pipeline
 name: build-main
 node:
   type: no-parallel
@@ -419,7 +440,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -435,7 +456,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -880,7 +901,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -896,7 +917,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -1091,6 +1112,12 @@ platform:
 services: []
 steps:
 - commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -1264,7 +1291,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -1280,7 +1307,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -1447,8 +1474,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - test-backend
-  - test-frontend
+  - grabpl
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.4.5
@@ -1457,8 +1483,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - test-backend
-  - test-frontend
+  - grabpl
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.4.5
@@ -1564,6 +1589,12 @@ platform:
   version: "1809"
 services: []
 steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
 - commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
@@ -1827,7 +1858,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -1843,7 +1874,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -2026,6 +2057,12 @@ platform:
 services: []
 steps:
 - commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -2200,7 +2237,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -2216,7 +2253,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -2375,8 +2412,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - test-backend
-  - test-frontend
+  - grabpl
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.4.5
@@ -2385,8 +2421,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - test-backend
-  - test-frontend
+  - grabpl
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.4.5
@@ -2492,6 +2527,12 @@ platform:
   version: "1809"
 services: []
 steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
 - commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
@@ -2760,7 +2801,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -2776,7 +2817,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -2936,6 +2977,12 @@ platform:
   version: "1809"
 services: []
 steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
 - commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
@@ -3105,7 +3152,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -3121,7 +3168,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - initialize
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -3285,8 +3332,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - test-backend
-  - test-frontend
+  - grabpl
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.4.5
@@ -3295,8 +3341,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - test-backend
-  - test-frontend
+  - grabpl
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.4.5
@@ -3402,6 +3447,12 @@ platform:
   version: "1809"
 services: []
 steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.5.5/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
 - commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
@@ -3531,6 +3582,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 0e3e2c1fb43055cd1b7d45dcfa6b5bdf7d90ebdc690aef3cb5b92822a388e688
+hmac: e731dba815e5a79a90813e0c99dde194ca444a3d254df15a6189f59a8263f5de
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -136,7 +136,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
     --variants linux-x64,linux-x64-musl,osx64,win64,armv6 --no-pull-enterprise
   depends_on:
-  - test-backend
+  - initialize
   environment: {}
   image: grafana/build-container:1.4.5
   name: build-backend
@@ -144,7 +144,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -414,7 +414,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
     --no-pull-enterprise
   depends_on:
-  - test-backend
+  - initialize
   environment: {}
   image: grafana/build-container:1.4.5
   name: build-backend
@@ -422,7 +422,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -875,7 +875,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise ${DRONE_TAG}
   depends_on:
-  - test-backend
+  - initialize
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -885,7 +885,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition oss --no-pull-enterprise ${DRONE_TAG}
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -1259,7 +1259,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise ${DRONE_TAG}
   depends_on:
-  - test-backend
+  - initialize
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1269,7 +1269,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition enterprise --no-pull-enterprise ${DRONE_TAG}
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -1333,7 +1333,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise ${DRONE_TAG}
   depends_on:
-  - test-backend-enterprise2
+  - initialize
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1822,7 +1822,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise v7.3.0-test
   depends_on:
-  - test-backend
+  - initialize
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -1832,7 +1832,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition oss --no-pull-enterprise v7.3.0-test
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -2195,7 +2195,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise v7.3.0-test
   depends_on:
-  - test-backend
+  - initialize
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2205,7 +2205,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition enterprise --no-pull-enterprise v7.3.0-test
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -2269,7 +2269,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
     --no-pull-enterprise v7.3.0-test
   depends_on:
-  - test-backend-enterprise2
+  - initialize
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -2755,7 +2755,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
     --no-pull-enterprise
   depends_on:
-  - test-backend
+  - initialize
   environment: {}
   image: grafana/build-container:1.4.5
   name: build-backend
@@ -2763,7 +2763,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -3100,7 +3100,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
     --no-pull-enterprise
   depends_on:
-  - test-backend
+  - initialize
   environment: {}
   image: grafana/build-container:1.4.5
   name: build-backend
@@ -3108,7 +3108,7 @@ steps:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition enterprise --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
-  - test-frontend
+  - initialize
   image: grafana/build-container:1.4.5
   name: build-frontend
 - commands:
@@ -3172,7 +3172,7 @@ steps:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
     --variants linux-x64 --no-pull-enterprise
   depends_on:
-  - test-backend-enterprise2
+  - initialize
   environment: {}
   image: grafana/build-container:1.4.5
   name: build-backend-enterprise2
@@ -3500,6 +3500,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 9f5633098fb9d66f85dd2278290c5886e8863d348bc66f3ebf302c0edb7b5f15
+hmac: 9437ec89add3c810b1e32d0d5c1f32b0e771c4555f6d0bb60d7031f7afd6b5b5
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,13 +85,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -394,13 +394,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -855,13 +855,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -1239,13 +1239,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -1351,13 +1351,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration-enterprise2
 - commands:
@@ -1802,13 +1802,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -2175,13 +2175,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -2287,13 +2287,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration-enterprise2
 - commands:
@@ -2735,13 +2735,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -3080,13 +3080,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration
 - commands:
@@ -3190,13 +3190,13 @@ steps:
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
-  - lint-backend
+  - initialize
   image: grafana/build-container:1.4.5
   name: test-backend-integration-enterprise2
 - commands:
@@ -3531,6 +3531,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: e6086427a556519668fd021b26de88a44597486e05ea57ccf9d3c6291dbbe64f
+hmac: 8dc023cfdfedfbef48a3cfbaa7f80a502de2c9abf684e07c3ea726525707c993
 
 ...

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -108,10 +108,10 @@ def pr_pipelines(edition):
     }
     return [
         pipeline(
-            name='test-pr', edition=edition, trigger=trigger, services=services, steps=test_steps,
+            name='pr-test', edition=edition, trigger=trigger, services=services, steps=test_steps,
             ver_mode=ver_mode,
         ), pipeline(
-            name='build-pr', edition=edition, trigger=trigger, services=[], steps=build_steps,
+            name='pr-build-e2e', edition=edition, trigger=trigger, services=[], steps=build_steps,
             ver_mode=ver_mode,
         ),
     ]

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -389,7 +389,7 @@ def test_backend_step(edition):
         'name': 'test-backend' + enterprise2_suffix(edition),
         'image': build_image,
         'depends_on': [
-            'lint-backend',
+            'initialize',
         ],
         'commands': [
             './bin/grabpl test-backend --edition {}'.format(edition),
@@ -401,7 +401,7 @@ def test_backend_integration_step(edition):
         'name': 'test-backend-integration' + enterprise2_suffix(edition),
         'image': build_image,
         'depends_on': [
-            'lint-backend',
+            'initialize',
         ],
         'commands': [
             './bin/grabpl integration-tests --edition {}'.format(edition),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -312,7 +312,7 @@ def build_backend_step(edition, ver_mode, variants=None, is_downstream=False):
         'name': 'build-backend' + enterprise2_suffix(edition),
         'image': build_image,
         'depends_on': [
-            'test-backend' + enterprise2_suffix(edition),
+            'initialize',
         ],
         'environment': env,
         'commands': cmds,
@@ -345,7 +345,7 @@ def build_frontend_step(edition, ver_mode, is_downstream=False):
         'name': 'build-frontend',
         'image': build_image,
         'depends_on': [
-            'test-frontend',
+            'initialize',
         ],
         'commands': cmds,
     }

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -124,7 +124,7 @@ def initialize_step(edition, platform, ver_mode, is_downstream=False, install_de
 
     return steps
 
-def download_grabpl():
+def download_grabpl_step():
     return {
         'name': 'grabpl',
         'image': curl_image,
@@ -688,7 +688,7 @@ def postgres_integration_tests_step():
         'name': 'postgres-integration-tests',
         'image': build_image,
         'depends_on': [
-            'initialize',
+            'grabpl',
         ],
         'environment': {
             'PGPASSWORD': 'grafanatest',
@@ -712,7 +712,7 @@ def mysql_integration_tests_step():
         'name': 'mysql-integration-tests',
         'image': build_image,
         'depends_on': [
-            'initialize',
+            'grabpl',
         ],
         'environment': {
             'GRAFANA_TEST_DB': 'mysql',
@@ -734,8 +734,7 @@ def redis_integration_tests_step():
         'name': 'redis-integration-tests',
         'image': build_image,
         'depends_on': [
-            'test-backend',
-            'test-frontend',
+            'grabpl',
         ],
         'environment': {
             'REDIS_URL': 'redis://redis:6379/0',
@@ -751,8 +750,7 @@ def memcached_integration_tests_step():
         'name': 'memcached-integration-tests',
         'image': build_image,
         'depends_on': [
-            'test-backend',
-            'test-frontend',
+            'grabpl',
         ],
         'environment': {
             'MEMCACHED_HOSTS': 'memcached:11211',
@@ -939,7 +937,7 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
         else:
             committish = '$$env:DRONE_COMMIT'
         # For enterprise, we have to clone both OSS and enterprise and merge the latter into the former
-        download_grabpl_cmds = [
+        download_grabpl_step_cmds = [
             '$$ProgressPreference = "SilentlyContinue"',
             'Invoke-WebRequest https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v{}/windows/grabpl.exe -OutFile grabpl.exe'.format(grabpl_version),
         ]
@@ -957,7 +955,7 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
             'environment': {
                 'GITHUB_TOKEN': from_secret(github_token),
             },
-            'commands': download_grabpl_cmds + clone_cmds,
+            'commands': download_grabpl_step_cmds + clone_cmds,
         })
         steps[1]['depends_on'] = [
             'clone',

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -375,7 +375,7 @@ def build_plugins_step(edition, sign=False):
         'name': 'build-plugins',
         'image': build_image,
         'depends_on': [
-            'lint-backend',
+            'initialize',
         ],
         'environment': env,
         'commands': [

--- a/scripts/drone/utils/utils.star
+++ b/scripts/drone/utils/utils.star
@@ -1,18 +1,16 @@
 load(
     'scripts/drone/steps/lib.star',
-    'initialize_step',
-    'download_grabpl',
+    'download_grabpl_step',
     'slack_step',
 )
 
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token')
 
 def pipeline(
-    name, edition, trigger, steps, ver_mode, services=[], platform='linux', depends_on=[],
-    is_downstream=False, install_deps=True,
+    name, edition, trigger, steps, services=[], platform='linux', depends_on=[],
     ):
     if platform != 'windows':
-        grabpl_step = [download_grabpl()]
+        grabpl_step = [download_grabpl_step()]
         platform_conf = {
             'platform': {
                 'os': 'linux',
@@ -40,9 +38,7 @@ def pipeline(
         'name': name,
         'trigger': trigger,
         'services': services,
-        'steps': grabpl_step + initialize_step(
-            edition, platform, is_downstream=is_downstream, install_deps=install_deps, ver_mode=ver_mode,
-        ) + steps,
+        'steps': steps,
         'depends_on': depends_on,
     }
     pipeline.update(platform_conf)

--- a/scripts/drone/utils/utils.star
+++ b/scripts/drone/utils/utils.star
@@ -10,7 +10,6 @@ def pipeline(
     name, edition, trigger, steps, services=[], platform='linux', depends_on=[],
     ):
     if platform != 'windows':
-        grabpl_step = [download_grabpl_step()]
         platform_conf = {
             'platform': {
                 'os': 'linux',
@@ -23,7 +22,6 @@ def pipeline(
             }
         }
     else:
-        grabpl_step = []
         platform_conf = {
             'platform': {
                 'os': 'windows',


### PR DESCRIPTION
**What this PR does / why we need it**:

Breaks down the monolith pipeline to 3 different autonomous ones:

* `pr-test`
* `pr-build-e2e`
* `pr-integration-tests`

Those three pipelines will run independently. The second pipeline (`pr-build-e2e`) is responsible for both building and running end-to-end tests, but that is a subject to change, once we split packaging from building as well. We don't expect huge build time improvements, but will definitely help us identify and understand what we need to restructure.

PR on top of this one https://github.com/grafana/grafana/pull/41730