### PR TITLE
Docs: Fix minor grammatical errors in alerting docs

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -31,13 +31,13 @@ This section describes the fields you fill out to create an alert.
 
 ### Query
 
-Add one or more [queries]({{< relref "../../../panels/queries.md" >}}) or [expressions]({{< relref "../../../panels/expressions.md" >}}). You can use classic condition expression to create a rule that will trigger a single alert if it's threshold is met, or use reduce and math expressions to create a multi dimensional alert rule that can trigger multiple alerts, one per matching series in the query result.
+Add one or more [queries]({{< relref "../../../panels/queries.md" >}}) or [expressions]({{< relref "../../../panels/expressions.md" >}}). You can use classic condition expression to create a rule that will trigger a single alert if its threshold is met, or use reduce and math expressions to create a multi dimensional alert rule that can trigger multiple alerts, one per matching series in the query result.
 
 > **Note:** Grafana does not support alert queries with template variables. More information is available at <https://community.grafana.com/t/template-variables-are-not-supported-in-alert-queries-while-setting-up-alert/2514>.
 
 #### Rule with classic condition
 
-You can use classic condition expression to create a rule that will trigger a single alert if it's conditions is met. It works about the same way as dashboard alerts in previous versions of Grafana.
+You can use classic condition expression to create a rule that will trigger a single alert if its conditions are met. It works about the same way as dashboard alerts in previous versions of Grafana.
 
 1. Add one or more queries
 1. Add an expression. Click on **Operation** dropdown and select **Classic condition**.


### PR DESCRIPTION
While reading through the alerting-rules docs for the unified alerting
feature, I noticed two places where the possessive "its" was misspelled
"it's".  Also, there was a verb which should have been plural to match the
number of the sentence's subject; this is also fixed here.

**What this PR does / why we need it**:

It fixes some minor grammatical errors I noticed while reading the documentation online (see commit message). The PR is submitted in the hope that it is useful; if you wish for any changes to it I'm more than happy to update it as appropriate and resubmit.