### PR TITLE
Explore: Fix running queries without a datasource property set

### DIFF
--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -239,7 +239,7 @@ describe('hasNonEmptyQuery', () => {
   });
 
   test('should return false if query is empty', () => {
-    expect(hasNonEmptyQuery([{ refId: '1', key: '2', context: 'panel' }])).toBeFalsy();
+    expect(hasNonEmptyQuery([{ refId: '1', key: '2', context: 'panel', datasource: 'some-ds' }])).toBeFalsy();
   });
 
   test('should return false if no queries exist', () => {

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -277,9 +277,12 @@ export function ensureQueries(queries?: DataQuery[]): DataQuery[] {
 }
 
 /**
- * A target is non-empty when it has keys (with non-empty values) other than refId, key and context.
+ * A target is non-empty when it has keys (with non-empty values) other than refId, key, context and datasource.
+ * FIXME: While this is reasonable for practical use cases, a query without any propery might still be "non-empty"
+ * in its own scope, for instance when there's no user input needed. This might be the case for an hypothetic datasource in
+ * which query options are only set in its config and the query object itself, as generated from its query editor it's always "empty"
  */
-const validKeys = ['refId', 'key', 'context'];
+const validKeys = ['refId', 'key', 'context', 'datasource'];
 export function hasNonEmptyQuery<TQuery extends DataQuery>(queries: TQuery[]): boolean {
   return (
     queries &&

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -326,7 +326,6 @@ export const runQueries = (
     const exploreItemState = getState().explore[exploreId]!;
     const {
       datasourceInstance,
-      queries,
       containerWidth,
       isLive: live,
       range,
@@ -340,6 +339,11 @@ export const runQueries = (
       logsVolumeDataProvider,
     } = exploreItemState;
     let newQuerySub;
+
+    const queries = exploreItemState.queries.map((query) => ({
+      ...query,
+      datasource: query.datasource || datasourceInstance?.name,
+    }));
 
     const cachedValue = getResultsFromCache(cache, absoluteRange);
 


### PR DESCRIPTION
When navigating to explore from a dashboard created by grafana prior to https://github.com/grafana/grafana/pull/40239 and adding a new query from within explore, running the query may result in an error saying `All queries must use the same datasource`.
This is because prior https://github.com/grafana/grafana/pull/40239 the query editor row component was not setting the `datasource` property, while now it does. When queries run through the backend (for backend datasources) we check that every given query has the same `datasource` property, what happens in this situation is that we send 2 queries: the first one may be without `datasource` while the second has it.
This PR loosely relates to https://github.com/grafana/grafana/pull/40784 which makes this check less strict on the backend but fixes Explore so that such property is always inserted in the queries.


## Some considerations:

We cannot rely on the value of `datasource` in query because:
* Is not guaranteed to be set for queries created in older grafana dashboards
* patching `getExploreUrl`  to always set it might not work because:
	* users can have shortened urls from older Grafana versions, these links should work also after an upgrade
* some datasources set it to their own name during variable interpolations, (ie. prometheus, Elasticsearch, graphite) others do not (ie. CloudWatch)
*  `datasource`  might get removed if `interpolateVariablesInQuery` decides to do so (it should be considered as a bug in the given datasource, we shouldn’t act)

## Solution
Given we cannot rely on `datasource` on queries being set, we must not expect, when not in Mixed mode, for queries to have that property.

When running queries via Explore, before running them we fill the `datasource` property with the currently selected datasource name if the query doesn’t have a datasource selected, this is the same behaviour as dashboards: [grafana/PanelQueryRunner.ts at d62ca1283c6bd27a9576734e5bde2d88bfd05173 · grafana/grafana · GitHub](https://github.com/grafana/grafana/blob/d62ca1283c6bd27a9576734e5bde2d88bfd05173/public/app/features/query/state/PanelQueryRunner.ts#L224)
```typescript
request.targets = request.targets.map((query) => {
  if (!query.datasource) {
    query.datasource = ds.name;
  }
  return query;
});
```

## Future considerations when implementing mixed mode
When using Mixed Datasource will rely on  `datasource` on queries being set, as mixed mode works by setting that property in each query. If during variable interpolation process some of the queries remove that property or for whatever reason `datasource` is not defined, we do nothing (or better, we still fill in the datasource, as described in the previous section, this is consistent with dashboards). MixedDatasource will be responsible of running such queries, therefore dashboards and explore will have the same behaviour which, at the time of this being written, is to ignore those queries:[grafana/MixedDataSource.ts at bad048b7ba1fecd28e76509c545a67fc8b70fdeb · grafana/grafana · GitHub](https://github.com/grafana/grafana/blob/bad048b7ba1fecd28e76509c545a67fc8b70fdeb/public/app/plugins/datasource/mixed/MixedDataSource.ts#L29-L31)
```typescript
const queries = request.targets.filter((t) => {
  return t.datasource !== MIXED_DATASOURCE_NAME;
});
```