### PR TITLE
Chore: Refactor GoConvey tests in alerting/conditions

### DIFF
--- a/pkg/services/alerting/conditions/evaluator_test.go
+++ b/pkg/services/alerting/conditions/evaluator_test.go
@@ -10,10 +10,10 @@ import (
 
 func evaluatorScenario(t *testing.T, json string, reducedValue float64, datapoints ...float64) bool {
 	jsonModel, err := simplejson.NewJson([]byte(json))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	evaluator, err := NewAlertEvaluator(jsonModel)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	return evaluator.Eval(null.FloatFrom(reducedValue))
 }

--- a/pkg/services/alerting/conditions/evaluator_test.go
+++ b/pkg/services/alerting/conditions/evaluator_test.go
@@ -50,10 +50,10 @@ func TestEvaluators(t *testing.T) {
 
 		t.Run("should be true when the series have no value", func(t *testing.T) {
 			jsonModel, err := simplejson.NewJson([]byte(`{"type": "no_value", "params": [] }`))
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			evaluator, err := NewAlertEvaluator(jsonModel)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			require.True(t, evaluator.Eval(null.FloatFromPtr(nil)))
 		})

--- a/pkg/services/alerting/conditions/evaluator_test.go
+++ b/pkg/services/alerting/conditions/evaluator_test.go
@@ -3,60 +3,59 @@ package conditions
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
-
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/stretchr/testify/require"
 )
 
-func evaluatorScenario(json string, reducedValue float64, datapoints ...float64) bool {
+func evaluatorScenario(t *testing.T, json string, reducedValue float64, datapoints ...float64) bool {
 	jsonModel, err := simplejson.NewJson([]byte(json))
-	So(err, ShouldBeNil)
+	require.Nil(t, err)
 
 	evaluator, err := NewAlertEvaluator(jsonModel)
-	So(err, ShouldBeNil)
+	require.Nil(t, err)
 
 	return evaluator.Eval(null.FloatFrom(reducedValue))
 }
 
 func TestEvaluators(t *testing.T) {
-	Convey("greater then", t, func() {
-		So(evaluatorScenario(`{"type": "gt", "params": [1] }`, 3), ShouldBeTrue)
-		So(evaluatorScenario(`{"type": "gt", "params": [3] }`, 1), ShouldBeFalse)
+	t.Run("greater then", func(t *testing.T) {
+		require.True(t, evaluatorScenario(t, `{"type": "gt", "params": [1] }`, 3))
+		require.False(t, evaluatorScenario(t, `{"type": "gt", "params": [3] }`, 1))
 	})
 
-	Convey("less then", t, func() {
-		So(evaluatorScenario(`{"type": "lt", "params": [1] }`, 3), ShouldBeFalse)
-		So(evaluatorScenario(`{"type": "lt", "params": [3] }`, 1), ShouldBeTrue)
+	t.Run("less then", func(t *testing.T) {
+		require.False(t, evaluatorScenario(t, `{"type": "lt", "params": [1] }`, 3))
+		require.True(t, evaluatorScenario(t, `{"type": "lt", "params": [3] }`, 1))
 	})
 
-	Convey("within_range", t, func() {
-		So(evaluatorScenario(`{"type": "within_range", "params": [1, 100] }`, 3), ShouldBeTrue)
-		So(evaluatorScenario(`{"type": "within_range", "params": [1, 100] }`, 300), ShouldBeFalse)
-		So(evaluatorScenario(`{"type": "within_range", "params": [100, 1] }`, 3), ShouldBeTrue)
-		So(evaluatorScenario(`{"type": "within_range", "params": [100, 1] }`, 300), ShouldBeFalse)
+	t.Run("within_range", func(t *testing.T) {
+		require.True(t, evaluatorScenario(t, `{"type": "within_range", "params": [1, 100] }`, 3))
+		require.False(t, evaluatorScenario(t, `{"type": "within_range", "params": [1, 100] }`, 300))
+		require.True(t, evaluatorScenario(t, `{"type": "within_range", "params": [100, 1] }`, 3))
+		require.False(t, evaluatorScenario(t, `{"type": "within_range", "params": [100, 1] }`, 300))
 	})
 
-	Convey("outside_range", t, func() {
-		So(evaluatorScenario(`{"type": "outside_range", "params": [1, 100] }`, 1000), ShouldBeTrue)
-		So(evaluatorScenario(`{"type": "outside_range", "params": [1, 100] }`, 50), ShouldBeFalse)
-		So(evaluatorScenario(`{"type": "outside_range", "params": [100, 1] }`, 1000), ShouldBeTrue)
-		So(evaluatorScenario(`{"type": "outside_range", "params": [100, 1] }`, 50), ShouldBeFalse)
+	t.Run("outside_range", func(t *testing.T) {
+		require.True(t, evaluatorScenario(t, `{"type": "outside_range", "params": [1, 100] }`, 1000))
+		require.False(t, evaluatorScenario(t, `{"type": "outside_range", "params": [1, 100] }`, 50))
+		require.True(t, evaluatorScenario(t, `{"type": "outside_range", "params": [100, 1] }`, 1000))
+		require.False(t, evaluatorScenario(t, `{"type": "outside_range", "params": [100, 1] }`, 50))
 	})
 
-	Convey("no_value", t, func() {
-		Convey("should be false if series have values", func() {
-			So(evaluatorScenario(`{"type": "no_value", "params": [] }`, 50), ShouldBeFalse)
+	t.Run("no_value", func(t *testing.T) {
+		t.Run("should be false if series have values", func(t *testing.T) {
+			require.False(t, evaluatorScenario(t, `{"type": "no_value", "params": [] }`, 50))
 		})
 
-		Convey("should be true when the series have no value", func() {
+		t.Run("should be true when the series have no value", func(t *testing.T) {
 			jsonModel, err := simplejson.NewJson([]byte(`{"type": "no_value", "params": [] }`))
-			So(err, ShouldBeNil)
+			require.Nil(t, err)
 
 			evaluator, err := NewAlertEvaluator(jsonModel)
-			So(err, ShouldBeNil)
+			require.Nil(t, err)
 
-			So(evaluator.Eval(null.FloatFromPtr(nil)), ShouldBeTrue)
+			require.True(t, evaluator.Eval(null.FloatFromPtr(nil)))
 		})
 	})
 }

--- a/pkg/services/alerting/conditions/reducer_test.go
+++ b/pkg/services/alerting/conditions/reducer_test.go
@@ -4,183 +4,103 @@ import (
 	"math"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
-
 	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleReducer(t *testing.T) {
-	Convey("Test simple reducer by calculating", t, func() {
-		Convey("sum", func() {
-			result := testReducer("sum", 1, 2, 3)
-			So(result, ShouldEqual, float64(6))
-		})
+	t.Run("sum", func(t *testing.T) {
+		result := testReducer("sum", 1, 2, 3)
+		require.Equal(t, float64(6), result)
+	})
 
-		Convey("min", func() {
-			result := testReducer("min", 3, 2, 1)
-			So(result, ShouldEqual, float64(1))
-		})
+	t.Run("min", func(t *testing.T) {
+		result := testReducer("min", 3, 2, 1)
+		require.Equal(t, float64(1), result)
+	})
 
-		Convey("max", func() {
-			result := testReducer("max", 1, 2, 3)
-			So(result, ShouldEqual, float64(3))
-		})
+	t.Run("max", func(t *testing.T) {
+		result := testReducer("max", 1, 2, 3)
+		require.Equal(t, float64(3), result)
+	})
 
-		Convey("count", func() {
-			result := testReducer("count", 1, 2, 3000)
-			So(result, ShouldEqual, float64(3))
-		})
+	t.Run("count", func(t *testing.T) {
+		result := testReducer("count", 1, 2, 3000)
+		require.Equal(t, float64(3), result)
+	})
 
-		Convey("last", func() {
-			result := testReducer("last", 1, 2, 3000)
-			So(result, ShouldEqual, float64(3000))
-		})
+	t.Run("last", func(t *testing.T) {
+		result := testReducer("last", 1, 2, 3000)
+		require.Equal(t, float64(3000), result)
+	})
 
-		Convey("median odd amount of numbers", func() {
-			result := testReducer("median", 1, 2, 3000)
-			So(result, ShouldEqual, float64(2))
-		})
+	t.Run("median odd amount of numbers", func(t *testing.T) {
+		result := testReducer("median", 1, 2, 3000)
+		require.Equal(t, float64(2), result)
+	})
 
-		Convey("median even amount of numbers", func() {
-			result := testReducer("median", 1, 2, 4, 3000)
-			So(result, ShouldEqual, float64(3))
-		})
+	t.Run("median even amount of numbers", func(t *testing.T) {
+		result := testReducer("median", 1, 2, 4, 3000)
+		require.Equal(t, float64(3), result)
+	})
 
-		Convey("median with one values", func() {
-			result := testReducer("median", 1)
-			So(result, ShouldEqual, float64(1))
-		})
+	t.Run("median with one values", func(t *testing.T) {
+		result := testReducer("median", 1)
+		require.Equal(t, float64(1), result)
+	})
 
-		Convey("median should ignore null values", func() {
-			reducer := newSimpleReducer("median")
+	t.Run("median should ignore null values", func(t *testing.T) {
+		reducer := newSimpleReducer("median")
+		series := plugins.DataTimeSeries{
+			Name: "test time series",
+		}
+
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(3)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(float64(1)), null.FloatFrom(4)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(float64(2)), null.FloatFrom(5)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(float64(3)), null.FloatFrom(6)})
+
+		result := reducer.Reduce(series)
+		require.Equal(t, true, result.Valid)
+		require.Equal(t, float64(2), result.Float64)
+	})
+
+	t.Run("avg", func(t *testing.T) {
+		result := testReducer("avg", 1, 2, 3)
+		require.Equal(t, float64(2), result)
+	})
+
+	t.Run("avg with only nulls", func(t *testing.T) {
+		reducer := newSimpleReducer("avg")
+		series := plugins.DataTimeSeries{
+			Name: "test time series",
+		}
+
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
+		require.Equal(t, false, reducer.Reduce(series).Valid)
+	})
+
+	t.Run("count_non_null", func(t *testing.T) {
+		t.Run("with null values and real values", func(t *testing.T) {
+			reducer := newSimpleReducer("count_non_null")
 			series := plugins.DataTimeSeries{
 				Name: "test time series",
 			}
 
 			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
 			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(3)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(float64(1)), null.FloatFrom(4)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(float64(2)), null.FloatFrom(5)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(float64(3)), null.FloatFrom(6)})
-
-			result := reducer.Reduce(series)
-			So(result.Valid, ShouldEqual, true)
-			So(result.Float64, ShouldEqual, float64(2))
-		})
-
-		Convey("avg", func() {
-			result := testReducer("avg", 1, 2, 3)
-			So(result, ShouldEqual, float64(2))
-		})
-
-		Convey("avg with only nulls", func() {
-			reducer := newSimpleReducer("avg")
-			series := plugins.DataTimeSeries{
-				Name: "test time series",
-			}
-
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
-			So(reducer.Reduce(series).Valid, ShouldEqual, false)
-		})
-
-		Convey("count_non_null", func() {
-			Convey("with null values and real values", func() {
-				reducer := newSimpleReducer("count_non_null")
-				series := plugins.DataTimeSeries{
-					Name: "test time series",
-				}
-
-				series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
-				series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
-				series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(3), null.FloatFrom(3)})
-				series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(3), null.FloatFrom(4)})
-
-				So(reducer.Reduce(series).Valid, ShouldEqual, true)
-				So(reducer.Reduce(series).Float64, ShouldEqual, 2)
-			})
-
-			Convey("with null values", func() {
-				reducer := newSimpleReducer("count_non_null")
-				series := plugins.DataTimeSeries{
-					Name: "test time series",
-				}
-
-				series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
-				series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
-
-				So(reducer.Reduce(series).Valid, ShouldEqual, false)
-			})
-		})
-
-		Convey("avg of number values and null values should ignore nulls", func() {
-			reducer := newSimpleReducer("avg")
-			series := plugins.DataTimeSeries{
-				Name: "test time series",
-			}
-
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(3), null.FloatFrom(1)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(3)})
+			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(3), null.FloatFrom(3)})
 			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(3), null.FloatFrom(4)})
 
-			So(reducer.Reduce(series).Float64, ShouldEqual, float64(3))
+			require.Equal(t, true, reducer.Reduce(series).Valid)
+			require.Equal(t, 2.0, reducer.Reduce(series).Float64)
 		})
 
-		// diff function Test Suite
-		Convey("diff of one positive point", func() {
-			result := testReducer("diff", 30)
-			So(result, ShouldEqual, float64(0))
-		})
-
-		Convey("diff of one negative point", func() {
-			result := testReducer("diff", -30)
-			So(result, ShouldEqual, float64(0))
-		})
-
-		Convey("diff of two positive points[1]", func() {
-			result := testReducer("diff", 30, 40)
-			So(result, ShouldEqual, float64(10))
-		})
-
-		Convey("diff of two positive points[2]", func() {
-			result := testReducer("diff", 30, 20)
-			So(result, ShouldEqual, float64(-10))
-		})
-
-		Convey("diff of two negative points[1]", func() {
-			result := testReducer("diff", -30, -40)
-			So(result, ShouldEqual, float64(-10))
-		})
-
-		Convey("diff of two negative points[2]", func() {
-			result := testReducer("diff", -30, -10)
-			So(result, ShouldEqual, float64(20))
-		})
-
-		Convey("diff of one positive and one negative point", func() {
-			result := testReducer("diff", 30, -40)
-			So(result, ShouldEqual, float64(-70))
-		})
-
-		Convey("diff of one negative and one positive point", func() {
-			result := testReducer("diff", -30, 40)
-			So(result, ShouldEqual, float64(70))
-		})
-
-		Convey("diff of three positive points", func() {
-			result := testReducer("diff", 30, 40, 50)
-			So(result, ShouldEqual, float64(20))
-		})
-
-		Convey("diff of three negative points", func() {
-			result := testReducer("diff", -30, -40, -50)
-			So(result, ShouldEqual, float64(-20))
-		})
-
-		Convey("diff with only nulls", func() {
-			reducer := newSimpleReducer("diff")
+		t.Run("with null values", func(t *testing.T) {
+			reducer := newSimpleReducer("count_non_null")
 			series := plugins.DataTimeSeries{
 				Name: "test time series",
 			}
@@ -188,212 +108,289 @@ func TestSimpleReducer(t *testing.T) {
 			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
 			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
 
-			So(reducer.Reduce(series).Valid, ShouldEqual, false)
+			require.Equal(t, false, reducer.Reduce(series).Valid)
 		})
+	})
 
-		// diff_abs function Test Suite
-		Convey("diff_abs of one positive point", func() {
-			result := testReducer("diff_abs", 30)
-			So(result, ShouldEqual, float64(0))
-		})
+	t.Run("avg of number values and null values should ignore nulls", func(t *testing.T) {
+		reducer := newSimpleReducer("avg")
+		series := plugins.DataTimeSeries{
+			Name: "test time series",
+		}
 
-		Convey("diff_abs of one negative point", func() {
-			result := testReducer("diff_abs", -30)
-			So(result, ShouldEqual, float64(0))
-		})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(3), null.FloatFrom(1)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(3)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFrom(3), null.FloatFrom(4)})
 
-		Convey("diff_abs of two positive points[1]", func() {
-			result := testReducer("diff_abs", 30, 40)
-			So(result, ShouldEqual, float64(10))
-		})
+		require.Equal(t, float64(3), reducer.Reduce(series).Float64)
+	})
 
-		Convey("diff_abs of two positive points[2]", func() {
-			result := testReducer("diff_abs", 30, 20)
-			So(result, ShouldEqual, float64(10))
-		})
+	// diff function Test Suite
+	t.Run("diff of one positive point", func(t *testing.T) {
+		result := testReducer("diff", 30)
+		require.Equal(t, float64(0), result)
+	})
 
-		Convey("diff_abs of two negative points[1]", func() {
-			result := testReducer("diff_abs", -30, -40)
-			So(result, ShouldEqual, float64(10))
-		})
+	t.Run("diff of one negative point", func(t *testing.T) {
+		result := testReducer("diff", -30)
+		require.Equal(t, float64(0), result)
+	})
 
-		Convey("diff_abs of two negative points[2]", func() {
-			result := testReducer("diff_abs", -30, -10)
-			So(result, ShouldEqual, float64(20))
-		})
+	t.Run("diff of two positive points[1]", func(t *testing.T) {
+		result := testReducer("diff", 30, 40)
+		require.Equal(t, float64(10), result)
+	})
 
-		Convey("diff_abs of one positive and one negative point", func() {
-			result := testReducer("diff_abs", 30, -40)
-			So(result, ShouldEqual, float64(70))
-		})
+	t.Run("diff of two positive points[2]", func(t *testing.T) {
+		result := testReducer("diff", 30, 20)
+		require.Equal(t, float64(-10), result)
+	})
 
-		Convey("diff_abs of one negative and one positive point", func() {
-			result := testReducer("diff_abs", -30, 40)
-			So(result, ShouldEqual, float64(70))
-		})
+	t.Run("diff of two negative points[1]", func(t *testing.T) {
+		result := testReducer("diff", -30, -40)
+		require.Equal(t, float64(-10), result)
+	})
 
-		Convey("diff_abs of three positive points", func() {
-			result := testReducer("diff_abs", 30, 40, 50)
-			So(result, ShouldEqual, float64(20))
-		})
+	t.Run("diff of two negative points[2]", func(t *testing.T) {
+		result := testReducer("diff", -30, -10)
+		require.Equal(t, float64(20), result)
+	})
 
-		Convey("diff_abs of three negative points", func() {
-			result := testReducer("diff_abs", -30, -40, -50)
-			So(result, ShouldEqual, float64(20))
-		})
+	t.Run("diff of one positive and one negative point", func(t *testing.T) {
+		result := testReducer("diff", 30, -40)
+		require.Equal(t, float64(-70), result)
+	})
 
-		Convey("diff_abs with only nulls", func() {
-			reducer := newSimpleReducer("diff_abs")
-			series := plugins.DataTimeSeries{
-				Name: "test time series",
-			}
+	t.Run("diff of one negative and one positive point", func(t *testing.T) {
+		result := testReducer("diff", -30, 40)
+		require.Equal(t, float64(70), result)
+	})
 
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
+	t.Run("diff of three positive points", func(t *testing.T) {
+		result := testReducer("diff", 30, 40, 50)
+		require.Equal(t, float64(20), result)
+	})
 
-			So(reducer.Reduce(series).Valid, ShouldEqual, false)
-		})
+	t.Run("diff of three negative points", func(t *testing.T) {
+		result := testReducer("diff", -30, -40, -50)
+		require.Equal(t, float64(-20), result)
+	})
 
-		// percent_diff function Test Suite
-		Convey("percent_diff of one positive point", func() {
-			result := testReducer("percent_diff", 30)
-			So(result, ShouldEqual, float64(0))
-		})
+	t.Run("diff with only nulls", func(t *testing.T) {
+		reducer := newSimpleReducer("diff")
+		series := plugins.DataTimeSeries{
+			Name: "test time series",
+		}
 
-		Convey("percent_diff of one negative point", func() {
-			result := testReducer("percent_diff", -30)
-			So(result, ShouldEqual, float64(0))
-		})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
 
-		Convey("percent_diff of two positive points[1]", func() {
-			result := testReducer("percent_diff", 30, 40)
-			So(result, ShouldEqual, float64(33.33333333333333))
-		})
+		require.Equal(t, false, reducer.Reduce(series).Valid)
+	})
 
-		Convey("percent_diff of two positive points[2]", func() {
-			result := testReducer("percent_diff", 30, 20)
-			So(result, ShouldEqual, float64(-33.33333333333333))
-		})
+	// diff_abs function Test Suite
+	t.Run("diff_abs of one positive point", func(t *testing.T) {
+		result := testReducer("diff_abs", 30)
+		require.Equal(t, float64(0), result)
+	})
 
-		Convey("percent_diff of two negative points[1]", func() {
-			result := testReducer("percent_diff", -30, -40)
-			So(result, ShouldEqual, float64(-33.33333333333333))
-		})
+	t.Run("diff_abs of one negative point", func(t *testing.T) {
+		result := testReducer("diff_abs", -30)
+		require.Equal(t, float64(0), result)
+	})
 
-		Convey("percent_diff of two negative points[2]", func() {
-			result := testReducer("percent_diff", -30, -10)
-			So(result, ShouldEqual, float64(66.66666666666666))
-		})
+	t.Run("diff_abs of two positive points[1]", func(t *testing.T) {
+		result := testReducer("diff_abs", 30, 40)
+		require.Equal(t, float64(10), result)
+	})
 
-		Convey("percent_diff of one positive and one negative point", func() {
-			result := testReducer("percent_diff", 30, -40)
-			So(result, ShouldEqual, float64(-233.33333333333334))
-		})
+	t.Run("diff_abs of two positive points[2]", func(t *testing.T) {
+		result := testReducer("diff_abs", 30, 20)
+		require.Equal(t, float64(10), result)
+	})
 
-		Convey("percent_diff of one negative and one positive point", func() {
-			result := testReducer("percent_diff", -30, 40)
-			So(result, ShouldEqual, float64(233.33333333333334))
-		})
+	t.Run("diff_abs of two negative points[1]", func(t *testing.T) {
+		result := testReducer("diff_abs", -30, -40)
+		require.Equal(t, float64(10), result)
+	})
 
-		Convey("percent_diff of three positive points", func() {
-			result := testReducer("percent_diff", 30, 40, 50)
-			So(result, ShouldEqual, float64(66.66666666666666))
-		})
+	t.Run("diff_abs of two negative points[2]", func(t *testing.T) {
+		result := testReducer("diff_abs", -30, -10)
+		require.Equal(t, float64(20), result)
+	})
 
-		Convey("percent_diff of three negative points", func() {
-			result := testReducer("percent_diff", -30, -40, -50)
-			So(result, ShouldEqual, float64(-66.66666666666666))
-		})
+	t.Run("diff_abs of one positive and one negative point", func(t *testing.T) {
+		result := testReducer("diff_abs", 30, -40)
+		require.Equal(t, float64(70), result)
+	})
 
-		Convey("percent_diff with only nulls", func() {
-			reducer := newSimpleReducer("percent_diff")
-			series := plugins.DataTimeSeries{
-				Name: "test time series",
-			}
+	t.Run("diff_abs of one negative and one positive point", func(t *testing.T) {
+		result := testReducer("diff_abs", -30, 40)
+		require.Equal(t, float64(70), result)
+	})
 
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
+	t.Run("diff_abs of three positive points", func(t *testing.T) {
+		result := testReducer("diff_abs", 30, 40, 50)
+		require.Equal(t, float64(20), result)
+	})
 
-			So(reducer.Reduce(series).Valid, ShouldEqual, false)
-		})
+	t.Run("diff_abs of three negative points", func(t *testing.T) {
+		result := testReducer("diff_abs", -30, -40, -50)
+		require.Equal(t, float64(20), result)
+	})
 
-		// percent_diff_abs function Test Suite
-		Convey("percent_diff_abs_abs of one positive point", func() {
-			result := testReducer("percent_diff_abs", 30)
-			So(result, ShouldEqual, float64(0))
-		})
+	t.Run("diff_abs with only nulls", func(t *testing.T) {
+		reducer := newSimpleReducer("diff_abs")
+		series := plugins.DataTimeSeries{
+			Name: "test time series",
+		}
 
-		Convey("percent_diff_abs of one negative point", func() {
-			result := testReducer("percent_diff_abs", -30)
-			So(result, ShouldEqual, float64(0))
-		})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
 
-		Convey("percent_diff_abs of two positive points[1]", func() {
-			result := testReducer("percent_diff_abs", 30, 40)
-			So(result, ShouldEqual, float64(33.33333333333333))
-		})
+		require.Equal(t, false, reducer.Reduce(series).Valid)
+	})
 
-		Convey("percent_diff_abs of two positive points[2]", func() {
-			result := testReducer("percent_diff_abs", 30, 20)
-			So(result, ShouldEqual, float64(33.33333333333333))
-		})
+	// percent_diff function Test Suite
+	t.Run("percent_diff of one positive point", func(t *testing.T) {
+		result := testReducer("percent_diff", 30)
+		require.Equal(t, float64(0), result)
+	})
 
-		Convey("percent_diff_abs of two negative points[1]", func() {
-			result := testReducer("percent_diff_abs", -30, -40)
-			So(result, ShouldEqual, float64(33.33333333333333))
-		})
+	t.Run("percent_diff of one negative point", func(t *testing.T) {
+		result := testReducer("percent_diff", -30)
+		require.Equal(t, float64(0), result)
+	})
 
-		Convey("percent_diff_abs of two negative points[2]", func() {
-			result := testReducer("percent_diff_abs", -30, -10)
-			So(result, ShouldEqual, float64(66.66666666666666))
-		})
+	t.Run("percent_diff of two positive points[1]", func(t *testing.T) {
+		result := testReducer("percent_diff", 30, 40)
+		require.Equal(t, float64(33.33333333333333), result)
+	})
 
-		Convey("percent_diff_abs of one positive and one negative point", func() {
-			result := testReducer("percent_diff_abs", 30, -40)
-			So(result, ShouldEqual, float64(233.33333333333334))
-		})
+	t.Run("percent_diff of two positive points[2]", func(t *testing.T) {
+		result := testReducer("percent_diff", 30, 20)
+		require.Equal(t, float64(-33.33333333333333), result)
+	})
 
-		Convey("percent_diff_abs of one negative and one positive point", func() {
-			result := testReducer("percent_diff_abs", -30, 40)
-			So(result, ShouldEqual, float64(233.33333333333334))
-		})
+	t.Run("percent_diff of two negative points[1]", func(t *testing.T) {
+		result := testReducer("percent_diff", -30, -40)
+		require.Equal(t, float64(-33.33333333333333), result)
+	})
 
-		Convey("percent_diff_abs of three positive points", func() {
-			result := testReducer("percent_diff_abs", 30, 40, 50)
-			So(result, ShouldEqual, float64(66.66666666666666))
-		})
+	t.Run("percent_diff of two negative points[2]", func(t *testing.T) {
+		result := testReducer("percent_diff", -30, -10)
+		require.Equal(t, float64(66.66666666666666), result)
+	})
 
-		Convey("percent_diff_abs of three negative points", func() {
-			result := testReducer("percent_diff_abs", -30, -40, -50)
-			So(result, ShouldEqual, float64(66.66666666666666))
-		})
+	t.Run("percent_diff of one positive and one negative point", func(t *testing.T) {
+		result := testReducer("percent_diff", 30, -40)
+		require.Equal(t, float64(-233.33333333333334), result)
+	})
 
-		Convey("percent_diff_abs with only nulls", func() {
-			reducer := newSimpleReducer("percent_diff_abs")
-			series := plugins.DataTimeSeries{
-				Name: "test time series",
-			}
+	t.Run("percent_diff of one negative and one positive point", func(t *testing.T) {
+		result := testReducer("percent_diff", -30, 40)
+		require.Equal(t, float64(233.33333333333334), result)
+	})
 
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
-			series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
+	t.Run("percent_diff of three positive points", func(t *testing.T) {
+		result := testReducer("percent_diff", 30, 40, 50)
+		require.Equal(t, float64(66.66666666666666), result)
+	})
 
-			So(reducer.Reduce(series).Valid, ShouldEqual, false)
-		})
+	t.Run("percent_diff of three negative points", func(t *testing.T) {
+		result := testReducer("percent_diff", -30, -40, -50)
+		require.Equal(t, float64(-66.66666666666666), result)
+	})
 
-		Convey("min should work with NaNs", func() {
-			result := testReducer("min", math.NaN(), math.NaN(), math.NaN())
-			So(result, ShouldEqual, float64(0))
-		})
+	t.Run("percent_diff with only nulls", func(t *testing.T) {
+		reducer := newSimpleReducer("percent_diff")
+		series := plugins.DataTimeSeries{
+			Name: "test time series",
+		}
 
-		Convey("isValid should treat NaN as invalid", func() {
-			result := isValid(null.FloatFrom(math.NaN()))
-			So(result, ShouldBeFalse)
-		})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
 
-		Convey("isValid should treat invalid null.Float as invalid", func() {
-			result := isValid(null.FloatFromPtr(nil))
-			So(result, ShouldBeFalse)
-		})
+		require.Equal(t, false, reducer.Reduce(series).Valid)
+	})
+
+	// percent_diff_abs function Test Suite
+	t.Run("percent_diff_abs_abs of one positive point", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", 30)
+		require.Equal(t, float64(0), result)
+	})
+
+	t.Run("percent_diff_abs of one negative point", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", -30)
+		require.Equal(t, float64(0), result)
+	})
+
+	t.Run("percent_diff_abs of two positive points[1]", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", 30, 40)
+		require.Equal(t, float64(33.33333333333333), result)
+	})
+
+	t.Run("percent_diff_abs of two positive points[2]", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", 30, 20)
+		require.Equal(t, float64(33.33333333333333), result)
+	})
+
+	t.Run("percent_diff_abs of two negative points[1]", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", -30, -40)
+		require.Equal(t, float64(33.33333333333333), result)
+	})
+
+	t.Run("percent_diff_abs of two negative points[2]", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", -30, -10)
+		require.Equal(t, float64(66.66666666666666), result)
+	})
+
+	t.Run("percent_diff_abs of one positive and one negative point", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", 30, -40)
+		require.Equal(t, float64(233.33333333333334), result)
+	})
+
+	t.Run("percent_diff_abs of one negative and one positive point", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", -30, 40)
+		require.Equal(t, float64(233.33333333333334), result)
+	})
+
+	t.Run("percent_diff_abs of three positive points", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", 30, 40, 50)
+		require.Equal(t, float64(66.66666666666666), result)
+	})
+
+	t.Run("percent_diff_abs of three negative points", func(t *testing.T) {
+		result := testReducer("percent_diff_abs", -30, -40, -50)
+		require.Equal(t, float64(66.66666666666666), result)
+	})
+
+	t.Run("percent_diff_abs with only nulls", func(t *testing.T) {
+		reducer := newSimpleReducer("percent_diff_abs")
+		series := plugins.DataTimeSeries{
+			Name: "test time series",
+		}
+
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(1)})
+		series.Points = append(series.Points, plugins.DataTimePoint{null.FloatFromPtr(nil), null.FloatFrom(2)})
+
+		require.Equal(t, false, reducer.Reduce(series).Valid)
+	})
+
+	t.Run("min should work with NaNs", func(t *testing.T) {
+		result := testReducer("min", math.NaN(), math.NaN(), math.NaN())
+		require.Equal(t, float64(0), result)
+	})
+
+	t.Run("isValid should treat NaN as invalid", func(t *testing.T) {
+		result := isValid(null.FloatFrom(math.NaN()))
+		require.False(t, result)
+	})
+
+	t.Run("isValid should treat invalid null.Float as invalid", func(t *testing.T) {
+		result := isValid(null.FloatFromPtr(nil))
+		require.False(t, result)
 	})
 }
 


### PR DESCRIPTION
Related to #40633 this PR removes GoConvey from alerting/conditions tests.
Mostly automatic PR, but query_test.go has been changed manually to call setup() directly from the tests rather than rely on a custom test runner (which in its turn relied on GoConvey execution order).