### PR TITLE
Loki: Use fixed bucket size for logs volume

### DIFF
--- a/public/app/features/explore/LogsVolumePanel.tsx
+++ b/public/app/features/explore/LogsVolumePanel.tsx
@@ -59,7 +59,7 @@ export function LogsVolumePanel(props: Props) {
   if (zoomRatio !== undefined && zoomRatio < 1) {
     zoomLevelInfo = (
       <>
-        <span className={styles.zoomInfo}>Reload to show higher resolution</span>
+        <span className={styles.zoomInfo}>Reload logs volume</span>
         <Button size="xs" icon="sync" variant="secondary" onClick={onLoadLogsVolume} />
       </>
     );

--- a/public/app/plugins/datasource/loki/dataProviders/logsVolumeProvider.test.ts
+++ b/public/app/plugins/datasource/loki/dataProviders/logsVolumeProvider.test.ts
@@ -40,6 +40,11 @@ describe('LokiLogsVolumeProvider', () => {
     request = ({
       targets: [{ expr: '{app="app01"}' }, { expr: '{app="app02"}' }],
       range: { from: 0, to: 1 },
+      scopedVars: {
+        __interval_ms: {
+          value: 1000,
+        },
+      },
     } as unknown) as DataQueryRequest<LokiQuery>;
     volumeProvider = createLokiLogsVolumeProvider((datasource as unknown) as LokiDatasource, request);
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This it to use fixed bucket width for Loki's logs volume histogram. Without fixed size it's impossible to correctly interpret results on y-axis. For example using `$__interval` results may get aggregated like below, every 2 seconds (i.e. every bar represents 2 seconds):

<img width="1480" alt="Screen Shot 2021-10-25 at 11 55 29" src="https://user-images.githubusercontent.com/745532/138680773-86de7ac0-aec4-4032-a7ed-5545ea6ad909.png">

This is because `$__interval` value is different depending on selected range and graph width and it's not obvious to the user.

This PR adds rounding the aggregation up to 1-second/1-minute/1-hour and max of 1 day. The graph above (2 second aggregation) will now look like below (1 minute aggregation):
 
<img width="1475" alt="Screen Shot 2021-10-25 at 11 55 16" src="https://user-images.githubusercontent.com/745532/138680824-d4ebd266-609c-4176-a3ed-bf2fcfcda079.png">

Notice how different is value on y-axis with higher resolution.

Also: timeout error message has been adjusted to mention the time range as well. Message to reload the histogram is more generic now as it may not necessary mean the histogram will have higher resolution after reloading.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes N/A

**Special notes for your reviewer**: CC @bboreham @slim-bean @cyriltovena 

