### PR TITLE
Chore: Refactor goconvey in tsdb package

### DIFF
--- a/pkg/tsdb/time_range_test.go
+++ b/pkg/tsdb/time_range_test.go
@@ -6,362 +6,360 @@ import (
 
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimeRange(t *testing.T) {
-	Convey("Time range", t, func() {
-		now := time.Now()
+	now := time.Now()
 
-		Convey("Can parse 5m, now", func() {
-			tr := TimeRange{
-				From: "5m",
-				To:   "now",
-				now:  now,
-			}
+	t.Run("Can parse 5m, now", func(t *testing.T) {
+		tr := TimeRange{
+			From: "5m",
+			To:   "now",
+			now:  now,
+		}
 
-			Convey("5m ago ", func() {
-				fiveMinAgo, err := time.ParseDuration("-5m")
-				So(err, ShouldBeNil)
-				expected := now.Add(fiveMinAgo)
-
-				res, err := tr.ParseFrom()
-				So(err, ShouldBeNil)
-				So(res.Unix(), ShouldEqual, expected.Unix())
-			})
-
-			Convey("now ", func() {
-				res, err := tr.ParseTo()
-				So(err, ShouldBeNil)
-				So(res.Unix(), ShouldEqual, now.Unix())
-			})
-		})
-
-		Convey("Can parse 5h, now-10m", func() {
-			tr := TimeRange{
-				From: "5h",
-				To:   "now-10m",
-				now:  now,
-			}
-
-			Convey("5h ago ", func() {
-				fiveHourAgo, err := time.ParseDuration("-5h")
-				So(err, ShouldBeNil)
-				expected := now.Add(fiveHourAgo)
-
-				res, err := tr.ParseFrom()
-				So(err, ShouldBeNil)
-				So(res.Unix(), ShouldEqual, expected.Unix())
-			})
-
-			Convey("now-10m ", func() {
-				tenMinAgo, err := time.ParseDuration("-10m")
-				So(err, ShouldBeNil)
-				expected := now.Add(tenMinAgo)
-				res, err := tr.ParseTo()
-				So(err, ShouldBeNil)
-				So(res.Unix(), ShouldEqual, expected.Unix())
-			})
-		})
-
-		now, err := time.Parse(time.RFC3339Nano, "2020-03-26T15:12:56.000Z")
-		So(err, ShouldBeNil)
-		Convey("Can parse now-1M/M, now-1M/M", func() {
-			tr := TimeRange{
-				From: "now-1M/M",
-				To:   "now-1M/M",
-				now:  now,
-			}
-
-			Convey("from now-1M/M ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-02-01T00:00:00.000Z")
-				So(err, ShouldBeNil)
-
-				res, err := tr.ParseFrom()
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
-
-			Convey("to now-1M/M ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-02-29T23:59:59.999Z")
-				So(err, ShouldBeNil)
-
-				res, err := tr.ParseTo()
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
-		})
-
-		Convey("Can parse now-3d, now+3w", func() {
-			tr := TimeRange{
-				From: "now-3d",
-				To:   "now+3w",
-				now:  now,
-			}
-
-			Convey("now-3d ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-03-23T15:12:56.000Z")
-				So(err, ShouldBeNil)
-
-				res, err := tr.ParseFrom()
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
-
-			Convey("now+3w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-04-16T15:12:56.000Z")
-				So(err, ShouldBeNil)
-
-				res, err := tr.ParseTo()
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
-		})
-
-		Convey("Can parse 1960-02-01T07:00:00.000Z, 1965-02-03T08:00:00.000Z", func() {
-			tr := TimeRange{
-				From: "1960-02-01T07:00:00.000Z",
-				To:   "1965-02-03T08:00:00.000Z",
-				now:  now,
-			}
-
-			Convey("1960-02-01T07:00:00.000Z ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "1960-02-01T07:00:00.000Z")
-				So(err, ShouldBeNil)
-
-				res, err := tr.ParseFrom()
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
-
-			Convey("1965-02-03T08:00:00.000Z ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "1965-02-03T08:00:00.000Z")
-				So(err, ShouldBeNil)
-
-				res, err := tr.ParseTo()
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
-		})
-
-		Convey("Can parse negative unix epochs", func() {
-			from := time.Date(1960, 2, 1, 7, 0, 0, 0, time.UTC)
-			to := time.Date(1965, 2, 3, 8, 0, 0, 0, time.UTC)
-			tr := NewTimeRange(strconv.FormatInt(from.UnixNano()/int64(time.Millisecond), 10), strconv.FormatInt(to.UnixNano()/int64(time.Millisecond), 10))
+		t.Run("5m ago ", func(t *testing.T) {
+			fiveMinAgo, err := time.ParseDuration("-5m")
+			require.Nil(t, err)
+			expected := now.Add(fiveMinAgo)
 
 			res, err := tr.ParseFrom()
-			So(err, ShouldBeNil)
-			So(res, ShouldEqual, from)
-
-			res, err = tr.ParseTo()
-			So(err, ShouldBeNil)
-			So(res, ShouldEqual, to)
+			require.Nil(t, err)
+			require.Equal(t, expected.Unix(), res.Unix())
 		})
 
-		Convey("can parse unix epochs", func() {
-			var err error
-			tr := TimeRange{
-				From: "1474973725473",
-				To:   "1474975757930",
-				now:  now,
-			}
+		t.Run("now ", func(t *testing.T) {
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, now.Unix(), res.Unix())
+		})
+	})
+
+	t.Run("Can parse 5h, now-10m", func(t *testing.T) {
+		tr := TimeRange{
+			From: "5h",
+			To:   "now-10m",
+			now:  now,
+		}
+
+		t.Run("5h ago ", func(t *testing.T) {
+			fiveHourAgo, err := time.ParseDuration("-5h")
+			require.Nil(t, err)
+			expected := now.Add(fiveHourAgo)
 
 			res, err := tr.ParseFrom()
-			So(err, ShouldBeNil)
-			So(res.UnixNano()/int64(time.Millisecond), ShouldEqual, int64(1474973725473))
-
-			res, err = tr.ParseTo()
-			So(err, ShouldBeNil)
-			So(res.UnixNano()/int64(time.Millisecond), ShouldEqual, int64(1474975757930))
+			require.Nil(t, err)
+			require.Equal(t, expected.Unix(), res.Unix())
 		})
 
-		Convey("Cannot parse asdf", func() {
-			var err error
-			tr := TimeRange{
-				From: "asdf",
-				To:   "asdf",
-				now:  now,
-			}
+		t.Run("now-10m ", func(t *testing.T) {
+			tenMinAgo, err := time.ParseDuration("-10m")
+			require.Nil(t, err)
+			expected := now.Add(tenMinAgo)
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected.Unix(), res.Unix())
+		})
+	})
 
-			_, err = tr.ParseFrom()
-			So(err, ShouldNotBeNil)
+	now, err := time.Parse(time.RFC3339Nano, "2020-03-26T15:12:56.000Z")
+	require.Nil(t, err)
+	t.Run("Can parse now-1M/M, now-1M/M", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1M/M",
+			To:   "now-1M/M",
+			now:  now,
+		}
 
-			_, err = tr.ParseTo()
-			So(err, ShouldNotBeNil)
+		t.Run("from now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-02-01T00:00:00.000Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
 		})
 
-		now, err = time.Parse(time.RFC3339Nano, "2020-07-26T15:12:56.000Z")
-		So(err, ShouldBeNil)
+		t.Run("to now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-02-29T23:59:59.999Z")
+			require.Nil(t, err)
 
-		Convey("Can parse now-1M/M, now-1M/M with America/Chicago timezone", func() {
-			tr := TimeRange{
-				From: "now-1M/M",
-				To:   "now-1M/M",
-				now:  now,
-			}
-			location, err := time.LoadLocation("America/Chicago")
-			So(err, ShouldBeNil)
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+	})
 
-			Convey("from now-1M/M ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-06-01T00:00:00.000-05:00")
-				So(err, ShouldBeNil)
+	t.Run("Can parse now-3d, now+3w", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-3d",
+			To:   "now+3w",
+			now:  now,
+		}
 
-				res, err := tr.ParseFromWithLocation(location)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+		t.Run("now-3d ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-03-23T15:12:56.000Z")
+			require.Nil(t, err)
 
-			Convey("to now-1M/M ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-06-30T23:59:59.999-05:00")
-				So(err, ShouldBeNil)
-
-				res, err := tr.ParseToWithLocation(location)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
 		})
 
-		Convey("Can parse now-3h, now+2h with America/Chicago timezone", func() {
-			tr := TimeRange{
-				From: "now-3h",
-				To:   "now+2h",
-				now:  now,
-			}
-			location, err := time.LoadLocation("America/Chicago")
-			So(err, ShouldBeNil)
+		t.Run("now+3w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-04-16T15:12:56.000Z")
+			require.Nil(t, err)
 
-			Convey("now-3h ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T07:12:56.000-05:00")
-				So(err, ShouldBeNil)
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+	})
 
-				res, err := tr.ParseFromWithLocation(location)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+	t.Run("Can parse 1960-02-01T07:00:00.000Z, 1965-02-03T08:00:00.000Z", func(t *testing.T) {
+		tr := TimeRange{
+			From: "1960-02-01T07:00:00.000Z",
+			To:   "1965-02-03T08:00:00.000Z",
+			now:  now,
+		}
 
-			Convey("now+2h ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T12:12:56.000-05:00")
-				So(err, ShouldBeNil)
+		t.Run("1960-02-01T07:00:00.000Z ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "1960-02-01T07:00:00.000Z")
+			require.Nil(t, err)
 
-				res, err := tr.ParseToWithLocation(location)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
 		})
 
-		Convey("Can parse now-1w/w, now-1w/w without timezone and week start on Monday", func() {
-			tr := TimeRange{
-				From: "now-1w/w",
-				To:   "now-1w/w",
-				now:  now,
-			}
-			weekstart := time.Monday
-			So(err, ShouldBeNil)
+		t.Run("1965-02-03T08:00:00.000Z ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "1965-02-03T08:00:00.000Z")
+			require.Nil(t, err)
 
-			Convey("from now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000Z")
-				So(err, ShouldBeNil)
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+	})
 
-				res, err := tr.ParseFromWithWeekStart(nil, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+	t.Run("Can parse negative unix epochs", func(t *testing.T) {
+		from := time.Date(1960, 2, 1, 7, 0, 0, 0, time.UTC)
+		to := time.Date(1965, 2, 3, 8, 0, 0, 0, time.UTC)
+		tr := NewTimeRange(strconv.FormatInt(from.UnixNano()/int64(time.Millisecond), 10), strconv.FormatInt(to.UnixNano()/int64(time.Millisecond), 10))
 
-			Convey("to now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999Z")
-				So(err, ShouldBeNil)
+		res, err := tr.ParseFrom()
+		require.Nil(t, err)
+		require.True(t, from.Equal(res))
 
-				res, err := tr.ParseToWithWeekStart(nil, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+		res, err = tr.ParseTo()
+		require.Nil(t, err)
+		require.True(t, to.Equal(res))
+	})
+
+	t.Run("can parse unix epochs", func(t *testing.T) {
+		var err error
+		tr := TimeRange{
+			From: "1474973725473",
+			To:   "1474975757930",
+			now:  now,
+		}
+
+		res, err := tr.ParseFrom()
+		require.Nil(t, err)
+		require.Equal(t, int64(1474973725473), res.UnixNano()/int64(time.Millisecond))
+
+		res, err = tr.ParseTo()
+		require.Nil(t, err)
+		require.Equal(t, int64(1474975757930), res.UnixNano()/int64(time.Millisecond))
+	})
+
+	t.Run("Cannot parse asdf", func(t *testing.T) {
+		var err error
+		tr := TimeRange{
+			From: "asdf",
+			To:   "asdf",
+			now:  now,
+		}
+
+		_, err = tr.ParseFrom()
+		require.Error(t, err)
+
+		_, err = tr.ParseTo()
+		require.Error(t, err)
+	})
+
+	now, err = time.Parse(time.RFC3339Nano, "2020-07-26T15:12:56.000Z")
+	require.Nil(t, err)
+
+	t.Run("Can parse now-1M/M, now-1M/M with America/Chicago timezone", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1M/M",
+			To:   "now-1M/M",
+			now:  now,
+		}
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("from now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-06-01T00:00:00.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFromWithLocation(location)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
 		})
 
-		Convey("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Monday", func() {
-			tr := TimeRange{
-				From: "now-1w/w",
-				To:   "now-1w/w",
-				now:  now,
-			}
-			weekstart := time.Monday
-			location, err := time.LoadLocation("America/Chicago")
-			So(err, ShouldBeNil)
+		t.Run("to now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-06-30T23:59:59.999-05:00")
+			require.Nil(t, err)
 
-			Convey("from now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000-05:00")
-				So(err, ShouldBeNil)
+			res, err := tr.ParseToWithLocation(location)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
 
-				res, err := tr.ParseFromWithWeekStart(location, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+	t.Run("Can parse now-3h, now+2h with America/Chicago timezone", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-3h",
+			To:   "now+2h",
+			now:  now,
+		}
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
 
-			Convey("to now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999-05:00")
-				So(err, ShouldBeNil)
+		t.Run("now-3h ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T07:12:56.000-05:00")
+			require.Nil(t, err)
 
-				res, err := tr.ParseToWithWeekStart(location, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+			res, err := tr.ParseFromWithLocation(location)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
 		})
 
-		Convey("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Sunday", func() {
-			tr := TimeRange{
-				From: "now-1w/w",
-				To:   "now-1w/w",
-				now:  now,
-			}
-			weekstart := time.Sunday
-			location, err := time.LoadLocation("America/Chicago")
-			So(err, ShouldBeNil)
+		t.Run("now+2h ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T12:12:56.000-05:00")
+			require.Nil(t, err)
 
-			Convey("from now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T00:00:00.000-05:00")
-				So(err, ShouldBeNil)
+			res, err := tr.ParseToWithLocation(location)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
 
-				res, err := tr.ParseFromWithWeekStart(location, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+	t.Run("Can parse now-1w/w, now-1w/w without timezone and week start on Monday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			now:  now,
+		}
+		weekstart := time.Monday
+		require.Nil(t, err)
 
-			Convey("to now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-25T23:59:59.999-05:00")
-				So(err, ShouldBeNil)
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000Z")
+			require.Nil(t, err)
 
-				res, err := tr.ParseToWithWeekStart(location, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+			res, err := tr.ParseFromWithWeekStart(nil, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
 		})
 
-		Convey("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Saturday", func() {
-			tr := TimeRange{
-				From: "now-1w/w",
-				To:   "now-1w/w",
-				now:  now,
-			}
-			weekstart := time.Saturday
-			location, err := time.LoadLocation("America/Chicago")
-			So(err, ShouldBeNil)
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999Z")
+			require.Nil(t, err)
 
-			Convey("from now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-18T00:00:00.000-05:00")
-				So(err, ShouldBeNil)
+			res, err := tr.ParseToWithWeekStart(nil, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
 
-				res, err := tr.ParseFromWithWeekStart(location, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+	t.Run("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Monday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			now:  now,
+		}
+		weekstart := time.Monday
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
 
-			Convey("to now-1w/w ", func() {
-				expected, err := time.Parse(time.RFC3339Nano, "2020-07-24T23:59:59.999-05:00")
-				So(err, ShouldBeNil)
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000-05:00")
+			require.Nil(t, err)
 
-				res, err := tr.ParseToWithWeekStart(location, weekstart)
-				So(err, ShouldBeNil)
-				So(res, ShouldEqual, expected)
-			})
+			res, err := tr.ParseFromWithWeekStart(location, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseToWithWeekStart(location, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+
+	t.Run("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Sunday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			now:  now,
+		}
+		weekstart := time.Sunday
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T00:00:00.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFromWithWeekStart(location, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-25T23:59:59.999-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseToWithWeekStart(location, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+
+	t.Run("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Saturday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			now:  now,
+		}
+		weekstart := time.Saturday
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-18T00:00:00.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFromWithWeekStart(location, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-24T23:59:59.999-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseToWithWeekStart(location, weekstart)
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
 		})
 	})
 }


### PR DESCRIPTION
Another automatic PR related to #40633 and a big thanks to @ying-jeanne who reminded how to compare time values properly (instead of using `require.Equal`).