### PR TITLE
InfluxDB: InfluxQL: handle infinite values when generating query

### DIFF
--- a/public/app/plugins/datasource/influxdb/query_builder.ts
+++ b/public/app/plugins/datasource/influxdb/query_builder.ts
@@ -18,8 +18,8 @@ function renderTagCondition(tag: { operator: any; value: string; condition: any;
     }
   }
 
-  // quote value unless regex or number, or if empty-string
-  if (value === '' || (operator !== '=~' && operator !== '!~' && isNaN(+value))) {
+  // quote value unless regex or finite number, or if empty-string
+  if (value === '' || (operator !== '=~' && operator !== '!~' && !isFinite(+value))) {
     value = "'" + value.replace(/\\/g, '\\\\').replace(/\'/g, "\\'") + "'";
   }
 

--- a/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/query_builder.test.ts
@@ -169,13 +169,31 @@ describe('InfluxQueryBuilder', () => {
       expect(query).toBe(`SHOW MEASUREMENTS WHERE "app" == 42 LIMIT 100`);
     });
 
-    it('should handle tag-value=number-ish getting tag-keys', () => {
+    it('should handle tag-value=finite-number-ish getting tag-keys', () => {
       const builder = new InfluxQueryBuilder(
         { measurement: undefined, tags: [{ key: 'app', value: '42', operator: '==' }] },
         undefined
       );
       const query = builder.buildExploreQuery('TAG_KEYS');
       expect(query).toBe(`SHOW TAG KEYS WHERE "app" == 42`);
+    });
+
+    it('should handle tag-value=positive-infinite-number-ish getting tag-keys', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: '1e1000', operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe(`SHOW TAG KEYS WHERE "app" == '1e1000'`);
+    });
+
+    it('should handle tag-value=negative-infinite-number-ish getting tag-keys', () => {
+      const builder = new InfluxQueryBuilder(
+        { measurement: undefined, tags: [{ key: 'app', value: '-1e1000', operator: '==' }] },
+        undefined
+      );
+      const query = builder.buildExploreQuery('TAG_KEYS');
+      expect(query).toBe(`SHOW TAG KEYS WHERE "app" == '-1e1000'`);
     });
 
     it('should handle tag-value-contains-backslash-character getting tag-keys', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the InfluxQL query generation to handle infinite numbers. Because InfluxDB does not support infinities - see [InfluxDB documentation](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_reference/#data-types).