### PR TITLE
Angular: only bootstrap the root application element

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -89,7 +89,7 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
     navigationLogger('AppWrapper', false, 'rendering');
 
     // @ts-ignore
-    const appSeed = `<grafana-app ng-cloak></app-notifications-list><div id="ngRoot"></div></grafana-app>`;
+    const appSeed = `<grafana-app ng-cloak></app-notifications-list></grafana-app>`;
 
     return (
       <Provider store={store}>
@@ -105,12 +105,15 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
                       {pageBanners.map((Banner, index) => (
                         <Banner key={index.toString()} />
                       ))}
+
                       <div
+                        id="ngRoot"
                         ref={this.container}
                         dangerouslySetInnerHTML={{
                           __html: appSeed,
                         }}
                       />
+
                       <AppNotificationList />
                       <SearchWrapper />
                       {this.state.ngInjector && this.container && this.renderRoutes()}

--- a/public/app/angular/AngularApp.ts
+++ b/public/app/angular/AngularApp.ts
@@ -104,7 +104,7 @@ export class AngularApp {
   }
 
   bootstrap() {
-    const injector = angular.bootstrap(document, this.ngModuleDependencies);
+    const injector = angular.bootstrap(document.getElementById('ngRoot')!, this.ngModuleDependencies);
 
     monkeyPatchInjectorWithPreAssignedBindings(injector);
 

--- a/public/app/plugins/panel/graph/jquery.flot.events.ts
+++ b/public/app/plugins/panel/graph/jquery.flot.events.ts
@@ -1,13 +1,13 @@
-import angular from 'angular';
 import $ from 'jquery';
 import { partition, each } from 'lodash';
 //@ts-ignore
 import Drop from 'tether-drop';
 import { CreatePlotOverlay } from '@grafana/data';
+import { getLegacyAngularInjector } from '@grafana/runtime';
 
 /** @ngInject */
 const createAnnotationToolip: CreatePlotOverlay = (element, event, plot) => {
-  const injector = angular.element(document).injector();
+  const injector = getLegacyAngularInjector();
   const content = document.createElement('div');
   content.innerHTML = '<annotation-tooltip event="event" on-edit="onEdit()"></annotation-tooltip>';
 
@@ -68,7 +68,7 @@ const createEditPopover: CreatePlotOverlay = (element, event, plot) => {
 
   // wait for element to be attached and positioned
   setTimeout(() => {
-    const injector = angular.element(document).injector();
+    const injector = getLegacyAngularInjector();
     const content = document.createElement('div');
     content.innerHTML = '<event-editor panel-ctrl="panelCtrl" event="event" close="close()"></event-editor>';
 


### PR DESCRIPTION
This changes the DOM element to which Angular app is being bootstrapped to. Angular has plenty of [built-in directives](https://github.com/angular/angular.js/blob/9bff2ce8fb170d7a33d3ad551922d7e23e9f82fc/src/AngularPublic.js#L179) that gets unnecessarily compiled against non-angular code.

This small change may have unpredictable consequences that I may be not seeing. Please help with testing the app in multiple scenarios:
- [x] Enterprise @Clarity-89 
- [ ] ng based plugins (apps, datasources, panels) cc @grafana/plugins-platform 
- [x] Core flows  cc @grafana/user-essentials, @grafana/observability-squad, @grafana/grafana-bi-squad