### PR TITLE
PluginsCatalog: detect latest compatible plugin version with current version of grafana

### DIFF
--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -14,6 +14,7 @@ import {
   RemotePluginJson,
 } from './types';
 
+// TODO<get rid of this logic once https://github.com/grafana/grafana-com/pull/3336 is merged>
 const getGrafanaDependency = (json?: RemotePluginJson) => {
   const dependencies = json?.dependencies;
 

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -91,7 +91,11 @@ async function getPluginVersions(id: string): Promise<Version[]> {
       `${GRAFANA_API_ROOT}/plugins/${id}/versions`
     );
 
-    return (versions.items || []).map(({ version, createdAt }) => ({ version, createdAt }));
+    return (versions.items || []).map((pluginVersion) => ({
+      version: pluginVersion.version,
+      createdAt: pluginVersion.createdAt,
+      grafanaDependency: pluginVersion.json?.dependencies?.grafanaDependency,
+    }));
   } catch (error) {
     // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
     error.isHandled = true;

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -1,28 +1,30 @@
-import React, { useState } from 'react';
+import React, { useState, ReactElement } from 'react';
 import { AppEvents } from '@grafana/data';
 import { Button, HorizontalGroup, ConfirmModal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 
-import { CatalogPlugin, PluginStatus } from '../../types';
+import { CatalogPlugin, PluginStatus, Version } from '../../types';
 import { useInstallStatus, useUninstallStatus, useInstall, useUninstall } from '../../state/hooks';
+import { InstallVersionButton } from './InstallVersionButton';
 
 type InstallControlsButtonProps = {
   plugin: CatalogPlugin;
   pluginStatus: PluginStatus;
 };
 
-export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsButtonProps) {
+export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsButtonProps): ReactElement {
   const { isInstalling, error: errorInstalling } = useInstallStatus();
   const { isUninstalling, error: errorUninstalling } = useUninstallStatus();
   const install = useInstall();
   const uninstall = useUninstall();
   const [isConfirmModalVisible, setIsConfirmModalVisible] = useState(false);
+  const [versionToInstall, setVersionToInstall] = useState(defaultVersionToInstall(plugin, pluginStatus));
   const showConfirmModal = () => setIsConfirmModalVisible(true);
   const hideConfirmModal = () => setIsConfirmModalVisible(false);
   const uninstallBtnText = isUninstalling ? 'Uninstalling' : 'Uninstall';
 
-  const onInstall = async () => {
-    await install(plugin.id, plugin.version);
+  const onInstall = async (version: Version) => {
+    await install(plugin.id, version.version);
     if (!errorInstalling) {
       appEvents.emit(AppEvents.alertSuccess, [`Installed ${plugin.name}`]);
     }
@@ -36,8 +38,8 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
     }
   };
 
-  const onUpdate = async () => {
-    await install(plugin.id, plugin.version, true);
+  const onUpdate = async (version: Version) => {
+    await install(plugin.id, version.version, true);
     if (!errorInstalling) {
       appEvents.emit(AppEvents.alertSuccess, [`Updated ${plugin.name}`]);
     }
@@ -67,9 +69,15 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
   if (pluginStatus === PluginStatus.UPDATE) {
     return (
       <HorizontalGroup height="auto">
-        <Button disabled={isInstalling} onClick={onUpdate}>
-          {isInstalling ? 'Updating' : 'Update'}
-        </Button>
+        <InstallVersionButton
+          version={versionToInstall}
+          versions={plugin.details?.versions ?? []}
+          disabled={isInstalling}
+          onInstall={onUpdate}
+          onChange={setVersionToInstall}
+        >
+          {isInstalling ? 'Updating' : `Update to v${versionToInstall.version}`}
+        </InstallVersionButton>
         <Button variant="destructive" disabled={isUninstalling} onClick={onUninstall}>
           {uninstallBtnText}
         </Button>
@@ -78,8 +86,41 @@ export function InstallControlsButton({ plugin, pluginStatus }: InstallControlsB
   }
 
   return (
-    <Button disabled={isInstalling} onClick={onInstall}>
-      {isInstalling ? 'Installing' : 'Install'}
-    </Button>
+    <InstallVersionButton
+      version={versionToInstall}
+      versions={plugin.details?.versions ?? []}
+      disabled={isInstalling}
+      onInstall={onInstall}
+      onChange={setVersionToInstall}
+    >
+      {isInstalling ? 'Installing' : `Install v${versionToInstall.version}`}
+    </InstallVersionButton>
   );
+}
+
+function defaultVersionToInstall(plugin: CatalogPlugin, pluginStatus: PluginStatus): Version {
+  const defaultVersion: Version = {
+    version: plugin.version,
+    createdAt: plugin.updatedAt,
+  };
+
+  if (pluginStatus === PluginStatus.UPDATE) {
+    return recommendedVersionToUpdateTo(plugin) ?? defaultVersion;
+  }
+
+  if (pluginStatus === PluginStatus.INSTALL) {
+    return recommendedVersionToInstall(plugin) ?? defaultVersion;
+  }
+
+  return defaultVersion;
+}
+
+function recommendedVersionToInstall(plugin: CatalogPlugin): Version | undefined {
+  const versions = plugin.details?.versions ?? [];
+  return versions.find((v) => v.version === plugin.version);
+}
+
+function recommendedVersionToUpdateTo(plugin: CatalogPlugin): Version | undefined {
+  const versions = plugin.details?.versions ?? [];
+  return versions[0];
 }

--- a/public/app/features/plugins/admin/components/InstallControls/InstallVersionButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallVersionButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { Badge, Button, ButtonGroup, ClickOutsideWrapper, Menu, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { PropsWithChildren } from 'react-router/node_modules/@types/react';
@@ -40,7 +40,9 @@ export function InstallVersionButton(props: PropsWithChildren<Props>): ReactElem
               {versions.map((v, i) => (
                 <div
                   key={v.version}
-                  className={styles.menuItem}
+                  className={cx(styles.menuItem, {
+                    [styles.activeItem]: v.version === version.version,
+                  })}
                   onClick={() => {
                     onChange(v);
                     setIsOpen(false);

--- a/public/app/features/plugins/admin/components/InstallControls/InstallVersionButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallVersionButton.tsx
@@ -1,0 +1,102 @@
+import React, { ReactElement, useState } from 'react';
+import { css } from '@emotion/css';
+import { Badge, Button, ButtonGroup, ClickOutsideWrapper, Menu, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { PropsWithChildren } from 'react-router/node_modules/@types/react';
+import { Version } from '../../types';
+
+type Props = {
+  disabled?: boolean;
+  version: Version;
+  versions: Version[];
+  onInstall: (version: Version) => void;
+  onChange: (version: Version) => void;
+};
+
+export function InstallVersionButton(props: PropsWithChildren<Props>): ReactElement {
+  const { version, versions, onInstall, onChange, children, disabled } = props;
+  const styles = useStyles2(getStyles);
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className={styles.container}>
+      <ButtonGroup>
+        <Button disabled={disabled} onClick={() => onInstall(version)}>
+          {children}
+        </Button>
+        <Button
+          disabled={disabled}
+          icon={isOpen ? 'angle-up' : 'angle-down'}
+          onClick={(event) => {
+            setIsOpen(!isOpen);
+            event.stopPropagation();
+          }}
+        />
+      </ButtonGroup>
+      {isOpen && (
+        <div className={styles.menu}>
+          <ClickOutsideWrapper onClick={() => setIsOpen(false)}>
+            <Menu>
+              {versions.map((v, i) => (
+                <div
+                  key={v.version}
+                  className={styles.menuItem}
+                  onClick={() => {
+                    onChange(v);
+                    setIsOpen(false);
+                  }}
+                >
+                  <span>v{v.version}</span>{' '}
+                  {i === 0 && (
+                    <div className={styles.badge}>
+                      <Badge text="Latest" color="blue" />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </Menu>
+          </ClickOutsideWrapper>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css`
+      position: relative;
+    `,
+    menu: css`
+      position: absolute;
+      z-index: ${theme.zIndex.dropdown};
+      top: ${theme.spacing(4)};
+      right: 0;
+    `,
+    menuItem: css`
+      background: none;
+      cursor: pointer;
+      white-space: nowrap;
+      color: ${theme.colors.text.primary};
+      display: flex;
+      padding: 5px 12px 5px 10px;
+      margin: 0;
+      border: none;
+      width: 100%;
+
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        background: ${theme.colors.action.hover};
+        color: ${theme.colors.text.primary};
+        text-decoration: none;
+      }
+    `,
+    activeItem: css`
+      background: ${theme.colors.action.selected};
+    `,
+    badge: css`
+      margin-left: ${theme.spacing(2)};
+    `,
+  };
+};

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -75,6 +75,16 @@ export interface CatalogPluginInfo {
   };
 }
 
+export type RemotePluginJson = {
+  dependencies: PluginDependencies;
+  info: {
+    links: Array<{
+      name: string;
+      url: string;
+    }>;
+  };
+};
+
 export type RemotePlugin = {
   createdAt: string;
   description: string;
@@ -83,15 +93,7 @@ export type RemotePlugin = {
   featured: number;
   id: number;
   internal: boolean;
-  json?: {
-    dependencies: PluginDependencies;
-    info: {
-      links: Array<{
-        name: string;
-        url: string;
-      }>;
-    };
-  };
+  json?: RemotePluginJson;
   links: Array<{ rel: string; href: string }>;
   name: string;
   orgId: number;
@@ -171,6 +173,7 @@ export interface Build {
 export interface Version {
   version: string;
   createdAt: string;
+  grafanaDependency?: string;
 }
 
 export interface PluginDetails {
@@ -268,5 +271,6 @@ export type PluginVersion = {
   verified: boolean;
   status: string;
   downloadSlug: string;
+  json?: RemotePluginJson;
   links: Array<{ rel: string; href: string }>;
 };

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -123,6 +123,8 @@ export type RemotePlugin = {
   versionSignedByOrg: string;
   versionSignedByOrgName: string;
   versionStatus: string;
+  // TODO<mark this as required once https://github.com/grafana/grafana-com/pull/3336 is merged>
+  grafanaDependency?: string;
 };
 
 export type LocalPlugin = {
@@ -273,4 +275,6 @@ export type PluginVersion = {
   downloadSlug: string;
   json?: RemotePluginJson;
   links: Array<{ rel: string; href: string }>;
+  // TODO<mark this as required once https://github.com/grafana/grafana-com/pull/3336 is merged>
+  grafanaDependency?: string;
 };


### PR DESCRIPTION
### What this PR does / why we need it:
To give the user the same possibilities of installing plugins via the catalog as they have when installing plugins via the CLI we would like to add a way of selecting a specific version of the plugin like to install.

By default we should suggest to install the latest compatible version based on the `grafanaDependency` in the `plugin.json` but this should be possible to override.
 
**Todo:**
- [ ] Extend the information to the gcom version api (https://github.com/grafana/grafana-com/pull/3336) to include the compatibility flag.
- [ ] Create a script that will migrate plugins that are missing the `grafanaDependency` in gcom.
- [x] Support scenario where we don't have any grafanaDependecy infromation specified in the plugin.
- [x] Jump on a call (BE + FE) and try to figure out and [document](https://docs.google.com/document/d/1MqLFLRn5iHGIvfXXDvszzB0FuXJNFo9Vqq7hBGaYIHU/) how the current API in gcom works with regards to the plugin version and grafana version.
- [x] Reach out to UX and ask for help on how to get this in place in the UI.
- [ ] Update the typescript types in plugins catalog to  include the grafana dependency.
- [ ] Add "warning" if user tries to install a version that we can't detect is compatible with the current grafana version.
- [x] Add possibility to select version to install/update in plugins catalog.
- [ ] Add tests to verify that this works as expected.

### Which issue(s) this PR fixes:
Fixes #37934

### Special notes for your reviewer:

