### PR TITLE
Chore: Refactor GoConvey in alerting tests

### DIFF
--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/encryption/ossencryption"
 	"github.com/grafana/grafana/pkg/setting"
-	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/stretchr/testify/require"
 )
 
 type FakeEvalHandler struct {
@@ -42,112 +43,110 @@ func (handler *FakeResultHandler) handle(evalContext *EvalContext) error {
 }
 
 func TestEngineProcessJob(t *testing.T) {
-	Convey("Alerting engine job processing", t, func() {
-		bus := bus.New()
-		usMock := &usagestats.UsageStatsMock{T: t}
-		engine := ProvideAlertEngine(nil, bus, nil, nil, usMock, ossencryption.ProvideService(), setting.NewCfg())
-		setting.AlertingEvaluationTimeout = 30 * time.Second
-		setting.AlertingNotificationTimeout = 30 * time.Second
-		setting.AlertingMaxAttempts = 3
-		engine.resultHandler = &FakeResultHandler{}
-		job := &Job{running: true, Rule: &Rule{}}
+	bus := bus.New()
+	usMock := &usagestats.UsageStatsMock{T: t}
+	engine := ProvideAlertEngine(nil, bus, nil, nil, usMock, ossencryption.ProvideService(), setting.NewCfg())
+	setting.AlertingEvaluationTimeout = 30 * time.Second
+	setting.AlertingNotificationTimeout = 30 * time.Second
+	setting.AlertingMaxAttempts = 3
+	engine.resultHandler = &FakeResultHandler{}
+	job := &Job{running: true, Rule: &Rule{}}
 
-		Convey("Should register usage metrics func", func() {
-			bus.AddHandler(func(q *models.GetAllAlertsQuery) error {
-				settings, err := simplejson.NewJson([]byte(`{"conditions": [{"query": { "datasourceId": 1}}]}`))
-				if err != nil {
-					return err
-				}
-				q.Result = []*models.Alert{{Settings: settings}}
-				return nil
-			})
-
-			bus.AddHandler(func(q *models.GetDataSourceQuery) error {
-				q.Result = &models.DataSource{Id: 1, Type: models.DS_PROMETHEUS}
-				return nil
-			})
-
-			report, err := usMock.GetUsageReport(context.Background())
-			So(err, ShouldBeNil)
-
-			So(report.Metrics["stats.alerting.ds.prometheus.count"], ShouldEqual, 1)
-			So(report.Metrics["stats.alerting.ds.other.count"], ShouldEqual, 0)
+	t.Run("Should register usage metrics func", func(t *testing.T) {
+		bus.AddHandler(func(q *models.GetAllAlertsQuery) error {
+			settings, err := simplejson.NewJson([]byte(`{"conditions": [{"query": { "datasourceId": 1}}]}`))
+			if err != nil {
+				return err
+			}
+			q.Result = []*models.Alert{{Settings: settings}}
+			return nil
 		})
 
-		Convey("Should trigger retry if needed", func() {
-			Convey("error + not last attempt -> retry", func() {
-				engine.evalHandler = NewFakeEvalHandler(0)
+		bus.AddHandler(func(q *models.GetDataSourceQuery) error {
+			q.Result = &models.DataSource{Id: 1, Type: models.DS_PROMETHEUS}
+			return nil
+		})
 
-				for i := 1; i < setting.AlertingMaxAttempts; i++ {
-					attemptChan := make(chan int, 1)
-					cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
+		report, err := usMock.GetUsageReport(context.Background())
+		require.Nil(t, err)
 
-					engine.processJob(i, attemptChan, cancelChan, job)
-					nextAttemptID, more := <-attemptChan
+		require.Equal(t, 1, report.Metrics["stats.alerting.ds.prometheus.count"])
+		require.Equal(t, 0, report.Metrics["stats.alerting.ds.other.count"])
+	})
 
-					So(nextAttemptID, ShouldEqual, i+1)
-					So(more, ShouldEqual, true)
-					So(<-cancelChan, ShouldNotBeNil)
-				}
-			})
+	t.Run("Should trigger retry if needed", func(t *testing.T) {
+		t.Run("error + not last attempt -> retry", func(t *testing.T) {
+			engine.evalHandler = NewFakeEvalHandler(0)
 
-			Convey("error + last attempt -> no retry", func() {
-				engine.evalHandler = NewFakeEvalHandler(0)
+			for i := 1; i < setting.AlertingMaxAttempts; i++ {
 				attemptChan := make(chan int, 1)
 				cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
 
-				engine.processJob(setting.AlertingMaxAttempts, attemptChan, cancelChan, job)
+				engine.processJob(i, attemptChan, cancelChan, job)
 				nextAttemptID, more := <-attemptChan
 
-				So(nextAttemptID, ShouldEqual, 0)
-				So(more, ShouldEqual, false)
-				So(<-cancelChan, ShouldNotBeNil)
-			})
-
-			Convey("no error -> no retry", func() {
-				engine.evalHandler = NewFakeEvalHandler(1)
-				attemptChan := make(chan int, 1)
-				cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
-
-				engine.processJob(1, attemptChan, cancelChan, job)
-				nextAttemptID, more := <-attemptChan
-
-				So(nextAttemptID, ShouldEqual, 0)
-				So(more, ShouldEqual, false)
-				So(<-cancelChan, ShouldNotBeNil)
-			})
+				require.Equal(t, i+1, nextAttemptID)
+				require.Equal(t, true, more)
+				require.NotNil(t, <-cancelChan)
+			}
 		})
 
-		Convey("Should trigger as many retries as needed", func() {
-			Convey("never success -> max retries number", func() {
-				expectedAttempts := setting.AlertingMaxAttempts
-				evalHandler := NewFakeEvalHandler(0)
-				engine.evalHandler = evalHandler
+		t.Run("error + last attempt -> no retry", func(t *testing.T) {
+			engine.evalHandler = NewFakeEvalHandler(0)
+			attemptChan := make(chan int, 1)
+			cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
 
-				err := engine.processJobWithRetry(context.TODO(), job)
-				So(err, ShouldBeNil)
-				So(evalHandler.CallNb, ShouldEqual, expectedAttempts)
-			})
+			engine.processJob(setting.AlertingMaxAttempts, attemptChan, cancelChan, job)
+			nextAttemptID, more := <-attemptChan
 
-			Convey("always success -> never retry", func() {
-				expectedAttempts := 1
-				evalHandler := NewFakeEvalHandler(1)
-				engine.evalHandler = evalHandler
+			require.Equal(t, 0, nextAttemptID)
+			require.Equal(t, false, more)
+			require.NotNil(t, <-cancelChan)
+		})
 
-				err := engine.processJobWithRetry(context.TODO(), job)
-				So(err, ShouldBeNil)
-				So(evalHandler.CallNb, ShouldEqual, expectedAttempts)
-			})
+		t.Run("no error -> no retry", func(t *testing.T) {
+			engine.evalHandler = NewFakeEvalHandler(1)
+			attemptChan := make(chan int, 1)
+			cancelChan := make(chan context.CancelFunc, setting.AlertingMaxAttempts)
 
-			Convey("some errors before success -> some retries", func() {
-				expectedAttempts := int(math.Ceil(float64(setting.AlertingMaxAttempts) / 2))
-				evalHandler := NewFakeEvalHandler(expectedAttempts)
-				engine.evalHandler = evalHandler
+			engine.processJob(1, attemptChan, cancelChan, job)
+			nextAttemptID, more := <-attemptChan
 
-				err := engine.processJobWithRetry(context.TODO(), job)
-				So(err, ShouldBeNil)
-				So(evalHandler.CallNb, ShouldEqual, expectedAttempts)
-			})
+			require.Equal(t, 0, nextAttemptID)
+			require.Equal(t, false, more)
+			require.NotNil(t, <-cancelChan)
+		})
+	})
+
+	t.Run("Should trigger as many retries as needed", func(t *testing.T) {
+		t.Run("never success -> max retries number", func(t *testing.T) {
+			expectedAttempts := setting.AlertingMaxAttempts
+			evalHandler := NewFakeEvalHandler(0)
+			engine.evalHandler = evalHandler
+
+			err := engine.processJobWithRetry(context.TODO(), job)
+			require.Nil(t, err)
+			require.Equal(t, expectedAttempts, evalHandler.CallNb)
+		})
+
+		t.Run("always success -> never retry", func(t *testing.T) {
+			expectedAttempts := 1
+			evalHandler := NewFakeEvalHandler(1)
+			engine.evalHandler = evalHandler
+
+			err := engine.processJobWithRetry(context.TODO(), job)
+			require.Nil(t, err)
+			require.Equal(t, expectedAttempts, evalHandler.CallNb)
+		})
+
+		t.Run("some errors before success -> some retries", func(t *testing.T) {
+			expectedAttempts := int(math.Ceil(float64(setting.AlertingMaxAttempts) / 2))
+			evalHandler := NewFakeEvalHandler(expectedAttempts)
+			engine.evalHandler = evalHandler
+
+			err := engine.processJobWithRetry(context.TODO(), job)
+			require.Nil(t, err)
+			require.Equal(t, expectedAttempts, evalHandler.CallNb)
 		})
 	})
 }

--- a/pkg/services/alerting/eval_handler_test.go
+++ b/pkg/services/alerting/eval_handler_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/validations"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 )
 
 type conditionStub struct {
@@ -22,188 +22,186 @@ func (c *conditionStub) Eval(context *EvalContext, reqHandler plugins.DataReques
 }
 
 func TestAlertingEvaluationHandler(t *testing.T) {
-	Convey("Test alert evaluation handler", t, func() {
-		handler := NewEvalHandler(nil)
+	handler := NewEvalHandler(nil)
 
-		Convey("Show return triggered with single passing condition", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{&conditionStub{
-					firing: true,
-				}},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return triggered with single passing condition", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{&conditionStub{
+				firing: true,
+			}},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, true)
-			So(context.ConditionEvals, ShouldEqual, "true = true")
-		})
+		handler.Eval(context)
+		require.Equal(t, true, context.Firing)
+		require.Equal(t, "true = true", context.ConditionEvals)
+	})
 
-		Convey("Show return triggered with single passing condition2", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{&conditionStub{firing: true, operator: "and"}},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return triggered with single passing condition2", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{&conditionStub{firing: true, operator: "and"}},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, true)
-			So(context.ConditionEvals, ShouldEqual, "true = true")
-		})
+		handler.Eval(context)
+		require.Equal(t, true, context.Firing)
+		require.Equal(t, "true = true", context.ConditionEvals)
+	})
 
-		Convey("Show return false with not passing asdf", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: true, operator: "and", matches: []*EvalMatch{{}, {}}},
-					&conditionStub{firing: false, operator: "and"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return false with not passing asdf", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: true, operator: "and", matches: []*EvalMatch{{}, {}}},
+				&conditionStub{firing: false, operator: "and"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, false)
-			So(context.ConditionEvals, ShouldEqual, "[true AND false] = false")
-		})
+		handler.Eval(context)
+		require.Equal(t, false, context.Firing)
+		require.Equal(t, "[true AND false] = false", context.ConditionEvals)
+	})
 
-		Convey("Show return true if any of the condition is passing with OR operator", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: true, operator: "and"},
-					&conditionStub{firing: false, operator: "or"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return true if any of the condition is passing with OR operator", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: true, operator: "and"},
+				&conditionStub{firing: false, operator: "or"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, true)
-			So(context.ConditionEvals, ShouldEqual, "[true OR false] = true")
-		})
+		handler.Eval(context)
+		require.Equal(t, true, context.Firing)
+		require.Equal(t, "[true OR false] = true", context.ConditionEvals)
+	})
 
-		Convey("Show return false if any of the condition is failing with AND operator", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: true, operator: "and"},
-					&conditionStub{firing: false, operator: "and"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return false if any of the condition is failing with AND operator", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: true, operator: "and"},
+				&conditionStub{firing: false, operator: "and"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, false)
-			So(context.ConditionEvals, ShouldEqual, "[true AND false] = false")
-		})
+		handler.Eval(context)
+		require.Equal(t, false, context.Firing)
+		require.Equal(t, "[true AND false] = false", context.ConditionEvals)
+	})
 
-		Convey("Show return true if one condition is failing with nested OR operator", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: true, operator: "and"},
-					&conditionStub{firing: true, operator: "and"},
-					&conditionStub{firing: false, operator: "or"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return true if one condition is failing with nested OR operator", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: true, operator: "and"},
+				&conditionStub{firing: true, operator: "and"},
+				&conditionStub{firing: false, operator: "or"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, true)
-			So(context.ConditionEvals, ShouldEqual, "[[true AND true] OR false] = true")
-		})
+		handler.Eval(context)
+		require.Equal(t, true, context.Firing)
+		require.Equal(t, "[[true AND true] OR false] = true", context.ConditionEvals)
+	})
 
-		Convey("Show return false if one condition is passing with nested OR operator", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: true, operator: "and"},
-					&conditionStub{firing: false, operator: "and"},
-					&conditionStub{firing: false, operator: "or"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return false if one condition is passing with nested OR operator", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: true, operator: "and"},
+				&conditionStub{firing: false, operator: "and"},
+				&conditionStub{firing: false, operator: "or"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, false)
-			So(context.ConditionEvals, ShouldEqual, "[[true AND false] OR false] = false")
-		})
+		handler.Eval(context)
+		require.Equal(t, false, context.Firing)
+		require.Equal(t, "[[true AND false] OR false] = false", context.ConditionEvals)
+	})
 
-		Convey("Show return false if a condition is failing with nested AND operator", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: true, operator: "and"},
-					&conditionStub{firing: false, operator: "and"},
-					&conditionStub{firing: true, operator: "and"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return false if a condition is failing with nested AND operator", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: true, operator: "and"},
+				&conditionStub{firing: false, operator: "and"},
+				&conditionStub{firing: true, operator: "and"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, false)
-			So(context.ConditionEvals, ShouldEqual, "[[true AND false] AND true] = false")
-		})
+		handler.Eval(context)
+		require.Equal(t, false, context.Firing)
+		require.Equal(t, "[[true AND false] AND true] = false", context.ConditionEvals)
+	})
 
-		Convey("Show return true if a condition is passing with nested OR operator", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: true, operator: "and"},
-					&conditionStub{firing: false, operator: "or"},
-					&conditionStub{firing: true, operator: "or"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Show return true if a condition is passing with nested OR operator", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: true, operator: "and"},
+				&conditionStub{firing: false, operator: "or"},
+				&conditionStub{firing: true, operator: "or"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, true)
-			So(context.ConditionEvals, ShouldEqual, "[[true OR false] OR true] = true")
-		})
+		handler.Eval(context)
+		require.Equal(t, true, context.Firing)
+		require.Equal(t, "[[true OR false] OR true] = true", context.ConditionEvals)
+	})
 
-		Convey("Should return false if no condition is firing using OR operator", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{firing: false, operator: "or"},
-					&conditionStub{firing: false, operator: "or"},
-					&conditionStub{firing: false, operator: "or"},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Should return false if no condition is firing using OR operator", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{firing: false, operator: "or"},
+				&conditionStub{firing: false, operator: "or"},
+				&conditionStub{firing: false, operator: "or"},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, false)
-			So(context.ConditionEvals, ShouldEqual, "[[false OR false] OR false] = false")
-		})
+		handler.Eval(context)
+		require.Equal(t, false, context.Firing)
+		require.Equal(t, "[[false OR false] OR false] = false", context.ConditionEvals)
+	})
 
-		// FIXME: What should the actual test case name be here?
-		Convey("Should not return NoDataFound if all conditions have data and using OR", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{operator: "or", noData: false},
-					&conditionStub{operator: "or", noData: false},
-					&conditionStub{operator: "or", noData: false},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	// FIXME: What should the actual test case name be here?
+	t.Run("Should not return NoDataFound if all conditions have data and using OR", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{operator: "or", noData: false},
+				&conditionStub{operator: "or", noData: false},
+				&conditionStub{operator: "or", noData: false},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.NoDataFound, ShouldBeFalse)
-		})
+		handler.Eval(context)
+		require.False(t, context.NoDataFound)
+	})
 
-		Convey("Should return NoDataFound if one condition has no data", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{operator: "and", noData: true},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Should return NoDataFound if one condition has no data", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{operator: "and", noData: true},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.Firing, ShouldEqual, false)
-			So(context.NoDataFound, ShouldBeTrue)
-		})
+		handler.Eval(context)
+		require.Equal(t, false, context.Firing)
+		require.True(t, context.NoDataFound)
+	})
 
-		Convey("Should not return no data if at least one condition has no data and using AND", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{operator: "and", noData: true},
-					&conditionStub{operator: "and", noData: false},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Should not return no data if at least one condition has no data and using AND", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{operator: "and", noData: true},
+				&conditionStub{operator: "and", noData: false},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.NoDataFound, ShouldBeFalse)
-		})
+		handler.Eval(context)
+		require.False(t, context.NoDataFound)
+	})
 
-		Convey("Should return no data if at least one condition has no data and using OR", func() {
-			context := NewEvalContext(context.TODO(), &Rule{
-				Conditions: []Condition{
-					&conditionStub{operator: "or", noData: true},
-					&conditionStub{operator: "or", noData: false},
-				},
-			}, &validations.OSSPluginRequestValidator{})
+	t.Run("Should return no data if at least one condition has no data and using OR", func(t *testing.T) {
+		context := NewEvalContext(context.TODO(), &Rule{
+			Conditions: []Condition{
+				&conditionStub{operator: "or", noData: true},
+				&conditionStub{operator: "or", noData: false},
+			},
+		}, &validations.OSSPluginRequestValidator{})
 
-			handler.Eval(context)
-			So(context.NoDataFound, ShouldBeTrue)
-		})
+		handler.Eval(context)
+		require.True(t, context.NoDataFound)
 	})
 }


### PR DESCRIPTION
Related to #40633 this PR removes GoConvey from the alerting package. Automatically generated.