### PR TITLE
prometheus: remove handling of control+enter

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreExtraField.tsx
@@ -48,7 +48,7 @@ export const PromExploreExtraField: React.FC<PromExploreExtraFieldProps> = memo(
     }
 
     function onReturnKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-      if (e.key === 'Enter' && (e.shiftKey || e.ctrlKey)) {
+      if (e.key === 'Enter' && e.shiftKey) {
         onRunQuery();
       }
     }


### PR DESCRIPTION
in our data sources we use shift+enter to run the query. prometheus supported ctrl+enter too, but we decided to remove this and focus on the "standard" shift+enter. this will happen with the switch to the monaco-based query editor, but it is also done in the min-step text-field. this pull request adjusts that one too.