### PR TITLE
Alerting: Fixes unified alerting alert manager SQL syntax errors

### DIFF
--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package kvstore
 
 import (

--- a/pkg/infra/kvstore/sql.go
+++ b/pkg/infra/kvstore/sql.go
@@ -88,7 +88,7 @@ func (kv *kvStoreSQL) Set(ctx context.Context, orgId int64, namespace string, ke
 // Del deletes an item from the store.
 func (kv *kvStoreSQL) Del(ctx context.Context, orgId int64, namespace string, key string) error {
 	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
-		_, err := dbSession.Exec("DELETE FROM kv_store WHERE org_id=? and namespace=? and key=?", orgId, namespace, key)
+		_, err := dbSession.Exec("DELETE FROM kv_store WHERE org_id=? and namespace=? and \"key\"=?", orgId, namespace, key)
 		return err
 	})
 	return err

--- a/pkg/infra/kvstore/sql.go
+++ b/pkg/infra/kvstore/sql.go
@@ -2,6 +2,7 @@ package kvstore
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -88,7 +89,8 @@ func (kv *kvStoreSQL) Set(ctx context.Context, orgId int64, namespace string, ke
 // Del deletes an item from the store.
 func (kv *kvStoreSQL) Del(ctx context.Context, orgId int64, namespace string, key string) error {
 	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
-		_, err := dbSession.Exec("DELETE FROM kv_store WHERE org_id=? and namespace=? and \"key\"=?", orgId, namespace, key)
+		query := fmt.Sprintf("DELETE FROM kv_store WHERE org_id=? and namespace=? and %s=?", kv.sqlStore.Quote("key"))
+		_, err := dbSession.Exec(query, orgId, namespace, key)
 		return err
 	})
 	return err
@@ -99,7 +101,7 @@ func (kv *kvStoreSQL) Del(ctx context.Context, orgId int64, namespace string, ke
 func (kv *kvStoreSQL) Keys(ctx context.Context, orgId int64, namespace string, keyPrefix string) ([]Key, error) {
 	var keys []Key
 	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
-		query := dbSession.Where("namespace = ?", namespace).And("\"key\" LIKE ?", keyPrefix+"%")
+		query := dbSession.Where("namespace = ?", namespace).And(fmt.Sprintf("%s LIKE ?", kv.sqlStore.Quote("key")), keyPrefix+"%")
 		if orgId != AllOrganizations {
 			query.And("org_id = ?", orgId)
 		}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -161,6 +161,11 @@ func (ss *SQLStore) Reset() error {
 	return ss.ensureMainOrgAndAdminUser()
 }
 
+// Quote quotes the value in the used SQL dialect
+func (ss *SQLStore) Quote(value string) string {
+	return ss.engine.Quote(value)
+}
+
 func (ss *SQLStore) ensureMainOrgAndAdminUser() error {
 	ctx := context.Background()
 	err := ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

We need to properly escape the columnname "key" as it is a reserved keyword in MariaDB and MySQL. The first patch that we introduced (#40788) unfortunately didn't fixed the problem. Using double quotes results in MariaDB and MySQL comparing the string literal.

Example:
```sql
MariaDB [(none)]> select 'abc123' AS xyz WHERE "xyz" LIKE "abc%";
Empty set (0.001 sec)

MariaDB [(none)]> select 'abc123' AS xyz WHERE "xyz" LIKE "xyz%";
+--------+
| xyz    |
+--------+
| abc123 |
+--------+
1 row in set (0.001 sec)
```

This PR introduces a new `Quote` method  on the `SQLStore` struct that we pass through from the engine used by xorm that will escape any value using the specific quotes for the used SQL dialect. 

I also flagged the kvstore test as part of the integration suite to make sure to always test against both supported Databases.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40833

**Special notes for your reviewer**:

