### PR TITLE
Chore: Use DispatchCtx in some missed places

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -659,7 +659,7 @@ func (hs *HTTPServer) RestoreDashboardVersion(c *models.ReqContext, apiCmd dtos.
 
 func GetDashboardTags(c *models.ReqContext) {
 	query := models.GetDashboardTagsQuery{OrgId: c.OrgId}
-	err := bus.Dispatch(&query)
+	err := bus.DispatchCtx(c.Req.Context(), &query)
 	if err != nil {
 		c.JsonApiErr(500, "Failed to get tags from database", err)
 		return

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -127,7 +127,7 @@ func (srv *CleanUpService) shouldCleanupTempFile(filemtime time.Time, now time.T
 
 func (srv *CleanUpService) deleteExpiredSnapshots() {
 	cmd := models.DeleteExpiredSnapshotsCommand{}
-	if err := bus.Dispatch(&cmd); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &cmd); err != nil {
 		srv.log.Error("Failed to delete expired snapshots", "error", err.Error())
 	} else {
 		srv.log.Debug("Deleted expired snapshots", "rows affected", cmd.DeletedRows)

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"sort"
 
 	"github.com/grafana/grafana/pkg/setting"
@@ -83,7 +84,7 @@ func (s *SearchService) searchHandler(query *Query) error {
 		dashboardQuery.Sort = sortOpt
 	}
 
-	if err := bus.Dispatch(&dashboardQuery); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &dashboardQuery); err != nil {
 		return err
 	}
 
@@ -119,7 +120,7 @@ func setStarredDashboards(userID int64, hits []*Hit) error {
 		UserId: userID,
 	}
 
-	if err := bus.Dispatch(&query); err != nil {
+	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I noticed some places weren't dispatching messages with contexts where it was expected.

For example:

```
WARN[10-21|09:33:54] Dispatch called with message handler registered using AddHandlerCtx and should be changed to use DispatchCtx logger=bus msgName=FindPersistedDashboardsQuery
WARN[10-21|09:33:54] Dispatch called with message handler registered using AddHandlerCtx and should be changed to use DispatchCtx logger=bus msgName=GetUserStarsQuery
WARN[10-21|09:33:55] Dispatch called with message handler registered using AddHandlerCtx and should be changed to use DispatchCtx logger=bus msgName=GetDashboardTagsQuery
WARN[10-21|09:37:51] Dispatch called with message handler registered using AddHandlerCtx and should be changed to use DispatchCtx logger=bus msgName=DeleteExpiredSnapshotsCommand
```